### PR TITLE
Fix-table compact mode to persist and saved from canvas editor

### DIFF
--- a/app/client/src/widgets/TableWidget.tsx
+++ b/app/client/src/widgets/TableWidget.tsx
@@ -400,7 +400,11 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           }}
           compactMode={this.props.compactMode || CompactModeTypes.DEFAULT}
           updateCompactMode={(compactMode: CompactMode) => {
-            super.updateWidgetProperty("compactMode", compactMode);
+            if (this.props.renderMode === RenderModes.CANVAS) {
+              super.updateWidgetProperty("compactMode", compactMode);
+            } else {
+              super.updateWidgetMetaProperty("compactMode", compactMode);
+            }
           }}
           sortTableColumn={(column: string, asc: boolean) => {
             this.resetSelectedRowIndex();

--- a/app/client/src/widgets/TableWidget.tsx
+++ b/app/client/src/widgets/TableWidget.tsx
@@ -400,7 +400,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           }}
           compactMode={this.props.compactMode || CompactModeTypes.DEFAULT}
           updateCompactMode={(compactMode: CompactMode) => {
-            super.updateWidgetMetaProperty("compactMode", compactMode);
+            super.updateWidgetProperty("compactMode", compactMode);
           }}
           sortTableColumn={(column: string, asc: boolean) => {
             this.resetSelectedRowIndex();


### PR DESCRIPTION
Since widget properties cannot be updated in published mode we are saving compact mode from editor and that value will persist on reload