### PR TITLE
Fix: Jump issue of APIPane fields

### DIFF
--- a/app/client/src/components/editorComponents/FormRow.tsx
+++ b/app/client/src/components/editorComponents/FormRow.tsx
@@ -5,5 +5,5 @@ export default styled.div`
   flex: 1;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
 `;

--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
@@ -7,7 +7,6 @@ import { ExplorerURLParams, getDatasourceIdFromURL } from "../helpers";
 import Entity, { EntityClassNames } from "../Entity";
 import { DATA_SOURCES_EDITOR_ID_URL } from "constants/routes";
 import history from "utils/history";
-import { useDispatch } from "react-redux";
 import { updateDatasource } from "actions/datasourceActions";
 
 type ExplorerDatasourceEntityProps = {
@@ -37,7 +36,7 @@ export const ExplorerDatasourceEntity = (
     (id: string, name: string) => {
       return updateDatasource({ ...props.datasource, name: name }, active);
     },
-    [props.datasource],
+    [props.datasource, active],
   );
   return (
     <Entity

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -24,9 +24,8 @@ type PropertyPaneTitleProps = {
 /* eslint-disable react/display-name */
 const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
   const dispatch = useDispatch();
-  const { updating, updateError } = useSelector((state: AppState) => ({
+  const { updating } = useSelector((state: AppState) => ({
     updating: state.ui.editor.loadingStates.updatingWidgetName,
-    updateError: state.ui.editor.loadingStates.updateWidgetNameError,
   }));
   const isNew = useSelector((state: AppState) => state.ui.propertyPane.isNew);
   const widgets = useSelector(getExistingWidgetNames);

--- a/app/client/src/widgets/TableWidget.tsx
+++ b/app/client/src/widgets/TableWidget.tsx
@@ -319,7 +319,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           return filter;
         },
       );
-      super.updateWidgetMetaProperty("filteredTableData", filteredTableData);
+      // super.updateWidgetMetaProperty("filteredTableData", filteredTableData);
       return filteredTableData;
     },
   );


### PR DESCRIPTION
Fix issues:
- Table component calls updateWidgetMetaProperties recursively. This is a temporary fix.
- Remove console warnings about unused variables
- align form row items to `flex-start` to fix the api pane fields from jumping on focus.