### PR TITLE
Fix selectedTab binding issue

### DIFF
--- a/app/client/src/widgets/TabsWidget.tsx
+++ b/app/client/src/widgets/TabsWidget.tsx
@@ -39,9 +39,7 @@ class TabsWidget extends BaseWidget<
   }
 
   static getDefaultPropertiesMap(): Record<string, string> {
-    return {
-      selectedTab: "defaultTab",
-    };
+    return {};
   }
 
   static getTriggerPropertyMap(): TriggerPropertiesMap {


### PR DESCRIPTION
## Description
Fixes issue where binding `selectedTab` of a tabs widget wasn't updating when tabs were switched.

Fixes #1889 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
