### PR TITLE
Encoding the mongo credentials in install.sh script

### DIFF
--- a/deploy/aws/boot.sh
+++ b/deploy/aws/boot.sh
@@ -34,6 +34,11 @@ mongo_host="mongo"
 mongo_database="appsmith"
 mongo_root_user=$( generate_random_string )
 mongo_root_password=$( generate_random_string )
+
+# The encoded strings are the same as the raw strings because we are generating them and hence it'll be without special characters
+encoded_mongo_root_user=mongo_root_user
+encoded_mongo_root_password=mongo_root_password
+
 user_encryption_password=$( generate_random_string )
 user_encryption_salt=$( generate_random_string )
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -152,6 +152,23 @@ wait_for_containers_start() {
     done
 }
 
+urlencode() {
+    # urlencode <string>
+    old_lc_collate=$LC_COLLATE
+    LC_COLLATE=C
+
+    local length="${#1}"
+    for (( i = 0; i < length; i++ )); do
+        local c="${1:i:1}"
+        case $c in
+            [a-zA-Z0-9.~_-]) printf "$c" ;;
+            *) printf '%%%02X' "'$c" ;;
+        esac
+    done
+
+    LC_COLLATE=$old_lc_collate
+}
+
 echo -e "\U1F44B  Thank you for trying out Appsmith! "
 echo ""
 
@@ -235,6 +252,10 @@ elif [ $fresh_install == "Y" -o $fresh_install == "y" -o $fresh_install == "yes"
     auto_generate_encryption="true"
 fi
 echo ""
+
+# urlencoding the Mongo username and password
+encoded_mongo_root_user=$( urlencode $mongo_root_user )
+encoded_mongo_root_password=$( urlencode $mongo_root_password )
 
 encryptionEnv=./template/encryption.env
 if test -f "$encryptionEnv"; then
@@ -345,8 +366,10 @@ else
     echo "No domain found. Skipping generation of SSL certificate."
 fi
 
+echo ""
 echo "Pulling the latest container images"
 sudo docker-compose pull
+echo ""
 echo "Starting the Appsmith containers"
 sudo docker-compose -f docker-compose.yml up -d --remove-orphans
 
@@ -370,12 +393,13 @@ else
     echo "Your installation is complete. Please run the following command to ensure that all the containers are running without errors:"
     echo ""
     echo "cd $install_dir && sudo docker-compose ps -a"
+    echo ""
+    echo "Your application is running on http://localhost"
     echo "+++++++++++++++++++++++++++++++++++++++++++++++++"
     echo ""
     echo "Need help troubleshooting?"
     echo "Join our Discord server https://discord.com/invite/rBTTVJp"
-    echo ""
-    echo "Your application is running on http://localhost"
 fi
 
+echo ""
 echo -e "Peace out \U1F596"

--- a/deploy/template/docker.env.sh
+++ b/deploy/template/docker.env.sh
@@ -37,6 +37,6 @@ APPSMITH_MAIL_ENABLED=false
 
 # ******** Database *************
 APPSMITH_REDIS_URL=redis://redis:6379
-APPSMITH_MONGODB_URI=mongodb://$mongo_root_user:$mongo_root_password@$mongo_host/appsmith?retryWrites=true
+APPSMITH_MONGODB_URI=mongodb://$encoded_mongo_root_user:$encoded_mongo_root_password@$mongo_host/appsmith?retryWrites=true
 # *******************************
 EOF


### PR DESCRIPTION
This is to ensure that we handle special characters in the mongo url that's given to the Java server during configuration.