### PR TITLE
Fix tab focus issue in code editor inputs

### DIFF
--- a/app/client/src/components/editorComponents/LightningMenu/LightningMenuTrigger.tsx
+++ b/app/client/src/components/editorComponents/LightningMenu/LightningMenuTrigger.tsx
@@ -77,6 +77,7 @@ export const LightningMenuTrigger = (props: LightningMenuTriggerProps) => {
         autoFocus={false}
         hoverOpenDelay={1000}
         content={LIGHTNING_MENU_DATA_TOOLTIP}
+        openOnTargetFocus={false}
       >
         <IconWrapper {...iconProps}>
           <LightningIcon />


### PR DESCRIPTION
The lightning menu popper was pulling focus when pressing TAB key. Added a prop to fix this