### PR TITLE
Adding dynamic redirect to form & OAuth2 login

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/AuthenticationSuccessHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/AuthenticationSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.authentication.handlers;
 
 import com.appsmith.server.constants.Security;
+import com.appsmith.server.helpers.RedirectHelper;
 import com.appsmith.server.solutions.ExamplesOrganizationCloner;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,7 +64,7 @@ public class AuthenticationSuccessHandler implements ServerAuthenticationSuccess
     private Mono<Void> handleOAuth2Redirect(WebFilterExchange webFilterExchange) {
         ServerWebExchange exchange = webFilterExchange.getExchange();
         String state = exchange.getRequest().getQueryParams().getFirst(Security.QUERY_PARAMETER_STATE);
-        String originHeader = "/";
+        String originHeader = RedirectHelper.DEFAULT_REDIRECT_URL;
         if (state != null && !state.isEmpty()) {
             String[] stateArray = state.split(",");
             for (int i = 0; i < stateArray.length; i++) {
@@ -84,12 +85,9 @@ public class AuthenticationSuccessHandler implements ServerAuthenticationSuccess
 
         // On authentication success, we send a redirect to the client's home page. This ensures that the session
         // is set in the cookie on the browser.
-        String originHeader = exchange.getRequest().getHeaders().getOrigin();
-        if (originHeader == null || originHeader.isEmpty()) {
-            originHeader = "/";
-        }
+        String redirectUrl = RedirectHelper.getRedirectUrl(exchange.getRequest().getHeaders());
 
-        URI defaultRedirectLocation = URI.create(originHeader);
+        URI defaultRedirectLocation = URI.create(redirectUrl);
         return this.redirectStrategy.sendRedirect(exchange, defaultRedirectLocation);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomServerOAuth2AuthorizationRequestResolver.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomServerOAuth2AuthorizationRequestResolver.java
@@ -4,6 +4,7 @@ import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.Security;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.RedirectHelper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -31,8 +32,6 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -191,24 +190,8 @@ public class CustomServerOAuth2AuthorizationRequestResolver implements ServerOAu
      */
     private String generateKey(HttpHeaders httpHeaders) {
         String stateKey = this.stateGenerator.generateKey();
-        String originHeader = httpHeaders.getOrigin();
-        if (originHeader == null || originHeader.isBlank()) {
-            String refererHeader = httpHeaders.getFirst(Security.REFERER_HEADER);
-            if (refererHeader != null && !refererHeader.isBlank()) {
-                URI uri = null;
-                try {
-                    uri = new URI(refererHeader);
-                    String authority = uri.getAuthority();
-                    String scheme = uri.getScheme();
-                    originHeader = scheme + "://" + authority;
-                } catch (URISyntaxException e) {
-                    originHeader = "/";
-                }
-            } else {
-                originHeader = "/";
-            }
-        }
-        stateKey = stateKey + "," + Security.STATE_PARAMETER_ORIGIN + originHeader;
+        String redirectUrl = RedirectHelper.getRedirectUrl(httpHeaders);
+        stateKey = stateKey + "," + Security.STATE_PARAMETER_ORIGIN + redirectUrl;
         return stateKey;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
@@ -1,0 +1,43 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.constants.Security;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class RedirectHelper {
+
+    public static String DEFAULT_REDIRECT_URL = "/applications";
+    private static String REDIRECT_URL_HEADER = "X-Redirect-Url";
+
+    public static String getRedirectUrl(HttpHeaders httpHeaders) {
+        // First check if the custom redirect header is set
+        String redirectUrl = httpHeaders.getFirst(REDIRECT_URL_HEADER);
+
+        // If not, then try to get the header from Origin. We append
+        if (StringUtils.isEmpty(redirectUrl) && !StringUtils.isEmpty(httpHeaders.getOrigin())) {
+            redirectUrl = httpHeaders.getOrigin() + DEFAULT_REDIRECT_URL;
+        }
+
+        if (StringUtils.isEmpty(redirectUrl)) {
+            // If the header is still empty
+            String refererHeader = httpHeaders.getFirst(Security.REFERER_HEADER);
+            if (refererHeader != null && !refererHeader.isBlank()) {
+                URI uri = null;
+                try {
+                    uri = new URI(refererHeader);
+                    String authority = uri.getAuthority();
+                    String scheme = uri.getScheme();
+                    redirectUrl = scheme + "://" + authority;
+                } catch (URISyntaxException e) {
+                    redirectUrl = DEFAULT_REDIRECT_URL;
+                }
+            } else {
+                redirectUrl = DEFAULT_REDIRECT_URL;
+            }
+        }
+        return redirectUrl;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
@@ -18,7 +18,11 @@ public class RedirectHelper {
 
         // If not, then try to get the redirect URL from Origin header.
         // We append DEFAULT_REDIRECT_URL to the Origin header by default.
-        if (StringUtils.isEmpty(redirectUrl) && !StringUtils.isEmpty(httpHeaders.getOrigin())) {
+        if (StringUtils.isEmpty(redirectUrl)) {
+            redirectUrl = DEFAULT_REDIRECT_URL;
+        }
+
+        if (!(redirectUrl.startsWith("http://") || redirectUrl.startsWith("https://")) && !StringUtils.isEmpty(httpHeaders.getOrigin())) {
             redirectUrl = httpHeaders.getOrigin() + DEFAULT_REDIRECT_URL;
         }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/RedirectHelper.java
@@ -9,18 +9,20 @@ import java.net.URISyntaxException;
 
 public class RedirectHelper {
 
-    public static String DEFAULT_REDIRECT_URL = "/applications";
-    private static String REDIRECT_URL_HEADER = "X-Redirect-Url";
+    public static final String DEFAULT_REDIRECT_URL = "/applications";
+    private static final String REDIRECT_URL_HEADER = "X-Redirect-Url";
 
     public static String getRedirectUrl(HttpHeaders httpHeaders) {
         // First check if the custom redirect header is set
         String redirectUrl = httpHeaders.getFirst(REDIRECT_URL_HEADER);
 
-        // If not, then try to get the header from Origin. We append
+        // If not, then try to get the redirect URL from Origin header.
+        // We append DEFAULT_REDIRECT_URL to the Origin header by default.
         if (StringUtils.isEmpty(redirectUrl) && !StringUtils.isEmpty(httpHeaders.getOrigin())) {
             redirectUrl = httpHeaders.getOrigin() + DEFAULT_REDIRECT_URL;
         }
 
+        // If the redirect Url is still empty, construct the redirect Url from the Referrer header.
         if (StringUtils.isEmpty(redirectUrl)) {
             // If the header is still empty
             String refererHeader = httpHeaders.getFirst(Security.REFERER_HEADER);


### PR DESCRIPTION
The client can send the redirect URL in X-Redirect-Url header. The server will honour the value set and redirect the client browser to this particular url. By default the server will redirect to /applications if the custom header is missing.