### PR TITLE
Entity explorer: Page click should open canvas

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
@@ -24,7 +24,7 @@ type ExplorerPageEntityProps = {
 export const ExplorerPageEntity = memo((props: ExplorerPageEntityProps) => {
   const params = useParams<ExplorerURLParams>();
   const switchPage = useCallback(() => {
-    if (!props.isCurrentPage && !!params.applicationId) {
+    if (!!params.applicationId) {
       history.push(BUILDER_PAGE_URL(params.applicationId, props.page.pageId));
     }
   }, [props.isCurrentPage, props.page.pageId, params.applicationId]);


### PR DESCRIPTION
Update: When the user clicks on a page in the entity explorer, the canvas should show up.