### PR TITLE
style: center login form when 3rd party auth is not enabled

### DIFF
--- a/app/client/src/pages/UserAuth/Login.tsx
+++ b/app/client/src/pages/UserAuth/Login.tsx
@@ -164,8 +164,12 @@ export const Login = (props: LoginFormProps) => {
             />
           </FormActions>
         </SpacedSubmitForm>
-        {SocialLoginList.length > 0 && <Divider />}
-        <ThirdPartyAuth type={"SIGNIN"} logins={SocialLoginList} />
+        {SocialLoginList.length > 0 && (
+          <>
+            <Divider />
+            <ThirdPartyAuth type={"SIGNIN"} logins={SocialLoginList} />
+          </>
+        )}
       </AuthCardBody>
       <AuthCardNavLink to={signupURL}>
         {LOGIN_PAGE_SIGN_UP_LINK_TEXT}

--- a/app/client/src/pages/UserAuth/SignUp.tsx
+++ b/app/client/src/pages/UserAuth/SignUp.tsx
@@ -163,8 +163,12 @@ export const SignUp = (props: SignUpFormProps) => {
             />
           </FormActions>
         </SpacedSubmitForm>
-        {SocialLoginList.length > 0 && <Divider />}
-        <ThirdPartyAuth type={"SIGNUP"} logins={SocialLoginList} />
+        {SocialLoginList.length > 0 && (
+          <>
+            <Divider />
+            <ThirdPartyAuth type={"SIGNUP"} logins={SocialLoginList} />
+          </>
+        )}
       </AuthCardBody>
       <AuthCardFooter>
         <TncPPLinks />

--- a/app/client/src/pages/UserAuth/StyledComponents.tsx
+++ b/app/client/src/pages/UserAuth/StyledComponents.tsx
@@ -83,6 +83,9 @@ export const SpacedSubmitForm = styled.form`
   & a {
     font-size: ${props => props.theme.fontSizes[3]}px;
   }
+  &:only-child {
+    margin-right: 0;
+  }
 `;
 
 export const FormActions = styled.div`


### PR DESCRIPTION
Closes #691.

The problem was that 3rd party auth container was rendered despite no 3rd party auth providers should be allowed. I have fixed by adding it to an conditional rendering used for divider.

The second problem was `margin-right` that was set on `form`. This PR removes the margin if the form is the only child, thus has no siblings like 3rd party auth providers.

The changes fix the issues for both Login and Signup.

![image](https://user-images.githubusercontent.com/44962077/95018941-e09ed780-0662-11eb-96c3-f66f657b2ac8.png)
![image](https://user-images.githubusercontent.com/44962077/95018976-0330f080-0663-11eb-8c0e-d7cd25c4c15d.png)

