### PR TITLE
fix(autocomplete): show selection background on hover for autocomplete

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -47,6 +47,12 @@ export const HintStyles = createGlobalStyle<{ editorTheme: EditorTheme }>`
   }
   .CodeMirror-Tern-completion {
     padding-left: 22px !important;
+    &:hover{
+      background: ${props =>
+        props.editorTheme === EditorTheme.DARK
+          ? "rgba(244,244,244,0.2)"
+          : "rgba(128,136,141,0.2)"};
+    }
   }
   .CodeMirror-Tern-completion:before {
     left: 4px !important;


### PR DESCRIPTION
## Description
This fix if merged shows the selection background by hovering on autocomplete options.

Fixes #946 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified in the front end with the changes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
![Screenshot from 2020-10-12 00-16-17](https://user-images.githubusercontent.com/26309938/95687650-93060a00-0c22-11eb-970a-cdcaa36a0f24.gif)

Hey @hetunandu @Nikhil-Nandagopal I have made changes and attached a screenshot, please review if it is the change we are expecting here.

Thanks !
