### PR TITLE
Adding nightly builds that will be generated on each push to master

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -229,6 +229,6 @@ jobs:
       if: success() && github.ref == 'refs/heads/master'
       run: |
         docker build -t appsmith/appsmith-editor:${GITHUB_SHA} .
-        docker build -t appsmith/appsmith-editor:latest .
+        docker build -t appsmith/appsmith-editor:nightly .
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-editor

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -56,6 +56,12 @@ jobs:
     - name: Push production image to Docker Hub with commit tag
       run: |
         docker build -t appsmith/appsmith-editor:${{steps.get_version.outputs.tag}}  .
+        
+        # Only build & tag with latest if the tag doesn't contain beta
+        if [[ ! ${{steps.get_version.outputs.tag}} == *"beta"* ]]; then 
+          docker build -t appsmith/appsmith-editor:latest  .
+        fi
+        
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-editor
 
@@ -98,6 +104,12 @@ jobs:
     - name: Push image to Docker Hub
       run: |
         docker build -t appsmith/appsmith-server:${{steps.get_version.outputs.tag}} .
+
+        # Only build & tag with latest if the tag doesn't contain beta
+        if [[ ! ${{steps.get_version.outputs.tag}} == *"beta"* ]]; then 
+          docker build -t appsmith/appsmith-server:latest .
+        fi
+
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-server
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -79,6 +79,6 @@ jobs:
       if: success() && github.ref == 'refs/heads/master'
       run: |
         docker build -t appsmith/appsmith-server:${GITHUB_SHA} .
-        docker build -t appsmith/appsmith-server:latest .
+        docker build -t appsmith/appsmith-server:nightly .
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-server


### PR DESCRIPTION
The latest tag will only be generated when a non-beta Github release is created.