### PR TITLE
Bug Fix : Reading the datasource configuration incorrectly from actionDTO instead of datasource object.

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -488,6 +488,7 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
                         return datasourceService.validateDatasource(datasource);
                     }
 
+                    // The external datasources have already been validated. No need to validate again.
                     return Mono.just(datasource);
                 })
                 .flatMap(datasource -> {
@@ -515,7 +516,8 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
                     final Datasource datasource = tuple.getT2();
                     final PluginExecutor pluginExecutor = tuple.getT3();
 
-                    DatasourceConfiguration datasourceConfiguration = action.getDatasource().getDatasourceConfiguration();
+
+                    DatasourceConfiguration datasourceConfiguration = datasource.getDatasourceConfiguration();
                     ActionConfiguration actionConfiguration = action.getActionConfiguration();
 
                     prepareConfigurationsForExecution(action, datasource, executeActionDTO, actionConfiguration, datasourceConfiguration);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/MockPluginExecutor.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/MockPluginExecutor.java
@@ -14,8 +14,19 @@ public class MockPluginExecutor implements PluginExecutor {
 
     @Override
     public Mono<ActionExecutionResult> execute(Object connection, DatasourceConfiguration datasourceConfiguration, ActionConfiguration actionConfiguration) {
+        if (actionConfiguration == null) {
+            return Mono.error(new Exception("ActionConfiguration is null"));
+        }
+        if (datasourceConfiguration == null) {
+            return Mono.error(new Exception("DatasourceConfiguration is null"));
+        }
         System.out.println("In the execute");
-        return null;
+
+        ActionExecutionResult actionExecutionResult = new ActionExecutionResult();
+        actionExecutionResult.setBody("");
+        actionExecutionResult.setIsExecutionSuccess(true);
+        actionExecutionResult.setStatusCode("200");
+        return Mono.just(actionExecutionResult);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1416

## Description
RestAPI throwing null pointer exception because of datasource configuration being null. This happened because we were reading datasource configuration from the action object instead of datasource object (which may or may not have been pulled from datasources collection). In case of external datasource, this was not populated correctly.

This was not caught during regression or manual testing because usually we do not use external datasources for rest api. We instead usually only use embedded datasources.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
