### PR TITLE
Fix infinite loop crash on widget drag

### DIFF
--- a/app/client/src/components/designSystems/appsmith/MapComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/MapComponent.tsx
@@ -178,22 +178,20 @@ const MyMapComponent = withScriptjs(
   }),
 );
 
-class MapComponent extends React.Component<MapComponentProps> {
-  render() {
-    const zoom = Math.floor(this.props.zoomLevel / 5);
-    return (
-      <MapWrapper onMouseLeave={this.props.enableDrag}>
-        <MyMapComponent
-          googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${this.props.apiKey}&v=3.exp&libraries=geometry,drawing,places`}
-          loadingElement={<MapContainerWrapper />}
-          containerElement={<MapContainerWrapper />}
-          mapElement={<MapContainerWrapper />}
-          {...this.props}
-          zoom={zoom}
-        />
-      </MapWrapper>
-    );
-  }
-}
+const MapComponent = (props: MapComponentProps) => {
+  const zoom = Math.floor(props.zoomLevel / 5);
+  return (
+    <MapWrapper onMouseLeave={props.enableDrag}>
+      <MyMapComponent
+        googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${props.apiKey}&v=3.exp&libraries=geometry,drawing,places`}
+        loadingElement={<MapContainerWrapper />}
+        containerElement={<MapContainerWrapper />}
+        mapElement={<MapContainerWrapper />}
+        {...props}
+        zoom={zoom}
+      />
+    </MapWrapper>
+  );
+};
 
 export default MapComponent;

--- a/app/client/src/components/editorComponents/DragLayerComponent.tsx
+++ b/app/client/src/components/editorComponents/DragLayerComponent.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  RefObject,
-  useRef,
-} from "react";
+import React, { useContext, useEffect, RefObject, useRef } from "react";
 import styled from "styled-components";
 import { useDragLayer, XYCoord } from "react-dnd";
 import DropZone from "./Dropzone";

--- a/app/client/src/components/editorComponents/DragLayerComponent.tsx
+++ b/app/client/src/components/editorComponents/DragLayerComponent.tsx
@@ -116,7 +116,7 @@ const DragLayerComponent = (props: DragLayerProps) => {
       : widget.rightColumn - widget.leftColumn;
     widgetHeight = widget.rows ? widget.rows : widget.bottomRow - widget.topRow;
   }
-  useLayoutEffect(() => {
+  useEffect(() => {
     const el = dropTargetMask.current;
     if (el) {
       const rect = el.getBoundingClientRect();


### PR DESCRIPTION
## Description

Changing `useLayoutEffect` to `useEffect` fixes the infinite loop issue.

Fixes #1833

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Dragged the widget around the boundary of the page / modal.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


Thank you for your help on repro! I was so lost without a proper repro.