### PR TITLE
Added email verification while creating user and sending email

### DIFF
--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -124,6 +124,12 @@
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
+
 
         <!-- Plugin dependencies -->
         <!-- This has to be declared BEFORE the com.appsmith:interfaces dependency. -->

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/User.java
@@ -15,6 +15,7 @@ import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.util.StringUtils;
 
+import javax.validation.constraints.Email;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,6 +31,7 @@ public class User extends BaseDomain implements UserDetails, OidcUser {
 
     private String name;
 
+    @Email
     private String email;
 
     //TODO: This is deprecated in favour of groups

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/controllers/UserControllerTest.java
@@ -1,0 +1,86 @@
+package com.appsmith.server.controllers;
+
+import com.appsmith.server.configurations.SecurityTestConfig;
+import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.services.UserOrganizationService;
+import com.appsmith.server.services.UserService;
+import com.appsmith.server.solutions.UserSignup;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@WebFluxTest(UserController.class)
+@Import(SecurityTestConfig.class)
+public class UserControllerTest {
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private SessionUserService sessionUserService;
+
+    @MockBean
+    private UserOrganizationService userOrganizationService;
+
+    @MockBean
+    private UserSignup userSignup;
+
+    @Test
+    @WithMockUser
+    public void createUserWithInvalidEmailAddress() {
+        List<String> invalidAddresses = Arrays.asList(
+                "plainaddress",
+                "#@%^%#$@#$@#.com",
+                "@example.com",
+                "Joe Smith <email@example.com>",
+                "email.example.com",
+                "email@example@example.com",
+                ".email@example.com",
+                "email.@example.com",
+                "email..email@example.com",
+                "email@example.com (Joe Smith)",
+                "email@-example.com",
+                "email@example..com",
+                "Abc..123@example.com"
+        );
+        for (String invalidAddress : invalidAddresses) {
+            try {
+                webTestClient.post().uri("/api/v1/users").
+                        contentType(MediaType.APPLICATION_JSON).
+                        body(BodyInserters.fromValue(String.format("{\"name\":\"test-name\"," +
+                                "\"email\":\"%s\",\"password\":\"test-password\"}", invalidAddress))).
+                        exchange().
+                        expectStatus().isEqualTo(400).
+                        expectBody().json("{\n" +
+                        "    \"responseMeta\": {\n" +
+                        "        \"status\": 400,\n" +
+                        "        \"success\": false,\n" +
+                        "        \"error\": {\n" +
+                        "            \"code\": 4028,\n" +
+                        "            \"message\": \"Validation Failure(s): {email=must be a well-formed email address}\"\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}");
+            } catch (Throwable exc) {
+                System.out.println("******************************");
+                System.out.println(String.format("Failed for >>> %s", invalidAddress));
+                System.out.println("******************************");
+                throw exc;
+            }
+        }
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/notifications/EmailSenderTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/notifications/EmailSenderTest.java
@@ -4,7 +4,6 @@ import com.appsmith.server.configurations.EmailConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -17,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -56,7 +56,7 @@ public class EmailSenderTest {
             try {
                 emailSender.sendMail(invalidAddress, "test-subject", "email/welcomeUserTemplate.html", Collections.emptyMap()).block();
 
-                Mockito.verifyNoInteractions(javaMailSender);
+                verifyNoInteractions(javaMailSender);
             } catch (Throwable exc) {
                 System.out.println("******************************");
                 System.out.println(String.format("Failed for >>> %s", invalidAddress));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/notifications/EmailSenderTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/notifications/EmailSenderTest.java
@@ -1,0 +1,68 @@
+package com.appsmith.server.notifications;
+
+import com.appsmith.server.configurations.EmailConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.doReturn;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@DirtiesContext
+public class EmailSenderTest {
+    @MockBean
+    private JavaMailSender javaMailSender;
+
+    @MockBean
+    private EmailConfig emailConfig;
+
+    @Autowired
+    private EmailSender emailSender;
+
+    @Test
+    public void itShouldNotSendMailsWithInvalidAddresses() {
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(true).when(emailConfig).isEmailEnabled();
+        List<String> invalidAddresses = Arrays.asList(
+                "plainaddress",
+                "#@%^%#$@#$@#.com",
+                "@example.com",
+                "Joe Smith <email@example.com>",
+                "email.example.com",
+                "email@example@example.com",
+                ".email@example.com",
+                "email.@example.com",
+                "email..email@example.com",
+                "email@example.com (Joe Smith)",
+                "email@-example.com",
+                "email@example..com",
+                "Abc..123@example.com"
+        );
+
+        for (String invalidAddress : invalidAddresses) {
+            try {
+                emailSender.sendMail(invalidAddress, "test-subject", "email/welcomeUserTemplate.html", Collections.emptyMap()).block();
+
+                Mockito.verifyNoInteractions(javaMailSender);
+            } catch (Throwable exc) {
+                System.out.println("******************************");
+                System.out.println(String.format("Failed for >>> %s", invalidAddress));
+                System.out.println("******************************");
+                throw exc;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Added email verification during `User `creation by adding Java validation API `@Email` annotation on the `email `field of the `User `object. Updated the email verification logic in the `EmailSender `using Apache commons validator's `EmailValidator`

Fixes #627 

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally using Postman

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
