### PR TITLE
Fix the hidden column list is not bounded and overflows in height (#981)

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableColumnsVisibility.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableColumnsVisibility.tsx
@@ -22,6 +22,9 @@ const DropDownWrapper = styled.div`
   z-index: 1;
   border-radius: 4px;
   border: 1px solid ${Colors.ATHENS_GRAY};
+  max-height: 500px;
+  max-width: 400px;
+  overflow: hidden scroll;
 `;
 
 const OptionWrapper = styled.div<{ selected: boolean }>`
@@ -44,6 +47,13 @@ const OptionWrapper = styled.div<{ selected: boolean }>`
     line-height: 24px;
   }
 `;
+
+const StyledOption = styled.div`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 90%;
+`
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -132,7 +142,7 @@ const TableColumnsVisibility = (props: TableColumnsVisibilityProps) => {
             }}
             className="t--table-column-visibility-column-toggle"
           >
-            <div className="option-title">{option.Header}</div>
+            <StyledOption className="option-title">{option.Header}</StyledOption>
             <VisibilityIcon visible={!option.isHidden} />
           </OptionWrapper>
         ))}


### PR DESCRIPTION
## Description
Hidden column list has now been bounded and had a scroll bar added.
Spacing added between name and Icon.
Text clipped for very long column names and width now bounded.

### Before fix
![Screenshot(5)](https://user-images.githubusercontent.com/25309929/95191569-d5fe5280-07c8-11eb-942b-4024c32033d6.png)


### After fix
![Screenshot(7)](https://user-images.githubusercontent.com/25309929/95191806-2e355480-07c9-11eb-8627-f9c54106c4db.png)

![Screenshot(8)](https://user-images.githubusercontent.com/25309929/95191911-52913100-07c9-11eb-83c2-6f184ed6ae9e.png)

Fixes #981 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually and verified on the following systems.

    Firefox on debian stretch 10
    Chrome on debian stretch 10

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
