### PR TITLE
Fix: Missing widgets when searching in entity explorer

### DIFF
--- a/app/client/src/pages/Editor/Explorer/hooks.ts
+++ b/app/client/src/pages/Editor/Explorer/hooks.ts
@@ -29,7 +29,10 @@ const findWidgets = (widgets: WidgetProps, keyword: string) => {
         findWidgets(widget, keyword),
       ),
     );
-    return widgets.children.length > 0 ? widgets : undefined;
+    return widgets.children.length > 0 ||
+      widgets.widgetName.toLowerCase().indexOf(keyword) > -1
+      ? widgets
+      : undefined;
   }
   if (widgets.widgetName.toLowerCase().indexOf(keyword) > -1) return widgets;
 };


### PR DESCRIPTION
Fix for issue: When searching in the entity explorer. The widgets which have child widgets would not show up in the search results.