### PR TITLE
[Bug Fix] : Clone Application creates corrupted clone when interrupted.

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
@@ -57,4 +57,5 @@ public class FieldName {
     public static String USERNAMES = "usernames";
     public static String ACTION = "action";
     public static String ASSET = "asset";
+    public static String APPLICATION = "application";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -50,23 +50,16 @@ public class Application extends BaseDomain {
 
     String icon;
 
-    public Application(String name,
-                       String organizationId,
-                       Boolean isPublic,
-                       ArrayList<ApplicationPage> pages,
-                       ArrayList<ApplicationPage> publishedPages,
-                       String clonedFromApplicationId,
-                       String color,
-                       String icon) {
+    // This constructor is used during clone application. It only deeply copies selected fields. The rest are either
+    // initialized newly or is left up to the calling function to set.
+    public Application(Application application) {
         super();
-        this.name = name;
-        this.organizationId = organizationId;
-        this.isPublic = isPublic;
-        this.pages = pages;
-        this.publishedPages = publishedPages;
-        this.clonedFromApplicationId = clonedFromApplicationId;
-        this.color = color;
-        this.icon = icon;
+        this.organizationId = application.getOrganizationId();
+        this.pages = new ArrayList<>();
+        this.publishedPages = new ArrayList<>();
+        this.clonedFromApplicationId = application.getId();
+        this.color = application.getColor();
+        this.icon = application.getIcon();
     }
 
     public List<ApplicationPage> getPages() {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -20,7 +20,6 @@ import java.util.List;
 @Setter
 @ToString
 @NoArgsConstructor
-@AllArgsConstructor
 @QueryEntity
 @Document
 public class Application extends BaseDomain {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -4,6 +4,7 @@ import com.appsmith.external.models.BaseDomain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryEntity;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,12 +13,14 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
+@AllArgsConstructor
 @QueryEntity
 @Document
 public class Application extends BaseDomain {
@@ -48,6 +51,25 @@ public class Application extends BaseDomain {
     String color;
 
     String icon;
+
+    public Application(String name,
+                       String organizationId,
+                       Boolean isPublic,
+                       ArrayList<ApplicationPage> pages,
+                       ArrayList<ApplicationPage> publishedPages,
+                       String clonedFromApplicationId,
+                       String color,
+                       String icon) {
+        super();
+        this.name = name;
+        this.organizationId = organizationId;
+        this.isPublic = isPublic;
+        this.pages = pages;
+        this.publishedPages = publishedPages;
+        this.clonedFromApplicationId = clonedFromApplicationId;
+        this.color = color;
+        this.icon = icon;
+    }
 
     public List<ApplicationPage> getPages() {
         return viewMode ? publishedPages : pages;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -4,7 +4,6 @@ import com.appsmith.external.models.BaseDomain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryEntity;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ApplicationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ApplicationRepository.java
@@ -13,4 +13,5 @@ public interface ApplicationRepository extends BaseRepository<Application, Strin
 
     Flux<Application> findByOrganizationId(String organizationId);
 
+    Flux<Application> findByClonedFromApplicationId(String clonedFromApplicationId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -444,8 +444,7 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                     newApplication.setOrganizationId(sourceApplication.getOrganizationId());
                     newApplication.setColor(sourceApplication.getColor());
                     newApplication.setIcon(sourceApplication.getIcon());
-                    newApplication.setIsPublic(sourceApplication.getIsPublic());
-
+                    
                     Mono<User> userMono = sessionUserService.getCurrentUser().cache();
                     // First set the correct policies for the new cloned application
                     return setApplicationPolicies(userMono, sourceApplication.getOrganizationId(), newApplication)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -435,15 +435,16 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                     Application sourceApplication = tuple.getT1();
                     String newName = tuple.getT2();
 
-                    // Create a new application object and copy the essential fields which would remain the same over cloning
-                    Application newApplication = new Application();
-                    newApplication.setClonedFromApplicationId(sourceApplication.getId());
-                    newApplication.setName(newName);
-                    newApplication.setPages(new ArrayList<>());
-                    newApplication.setPublishedPages(new ArrayList<>());
-                    newApplication.setOrganizationId(sourceApplication.getOrganizationId());
-                    newApplication.setColor(sourceApplication.getColor());
-                    newApplication.setIcon(sourceApplication.getIcon());
+                    // Create a new clone application object without the pages using the parametrized Application constructor
+                    Application newApplication = new Application(
+                            newName,
+                            sourceApplication.getOrganizationId(),
+                            false,
+                            new ArrayList<>(),
+                            new ArrayList<>(),
+                            sourceApplication.getId(),
+                            sourceApplication.getColor(),
+                            sourceApplication.getIcon());
                     
                     Mono<User> userMono = sessionUserService.getCurrentUser().cache();
                     // First set the correct policies for the new cloned application

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -436,15 +436,8 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                     String newName = tuple.getT2();
 
                     // Create a new clone application object without the pages using the parametrized Application constructor
-                    Application newApplication = new Application(
-                            newName,
-                            sourceApplication.getOrganizationId(),
-                            false,
-                            new ArrayList<>(),
-                            new ArrayList<>(),
-                            sourceApplication.getId(),
-                            sourceApplication.getColor(),
-                            sourceApplication.getIcon());
+                    Application newApplication = new Application(sourceApplication);
+                    newApplication.setName(newName);
                     
                     Mono<User> userMono = sessionUserService.getCurrentUser().cache();
                     // First set the correct policies for the new cloned application

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -60,7 +60,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
 
             } else {
                 // We are trying to fetch published page but it doesnt exist because the page hasn't been published yet
-                return Mono.empty();
+                page = new PageDTO();
             }
         } else {
             if (newPage.getUnpublishedPage() != null) {
@@ -78,7 +78,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
         }
 
         // We shouldn't reach here.
-        return Mono.empty();
+        return Mono.error(new AppsmithException(AppsmithError.INTERNAL_SERVER_ERROR));
 
     }
 
@@ -155,7 +155,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
     @Override
     public Mono<ApplicationPagesDTO> findNamesByApplicationIdAndViewMode(String applicationId, Boolean view) {
         Mono<Application> applicationMono = applicationService.findById(applicationId, AclPermission.READ_APPLICATIONS)
-                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.PAGE + "by application id", applicationId)))
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION, applicationId)))
                 .cache();
 
         Mono<List<PageNameIdDTO>> pagesListMono = applicationMono
@@ -196,8 +196,9 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
 
     private Flux<PageNameIdDTO> findNamesByApplication(Application application, Boolean viewMode) {
         List<ApplicationPage> pages = application.getPages();
+
         return findByApplicationId(application.getId(), AclPermission.READ_PAGES, viewMode)
-                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.PAGE + "by application name", application.getName())))
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.PAGE + " by application id", application.getId())))
                 .map(page -> {
                     PageNameIdDTO pageNameIdDTO = new PageNameIdDTO();
                     pageNameIdDTO.setId(page.getId());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -22,6 +22,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.NewPageRepository;
 import com.appsmith.server.solutions.ApplicationFetcher;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -97,6 +99,9 @@ public class ApplicationServiceTest {
 
     @Autowired
     NewPageRepository newPageRepository;
+
+    @Autowired
+    ApplicationRepository applicationRepository;
 
     String orgId;
 
@@ -857,5 +862,102 @@ public class ApplicationServiceTest {
                     assertThat(editedApplicationPages).containsAnyOf(applicationPage);
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void validCloneApplicationWhenCancelledMidWay() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Application testApplication = new Application();
+        String appName = "ApplicationServiceTest Clone Application Midway Cancellation";
+        testApplication.setName(appName);
+
+        Application originalApplication = applicationPageService.createApplication(testApplication, orgId)
+                .block();
+
+        String pageId = originalApplication.getPages().get(0).getId();
+
+        Plugin plugin = pluginService.findByName("Installed Plugin Name").block();
+        Datasource datasource = new Datasource();
+        datasource.setName("Cloned App Test");
+        datasource.setPluginId(plugin.getId());
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        datasource.setDatasourceConfiguration(datasourceConfiguration);
+        datasource.setOrganizationId(orgId);
+
+        Datasource savedDatasource = datasourceService.create(datasource).block();
+
+        ActionDTO action1 = new ActionDTO();
+        action1.setName("Clone App Test action1");
+        action1.setPageId(pageId);
+        action1.setDatasource(savedDatasource);
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action1.setActionConfiguration(actionConfiguration);
+
+        ActionDTO savedAction1 = newActionService.createAction(action1).block();
+
+        ActionDTO action2 = new ActionDTO();
+        action2.setName("Clone App Test action2");
+        action2.setPageId(pageId);
+        action2.setDatasource(savedDatasource);
+        action2.setActionConfiguration(actionConfiguration);
+
+        ActionDTO savedAction2 = newActionService.createAction(action2).block();
+
+        ActionDTO action3 = new ActionDTO();
+        action3.setName("Clone App Test action3");
+        action3.setPageId(pageId);
+        action3.setDatasource(savedDatasource);
+        action3.setActionConfiguration(actionConfiguration);
+
+        ActionDTO savedAction3 = newActionService.createAction(action3).block();
+
+
+        // Trigger the clone of application now.
+        applicationPageService.cloneApplication(originalApplication.getId())
+                .timeout(Duration.ofMillis(10))
+                .subscribe();
+
+        Mono<Application> clonedAppFromDbMono = Mono.just(originalApplication)
+                .flatMap(originalApp -> {
+                    try {
+                        // Before fetching the cloned application, sleep for 5 seconds to ensure that the cloning finishes
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    return applicationRepository.findByClonedFromApplicationId(originalApp.getId()).next();
+                })
+                .cache();
+
+        Mono<List<NewAction>> actionsMono = clonedAppFromDbMono
+                .flatMap(clonedAppFromDb -> newActionService
+                        .findAllByApplicationIdAndViewMode(clonedAppFromDb.getId(), false, READ_ACTIONS, null)
+                        .collectList()
+                );
+
+        Mono<List<PageDTO>> pagesMono = clonedAppFromDbMono
+                .flatMapMany(application -> Flux.fromIterable(application.getPages()))
+                .flatMap(applicationPage -> newPageService.findPageById(applicationPage.getId(), READ_PAGES, false))
+                .collectList();
+
+        StepVerifier
+                .create(Mono.zip(clonedAppFromDbMono, actionsMono, pagesMono))
+                .assertNext(tuple -> {
+                    Application cloneApp = tuple.getT1();
+                    List<NewAction> actions = tuple.getT2();
+                    List<PageDTO> pages = tuple.getT3();
+
+                    assertThat(cloneApp).isNotNull();
+                    assertThat(pages.get(0).getId()).isNotEqualTo(pageId);
+                    assertThat(actions.size()).isEqualTo(3);
+                    Set<String> actionNames = actions.stream().map(action -> action.getUnpublishedAction().getName()).collect(Collectors.toSet());
+                    assertThat(actionNames).containsExactlyInAnyOrder("Clone App Test action1", "Clone App Test action2", "Clone App Test action3");
+                })
+                .verifyComplete();
+
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -45,6 +45,7 @@ import reactor.test.StepVerifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.EXECUTE_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.EXECUTE_DATASOURCES;
@@ -613,6 +614,11 @@ public class ApplicationServiceTest {
                     assertThat(application.getName().equals("ApplicationServiceTest Clone Source TestApp Copy"));
                     assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
                     assertThat(application.getOrganizationId().equals(orgId));
+                    List<ApplicationPage> pages = application.getPages();
+                    Set<String> pageIdsFromApplication = pages.stream().map(page -> page.getId()).collect(Collectors.toSet());
+                    Set<String> pageIdsFromDb = pageList.stream().map(page -> page.getId()).collect(Collectors.toSet());
+
+                    assertThat(pageIdsFromApplication.containsAll(pageIdsFromDb));
 
                     assertThat(pageList).isNotEmpty();
                     for (PageDTO page : pageList) {


### PR DESCRIPTION
## Description
The cloned application process, when interrupted by client cancellation (due to request timeout) leads to the flow getting cancelled mid way. This leads to a clone getting created (and can be viewed by the user) which wasn't created completely and is in a corrupted state. To solve this, two changes have been made :
1. When creating the clone, start with a deep copy of the original application without the pages being copied. This ensures that even if the cloning process stops midway, the cloned application does not point to the original application's pages.
2. Ensuring that if the client cancels the request, the server still finishes the entire request, whether or not the client is interested. This ensures that once triggered, the clone of the application would be available on the user's home screen in a sane state on home page refresh.
Fixes #1707 

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
