### PR TITLE
[wip] hide datetime popover when dragged

### DIFF
--- a/app/client/src/components/designSystems/blueprint/DatePickerComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/DatePickerComponent.tsx
@@ -10,6 +10,8 @@ import { DatePickerType } from "widgets/DatePickerWidget";
 import { WIDGET_PADDING } from "constants/WidgetConstants";
 import { TimePrecision } from "@blueprintjs/datetime";
 import { Colors } from "constants/Colors";
+import { connect } from "react-redux";
+import { AppState } from "reducers";
 
 const StyledControlGroup = styled(ControlGroup)`
   &&& {
@@ -108,6 +110,7 @@ class DatePickerComponent extends React.Component<
         )}
         {this.props.datePickerType === "DATE_PICKER" ? (
           <DateInput
+            popoverProps={{ usePortal: !this.props.isDragged }}
             className={this.props.isLoading ? "bp3-skeleton" : ""}
             formatDate={this.formatDate}
             parseDate={this.parseDate}
@@ -189,10 +192,19 @@ interface DatePickerComponentProps extends ComponentProps {
   isDisabled: boolean;
   onDateSelected: (selectedDate: string) => void;
   isLoading: boolean;
+  isDragged?: boolean;
 }
 
 interface DatePickerComponentState {
   selectedDate?: string;
 }
 
-export default DatePickerComponent;
+const mapStateToProps = (state: AppState, props: DatePickerComponentProps) => {
+  const isDragging = state.ui.widgetDragResize.isDragging;
+  const selectedWidget = state.ui.widgetDragResize.selectedWidget;
+  const isDragged = isDragging && selectedWidget === props.widgetId;
+
+  return { isDragged };
+};
+
+export default connect(mapStateToProps)(DatePickerComponent);

--- a/app/client/src/components/designSystems/blueprint/DatePickerComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/DatePickerComponent.tsx
@@ -110,7 +110,7 @@ class DatePickerComponent extends React.Component<
         )}
         {this.props.datePickerType === "DATE_PICKER" ? (
           <DateInput
-            popoverProps={{ usePortal: !this.props.isDragged }}
+            popoverProps={{ usePortal: !this.props.isDragged }} // to fix popover position when dragged
             className={this.props.isLoading ? "bp3-skeleton" : ""}
             formatDate={this.formatDate}
             parseDate={this.parseDate}


### PR DESCRIPTION
## Description
Looking for feedback here in terms of:
would this be a good way to make a widget aware it is being dragged?

If this is ok would do the cleanup (using predefined selectors)

Fixes #612

## Type of change
- Bug fix

## How Has This Been Tested?
- drag a datepicker widget, datepicker popover should be hidden while dragged

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
