### PR TITLE
[Bug Fix] Indices not working for fetching actions during update layout

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -1226,38 +1226,25 @@ public class DatabaseChangelog {
                 );
     }
 
-    @ChangeSet(order = "042", id = "update-action-add-index-pageId", author = "")
-    public void updateNewActionIndexForPageId(MongoTemplate mongoTemplate) {
+    @ChangeSet(order = "042", id = "update-action-index-to-single-multiple-indices", author = "")
+    public void updateCompoundIndex3(MongoTemplate mongoTemplate) {
+
+        dropIndexIfExists(mongoTemplate, NewAction.class, "applicationId_deleted_unpublishedPageId_compound_index");
+
+        ensureIndexes(mongoTemplate, NewAction.class,
+                makeIndex("applicationId")
+                        .named("applicationId")
+        );
 
         ensureIndexes(mongoTemplate, NewAction.class,
                 makeIndex("unpublishedAction.pageId")
-                        .named("unpublishedActionPageId_index")
+                        .named("unpublishedAction_pageId")
         );
-    }
-
-    @ChangeSet(order = "043", id = "update-compound-index1", author = "")
-    public void updateCompoundIndex1(MongoTemplate mongoTemplate) {
-
-        dropIndexIfExists(mongoTemplate, NewAction.class, "applicationId_deleted_unpublishedPageId_compound_index");
-        dropIndexIfExists(mongoTemplate, NewAction.class, "unpublishedActionPageId_index");
 
         ensureIndexes(mongoTemplate, NewAction.class,
-                makeIndex("deleted", "unpublishedAction.pageId")
-                        .named("applicationId_deleted_unpublishedPageId_compound_index")
+                makeIndex("deleted")
+                        .named("deleted")
         );
-        // This worked for fetching actions by page id
-    }
-
-    @ChangeSet(order = "044", id = "update-compound-index2", author = "")
-    public void updateCompoundIndex2(MongoTemplate mongoTemplate) {
-
-        dropIndexIfExists(mongoTemplate, NewAction.class, "applicationId_deleted_unpublishedPageId_compound_index");
-
-        ensureIndexes(mongoTemplate, NewAction.class,
-                makeIndex("applicationId", "unpublishedAction.pageId")
-                        .named("applicationId_deleted_unpublishedPageId_compound_index")
-        );
-        // Does not work for fetching actions by page id.
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -1226,4 +1226,38 @@ public class DatabaseChangelog {
                 );
     }
 
+    @ChangeSet(order = "042", id = "update-action-add-index-pageId", author = "")
+    public void updateNewActionIndexForPageId(MongoTemplate mongoTemplate) {
+
+        ensureIndexes(mongoTemplate, NewAction.class,
+                makeIndex("unpublishedAction.pageId")
+                        .named("unpublishedActionPageId_index")
+        );
+    }
+
+    @ChangeSet(order = "043", id = "update-compound-index1", author = "")
+    public void updateCompoundIndex1(MongoTemplate mongoTemplate) {
+
+        dropIndexIfExists(mongoTemplate, NewAction.class, "applicationId_deleted_unpublishedPageId_compound_index");
+        dropIndexIfExists(mongoTemplate, NewAction.class, "unpublishedActionPageId_index");
+
+        ensureIndexes(mongoTemplate, NewAction.class,
+                makeIndex("deleted", "unpublishedAction.pageId")
+                        .named("applicationId_deleted_unpublishedPageId_compound_index")
+        );
+        // This worked for fetching actions by page id
+    }
+
+    @ChangeSet(order = "044", id = "update-compound-index2", author = "")
+    public void updateCompoundIndex2(MongoTemplate mongoTemplate) {
+
+        dropIndexIfExists(mongoTemplate, NewAction.class, "applicationId_deleted_unpublishedPageId_compound_index");
+
+        ensureIndexes(mongoTemplate, NewAction.class,
+                makeIndex("applicationId", "unpublishedAction.pageId")
+                        .named("applicationId_deleted_unpublishedPageId_compound_index")
+        );
+        // Does not work for fetching actions by page id.
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -1227,7 +1227,7 @@ public class DatabaseChangelog {
     }
 
     @ChangeSet(order = "042", id = "update-action-index-to-single-multiple-indices", author = "")
-    public void updateCompoundIndex3(MongoTemplate mongoTemplate) {
+    public void updateActionIndexToSingleMultipleIndices(MongoTemplate mongoTemplate) {
 
         dropIndexIfExists(mongoTemplate, NewAction.class, "applicationId_deleted_unpublishedPageId_compound_index");
 


### PR DESCRIPTION
Updated the indices to single indices and removed the compound index. This ensures that both fetch actions by app id (during load of actions in edit/view mode) and fetch actions by page id (during update layout) are indexed queries.