### PR TITLE
Add new boolean field on Application to indicate whether to clone as example for new users

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -30,6 +30,9 @@ public class Application extends BaseDomain {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     Boolean isPublic = false;
 
+    @JsonIgnore
+    Boolean cloneOnSignUp = false;
+
     List<ApplicationPage> pages;
 
     @Transient

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -719,6 +719,7 @@ public class DatabaseChangelog {
             final List<Map<String, Object>> embeddedPages = new ArrayList<>();
 
             application.put(FieldName.ORGANIZATION_ID, organizationId);
+            application.put(FieldName.CREATED_AT, Instant.now());
             mongoTemplate.insert(application, mongoTemplate.getCollectionName(Application.class));
             final String applicationId = ((ObjectId) application.get("_id")).toHexString();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ApplicationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ApplicationRepository.java
@@ -7,7 +7,7 @@ import reactor.core.publisher.Flux;
 @Repository
 public interface ApplicationRepository extends BaseRepository<Application, String>, CustomApplicationRepository {
 
-    Flux<Application> findByOrganizationIdAndIsPublicTrue(String organizationId);
+    Flux<Application> findByOrganizationIdAndCloneOnSignUpTrue(String organizationId);
 
     Flux<Application> findByOrganizationId(String organizationId);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -157,7 +157,7 @@ public class ExamplesOrganizationCloner {
         final List<Page> clonedPages = new ArrayList<>();
 
         return applicationRepository
-                .findByOrganizationIdAndIsPublicTrue(fromOrganizationId)
+                .findByOrganizationIdAndCloneOnSignUpTrue(fromOrganizationId)
                 .flatMap(application -> {
                     application.setOrganizationId(toOrganizationId);
 

--- a/app/server/appsmith-server/src/main/resources/examples-organization.json
+++ b/app/server/appsmith-server/src/main/resources/examples-organization.json
@@ -49,6 +49,7 @@
     {
       "name": "Charts Tutorial",
       "isPublic": true,
+      "cloneOnSignUp": true,
       "$pages": [
         {
           "name": "1. Display Chart Data",
@@ -1105,6 +1106,7 @@
     {
       "name": "Customer Support Dashboard",
       "isPublic": true,
+      "cloneOnSignUp": true,
       "$pages": [
         {
           "name": "Users Page",
@@ -5178,6 +5180,7 @@
     {
       "name": "Form Tutorial",
       "isPublic": true,
+      "cloneOnSignUp": true,
       "$pages": [
         {
           "name": "1. Simple Form Submit",
@@ -9654,6 +9657,7 @@
       "name": "Table Tutorial",
       "organizationId": "5f2a944780ca1f6faaed4e38",
       "isPublic": true,
+      "cloneOnSignUp": true,
       "$pages": [
         {
           "name": "1. Displaying Data",

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -183,7 +183,7 @@ public class ExamplesOrganizationClonerTests {
                     Application app1 = new Application();
                     app1.setName("1 - public app");
                     app1.setOrganizationId(organization.getId());
-                    app1.setIsPublic(true);
+                    app1.setCloneOnSignUp(true);
 
                     Application app2 = new Application();
                     app2.setOrganizationId(organization.getId());
@@ -215,7 +215,7 @@ public class ExamplesOrganizationClonerTests {
 
     @Test
     @WithUserDetails(value = "api_user")
-    public void cloneOrganizationWithOnlyPublicApplications() {
+    public void cloneOrganizationWithOnlyApplicationsThatShouldBeCloned() {
         Organization newOrganization = new Organization();
         newOrganization.setName("Template Organization 2");
         final Mono<OrganizationData> resultMono = Mono
@@ -229,12 +229,12 @@ public class ExamplesOrganizationClonerTests {
                     Application app1 = new Application();
                     app1.setName("1 - public app more");
                     app1.setOrganizationId(organization.getId());
-                    app1.setIsPublic(true);
+                    app1.setCloneOnSignUp(true);
 
                     Application app2 = new Application();
                     app2.setOrganizationId(organization.getId());
                     app2.setName("2 - another public app more");
-                    app2.setIsPublic(true);
+                    app2.setCloneOnSignUp(true);
 
                     return Mono.zip(
                             applicationPageService.createApplication(app1),
@@ -406,12 +406,12 @@ public class ExamplesOrganizationClonerTests {
                     final Application app1 = new Application();
                     app1.setName("first application");
                     app1.setOrganizationId(organization.getId());
-                    app1.setIsPublic(true);
+                    app1.setCloneOnSignUp(true);
 
                     final Application app2 = new Application();
                     app2.setName("second application");
                     app2.setOrganizationId(organization.getId());
-                    app2.setIsPublic(true);
+                    app2.setCloneOnSignUp(true);
 
                     final Datasource ds1 = new Datasource();
                     ds1.setName("datasource 1");
@@ -470,12 +470,12 @@ public class ExamplesOrganizationClonerTests {
                     final Application app1 = new Application();
                     app1.setName("first application");
                     app1.setOrganizationId(organization.getId());
-                    app1.setIsPublic(true);
+                    app1.setCloneOnSignUp(true);
 
                     final Application app2 = new Application();
                     app2.setName("second application");
                     app2.setOrganizationId(organization.getId());
-                    app2.setIsPublic(true);
+                    app2.setCloneOnSignUp(true);
 
                     final Datasource ds1 = new Datasource();
                     ds1.setName("datasource 1");


### PR DESCRIPTION
Currently, all public apps in the examples organization are cloned for a
newly signed up user. This loses some flexibility in that there's no way
now to have public applications in the examples organization, that shouldn't
be cloned for new users.

This flag introduces this flexibility.
