### PR TITLE
Table column max width limit removed

### DIFF
--- a/app/client/src/components/designSystems/appsmith/Table.tsx
+++ b/app/client/src/components/designSystems/appsmith/Table.tsx
@@ -64,7 +64,6 @@ interface TableProps {
 const defaultColumn = {
   minWidth: 30,
   width: 150,
-  maxWidth: 400,
 };
 
 export const Table = (props: TableProps) => {


### PR DESCRIPTION
## Description
Table column max width limit removed so that column can be resized to whatever level user wants. 

Fixes #1835 
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually Tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
