### PR TITLE
Fixing the condition in Github Actions to set React env during release build

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -54,7 +54,7 @@ jobs:
         REACT_APP_ENVIRONMENT="DEVELOPMENT"  
         if [ ${GITHUB_REF} == '/refs/heads/master' ]; then
             REACT_APP_ENVIRONMENT="PRODUCTION"
-        elif [ ${GITHUB_REF} == '/refs/heads/master' ]; then
+        elif [ ${GITHUB_REF} == '/refs/heads/release' ]; then
             REACT_APP_ENVIRONMENT="STAGING"
         fi
         echo ::set-output name=REACT_APP_ENVIRONMENT::${REACT_APP_ENVIRONMENT}


### PR DESCRIPTION
In the release Docker image, we should set the build environment to STAGING. 