### PR TITLE
Fixing the build for mssql plugin

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/mssqlPlugin/pom.xml
@@ -104,6 +104,16 @@
                         </manifestEntries>
                     </transformer>
                     </transformers>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This is a hotfix for fixing the build step for the MsSQL jar. Since the dependency is a signed jar, we need to exclude some of files from the Manifest file in the final jar. Without this exclusion, the `mssql-plugin` will not come up.