### PR TITLE
Getting Cypress to work correctly for internal pull requests

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -190,6 +190,10 @@ jobs:
         CYPRESS_TESTPASSWORD1: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
         CYPRESS_TESTUSERNAME2: ${{ secrets.CYPRESS_TESTUSERNAME2 }}
         CYPRESS_TESTPASSWORD2: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
+        COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+        # Recommended: pass the GitHub token lets this action correctly
+        # determine the unique run id necessary to re-run the checks
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         browser: chrome
         headless: true
@@ -200,6 +204,8 @@ jobs:
         ci-build-id: '${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}'
         spec: 'cypress/integration/Smoke_TestSuite/*/*'
         working-directory: app/client
+        # tag will be either "push" or "pull_request_target"
+        tag: ${{ github.event_name }}
 
     # Upload the screenshots as artifacts if there's a failure
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Our Cypress tests are not working properly for internal pull requests & re-running of Github Actions. This is a potential fix for that.