### PR TITLE
Fix: maps widgets bugs

### DIFF
--- a/app/client/.gitignore
+++ b/app/client/.gitignore
@@ -30,7 +30,9 @@ yarn-error.log*
 .storybook-out/
 cypress/videos
 cypress/screenshots
+/cypress.env.json
 results/
+
 
 /docker/*.pem
 /docker/nginx.conf

--- a/app/client/cypress/integration/Smoke_TestSuite/DisplayWidgets/Map_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/DisplayWidgets/Map_spec.js
@@ -1,128 +1,138 @@
-// const commonlocators = require("../../../locators/commonlocators.json");
-// const viewWidgetsPage = require("../../../locators/ViewWidgets.json");
-// const dsl = require("../../../fixtures/Mapdsl.json");
-// const publishPage = require("../../../locators/publishWidgetspage.json");
-//
-// describe("Map Widget Functionality", function() {
-//   before(() => {
-//     cy.addDsl(dsl);
-//   });
-//
-//   it("Map Widget Functionality", function() {
-//     cy.openPropertyPane("mapwidget");
-//     /**
-//      * @param{Text} Random Text
-//      * @param{MapWidget}Mouseover
-//      * @param{MapPre Css} Assertion
-//      */
-//     cy.widgetText(
-//       "Maptest",
-//       viewWidgetsPage.mapWidget,
-//       viewWidgetsPage.mapInner,
-//     );
-//     cy.get(viewWidgetsPage.mapinitialloc)
-//       .click({ force: true })
-//       .clear()
-//       .type(this.data.country)
-//       .type("{enter}");
-//     cy.get(viewWidgetsPage.mapInput)
-//       .click({ force: true })
-//       .type(this.data.command)
-//       .type(JSON.stringify(this.data.marker), {
-//         parseSpecialCharSequences: false,
-//       });
-//     cy.get(viewWidgetsPage.zoomLevel)
-//       .eq(0)
-//       .click({ force: true });
-//     cy.get(viewWidgetsPage.zoomLevel)
-//       .eq(1)
-//       .click({ force: true });
-//     cy.get(viewWidgetsPage.mapSearch)
-//       .click({ force: true })
-//       .clear()
-//       .type(this.data.location2)
-//       .type("{enter}");
-//   });
-//
-//   it("Map-Enable Location,Map search and Create Marker Property Validation", function() {
-//     /**
-//      * Enable the Search Location checkbox and Validate the same in editor mode
-//      */
-//     cy.CheckWidgetProperties(commonlocators.enableSearchLocCheckbox);
-//     cy.get(viewWidgetsPage.mapSearch).should("be.visible");
-//     cy.get(viewWidgetsPage.mapSearch)
-//       .invoke("attr", "placeholder")
-//       .should("contain", "Enter location to search");
-//     /**
-//      * Enable the Pick Location checkbox and Validate the same in editor mode
-//      */
-//     cy.CheckWidgetProperties(commonlocators.enablePickLocCheckbox);
-//     cy.get(viewWidgetsPage.pickMyLocation).should("exist");
-//
-//     /**
-//      * Enable the Createnew Marker checkbox and Validate the same in editor mode
-//      */
-//     cy.CheckWidgetProperties(commonlocators.enableCreateMarkerCheckbox);
-//     /**
-//      * Validation will be added when create marker fun is working fine
-//      */
-//
-//     cy.PublishtheApp();
-//     /**
-//      * Publish mode Validation
-//      */
-//     cy.get(publishPage.mapSearch).should("be.visible");
-//     cy.get(publishPage.mapSearch)
-//       .invoke("attr", "placeholder")
-//       .should("contain", "Enter location to search");
-//     cy.get(publishPage.pickMyLocation).should("exist");
-//     cy.get(publishPage.backToEditor).click();
-//   });
-//
-//   it("Map-Disable Location, Mapsearch and Create Marker Property Validation", function() {
-//     cy.openPropertyPane("mapwidget");
-//     /**
-//      * Disable the Search Location checkbox and Validate the same in editor mode
-//      */
-//     cy.UncheckWidgetProperties(commonlocators.enableSearchLocCheckbox);
-//     cy.get(viewWidgetsPage.mapSearch).should("not.be.visible");
-//     /**
-//      * Disable the Pick Location checkbox and Validate the same in editor mode
-//      */
-//     cy.UncheckWidgetProperties(commonlocators.enablePickLocCheckbox);
-//     cy.get(viewWidgetsPage.pickMyLocation).should("not.exist");
-//
-//     /**
-//      * Disable the Createnew Marker checkbox and Validate the same in editor mode
-//      */
-//     cy.UncheckWidgetProperties(commonlocators.enableCreateMarkerCheckbox);
-//     /**
-//      * Validation will be added when create marker fun is working fine
-//      */
-//
-//     cy.PublishtheApp();
-//     /**
-//      * Publish mode Validation
-//      */
-//     cy.get(publishPage.mapSearch).should("not.be.visible");
-//     cy.get(publishPage.pickMyLocation).should("not.exist");
-//     cy.get(publishPage.backToEditor).click();
-//   });
-//
-//   it("Map-Check Visible field Validation", function() {
-//     cy.openPropertyPane("mapwidget");
-//     //Check the disableed checkbox and Validate
-//     cy.CheckWidgetProperties(commonlocators.visibleCheckbox);
-//     cy.PublishtheApp();
-//     cy.get(publishPage.mapWidget).should("be.visible");
-//     cy.get(publishPage.backToEditor).click();
-//   });
-//
-//   it("Map-Unckeck Visible field Validation", function() {
-//     cy.openPropertyPane("mapwidget");
-//     //Uncheck the disabled checkbox and validate
-//     cy.UncheckWidgetProperties(commonlocators.visibleCheckbox);
-//     cy.PublishtheApp();
-//     cy.get(publishPage.mapWidget).should("not.be.visible");
-//   });
-// });
+const commonlocators = require("../../../locators/commonlocators.json");
+const viewWidgetsPage = require("../../../locators/ViewWidgets.json");
+const dsl = require("../../../fixtures/Mapdsl.json");
+const publishPage = require("../../../locators/publishWidgetspage.json");
+
+if (Cypress.env("APPSMITH_GOOGLE_MAPS_API_KEY")) {
+  describe("Map Widget Functionality", function() {
+    before(() => {
+      cy.addDsl(dsl);
+    });
+
+    it("Map Widget Functionality", function() {
+      cy.openPropertyPane("mapwidget");
+      /**
+       * @param{Text} Random Text
+       * @param{MapWidget}Mouseover
+       * @param{MapPre Css} Assertion
+       */
+      cy.widgetText(
+        "Maptest",
+        viewWidgetsPage.mapWidget,
+        viewWidgetsPage.mapInner,
+      );
+      cy.get(viewWidgetsPage.mapinitialloc)
+        .click({ force: true })
+        .clear()
+        .type(this.data.country)
+        .type("{enter}");
+      cy.get(viewWidgetsPage.mapInput)
+        .click({ force: true })
+        .type(this.data.command)
+        .type(JSON.stringify(this.data.marker), {
+          parseSpecialCharSequences: false,
+        });
+      cy.get(viewWidgetsPage.zoomLevel)
+        .eq(0)
+        .click({ force: true });
+      cy.get(viewWidgetsPage.zoomLevel)
+        .eq(1)
+        .click({ force: true });
+      cy.get(viewWidgetsPage.mapSearch)
+        .click({ force: true })
+        .clear()
+        .type(this.data.location2)
+        .type("{enter}");
+    });
+
+    it("Map-Enable Location,Map search and Create Marker Property Validation", function() {
+      /**
+       * Enable the Search Location checkbox and Validate the same in editor mode
+       */
+      cy.CheckWidgetProperties(commonlocators.enableSearchLocCheckbox);
+      cy.get(viewWidgetsPage.mapSearch).should("be.visible");
+      cy.get(viewWidgetsPage.mapSearch)
+        .invoke("attr", "placeholder")
+        .should("contain", "Enter location to search");
+      /**
+       * Enable the Pick Location checkbox and Validate the same in editor mode
+       */
+      cy.CheckWidgetProperties(commonlocators.enablePickLocCheckbox);
+      cy.get(viewWidgetsPage.pickMyLocation).should("exist");
+
+      /**
+       * Enable the Createnew Marker checkbox and Validate the same in editor mode
+       */
+      cy.CheckWidgetProperties(commonlocators.enableCreateMarkerCheckbox);
+      /**
+       * Validation will be added when create marker fun is working fine
+       */
+
+      cy.PublishtheApp();
+      /**
+       * Publish mode Validation
+       */
+      cy.get(publishPage.mapSearch).should("be.visible");
+      cy.get(publishPage.mapSearch)
+        .invoke("attr", "placeholder")
+        .should("contain", "Enter location to search");
+      cy.get(publishPage.pickMyLocation).should("exist");
+      cy.get(publishPage.backToEditor).click();
+    });
+
+    it("Map-Disable Location, Mapsearch and Create Marker Property Validation", function() {
+      cy.openPropertyPane("mapwidget");
+      /**
+       * Disable the Search Location checkbox and Validate the same in editor mode
+       */
+      cy.UncheckWidgetProperties(commonlocators.enableSearchLocCheckbox);
+      cy.get(viewWidgetsPage.mapSearch).should("not.be.visible");
+      /**
+       * Disable the Pick Location checkbox and Validate the same in editor mode
+       */
+      cy.UncheckWidgetProperties(commonlocators.enablePickLocCheckbox);
+      cy.get(viewWidgetsPage.pickMyLocation).should("not.exist");
+
+      /**
+       * Disable the Createnew Marker checkbox and Validate the same in editor mode
+       */
+      cy.UncheckWidgetProperties(commonlocators.enableCreateMarkerCheckbox);
+      /**
+       * Validation will be added when create marker fun is working fine
+       */
+
+      cy.PublishtheApp();
+      /**
+       * Publish mode Validation
+       */
+      cy.get(publishPage.mapSearch).should("not.be.visible");
+      cy.get(publishPage.pickMyLocation).should("not.exist");
+      cy.get(publishPage.backToEditor).click();
+    });
+
+    it("Map-Initial location should persist after reopen", function() {
+      cy.openPropertyPane("mapwidget");
+      cy.get(viewWidgetsPage.mapinitialloc).should(
+        "have.value",
+        this.data.country,
+      );
+    });
+
+    it("Map-Check Visible field Validation", function() {
+      cy.openPropertyPane("mapwidget");
+      //Check the disableed checkbox and Validate
+      cy.CheckWidgetProperties(commonlocators.visibleCheckbox);
+      cy.PublishtheApp();
+      cy.get(publishPage.mapWidget).should("be.visible");
+      cy.get(publishPage.backToEditor).click();
+    });
+
+    it("Map-Unckeck Visible field Validation", function() {
+      cy.openPropertyPane("mapwidget");
+      //Uncheck the disabled checkbox and validate
+      cy.UncheckWidgetProperties(commonlocators.visibleCheckbox);
+      cy.PublishtheApp();
+      cy.get(publishPage.mapWidget).should("not.be.visible");
+    });
+  });
+}

--- a/app/client/src/widgets/MapWidget.tsx
+++ b/app/client/src/widgets/MapWidget.tsx
@@ -40,6 +40,7 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
       enablePickLocation: VALIDATION_TYPES.BOOLEAN,
       allowZoom: VALIDATION_TYPES.BOOLEAN,
       zoomLevel: VALIDATION_TYPES.NUMBER,
+      mapCenter: VALIDATION_TYPES.OBJECT,
     };
   }
 
@@ -189,6 +190,7 @@ export interface MapWidgetProps extends WidgetProps, WithMeta {
   mapCenter: {
     lat: number;
     long: number;
+    title?: string;
   };
   center?: {
     lat: number;


### PR DESCRIPTION
## Description
- Initial location title now shows up on reopening the widget.
- Fix for that also fixes the crash in map widget. (#1506)
- Added a workaround for a race condition on declaring and using `window.google` (#1808)

Fixes #1430 #1431 #1506 

Temporary hotfix for #1808 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually verified
- Added automated tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
