### PR TITLE
Adding index for unpublishedAction.pageId 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -1215,4 +1215,15 @@ public class DatabaseChangelog {
 
     }
 
+    @ChangeSet(order = "041", id = "new-action-add-index-pageId", author = "")
+    public void addNewActionIndexForPageId(MongoTemplate mongoTemplate) {
+
+        dropIndexIfExists(mongoTemplate, NewAction.class, "applicationId_deleted_createdAt_compound_index");
+
+        ensureIndexes(mongoTemplate, NewAction.class,
+                makeIndex("applicationId", "deleted", "unpublishedAction.pageId")
+                          .named("applicationId_deleted_unpublishedPageId_compound_index")
+                );
+    }
+
 }


### PR DESCRIPTION
This change has been made to bring down the number of documents fetched in mongo db query during update layouts' fetching actions on page load.

Fixes #1730 

## Type of change

> Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
