### PR TITLE
Fixes #1990: NGINX error in Kubernetes deployment

### DIFF
--- a/deploy/k8s/scripts/appsmith-ingress.yaml.sh
+++ b/deploy/k8s/scripts/appsmith-ingress.yaml.sh
@@ -20,7 +20,7 @@ if [[ "$ssl_enable" == "true" ]]; then
             - $custom_domain
           secretName: lego-tls
       backend:
-        serviceName: "appsmith-editor"
+        serviceName: appsmith-editor
         servicePort: 80
       rules:
       - host: $custom_domain
@@ -29,17 +29,17 @@ if [[ "$ssl_enable" == "true" ]]; then
           - path: /api
             pathType: Prefix
             backend:
-              serviceName: appsmith-backend-service
+              serviceName: appsmith-internal-server
               servicePort: 8080
           - path: /oauth
             pathType: Prefix
             backend:
-              serviceName: appsmith-backend-service
+              serviceName: appsmith-internal-server
               servicePort: 8080
           - path: /login
             pathType: Prefix
             backend:
-              serviceName: appsmith-backend-service
+              serviceName: appsmith-internal-server
               servicePort: 8080
           - path: /static
             pathType: Prefix
@@ -63,7 +63,7 @@ else
     spec:
 
       backend:
-        serviceName: "appsmith-editor"
+        serviceName: appsmith-editor
         servicePort: 80
       rules:
       - host: $custom_domain
@@ -72,17 +72,17 @@ else
           - path: /api
             pathType: Prefix
             backend:
-              serviceName: appsmith-backend-service
+              serviceName: appsmith-internal-server
               servicePort: 8080
           - path: /oauth
             pathType: Prefix
             backend:
-              serviceName: appsmith-backend-service
+              serviceName: appsmith-internal-server
               servicePort: 8080
           - path: /login
             pathType: Prefix
             backend:
-              serviceName: appsmith-backend-service
+              serviceName: appsmith-internal-server
               servicePort: 8080
           - path: /static
             pathType: Prefix

--- a/deploy/k8s/scripts/nginx-configmap.yaml
+++ b/deploy/k8s/scripts/nginx-configmap.yaml
@@ -3,7 +3,11 @@ kind: ConfigMap
 metadata:
   name: nginx-config-template
 data:
-  nginx.conf.template: "
+  nginx.conf.template: |
+  upstream appsmith-internal-server {
+    server appsmith-internal-server:8080;
+  }
+
   server {
     listen 80;
     client_max_body_size 10m;
@@ -41,4 +45,16 @@ data:
     location /f {
        proxy_pass https://cdn.optimizely.com/;
     }
-}"
+
+    location /api {
+      proxy_pass http://appsmith-internal-server;
+    }
+
+    location /oauth2 {
+      proxy_pass http://appsmith-internal-server;
+    }
+      
+    location /login {
+      proxy_pass http://appsmith-internal-server;
+    }
+  }

--- a/deploy/k8s/templates/backend-template.yaml
+++ b/deploy/k8s/templates/backend-template.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: appsmith-backend-service
+  name: appsmith-internal-server
   labels:
-    app: appsmith-backend-service
+    app: appsmith-internal-server
 spec:
   selector:
     app: appsmith-internal-server

--- a/deploy/k8s/templates/frontend-template.yaml
+++ b/deploy/k8s/templates/frontend-template.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   selector:
     app: appsmith-editor
+  type: NodePort
   ports:
   - port: 80
     targetPort: 80


### PR DESCRIPTION
### Changelogs:

1. Added `proxy_pass` for `appsmith-internal-server` ingress in NGINX template.
2. Added upstream in NGINX for `appsmith-internal-server`.
3. Added pipe convention to define NGINX template. Pipe convention is helpful to pretty print yamls when debugging pods/configmaps in K8s.
4. Added `type: NodePort` for the `appsmith-editor`.
5. Rename `appsmith-backend-server` to `appsmith-internal-server` for making debugging easier.