### PR TITLE
Hotfix crash on navigate to API page after widget rename

### DIFF
--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -233,9 +233,10 @@ const mapStateToProps = (
 ): ReduxStateProps => {
   const datasourceFromAction = apiFormValueSelector(state, "datasource");
   let datasourceMerged = datasourceFromAction;
+  // Todo: fix this properly later in #2164
   if (datasourceFromAction && "id" in datasourceFromAction) {
     const datasourceFromDataSourceList = state.entities.datasources.list.find(
-      d => d.id == datasourceFromAction.id,
+      d => d.id === datasourceFromAction.id,
     );
     if (datasourceFromDataSourceList) {
       datasourceMerged = _.merge(

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -231,9 +231,24 @@ const mapStateToProps = (
   state: AppState,
   ownProps: { pluginId: string },
 ): ReduxStateProps => {
+  const datasourceFromAction = apiFormValueSelector(state, "datasource");
+  let datasourceMerged = datasourceFromAction;
+  if (datasourceFromAction && "id" in datasourceFromAction) {
+    const datasourceFromDataSourceList = state.entities.datasources.list.find(
+      d => d.id == datasourceFromAction.id,
+    );
+    if (datasourceFromDataSourceList) {
+      datasourceMerged = _.merge(
+        {},
+        datasourceFromAction,
+        datasourceFromDataSourceList,
+      );
+    }
+  }
+
   return {
     orgId: state.ui.orgs.currentOrg.id,
-    datasource: apiFormValueSelector(state, "datasource"),
+    datasource: datasourceMerged,
     datasourceList: state.entities.datasources.list.filter(
       d => d.pluginId === ownProps.pluginId && d.isValid,
     ),

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -58,15 +58,10 @@ const actionsReducer = createReducer(initialState, {
       const payloadActionMap = _.keyBy(action.payload, "id");
       return state.map((stateAction: ActionData) => {
         if (stateAction.config.pageId === action.payload[0].pageId) {
-          const config = _.merge(
-            {},
-            stateAction.config,
-            payloadActionMap[stateAction.config.id],
-          );
           return {
             data: stateAction.data,
             isLoading: false,
-            config: config,
+            config: payloadActionMap[stateAction.config.id],
           };
         }
         return stateAction;

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -58,10 +58,15 @@ const actionsReducer = createReducer(initialState, {
       const payloadActionMap = _.keyBy(action.payload, "id");
       return state.map((stateAction: ActionData) => {
         if (stateAction.config.pageId === action.payload[0].pageId) {
+          const config = _.merge(
+            {},
+            stateAction.config,
+            payloadActionMap[stateAction.config.id],
+          );
           return {
             data: stateAction.data,
             isLoading: false,
-            config: payloadActionMap[stateAction.config.id],
+            config: config,
           };
         }
         return stateAction;


### PR DESCRIPTION
## Description
Merge existing data source into action config. This is a hotfix to avoid crashing. A longer proper refactor will be part of #2167

Fixes #2102

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Automated tests from #2087 cover the underlying case.
#2167 will remove the hotfix from here and #2087.

Manual QA steps on hotfix:
- Create a widget
- Create an API
- Convert API to data source
- Navigate to canvas
- Rename a widget
- Navigate to API

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
