### PR TITLE
NumericInput component breaks table widget when no data is in table, …

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableHeader.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableHeader.tsx
@@ -37,7 +37,7 @@ const PageNumberInput = (props: {
     <PageNumberInputWrapper
       value={props.pageNo}
       min={1}
-      max={props.pageCount}
+      max={props.pageCount || 1}
       buttonPosition="none"
       clampValueOnBlur={true}
       onValueChange={(value: number) => {


### PR DESCRIPTION
…since props.pageCount becomes 0. So to fix this changed it to 1 when it is 0.