### PR TITLE
Github action to push to Docker Hub and create Github release

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -225,10 +225,10 @@ jobs:
         docker push appsmith/appsmith-editor
     
     # Build master Docker image and push to Docker Hub
-    # - name: Push production image to Docker Hub with commit tag
-    #   if: success() && github.ref == 'refs/heads/master'
-    #   run: |
-    #     docker build -t appsmith/appsmith-editor:${GITHUB_SHA} .
-    #     docker build -t appsmith/appsmith-editor:latest .
-    #     echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-    #     docker push appsmith/appsmith-editor
+    - name: Push production image to Docker Hub with commit tag
+      if: success() && github.ref == 'refs/heads/master'
+      run: |
+        docker build -t appsmith/appsmith-editor:${GITHUB_SHA} .
+        docker build -t appsmith/appsmith-editor:latest .
+        echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+        docker push appsmith/appsmith-editor

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -37,7 +37,7 @@ jobs:
       env:
         cache-name: cache-yarn-dependencies
       with:
-        # maven dependencies are stored in `~/.m2` on Linux/macOS
+        # npm dependencies are stored in `~/.m2` on Linux/macOS
         path: ~/.npm
         key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
@@ -225,10 +225,10 @@ jobs:
         docker push appsmith/appsmith-editor
     
     # Build master Docker image and push to Docker Hub
-    - name: Push production image to Docker Hub with commit tag
-      if: success() && github.ref == 'refs/heads/master'
-      run: |
-        docker build -t appsmith/appsmith-editor:${GITHUB_SHA} .
-        docker build -t appsmith/appsmith-editor:latest .
-        echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-        docker push appsmith/appsmith-editor
+    # - name: Push production image to Docker Hub with commit tag
+    #   if: success() && github.ref == 'refs/heads/master'
+    #   run: |
+    #     docker build -t appsmith/appsmith-editor:${GITHUB_SHA} .
+    #     docker build -t appsmith/appsmith-editor:latest .
+    #     echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+    #     docker push appsmith/appsmith-editor

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -37,7 +37,7 @@ jobs:
       env:
         cache-name: cache-yarn-dependencies
       with:
-        # npm dependencies are stored in `~/.m2` on Linux/macOS
+        # npm dependencies are stored in `~/.npm` on Linux/macOS
         path: ~/.npm
         key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -54,7 +54,6 @@ jobs:
         if: success() && github.ref == 'refs/heads/master'
         run: |
           docker build -t appsmith/appsmith-editor:${{ github.ref }} .
-          docker build -t appsmith/appsmith-editor:latest .
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
           docker push appsmith/appsmith-editor
 
@@ -98,7 +97,6 @@ jobs:
     # Build Docker image and push to Docker Hub
     - name: Push image to Docker Hub
       run: |
-        docker build -t appsmith/appsmith-server:${{steps.vars.outputs.tag}} .
         docker build -t appsmith/appsmith-server:${{ github.ref }} .
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-server

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,124 @@
+name: Appsmith Github Release Workflow 
+
+on:
+  push:
+    branches: master
+    # Only trigger if a tag has been created and pushed to this branch
+    tags:
+      - 'v*'
+
+jobs:
+  build-client:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/client
+
+    steps:
+    # Checkout the code
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js 10.16.3
+      uses: actions/setup-node@v1
+      with:
+      node-version: '10.16.3'
+        
+    # Retrieve npm dependencies from cache. After a successful run, these dependencies are cached again
+    - name: Cache npm dependencies
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-yarn-dependencies
+      with:
+        # npm dependencies are stored in `~/.m2` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+  
+      # Install all the dependencies
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Set the build environment based on the branch
+        id: vars
+        run: |
+          REACT_APP_ENVIRONMENT="PRODUCTION"
+          echo ::set-output name=REACT_APP_ENVIRONMENT::${REACT_APP_ENVIRONMENT}
+    
+      - name: Create the bundle
+        run: REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} yarn build
+    
+      # Build master Docker image and push to Docker Hub
+      - name: Push production image to Docker Hub with commit tag
+        if: success() && github.ref == 'refs/heads/master'
+        run: |
+          docker build -t appsmith/appsmith-editor:${{ github.ref }} .
+          docker build -t appsmith/appsmith-editor:latest .
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          docker push appsmith/appsmith-editor
+
+  build-server:
+    runs-on: ubuntu-latest
+    defaults:
+    run:
+        working-directory: app/server
+
+    steps:
+    # Checkout the code
+    - uses: actions/checkout@v2
+    
+    # Setup Java
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    
+    # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
+    - name: Cache maven dependencies
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-maven-dependencies
+      with:
+        # maven dependencies are stored in `~/.m2` on Linux/macOS
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    
+    # Build the code
+    - name: Build without running any tests
+      run: mvn -B package -DskipTests
+    
+    # Here, the GITHUB_REF is of type /refs/head/<branch_name>. We extract branch_name from this by removing the
+    # first 11 characters. This can be used to build images for several branches
+    - name: Get the version to tag the Docker image
+      id: vars
+      run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
+    
+    # Build Docker image and push to Docker Hub
+    - name: Push image to Docker Hub
+      run: |
+        docker build -t appsmith/appsmith-server:${{steps.vars.outputs.tag}} .
+        docker build -t appsmith/appsmith-server:${{ github.ref }} .
+        echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+        docker push appsmith/appsmith-server
+
+  create-release:
+    needs: 
+      - build-server
+      - build-client
+    runs-on: ubuntu-latest
+
+    steps:
+    # Creating the release on Github
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false    
+        

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -48,12 +48,15 @@ jobs:
     
       - name: Create the bundle
         run: REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} yarn build
