### PR TITLE
Fix column alias names in MySQL actions

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -90,7 +90,7 @@ public class MySqlPlugin extends BasePlugin {
                     while (resultSet.next()) {
                         Map<String, Object> row = new HashMap<>(colCount);
                         for (int i = 1; i <= colCount; i++) {
-                            row.put(metaData.getColumnName(i), resultSet.getObject(i));
+                            row.put(metaData.getColumnLabel(i), resultSet.getObject(i));
                         }
                         rowsList.add(row);
                     }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -103,13 +103,16 @@ public class MySqlPlugin extends BasePlugin {
                             } else if (DATE_COLUMN_TYPE_NAME.equalsIgnoreCase(typeName)) {
                                 value = DateTimeFormatter.ISO_DATE.format(resultSet.getDate(i).toLocalDate());
 
-                            } else if ("datetime".equalsIgnoreCase(typeName)) {
+                            } else if ("datetime".equalsIgnoreCase(typeName) || "timestamp".equalsIgnoreCase(typeName)) {
                                 value = DateTimeFormatter.ISO_DATE_TIME.format(
                                         LocalDateTime.of(
                                                 resultSet.getDate(i).toLocalDate(),
                                                 resultSet.getTime(i).toLocalTime()
                                         )
                                 ) + "Z";
+
+                            } else if ("year".equalsIgnoreCase(typeName)) {
+                                value = resultSet.getDate(i).toLocalDate().getYear();
 
                             } else {
                                 value = resultSet.getObject(i);

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -28,8 +28,8 @@ import java.sql.Statement;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -92,7 +92,8 @@ public class MySqlPlugin extends BasePlugin {
                     ResultSetMetaData metaData = resultSet.getMetaData();
                     int colCount = metaData.getColumnCount();
                     while (resultSet.next()) {
-                        Map<String, Object> row = new HashMap<>(colCount);
+                        // Use `LinkedHashMap` here so that the column ordering is preserved in the response.
+                        Map<String, Object> row = new LinkedHashMap<>(colCount);
                         rowsList.add(row);
 
                         for (int i = 1; i <= colCount; i++) {

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -93,6 +93,8 @@ public class MySqlPlugin extends BasePlugin {
                     int colCount = metaData.getColumnCount();
                     while (resultSet.next()) {
                         Map<String, Object> row = new HashMap<>(colCount);
+                        rowsList.add(row);
+
                         for (int i = 1; i <= colCount; i++) {
                             Object value;
                             final String typeName = metaData.getColumnTypeName(i);
@@ -119,9 +121,8 @@ public class MySqlPlugin extends BasePlugin {
 
                             }
 
-                            row.put(metaData.getColumnName(i), value);
+                            row.put(metaData.getColumnLabel(i), value);
                         }
-                        rowsList.add(row);
                     }
 
                 } else {

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -25,6 +25,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -101,6 +102,14 @@ public class MySqlPlugin extends BasePlugin {
 
                             } else if (DATE_COLUMN_TYPE_NAME.equalsIgnoreCase(typeName)) {
                                 value = DateTimeFormatter.ISO_DATE.format(resultSet.getDate(i).toLocalDate());
+
+                            } else if ("datetime".equalsIgnoreCase(typeName)) {
+                                value = DateTimeFormatter.ISO_DATE_TIME.format(
+                                        LocalDateTime.of(
+                                                resultSet.getDate(i).toLocalDate(),
+                                                resultSet.getTime(i).toLocalTime()
+                                        )
+                                ) + "Z";
 
                             } else {
                                 value = resultSet.getObject(i);

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -25,6 +25,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +43,8 @@ public class MySqlPlugin extends BasePlugin {
     private static final String USER = "user";
     private static final String PASSWORD = "password";
     private static final int VALIDITY_CHECK_TIMEOUT = 5;
+
+    private static final String DATE_COLUMN_TYPE_NAME = "date";
 
     public MySqlPlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -90,7 +93,21 @@ public class MySqlPlugin extends BasePlugin {
                     while (resultSet.next()) {
                         Map<String, Object> row = new HashMap<>(colCount);
                         for (int i = 1; i <= colCount; i++) {
-                            row.put(metaData.getColumnLabel(i), resultSet.getObject(i));
+                            Object value;
+                            final String typeName = metaData.getColumnTypeName(i);
+
+                            if (resultSet.getObject(i) == null) {
+                                value = null;
+
+                            } else if (DATE_COLUMN_TYPE_NAME.equalsIgnoreCase(typeName)) {
+                                value = DateTimeFormatter.ISO_DATE.format(resultSet.getDate(i).toLocalDate());
+
+                            } else {
+                                value = resultSet.getObject(i);
+
+                            }
+
+                            row.put(metaData.getColumnName(i), value);
                         }
                         rowsList.add(row);
                     }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -1,6 +1,13 @@
 package com.external.plugins;
 
-import com.appsmith.external.models.*;
+import com.appsmith.external.models.ActionConfiguration;
+import com.appsmith.external.models.ActionExecutionResult;
+import com.appsmith.external.models.AuthenticationDTO;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.Endpoint;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.extern.log4j.Log4j;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -10,12 +17,19 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.ArrayList;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @Log4j
 public class MySqlPluginTest {
@@ -34,11 +48,71 @@ public class MySqlPluginTest {
 
     @Before
     public void setUp() {
+        if (address != null) {
+            return;
+        }
+
         address = mySQLContainer.getContainerIpAddress();
         port = mySQLContainer.getFirstMappedPort();
         username = mySQLContainer.getUsername();
         password = mySQLContainer.getPassword();
         createDatasourceConfiguration();
+
+        Properties properties = new Properties();
+        properties.putAll(Map.of(
+                "user", username,
+                "password", password
+        ));
+
+        try (Connection connection = DriverManager.getConnection(
+                "jdbc:mysql://" + address + ":" + port + "/" + username,
+                properties
+        )) {
+
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SET @@time_zone = '+00:00'");
+            }
+
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("DROP TABLE IF EXISTS users");
+            }
+
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE users(\n" +
+                        "    id serial PRIMARY KEY,\n" +
+                        "    username VARCHAR (50) UNIQUE NOT NULL,\n" +
+                        "    password VARCHAR (50) NOT NULL,\n" +
+                        "    email VARCHAR (355) UNIQUE NOT NULL,\n" +
+                        "    spouse_dob DATE,\n" +
+                        "    dob DATE NOT NULL,\n" +
+                        "    yob YEAR NOT NULL,\n" +
+                        "    time1 TIME NOT NULL,\n" +
+                        "    created_on TIMESTAMP NOT NULL,\n" +
+                        "    updated_on DATETIME NOT NULL\n" +
+                        ")");
+            }
+
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(
+                        "INSERT INTO users VALUES (" +
+                                "1, 'Jack', 'jill', 'jack@exemplars.com', NULL, '2018-12-31', 2018," +
+                                " '18:32:45'," +
+                                " '2018-11-30 20:45:15', '2018-11-30 20:45:15'" +
+                                ")");
+            }
+
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(
+                        "INSERT INTO users VALUES (" +
+                                "2, 'Jill', 'jack', 'jill@exemplars.com', NULL, '2019-12-31', 2019," +
+                                " '15:45:30'," +
+                                " '2019-11-30 23:59:59', '2019-11-30 23:59:59'" +
+                                ")");
+            }
+
+        } catch (SQLException throwable) {
+            throwable.printStackTrace();
+        }
     }
 
     private DatasourceConfiguration createDatasourceConfiguration() {
@@ -138,6 +212,60 @@ public class MySqlPluginTest {
                 })
                 .verifyComplete();
 
+    }
+
+    @Test
+    public void testExecuteDataTypes() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setBody("SELECT * FROM users WHERE id = 1");
+
+        Mono<Object> executeMono = dsConnectionMono.flatMap(conn -> pluginExecutor.execute(conn, dsConfig, actionConfiguration));
+
+        StepVerifier.create(executeMono)
+                .assertNext(obj -> {
+                    ActionExecutionResult result = (ActionExecutionResult) obj;
+
+                    assertNotNull(result);
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+
+                    final JsonNode node = ((ArrayNode) result.getBody()).get(0);
+                    assertEquals("2018-12-31", node.get("dob").asText());
+                    assertEquals("2018", node.get("yob").asText());
+                    assertTrue(node.get("time1").asText().matches("\\d{2}:\\d{2}:\\d{2}"));
+                    assertTrue(node.get("created_on").asText().matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"));
+                    assertTrue(node.get("updated_on").asText().matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"));
+
+                    // Check the order of the columns.
+                    assertArrayEquals(
+                            List
+                                    .of(
+                                            "id",
+                                            "username",
+                                            "password",
+                                            "email",
+                                            "spouse_dob",
+                                            "dob",
+                                            "yob",
+                                            "time1",
+                                            "created_on",
+                                            "updated_on"
+                                    )
+                                    .stream()
+                                    .sorted()
+                                    .toArray(),
+                            new ObjectMapper()
+                                    .convertValue(node, LinkedHashMap.class)
+                                    .keySet()
+                                    .stream()
+                                    .sorted()
+                                    .toArray()
+                    );
+                })
+                .verifyComplete();
     }
 
 }

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -47,8 +47,9 @@ public class PostgresPlugin extends BasePlugin {
     private static final String USER = "user";
     private static final String PASSWORD = "password";
     private static final String SSL = "ssl";
-    private static final String DATE_COLUMN_TYPE_NAME = "date";
     private static final int VALIDITY_CHECK_TIMEOUT = 5;
+
+    private static final String DATE_COLUMN_TYPE_NAME = "date";
 
     public PostgresPlugin(PluginWrapper wrapper) {
         super(wrapper);

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -38,6 +38,7 @@ public class PostgresPluginTest {
 
     PostgresPlugin.PostgresPluginExecutor pluginExecutor = new PostgresPlugin.PostgresPluginExecutor();
 
+    @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is pseudo-optional.
     @ClassRule
     public static final PostgreSQLContainer pgsqlContainer = new PostgreSQLContainer<>("postgres:alpine")
             .withExposedPorts(5432)
@@ -79,7 +80,7 @@ public class PostgresPluginTest {
             }
 
             try (Statement statement = connection.createStatement()) {
-                statement.execute("CREATE TABLE users(\n" +
+                statement.execute("CREATE TABLE users (\n" +
                         "    id serial PRIMARY KEY,\n" +
                         "    username VARCHAR (50) UNIQUE NOT NULL,\n" +
                         "    password VARCHAR (50) NOT NULL,\n" +
@@ -152,6 +153,33 @@ public class PostgresPluginTest {
     }
 
     @Test
+    public void testAliasColumnNames() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setBody("SELECT id as user_id FROM users WHERE id = 1");
+
+        Mono<ActionExecutionResult> executeMono = dsConnectionMono
+                .flatMap(conn -> pluginExecutor.execute(conn, dsConfig, actionConfiguration));
+
+        StepVerifier.create(executeMono)
+                .assertNext(result -> {
+                    final JsonNode node = ((ArrayNode) result.getBody()).get(0);
+                    assertArrayEquals(
+                            new String[]{
+                                    "user_id"
+                            },
+                            new ObjectMapper()
+                                    .convertValue(node, LinkedHashMap.class)
+                                    .keySet()
+                                    .toArray()
+                    );
+                })
+                .verifyComplete();
+    }
+
+    @Test
     public void testExecute() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
@@ -159,12 +187,11 @@ public class PostgresPluginTest {
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("SELECT * FROM users WHERE id = 1");
 
-        Mono<Object> executeMono = dsConnectionMono.flatMap(conn -> pluginExecutor.execute(conn, dsConfig, actionConfiguration));
+        Mono<ActionExecutionResult> executeMono = dsConnectionMono
+                .flatMap(conn -> pluginExecutor.execute(conn, dsConfig, actionConfiguration));
 
         StepVerifier.create(executeMono)
-                .assertNext(obj -> {
-                    ActionExecutionResult result = (ActionExecutionResult) obj;
-
+                .assertNext(result -> {
                     assertNotNull(result);
                     assertTrue(result.getIsExecutionSuccess());
                     assertNotNull(result.getBody());

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -114,8 +114,8 @@ public class PostgresPluginTest {
                                 ")");
             }
 
-    } catch (SQLException throwables) {
-            throwables.printStackTrace();
+        } catch (SQLException throwable) {
+            throwable.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Also fixes the following problems:

1. Give a predictable column ordering. The column order should now be in sync with that in the SELECT query executed.
1. Fix display of the various temporal data types in MySQL.
