### PR TITLE
Check boolean env values against 'true' string

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -102,6 +102,7 @@
     const APP_ID = parseConfig("__APPSMITH_INTERCOM_APP_ID__");
     const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__").length > 0;
     const DISABLE_TELEMETRY = parseConfig("__APPSMITH_DISABLE_TELEMETRY__").toLowerCase();
+    const MAIL_ENABLED = parseConfig("__APPSMITH_MAIL_ENABLED__").toLowerCase();
 
     // Initialize the Intercom library
     if (APP_ID.length && APP_ID[0] !== "%" && CLOUD_HOSTING) {
@@ -144,7 +145,7 @@
         releaseDate: parseConfig("__APPSMITH_VERSION_RELEASE_DATE__")
       },
       intercomAppID: APP_ID,
-      mailEnabled: parseConfig("__APPSMITH_MAIL_ENABLED__").length > 0,
+      mailEnabled: MAIL_ENABLED && MAIL_ENABLED === "true",
       disableTelemetry: DISABLE_TELEMETRY === "" || DISABLE_TELEMETRY === 'true' ,
     };
 

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -106,7 +106,7 @@
     const CONFIG_LOG_LEVEL_INDEX = LOG_LEVELS.indexOf(parseConfig("__APPSMITH_CLIENT_LOG_LEVEL__"));
 
     const APP_ID = parseConfig("__APPSMITH_INTERCOM_APP_ID__");
-    const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__");
+    const CLOUD_HOSTING = !!parseConfig("__APPSMITH_CLOUD_HOSTING__");
     const DISABLE_TELEMETRY = parseConfig("__APPSMITH_DISABLE_TELEMETRY__").toLowerCase();
 
     // Initialize the Intercom library

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -94,15 +94,20 @@
     const parseConfig = (config) => {
       if (config.indexOf("__") === 0 || config.indexOf("$") === 0)
         return "";
-      return config.trim();
+
+      const result = config.trim();
+      if (result.toLowerCase() === "false") {
+        return "";
+      }
+
+      return result;
     }
     const LOG_LEVELS = ["debug", "error"];
     const CONFIG_LOG_LEVEL_INDEX = LOG_LEVELS.indexOf(parseConfig("__APPSMITH_CLIENT_LOG_LEVEL__"));
 
     const APP_ID = parseConfig("__APPSMITH_INTERCOM_APP_ID__");
-    const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__").length > 0;
+    const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__");
     const DISABLE_TELEMETRY = parseConfig("__APPSMITH_DISABLE_TELEMETRY__").toLowerCase();
