### PR TITLE
Only mark applications as example applications if the application id …

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -275,12 +275,18 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     }
 
     private Flux<Application> setTransientFields(Flux<Application> applicationsFlux) {
-        return configService.getTemplateOrganizationId()
+        return configService.getTemplateApplications()
+                .map(application -> application.getId())
                 .defaultIfEmpty("")
+                .collectList()
                 .cache()
                 .repeat()
-                .zipWith(applicationsFlux, (templateOrganizationId, application) -> {
-                    application.setAppIsExample(templateOrganizationId.equals(application.getOrganizationId()));
+                .zipWith(applicationsFlux)
+                .map(tuple -> {
+                    List<String> templateApplicationIds = tuple.getT1();
+                    Application application = tuple.getT2();
+
+                    application.setAppIsExample(templateApplicationIds.contains(application.getId()));
                     return application;
                 });
     }


### PR DESCRIPTION
…exists in the template configuration.

> Pull Request Template
>
> Use this template to quickly create a well written pull request. Delete all quotes before creating the pull request.

## Description
Currently all the applications inside the example organization are marked as example applications. Instead of this, make this configurable and only applications which have been explicitly mentioned in the configuration as examples should be marked as example organizations.

Fixes # (issue)
> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce. 
> Please also list any relevant details for your test configuration.

- Test `exampleApplicationsAreMarked` has been updated to include 4 applications in the example organization but the config service fetching the example apps only includes 3 out of 4. This is asserted.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
