### PR TITLE
Fix race condition in setting default page in application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomApplicationRepository.java
@@ -2,7 +2,6 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.Application;
-import com.appsmith.server.domains.Page;
 import com.mongodb.client.result.UpdateResult;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -21,6 +20,8 @@ public interface CustomApplicationRepository extends AppsmithRepository<Applicat
 
     Flux<Application> findByClonedFromApplicationId(String applicationId, AclPermission permission);
 
-    Mono<UpdateResult> addPageToApplication(Application application, Page page, boolean isDefault);
+    Mono<UpdateResult> addPageToApplication(String applicationId, String pageId, boolean isDefault);
+
+    Mono<UpdateResult> setDefaultPage(String applicationId, String pageId);
 
 }


### PR DESCRIPTION
We are currently getting the *list* of all pages, updating the
`isDefault` fields inside, and then saving the whole *list* of
all pages. If a new page got added to that list in the DB during
this process, that page would be lost. This commit fixes this
problem.

This race condition was causing tests for cloning applications
to fail *sometimes*.
