### PR TITLE
docs: client setup troubleshooting for Ubuntu

### DIFF
--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -1,6 +1,6 @@
 ## Running Client Codebase
 Appsmith's client (UI/frontend) uses the ReactJS library and Typescript. The application also uses libraries like react-redux and redux-saga for workflows. We use VS Code Editor as our primary editor
- 
+
 ### Pre-requisites:
 
 On your development machine, please ensure that:
@@ -45,13 +45,13 @@ cd app/client
 Your client is pointing to the cloud staging server https://release-api.appsmith.com
 
 #### If you would like to hit a different appsmith server:
-- Change the API endpoint in the Nginx configuration files (`app/client/docker/templates/nginx-linux.conf.template` or `app/client/docker/templates/nginx-mac.conf.template`). 
+- Change the API endpoint in the Nginx configuration files (`app/client/docker/templates/nginx-linux.conf.template` or `app/client/docker/templates/nginx-mac.conf.template`).
 - Run `start-https.sh` script again.
 - Run
 ```bash
 REACT_APP_ENVIRONMENT=DEVELOPMENT HOST=dev.appsmith.com craco start
 ```
-    
+
 
 #### If you are unable to run docker:
 
@@ -59,3 +59,4 @@ REACT_APP_ENVIRONMENT=DEVELOPMENT HOST=dev.appsmith.com craco start
 2. `proxy_pass` value must be changed from `http://host.docker.internal:3000` to `http://localhost:3000`
 3. Generate the certificates manually via `mkcert`. Check the command in `start-https-server.sh` file.
 4. Change the value of the certificate location for keys `ssl_certificate` & `ssl_certificate_key` to the place where these certificates were generated.
+5. If you ran `./start-https`, but containers failed to start (you have to check with `docker ps` since it fails silently). Some Linux distros (`Ubuntu` for example) have installed and running `apache2` webserver on port `80`. This can result in `Address already in use` error (you can check with `docker logs wildcard-nginx`). Simple solution for this is simply turning it off temporarily with `sudo systemctl stop apache2`. After that just run `./start-https` again.


### PR DESCRIPTION
I have faced a minor issue during client setup that I thought can save somebody (especially not that skilled in Docker yet - like me) fair amount of time. I couldn't start my container via `./start-https` due to conficting ports. The solution was to turn off the default `apache2` webserver on port `80` that is installed by default on Linux Ubuntu (18.04).