-    const MAIL_ENABLED = parseConfig("__APPSMITH_MAIL_ENABLED__").toLowerCase();
 
     // Initialize the Intercom library
     if (APP_ID.length && APP_ID[0] !== "%" && CLOUD_HOSTING) {
@@ -119,9 +124,9 @@
       smartLook: {
         id: parseConfig("__APPSMITH_SMART_LOOK_ID__"),
       },
-      enableGoogleOAuth: parseConfig("__APPSMITH_OAUTH2_GOOGLE_CLIENT_ID__").length > 0,
-      enableGithubOAuth: parseConfig("__APPSMITH_OAUTH2_GITHUB_CLIENT_ID__").length > 0,
-      enableRapidAPI: parseConfig("__APPSMITH_MARKETPLACE_ENABLED__").length > 0,
+      enableGoogleOAuth: !!parseConfig("__APPSMITH_OAUTH2_GOOGLE_CLIENT_ID__"),
+      enableGithubOAuth: !!parseConfig("__APPSMITH_OAUTH2_GITHUB_CLIENT_ID__"),
+      enableRapidAPI: !!parseConfig("__APPSMITH_MARKETPLACE_ENABLED__"),
       segment: {
         apiKey: parseConfig("__APPSMITH_SEGMENT_KEY__"),
         ceKey: parseConfig("__APPSMITH_SEGMENT_CE_KEY__"),
@@ -130,7 +135,7 @@
         licenseKey: parseConfig("__APPSMITH_FUSIONCHARTS_LICENSE_KEY__")
       },
       optimizely: parseConfig("__APPSMITH_OPTIMIZELY_KEY__"),
-      enableMixpanel: parseConfig("__APPSMITH_SEGMENT_KEY__").length > 0,
+      enableMixpanel: !!parseConfig("__APPSMITH_SEGMENT_KEY__"),
       algolia: {
         apiId: parseConfig("__APPSMITH_ALGOLIA_API_ID__"),
         apiKey: parseConfig("__APPSMITH_ALGOLIA_API_KEY__"),
@@ -139,14 +144,14 @@
       logLevel: CONFIG_LOG_LEVEL_INDEX > -1 ? LOG_LEVELS[CONFIG_LOG_LEVEL_INDEX] : LOG_LEVELS[1],
       google: parseConfig("__APPSMITH_GOOGLE_MAPS_API_KEY__"),
       cloudHosting: CLOUD_HOSTING,
-      enableTNCPP: parseConfig("__APPSMITH_TNC_PP__").length > 0,
+      enableTNCPP: !!parseConfig("__APPSMITH_TNC_PP__"),
       appVersion: {
         id: parseConfig("__APPSMITH_VERSION_ID__"),
         releaseDate: parseConfig("__APPSMITH_VERSION_RELEASE_DATE__")
       },
       intercomAppID: APP_ID,
-      mailEnabled: MAIL_ENABLED && MAIL_ENABLED === "true",
-      disableTelemetry: DISABLE_TELEMETRY === "" || DISABLE_TELEMETRY === 'true' ,
+      mailEnabled: !!parseConfig("__APPSMITH_MAIL_ENABLED__"),
+      disableTelemetry: DISABLE_TELEMETRY === "" || DISABLE_TELEMETRY === "true",
     };
 
   </script>

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -91,13 +91,17 @@
     registerPageServiceWorker();
   </script>
   <script type="text/javascript">
+    // '' (empty strings), 'false' are falsy
+    // could return either boolean or string based on value
     const parseConfig = (config) => {
       if (config.indexOf("__") === 0 || config.indexOf("$") === 0)
         return "";
 
       const result = config.trim();
-      if (result.toLowerCase() === "false") {
-        return "";
+      if (result.toLowerCase() === "false" || result === "") {
+        return false;
+      } else if (result.toLowerCase() === "true") {
+        return true;
       }
 
       return result;
@@ -106,8 +110,8 @@
     const CONFIG_LOG_LEVEL_INDEX = LOG_LEVELS.indexOf(parseConfig("__APPSMITH_CLIENT_LOG_LEVEL__"));
 
     const APP_ID = parseConfig("__APPSMITH_INTERCOM_APP_ID__");
-    const CLOUD_HOSTING = !!parseConfig("__APPSMITH_CLOUD_HOSTING__");
-    const DISABLE_TELEMETRY = parseConfig("__APPSMITH_DISABLE_TELEMETRY__").toLowerCase();
+    const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__");
+    const DISABLE_TELEMETRY = parseConfig("__APPSMITH_DISABLE_TELEMETRY__");
 
     // Initialize the Intercom library
     if (APP_ID.length && APP_ID[0] !== "%" && CLOUD_HOSTING) {
@@ -124,9 +128,9 @@
       smartLook: {
         id: parseConfig("__APPSMITH_SMART_LOOK_ID__"),
       },
-      enableGoogleOAuth: !!parseConfig("__APPSMITH_OAUTH2_GOOGLE_CLIENT_ID__"),
-      enableGithubOAuth: !!parseConfig("__APPSMITH_OAUTH2_GITHUB_CLIENT_ID__"),
-      enableRapidAPI: !!parseConfig("__APPSMITH_MARKETPLACE_ENABLED__"),
+      enableGoogleOAuth: parseConfig("__APPSMITH_OAUTH2_GOOGLE_CLIENT_ID__"),
+      enableGithubOAuth: parseConfig("__APPSMITH_OAUTH2_GITHUB_CLIENT_ID__"),
+      enableRapidAPI: parseConfig("__APPSMITH_MARKETPLACE_ENABLED__"),
       segment: {
         apiKey: parseConfig("__APPSMITH_SEGMENT_KEY__"),
         ceKey: parseConfig("__APPSMITH_SEGMENT_CE_KEY__"),
@@ -135,7 +139,7 @@
         licenseKey: parseConfig("__APPSMITH_FUSIONCHARTS_LICENSE_KEY__")
       },
       optimizely: parseConfig("__APPSMITH_OPTIMIZELY_KEY__"),
-      enableMixpanel: !!parseConfig("__APPSMITH_SEGMENT_KEY__"),
+      enableMixpanel: parseConfig("__APPSMITH_SEGMENT_KEY__"),
       algolia: {
         apiId: parseConfig("__APPSMITH_ALGOLIA_API_ID__"),
         apiKey: parseConfig("__APPSMITH_ALGOLIA_API_KEY__"),
@@ -144,14 +148,14 @@
       logLevel: CONFIG_LOG_LEVEL_INDEX > -1 ? LOG_LEVELS[CONFIG_LOG_LEVEL_INDEX] : LOG_LEVELS[1],
       google: parseConfig("__APPSMITH_GOOGLE_MAPS_API_KEY__"),
       cloudHosting: CLOUD_HOSTING,
-      enableTNCPP: !!parseConfig("__APPSMITH_TNC_PP__"),
+      enableTNCPP: parseConfig("__APPSMITH_TNC_PP__"),
       appVersion: {
         id: parseConfig("__APPSMITH_VERSION_ID__"),
         releaseDate: parseConfig("__APPSMITH_VERSION_RELEASE_DATE__")
       },
       intercomAppID: APP_ID,
-      mailEnabled: !!parseConfig("__APPSMITH_MAIL_ENABLED__"),
-      disableTelemetry: DISABLE_TELEMETRY === "" || DISABLE_TELEMETRY === "true",
+      mailEnabled: parseConfig("__APPSMITH_MAIL_ENABLED__"),
+      disableTelemetry: DISABLE_TELEMETRY === "" || DISABLE_TELEMETRY,
     };
 
   </script>


### PR DESCRIPTION
## Description
Check boolean env variables against 'true' string

Fixes #2036

## Type of change
Convention with respect to boolean env variables (currently affects just `mailEnabled`)

## How Has This Been Tested?

### setting value as falsy
- set `APPSMITH_MAIL_ENABLED` as  'false' or '' or omit
- restart nginx
  - `cd app/client`
  - `./start-https.sh`
- Forgot password page should show email not configured warning

### setting value as truthy
- set `APPSMITH_MAIL_ENABLED` as  any non empty string
- restart nginx
  - `cd app/client`
  - `./start-https.sh`
- Forgot password page should `not` show email not configured warning

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
