### PR TITLE
Handle null regex parts in input widget regex function

### DIFF
--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -58,19 +58,20 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
             * Example /appsmith/i will be split into ["/appsmith/gi", "/", "appsmith", "gi"]
             */
             const regexParts = this.regex.match(/(\\/?)(.+)\\1([a-z]*)/i);
-            if (regexParts === null) {
+            if (!regexParts) {
               parsedRegex = new RegExp(this.regex);
+            } else {
+              /*
+              * if we don't have a regex flags (gmisuy), convert provided string into regexp directly
+              /*
+              if (regexParts[3] && !/^(?!.*?(.).*?\\1)[gmisuy]+$/.test(regexParts[3])) {
+                parsedRegex = RegExp(this.regex);
+              }
+              /*
+              * if we have a regex flags, use it to form regexp
+              */
+              parsedRegex = new RegExp(regexParts[2], regexParts[3]);
             }
-            /*
-            * if we don't have a regex flags (gmisuy), convert provided string into regexp directly
-            /*
-            if (regexParts[3] && !/^(?!.*?(.).*?\\1)[gmisuy]+$/.test(regexParts[3])) {
-              parsedRegex = RegExp(this.regex);
-            }
-            /*
-            * if we have a regex flags, use it to form regexp
-            */
-            parsedRegex = new RegExp(regexParts[2], regexParts[3]);
           }
           if (this.inputType === "EMAIL") {
             const emailRegex = new RegExp(/^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$/);


### PR DESCRIPTION
## Description
Input widget's regex function fails when `regexParts` is null.
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