-    
-      # Build master Docker image and push to Docker Hub
+      
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+      
+      # Build Docker image and push to Docker Hub
       - name: Push production image to Docker Hub with commit tag
-        if: success() && github.ref == 'refs/heads/master'
         run: |
-          docker build -t appsmith/appsmith-editor:${{ github.ref }} .
+          docker build -t appsmith/appsmith-editor:${{steps.get_version.outputs.tag}}  .
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
           docker push appsmith/appsmith-editor
 
@@ -88,16 +91,14 @@ jobs:
     - name: Build without running any tests
       run: mvn -B package -DskipTests
     
-    # Here, the GITHUB_REF is of type /refs/head/<branch_name>. We extract branch_name from this by removing the
-    # first 11 characters. This can be used to build images for several branches
-    - name: Get the version to tag the Docker image
-      id: vars
-      run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
     
     # Build Docker image and push to Docker Hub
     - name: Push image to Docker Hub
       run: |
-        docker build -t appsmith/appsmith-server:${{ github.ref }} .
+        docker build -t appsmith/appsmith-server:${{steps.get_version.outputs.tag}} .
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-server
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -75,10 +75,10 @@ jobs:
         docker push appsmith/appsmith-server
 
     # Build master Docker image and push to Docker Hub
-    - name: Push master image to Docker Hub with commit tag
-      if: success() && github.ref == 'refs/heads/master'
-      run: |
-        docker build -t appsmith/appsmith-server:${GITHUB_SHA} .
-        docker build -t appsmith/appsmith-server:latest .
-        echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-        docker push appsmith/appsmith-server
+    # - name: Push master image to Docker Hub with commit tag
+    #   if: success() && github.ref == 'refs/heads/master'
+    #   run: |
+    #     docker build -t appsmith/appsmith-server:${GITHUB_SHA} .
+    #     docker build -t appsmith/appsmith-server:latest .
+    #     echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+    #     docker push appsmith/appsmith-server

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -75,10 +75,10 @@ jobs:
         docker push appsmith/appsmith-server
 
     # Build master Docker image and push to Docker Hub
-    # - name: Push master image to Docker Hub with commit tag
-    #   if: success() && github.ref == 'refs/heads/master'
-    #   run: |
-    #     docker build -t appsmith/appsmith-server:${GITHUB_SHA} .
-    #     docker build -t appsmith/appsmith-server:latest .
-    #     echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-    #     docker push appsmith/appsmith-server
+    - name: Push master image to Docker Hub with commit tag
+      if: success() && github.ref == 'refs/heads/master'
+      run: |
+        docker build -t appsmith/appsmith-server:${GITHUB_SHA} .
+        docker build -t appsmith/appsmith-server:latest .
+        echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+        docker push appsmith/appsmith-server


### PR DESCRIPTION
This will happen only when a tag is created on master branch. All pushes to master will still create the Docker image (with tag `latest`) but the Git tag will now create a tagged release with the version number on the image as well.