### PR TITLE
[Bug] Propagte mysql test datasource failure to UI.

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -715,6 +715,7 @@ function* executePageLoadAction(pageAction: PageAction) {
         isPageLoad: true,
       }),
     );
+    yield take(ReduxActionTypes.SET_EVALUATED_TREE);
   }
 }
 

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -356,7 +356,7 @@ public class MySqlPlugin extends BasePlugin {
                     .then(Mono.just(new DatasourceTestResult()))
                     .onErrorResume(error -> {
                         log.error("Error when testing MySQL datasource.", error);
-                        return Mono.error(Exceptions.propagate(error));
+                        return Mono.just(new DatasourceTestResult(error.getMessage()));
                     })
                     .subscribeOn(scheduler);
 

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -23,11 +23,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
 @Log4j
 public class MySqlPluginTest {
@@ -174,14 +174,18 @@ public class MySqlPluginTest {
     public void testTestDatasource() {
         /* Expect no error */
         StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
-                .expectNextCount(1)
+                .assertNext(datasourceTestResult -> {
+                    assertEquals(0, datasourceTestResult.getInvalids().size());
+                })
                 .verifyComplete();
 
         /* Create bad datasource configuration and expect error */
         dsConfig.getEndpoints().get(0).setHost("badHost");
         StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
-                .expectError()
-                .verify();
+                .assertNext(datasourceTestResult -> {
+                    assertNotEquals(0, datasourceTestResult.getInvalids().size());
+                })
+                .verifyComplete();
 
         /* Reset dsConfig */
         createDatasourceConfiguration();


### PR DESCRIPTION
## Description
1. Propagte mysql test datasource failure exception message to UI. 
2. Change build TC to reflect the same. 
 
Fixes appsmithorg/appsmith #2000 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- By providing false and true authentication credentials when testing datasource. 
![Screenshot 2020-12-02 at 5 21 52 PM](https://user-images.githubusercontent.com/1757421/100869783-8a63de80-34c3-11eb-959f-79f5e3e4b981.png)
![Screenshot 2020-12-02 at 5 21 59 PM](https://user-images.githubusercontent.com/1757421/100869788-8df76580-34c3-11eb-8e1a-6b4aa709b890.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
