### PR TITLE
fix lightning bolt menu onhover bug

### DIFF
--- a/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
+++ b/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
@@ -62,7 +62,7 @@ export const getApiOptions = (
     text: LIGHTNING_MENU_DATA_API,
   },
   openDirection: Directions.RIGHT,
-  openOnHover: false,
+  openOnHover: true,
   skin: skin,
   modifiers: {
     offset: {

--- a/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
+++ b/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
@@ -111,7 +111,7 @@ export const getQueryOptions = (
     text: LIGHTNING_MENU_DATA_QUERY,
   },
   openDirection: Directions.RIGHT,
-  openOnHover: false,
+  openOnHover: true,
   skin: skin,
   modifiers: {
     offset: {
@@ -141,7 +141,7 @@ export const getWidgetOptions = (
     text: LIGHTNING_MENU_DATA_WIDGET,
   },
   openDirection: Directions.RIGHT,
-  openOnHover: false,
+  openOnHover: true,
   skin: skin,
   modifiers: {
     offset: {


### PR DESCRIPTION
## Description
The widgets can call for data from API or Datasources. This happens when the user will click on the lightning bolt to choose a data source. The interaction as of now is that they have to click on each of them to add. This has been changed to hover in this PR.

Fixes #1363 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- UI test
- Cypress does not have a [`cy.hover()`](https://docs.cypress.io/api/commands/hover.htm) command. As suggested in workaround, test cases remain as `click({ force: true })`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
