### PR TITLE
Fix failing Radio tests

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/FormWidgets/Radio_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/FormWidgets/Radio_spec.js
@@ -33,13 +33,10 @@ describe("Radio Widget Functionality", function() {
     cy.radioInput(2, this.data.radio2);
     cy.get(formWidgetsPage.labelradio)
       .eq(1)
-      .should("have.text", "test2");
+      .should("have.text", this.data.radio2);
     cy.radioInput(3, "2");
     cy.get(formWidgetsPage.radioAddButton).click({ force: true });
     cy.radioInput(4, this.data.radio4);
-    cy.get(formWidgetsPage.labelradio)
-      .eq(2)
-      .should("have.text", "test4");
     cy.get(formWidgetsPage.deleteradiovalue)
       .eq(2)
       .click({ force: true });

--- a/app/client/src/utils/Validators.ts
+++ b/app/client/src/utils/Validators.ts
@@ -366,10 +366,10 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
     const hasOptions = _.every(parsed, (datum: { label: any; value: any }) => {
       if (_.isObject(datum)) {
         return (
-            _.isString(datum.label) 
-            && _.isString(datum.value) 
-            && !_.isEmpty(datum.label) 
-            && !_.isEmpty(datum.value)
+          _.isString(datum.label) &&
+          _.isString(datum.value) &&
+          !_.isEmpty(datum.label) &&
+          !_.isEmpty(datum.value)
         );
       } else {
         return false;
@@ -378,7 +378,13 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
     if (!hasOptions) {
       return {
         isValid: false,
-        parsed: [],
+        parsed: parsed.filter(
+          (option: { label: any; value: any }) =>
+            _.isString(option.label) &&
+            _.isString(option.value) &&
+            !_.isEmpty(option.label) &&
+            !_.isEmpty(option.value),
+        ),
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Options Data`,
       };
     }

--- a/app/client/src/utils/Validators.ts
+++ b/app/client/src/utils/Validators.ts
@@ -356,7 +356,6 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
       props,
       dataTree,
     );
-
     if (!isValid) {
       return {
         isValid,

--- a/app/client/src/utils/Validators.ts
+++ b/app/client/src/utils/Validators.ts
@@ -363,6 +363,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Options Data`,
       };
     }
+
     const isValidOption = (option: { label: any; value: any }) =>
       _.isString(option.label) &&
       _.isString(option.value) &&

--- a/app/client/src/utils/Validators.ts
+++ b/app/client/src/utils/Validators.ts
@@ -356,6 +356,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
       props,
       dataTree,
     );
+
     if (!isValid) {
       return {
         isValid,

--- a/app/client/src/utils/Validators.ts
+++ b/app/client/src/utils/Validators.ts
@@ -363,14 +363,15 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Options Data`,
       };
     }
+    const isValidOption = (option: { label: any; value: any }) =>
+      _.isString(option.label) &&
+      _.isString(option.value) &&
+      !_.isEmpty(option.label) &&
+      !_.isEmpty(option.value);
+
     const hasOptions = _.every(parsed, (datum: { label: any; value: any }) => {
       if (_.isObject(datum)) {
-        return (
-          _.isString(datum.label) &&
-          _.isString(datum.value) &&
-          !_.isEmpty(datum.label) &&
-          !_.isEmpty(datum.value)
-        );
+        return isValidOption(datum);
       } else {
         return false;
       }
@@ -378,13 +379,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
     if (!hasOptions) {
       return {
         isValid: false,
-        parsed: parsed.filter(
-          (option: { label: any; value: any }) =>
-            _.isString(option.label) &&
-            _.isString(option.value) &&
-            !_.isEmpty(option.label) &&
-            !_.isEmpty(option.value),
-        ),
+        parsed: parsed.filter(isValidOption),
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Options Data`,
       };
     }


### PR DESCRIPTION
## Description
After changing the validator for radio options (#662), we started seeing tests failing. This was because the validator was sending in empty array (no options) when even one option is invalid. The cypress test was asserting values which will not be present since it is treated as invalid. This PR will fix validator to return valid options and filter out invalid options and also fix the test to not assert invalid options

Fixes #662

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Fixes the cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
