### PR TITLE
Remove redundant widget delete hotkey

### DIFF
--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -131,17 +131,6 @@ class Editor extends Component<Props> {
         />
         <Hotkey
           global={true}
-          combo="del"
-          label="Delete Widget"
-          group="Canvas"
-          onKeyDown={(e: any) => {
-            this.props.deleteSelectedWidget();
-          }}
-          preventDefault
-          stopPropagation
-        />
-        <Hotkey
-          global={true}
           combo="mod + x"
           label="Cut Widget"
           group="Canvas"


### PR DESCRIPTION
## Description
Two delete toasts used to appear when using the "del" key to delete a widget.

Fixes #1981 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
