### PR TITLE
Make sure google is available before loading components

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/DisplayWidgets/Map_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/DisplayWidgets/Map_spec.js
@@ -110,12 +110,21 @@ if (Cypress.env("APPSMITH_GOOGLE_MAPS_API_KEY")) {
       cy.get(publishPage.backToEditor).click();
     });
 
-    it("Map-Initial location should persist after reopen", function() {
+    it("Map-Initial location should work", function() {
       cy.openPropertyPane("mapwidget");
+
       cy.get(viewWidgetsPage.mapinitialloc).should(
         "have.value",
         this.data.country,
       );
+
+      /**
+       * Clearing initial location used to reset it, this check makes sure it actually clears
+       */
+      cy.get(viewWidgetsPage.mapinitialloc)
+        .click({ force: true })
+        .clear()
+        .should("have.value", "");
     });
 
     it("Map-Check Visible field Validation", function() {

--- a/app/client/src/components/designSystems/appsmith/MapComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/MapComponent.tsx
@@ -1,14 +1,10 @@
 import React, { useEffect } from "react";
-import {
-  withScriptjs,
-  withGoogleMap,
-  GoogleMap,
-  Marker,
-} from "react-google-maps";
+import { withGoogleMap, GoogleMap, Marker } from "react-google-maps";
 import SearchBox from "react-google-maps/lib/components/places/SearchBox";
 import { MarkerProps } from "widgets/MapWidget";
 import PickMyLocation from "./PickMyLocation";
 import styled from "styled-components";
+import { useScript, ScriptStatuses } from "utils/hooks/useScript";
 
 interface MapComponentProps {
   apiKey: string;
@@ -73,123 +69,126 @@ const PickMyLocationWrapper = styled.div<PickMyLocationProps>`
   width: 140px;
 `;
 
-const MyMapComponent = withScriptjs(
-  withGoogleMap((props: any) => {
-    const [mapCenter, setMapCenter] = React.useState<
-      | {
-          lat: number;
-          lng: number;
-          title?: string;
-          description?: string;
-        }
-      | undefined
-    >({
-      ...props.center,
-      lng: props.center.long,
-    });
-    const searchBox = React.createRef<SearchBox>();
-    const onPlacesChanged = () => {
-      const node: any = searchBox.current;
-      if (node) {
-        const places: any = node.getPlaces();
-        if (
-          places &&
-          places.length &&
-          places[0].geometry &&
-          places[0].geometry.location
-        ) {
-          const location = places[0].geometry.location;
-          const lat = location.lat();
-          const long = location.lng();
-          setMapCenter({ lat, lng: long });
-          props.updateCenter(lat, long);
-          props.unselectMarker();
-        }
+const MyMapComponent = withGoogleMap((props: any) => {
+  const [mapCenter, setMapCenter] = React.useState<
+    | {
+        lat: number;
+        lng: number;
+        title?: string;
+        description?: string;
       }
-    };
-    useEffect(() => {
-      if (!props.selectedMarker) {
-        setMapCenter({
-          ...props.center,
-          lng: props.center.long,
-        });
+    | undefined
+  >({
+    ...props.center,
+    lng: props.center.long,
+  });
+  const searchBox = React.createRef<SearchBox>();
+  const onPlacesChanged = () => {
+    const node: any = searchBox.current;
+    if (node) {
+      const places: any = node.getPlaces();
+      if (
+        places &&
+        places.length &&
+        places[0].geometry &&
+        places[0].geometry.location
+      ) {
+        const location = places[0].geometry.location;
+        const lat = location.lat();
+        const long = location.lng();
+        setMapCenter({ lat, lng: long });
+        props.updateCenter(lat, long);
+        props.unselectMarker();
       }
-    }, [props.center, props.selectedMarker]);
-    return (
-      <GoogleMap
-        options={{
-          zoomControl: props.allowZoom,
-          fullscreenControl: false,
-          mapTypeControl: false,
-          scrollwheel: false,
-          rotateControl: false,
-          streetViewControl: false,
-        }}
-        zoom={props.zoom}
-        center={mapCenter}
-        onClick={e => {
-          if (props.enableCreateMarker) {
-            props.saveMarker(e.latLng.lat(), e.latLng.lng());
+    }
+  };
+  useEffect(() => {
+    if (!props.selectedMarker) {
+      setMapCenter({
+        ...props.center,
+        lng: props.center.long,
+      });
+    }
+  }, [props.center, props.selectedMarker]);
+  return (
+    <GoogleMap
+      options={{
+        zoomControl: props.allowZoom,
+        fullscreenControl: false,
+        mapTypeControl: false,
+        scrollwheel: false,
+        rotateControl: false,
+        streetViewControl: false,
+      }}
+      zoom={props.zoom}
+      center={mapCenter}
+      onClick={e => {
+        if (props.enableCreateMarker) {
+          props.saveMarker(e.latLng.lat(), e.latLng.lng());
+        }
+      }}
+    >
+      {props.enableSearch && (
+        <SearchBox
+          controlPosition={2}
+          onPlacesChanged={onPlacesChanged}
+          ref={searchBox}
+        >
+          <StyledInput type="text" placeholder="Enter location to search" />
+        </SearchBox>
+      )}
+      {props.markers.map((marker: any, index: number) => (
+        <Marker
+          key={index}
+          title={marker.title}
+          position={{ lat: marker.lat, lng: marker.long }}
+          clickable
+          draggable={
+            props.selectedMarker &&
+            props.selectedMarker.lat === marker.lat &&
+            props.selectedMarker.long === marker.long
           }
-        }}
-      >
-        {props.enableSearch && (
-          <SearchBox
-            controlPosition={2}
-            onPlacesChanged={onPlacesChanged}
-            ref={searchBox}
-          >
-            <StyledInput type="text" placeholder="Enter location to search" />
-          </SearchBox>
-        )}
-        {props.markers.map((marker: any, index: number) => (
-          <Marker
-            key={index}
-            title={marker.title}
-            position={{ lat: marker.lat, lng: marker.long }}
-            clickable
-            draggable={
-              props.selectedMarker &&
-              props.selectedMarker.lat === marker.lat &&
-              props.selectedMarker.long === marker.long
-            }
-            onClick={e => {
-              setMapCenter({
-                ...marker,
-                lng: marker.long,
-              });
-              props.selectMarker(marker.lat, marker.long, marker.title);
-            }}
-            onDragEnd={de => {
-              props.updateMarker(de.latLng.lat(), de.latLng.lng(), index);
-            }}
-          />
-        ))}
-        {props.enablePickLocation && (
-          <PickMyLocationWrapper
-            title="Pick My Location"
-            allowZoom={props.allowZoom}
-          >
-            <PickMyLocation updateCenter={props.updateCenter} />
-          </PickMyLocationWrapper>
-        )}
-      </GoogleMap>
-    );
-  }),
-);
+          onClick={e => {
+            setMapCenter({
+              ...marker,
+              lng: marker.long,
+            });
+            props.selectMarker(marker.lat, marker.long, marker.title);
+          }}
+          onDragEnd={de => {
+            props.updateMarker(de.latLng.lat(), de.latLng.lng(), index);
+          }}
+        />
+      ))}
+      {props.enablePickLocation && (
+        <PickMyLocationWrapper
+          title="Pick My Location"
+          allowZoom={props.allowZoom}
+        >
+          <PickMyLocation updateCenter={props.updateCenter} />
+        </PickMyLocationWrapper>
+      )}
+    </GoogleMap>
+  );
+});
 
 const MapComponent = (props: MapComponentProps) => {
   const zoom = Math.floor(props.zoomLevel / 5);
+  const status = useScript(
+    `https://maps.googleapis.com/maps/api/js?key=${props.apiKey}&v=3.exp&libraries=geometry,drawing,places`,
+    true,
+  );
   return (
     <MapWrapper onMouseLeave={props.enableDrag}>
-      <MyMapComponent
-        googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${props.apiKey}&v=3.exp&libraries=geometry,drawing,places`}
-        loadingElement={<MapContainerWrapper />}
-        containerElement={<MapContainerWrapper />}
-        mapElement={<MapContainerWrapper />}
-        {...props}
-        zoom={zoom}
-      />
+      {status === ScriptStatuses.READY && (
+        <MyMapComponent
+          loadingElement={<MapContainerWrapper />}
+          containerElement={<MapContainerWrapper />}
+          mapElement={<MapContainerWrapper />}
+          {...props}
+          zoom={zoom}
+        />
+      )}
     </MapWrapper>
   );
 };

--- a/app/client/src/components/designSystems/appsmith/MapComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/MapComponent.tsx
@@ -4,7 +4,7 @@ import SearchBox from "react-google-maps/lib/components/places/SearchBox";
 import { MarkerProps } from "widgets/MapWidget";
 import PickMyLocation from "./PickMyLocation";
 import styled from "styled-components";
-import { useScript, ScriptStatuses } from "utils/hooks/useScript";
+import { useScript, ScriptStatus, AddScriptTo } from "utils/hooks/useScript";
 
 interface MapComponentProps {
   apiKey: string;
@@ -176,11 +176,11 @@ const MapComponent = (props: MapComponentProps) => {
   const zoom = Math.floor(props.zoomLevel / 5);
   const status = useScript(
     `https://maps.googleapis.com/maps/api/js?key=${props.apiKey}&v=3.exp&libraries=geometry,drawing,places`,
-    true,
+    AddScriptTo.HEAD,
   );
   return (
     <MapWrapper onMouseLeave={props.enableDrag}>
-      {status === ScriptStatuses.READY && (
+      {status === ScriptStatus.READY && (
         <MyMapComponent
           loadingElement={<MapContainerWrapper />}
           containerElement={<MapContainerWrapper />}

--- a/app/client/src/components/designSystems/blueprint/ButtonComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/ButtonComponent.tsx
@@ -10,7 +10,7 @@ import { ButtonStyle } from "widgets/ButtonWidget";
 import { Theme, darkenHover, darkenActive } from "constants/DefaultTheme";
 import _ from "lodash";
 import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
-import { useScript, ScriptStatuses } from "utils/hooks/useScript";
+import { useScript, ScriptStatus } from "utils/hooks/useScript";
 import {
   GOOGLE_RECAPTCHA_KEY_ERROR,
   GOOGLE_RECAPTCHA_DOMAIN_ERROR,
@@ -179,7 +179,7 @@ const RecaptchaComponent = (
   return (
     <div
       onClick={(event: React.MouseEvent<HTMLElement>) => {
-        if (status === ScriptStatuses.READY) {
+        if (status === ScriptStatus.READY) {
           (window as any).grecaptcha.ready(() => {
             try {
               (window as any).grecaptcha

--- a/app/client/src/components/designSystems/blueprint/ButtonComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/ButtonComponent.tsx
@@ -10,7 +10,7 @@ import { ButtonStyle } from "widgets/ButtonWidget";
 import { Theme, darkenHover, darkenActive } from "constants/DefaultTheme";
 import _ from "lodash";
 import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
-import useScript from "utils/hooks/useScript";
+import { useScript, ScriptStatuses } from "utils/hooks/useScript";
 import {
   GOOGLE_RECAPTCHA_KEY_ERROR,
   GOOGLE_RECAPTCHA_DOMAIN_ERROR,
@@ -179,7 +179,7 @@ const RecaptchaComponent = (
   return (
     <div
       onClick={(event: React.MouseEvent<HTMLElement>) => {
-        if (status === "ready") {
+        if (status === ScriptStatuses.READY) {
           (window as any).grecaptcha.ready(() => {
             try {
               (window as any).grecaptcha

--- a/app/client/src/components/propertyControls/LocationSearchControl.tsx
+++ b/app/client/src/components/propertyControls/LocationSearchControl.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import BaseControl, { ControlProps } from "./BaseControl";
 import styled from "styled-components";
 import SearchBox from "react-google-maps/lib/components/places/SearchBox";
 import StandaloneSearchBox from "react-google-maps/lib/components/places/StandaloneSearchBox";
 import { getAppsmithConfigs } from "configs";
+import { useScript, ScriptStatuses } from "utils/hooks/useScript";
 
 const StyledInput = styled.input`
   box-sizing: border-box;
@@ -28,11 +29,13 @@ const { google } = getAppsmithConfigs();
 
 class LocationSearchControl extends BaseControl<ControlProps> {
   searchBox: any = null;
-  state: any = { title: "" };
 
-  handleChange = (ev: any) => {
-    const val = ev.target.value;
-    this.setState({ title: val });
+  clearLocation = () => {
+    this.updateProperty(this.props.propertyName, {
+      lat: -34.397,
+      long: 150.644,
+      title: "",
+    });
   };
 
   onLocationSelection = () => {
@@ -43,7 +46,6 @@ class LocationSearchControl extends BaseControl<ControlProps> {
     const long = location.lng();
     const value = { lat, long, title };
     this.updateProperty(this.props.propertyName, value);
-    this.setState({ title: title });
   };
 
   onSearchBoxMounted = (ref: SearchBox) => {
@@ -51,22 +53,13 @@ class LocationSearchControl extends BaseControl<ControlProps> {
   };
 
   render() {
-    // Todo: figure out why there's a race here.
-    if (!window.google) return null;
     return (
-      <div data-standalone-searchbox="">
-        <StandaloneSearchBox
-          ref={this.onSearchBoxMounted}
-          onPlacesChanged={this.onLocationSelection}
-        >
-          <StyledInput
-            type="text"
-            placeholder="Enter location"
-            value={this.state.title || this.props.propertyValue.title}
-            onChange={this.handleChange}
-          />
-        </StandaloneSearchBox>
-      </div>
+      <MapScriptWrapper
+        onSearchBoxMounted={this.onSearchBoxMounted}
+        onPlacesChanged={this.onLocationSelection}
+        propertyValue={this.props.propertyValue}
+        clearLocation={this.clearLocation}
+      />
     );
   }
 
@@ -74,5 +67,47 @@ class LocationSearchControl extends BaseControl<ControlProps> {
     return "LOCATION_SEARCH";
   }
 }
+
+interface MapScriptWrapperProps {
+  onSearchBoxMounted: (ref: SearchBox) => void;
+  onPlacesChanged: () => void;
+  clearLocation: () => void;
+  propertyValue: any;
+}
+
+const MapScriptWrapper = (props: MapScriptWrapperProps) => {
+  const status = useScript(
+    `https://maps.googleapis.com/maps/api/js?key=${google.apiKey}&v=3.exp&libraries=geometry,drawing,places`,
+    true,
+  );
+  const [title, setTitle] = useState("");
+  return (
+    <div data-standalone-searchbox="">
+      {status === ScriptStatuses.READY && (
+        <StandaloneSearchBox
+          ref={props.onSearchBoxMounted}
+          onPlacesChanged={() => {
+            console.log("placed changed");
+            props.onPlacesChanged();
+            setTitle("");
+          }}
+        >
+          <StyledInput
+            type="text"
+            placeholder="Enter location"
+            value={title || props.propertyValue.title}
+            onChange={ev => {
+              const val = ev.target.value;
+              if (val === "") {
+                props.clearLocation();
+              }
+              setTitle(val);
+            }}
+          />
+        </StandaloneSearchBox>
+      )}
+    </div>
+  );
+};
 
 export default LocationSearchControl;

--- a/app/client/src/components/propertyControls/LocationSearchControl.tsx
+++ b/app/client/src/components/propertyControls/LocationSearchControl.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import SearchBox from "react-google-maps/lib/components/places/SearchBox";
 import StandaloneSearchBox from "react-google-maps/lib/components/places/StandaloneSearchBox";
 import { getAppsmithConfigs } from "configs";
-import { useScript, ScriptStatuses } from "utils/hooks/useScript";
+import { useScript, ScriptStatus, AddScriptTo } from "utils/hooks/useScript";
 
 const StyledInput = styled.input`
   box-sizing: border-box;
@@ -19,11 +19,6 @@ const StyledInput = styled.input`
   background: #272821;
   color: ${props => props.theme.colors.textOnDarkBG};
 `;
-
-interface StandaloneSearchBoxProps {
-  onSearchBoxMounted: (ref: any) => void;
-  onPlacesChanged: () => void;
-}
 
 const { google } = getAppsmithConfigs();
 
@@ -78,16 +73,15 @@ interface MapScriptWrapperProps {
 const MapScriptWrapper = (props: MapScriptWrapperProps) => {
   const status = useScript(
     `https://maps.googleapis.com/maps/api/js?key=${google.apiKey}&v=3.exp&libraries=geometry,drawing,places`,
-    true,
+    AddScriptTo.HEAD,
   );
   const [title, setTitle] = useState("");
   return (
     <div data-standalone-searchbox="">
-      {status === ScriptStatuses.READY && (
+      {status === ScriptStatus.READY && (
         <StandaloneSearchBox
           ref={props.onSearchBoxMounted}
           onPlacesChanged={() => {
-            console.log("placed changed");
             props.onPlacesChanged();
             setTitle("");
           }}

--- a/app/client/src/utils/hooks/useScript.tsx
+++ b/app/client/src/utils/hooks/useScript.tsx
@@ -44,7 +44,6 @@ export function useScript(src: string, head = false): ScriptStatuses {
         // Store status in attribute on script
         // This can be read by other instances of this hook
         const setAttributeFromEvent = (event: any) => {
-          console.log("myhahaha", event);
           script.setAttribute(
             "data-status",
             event.type === "load" ? ScriptStatuses.READY : ScriptStatuses.ERROR,
@@ -62,7 +61,6 @@ export function useScript(src: string, head = false): ScriptStatuses {
       // Note: Even if the script already exists we still need to add
       // event handlers to update the state for *this* hook instance.
       const setStateFromEvent = (event: any) => {
-        console.log("wait what why?", event);
         setStatus(
           event.type === "load" ? ScriptStatuses.READY : ScriptStatuses.ERROR,
         );

--- a/app/client/src/widgets/MapWidget.tsx
+++ b/app/client/src/widgets/MapWidget.tsx
@@ -38,6 +38,7 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
       isVisible: VALIDATION_TYPES.BOOLEAN,
       enableSearch: VALIDATION_TYPES.BOOLEAN,
       enablePickLocation: VALIDATION_TYPES.BOOLEAN,
+      enableCreateMarker: VALIDATION_TYPES.BOOLEAN,
       allowZoom: VALIDATION_TYPES.BOOLEAN,
       zoomLevel: VALIDATION_TYPES.NUMBER,
       mapCenter: VALIDATION_TYPES.OBJECT,
@@ -86,19 +87,20 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
 
   onCreateMarker = (lat: number, long: number) => {
     this.disableDrag(true);
-    this.props.updateWidgetMetaProperty(
-      "selectedMarker",
-      {
-        lat,
-        long,
+    const marker = { lat, long, title: "" };
+
+    const markers = [];
+    (this.props.markers || []).forEach(m => {
+      markers.push(m);
+    });
+    markers.push(marker);
+    this.props.updateWidgetMetaProperty("markers", markers);
+    this.props.updateWidgetMetaProperty("selectedMarker", marker, {
+      dynamicString: this.props.onCreateMarker,
+      event: {
+        type: EventType.ON_CREATE_MARKER,
       },
-      {
-        dynamicString: this.props.onCreateMarker,
-        event: {
-          type: EventType.ON_CREATE_MARKER,
-        },
-      },
-    );
+    });
   };
 
   unselectMarker = () => {
@@ -148,7 +150,7 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
             zoomLevel={this.props.zoomLevel}
             allowZoom={this.props.allowZoom}
             center={this.props.center || this.props.mapCenter || DefaultCenter}
-            enableCreateMarker
+            enableCreateMarker={this.props.enableCreateMarker}
             selectedMarker={this.props.selectedMarker}
             updateCenter={this.updateCenter}
             isDisabled={this.props.isDisabled}


### PR DESCRIPTION
## Description
- Add `head` option to `useScript`
- Start using enum `ScriptStatuses` instead of strings in `useScript`
- Switch `LocationSearchControl` and `MapComponent` to `useScript`
- Fix a bug where user could not clear initial location.

Fixes #1808

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually, there should be no regression.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
