### PR TITLE
Update Entity Explorer to avoid extra evals of data tree

### DIFF
--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -18,7 +18,6 @@ import {
 } from "pages/Applications/permissionHelpers";
 import { getInitialsAndColorCode, getColorCode } from "utils/AppsmithUtils";
 import { ControlIcons } from "icons/ControlIcons";
-import history from "utils/history";
 import { omit } from "lodash";
 
 type NameWrapperProps = {

--- a/app/client/src/pages/Editor/Explorer/hooks.ts
+++ b/app/client/src/pages/Editor/Explorer/hooks.ts
@@ -18,7 +18,7 @@ import { compact } from "lodash";
 import { Datasource } from "api/DatasourcesApi";
 import { debounce } from "lodash";
 import { WidgetProps } from "widgets/BaseWidget";
-import { evaluateDataTreeWithFunctions } from "selectors/dataTreeSelectors";
+import { evaluateDataTreeWithoutFunctions } from "selectors/dataTreeSelectors";
 import { ActionData } from "reducers/entityReducers/actionsReducer";
 import log from "loglevel";
 
@@ -56,7 +56,7 @@ export const useFilteredEntities = (
   const start = performance.now();
   const [searchKeyword, setSearchKeyword] = useState<string | null>(null);
 
-  const dataTree: DataTree = useSelector(evaluateDataTreeWithFunctions);
+  const dataTree: DataTree = useSelector(evaluateDataTreeWithoutFunctions);
   const pages = useSelector((state: AppState) => {
     return state.entities.pageList.pages;
   });

--- a/app/client/src/pages/Editor/Explorer/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, MutableRefObject, useEffect } from "react";
+import React, { useRef, MutableRefObject } from "react";
 import styled from "styled-components";
 import Divider from "components/editorComponents/Divider";
 import { useFilteredEntities } from "./hooks";
@@ -7,8 +7,6 @@ import ExplorerPageGroup from "./Pages/PageGroup";
 import ExplorerDatasourcesGroup from "./Datasources/DatasourcesGroup";
 import { scrollbarDark } from "constants/DefaultTheme";
 import { NonIdealState, Classes } from "@blueprintjs/core";
-import { ENTITY_EXPLORER_SEARCH_LOCATION_HASH } from "constants/Explorer";
-import { useLocation } from "react-router";
 
 const Wrapper = styled.div`
   height: 100%;
@@ -40,17 +38,6 @@ const EntityExplorer = () => {
     searchKeyword,
     clearSearch,
   } = useFilteredEntities(searchInputRef);
-
-  // TODO (abhinav)
-  // Commenting out cause it causes re renders and re evaluations via userFilteredEntities
-  // Suggest to move this functionality somewhere else to avoid this
-  //
-  // const location = useLocation();
-  // useEffect(() => {
-  //   if (location.hash === ENTITY_EXPLORER_SEARCH_LOCATION_HASH) {
-  //     searchInputRef.current?.focus();
-  //   }
-  // }, [location, searchInputRef]);
 
   const explorerPageGroup = (
     <ExplorerPageGroup

--- a/app/client/src/pages/Editor/Explorer/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/index.tsx
@@ -41,12 +41,16 @@ const EntityExplorer = () => {
     clearSearch,
   } = useFilteredEntities(searchInputRef);
 
-  const location = useLocation();
-  useEffect(() => {
-    if (location.hash === ENTITY_EXPLORER_SEARCH_LOCATION_HASH) {
-      searchInputRef.current?.focus();
-    }
-  }, [location, searchInputRef]);
+  // TODO (abhinav)
+  // Commenting out cause it causes re renders and re evaluations via userFilteredEntities
+  // Suggest to move this functionality somewhere else to avoid this
+  //
+  // const location = useLocation();
+  // useEffect(() => {
+  //   if (location.hash === ENTITY_EXPLORER_SEARCH_LOCATION_HASH) {
+  //     searchInputRef.current?.focus();
+  //   }
+  // }, [location, searchInputRef]);
 
   const explorerPageGroup = (
     <ExplorerPageGroup


### PR DESCRIPTION
- Use the without functions method since it is cached via selector
- Remove functionality where entity search is appended on the url