### PR TITLE
Fix: Datasource password gets double encrypted on cloning

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -146,7 +146,7 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
 
     @Override
     public AuthenticationDTO decryptSensitiveFields(AuthenticationDTO authenticationDTO) {
-        if (authenticationDTO.getPassword() != null) {
+        if (authenticationDTO != null && authenticationDTO.getPassword() != null) {
             authenticationDTO.setPassword(encryptionService.decryptString(authenticationDTO.getPassword()));
         }
         return authenticationDTO;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -232,7 +232,9 @@ public class ExamplesOrganizationCloner {
                     makePristine(datasource);
                     datasource.setOrganizationId(toOrganizationId);
                     datasource.setName(datasource.getName());
-                    datasourceContextService.decryptSensitiveFields(datasource.getDatasourceConfiguration().getAuthentication());
+                    if (datasource.getDatasourceConfiguration() != null) {
+                        datasourceContextService.decryptSensitiveFields(datasource.getDatasourceConfiguration().getAuthentication());
+                    }
                     return Mono.zip(
                             Mono.just(templateDatasourceId),
                             datasourceService.create(datasource)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -18,6 +18,7 @@ import com.appsmith.server.repositories.OrganizationRepository;
 import com.appsmith.server.repositories.PageRepository;
 import com.appsmith.server.services.ActionService;
 import com.appsmith.server.services.ApplicationPageService;
+import com.appsmith.server.services.DatasourceContextService;
 import com.appsmith.server.services.DatasourceService;
 import com.appsmith.server.services.OrganizationService;
 import com.appsmith.server.services.SessionUserService;
@@ -51,6 +52,7 @@ public class ExamplesOrganizationCloner {
     private final SessionUserService sessionUserService;
     private final UserService userService;
     private final ApplicationPageService applicationPageService;
+    private final DatasourceContextService datasourceContextService;
 
     public Mono<Organization> cloneExamplesOrganization() {
         return sessionUserService
@@ -230,6 +232,7 @@ public class ExamplesOrganizationCloner {
                     makePristine(datasource);
                     datasource.setOrganizationId(toOrganizationId);
                     datasource.setName(datasource.getName());
+                    datasourceContextService.decryptSensitiveFields(datasource.getDatasourceConfiguration().getAuthentication());
                     return Mono.zip(
                             Mono.just(templateDatasourceId),
                             datasourceService.create(datasource)


### PR DESCRIPTION
This PR decrypts sensitive fields before cloning a datasource so they are encrypted only once.