### PR TITLE
add step for running cypress tests at code contribution guidelines

### DIFF
--- a/contributions/CodeContributionsGuidelines.md
+++ b/contributions/CodeContributionsGuidelines.md
@@ -29,7 +29,16 @@ We use [Github Flow](https://guides.github.com/introduction/flow/index.html), so
 ### 🧪 Running tests
 
 #### Client
-1. In order to run the Cypress integration tests, run:
+1. In order to run the Cypress integration tests, you can create a local file `app/client/cypress.env.json` to populate `USERNAME` and `PASSWORD` env variables or use one of the methods [from their docs](https://docs.cypress.io/guides/guides/environment-variables.html#Setting).
+
+   ```json
+   {
+     "USERNAME": "Enter username",
+     "PASSWORD": "Enter password"
+   }
+   ```
+
+1. run:
 ```bash
   cd app/client
   yarn run test


### PR DESCRIPTION
## Description
Although the test automation doc contains details for integration tests, felt might be useful to add it here as well.

## Type of change
- doc update

