### PR TITLE
Add a connection type variable for Plugin implementations

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -10,7 +10,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Set;
 
-public interface PluginExecutor extends ExtensionPoint {
+public interface PluginExecutor<C> extends ExtensionPoint {
 
     /**
      * This function is used to execute the action.
@@ -21,7 +21,7 @@ public interface PluginExecutor extends ExtensionPoint {
      * @param actionConfiguration     : These are the configurations which have been used to create an Action from a Datasource.
      * @return ActionExecutionResult : This object is returned to the user which contains the result values from the execution.
      */
-    Mono<ActionExecutionResult> execute(Object connection, DatasourceConfiguration datasourceConfiguration, ActionConfiguration actionConfiguration);
+    Mono<ActionExecutionResult> execute(C connection, DatasourceConfiguration datasourceConfiguration, ActionConfiguration actionConfiguration);
 
     /**
      * This function is responsible for creating the connection to the data source and returning the connection variable
@@ -30,14 +30,14 @@ public interface PluginExecutor extends ExtensionPoint {
      * @param datasourceConfiguration
      * @return Connection object
      */
-    Mono<Object> datasourceCreate(DatasourceConfiguration datasourceConfiguration);
+    Mono<C> datasourceCreate(DatasourceConfiguration datasourceConfiguration);
 
     /**
      * This function is used to bring down/destroy the connection to the data source.
      *
      * @param connection
      */
-    void datasourceDestroy(Object connection);
+    void datasourceDestroy(C connection);
 
     default boolean isDatasourceValid(DatasourceConfiguration datasourceConfiguration) {
         return CollectionUtils.isEmpty(validateDatasource(datasourceConfiguration));

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -66,24 +66,23 @@ public class MongoPlugin extends BasePlugin {
 
     @Slf4j
     @Extension
-    public static class MongoPluginExecutor implements PluginExecutor {
+    public static class MongoPluginExecutor implements PluginExecutor<MongoClient> {
 
         /**
          * For reference on creating the json queries for Mongo please head to
          * https://docs.huihoo.com/mongodb/3.4/reference/command/index.html
          *
-         * @param connection              : This is the connection that is established to the data source. This connection is according
+         * @param mongoClient             : This is the connection that is established to the data source. This connection is according
          *                                to the parameters in Datasource Configuration
          * @param datasourceConfiguration : These are the configurations which have been used to create a Datasource from a Plugin
          * @param actionConfiguration     : These are the configurations which have been used to create an Action from a Datasource.
          * @return Result data from executing the action's query.
          */
         @Override
-        public Mono<ActionExecutionResult> execute(Object connection,
+        public Mono<ActionExecutionResult> execute(MongoClient mongoClient,
                                                    DatasourceConfiguration datasourceConfiguration,
                                                    ActionConfiguration actionConfiguration) {
 
-            MongoClient mongoClient = (MongoClient) connection;
             if (mongoClient == null) {
                 return Mono.error(new AppsmithPluginException("Mongo Client is null."));
             }
@@ -165,7 +164,7 @@ public class MongoPlugin extends BasePlugin {
         }
 
         @Override
-        public Mono<Object> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
+        public Mono<MongoClient> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
             // TODO: ReadOnly seems to be not supported at the driver level. The recommendation is to connect with a
             //   user that doesn't have write permissions on the database.
             //   Ref: https://api.mongodb.com/java/2.13/com/mongodb/DB.html#setReadOnly-java.lang.Boolean-
@@ -246,8 +245,7 @@ public class MongoPlugin extends BasePlugin {
         }
 
         @Override
-        public void datasourceDestroy(Object connection) {
-            MongoClient mongoClient = (MongoClient) connection;
+        public void datasourceDestroy(MongoClient mongoClient) {
             if (mongoClient != null) {
                 mongoClient.close();
             }
@@ -304,8 +302,7 @@ public class MongoPlugin extends BasePlugin {
         public Mono<DatasourceTestResult> testDatasource(DatasourceConfiguration datasourceConfiguration) {
             final Connection.Type connectionType = datasourceConfiguration.getConnection().getType();
             return datasourceCreate(datasourceConfiguration)
-                    .map(mongoClientObj -> {
-                        final MongoClient mongoClient = (MongoClient) mongoClientObj;
+                    .map(mongoClient -> {
                         ClientSession clientSession = null;
 
                         try {

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -87,7 +87,7 @@ public class MongoPluginTest {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         System.out.println(dsConfig);
 
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<MongoClient> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
         StepVerifier.create(dsConnectionMono)
                 .assertNext(obj -> {
                     MongoClient client = (MongoClient) obj;
@@ -100,7 +100,7 @@ public class MongoPluginTest {
     @Test
     public void testExecuteReadQuery() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<MongoClient> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("{\n" +
@@ -126,7 +126,7 @@ public class MongoPluginTest {
     @Test
     public void testExecuteWriteQuery() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<MongoClient> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("{\n" +
@@ -155,7 +155,7 @@ public class MongoPluginTest {
     @Test
     public void testFindAndModify() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<MongoClient> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("{\n" +
@@ -186,7 +186,7 @@ public class MongoPluginTest {
     @Test
     public void testCleanUp() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<MongoClient> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("{\n" +

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -134,7 +134,7 @@ public class MySqlPluginTest {
     @Test
     public void testConnectMySQLContainer() {
 
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         StepVerifier.create(dsConnectionMono)
                 .assertNext(connection -> {
@@ -146,7 +146,7 @@ public class MySqlPluginTest {
 
     @Test
     public void testExecute() {
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("show databases");
@@ -197,7 +197,7 @@ public class MySqlPluginTest {
     @Test
     public void testDatasourceDestroy() {
 
-        Mono<Object> connectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> connectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         StepVerifier.create(connectionMono)
                 .assertNext(connection -> {
@@ -215,7 +215,7 @@ public class MySqlPluginTest {
     @Test
     public void testAliasColumnNames() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("SELECT id as user_id FROM users WHERE id = 1");
@@ -242,7 +242,7 @@ public class MySqlPluginTest {
     @Test
     public void testExecuteDataTypes() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("SELECT * FROM users WHERE id = 1");

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -142,7 +142,7 @@ public class PostgresPluginTest {
 
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
 
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         StepVerifier.create(dsConnectionMono)
                 .assertNext(connection -> {
@@ -155,7 +155,7 @@ public class PostgresPluginTest {
     @Test
     public void testAliasColumnNames() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("SELECT id as user_id FROM users WHERE id = 1");
@@ -182,7 +182,7 @@ public class PostgresPluginTest {
     @Test
     public void testExecute() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-        Mono<Object> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+        Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("SELECT * FROM users WHERE id = 1");

--- a/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
+++ b/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
@@ -51,13 +51,13 @@ public class RapidApiPlugin extends BasePlugin {
 
     @Slf4j
     @Extension
-    public static class RapidApiPluginExecutor implements PluginExecutor {
+    public static class RapidApiPluginExecutor implements PluginExecutor<Void> {
 
         private static final String RAPID_API_KEY_NAME = "X-RapidAPI-Key";
         private static final String RAPID_API_KEY_VALUE = System.getenv("APPSMITH_RAPID_API_KEY_VALUE");
 
         @Override
-        public Mono<ActionExecutionResult> execute(Object connection,
+        public Mono<ActionExecutionResult> execute(Void ignored,
                                                    DatasourceConfiguration datasourceConfiguration,
                                                    ActionConfiguration actionConfiguration) {
 
@@ -256,12 +256,12 @@ public class RapidApiPlugin extends BasePlugin {
         }
 
         @Override
-        public Mono<Object> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
+        public Mono<Void> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
             return Mono.empty();
         }
 
         @Override
-        public void datasourceDestroy(Object connection) {
+        public void datasourceDestroy(Void connection) {
 
         }
 

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -63,10 +63,10 @@ public class RestApiPlugin extends BasePlugin {
 
     @Slf4j
     @Extension
-    public static class RestApiPluginExecutor implements PluginExecutor {
+    public static class RestApiPluginExecutor implements PluginExecutor<Void> {
 
         @Override
-        public Mono<ActionExecutionResult> execute(Object connection,
+        public Mono<ActionExecutionResult> execute(Void ignored,
                                                    DatasourceConfiguration datasourceConfiguration,
                                                    ActionConfiguration actionConfiguration) {
 
@@ -307,12 +307,12 @@ public class RestApiPlugin extends BasePlugin {
         }
 
         @Override
-        public Mono<Object> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
+        public Mono<Void> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
             return Mono.empty();
         }
 
         @Override
-        public void datasourceDestroy(Object connection) {
+        public void datasourceDestroy(Void connection) {
             // REST API plugin doesn't have a datasource.
         }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -85,7 +85,7 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
                         datasource1.getDatasourceConfiguration().setAuthentication(decryptSensitiveFields(authentication));
                     }
 
-                    PluginExecutor pluginExecutor = objects.getT2();
+                    PluginExecutor<Object> pluginExecutor = objects.getT2();
 
                     if (isStale) {
                         final Object connection = datasourceContextMap.get(datasourceId).getConnection();
@@ -137,7 +137,7 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
                 )
                 .map(tuple -> {
                     final Datasource datasource = tuple.getT1();
-                    final PluginExecutor pluginExecutor = tuple.getT2();
+                    final PluginExecutor<Object> pluginExecutor = tuple.getT2();
                     log.info("Clearing datasource context for datasource ID {}.", datasource.getId());
                     pluginExecutor.datasourceDestroy(datasourceContext.getConnection());
                     return datasourceContextMap.remove(datasourceId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
@@ -44,7 +44,7 @@ public class DatasourceStructureSolution {
                 )
                 .flatMap(tuple -> {
                     final Datasource datasource = tuple.getT1();
-                    final PluginExecutor pluginExecutor = tuple.getT2();
+                    final PluginExecutor<Object> pluginExecutor = tuple.getT2();
 
                     return datasourceContextService.retryOnce(
                             datasource,
@@ -64,7 +64,7 @@ public class DatasourceStructureSolution {
                     log.error("In the datasource structure error mode.", e);
                     return new AppsmithPluginException(AppsmithPluginError.PLUGIN_STRUCTURE_ERROR, e.getMessage());
                 })
-                .defaultIfEmpty(new com.appsmith.external.models.DatasourceStructure());
+                .defaultIfEmpty(new DatasourceStructure());
     }
 
     private Datasource decryptPasswordInDatasource(Datasource datasource) {


### PR DESCRIPTION
This type variable is intended to represent the type of the
connection object, if any, that the plugin will use. This will
help make the implementations more robust by leveraging Java's
type checking instead of rudimentary type casts over the
connection objects.