### PR TITLE
BugFix (#944): Add HTTP prefix to URLs in RestApiPlugin and RapidApiPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Appsmith doesn't take the fun out of coding, because it treats every block as an
 * **5 minute setup**: Deploy Appsmith on your servers in 5 minutes.
 * **Build custom UI**: Drag & drop, resize and style widgets **without HTML / CSS**.
 * **Query data**: Query & update your database directly from the UI. Connect to **PostgreSQL, MongoDB, MySQL, REST & GraphQL APIs**.
-* **JS Logic**: Write snippets of business logic using JS to transform data, manipuate UI or trigger workflows. Use popular libraries like lodash & moment anywhere in the app
+* **JS Logic**: Write snippets of business logic using JS to transform data, manipulate UI or trigger workflows. Use popular libraries like lodash & moment anywhere in the app
 * **Data Workflows**: Simple configuration to create flows when users interact with the UI.
 * **Realtime Editor**: Changes in your application reflect instantly with every edit. No need to compile!
 * **Works with existing, live databases**: Connect directly to any PostgreSQL, MySQL & MongoDB

--- a/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
+++ b/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
@@ -289,7 +289,7 @@ public class RapidApiPlugin extends BasePlugin {
         }
 
         private String addHttpToUrlWhenPrefixNotPresent(String url) {
-            if (url.toLowerCase().startsWith("http") || url.contains("://")) {
+            if (url == null || url.toLowerCase().startsWith("http") || url.contains("://")) {
                 return url;
             }
             return "http://" + url;

--- a/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
+++ b/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
@@ -103,7 +103,8 @@ public class RapidApiPlugin extends BasePlugin {
 
             URI uri;
             try {
-                uri = createFinalUriWithQueryParams(url, actionConfiguration.getQueryParameters());
+                String httpUrl = addHttpToUrlWhenPrefixNotPresent(url);
+                uri = createFinalUriWithQueryParams(httpUrl, actionConfiguration.getQueryParameters());
                 log.info("Final URL is : {}", uri);
             } catch (URISyntaxException e) {
                 e.printStackTrace();
@@ -285,6 +286,13 @@ public class RapidApiPlugin extends BasePlugin {
                     webClientBuilder.defaultHeader(header.getKey(), header.getValue());
                 }
             }
+        }
+
+        private String addHttpToUrlWhenPrefixNotPresent(String url) {
+            if (url.toLowerCase().startsWith("http") || url.contains("://")) {
+                return url;
+            }
+            return "http://" + url;
         }
 
         private URI createFinalUriWithQueryParams(String url, List<Property> queryParams) throws URISyntaxException {

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -364,7 +364,7 @@ public class RestApiPlugin extends BasePlugin {
         }
 
         private String addHttpToUrlWhenPrefixNotPresent(String url) {
-            if (url.toLowerCase().startsWith("http") || url.contains("://")) {
+            if (url == null || url.toLowerCase().startsWith("http") || url.contains("://")) {
                 return url;
             }
             return "http://" + url;

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -81,7 +81,8 @@ public class RestApiPlugin extends BasePlugin {
             HttpMethod httpMethod = actionConfiguration.getHttpMethod();
             URI uri;
             try {
-                uri = createFinalUriWithQueryParams(url, actionConfiguration.getQueryParameters());
+                String httpUrl = addHttpToUrlWhenPrefixNotPresent(url);
+                uri = createFinalUriWithQueryParams(httpUrl, actionConfiguration.getQueryParameters());
             } catch (URISyntaxException e) {
                 ActionExecutionRequest actionExecutionRequest = populateRequestFields(actionConfiguration, null);
                 actionExecutionRequest.setUrl(url);
@@ -360,6 +361,13 @@ public class RestApiPlugin extends BasePlugin {
                 }
             }
             return contentType;
+        }
+
+        private String addHttpToUrlWhenPrefixNotPresent(String url) {
+            if (url.toLowerCase().startsWith("http") || url.contains("://")) {
+                return url;
+            }
+            return "http://" + url;
         }
 
         private URI createFinalUriWithQueryParams(String url, List<Property> queryParams) throws URISyntaxException {


### PR DESCRIPTION
## Description
Both REST and Rapid API Plugins had a dependency on the user adding the URL prefix, such as HTTP or HTTPS. With this change, by default, when the URL does not have a prefix, "http://" is added to the URL.
Additionally, found a quick typo in the main README.md for the word "manipulate" and fixed it.

Fixes #944 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce. 
> Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
