### PR TITLE
Display warning icon for login screen credential errors

### DIFF
--- a/app/client/src/pages/UserAuth/ForgotPassword.tsx
+++ b/app/client/src/pages/UserAuth/ForgotPassword.tsx
@@ -86,7 +86,9 @@ export const ForgotPassword = (props: ForgotPasswordProps) => {
           ]}
         />
       )}
-      {submitFailed && error && <FormMessage intent="danger" message={error} />}
+      {submitFailed && error && (
+        <FormMessage intent="warning" message={error} />
+      )}
       <AuthCardHeader>
         <h1>{FORGOT_PASSWORD_PAGE_TITLE}</h1>
         <h5>{FORGOT_PASSWORD_PAGE_SUBTITLE}</h5>

--- a/app/client/src/pages/UserAuth/Login.tsx
+++ b/app/client/src/pages/UserAuth/Login.tsx
@@ -106,7 +106,7 @@ export const Login = (props: LoginFormProps) => {
     <AuthCardContainer>
       {showError && (
         <FormMessage
-          intent="danger"
+          intent="warning"
           message={LOGIN_PAGE_INVALID_CREDS_ERROR}
           actions={[
             {


### PR DESCRIPTION
Addressing issue found in https://github.com/appsmithorg/appsmith/issues/587

Changed login page credential errors to display the warning icon instead of the danger icon on the form message.