### PR TITLE
Fix action execution params static values getting evaluated

### DIFF
--- a/app/client/src/components/editorComponents/actioncreator/ActionCreator.tsx
+++ b/app/client/src/components/editorComponents/actioncreator/ActionCreator.tsx
@@ -83,7 +83,7 @@ export const modalGetter = (value: string) => {
   return name;
 };
 
-const stringToJS = (string: string): string => {
+export const stringToJS = (string: string): string => {
   const { stringSegments, jsSnippets } = getDynamicBindings(string);
   const js = stringSegments
     .map((segment, index) => {
@@ -97,7 +97,7 @@ const stringToJS = (string: string): string => {
   return js;
 };
 
-const JSToString = (js: string): string => {
+export const JSToString = (js: string): string => {
   const segments = js.split(" + ");
   return segments
     .map(segment => {

--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -63,7 +63,7 @@ import {
 import { AppState } from "reducers";
 import { mapToPropList } from "utils/AppsmithUtils";
 import { validateResponse } from "sagas/ErrorSagas";
-import { ToastType, TypeOptions } from "react-toastify";
+import { TypeOptions } from "react-toastify";
 import { PLUGIN_TYPE_API } from "constants/ApiEditorConstants";
 import { DEFAULT_EXECUTE_ACTION_TIMEOUT_MS } from "constants/ApiConstants";
 import { updateAppStore } from "actions/pageActions";
@@ -71,7 +71,7 @@ import { getAppStoreName } from "constants/AppConstants";
 import downloadjs from "downloadjs";
 import { getType, Types } from "utils/TypeHelpers";
 import { Toaster } from "components/ads/Toast";
-import { Variant, ToastVariant } from "components/ads/common";
+import { Variant } from "components/ads/common";
 import PerformanceTracker, {
   PerformanceTransactionName,
 } from "utils/PerformanceTracker";
@@ -294,7 +294,11 @@ export function* getActionParams(
   // Evaluate all values
   const values: any = yield all(
     dataTreeBindings.map((binding: string) => {
-      return call(evaluateDynamicBoundValueSaga, binding);
+      if (isDynamicValue(binding)) {
+        return call(evaluateDynamicBoundValueSaga, binding);
+      } else {
+        return binding;
+      }
     }),
   );
   // convert to object and transform non string values


### PR DESCRIPTION
## Description
When passing static values in execution params argument of an action run, and referencing it in the action, it would try to evaluate it via bindings. Added a change that would force binding brackets if a user wants to evaluate this param, and it would pass the string as is if no binding brackets `{{ }}` are wrapped around the param value

> With binding
```
{{
  Api1.run(undefined, undefined, { message: "{{ Text1.text }}" })
}}
```
> Without binding
```
{{
  Api1.run(undefined, undefined, { message: "Hello" })
}}
```


## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
