### PR TITLE
Fix Reset password not disabled after successful reset

### DIFF
--- a/app/client/src/pages/UserAuth/ResetPassword.tsx
+++ b/app/client/src/pages/UserAuth/ResetPassword.tsx
@@ -159,6 +159,7 @@ export const ResetPassword = (props: ResetPasswordProps) => {
               name="password"
               type="password"
               placeholder={RESET_PASSWORD_PAGE_PASSWORD_INPUT_PLACEHOLDER}
+              disabled={submitSucceeded}
             />
           </FormGroup>
           <Field type="hidden" name="email" component="input" />
@@ -170,7 +171,7 @@ export const ResetPassword = (props: ResetPasswordProps) => {
               type="submit"
               text={RESET_PASSWORD_SUBMIT_BUTTON_TEXT}
               intent="primary"
-              disabled={pristine}
+              disabled={pristine || submitSucceeded}
               loading={submitting}
             />
           </FormActions>


### PR DESCRIPTION
## Description
The `Reset` button in the reset password page was not disabled after the password was reset successfully. This has been fixed by disabling the `Reset` button and 'New Password' input field after a successful password reset.

**After the changes**
<img src="https://user-images.githubusercontent.com/21107799/95184896-9f830080-07e5-11eb-8061-cd117e15bdc5.jpg" width="450">


Fixes #636 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested it manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
