### PR TITLE
fix theme breaking with a slash in url

### DIFF
--- a/app/client/src/AppRouter.tsx
+++ b/app/client/src/AppRouter.tsx
@@ -42,8 +42,8 @@ const loadingIndicator = <PageLoadingBar />;
 
 function changeAppBackground(currentTheme: any) {
   if (
-    window.location.pathname === "/applications" ||
-    window.location.pathname.indexOf("/settings/") !== -1
+    window.location.pathname.indexOf("/applications") !== -1 ||
+    window.location.pathname.indexOf("/settings") !== -1
   ) {
     document.body.style.backgroundColor =
       currentTheme.colors.homepageBackground;

--- a/app/client/src/AppRouter.tsx
+++ b/app/client/src/AppRouter.tsx
@@ -36,14 +36,16 @@ import { connect } from "react-redux";
 
 import * as Sentry from "@sentry/react";
 import AnalyticsUtil from "utils/AnalyticsUtil";
+import { trimTrailingSlash } from "utils/helpers";
+
 const SentryRoute = Sentry.withSentryRouting(Route);
 
 const loadingIndicator = <PageLoadingBar />;
 
 function changeAppBackground(currentTheme: any) {
   if (
-    window.location.pathname.indexOf("/applications") !== -1 ||
-    window.location.pathname.indexOf("/settings") !== -1
+    trimTrailingSlash(window.location.pathname) === "/applications" ||
+    window.location.pathname.indexOf("/settings/") !== -1
   ) {
     document.body.style.backgroundColor =
       currentTheme.colors.homepageBackground;

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -117,3 +117,22 @@ export const isMac = () => {
     typeof navigator !== "undefined" ? navigator.platform : undefined;
   return !platform ? false : /Mac|iPod|iPhone|iPad/.test(platform);
 };
+
+/**
+ * Removes the trailing slashes from the path
+ * @param path
+ * @example
+ * ```js
+ * let trimmedUrl = trimTrailingSlash('/url/')
+ * console.log(trimmedUrl) //will output /url
+ * ```
+ * @example
+ * ```js
+ * let trimmedUrl = trimTrailingSlash('/yet-another-url//')
+ * console.log(trimmedUrl) // will output /yet-another-url
+ * ```
+ */
+export const trimTrailingSlash = (path: string) => {
+  const trailingUrlRegex = /\/+$/;
+  return path.replace(trailingUrlRegex, "");
+};


### PR DESCRIPTION
## Description
Fixes the issue of theme not properly loading in /applications/ route

Fixes #1386

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A tested with loading `/applications`, `/applications/`, `/settings`, `/settings/` routes theme was loading properly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Hey @trishaanand @mohanarpit can you review the code for the fix?