### PR TITLE
Example app being cloned must be set to private instead of public

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -270,6 +270,7 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
         application.setId(null);
         application.setPolicies(new HashSet<>());
         application.setPages(new ArrayList<>());
+        application.setIsPublic(false);
 
         Mono<User> userMono = sessionUserService.getCurrentUser().cache();
         Mono<Application> applicationWithPoliciesMono = userMono


### PR DESCRIPTION
This is because public permissions are not given during cloning.