### PR TITLE
Fix keyboard shortcuts on windows and linux machines

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ExplorerTests/Entity_Explorer_Widgets_Copy_Paste_Delete_Undo_Keyboard_Event_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ExplorerTests/Entity_Explorer_Widgets_Copy_Paste_Delete_Undo_Keyboard_Event_spec.js
@@ -8,13 +8,14 @@ const widgetsPage = require("../../../locators/Widgets.json");
 const dsl = require("../../../fixtures/formWidgetdsl.json");
 
 const pageid = "MyPage";
-
 before(() => {
   cy.addDsl(dsl);
 });
 
 describe("Test Suite to validate copy/delete/undo functionalites", function() {
   it("Drag and drop form widget and validate copy widget via toast message", function() {
+    const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
+
     cy.openPropertyPane("formwidget");
     cy.widgetText(
       "FormTest",
@@ -22,12 +23,12 @@ describe("Test Suite to validate copy/delete/undo functionalites", function() {
       formWidgetsPage.formInner,
     );
     cy.get("body").click();
-    cy.get("body").type("{meta}c");
+    cy.get("body").type(`{${modifierKey}}c`);
     cy.wait(500);
     cy.get(commonlocators.toastBody)
       .first()
       .contains("Copied");
-    cy.get("body").type("{meta}v", { force: true });
+    cy.get("body").type(`{${modifierKey}}v`, { force: true });
     cy.wait("@updateLayout").should(
       "have.nested.property",
       "response.body.responseMeta.status",

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -69,7 +69,7 @@ class Editor extends Component<Props> {
       <Hotkeys>
         <Hotkey
           global={true}
-          combo="meta + f"
+          combo="mod + f"
           label="Search entities"
           onKeyDown={(e: any) => {
             const entitySearchInput = document.getElementById(
@@ -86,7 +86,7 @@ class Editor extends Component<Props> {
         />
         <Hotkey
           global={true}
-          combo="meta + c"
+          combo="mod + c"
           label="Copy Widget"
           group="Canvas"
           onKeyDown={(e: any) => {
@@ -97,7 +97,7 @@ class Editor extends Component<Props> {
         />
         <Hotkey
           global={true}
-          combo="meta + v"
+          combo="mod + v"
           label="Paste Widget"
           group="Canvas"
           onKeyDown={(e: any) => {
@@ -141,7 +141,7 @@ class Editor extends Component<Props> {
         />
         <Hotkey
           global={true}
-          combo="meta + x"
+          combo="mod + x"
           label="Cut Widget"
           group="Canvas"
           onKeyDown={(e: any) => {


### PR DESCRIPTION
## Description
Due to the use of incorrect hotkey modifier, Ctrl + C, Ctrl + V and Ctrl + X combos did not work on windows and linux machines.

Fixes #704 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested on Windows machine.
Not tested on linux machines.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
