### PR TITLE
Fix form widget eval loops for arrays

### DIFF
--- a/app/client/src/widgets/FormWidget.tsx
+++ b/app/client/src/widgets/FormWidget.tsx
@@ -4,7 +4,6 @@ import { WidgetProps } from "./BaseWidget";
 import { WidgetType } from "constants/WidgetConstants";
 import ContainerWidget, { ContainerWidgetProps } from "widgets/ContainerWidget";
 import { ContainerComponentProps } from "components/designSystems/appsmith/ContainerComponent";
-import shallowEqual from "shallowequal";
 import * as Sentry from "@sentry/react";
 import withMeta from "./MetaHOC";
 
@@ -38,7 +37,7 @@ class FormWidget extends ContainerWidget {
   updateFormData() {
     if (this.props.children) {
       const formData = this.getFormData(this.props.children[0]);
-      if (!shallowEqual(formData, this.props.data)) {
+      if (!_.isEqual(formData, this.props.data)) {
         this.props.updateWidgetMetaProperty("data", formData);
       }
     }


### PR DESCRIPTION
## Description
Form widget checks for children values and sets its property accordingly. While doing this it would check for previous values with `shalowEqual` which will always return `true` for arrays. Moving to lodash deep isEqual which does a value check solved this issue

Fixes #1280

## Type of change
- Bug fix (non-breaking change which fixes an issue)

