### PR TITLE
Chore/remove implicit permissions

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/pom.xml
+++ b/app/server/appsmith-plugins/postgresPlugin/pom.xml
@@ -49,6 +49,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.2.12</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/app/server/appsmith-plugins/postgresPlugin/pom.xml
+++ b/app/server/appsmith-plugins/postgresPlugin/pom.xml
@@ -49,7 +49,6 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.2.12</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionService.java
@@ -8,7 +8,6 @@ import com.appsmith.server.dtos.ExecuteActionDTO;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -18,7 +17,7 @@ public interface ActionService extends CrudService<Action, String> {
 
     Mono<Action> save(Action action);
 
-    Mono<Action> findByNameAndPageId(String name, String pageId);
+    Mono<Action> findByNameAndPageId(String name, String pageId, AclPermission permission);
 
     Flux<Action> findOnLoadActionsInPage(Set<String> names, String pageId);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
@@ -476,8 +476,8 @@ public class ActionServiceImpl extends BaseService<ActionRepository, Action, Str
     }
 
     @Override
-    public Mono<Action> findByNameAndPageId(String name, String pageId) {
-        return repository.findByNameAndPageId(name, pageId, READ_ACTIONS);
+    public Mono<Action> findByNameAndPageId(String name, String pageId, AclPermission permission) {
+        return repository.findByNameAndPageId(name, pageId, permission);
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -267,7 +267,7 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, "application", id)))
                 .flatMap(application -> {
                     log.debug("Archiving pages for applicationId: {}", id);
-                    return pageService.findByApplicationId(id)
+                    return pageService.findByApplicationId(id, READ_PAGES)
                             .flatMap(page -> pageService.delete(page.getId()))
                             .collectList()
                             .thenReturn(application);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationService.java
@@ -12,7 +12,7 @@ public interface ApplicationService extends CrudService<Application, String> {
 
     Mono<Application> findById(String id, AclPermission aclPermission);
 
-    Mono<Application> findByIdAndOrganizationId(String id, String organizationId);
+    Mono<Application> findByIdAndOrganizationId(String id, String organizationId, AclPermission permission);
 
     Mono<Application> findByName(String name, AclPermission permission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -102,8 +102,8 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     }
 
     @Override
-    public Mono<Application> findByIdAndOrganizationId(String id, String organizationId) {
-        return repository.findByIdAndOrganizationId(id, organizationId, READ_APPLICATIONS);
+    public Mono<Application> findByIdAndOrganizationId(String id, String organizationId, AclPermission permission) {
+        return repository.findByIdAndOrganizationId(id, organizationId, permission);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceService.java
@@ -11,7 +11,7 @@ public interface DatasourceService extends CrudService<Datasource, String> {
 
     Mono<DatasourceTestResult> testDatasource(Datasource datasource);
 
-    Mono<Datasource> findByName(String name);
+    Mono<Datasource> findByName(String name, AclPermission per);
 
     Mono<Datasource> findById(String id, AclPermission aclPermission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceService.java
@@ -11,7 +11,7 @@ public interface DatasourceService extends CrudService<Datasource, String> {
 
     Mono<DatasourceTestResult> testDatasource(Datasource datasource);
 
-    Mono<Datasource> findByName(String name, AclPermission per);
+    Mono<Datasource> findByName(String name, AclPermission permission);
 
     Mono<Datasource> findById(String id, AclPermission aclPermission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -252,8 +252,8 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
     }
 
     @Override
-    public Mono<Datasource> findByName(String name) {
-        return repository.findByName(name, AclPermission.READ_DATASOURCES);
+    public Mono<Datasource> findByName(String name, AclPermission permission) {
+        return repository.findByName(name, permission);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
+import static com.appsmith.server.acl.AclPermission.READ_ACTIONS;
 import static com.appsmith.server.helpers.BeanCopyUtils.copyNewFieldValuesIntoOldObject;
 import static java.util.stream.Collectors.toSet;
 
@@ -267,7 +268,7 @@ public class LayoutActionServiceImpl implements LayoutActionService {
                         return Mono.error(new AppsmithException(AppsmithError.NAME_CLASH_NOT_ALLOWED_IN_REFACTOR, oldName, newName));
                     }
                     return actionService
-                            .findByNameAndPageId(oldName, pageId);
+                            .findByNameAndPageId(oldName, pageId, READ_ACTIONS);
                 })
                 .flatMap(action -> {
                     action.setName(newName);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PageService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PageService.java
@@ -11,13 +11,13 @@ public interface PageService extends CrudService<Page, String> {
 
     Mono<Page> findById(String pageId, AclPermission aclPermission);
 
-    Flux<Page> findByApplicationId(String applicationId);
+    Flux<Page> findByApplicationId(String applicationId, AclPermission permission);
 
     Mono<Page> save(Page page);
 
     Mono<Page> findByIdAndLayoutsId(String pageId, String layoutId, AclPermission aclPermission);
 
-    Mono<Page> findByName(String name);
+    Mono<Page> findByName(String name, AclPermission permission);
 
     Mono<Void> deleteAll();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PageServiceImpl.java
@@ -58,8 +58,8 @@ public class PageServiceImpl extends BaseService<PageRepository, Page, String> i
     }
 
     @Override
-    public Flux<Page> findByApplicationId(String applicationId) {
-        return repository.findByApplicationId(applicationId, AclPermission.READ_PAGES);
+    public Flux<Page> findByApplicationId(String applicationId, AclPermission permission) {
+        return repository.findByApplicationId(applicationId, permission);
     }
 
     @Override
@@ -73,8 +73,8 @@ public class PageServiceImpl extends BaseService<PageRepository, Page, String> i
     }
 
     @Override
-    public Mono<Page> findByName(String name) {
-        return repository.findByName(name, AclPermission.READ_PAGES);
+    public Mono<Page> findByName(String name, AclPermission permission) {
+        return repository.findByName(name, permission);
     }
 
     @Override
@@ -177,7 +177,7 @@ public class PageServiceImpl extends BaseService<PageRepository, Page, String> i
 
     private Flux<PageNameIdDTO> findNamesByApplication(Application application) {
         List<ApplicationPage> pages = application.getPages();
-        return repository.findByApplicationId(application.getId(), AclPermission.READ_PAGES)
+        return findByApplicationId(application.getId(), AclPermission.READ_PAGES)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.PAGE + "by application name", application.getName())))
                 .map(page -> {
                     PageNameIdDTO pageNameIdDTO = new PageNameIdDTO();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -116,7 +116,7 @@ public class ApplicationServiceTest {
         testApplication.setName("ApplicationServiceTest TestAppForTestingPage");
         Flux<Page> pagesFlux = applicationPageService
                 .createApplication(testApplication, orgId)
-                .flatMapMany(application -> pageService.findByApplicationId(application.getId()));
+                .flatMapMany(application -> pageService.findByApplicationId(application.getId(), READ_PAGES));
 
         Policy managePagePolicy = Policy.builder().permission(MANAGE_PAGES.getValue())
                 .users(Set.of("api_user"))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services;
 
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.plugins.PluginExecutor;
+import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Action;
 import com.appsmith.server.domains.Application;
@@ -167,7 +168,7 @@ public class LayoutServiceTest {
 
     private Mono<Page> createPage(Application app, Page page) {
         Mono<Page> pageMono = pageService
-                .findByName(page.getName())
+                .findByName(page.getName(), AclPermission.READ_PAGES)
                 .switchIfEmpty(applicationPageService.createApplication(app, orgId)
                         .map(application -> {
                             page.setApplicationId(application.getId());
@@ -255,7 +256,7 @@ public class LayoutServiceTest {
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
 
         Mono<Layout> testMono = pageService
-                .findByName("validPageName")
+                .findByName("validPageName", AclPermission.READ_PAGES)
                 .flatMap(page1 -> {
                     List<Mono<Action>> monos = new ArrayList<>();
 


### PR DESCRIPTION
Some `find*` methods inside service implementations don't take a permission explicitly as a method argument. Instead, the permission is hard-coded inside the method. This creates problem where although the `find*` operation can be called for very different purposes (like viewing vs updating some related object), the permission used to find was always the same. This PR makes that explicit by have the caller of these methods provide a permission as an extra argument to the method.