### PR TITLE
Clear application pages list before cloning

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -143,6 +143,9 @@ public class ExamplesOrganizationCloner {
                     final String templateApplicationId = application.getId();
                     makePristine(application);
                     application.setOrganizationId(toOrganizationId);
+                    if (!CollectionUtils.isEmpty(application.getPages())) {
+                        application.getPages().clear();
+                    }
                     return Flux.combineLatest(
                             pageRepository.findByApplicationId(templateApplicationId),
                             applicationPageService.createApplication(application).cache(),

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -116,6 +116,8 @@ public class ExamplesOrganizationClonerTests {
                                     "1 - public app"
                             );
 
+                    assertThat(applications.get(0).getPages()).hasSize(1);
+
                     final List<Datasource> datasources = tuple.getT3();
                     assertThat(datasources).isEmpty();
                 })


### PR DESCRIPTION
Currently, the page list inside application objects is not cleared before cloning. So, the page list in cloned application objects contain links to new cloned pages as well old pages. This PR fixes this problem by clearing the page list in the application objects, just before cloning.