### PR TITLE
Add client-max-body-size directive to nginx https proxy

### DIFF
--- a/app/client/docker/templates/nginx-linux.conf.template
+++ b/app/client/docker/templates/nginx-linux.conf.template
@@ -66,6 +66,7 @@ server {
 server {
     listen 443 ssl http2;
     server_name dev.appsmith.com;
+    client_max_body_size 10m;
 
     ssl_certificate /etc/certificate/dev.appsmith.com.pem;
     ssl_certificate_key /etc/certificate/dev.appsmith.com-key.pem;

--- a/app/client/docker/templates/nginx-mac.conf.template
+++ b/app/client/docker/templates/nginx-mac.conf.template
@@ -68,6 +68,7 @@ server {
 server {
     listen 443 ssl http2;
     server_name dev.appsmith.com;
+    client_max_body_size 10m;
 
     ssl_certificate /etc/certificate/dev.appsmith.com.pem;
     ssl_certificate_key /etc/certificate/dev.appsmith.com-key.pem;

--- a/deploy/template/nginx_app.conf.sh
+++ b/deploy/template/nginx_app.conf.sh
@@ -71,6 +71,7 @@ $NGINX_SSL_CMNT    server_name $custom_domain ;
 $NGINX_SSL_CMNT server {
 $NGINX_SSL_CMNT    listen 443 ssl;
 $NGINX_SSL_CMNT    server_name $custom_domain;
+$NGINX_SSL_CMNT    client_max_body_size 10m;
 $NGINX_SSL_CMNT
 $NGINX_SSL_CMNT    ssl_certificate /etc/letsencrypt/live/$custom_domain/fullchain.pem;
 $NGINX_SSL_CMNT    ssl_certificate_key /etc/letsencrypt/live/$custom_domain/privkey.pem;


### PR DESCRIPTION
## Description
`client-max-body-size` directive is missing in the nginx https proxy server, resulting in a limit to the api request body sizes.

Fixes #1694
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
