### PR TITLE
Fix: Added undefined check on selectedRowIndices property before checking length

### DIFF
--- a/app/client/src/widgets/TableWidget.tsx
+++ b/app/client/src/widgets/TableWidget.tsx
@@ -417,11 +417,12 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           this.getSelectedRow(filteredTableData, selectedRowIndex),
         );
       } else {
-        const selectedRowIndices = this.props.selectedRowIndices.length
-          ? this.props.selectedRowIndices
-          : Array.isArray(this.props.defaultSelectedRow)
-          ? this.props.defaultSelectedRow
-          : [];
+        const selectedRowIndices =
+          this.props.selectedRowIndices && this.props.selectedRowIndices.length
+            ? this.props.selectedRowIndices
+            : Array.isArray(this.props.defaultSelectedRow)
+            ? this.props.defaultSelectedRow
+            : [];
         this.props.updateWidgetMetaProperty(
           "selectedRowIndices",
           selectedRowIndices,


### PR DESCRIPTION
## Description
Added undefined check on selectedRowIndices property before checking its length since it can be undefined

Fixes #2110 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
