### PR TITLE
Multi User Invite

### DIFF
--- a/app/client/src/api/UserApi.tsx
+++ b/app/client/src/api/UserApi.tsx
@@ -100,7 +100,6 @@ class UserApi extends Api {
   }
 
   static inviteUser(request: InviteUserRequest): AxiosPromise<ApiResponse> {
-    request.status = "INVITED";
     return Api.post(UserApi.inviteUserURL, request);
   }
 

--- a/app/client/src/pages/organization/helpers.ts
+++ b/app/client/src/pages/organization/helpers.ts
@@ -56,7 +56,7 @@ export const inviteUsersToOrgSubmitHandler = (
 export const inviteUsersToOrg = (values: any, dispatch: any): Promise<any> => {
   const data = {
     roleName: values.role,
-    emails: values.users ? values.users.split(",") : [],
+    usernames: values.users ? values.users.split(",") : [],
     orgId: values.orgId,
   };
   return new Promise((resolve, reject) => {

--- a/app/client/src/reducers/uiReducers/orgReducer.ts
+++ b/app/client/src/reducers/uiReducers/orgReducer.ts
@@ -72,6 +72,13 @@ const orgReducer = createReducer(initialState, {
       isFetchAllUsers: false,
     },
   }),
+  [ReduxActionTypes.INVITE_USERS_TO_ORG_SUCCESS]: (
+    state: OrgReduxState,
+    action: ReduxAction<OrgUser[]>,
+  ) => ({
+    ...state,
+    orgUsers: [...state.orgUsers, ...action.payload],
+  }),
   [ReduxActionTypes.FETCH_ALL_ROLES_SUCCESS]: (
     state: OrgReduxState,
     action: ReduxAction<Org[]>,

--- a/app/client/src/sagas/userSagas.tsx
+++ b/app/client/src/sagas/userSagas.tsx
@@ -202,34 +202,25 @@ export function* inviteUser(
 
 export function* inviteUsers(
   action: ReduxActionWithPromise<{
-    data: { emails: string[]; orgId: string; roleName: string };
+    data: { usernames: string[]; orgId: string; roleName: string };
   }>,
 ) {
   const { data, resolve, reject } = action.payload;
   try {
-    const sagasToCall: any[] = [];
-
-    data.emails.forEach((email: string) => {
-      sagasToCall.push(
-        call(
-          inviteUser,
-          { email, orgId: data.orgId, roleName: data.roleName },
-          reject,
-        ),
-      );
+    const response: ApiResponse = yield callAPI(UserApi.inviteUser, {
+      usernames: data.usernames,
+      orgId: data.orgId,
+      roleName: data.roleName,
     });
-    yield all(sagasToCall);
+    const isValidResponse = yield validateResponse(response);
+    if (!isValidResponse) {
+      let errorMessage = `${data.usernames}:  `;
+      errorMessage += getResponseErrorMessage(response);
+      yield call(reject, { _error: errorMessage });
+    }
     yield put({
       type: ReduxActionTypes.INVITE_USERS_TO_ORG_SUCCESS,
-      payload: {
-        inviteCount: sagasToCall.length,
-      },
-    });
-    yield put({
-      type: ReduxActionTypes.FETCH_ALL_USERS_INIT,
-      payload: {
-        orgId: data.orgId,
-      },
+      payload: response.data,
     });
     yield call(resolve);
     yield put(reset(INVITE_USERS_TO_ORG_FORM));


### PR DESCRIPTION
- Use updated API structure
- Use single API to invite multiple users instead of looping.