### PR TITLE
Invite user modal in view mode can be closed by clicking outside

### DIFF
--- a/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
+++ b/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
@@ -214,6 +214,7 @@ export const AppViewerHeader = (props: AppViewerHeaderProps) => {
                 orgId={currentOrgId}
                 applicationId={currentApplicationDetails.id}
                 title={currentApplicationDetails.name}
+                canOutsideClickClose={true}
               />
               {CTA}
             </>


### PR DESCRIPTION
Fixes #717 

Added `canOutsideClickClose` to form dialog for share link window which would close the window if clicked outside it.

@satbir121 @Nikhil-Nandagopal for review.

Thanks.