### PR TITLE
Entity Explorer Fixes

### DIFF
--- a/app/client/src/actions/datasourceActions.ts
+++ b/app/client/src/actions/datasourceActions.ts
@@ -15,10 +15,13 @@ export const createDatasourceFromForm = (payload: CreateDatasourceConfig) => {
   };
 };
 
-export const updateDatasource = (payload: Datasource) => {
+export const updateDatasource = (
+  payload: Datasource,
+  reinitializeForm?: boolean,
+) => {
   return {
     type: ReduxActionTypes.UPDATE_DATASOURCE_INIT,
-    payload,
+    payload: { datasource: payload, reinitializeForm: !!reinitializeForm },
   };
 };
 

--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -155,7 +155,7 @@ export const CurrentValueViewer = (props: {
   }
   return (
     <React.Fragment>
-      <StyledTitle>Evaluated Value</StyledTitle>
+      {!props.hideLabel && <StyledTitle>Evaluated Value</StyledTitle>}
       <CurrentValueWrapper>{content}</CurrentValueWrapper>
     </React.Fragment>
   );

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -30,6 +30,7 @@ import {
   useShowPropertyPane,
   useWidgetSelection,
   useCanvasSnapRowsUpdateHook,
+  useToggleEditWidgetName,
 } from "utils/hooks/dragResizeHooks";
 import { getOccupiedSpaces } from "selectors/editorSelectors";
 
@@ -105,6 +106,7 @@ export const DropTargetComponent = memo((props: DropTargetComponentProps) => {
   const [rows, setRows] = useState(snapRows);
 
   const showPropertyPane = useShowPropertyPane();
+  const toggleEditWidgetName = useToggleEditWidgetName();
   const { selectWidget, focusWidget } = useWidgetSelection();
   const updateCanvasSnapRows = useCanvasSnapRowsUpdateHook();
 
@@ -183,13 +185,12 @@ export const DropTargetComponent = memo((props: DropTargetComponentProps) => {
         // Only show propertypane if this is a new widget.
         // If it is not a new widget, then let the DraggableComponent handle it.
         // Give evaluations a second to complete.
-        setTimeout(
-          () =>
-            showPropertyPane &&
-            updateWidgetParams.payload.newWidgetId &&
-            showPropertyPane(updateWidgetParams.payload.newWidgetId),
-          100,
-        );
+        setTimeout(() => {
+          if (showPropertyPane && updateWidgetParams.payload.newWidgetId) {
+            showPropertyPane(updateWidgetParams.payload.newWidgetId);
+            toggleEditWidgetName(updateWidgetParams.payload.newWidgetId, true);
+          }
+        }, 100);
 
         // Select the widget if it is a new widget
         selectWidget && selectWidget(widget.widgetId);

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -91,7 +91,8 @@ export const EditableText = (props: EditableTextProps) => {
 
   useEffect(() => {
     setValue(props.defaultValue);
-  }, [props.defaultValue]);
+    setIsEditing(!!props.isEditingDefault);
+  }, [props.defaultValue, props.isEditingDefault]);
 
   useEffect(() => {
     if (props.forceDefault === true) setValue(props.defaultValue);

--- a/app/client/src/components/editorComponents/FormRow.tsx
+++ b/app/client/src/components/editorComponents/FormRow.tsx
@@ -5,5 +5,5 @@ export default styled.div`
   flex: 1;
   flex-direction: row;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
 `;

--- a/app/client/src/constants/ReduxActionConstants.tsx
+++ b/app/client/src/constants/ReduxActionConstants.tsx
@@ -246,6 +246,8 @@ export const ReduxActionTypes: { [key: string]: string } = {
   FETCH_PAGE_DSL_INIT: "FETCH_PAGE_DSL_INIT",
   FETCH_PAGE_DSL_SUCCESS: "FETCH_PAGE_DSL_SUCCESS",
   SET_URL_DATA: "SET_URL_DATA",
+  TOGGLE_PROPERTY_PANE_WIDGET_NAME_EDIT:
+    "TOGGLE_PROPERTY_PANE_WIDGET_NAME_EDIT",
 };
 
 export type ReduxActionType = typeof ReduxActionTypes[keyof typeof ReduxActionTypes];

--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -13,6 +13,10 @@ body {
   background: #efefef;
 }
 
+body.dragging *{
+  cursor: grabbing !important;
+}
+
 body.fontLoaded {
   font-family: "DM Sans", sans-serif;
 }

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -53,7 +53,8 @@ const MainConfiguration = styled.div`
 `;
 
 const ActionButtons = styled.div`
-  flex: 1;
+  flex: 0 1 150px;
+  justify-self: flex-end;
   display: flex;
   flex-direction: row;
 `;
@@ -61,7 +62,9 @@ const ActionButtons = styled.div`
 const ActionButton = styled(BaseButton)`
   &&& {
     max-width: 72px;
-    margin-left: 16px;
+    &:last-of-type {
+      margin-left: 16px;
+    }
     min-height: 32px;
   }
 `;
@@ -80,6 +83,11 @@ const SecondaryWrapper = styled.div`
 const TabbedViewContainer = styled.div`
   flex: 1;
   padding-top: 12px;
+  &&& {
+    ul.react-tabs__tab-list {
+      padding-left: 23px;
+    }
+  }
 `;
 
 export const BindingText = styled.span`

--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
@@ -7,6 +7,8 @@ import { ExplorerURLParams, getDatasourceIdFromURL } from "../helpers";
 import Entity, { EntityClassNames } from "../Entity";
 import { DATA_SOURCES_EDITOR_ID_URL } from "constants/routes";
 import history from "utils/history";
+import { useDispatch } from "react-redux";
+import { updateDatasource } from "actions/datasourceActions";
 
 type ExplorerDatasourceEntityProps = {
   datasource: Datasource;
@@ -30,6 +32,13 @@ export const ExplorerDatasourceEntity = (
   );
   const datasourceIdFromURL = getDatasourceIdFromURL();
   const active = datasourceIdFromURL === props.datasource.id;
+
+  const updateDatasourceName = useCallback(
+    (id: string, name: string) => {
+      return updateDatasource({ ...props.datasource, name: name }, active);
+    },
+    [props.datasource],
+  );
   return (
     <Entity
       entityId={props.datasource.id}
@@ -41,6 +50,7 @@ export const ExplorerDatasourceEntity = (
       step={props.step + 1}
       searchKeyword={props.searchKeyword}
       action={switchDatasource}
+      updateEntityName={updateDatasourceName}
       contextMenu={
         <DataSourceContextMenu
           datasourceId={props.datasource.id}

--- a/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
@@ -27,7 +27,7 @@ export const ExplorerPageEntity = memo((props: ExplorerPageEntityProps) => {
     if (!!params.applicationId) {
       history.push(BUILDER_PAGE_URL(params.applicationId, props.page.pageId));
     }
-  }, [props.isCurrentPage, props.page.pageId, params.applicationId]);
+  }, [props.page.pageId, params.applicationId]);
 
   const contextMenu = (
     <PageContextMenu

--- a/app/client/src/pages/Editor/Explorer/Widgets/WidgetGroup.tsx
+++ b/app/client/src/pages/Editor/Explorer/Widgets/WidgetGroup.tsx
@@ -159,8 +159,13 @@ export const ExplorerWidgetGroup = memo((props: ExplorerWidgetGroupProps) => {
         ) : (
           "  "
         )}
-        click the <strong>Widgets</strong> navigation menu icon on the left to
-        drag and drop widgets
+        click the{" "}
+        <React.Fragment>
+          <StyledLink to={WIDGETS_URL(params.applicationId, props.pageId)}>
+            Widgets
+          </StyledLink>
+        </React.Fragment>{" "}
+        navigation menu icon on the left to drag and drop widgets
       </EntityPlaceholder>
     );
   }

--- a/app/client/src/pages/Editor/Explorer/Widgets/WidgetGroup.tsx
+++ b/app/client/src/pages/Editor/Explorer/Widgets/WidgetGroup.tsx
@@ -10,7 +10,7 @@ import {
 } from "constants/WidgetConstants";
 import { useParams } from "react-router";
 import { ExplorerURLParams } from "../helpers";
-import { BUILDER_PAGE_URL } from "constants/routes";
+import { BUILDER_PAGE_URL, WIDGETS_URL } from "constants/routes";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { AppState } from "reducers";

--- a/app/client/src/pages/Editor/PropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/index.tsx
@@ -324,7 +324,7 @@ const mapDispatchToProps = (dispatch: any): PropertyPaneFunctions => {
 export interface PropertyPaneProps {
   propertySections?: PropertySection[];
   widgetId?: string;
-  widgetProperties?: WidgetProps; //TODO(abhinav): Secure type definition
+  widgetProperties?: WidgetProps;
   isVisible: boolean;
 }
 

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -9,6 +9,7 @@ import { AppState } from "reducers";
 import Spinner from "components/editorComponents/Spinner";
 import { getExistingWidgetNames } from "sagas/selectors";
 import { convertToCamelCase } from "utils/helpers";
+import { useToggleEditWidgetName } from "utils/hooks/dragResizeHooks";
 const Wrapper = styled.div`
   display: flex;
   justify-content: flex-start;
@@ -27,8 +28,9 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
     updating: state.ui.editor.loadingStates.updatingWidgetName,
     updateError: state.ui.editor.loadingStates.updateWidgetNameError,
   }));
+  const isNew = useSelector((state: AppState) => state.ui.propertyPane.isNew);
   const widgets = useSelector(getExistingWidgetNames);
-
+  const toggleEditWidgetName = useToggleEditWidgetName();
   const [name, setName] = useState(props.title);
   const updateTitle = useCallback(
     (value: string) => {
@@ -52,6 +54,10 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
     }
   }, [updateError, props.title]);
 
+  const exitEditMode = useCallback(() => {
+    props.widgetId && toggleEditWidgetName(props.widgetId, false);
+  }, [toggleEditWidgetName, props.widgetId]);
+
   return props.widgetId ? (
     <Wrapper>
       <EditableText
@@ -62,6 +68,8 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
         placeholder={props.title}
         updating={updating}
         editInteractionKind={EditInteractionKind.SINGLE}
+        isEditingDefault={isNew}
+        onBlur={exitEditMode}
       />
       {updating && <Spinner size={16} />}
     </Wrapper>

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -49,10 +49,8 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
     [dispatch, widgets, setName, props.widgetId, props.title],
   );
   useEffect(() => {
-    if (updateError) {
-      setName(props.title);
-    }
-  }, [updateError, props.title]);
+    setName(props.title);
+  }, [props.title]);
 
   const exitEditMode = useCallback(() => {
     props.widgetId && toggleEditWidgetName(props.widgetId, false);

--- a/app/client/src/pages/Editor/QueryEditor/Form.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Form.tsx
@@ -74,9 +74,18 @@ const QueryFormContainer = styled.div`
   }
 `;
 
+const ActionsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex: 1 1 50%;
+  justify-content: flex-end;
+`;
+
 const ActionButtons = styled.div`
-  flex: 1;
+  display: flex;
   margin-left: 10px;
+  flex: 0 1 150px;
+  justify-content: flex-end;
 `;
 
 const ActionButton = styled(BaseButton)`
@@ -189,7 +198,6 @@ const StyledOpenDocsIcon = styled(Icon)`
 `;
 
 const NameWrapper = styled.div`
-  width: 39%;
   display: flex;
   justify-content: space-between;
   input {
@@ -335,74 +343,76 @@ const QueryEditorForm: React.FC<Props> = (props: Props) => {
           <NameWrapper>
             <ActionNameEditor />
           </NameWrapper>
-          <DropdownSelect>
-            <DropdownField
-              placeholder="Datasource"
-              name="datasource.id"
-              options={DATASOURCES_OPTIONS}
-              width={232}
-              maxMenuHeight={200}
-              components={{ MenuList, Option: CustomOption, SingleValue }}
-            />
-          </DropdownSelect>
-          <ActionButtons>
-            <ActionButton
-              className="t--delete-query"
-              text="Delete"
-              accent="error"
-              loading={isDeleting}
-              onClick={onDeleteClick}
-            />
-            {dataSources.length === 0 ? (
-              <>
-                <TooltipStyles />
-                <Popover
-                  autoFocus={true}
-                  canEscapeKeyClose={true}
-                  content="You don’t have a Data Source to run this query"
-                  position="bottom"
-                  defaultIsOpen={false}
-                  usePortal
-                  portalClassName="helper-tooltip"
-                >
-                  <ActionButton
-                    className="t--run-query"
-                    text="Run"
-                    filled
-                    loading={isRunning}
-                    accent="primary"
-                    onClick={onRunClick}
-                  />
-                  <div>
-                    <p className="popuptext">
-                      You don’t have a Data Source to run this query
-                    </p>
-                    <Button
-                      onClick={() =>
-                        history.push(
-                          DATA_SOURCES_EDITOR_URL(applicationId, pageId),
-                        )
-                      }
-                      text="Add Datasource"
-                      intent="primary"
-                      filled
-                      size="small"
-                      className="popoverBtn"
-                    />
-                  </div>
-                </Popover>
-              </>
-            ) : (
-              <ActionButton
-                className="t--run-query"
-                text="Run"
-                filled
-                loading={isRunning}
-                accent="primary"
-                onClick={onRunClick}
+          <ActionsWrapper>
+            <DropdownSelect>
+              <DropdownField
+                placeholder="Datasource"
+                name="datasource.id"
+                options={DATASOURCES_OPTIONS}
+                width={232}
+                maxMenuHeight={200}
+                components={{ MenuList, Option: CustomOption, SingleValue }}
               />
-            )}
-          </ActionButtons>
+            </DropdownSelect>
+            <ActionButtons>
+              <ActionButton
+                className="t--delete-query"
+                text="Delete"
+                accent="error"
+                loading={isDeleting}
+                onClick={onDeleteClick}
+              />
+              {dataSources.length === 0 ? (
+                <>
+                  <TooltipStyles />
+                  <Popover
+                    autoFocus={true}
+                    canEscapeKeyClose={true}
+                    content="You don’t have a Data Source to run this query"
+                    position="bottom"
+                    defaultIsOpen={false}
+                    usePortal
+                    portalClassName="helper-tooltip"
+                  >
+                    <ActionButton
+                      className="t--run-query"
+                      text="Run"
+                      filled
+                      loading={isRunning}
+                      accent="primary"
+                      onClick={onRunClick}
+                    />
+                    <div>
+                      <p className="popuptext">
+                        You don’t have a Data Source to run this query
+                      </p>
+                      <Button
+                        onClick={() =>
+                          history.push(
+                            DATA_SOURCES_EDITOR_URL(applicationId, pageId),
+                          )
+                        }
+                        text="Add Datasource"
+                        intent="primary"
+                        filled
+                        size="small"
+                        className="popoverBtn"
+                      />
+                    </div>
+                  </Popover>
+                </>
+              ) : (
+                <ActionButton
+                  className="t--run-query"
+                  text="Run"
+                  filled
+                  loading={isRunning}
+                  accent="primary"
+                  onClick={onRunClick}
+                />
+              )}
+            </ActionButtons>
+          </ActionsWrapper>
         </FormRow>
 
         <div

--- a/app/client/src/pages/Editor/WidgetCard.tsx
+++ b/app/client/src/pages/Editor/WidgetCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useDrag, DragSourceMonitor, DragPreviewImage } from "react-dnd";
+import { useDrag, DragPreviewImage } from "react-dnd";
 import blankImage from "assets/images/blank.png";
 import { WidgetCardProps } from "widgets/BaseWidget";
 import styled from "styled-components";

--- a/app/client/src/pages/Editor/WidgetCard.tsx
+++ b/app/client/src/pages/Editor/WidgetCard.tsx
@@ -72,9 +72,6 @@ const WidgetCard = (props: CardProps) => {
   const showPropertyPane = useShowPropertyPane();
   const [, drag, preview] = useDrag({
     item: { ...props.details, widgetId },
-    collect: (monitor: DragSourceMonitor) => ({
-      isDragging: monitor.isDragging(),
-    }),
     begin: () => {
       AnalyticsUtil.logEvent("WIDGET_CARD_DRAG", {
         widgetType: props.details.type,

--- a/app/client/src/pages/Editor/routes.tsx
+++ b/app/client/src/pages/Editor/routes.tsx
@@ -13,13 +13,13 @@ import {
   QUERIES_EDITOR_ID_URL,
   DATA_SOURCES_EDITOR_URL,
   DATA_SOURCES_EDITOR_ID_URL,
-  BUILDER_BASE_URL,
   BUILDER_PAGE_URL,
   BuilderRouteParams,
   APIEditorRouteParams,
   getCurlImportPageURL,
   API_EDITOR_URL_WITH_SELECTED_PAGE_ID,
   getProviderTemplatesURL,
+  WIDGETS_URL,
 } from "constants/routes";
 import styled from "styled-components";
 import AppRoute from "pages/common/AppRoute";
@@ -30,11 +30,11 @@ import {
 import { closeAllModals } from "actions/widgetActions";
 import { useDispatch } from "react-redux";
 
-const Wrapper = styled.div<{ isVisible: boolean; showOnlySidebar?: boolean }>`
+const Wrapper = styled.div<{ isVisible: boolean }>`
   position: absolute;
   top: 0;
   left: 0;
-  width: ${props => (props.showOnlySidebar ? "0px" : "100%")};
+  width: ${props => (!props.isVisible ? "0px" : "100%")};
   height: calc(100vh - ${props => props.theme.headerHeight});
   background-color: ${props =>
     props.isVisible ? "rgba(0, 0, 0, 0.26)" : "transparent"};
@@ -43,16 +43,14 @@ const Wrapper = styled.div<{ isVisible: boolean; showOnlySidebar?: boolean }>`
 
 const DrawerWrapper = styled.div<{
   isVisible: boolean;
-  showOnlySidebar?: boolean;
 }>`
   background-color: white;
-  width: ${props => (props.showOnlySidebar ? "0px" : "75%")};
+  width: ${props => (!props.isVisible ? "0px" : "75%")};
   height: 100%;
 `;
 
 interface RouterState {
   isVisible: boolean;
-  showOnlySidebar: boolean;
 }
 
 class EditorsRouter extends React.Component<
@@ -64,22 +62,9 @@ class EditorsRouter extends React.Component<
     const { applicationId, pageId } = this.props.match.params;
     this.state = {
       isVisible:
-        this.props.location.pathname !== BUILDER_BASE_URL(applicationId) &&
         this.props.location.pathname !==
-          BUILDER_PAGE_URL(applicationId, pageId),
-      showOnlySidebar:
-        // TODO: Please optimise this
-        !(
-          this.props.location.pathname.indexOf(
-            DATA_SOURCES_EDITOR_URL(applicationId, pageId),
-          ) !== -1 ||
-          this.props.location.pathname.indexOf(
-            API_EDITOR_URL(applicationId, pageId),
-          ) !== -1 ||
-          this.props.location.pathname.indexOf(
-            QUERIES_EDITOR_URL(applicationId, pageId),
-          ) !== -1
-        ),
+          BUILDER_PAGE_URL(applicationId, pageId) &&
+        this.props.location.pathname !== WIDGETS_URL(applicationId, pageId),
     };
   }
 
@@ -88,22 +73,9 @@ class EditorsRouter extends React.Component<
       const { applicationId, pageId } = this.props.match.params;
       this.setState({
         isVisible:
-          this.props.location.pathname !== BUILDER_BASE_URL(applicationId) &&
           this.props.location.pathname !==
-            BUILDER_PAGE_URL(applicationId, pageId),
-        showOnlySidebar:
-          // TODO: Please optimise this
-          !(
-            this.props.location.pathname.indexOf(
-              DATA_SOURCES_EDITOR_URL(applicationId, pageId),
-            ) !== -1 ||
-            this.props.location.pathname.indexOf(
-              API_EDITOR_URL(applicationId, pageId),
-            ) !== -1 ||
-            this.props.location.pathname.indexOf(
-              QUERIES_EDITOR_URL(applicationId, pageId),
-            ) !== -1
-          ),
+            BUILDER_PAGE_URL(applicationId, pageId) &&
+          this.props.location.pathname !== WIDGETS_URL(applicationId, pageId),
       });
     }
   }
