### PR TITLE
Allow Download File Type dropdown to be deselected

### DIFF
--- a/app/client/src/components/editorComponents/actioncreator/ActionCreator.tsx
+++ b/app/client/src/components/editorComponents/actioncreator/ActionCreator.tsx
@@ -37,6 +37,7 @@ const ALERT_STYLE_OPTIONS = [
 ];
 
 const FILE_TYPE_OPTIONS = [
+  { label: 'Select file type (optional)', value: "", id: "" },
   { label: "Plain text", value: "'text/plain'", id: "text/plain" },
   { label: "HTML", value: "'text/html'", id: "text/html" },
   { label: "CSV", value: "'text/csv'", id: "text/csv" },


### PR DESCRIPTION
## Description
Add a default selection to the Download File Type dropdown so that it can be deselected.
![image](https://user-images.githubusercontent.com/17351764/95851548-f4de8500-0d84-11eb-94fa-bacf98d3b977.png)

Fixes #674

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
