### PR TITLE
Rename example applications organization

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationService.java
@@ -19,7 +19,7 @@ public interface OrganizationService extends CrudService<Organization, String> {
 
     Mono<String> getNextUniqueSlug(String initialSlug);
 
-    Mono<Organization> createPersonal(Organization organization, User user);
+    Mono<Organization> createPersonal(Organization organization, User user, String suffix);
 
     Mono<Organization> create(Organization organization, User user);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -104,11 +105,12 @@ public class OrganizationServiceImpl extends BaseService<OrganizationRepository,
      * is discarded.
      * @param organization Organization object to be created.
      * @param user User to whom this organization will belong to, as a personal organization.
+     * @param suffix A string suffix to append to the organization name.
      * @return Publishes the saved organization.
      */
     @Override
-    public Mono<Organization> createPersonal(final Organization organization, User user) {
-        organization.setName(user.computeFirstName() + "'s Personal Organization");
+    public Mono<Organization> createPersonal(final Organization organization, User user, String suffix) {
+        organization.setName(StringUtils.capitalize(user.computeFirstName()) + "'s " + suffix);
         return create(organization, user);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -459,7 +459,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                         // Since template organization is not configured, we create an empty personal organization.
                         final User savedUser = tuple.getT1();
                         log.debug("Creating blank personal organization for user '{}'.", savedUser.getEmail());
-                        return organizationService.createPersonal(new Organization(), savedUser);
+                        return organizationService.createPersonal(new Organization(), savedUser, "Personal Organization");
                     }
 
                     return Mono.empty();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -125,7 +125,7 @@ public class ExamplesOrganizationCloner {
                         organization.getUserRoles().clear();
                     }
                     organization.setSlug(null);
-                    return organizationService.createPersonal(organization, user);
+                    return organizationService.createPersonal(organization, user, "Example Applications");
                 })
                 .flatMap(newOrganization -> {
                     User userUpdate = new User();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -158,7 +158,7 @@ public class ExamplesOrganizationClonerTests {
                 .assertNext(data -> {
                     assertThat(data.organization).isNotNull();
                     assertThat(data.organization.getId()).isNotNull();
-                    assertThat(data.organization.getName()).isEqualTo("api_user's Personal Organization");
+                    assertThat(data.organization.getName()).isEqualTo("Api_user's Example Applications");
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.applications).isEmpty();
@@ -200,7 +200,7 @@ public class ExamplesOrganizationClonerTests {
                 .assertNext(data -> {
                     assertThat(data.organization).isNotNull();
                     assertThat(data.organization.getId()).isNotNull();
-                    assertThat(data.organization.getName()).isEqualTo("api_user's Personal Organization");
+                    assertThat(data.organization.getName()).isEqualTo("Api_user's Example Applications");
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.applications).hasSize(1);
@@ -252,7 +252,7 @@ public class ExamplesOrganizationClonerTests {
                 .assertNext(data -> {
                     assertThat(data.organization).isNotNull();
                     assertThat(data.organization.getId()).isNotNull();
-                    assertThat(data.organization.getName()).isEqualTo("api_user's Personal Organization");
+                    assertThat(data.organization.getName()).isEqualTo("Api_user's Example Applications");
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.applications).hasSize(2);
@@ -307,7 +307,7 @@ public class ExamplesOrganizationClonerTests {
                 .assertNext(data -> {
                     assertThat(data.organization).isNotNull();
                     assertThat(data.organization.getId()).isNotNull();
-                    assertThat(data.organization.getName()).isEqualTo("api_user's Personal Organization");
+                    assertThat(data.organization.getName()).isEqualTo("Api_user's Example Applications");
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.applications).isEmpty();
@@ -358,7 +358,7 @@ public class ExamplesOrganizationClonerTests {
                 .assertNext(data -> {
                     assertThat(data.organization).isNotNull();
                     assertThat(data.organization.getId()).isNotNull();
-                    assertThat(data.organization.getName()).isEqualTo("api_user's Personal Organization");
+                    assertThat(data.organization.getName()).isEqualTo("Api_user's Example Applications");
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.datasources).hasSize(2);
@@ -434,7 +434,7 @@ public class ExamplesOrganizationClonerTests {
                 .assertNext(data -> {
                     assertThat(data.organization).isNotNull();
                     assertThat(data.organization.getId()).isNotNull();
-                    assertThat(data.organization.getName()).isEqualTo("api_user's Personal Organization");
+                    assertThat(data.organization.getName()).isEqualTo("Api_user's Example Applications");
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.applications).hasSize(2);
@@ -580,7 +580,7 @@ public class ExamplesOrganizationClonerTests {
                 .assertNext(data -> {
                     assertThat(data.organization).isNotNull();
                     assertThat(data.organization.getId()).isNotNull();
-                    assertThat(data.organization.getName()).isEqualTo("api_user's Personal Organization");
+                    assertThat(data.organization.getName()).isEqualTo("Api_user's Example Applications");
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.applications).hasSize(2);


### PR DESCRIPTION
Name the clone of example organizations as "Examples organization", when they contain examples, and as "Personal organization" when it's empty.