### PR TITLE
Update widgetId references to a copied TABS_WIDGET's tabs property

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -42,7 +42,7 @@ import {
 } from "actions/controlActions";
 import { isDynamicValue } from "utils/DynamicBindingUtils";
 import { WidgetProps } from "widgets/BaseWidget";
-import _ from "lodash";
+import _, { isString } from "lodash";
 import WidgetFactory from "utils/WidgetFactory";
 import {
   buildWidgetBlueprint,
@@ -867,6 +867,26 @@ function* pasteWidgetSaga() {
           }
         });
       }
+
+      // Update the tabs for the tabs widget.
+      if (widget.tabs && widget.type === WidgetTypes.TABS_WIDGET) {
+        try {
+          const tabs = isString(widget.tabs)
+            ? JSON.parse(widget.tabs)
+            : widget.tabs;
+          if (Array.isArray(tabs)) {
+            widget.tabs = JSON.stringify(
+              tabs.map(tab => {
+                tab.widgetId = widgetIdMap[tab.widgetId];
+                return tab;
+              }),
+            );
+          }
+        } catch (error) {
+          log.debug("Error updating tabs", error);
+        }
+      }
+
       // If it is the copied widget, update position properties
       if (widget.widgetId === widgetIdMap[copiedWidget.widgetId]) {
         newWidgetId = widget.widgetId;


### PR DESCRIPTION
## Description
The issue was caused due to the fact that when pasting a tabs widget, the references to the new child widgetIds in the `tabs` property of the tabs widget were not updated. Resulting in pasted widgets being reflected in the original tabs widget.

Fixes #1258 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- The fix will not fix existing widgets. Users with "copied" tabs widget, will have to delete them and paste again for the fix to work.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
