### PR TITLE
Handle stale database connection from datasources

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/pluginExceptions/AppsmithPluginException.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/pluginExceptions/AppsmithPluginException.java
@@ -29,7 +29,7 @@ public class AppsmithPluginException extends Exception {
     }
 
     public Integer getAppErrorCode() {
-        return this.error.getAppErrorCode();
+        return this.error == null ? 0 : this.error.getAppErrorCode();
     }
 
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/pluginExceptions/StaleConnectionException.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/pluginExceptions/StaleConnectionException.java
@@ -1,0 +1,4 @@
+package com.appsmith.external.pluginExceptions;
+
+public class StaleConnectionException extends RuntimeException {
+}

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -69,7 +69,7 @@ public class MySqlPlugin extends BasePlugin {
             } catch (SQLException error) {
                 // This exception is thrown only when the timeout to `isValid` is negative. Since, that's not the case,
                 // here, this should never happen.
-                log.error("Error checking validity of Postgres connection.", error);
+                log.error("Error checking validity of MySQL connection.", error);
             }
 
             String query = actionConfiguration.getBody();

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -41,6 +41,7 @@ public class MySqlPlugin extends BasePlugin {
 
     private static final String USER = "user";
     private static final String PASSWORD = "password";
+    private static final int VALIDITY_CHECK_TIMEOUT = 5;
 
     public MySqlPlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -62,7 +63,7 @@ public class MySqlPlugin extends BasePlugin {
             Connection conn = (Connection) connection;
 
             try {
-                if (conn == null || conn.isClosed() || !conn.isValid(5)) {
+                if (conn == null || conn.isClosed() || !conn.isValid(VALIDITY_CHECK_TIMEOUT)) {
                     log.info("Encountered stale connection in MySQL plugin. Reporting back.");
                     throw new StaleConnectionException();
                 }

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -9,6 +9,7 @@ import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.SSLDetails;
 import com.appsmith.external.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.pluginExceptions.StaleConnectionException;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import lombok.NonNull;
@@ -61,11 +62,22 @@ public class PostgresPlugin extends BasePlugin {
     public static class PostgresPluginExecutor implements PluginExecutor {
 
         @Override
-        public Mono<Object> execute(@NonNull Object connection,
+        public Mono<Object> execute(Object connection,
                                     DatasourceConfiguration datasourceConfiguration,
                                     ActionConfiguration actionConfiguration) {
 
             Connection conn = (Connection) connection;
+
+            try {
+                if (conn == null || conn.isClosed() || !conn.isValid(5)) {
+                    log.info("Encountered stale connection in Postgres plugin. Reporting back.");
+                    throw new StaleConnectionException();
+                }
+            } catch (SQLException error) {
+                // This exception is thrown only when the timeout to `isValid` is negative. Since, that's not the case,
+                // here, this should never happen.
+                log.error("Error checking validity of Postgres connection.", error);
+            }
 
             String query = actionConfiguration.getBody();
 

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -48,6 +48,7 @@ public class PostgresPlugin extends BasePlugin {
     private static final String PASSWORD = "password";
     private static final String SSL = "ssl";
     private static final String DATE_COLUMN_TYPE_NAME = "date";
+    private static final int VALIDITY_CHECK_TIMEOUT = 5;
 
     public PostgresPlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -69,7 +70,7 @@ public class PostgresPlugin extends BasePlugin {
             Connection conn = (Connection) connection;
 
             try {
-                if (conn == null || conn.isClosed() || !conn.isValid(5)) {
+                if (conn == null || conn.isClosed() || !conn.isValid(VALIDITY_CHECK_TIMEOUT)) {
                     log.info("Encountered stale connection in Postgres plugin. Reporting back.");
                     throw new StaleConnectionException();
                 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
@@ -432,6 +432,13 @@ public class ActionServiceImpl extends BaseService<ActionRepository, Action, Str
                                         .then(executionMono);
                             })
                             .timeout(Duration.ofMillis(timeoutDuration))
+                            .onErrorMap(
+                                    StaleConnectionException.class,
+                                    error -> new AppsmithPluginException(
+                                            AppsmithPluginError.PLUGIN_ERROR,
+                                            "Secondary stale connection error."
+                                    )
+                            )
                             .onErrorResume(e -> {
                                 log.debug("In the action execution error mode.", e);
                                 ActionExecutionResult result = new ActionExecutionResult();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
@@ -11,6 +11,7 @@ import com.appsmith.external.models.Property;
 import com.appsmith.external.models.Provider;
 import com.appsmith.external.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.pluginExceptions.StaleConnectionException;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.acl.PolicyGenerator;
@@ -412,16 +413,27 @@ public class ActionServiceImpl extends BaseService<ActionRepository, Action, Str
                             action.getPageId(), action.getId(), action.getName(), datasourceConfiguration,
                             actionConfiguration);
 
-                    return datasourceContextService
-                            .getDatasourceContext(datasource)
-                            //Now that we have the context (connection details, execute the action
-                            .flatMap(resourceContext -> pluginExecutor.execute(
-                                    resourceContext.getConnection(),
-                                    datasourceConfiguration,
-                                    actionConfiguration))
+                    Mono<Object> executionMono = Mono.just(datasource)
+                            .flatMap(datasourceContextService::getDatasourceContext)
+                            // Now that we have the context (connection details), execute the action.
+                            .flatMap(
+                                    resourceContext -> pluginExecutor.execute(
+                                            resourceContext.getConnection(),
+                                            datasourceConfiguration,
+                                            actionConfiguration
+                                    )
+                            );
+
+                    return executionMono
+                            .onErrorResume(StaleConnectionException.class, error -> {
+                                log.info("Looks like the connection is stale. Retrying with a fresh context.");
+                                return datasourceContextService
+                                        .deleteDatasourceContext(datasource.getId())
+                                        .then(executionMono);
+                            })
                             .timeout(Duration.ofMillis(timeoutDuration))
                             .onErrorResume(e -> {
-                                log.debug("In the action execution error mode. Cause: {}", e.getMessage());
+                                log.debug("In the action execution error mode.", e);
                                 ActionExecutionResult result = new ActionExecutionResult();
                                 result.setBody(e.getMessage());
                                 result.setIsExecutionSuccess(false);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -57,7 +57,7 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
             return Mono.just(datasourceContextMap.get(datasourceId));
         }
 
-        log.debug("Datasource context doesn't exist. Creating connection");
+        log.debug("Datasource context doesn't exist. Creating connection.");
 
         Mono<Datasource> datasourceMono;
 
@@ -124,26 +124,24 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
 
     @Override
     public Mono<DatasourceContext> deleteDatasourceContext(String datasourceId) {
-
         DatasourceContext datasourceContext = datasourceContextMap.get(datasourceId);
         if (datasourceContext == null) {
-            //No resource context exists for this resource. Return void;
+            // No resource context exists for this resource. Return void.
             return Mono.empty();
         }
 
-        Mono<Datasource> datasourceMono = datasourceService.findById(datasourceId, EXECUTE_DATASOURCES);
-
-        Mono<Plugin> pluginMono = datasourceMono
-                .flatMap(datasource -> pluginService.findById(datasource.getPluginId()));
-
-        //Datasource Context has not been created for this resource on this machine. Create one now.
-        Mono<PluginExecutor> pluginExecutorMono = pluginExecutorHelper.getPluginExecutor(pluginMono);
-
-        return Mono.zip(datasourceMono, pluginExecutorMono, ((datasource, pluginExecutor) -> {
-            pluginExecutor.datasourceDestroy(datasourceContext.getConnection());
-            datasourceContextMap.remove(datasourceId);
-            return datasourceContext;
-        }));
+        return datasourceService
+                .findById(datasourceId, EXECUTE_DATASOURCES)
+                .zipWhen(datasource1 ->
+                        pluginExecutorHelper.getPluginExecutor(pluginService.findById(datasource1.getPluginId()))
+                )
+                .map(tuple -> {
+                    final Datasource datasource = tuple.getT1();
+                    final PluginExecutor pluginExecutor = tuple.getT2();
+                    log.info("Clearing datasource context for datasource ID {}.", datasource.getId());
+                    pluginExecutor.datasourceDestroy(datasourceContext.getConnection());
+                    return datasourceContextMap.remove(datasourceId);
+                });
     }
 
     @Override


### PR DESCRIPTION
This PR introduces handling of stale database connections from datasources and creating new connections when such situation occurs.

The way this is implemented is that when a connection is identified as being stale by a plugin, it is expected to throw an instance of `StaleConnectionException`. When that happens, we destroy the connection context we have for that datasource, recreate a new connection context, and start the execution process again.

This has been currently implemented for Postgres and MySQL database plugins. The MongoDB driver seems to be clever enough to seamlessly handle such scenarios all by itself (in my tests). It still makes a log entry about the connection being closed, but it subsequently reconnects and continues as usual.
