### PR TITLE
Fix blank scrollbars on Firefox

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -66,6 +66,7 @@ const CodeWrapper = styled.pre<{ colorTheme: EditorTheme }>`
   margin: 0px 0px;
   background-color: ${props => THEMES[props.colorTheme].editorBackground};
   color: ${props => THEMES[props.colorTheme].editorColor};
+  scrollbar-width: none;
   ::-webkit-scrollbar {
     display: none;
   }
@@ -78,6 +79,7 @@ const TypeText = styled.pre<{ colorTheme: EditorTheme }>`
   padding: 5px;
   background-color: ${props => THEMES[props.colorTheme].editorBackground};
   color: ${props => THEMES[props.colorTheme].editorColor};
+  scrollbar-width: none;
   ::-webkit-scrollbar {
     display: none;
   }

--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -66,7 +66,6 @@ const CodeWrapper = styled.pre<{ colorTheme: EditorTheme }>`
   margin: 0px 0px;
   background-color: ${props => THEMES[props.colorTheme].editorBackground};
   color: ${props => THEMES[props.colorTheme].editorColor};
-  overflow: scroll;
   ::-webkit-scrollbar {
     display: none;
   }
@@ -79,7 +78,6 @@ const TypeText = styled.pre<{ colorTheme: EditorTheme }>`
   padding: 5px;
   background-color: ${props => THEMES[props.colorTheme].editorBackground};
   color: ${props => THEMES[props.colorTheme].editorColor};
-  overflow: scroll;
   ::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
## Description
Fix extra blank scrollbars that showup in the evaluated value popup on Firefox, when there's an external mouse connected.

## Type of change

This is a Bug fix (non-breaking change which fixes an issue).

Before this PR:
![Screenshot 2020-10-13 at 17 02 36](https://user-images.githubusercontent.com/120119/95855588-46cbde80-0d76-11eb-9979-764f6486befa.png)

After this PR:
![Screenshot 2020-10-13 at 17 03 20](https://user-images.githubusercontent.com/120119/95855611-4b909280-0d76-11eb-892a-4b2504031cc3.png)
