### PR TITLE
Fix query response table style

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -24,6 +24,7 @@ const StyledTableWrapped = styled(TableWrapper)`
     flex-direction: column;
     height: auto;
     .tbody {
+      height: auto;
       overflow: auto;
     }
   }


### PR DESCRIPTION
- Overide table body height to auto to take the available space