### PR TITLE
Fixes date widget crashing when no Date format is mentioned

### DIFF
--- a/app/client/src/constants/WidgetValidation.ts
+++ b/app/client/src/constants/WidgetValidation.ts
@@ -33,3 +33,5 @@ export type Validator = (
   props: WidgetProps,
   dataTree?: DataTree,
 ) => ValidationResponse;
+
+export const ISO_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ss.SSSZ";

--- a/app/client/src/utils/Validators.ts
+++ b/app/client/src/utils/Validators.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import {
+  ISO_DATE_FORMAT,
   VALIDATION_TYPES,
   ValidationResponse,
   ValidationType,
@@ -392,8 +393,8 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
       .minute(0)
       .second(0)
       .millisecond(0);
-    const dateFormat = props.dateFormat ? props.dateFormat : moment.ISO_8601;
-    // const dateStr = moment().toISOString();
+    const dateFormat = props.dateFormat ? props.dateFormat : ISO_DATE_FORMAT;
+
     const todayDateString = today.format(dateFormat);
     if (dateString === undefined) {
       return {


### PR DESCRIPTION
Fixed by using a proper default format string for ISO dates