### PR TITLE
Fix: Theme restricted for selected account

### DIFF
--- a/app/client/src/sagas/userSagas.tsx
+++ b/app/client/src/sagas/userSagas.tsx
@@ -357,6 +357,7 @@ export function* logoutSaga() {
       AnalyticsUtil.reset();
       yield put(logoutUserSuccess());
       history.push(AUTH_LOGIN_URL);
+      localStorage.removeItem("THEME");
     }
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
### Description
> With this fix, the theme flag stored in localStorage will be cleared out when the user logout.

Fixes #963 

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
