### PR TITLE
Fix long app names not visible

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
@@ -61,11 +61,13 @@ describe("Update Application", function() {
       .first()
       .click({ force: true });
     cy.get(homePage.applicationName).type(veryLongAppName + "{enter}");
+    cy.get(homePage.appsContainer).click();
     cy.wait("@updateApplication").should(
       "have.nested.property",
       "response.body.responseMeta.status",
       200,
     );
+    cy.wait(2000);
 
     cy.get(homePage.applicationCard)
       .first()

--- a/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
@@ -71,7 +71,9 @@ describe("Update Application", function() {
 
     cy.get(homePage.applicationCard)
       .first()
-      .find(`[class^="Tooltip__TooltipWrapper"]`)
-      .should("have.length", 1);
+      .find(homePage.applicationCardName)
+      .trigger("mouseover");
+
+    cy.get(".bp3-popover-target.bp3-popover-open").should("have.length", 1);
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
@@ -51,6 +51,7 @@ describe("Update Application", function() {
 
   it("Updates the name of first application to very long name and checks whether update is reflected in the application card with a popover", function() {
     cy.get(commonlocators.homeIcon).click({ force: true });
+    cy.get(homePage.searchInput).clear();
     cy.wait(2000);
 
     cy.get(homePage.applicationCard)

--- a/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Applications/UpdateApplication_spec.js
@@ -6,6 +6,9 @@ describe("Update Application", function() {
   let appname;
   let iconname;
   let colorname;
+  let veryLongAppName = `gnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionih1gnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionih1${Math.random()
+    .toString(36)
+    .slice(2, -1)}`;
 
   it("Open the application menu and update name and then check whether update is reflected in the application card", function() {
     cy.get(commonlocators.homeIcon).click({ force: true });
@@ -46,25 +49,26 @@ describe("Update Application", function() {
       });
   });
 
-  it("Open the application menu and update card color and then check whether update is reflected in the application card", function() {
-    cy.get(homePage.applicationColorSelector)
-      .first()
-      .click();
-    cy.wait("@updateApplication")
-      .then(xhr => {
-        colorname = tinycolor(xhr.response.body.data.color).toRgbString();
-      })
-      .should("have.nested.property", "response.body.responseMeta.status", 200);
+  it("Updates the name of first application to very long name and checks whether update is reflected in the application card with a popover", function() {
+    cy.get(commonlocators.homeIcon).click({ force: true });
     cy.wait(2000);
 
     cy.get(homePage.applicationCard)
       .first()
-      .within(() => {
-        cy.get(homePage.applicationBackgroundColor).should(
-          "have.css",
-          "background-color",
-          colorname,
-        );
-      });
+      .trigger("mouseover");
+    cy.get(homePage.appMoreIcon)
+      .first()
+      .click({ force: true });
+    cy.get(homePage.applicationName).type(veryLongAppName + "{enter}");
+    cy.wait("@updateApplication").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
+
+    cy.get(homePage.applicationCard)
+      .first()
+      .find(`[class^="Tooltip__TooltipWrapper"]`)
+      .should("have.length", 1);
   });
 });

--- a/app/client/src/components/ads/Tooltip.tsx
+++ b/app/client/src/components/ads/Tooltip.tsx
@@ -11,9 +11,10 @@ type TooltipProps = CommonComponentProps & {
   position?: Position;
   children: JSX.Element;
   variant?: Variant;
+  maxWidth?: number;
 };
 
-const TooltipWrapper = styled.div<{ variant?: Variant }>`
+const TooltipWrapper = styled.div<{ variant?: Variant; maxWidth?: number }>`
   .${Classes.TOOLTIP} .${Classes.POPOVER_CONTENT} {
     padding: 10px 12px;
     border-radius: 0px;
@@ -27,7 +28,8 @@ const TooltipWrapper = styled.div<{ variant?: Variant }>`
   }
   .${Classes.TOOLTIP} {
     box-shadow: 0px 12px 20px rgba(0, 0, 0, 0.35);
-  }
+    max-width: ${props => (props.maxWidth ? `${props.maxWidth}px` : null)};
+
   .${Classes.TOOLTIP}
     .${CsClasses.BP3_POPOVER_ARROW_BORDER},
     &&&&
@@ -42,7 +44,11 @@ const TooltipWrapper = styled.div<{ variant?: Variant }>`
 
 const TooltipComponent = (props: TooltipProps) => {
   return (
-    <TooltipWrapper variant={props.variant} data-cy={props.cypressSelector}>
+    <TooltipWrapper
+      variant={props.variant}
+      data-cy={props.cypressSelector}
+      maxWidth={props.maxWidth}
+    >
       <Tooltip
         content={props.content}
         position={props.position}

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -535,9 +535,7 @@ export const ApplicationCard = (props: ApplicationCardProps) => {
               {appNameText}
             </TooltipComponent>
           ) : (
-            <Text type={TextType.H3} cypressSelector="t--app-card-name">
-              {appNameText}
-            </Text>
+            appNameText
           )}
         </AppNameWrapper>
       </>

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useEffect, useState } from "react";
+import React, { createRef, useEffect, useState, useRef } from "react";
 import styled from "styled-components";
 import {
   getApplicationViewerPageURL,
@@ -44,6 +44,8 @@ import {
   getIsSavingAppName,
 } from "selectors/applicationSelectors";
 import { Classes as CsClasses } from "components/ads/common";
+import TooltipComponent from "components/ads/Tooltip";
+import { isEllipsisActive } from "utils/helpers";
 
 type NameWrapperProps = {
   hasReadPermission: boolean;
@@ -194,6 +196,8 @@ const MoreOptionsContainer = styled.div`
 const AppNameWrapper = styled.div<{ isFetching: boolean }>`
   padding: 12px;
   padding-top: 0;
+  padding-bottom: 0;
+  margin-bottom: 12px;
   ${props =>
     props.isFetching
       ? `
@@ -202,6 +206,13 @@ const AppNameWrapper = styled.div<{ isFetching: boolean }>`
     margin-left: 10px;
   `
       : null};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3; /* number of lines to show */
+  -webkit-box-orient: vertical;
+  word-break: break-all;
+  color: ${props => props.theme.colors.text.heading};
 `;
 type ApplicationCardProps = {
   application: ApplicationPayload;
@@ -249,6 +260,7 @@ export const ApplicationCard = (props: ApplicationCardProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [lastUpdatedValue, setLastUpdatedValue] = useState("");
   const menuIconRef = createRef<HTMLSpanElement>();
+  const appNameWrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setSelectedColor(colorCode);
@@ -509,12 +521,24 @@ export const ApplicationCard = (props: ApplicationCardProps) => {
           )}
         </Wrapper>
         <AppNameWrapper
+          ref={appNameWrapperRef}
           isFetching={isFetchingApplications}
           className={isFetchingApplications ? Classes.SKELETON : ""}
         >
-          <Text type={TextType.H3} cypressSelector="t--app-card-name">
-            {props.application.name}
-          </Text>
+          {isEllipsisActive(appNameWrapperRef?.current) ? (
+            <TooltipComponent
+              position={Position.BOTTOM}
+              content={props.application.name}
+            >
+              <Text type={TextType.H3} cypressSelector="t--app-card-name">
+                {props.application.name}
+              </Text>
+            </TooltipComponent>
+          ) : (
+            <Text type={TextType.H3} cypressSelector="t--app-card-name">
+              {props.application.name}
+            </Text>
+          )}
         </AppNameWrapper>
       </>
     </NameWrapper>

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -527,6 +527,7 @@ export const ApplicationCard = (props: ApplicationCardProps) => {
         >
           {isEllipsisActive(appNameWrapperRef?.current) ? (
             <TooltipComponent
+              maxWidth={400}
               position={Position.BOTTOM}
               content={props.application.name}
             >

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -358,6 +358,11 @@ export const ApplicationCard = (props: ApplicationCardProps) => {
     props.application.id,
     props.application.defaultPageId,
   );
+  const appNameText = (
+    <Text type={TextType.H3} cypressSelector="t--app-card-name">
+      {props.application.name}
+    </Text>
+  );
 
   const ContextMenu = (
     <ContextDropdownWrapper>
@@ -526,18 +531,12 @@ export const ApplicationCard = (props: ApplicationCardProps) => {
           className={isFetchingApplications ? Classes.SKELETON : ""}
         >
           {isEllipsisActive(appNameWrapperRef?.current) ? (
-            <TooltipComponent
-              maxWidth={400}
-              position={Position.BOTTOM}
-              content={props.application.name}
-            >
-              <Text type={TextType.H3} cypressSelector="t--app-card-name">
-                {props.application.name}
-              </Text>
+            <TooltipComponent maxWidth={400} content={props.application.name}>
+              {appNameText}
             </TooltipComponent>
           ) : (
             <Text type={TextType.H3} cypressSelector="t--app-card-name">
-              {props.application.name}
+              {appNameText}
             </Text>
           )}
         </AppNameWrapper>

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -136,3 +136,16 @@ export const trimTrailingSlash = (path: string) => {
   const trailingUrlRegex = /\/+$/;
   return path.replace(trailingUrlRegex, "");
 };
+
+/**
+ * checks if ellipsis is active on the DOM element
+ *
+ * @param element
+ */
+export const isEllipsisActive = (element: HTMLElement | null) => {
+  return (
+    element &&
+    (element.offsetWidth < element.scrollWidth ||
+      element.offsetHeight < element.scrollHeight)
+  );
+};

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -138,7 +138,10 @@ export const trimTrailingSlash = (path: string) => {
 };
 
 /**
- * checks if ellipsis is active on the DOM element
+ * checks if ellipsis is active
+ * this function is meant for checking the existence of ellipsis by CSS.
+ * Since ellipsis by CSS are not part of DOM, we are checking with scroll width\height and offsetidth\height.
+ * ScrollWidth\ScrollHeight is always greater than the offsetWidth\OffsetHeight when ellipsis made by CSS is active.
  *
  * @param element
  */


### PR DESCRIPTION
Description:
Adding an ellipsis by CSS for the text longer than 3 lines and adding popover that will show the full name on hover.

Fixes #720 
