### PR TITLE
Fix-Table header and body length going out of sync if extended via width

### DIFF
--- a/app/client/src/components/designSystems/appsmith/Table.tsx
+++ b/app/client/src/components/designSystems/appsmith/Table.tsx
@@ -151,7 +151,11 @@ export const Table = (props: TableProps) => {
       />
       <div className={props.isLoading ? Classes.SKELETON : "tableWrap"}>
         <div {...getTableProps()} className="table">
-          <div onMouseOver={props.disableDrag} onMouseLeave={props.enableDrag}>
+          <div
+            onMouseOver={props.disableDrag}
+            onMouseLeave={props.enableDrag}
+            className="thead"
+          >
             {headerGroups.map((headerGroup: any, index: number) => (
               <div
                 {...headerGroup.getHeaderGroupProps()}

--- a/app/client/src/components/designSystems/appsmith/TableStyledWrappers.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableStyledWrappers.tsx
@@ -21,8 +21,7 @@ export const TableWrapper = styled.div<{
   .tableWrap {
     height: 100%;
     display: block;
-    overflow-x: auto;
-    overflow-y: hidden;
+    overflow: auto;
   }
   .table {
     border-spacing: 0;
@@ -36,13 +35,6 @@ export const TableWrapper = styled.div<{
       overflow: hidden;
     }
     .tbody {
-      overflow-y: scroll;
-      /* Subtracting 9px to handling widget padding */
-      height: ${props =>
-        props.height -
-        props.tableSizes.TABLE_HEADER_HEIGHT -
-        props.tableSizes.COLUMN_HEADER_HEIGHT -
-        9}px;
       .tr {
         width: 100%;
       }
@@ -103,6 +95,11 @@ export const TableWrapper = styled.div<{
       height: ${props => props.tableSizes.ROW_HEIGHT}px;
       line-height: ${props => props.tableSizes.ROW_HEIGHT}px;
       padding: 0 10px;
+    }
+    .thead {
+      position: sticky;
+      top: 0;
+      z-index: 1;
     }
   }
   .draggable-header,


### PR DESCRIPTION
## Description
Used display table to style table and adding overflow to wrapper div of table instead inner overflow.

Fixes #982 
> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
