### PR TITLE
Hide AppViewer Header

### DIFF
--- a/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
+++ b/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useRef } from "react";
-import { Link, NavLink } from "react-router-dom";
+import { Link, NavLink, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import StyledHeader from "components/designSystems/appsmith/StyledHeader";
 import AppsmithLogo from "assets/images/appsmith_logo_white.png";
@@ -154,7 +154,9 @@ export const AppViewerHeader = (props: AppViewerHeaderProps) => {
   const userPermissions = currentApplicationDetails?.userPermissions ?? [];
   const permissionRequired = PERMISSION_TYPE.MANAGE_APPLICATION;
   const canEdit = isPermitted(userPermissions, permissionRequired);
-
+  const queryParams = new URLSearchParams(useLocation().search);
+  const hideHeader = !!queryParams.get("embed");
+  if (hideHeader) return null;
   // Mark default page as first page
   const appPages = pages;
   if (appPages.length > 1) {


### PR DESCRIPTION
## Description
Feature: Hide header in appviewer to embed a page in an iframe

Fixes #1765 


## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested with `embed=true` queryParams in Appviewer
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
