### PR TITLE
Add maven-license-plugin to the project

### DIFF
--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -40,6 +40,13 @@
             </resource>
         </resources>
 
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.0.0</version>
+            </plugin>
+        </plugins>
 
     </build>
 


### PR DESCRIPTION
To generate a license listing text file with license details of all dependencies, run `mvn clean license:aggregate-add-third-party`.