### PR TITLE
Improve action pane performance

### DIFF
--- a/app/client/src/pages/Editor/MainContainer.tsx
+++ b/app/client/src/pages/Editor/MainContainer.tsx
@@ -3,6 +3,9 @@ import EditorsRouter from "./routes";
 import WidgetsEditor from "./WidgetsEditor";
 import styled from "styled-components";
 import Sidebar from "components/editorComponents/Sidebar";
+import { Switch } from "react-router";
+import AppRoute from "../common/AppRoute";
+import { BUILDER_URL } from "constants/routes";
 
 const Container = styled.div`
   display: flex;
@@ -19,8 +22,15 @@ const MainContainer = () => {
     <Container>
       <Sidebar />
       <EditorContainer>
-        <EditorsRouter />
-        <WidgetsEditor />
+        <Switch>
+          <AppRoute
+            exact
+            path={BUILDER_URL}
+            component={WidgetsEditor}
+            name={"WidgetsEditor"}
+          />
+          <AppRoute component={EditorsRouter} name={"OtherEditors"} />
+        </Switch>
       </EditorContainer>
     </Container>
   );


### PR DESCRIPTION
Add a switch router to not render the widgets editor while rendering the drawers (action panes) above it to get around 50% lesser frame drops in larger apps

Before 
<img width="1920" alt="Screenshot 2020-09-18 at 9 54 46 AM" src="https://user-images.githubusercontent.com/12022471/93556641-d4dec000-f996-11ea-8aab-e966fb3d3818.png">

After
<img width="1920" alt="Screenshot 2020-09-18 at 9 56 27 AM" src="https://user-images.githubusercontent.com/12022471/93556653-da3c0a80-f996-11ea-84af-6b549f39a155.png">
