### PR TITLE
Solving issue with page naming

### DIFF
--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -102,11 +102,7 @@ export const flashElementById = (id: string) => {
 };
 
 export const resolveAsSpaceChar = (value: string, limit?: number) => {
-  const separatorRegex = /[\W_]+/;
-  return value
-    .split(separatorRegex)
-    .join(" ")
-    .slice(0, limit || 30);
+  return value.slice(0, limit || 30);
 };
 
 export const isMac = () => {


### PR DESCRIPTION

## Description
Page names were not accepting special characters , there is a function 'resolveAsSpaceChar' in helpers , that converted any special character to a space , which was being used in the page name editor , ''onNameEdit" , I updated this resolve function to not convert it into spaces and thus now special characters are allowed. Solving issue #955 

Fixes #955 

## Type of change
Changed function 'resolveAsSpaceChar' , in helpers

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local device testing over yarn start server
- Test on code and demo
- Ran cypress integration test

## Checklist:

- [Y ] My code follows the style guidelines of this project
- [Y ] I have performed a self-review of my own code
- [Y ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [Y ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [Y ] New and existing unit tests pass locally with my changes
