### PR TITLE
Don't append " Copy" suffix to cloned pages in cloned application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -327,10 +327,6 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                 .flatMap(page -> clonePageGivenApplicationId(pageId, page.getApplicationId(), " Copy"));
     }
 
-    private Mono<Page> clonePage(Page page) {
-        return clonePageGivenApplicationId(page.getId(), page.getApplicationId(), " Copy");
-    }
-
     private Mono<Page> clonePageGivenApplicationId(String pageId, String applicationId,
                                                    @Nullable String newPageNameSuffix) {
         // Find the source page and then prune the page layout fields to only contain the required fields that should be

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -370,15 +370,20 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                         .map(pageNameIdDTO -> pageNameIdDTO.getName()).collect(Collectors.toSet());
 
                                 String pageName = page.getName();
-                                String newPageName = Strings.isNullOrEmpty(newPageNameSuffix) ?
-                                        pageName : pageName + newPageNameSuffix;
-                                int i = 0;
-                                String name = newPageName;
-                                while(names.contains(name)) {
-                                    i++;
-                                    name = newPageName + i;
+                                String newPageName;
+                                if (Strings.isNullOrEmpty(newPageNameSuffix)) {
+                                    newPageName = pageName;
+                                } else {
+                                    newPageName = pageName + newPageNameSuffix;
+
+                                    int i = 0;
+                                    String name = newPageName;
+                                    while (names.contains(name)) {
+                                        i++;
+                                        name = newPageName + i;
+                                    }
+                                    newPageName = name;
                                 }
-                                newPageName = name;
                                 // Proceed with creating the copy of the page
                                 page.setId(null);
                                 page.setName(newPageName);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -362,7 +362,8 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                     Mono<ApplicationPagesDTO> pageNamesMono = pageService
                             .findNamesByApplicationId(page.getApplicationId());
                     return pageNamesMono
-                            // Set a unique name for the cloned page and then create the page.
+                            // If a new page name suffix is given,
+                            // set a unique name for the cloned page and then create the page.
                             .flatMap(pageNames -> {
                                 Set<String> names = pageNames.getPages()
                                         .stream()
@@ -378,7 +379,7 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                     name = newPageName + i;
                                 }
                                 newPageName = name;
-                                // Now we have a unique name. Proceed with creating the copy of the page
+                                // Proceed with creating the copy of the page
                                 page.setId(null);
                                 page.setName(newPageName);
                                 page.setApplicationId(applicationId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -12,6 +12,7 @@ import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.Page;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
+import com.appsmith.server.dtos.PageNameIdDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.repositories.ApplicationRepository;
@@ -361,16 +362,13 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                             // If a new page name suffix is given,
                             // set a unique name for the cloned page and then create the page.
                             .flatMap(pageNames -> {
-                                Set<String> names = pageNames.getPages()
-                                        .stream()
-                                        .map(pageNameIdDTO -> pageNameIdDTO.getName()).collect(Collectors.toSet());
+                                if (!Strings.isNullOrEmpty(newPageNameSuffix)) {
+                                    String newPageName = page.getName() + newPageNameSuffix;
 
-                                String pageName = page.getName();
-                                String newPageName;
-                                if (Strings.isNullOrEmpty(newPageNameSuffix)) {
-                                    newPageName = pageName;
-                                } else {
-                                    newPageName = pageName + newPageNameSuffix;
+                                    Set<String> names = pageNames.getPages()
+                                            .stream()
+                                            .map(PageNameIdDTO::getName)
+                                            .collect(Collectors.toSet());
 
                                     int i = 0;
                                     String name = newPageName;
@@ -379,10 +377,11 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                         name = newPageName + i;
                                     }
                                     newPageName = name;
+
+                                    page.setName(newPageName);
                                 }
                                 // Proceed with creating the copy of the page
                                 page.setId(null);
-                                page.setName(newPageName);
                                 page.setApplicationId(applicationId);
                                 return pageService.createDefault(page);
                             });

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -560,7 +560,8 @@ public class ApplicationServiceTest {
         Application testApplication = new Application();
         testApplication.setName("ApplicationServiceTest Clone Source TestApp");
 
-        Mono<Application> testApplicationMono = applicationPageService.createApplication(testApplication, orgId);
+        Mono<Application> testApplicationMono = applicationPageService.createApplication(testApplication, orgId)
+                .cache();
 
         Mono<Application> applicationMono = testApplicationMono
                 .flatMap(application -> applicationPageService.cloneApplication(application.getId()))


### PR DESCRIPTION
## Description
When an Application is cloned, the cloned Pages are suffixed with ` Copy` as well. This PR fixes it to not rename Pages that are cloned as part of cloning an Application.

Fixes #698 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
