### PR TITLE
Tab Widget Fixes

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TabsComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/TabsComponent.tsx
@@ -103,6 +103,7 @@ const StyledText = styled.div<TabProps>`
 `;
 
 const TabsComponent = (props: TabsComponentProps) => {
+  const { onTabChange, ...remainingProps } = props;
   const tabContainerRef: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
     null,
   );
@@ -135,7 +136,7 @@ const TabsComponent = (props: TabsComponentProps) => {
       )}
       <ChildrenWrapper>
         <ScrollableCanvasWrapper
-          {...props}
+          {...remainingProps}
           className={`${
             props.shouldScrollContents ? getCanvasClassName() : ""
           } ${generateClassName(props.widgetId)}`}

--- a/app/client/src/components/propertyControls/TabControl.tsx
+++ b/app/client/src/components/propertyControls/TabControl.tsx
@@ -7,6 +7,7 @@ import { ControlIcons } from "icons/ControlIcons";
 import { AnyStyledComponent } from "styled-components";
 import { generateReactKey } from "utils/generators";
 import { DroppableComponent } from "../designSystems/appsmith/DraggableListComponent";
+import { getNextEntityName } from "utils/AppsmithUtils";
 import _ from "lodash";
 
 const StyledDeleteIcon = styled(FormIcons.DELETE_ICON as AnyStyledComponent)`
@@ -161,7 +162,11 @@ class TabControl extends BaseControl<ControlProps> {
       ? JSON.parse(this.props.propertyValue)
       : this.props.propertyValue;
     const newTabId = generateReactKey({ prefix: "tab" });
-    tabs.push({ id: newTabId, label: `Tab ${tabs.length + 1}` });
+    const newTabLabel = getNextEntityName(
+      "Tab ",
+      tabs.map(tab => tab.label),
+    );
+    tabs.push({ id: newTabId, label: newTabLabel });
     this.updateProperty(this.props.propertyName, JSON.stringify(tabs));
   };
 

--- a/app/client/src/widgets/TabsWidget.tsx
+++ b/app/client/src/widgets/TabsWidget.tsx
@@ -128,6 +128,7 @@ class TabsWidget extends BaseWidget<
 
   removeTabContainer = () => {
     let removedContainerWidgetId = "";
+    let removedTabId = "";
     const tabIds: string[] = this.props.tabs.map(tab => {
       return tab.id;
     });
@@ -135,7 +136,20 @@ class TabsWidget extends BaseWidget<
       const children = this.props.children[index];
       if (!tabIds.includes(children.tabId)) {
         removedContainerWidgetId = children.widgetId;
+        removedTabId = children.tabId;
       }
+    }
+    /* Selecting first tab as default tab when no tab is selected */
+    if (
+      this.props.tabs.length > 1 &&
+      removedTabId === this.props.selectedTabId
+    ) {
+      setTimeout(() => {
+        this.updateWidgetProperty(
+          "defaultTab",
+          this.props.tabs.filter(tab => tab.id !== removedTabId)[0].label,
+        );
+      }, 0);
     }
     this.updateWidget(WidgetOperations.DELETE, removedContainerWidgetId, {
       parentId: this.props.widgetId,

--- a/app/client/src/widgets/TabsWidget.tsx
+++ b/app/client/src/widgets/TabsWidget.tsx
@@ -60,21 +60,26 @@ class TabsWidget extends BaseWidget<
 
   renderComponent = () => {
     const selectedTabId = this.props.selectedTabId;
-    const children = this.props.children.filter(item => {
-      return selectedTabId === item.tabId;
-    })[0];
-    const childWidgetData: TabContainerWidgetProps = children;
+    const childWidgetData: TabContainerWidgetProps = this.props.children.filter(
+      item => {
+        return selectedTabId === item.tabId;
+      },
+    )[0];
+
     if (!childWidgetData) {
-      return <div></div>;
+      return null;
     }
     childWidgetData.shouldScrollContents = false;
     childWidgetData.canExtend = this.props.shouldScrollContents;
     const { componentWidth, componentHeight } = this.getComponentDimensions();
     childWidgetData.rightColumn = componentWidth;
+    childWidgetData.isVisible = this.props.isVisible;
     childWidgetData.bottomRow = this.props.shouldScrollContents
-      ? (this.props.bottomRow - this.props.topRow - 1) *
-        this.props.parentRowSpace
-      : componentHeight;
+      ? childWidgetData.bottomRow
+      : componentHeight - 1;
+    childWidgetData.parentId = this.props.widgetId;
+    childWidgetData.minHeight = componentHeight;
+
     return WidgetFactory.createWidget(childWidgetData, this.props.renderMode);
   };
 

--- a/app/client/src/widgets/TabsWidget.tsx
+++ b/app/client/src/widgets/TabsWidget.tsx
@@ -8,6 +8,7 @@ import { WidgetPropertyValidationType } from "utils/ValidationFactory";
 import { VALIDATION_TYPES } from "constants/WidgetValidation";
 import _ from "lodash";
 import { EventType } from "constants/ActionConstants";
+import { WidgetOperations } from "widgets/BaseWidget";
 
 class TabsWidget extends BaseWidget<
   TabsWidgetProps<TabContainerWidgetProps>,
@@ -122,7 +123,7 @@ class TabsWidget extends BaseWidget<
         children: [],
       },
     };
-    this.updateWidget("ADD_CHILD", this.props.widgetId, config);
+    this.updateWidget(WidgetOperations.ADD_CHILD, this.props.widgetId, config);
   };
 
   removeTabContainer = () => {
@@ -136,7 +137,7 @@ class TabsWidget extends BaseWidget<
         removedContainerWidgetId = children.widgetId;
       }
     }
-    this.updateWidget("REMOVE_CHILD", removedContainerWidgetId, {
+    this.updateWidget(WidgetOperations.DELETE, removedContainerWidgetId, {
       parentId: this.props.widgetId,
     });
   };


### PR DESCRIPTION
- [x] Tabs widget's child canvas widget's minHeight is not updating resulting in collision when dragging a widget into the tab widget.

- [x] Warning removed for unused onTabChange event handler 

- [x] Selecting first tab as default tab when no tab is selected in tabs widget. This happens when we deletes a selected tab.

- [x] Used getNextEntityName function to generate new tab name