### PR TITLE
Adding dummy check in server build to satisfy required status checks

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -75,7 +75,6 @@ jobs:
   ui-test:
     needs: build
     runs-on: ubuntu-latest
-    # container: appsmith/cypress-nginx
     defaults:
       run:
         working-directory: app/client

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -99,9 +99,9 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Do nothing as this is a dummy step
-        shell: bash
-        run: |
-          exit 0
+      shell: bash
+      run: |
+        exit 0
   
   package:
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Do nothing as this is a dummy step
-        shell: bash
-        run: |
-          exit 0
+      shell: bash
+      run: |
+        exit 0
           

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -96,11 +96,13 @@ jobs:
     
     steps:
       - name: Do nothing as this is a dummy step
-        run: exit 0
+        shell: bash
+        run: echo "Dummy step"
   
   package:
     runs-on: ubuntu-latest
     steps:
       - name: Do nothing as this is a dummy step
-        run: exit 0
+        shell: bash
+        run: echo "Dummy step"
           

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -89,29 +89,29 @@ jobs:
   # Check support request at: https://github.community/t/feature-request-conditional-required-checks/16761
   ui-test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: app/server
     strategy:
       fail-fast: false
       matrix:
         job: [0, 1, 2, 3, 4, 5, 6]
     
     steps:
-      - name: Do nothing as this is a dummy step
+    # Checkout the code
+    - uses: actions/checkout@v2
+    
+    - name: Do nothing as this is a dummy step
         shell: bash
         run: |
-          echo "Dummy step"
+          exit 0
   
   package:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: app/server
 
     steps:
-      - name: Do nothing as this is a dummy step
+    # Checkout the code
+    - uses: actions/checkout@v2
+    
+    - name: Do nothing as this is a dummy step
         shell: bash
         run: |
-          echo "Dummy step"
+          exit 0
           

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -82,3 +82,18 @@ jobs:
         docker build -t appsmith/appsmith-server:nightly .
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-server
+  
+  # This is a dummy step in the build to satisfy required status checks for merging PRs. This is a hack because Github doesn't support conditional 
+  # required checks in monorepos. This job is a clone of a similarly named job in client.yml. 
+  #
+  # Check support request at: https://github.community/t/feature-request-conditional-required-checks/16761
+  ui-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        job: [0, 1, 2, 3, 4, 5, 6]
+    
+    steps:
+      - name: Do nothing as this is a dummy check
+        run: exit 0

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -83,8 +83,8 @@ jobs:
         echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
         docker push appsmith/appsmith-server
   
-  # This is a dummy step in the build to satisfy required status checks for merging PRs. This is a hack because Github doesn't support conditional 
-  # required checks in monorepos. This job is a clone of a similarly named job in client.yml. 
+  # These are dummy jobs in the CI build to satisfy required status checks for merging PRs. This is a hack because Github doesn't support conditional 
+  # required checks in monorepos. These jobs are a clone of similarly named jobs in client.yml. 
   #
   # Check support request at: https://github.community/t/feature-request-conditional-required-checks/16761
   ui-test:
@@ -95,5 +95,12 @@ jobs:
         job: [0, 1, 2, 3, 4, 5, 6]
     
     steps:
-      - name: Do nothing as this is a dummy check
+      - name: Do nothing as this is a dummy step
         run: exit 0
+  
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do nothing as this is a dummy step
+        run: exit 0
+          

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -89,6 +89,9 @@ jobs:
   # Check support request at: https://github.community/t/feature-request-conditional-required-checks/16761
   ui-test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/server
     strategy:
       fail-fast: false
       matrix:
@@ -97,12 +100,18 @@ jobs:
     steps:
       - name: Do nothing as this is a dummy step
         shell: bash
-        run: echo "Dummy step"
+        run: |
+          echo "Dummy step"
   
   package:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/server
+
     steps:
       - name: Do nothing as this is a dummy step
         shell: bash
-        run: echo "Dummy step"
+        run: |
+          echo "Dummy step"
           

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -12,7 +12,7 @@ For example:
 $ ./build.sh -DskipTests
 ```
 
-This will 
+This script will perform the following steps:
 1. Compile the code
 2. Generate the jars for server & plugins
 3. Copy them into the `dist` directory


### PR DESCRIPTION
This is a hack to get around the fact that Github Actions doesn't support conditional status checks for monorepo PRs. Hence, we create similar jobs in the both server & client builds. In the server build, those jobs are dummy jobs that do nothing but satisfy the all-encompassing green tick so that PRs can be merged without using Admin privileges.