### PR TITLE
Added an WebExceptionHandler

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.appsmith.server.exceptions;
+
+import com.appsmith.server.dtos.ResponseDTO;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.ResourceProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.DefaultErrorWebExceptionHandler;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.reactive.result.view.ViewResolver;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.all;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+@Component
+@Order(-2)
+public class AppSmithErrorWebExceptionHandler extends DefaultErrorWebExceptionHandler {
+    @Autowired
+    public AppSmithErrorWebExceptionHandler(ErrorAttributes errorAttributes, ResourceProperties resourceProperties,
+                                            ServerProperties serverProperties, ApplicationContext applicationContext,
+                                            ObjectProvider<ViewResolver> viewResolvers,
+                                            ServerCodecConfigurer serverCodecConfigurer) {
+        super(errorAttributes, resourceProperties, serverProperties.getError(), applicationContext);
+        this.setViewResolvers(viewResolvers.orderedStream().collect(Collectors.toList()));
+        this.setMessageWriters(serverCodecConfigurer.getWriters());
+        this.setMessageReaders(serverCodecConfigurer.getReaders());
+    }
+
+    @Override
+    protected RouterFunction<ServerResponse> getRoutingFunction(ErrorAttributes errorAttributes) {
+        return route(all(), this::render);
+    }
+
+    private Mono<ServerResponse> render(ServerRequest request) {
+        Map<String, Object> error = getErrorAttributes(request, false);
+        int errorCode = getHttpStatus(error);
+
+        return ServerResponse.status(errorCode).
+                contentType(MediaType.APPLICATION_JSON).
+                body(BodyInserters.
+                        fromValue(new ResponseDTO<>(errorCode, new ErrorDTO(errorCode, String.valueOf(error.get("error"))))));
+    }
+}


### PR DESCRIPTION
## Description
All the errors which are not handled by `@ExceptionHandler` (ex- 404 by the Netty) are handled by [DefaultErrorWebExceptionHandler](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.html) which is autoconfigured by [Spring boot](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/web/reactive/error/ErrorWebFluxAutoConfiguration.html).

The behaviour of this particular handler is to render an HTML for browsers and JSON for machines (ex- Postman):
https://github.com/spring-projects/spring-boot/blob/bd27756efcad283cf5b6bf790e54ce2a4192c0c7/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandler.java#L109

You can see the below screen shots:
![image](https://user-images.githubusercontent.com/14848874/95925733-7ac4f500-0db2-11eb-8057-f143b24eb16c.png)
![image](https://user-images.githubusercontent.com/14848874/95925742-81ec0300-0db2-11eb-86cc-4a7cd449811d.png)

But for APIs, we can create a custom handler to always render JSON, especially in our expected format. 
Screenshot with this handler:
![image](https://user-images.githubusercontent.com/14848874/95925837-bf509080-0db2-11eb-8ef7-d047c9a157a6.png)

Fixes #804  

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
