### PR TITLE
Giving higher preference to window variables instead of build variables in configuration

### DIFF
--- a/app/client/src/configs/index.ts
+++ b/app/client/src/configs/index.ts
@@ -103,8 +103,8 @@ const getConfigsFromEnvVars = (): INJECTED_CONFIGS => {
 };
 
 const getConfig = (fromENV: string, fromWindow: string) => {
-  if (fromENV.length > 0) return { enabled: true, value: fromENV };
-  else if (fromWindow.length > 0) return { enabled: true, value: fromWindow };
+  if (fromWindow.length > 0) return { enabled: true, value: fromWindow };
+  else if (fromENV.length > 0) return { enabled: true, value: fromENV };
   return { enabled: false, value: "" };
 };
 


### PR DESCRIPTION
This is because window configurations have been set by the user while the build configurations have been set by the build script.