### PR TITLE
Remove unsafe functions from eval

### DIFF
--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -232,3 +232,5 @@ export const isPathADynamicProperty = (
   }
   return false;
 };
+
+export const unsafeFunctionForEval = ["setTimeout", "fetch"];

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -233,4 +233,4 @@ export const isPathADynamicProperty = (
   return false;
 };
 
-export const unsafeFunctionForEval = ["setTimeout", "fetch"];
+export const unsafeFunctionForEval = ["setTimeout", "fetch", "setInterval", "Promise"];

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -39,6 +39,7 @@ import {
   EvalError,
   EvalErrorTypes,
   extraLibraries,
+  unsafeFunctionForEval,
   getEntityDynamicBindingPathList,
   getWidgetDynamicTriggerPathList,
   isPathADynamicBinding,
@@ -971,6 +972,13 @@ const evaluate = (
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         self[library.accessor] = library.lib;
+      });
+
+      ///// Remove all unsafe functions
+      unsafeFunctionForEval.forEach(func => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: No types available
+        self[func] = undefined;
       });
 
       const evalResult = eval(script);


### PR DESCRIPTION
## Description
Certain functions defer execution to later that happen after our eval context. This is not safe and should not be allowed to reference

Fixes #1816

## Type of change
- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