@@ -123,16 +95,9 @@ class EditorsRouter extends React.Component<
 
   render(): React.ReactNode {
     return (
-      <Wrapper
-        isVisible={this.state.isVisible}
-        onClick={
-          !this.state.showOnlySidebar ? this.handleClose : this.preventClose
-        }
-        showOnlySidebar={this.state.showOnlySidebar}
-      >
+      <Wrapper isVisible={this.state.isVisible} onClick={this.handleClose}>
         <PaneDrawer
           isVisible={this.state.isVisible}
-          showOnlySidebar={this.state.showOnlySidebar}
           onClick={this.preventClose}
         >
           <Switch>
@@ -199,7 +164,6 @@ class EditorsRouter extends React.Component<
 }
 type PaneDrawerProps = {
   isVisible: boolean;
-  showOnlySidebar: boolean;
   onClick: (e: React.MouseEvent) => void;
   children: ReactNode;
 };

--- a/app/client/src/reducers/uiReducers/propertyPaneReducer.tsx
+++ b/app/client/src/reducers/uiReducers/propertyPaneReducer.tsx
@@ -9,6 +9,7 @@ const initialState: PropertyPaneReduxState = {
   isVisible: false,
   widgetId: undefined,
   lastWidgetId: undefined,
+  isNew: false,
 };
 
 const propertyPaneReducer = createReducer(initialState, {
@@ -58,6 +59,14 @@ const propertyPaneReducer = createReducer(initialState, {
       lastWidgetId: state.widgetId,
     };
   },
+  [ReduxActionTypes.TOGGLE_PROPERTY_PANE_WIDGET_NAME_EDIT]: (
+    state: PropertyPaneReduxState,
+    action: ReduxAction<{ enable: boolean; widgetId: string }>,
+  ) => {
+    if (action.payload.widgetId === state.widgetId)
+      return { ...state, isNew: action.payload.enable };
+    return state;
+  },
 });
 
 export interface PropertyPaneReduxState {
@@ -65,6 +74,7 @@ export interface PropertyPaneReduxState {
   isVisible: boolean;
   lastWidgetId?: string;
   isVisibleBeforeAction?: boolean;
+  isNew: boolean;
 }
 
 export default propertyPaneReducer;

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -54,7 +54,11 @@ import {
 } from "selectors/entitiesSelector";
 import { PLUGIN_TYPE_API } from "constants/ApiEditorConstants";
 import history from "utils/history";
-import { API_EDITOR_URL, QUERIES_EDITOR_URL } from "constants/routes";
+import {
+  API_EDITOR_URL,
+  QUERIES_EDITOR_URL,
+  API_EDITOR_ID_URL,
+} from "constants/routes";
 import { changeApi } from "actions/apiPaneActions";
 import { changeQuery } from "actions/queryPaneActions";
 
@@ -287,6 +291,11 @@ function* moveActionSaga(
       apiID: response.data.id,
     });
     yield put(moveActionSuccess(response.data));
+    const applicationId = yield select(getCurrentApplicationId);
+
+    history.push(
+      API_EDITOR_ID_URL(applicationId, response.data.pageId, response.data.id),
+    );
   } catch (e) {
     AppToaster.show({
       message: `Error while moving action ${actionObject.name}`,
@@ -331,6 +340,10 @@ function* copyActionSaga(
       apiID: response.data.id,
     });
     yield put(copyActionSuccess(response.data));
+    const applicationId = yield select(getCurrentApplicationId);
+    history.push(
+      API_EDITOR_ID_URL(applicationId, response.data.pageId, response.data.id),
+    );
   } catch (e) {
     AppToaster.show({
       message: `Error while copying action ${actionObject.name}`,

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -155,16 +155,21 @@ export function* deleteDatasourceSaga(
   }
 }
 
-function* updateDatasourceSaga(actionPayload: ReduxAction<Datasource>) {
+function* updateDatasourceSaga(
+  actionPayload: ReduxAction<{
+    datasource: Datasource;
+    reinitializeForm: boolean;
+  }>,
+) {
   try {
     const response: GenericApiResponse<Datasource> = yield DatasourcesApi.updateDatasource(
-      actionPayload.payload,
-      actionPayload.payload.id,
+      actionPayload.payload.datasource,
+      actionPayload.payload.datasource.id,
     );
     const isValidResponse = yield validateResponse(response);
     if (isValidResponse) {
       AppToaster.show({
-        message: `${actionPayload.payload.name} Datasource updated`,
+        message: `${actionPayload.payload.datasource.name} Datasource updated`,
         type: ToastType.SUCCESS,
       });
       yield put({
@@ -177,6 +182,11 @@ function* updateDatasourceSaga(actionPayload: ReduxAction<Datasource>) {
           id: response.data.id,
         },
       });
+      if (actionPayload.payload.reinitializeForm) {
+        yield put(
+          initialize(DATASOURCE_DB_FORM, actionPayload.payload.datasource),
+        );
+      }
     }
   } catch (error) {
     yield put({

--- a/app/client/src/utils/hooks/dragResizeHooks.tsx
+++ b/app/client/src/utils/hooks/dragResizeHooks.tsx
@@ -26,6 +26,22 @@ export const useShowPropertyPane = () => {
   );
 };
 
+export const useToggleEditWidgetName = () => {
+  const dispatch = useDispatch();
+  return useCallback(
+    (widgetId: string, enable: boolean) => {
+      dispatch({
+        type: ReduxActionTypes.TOGGLE_PROPERTY_PANE_WIDGET_NAME_EDIT,
+        payload: {
+          enable,
+          widgetId,
+        },
+      });
+    },
+    [dispatch],
+  );
+};
+
 export const useCanvasSnapRowsUpdateHook = () => {
   const dispatch = useDispatch();
   const updateCanvasSnapRows = useCallback(

--- a/app/client/src/utils/hooks/dragResizeHooks.tsx
+++ b/app/client/src/utils/hooks/dragResizeHooks.tsx
@@ -66,11 +66,17 @@ export const useWidgetDragResize = () => {
   const dispatch = useDispatch();
   return {
     setIsDragging: useCallback(
-      (isDragging: boolean) =>
+      (isDragging: boolean) => {
+        if (isDragging) {
+          document.body.classList.add("dragging");
+        } else {
+          document.body.classList.remove("dragging");
+        }
         dispatch({
           type: ReduxActionTypes.SET_WIDGET_DRAGGING,
           payload: { isDragging },
-        }),
+        });
+      },
       [dispatch],
     ),
     setIsResizing: useCallback(


### PR DESCRIPTION
- [x] Fix for issue: Modal widget closes when moving from explorer to widgets sidebar.

- [x] Align "run" and "delete" buttons to the right in the query editor pane

- [x] Align the "API Input" tab in the api editor pane with the headers fields.

- [x] While dragging widgets, the cursor must be of 'grabbing' type

- [x] New Widgets should have their names in editable state when they're freshly created via drag and drop

- [x] Fix for issue: While property pane is open, changing the widget name in entity explorer does not update the name in the property pane

- [x] Fix: Do not show popup's label when showing full value of truncated entity property.

- [x] Feature: Edit datasource name from entity explorer

- [x] When a page doesn't have any widgets, allow users to navigate directly to the widgets pane and canvas of the page via a link in the placeholder text.

- [x] Update: When moving or copying an API, navigate to the newly created API