### PR TITLE
Removing SSH Tunnel from Mongo & Postgres plugins (#529)

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/form.json
@@ -145,68 +145,6 @@
           "controlType": "FILE_PICKER"
         }
       ]
-    },
-    {
-      "sectionName": "SSH Tunnel (optional)",
-      "children": [
-        {
-          "label": "Enable SSH Tunneling",
-          "configProperty": "sshTunneling",
-          "controlType": "SWITCH"
-        },
-        {
-          "sectionName": null,
-          "children": [
-            {
-              "label": "SSH Address",
-              "configProperty": "datasourceConfiguration.sshProxy.host",
-              "controlType": "INPUT_TEXT",
-              "placeholderText": "0.0.0.0"
-            },
-            {
-              "label": "Port",
-              "configProperty": "datasourceConfiguration.sshProxy.port",
-              "controlType": "INPUT_TEXT",
-              "placeholderText": "8080"
-            }
-          ]
-        },
-        {
-          "label": "Username",
-          "configProperty": "datasourceConfiguration.sshProxy.username",
-          "controlType": "INPUT_TEXT",
-          "placeholderText": "SSH Proxy Username"
-        },
-        {
-          "label": "Authentication Type",
-          "configProperty": "datasourceConfiguration.authenticationType",
-          "controlType": "DROP_DOWN",
-          "options": [
-            {
-              "label": "Password",
-              "value": "PASSWORD"
-            },
-            {
-              "label": "Identity File",
-              "value": "IDENTITY_FILE"
-            }
-          ]
-        },
-        {
-          "label": "Password",
-          "configProperty": "datasourceConfiguration.ssh.tunnelPassword",
-          "dataType": "PASSWORD",
-          "controlType": "INPUT_TEXT",
-          "placeholderText": "SSH Tunnel password"
-        },
-        {
-          "label": "Passphrase",
-          "configProperty": "datasourceConfiguration.ssh.tunnelPassphrase",
-          "dataType": "PASSWORD",
-          "controlType": "INPUT_TEXT",
-          "placeholderText": "SSH Tunnel passphrase"
-        }
-      ]
     }
   ]
 }

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/form.json
@@ -149,62 +149,6 @@
           ]
         }
       ]
-    },
-    {
-      "sectionName": "SSH (optional)",
-      "id": 4,
-      "children": [
-        {
-          "label": "Enable SSH",
-          "configProperty": "enableSSH",
-          "controlType": "SWITCH"
-        },
-        {
-          "sectionName": null,
-          "children": [
-            {
-              "label": "Tunnel Host",
-              "configProperty": "datasourceConfiguration.sshProxy.host",
-              "controlType": "INPUT_TEXT",
-              "placeholderText": "0.0.0.0"
-            },
-            {
-              "label": "Tunnel Port",
-              "configProperty": "datasourceConfiguration.sshProxy.port",
-              "controlType": "INPUT_TEXT",
-              "placeholderText": "8080"
-            }
-          ]
-        },
-        {
-          "label": "Username",
-          "configProperty": "datasourceConfiguration.sshProxy.username",
-          "controlType": "INPUT_TEXT",
-          "placeholderText": "SSH Proxy username"
-        },
-        {
-          "label": "Password",
-          "configProperty": "datasourceConfiguration.sshProxy.password",
-          "dataType": "PASSWORD",
-          "controlType": "INPUT_TEXT",
-          "placeholderText": "SSH Proxy password"
-        },
-        {
-          "label": "Authentication Type",
-          "configProperty": "datasourceConfiguration.sshProxy.authType",
-          "controlType": "DROP_DOWN",
-          "options": [
-            {
-              "label": "Password",
-              "value": "PASSWORD"
-            },
-            {
-              "label": "Identity File",
-              "value": "IDENTITY_FILE"
-            }
-          ]
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
We don't yet support this feature hence removing it from the UI. Will add it back again once the backend supports SSH tunnelling.