### PR TITLE
Added fallback email to new organization from user email

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
@@ -147,6 +147,10 @@ public class OrganizationServiceImpl extends BaseService<OrganizationRepository,
             return Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS));
         }
 
+        if (organization.getEmail() == null) {
+            organization.setEmail(user.getEmail());
+        }
+
         Mono<Organization> setSlugMono;
         if (organization.getName() == null) {
             setSlugMono = Mono.just(organization);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
@@ -148,6 +148,7 @@ public class OrganizationServiceTest {
                     assertThat(organization1.getPolicies()).isNotEmpty();
                     assertThat(organization1.getPolicies()).containsAll(Set.of(manageOrgAppPolicy, manageOrgPolicy));
                     assertThat(organization1.getSlug() != null);
+                    assertThat(organization1.getEmail()).isEqualTo("api_user");
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
Modified new organization creation to use the current user email as default if no email has been provided. This behaviour is meant to indicate POC for a new organization. Possible UI change corresponding to this is being discussed in the issue.

Fixes #782 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Added additional assertion to create organization test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
