### PR TITLE
Add post eval action support

### DIFF
--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -2,6 +2,7 @@ import { FetchPageRequest, SavePageResponse } from "api/PageApi";
 import { WidgetOperation, WidgetProps } from "widgets/BaseWidget";
 import { WidgetType } from "constants/WidgetConstants";
 import {
+  EvaluationReduxAction,
   ReduxAction,
   ReduxActionTypes,
   UpdateCanvasPayload,
@@ -46,9 +47,13 @@ export const fetchPublishedPage = (pageId: string, bustCache = false) => ({
   },
 });
 
-export const fetchPageSuccess = () => {
+export const fetchPageSuccess = (
+  postEvalActions: ReduxAction<unknown>[],
+): EvaluationReduxAction<unknown> => {
   return {
     type: ReduxActionTypes.FETCH_PAGE_SUCCESS,
+    payload: {},
+    postEvalActions,
   };
 };
 
@@ -60,9 +65,11 @@ export type FetchPublishedPageSuccessPayload = {
 
 export const fetchPublishedPageSuccess = (
   payload: FetchPublishedPageSuccessPayload,
-) => ({
+  postEvalActions: ReduxAction<unknown>[],
+): EvaluationReduxAction<FetchPublishedPageSuccessPayload> => ({
   type: ReduxActionTypes.FETCH_PUBLISHED_PAGE_SUCCESS,
   payload,
+  postEvalActions,
 });
 
 export const updateCurrentPage = (id: string) => ({

--- a/app/client/src/actions/widgetActions.tsx
+++ b/app/client/src/actions/widgetActions.tsx
@@ -30,11 +30,10 @@ export const executeActionError = (
 
 export const executePageLoadActions = (
   payload: PageAction[][],
-): BatchAction<PageAction[][]> =>
-  batchAction({
-    type: ReduxActionTypes.EXECUTE_PAGE_LOAD_ACTIONS,
-    payload,
-  });
+): ReduxAction<PageAction[][]> => ({
+  type: ReduxActionTypes.EXECUTE_PAGE_LOAD_ACTIONS,
+  payload,
+});
 
 export const disableDragAction = (
   isDraggingDisabled: boolean,

--- a/app/client/src/constants/ReduxActionConstants.tsx
+++ b/app/client/src/constants/ReduxActionConstants.tsx
@@ -410,6 +410,11 @@ export type ReduxActionWithoutPayload = Pick<ReduxAction<undefined>, "type">;
 export interface ReduxActionWithMeta<T, M> extends ReduxAction<T> {
   meta: M;
 }
+
+export interface EvaluationReduxAction<T> extends ReduxAction<T> {
+  postEvalActions?: ReduxAction<any>[];
+}
+
 export interface PromisePayload {
   reject: any;
   resolve: any;

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -43,6 +43,7 @@ import {
   select,
   takeLatest,
   takeLeading,
+  take,
 } from "redux-saga/effects";
 import history from "utils/history";
 import { BUILDER_PAGE_URL } from "constants/routes";
@@ -173,9 +174,12 @@ export function* fetchPageSaga(
       // set current page
       yield put(updateCurrentPage(id));
       // dispatch fetch page success
-      yield put(fetchPageSuccess());
-      // Execute page load actions
-      yield put(executePageLoadActions(canvasWidgetsPayload.pageActions));
+      yield put(
+        fetchPageSuccess([
+          // Execute page load actions after evaluation of fetch page
+          executePageLoadActions(canvasWidgetsPayload.pageActions),
+        ]),
+      );
 
       // Add this to the page DSLs for entity explorer
       yield put({
@@ -237,17 +241,19 @@ export function* fetchPublishedPageSaga(
       yield put(updateCurrentPage(pageId));
       // dispatch fetch page success
       yield put(
-        fetchPublishedPageSuccess({
-          dsl: response.data.layouts[0].dsl,
-          pageId: request.pageId,
-          pageWidgetId: canvasWidgetsPayload.pageWidgetId,
-        }),
+        fetchPublishedPageSuccess(
+          {
+            dsl: response.data.layouts[0].dsl,
+            pageId: request.pageId,
+            pageWidgetId: canvasWidgetsPayload.pageWidgetId,
+          },
+          // Execute page load actions post published page eval
+          [executePageLoadActions(canvasWidgetsPayload.pageActions)],
+        ),
       );
-      // Execute page load actions
       PerformanceTracker.stopAsyncTracking(
         PerformanceTransactionName.FETCH_PAGE_API,
       );
-      yield put(executePageLoadActions(canvasWidgetsPayload.pageActions));
     }
   } catch (error) {
     PerformanceTracker.stopAsyncTracking(

--- a/app/client/src/selectors/dataTreeSelectors.ts
+++ b/app/client/src/selectors/dataTreeSelectors.ts
@@ -3,7 +3,6 @@ import { getActionsForCurrentPage, getAppData } from "./entitiesSelector";
 import { ActionDataState } from "reducers/entityReducers/actionsReducer";
 import { DataTree, DataTreeFactory } from "entities/DataTree/dataTreeFactory";
 import { getWidgets, getWidgetsMeta } from "sagas/selectors";
-import * as log from "loglevel";
 import "url-search-params-polyfill";
 import { getPageList } from "./appViewSelectors";
 import PerformanceTracker, {

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -942,14 +942,14 @@ const evaluate = (
 
       // Set it to self
       Object.keys(GLOBAL_DATA).forEach(key => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
         self[key] = GLOBAL_DATA[key];
       });
 
       ///// Adding extra libraries separately
       extraLibraries.forEach(library => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
         self[library.accessor] = library.lib;
       });
@@ -959,7 +959,7 @@ const evaluate = (
       // Remove it from self
       // This is needed so that next eval can have a clean sheet
       Object.keys(GLOBAL_DATA).forEach(key => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
         delete self[key];
       });

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -63,8 +63,7 @@ ctx.addEventListener("message", e => {
     }
     case EVAL_WORKER_ACTIONS.EVAL_SINGLE: {
       const { binding, dataTree } = rest;
-      const evalTree = getEvaluatedDataTree(dataTree);
-      const withFunctions = addFunctions(evalTree);
+      const withFunctions = addFunctions(dataTree);
       const value = getDynamicValue(binding, withFunctions, false);
       ctx.postMessage({ value, errors: ERRORS });
       ERRORS = [];
@@ -943,14 +942,14 @@ const evaluate = (
 
       // Set it to self
       Object.keys(GLOBAL_DATA).forEach(key => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         self[key] = GLOBAL_DATA[key];
       });
 
       ///// Adding extra libraries separately
       extraLibraries.forEach(library => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         self[library.accessor] = library.lib;
       });
@@ -960,7 +959,7 @@ const evaluate = (
       // Remove it from self
       // This is needed so that next eval can have a clean sheet
       Object.keys(GLOBAL_DATA).forEach(key => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         delete self[key];
       });


### PR DESCRIPTION
## Description
Action execution needs an evaluation of all bindings before the server call is made. This means onLoadActions need to ensure an evaluation has taken place before it can execute. This PR will implement a postEvalActions support to any eval subscriber actions which lets it list any actions that need to be dispatched after evaluation trigger has successfully evaluated.

Fixes #1504

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
