### PR TITLE
Reset default fields of User object before update

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -118,6 +118,9 @@ public class ExamplesOrganizationCloner {
                     User userUpdate = new User();
                     userUpdate.setExamplesOrganizationId(newOrganization.getId());
                     userUpdate.setPasswordResetInitiated(user.getPasswordResetInitiated());
+                    userUpdate.setSource(user.getSource());
+                    userUpdate.setGroupIds(null);
+                    userUpdate.setPolicies(null);
                     return Mono
                             .when(
                                     userService.update(user.getId(), userUpdate),


### PR DESCRIPTION
The policies of `User` objects is an empty set by default. So, when using a new `User` object to call `update`, it also updates existing policies to be an empty list.