### PR TITLE
Email sending is now non-blocking. 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
@@ -133,8 +133,8 @@ public class UserController extends BaseController<UserService, User, String> {
      * @return List of new users who have been created/existing users who have been added to the organization.
      */
     @PostMapping("/invite")
-    public Mono<ResponseDTO<List<User>>> inviteUser(@RequestBody InviteUsersDTO inviteUsersDTO, @RequestHeader("Origin") String originHeader) {
-        return service.inviteUser(inviteUsersDTO, originHeader).collectList()
+    public Mono<ResponseDTO<List<User>>> inviteUsers(@RequestBody InviteUsersDTO inviteUsersDTO, @RequestHeader("Origin") String originHeader) {
+        return service.inviteUsers(inviteUsersDTO, originHeader).collectList()
                 .map(users -> new ResponseDTO<>(HttpStatus.OK.value(), users, null));
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationServiceImpl.java
@@ -300,15 +300,11 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
                                     params.put("inviteUrl", originHeader);
                                     params.put("user_role_name", userRole.getRoleName());
 
-                                    Mono<String> emailMono = emailSender.sendMail(user.getEmail(),
+                                    Mono<Boolean> emailMono = emailSender.sendMail(user.getEmail(),
                                         "Appsmith: Your Role has been changed",
                                         UPDATE_ROLE_EXISTING_USER_TEMPLATE, params);
                                     return emailMono
-                                           .thenReturn(addedOrganization)
-                                           .onErrorResume(error -> {
-                                                log.error("Unable to send role change email to {}. Cause: ", user.getEmail(), error);
-                                            return Mono.just(addedOrganization);
-                                            });
+                                           .thenReturn(addedOrganization);
                                 });
                             } else {
                                 // If the roleName was not present, then it implies that the user is being removed from the org.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserService.java
@@ -29,5 +29,5 @@ public interface UserService extends CrudService<User, String> {
 
     Mono<User> userCreate(User user);
 
-    Flux<User> inviteUser(InviteUsersDTO inviteUsersDTO, String originHeader);
+    Flux<User> inviteUsers(InviteUsersDTO inviteUsersDTO, String originHeader);
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
@@ -335,7 +335,7 @@ public class OrganizationServiceTest {
                     inviteUsersDTO.setOrgId(organization1.getId());
                     inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_ADMIN.getName());
 
-                    return userService.inviteUser(inviteUsersDTO, "http://localhost:8080")
+                    return userService.inviteUsers(inviteUsersDTO, "http://localhost:8080")
                             .collectList();
                 })
                 .cache();
@@ -395,7 +395,7 @@ public class OrganizationServiceTest {
                     inviteUsersDTO.setOrgId(organization1.getId());
                     inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_ADMIN.getName());
 
-                    return userService.inviteUser(inviteUsersDTO, "http://localhost:8080")
+                    return userService.inviteUsers(inviteUsersDTO, "http://localhost:8080")
                             .collectList();
                 })
                 .cache();
@@ -468,7 +468,7 @@ public class OrganizationServiceTest {
                     inviteUsersDTO.setOrgId(organization1.getId());
                     inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_VIEWER.getName());
 
-                    return userService.inviteUser(inviteUsersDTO, "http://localhost:8080")
+                    return userService.inviteUsers(inviteUsersDTO, "http://localhost:8080")
                             .collectList();
                 })
                 .cache();
@@ -857,7 +857,7 @@ public class OrganizationServiceTest {
                     inviteUsersDTO.setOrgId(organization1.getId());
                     inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_VIEWER.getName());
 
-                    return userService.inviteUser(inviteUsersDTO, "http://localhost:8080")
+                    return userService.inviteUsers(inviteUsersDTO, "http://localhost:8080")
                             .collectList();
                 })
                 .cache();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -361,7 +361,7 @@ public class UserServiceTest {
                     inviteUsersDTO.setOrgId(organization1.getId());
                     inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_VIEWER.getName());
 
-                    return userService.inviteUser(inviteUsersDTO, "http://localhost:8080")
+                    return userService.inviteUsers(inviteUsersDTO, "http://localhost:8080")
                             .collectList();
                 }).block();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ShareOrganizationPermissionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ShareOrganizationPermissionTests.java
@@ -75,7 +75,7 @@ public class ShareOrganizationPermissionTests {
         emails.add("admin@solutiontest.com");
         inviteUsersDTO.setUsernames(emails);
         inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_ADMIN.getName());
-        userService.inviteUser(inviteUsersDTO, "http://localhost:8080").blockLast();
+        userService.inviteUsers(inviteUsersDTO, "http://localhost:8080").blockLast();
 
         emails.clear();
 
@@ -83,7 +83,7 @@ public class ShareOrganizationPermissionTests {
         emails.add("developer@solutiontest.com");
         inviteUsersDTO.setUsernames(emails);
         inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_DEVELOPER.getName());
-        userService.inviteUser(inviteUsersDTO, "http://localhost:8080").blockLast();
+        userService.inviteUsers(inviteUsersDTO, "http://localhost:8080").blockLast();
     }
 
     @Test


### PR DESCRIPTION

## Description
The blocking code for email sending is triggered and then immediately returned.

Fixes #1761 


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This code has been tested by using Thread.sleep instead of blocking send mail call to ensure that the invite flow returns back successfully before the threads wake up.

