### PR TITLE
Adding null checks before encrypting or decrypting the password 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -148,7 +148,9 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
 
     @Override
     public AuthenticationDTO decryptSensitiveFields(AuthenticationDTO authenticationDTO) {
-        authenticationDTO.setPassword(encryptionService.decryptString(authenticationDTO.getPassword()));
+        if (authenticationDTO.getPassword() != null) {
+            authenticationDTO.setPassword(encryptionService.decryptString(authenticationDTO.getPassword()));
+        }
         return authenticationDTO;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -207,7 +207,9 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
                 datasource.getDatasourceConfiguration().getAuthentication() != null) {
             AuthenticationDTO authentication = datasource.getDatasourceConfiguration().getAuthentication();
             // Encrypt password before saving
-            authentication.setPassword(encryptionService.encryptString(authentication.getPassword()));
+            if (authentication.getPassword() != null) {
+                authentication.setPassword(encryptionService.encryptString(authentication.getPassword()));
+            }
             datasource.getDatasourceConfiguration().setAuthentication(authentication);
         }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -422,7 +422,7 @@ public class DatasourceServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
-    public void checkEncryptionofAunthenticationDTOTest() {
+    public void checkEncryptionOfAuthenticationDTOTest() {
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
         
         Mono<Plugin> pluginMono = pluginService.findByName("Installed Plugin Name");
@@ -450,6 +450,37 @@ public class DatasourceServiceTest {
                     AuthenticationDTO authentication = savedDatasource.getDatasourceConfiguration().getAuthentication();
                     assertThat(authentication.getUsername()).isEqualTo(username);
                     assertThat(authentication.getPassword()).isEqualTo(encryptionService.encryptString(password));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void checkEncryptionOfAuthenticationDTONullPassword() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Mono<Plugin> pluginMono = pluginService.findByName("Installed Plugin Name");
+        Datasource datasource = new Datasource();
+        datasource.setName("test datasource name for authenticated fields encryption test");
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        AuthenticationDTO authenticationDTO = new AuthenticationDTO();
+        authenticationDTO.setDatabaseName("admin");
+        datasourceConfiguration.setAuthentication(authenticationDTO);
+        datasource.setDatasourceConfiguration(datasourceConfiguration);
+        datasource.setOrganizationId(orgId);
+
+        Mono<Datasource> datasourceMono = pluginMono.map(plugin -> {
+            datasource.setPluginId(plugin.getId());
+            return datasource;
+        }).flatMap(datasourceService::create);
+
+        StepVerifier
+                .create(datasourceMono)
+                .assertNext(savedDatasource -> {
+                    AuthenticationDTO authentication = savedDatasource.getDatasourceConfiguration().getAuthentication();
+                    assertThat(authentication.getUsername()).isNull();
+                    assertThat(authentication.getPassword()).isNull();
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
In the AuthenticationDTO object, if the password is null, the encryption and decryption process throws a NPE. This null check avoids that from happening.