### PR TITLE
Fix numbers being converted to floats in JSON Post body

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -242,11 +242,9 @@ public class RestApiPlugin extends BasePlugin {
                 ));
             }
 
-            Object requestBodyAsObject = null;
-
             if (MediaType.APPLICATION_JSON_VALUE.equals(contentType)) {
                 try {
-                    requestBodyAsObject = objectFromJson(requestBodyAsString);
+                    objectFromJson(requestBodyAsString);
                 } catch (JsonSyntaxException e) {
                     return Mono.error(new AppsmithPluginException(
                             AppsmithPluginError.PLUGIN_ERROR,
@@ -255,14 +253,10 @@ public class RestApiPlugin extends BasePlugin {
                 }
             }
 
-            if (requestBodyAsObject == null) {
-                requestBodyAsObject = requestBodyAsString;
-            }
-
             return webClient
                     .method(httpMethod)
                     .uri(uri)
-                    .body(BodyInserters.fromObject(requestBodyAsObject))
+                    .body(BodyInserters.fromObject(requestBodyAsString))
                     .exchange()
                     .doOnError(e -> Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, e)))
                     .flatMap(response -> {


### PR DESCRIPTION
When the POST body for a REST API action contains something like the following:

```JSON
{ "amount": 100 }
```

The REST API Plugin sends the following to the endpoint instead:

```JSON
{ "amount": 100.0 }
```

(You can inspect this by posting this body to `http://httpbin.org/post` as the URL).

Technically, this is okay, since JSON spec doesn't distinguish between integers and double numbers. However, it appears
APIs like that of RazorPay choke on such differences. Their API endpoints only accept integers, not floats or doubles.

To address this, I remove the part of the code that's deserializing the POST body and then serializing it again. There's no tests that broke because of this change, and I tested with a cases with newlines and tab characters, but couldn't reproduce a problem. If you have a test case handy that breaks without this deserialization+reserialization code, please share and I'll look into it.

If however, it looks fine to be merged, let me know and I'll add tests. I'm marking it as draft until then.