### PR TITLE
Pass execution params to action callback

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -385,7 +385,7 @@ export function* executeActionSaga(
               ...event,
               type: EventType.ON_ERROR,
             },
-            responseData: payload,
+            responseData: { response: payload.body, params },
           }),
         );
       } else {
@@ -412,7 +412,7 @@ export function* executeActionSaga(
               ...event,
               type: EventType.ON_SUCCESS,
             },
-            responseData: payload,
+            responseData: { response: payload.body, params },
           }),
         );
       } else {

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -903,7 +903,7 @@ const evaluate = (
   const scriptWithCallback = `
          function callback (script) {
             const userFunction = script;
-            const result = userFunction(CALLBACK_DATA);
+            const result = userFunction.apply(self, Object.values(CALLBACK_DATA));
             return { result, triggers: self.triggers };
          }
          callback(${js});


### PR DESCRIPTION
## Description
Pass the execution params in the action execution callback functions so that you can access them later on
