### PR TITLE
Add logging to segment SDK

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SegmentConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SegmentConfig.java
@@ -1,11 +1,14 @@
 package com.appsmith.server.configurations;
 
 import com.segment.analytics.Analytics;
+import com.segment.analytics.Log;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@Slf4j
 @Configuration
 @ConditionalOnExpression(value = "!'${segment.writeKey:}'.isEmpty()")
 public class SegmentConfig {
@@ -15,7 +18,26 @@ public class SegmentConfig {
 
     @Bean
     public Analytics analyticsRunner() {
-        return Analytics.builder(writeKey).build();
+        final Log logProcessor = new Log() {
+            @Override
+            public void print(Level level, String format, Object... args) {
+                print(level, null, format, args);
+            }
+
+            @Override
+            public void print(Level level, Throwable error, String format, Object... args) {
+                final String message = "SEGMENT: " + format;
+                if (level == Level.VERBOSE) {
+                    log.trace(message, error, args);
+                } else if (level == Level.DEBUG) {
+                    log.debug(message, error, args);
+                } else if (level == Level.ERROR) {
+                    log.error(message, error, args);
+                }
+            }
+        };
+
+        return Analytics.builder(writeKey).log(logProcessor).build();
     }
 
 }


### PR DESCRIPTION
This implementation allows us to configure the log level of Segment via setting the application property `logging.level.com.appsmith.server.configurations=trace`.