### PR TITLE
Remove extra dependency and use browser atob and btoa

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -62,7 +62,6 @@
     "instantsearch.js": "^4.4.1",
     "interweave": "^12.1.1",
     "interweave-autolink": "^4.0.1",
-    "js-base64": "^3.4.5",
     "js-sha256": "^0.9.0",
     "json-fn": "^1.1.1",
     "lint-staged": "^9.2.5",

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -5,7 +5,6 @@ import {
 } from "constants/BindingsConstants";
 import { Action } from "entities/Action";
 import moment from "moment-timezone";
-import { atob, btoa, version as BASE64LIBVERSION } from "js-base64";
 
 type StringTuple = [string, string];
 
@@ -127,19 +126,5 @@ export const extraLibraries: ExtraLibrary[] = [
     version: moment.version,
     docsURL: `https://momentjs.com/docs/`,
     displayName: "moment",
-  },
-  {
-    accessor: "btoa",
-    lib: btoa,
-    version: BASE64LIBVERSION,
-    docsURL: "https://github.com/dankogai/js-base64#readme",
-    displayName: "btoa",
-  },
-  {
-    accessor: "atob",
-    lib: atob,
-    version: BASE64LIBVERSION,
-    docsURL: "https://github.com/dankogai/js-base64#readme",
-    displayName: "atob",
   },
 ];

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11776,11 +11776,6 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
-js-base64@^3.4.5:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.5.2.tgz#3cc800e4f10812b55fb5ec53e7cabaef35dc6d3c"
-  integrity sha512-VG2qfvV5rEQIVxq9UmAVyWIaOdZGt9M16BLu8vFkyWyhv709Hyg4nKUb5T+Ru+HmAr9RHdF+kQDKAhbJlcdKeQ==
-
 js-sha256@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"


### PR DESCRIPTION
## Description
After moving to worker based evaluation, we did not need the atob and btoa dependencies anymore. Using this was causing a maximum call stack error in our worker by calling itself again(same reference). This PR will fix this by removing that extra dependency and use the browser provided functions instead

Fixes #1611


## Type of change

- Bug fix (non-breaking change which fixes an issue)

