### PR TITLE
Removing cacheResponse from the JSON response for actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Action.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Action.java
@@ -56,6 +56,7 @@ public class Action extends BaseDomain {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     Set<String> jsonPathKeys;
 
+    @JsonIgnore
     String cacheResponse;
 
     String templateId; //If action is created via a template, store the id here.


### PR DESCRIPTION
This is because this `cacheResponse` field is only used for auto-complete on the UI. The user can still run the action manually and get the auto-complete to work. The downside to sending the `cacheResponse` field in the JSON response is that for large responses, the client times out as our response times increase to 20 secs. Hence removing this for now.

In future, we'll extract the JSON schema structure from the response body and send that to the client for populating auto-complete.