### PR TITLE
Moving the intercom initialization to the body in index.html

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -122,7 +122,7 @@
   },
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "start": "EXTEND_ESLINT=true REACT_APP_ENVIRONMENT=DEVELOPMENT HOST=dev.appsmith.com craco start",
+    "start": "BROWSER=none EXTEND_ESLINT=true REACT_APP_ENVIRONMENT=DEVELOPMENT HOST=dev.appsmith.com craco start",
     "build": "./build.sh",
     "build-local": "craco --max-old-space-size=4096 build --config craco.build.config.js",
     "build-staging": "REACT_APP_ENVIRONMENT=STAGING craco --max-old-space-size=4096 build --config craco.build.config.js",

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -17,14 +17,6 @@
       transition: all ease-in 0.3s;
     }
   </style>
-  <script type="text/javascript">
-    // INTERCOM SETUP
-    const APP_ID = "%REACT_APP_INTERCOM_APP_ID%"
-    const CLOUD_HOSTING = "%REACT_APP_CLOUD_HOSTING%"
-    if (APP_ID.length && APP_ID[0] !== "%" && CLOUD_HOSTING.length) {
-      (function () { var w = window; var ic = w.Intercom; if (typeof ic === "function") { ic('reattach_activator'); ic('update', w.intercomSettings); } else { var d = document; var i = function () { i.c(arguments); }; i.q = []; i.c = function (args) { i.q.push(args); }; w.Intercom = i; var l = function () { var s = d.createElement('script'); s.type = 'text/javascript'; s.async = true; s.src = 'https://widget.intercom.io/widget/' + APP_ID; var x = d.getElementsByTagName('script')[0]; x.parentNode.insertBefore(s, x); }; if (document.readyState === 'complete') { l(); } else if (w.attachEvent) { w.attachEvent('onload', l); } else { w.addEventListener('load', l, false); } } })();
-    }
-  </script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_ANALYTICS_ID%"></script>
   <script>
     // GA SETUP
@@ -106,6 +98,14 @@
     }
     const LOG_LEVELS = ["debug", "error"];
     const CONFIG_LOG_LEVEL_INDEX = LOG_LEVELS.indexOf(parseConfig("__APPSMITH_CLIENT_LOG_LEVEL__"));
+    
+    const APP_ID = parseConfig("__APPSMITH_INTERCOM_APP_ID__");
+    const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__").length > 0;
+    // Initialize the Intercom library
+    if (APP_ID.length && APP_ID[0] !== "%" && CLOUD_HOSTING) {
+      (function () { var w = window; var ic = w.Intercom; if (typeof ic === "function") { ic('reattach_activator'); ic('update', w.intercomSettings); } else { var d = document; var i = function () { i.c(arguments); }; i.q = []; i.c = function (args) { i.q.push(args); }; w.Intercom = i; var l = function () { var s = d.createElement('script'); s.type = 'text/javascript'; s.async = true; s.src = 'https://widget.intercom.io/widget/' + APP_ID; var x = d.getElementsByTagName('script')[0]; x.parentNode.insertBefore(s, x); }; if (document.readyState === 'complete') { l(); } else if (w.attachEvent) { w.attachEvent('onload', l); } else { w.addEventListener('load', l, false); } } })();
+    }
+
     window.SENTRY_CONFIG = parseConfig("__APPSMITH_SENTRY_DSN__");
     window.APPSMITH_FEATURE_CONFIGS = {
       sentry: {
@@ -132,13 +132,13 @@
       },
       logLevel: CONFIG_LOG_LEVEL_INDEX > -1 ? LOG_LEVELS[CONFIG_LOG_LEVEL_INDEX] : LOG_LEVELS[1],
       google: parseConfig("__APPSMITH_GOOGLE_MAPS_API_KEY__"),
-      cloudHosting: parseConfig("__APPSMITH_CLOUD_HOSTING__").length > 0,
+      cloudHosting: CLOUD_HOSTING,
       enableTNCPP: parseConfig("__APPSMITH_TNC_PP__").length > 0,
       appVersion: {
         id: parseConfig("__APPSMITH_VERSION_ID__"),
         releaseDate: parseConfig("__APPSMITH_VERSION_RELEASE_DATE__")
       },
-      intercomAppID: parseConfig("__APPSMITH_INTERCOM_APP_ID__"),
+      intercomAppID: APP_ID,
       mailEnabled: parseConfig("__APPSMITH_MAIL_ENABLED__").length > 0,
       disableTelemetry: parseConfig("__APPSMITH_DISABLE_TELEMETRY__").toLowerCase() === 'true' ,
     };


### PR DESCRIPTION
## Description
This is to allow us to enable/disable Intercom chat based on the INTERCOM_APP_ID and CLOUD_HOSTED environment variables. Currently, the code would enable these configurations using build time variables. Now Intercom initialization is moved to a runtime variable.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
