### PR TITLE
Fix page name special character bug

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
@@ -14,7 +14,7 @@ import { DataTreeAction } from "entities/DataTree/dataTreeFactory";
 import { homePageIcon, pageIcon } from "../ExplorerIcons";
 import { getActionGroups } from "../Actions/helpers";
 import ExplorerWidgetGroup from "../Widgets/WidgetGroup";
-import { resolveAsEmptyChar } from "utils/helpers";
+import { resolveAsSpaceChar } from "utils/helpers";
 
 type ExplorerPageEntityProps = {
   page: Page;
@@ -66,7 +66,7 @@ export const ExplorerPageEntity = (props: ExplorerPageEntityProps) => {
       isDefaultExpanded={isCurrentPage || !!props.searchKeyword}
       updateEntityName={updatePage}
       contextMenu={contextMenu}
-      onNameEdit={resolveAsEmptyChar}
+      onNameEdit={resolveAsSpaceChar}
     >
       <ExplorerWidgetGroup
         step={props.step + 1}

--- a/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
@@ -14,7 +14,7 @@ import { DataTreeAction } from "entities/DataTree/dataTreeFactory";
 import { homePageIcon, pageIcon } from "../ExplorerIcons";
 import { getActionGroups } from "../Actions/helpers";
 import ExplorerWidgetGroup from "../Widgets/WidgetGroup";
-import { resolveAsSpaceChar } from "utils/helpers";
+import { resolveAsEmptyChar } from "utils/helpers";
 
 type ExplorerPageEntityProps = {
   page: Page;
@@ -66,7 +66,7 @@ export const ExplorerPageEntity = (props: ExplorerPageEntityProps) => {
       isDefaultExpanded={isCurrentPage || !!props.searchKeyword}
       updateEntityName={updatePage}
       contextMenu={contextMenu}
-      onNameEdit={resolveAsSpaceChar}
+      onNameEdit={resolveAsEmptyChar}
     >
       <ExplorerWidgetGroup
         step={props.step + 1}

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -104,13 +104,11 @@ export const flashElementById = (id: string) => {
 export const resolveAsSpaceChar = (value: string, limit?: number) => {
   const separatorRegex = /[^\w\s]/;
   const duplicateSpaceRegex = /\s+/;
-  const endSpaceRegex = /\s*$/;
   return value
     .split(separatorRegex)
     .join("")
     .split(duplicateSpaceRegex)
     .join(" ")
-    .replace(endSpaceRegex, "")
     .slice(0, limit || 30);
 };
 

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -101,11 +101,16 @@ export const flashElementById = (id: string) => {
   if (el) flashElement(el);
 };
 
-export const resolveAsEmptyChar = (value: string, limit?: number) => {
-  const separatorRegex = /[\W_]+/;
+export const resolveAsSpaceChar = (value: string, limit?: number) => {
+  const separatorRegex = /[^\w\s]/;
+  const duplicateSpaceRegex = /\s+/;
+  const endSpaceRegex = /\s*$/;
   return value
     .split(separatorRegex)
     .join("")
+    .split(duplicateSpaceRegex)
+    .join(" ")
+    .replace(endSpaceRegex, "")
     .slice(0, limit || 30);
 };
 

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -101,11 +101,11 @@ export const flashElementById = (id: string) => {
   if (el) flashElement(el);
 };
 
-export const resolveAsSpaceChar = (value: string, limit?: number) => {
+export const resolveAsEmptyChar = (value: string, limit?: number) => {
   const separatorRegex = /[\W_]+/;
   return value
     .split(separatorRegex)
-    .join(" ")
+    .join("")
     .slice(0, limit || 30);
 };
 


### PR DESCRIPTION
## Description
In page name edit, when the user entered a special character cursor shouldn't move with space. Previously defined `resolveAsSpaceChar` function was replace with `resolveAsEmptyChar` function.

Fixes #765 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
