### PR TITLE
Refactor actions, separate entities.actions from entities.datasources

### DIFF
--- a/app/client/src/actions/actionActions.ts
+++ b/app/client/src/actions/actionActions.ts
@@ -7,9 +7,7 @@ import {
 import { Action } from "entities/Action";
 import { batchAction } from "actions/batchActions";
 
-export const createActionRequest = (
-  payload: Partial<Action> & { eventData: any },
-) => {
+export const createActionRequest = (payload: Partial<Action>) => {
   return {
     type: ReduxActionTypes.CREATE_ACTION_INIT,
     payload,

--- a/app/client/src/actions/datasourceActions.ts
+++ b/app/client/src/actions/datasourceActions.ts
@@ -1,5 +1,6 @@
 import { ReduxAction, ReduxActionTypes } from "constants/ReduxActionConstants";
-import { CreateDatasourceConfig, Datasource } from "api/DatasourcesApi";
+import { CreateDatasourceConfig } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 
 export const createDatasourceFromForm = (payload: CreateDatasourceConfig) => {
   return {

--- a/app/client/src/actions/queryPaneActions.ts
+++ b/app/client/src/actions/queryPaneActions.ts
@@ -1,7 +1,7 @@
 import { ReduxActionTypes, ReduxAction } from "constants/ReduxActionConstants";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 
-export const createQueryRequest = (payload: Partial<RestAction>) => {
+export const createQueryRequest = (payload: Partial<Action>) => {
   return {
     type: ReduxActionTypes.CREATE_QUERY_INIT,
     payload,

--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -5,8 +5,7 @@ import {
   DEFAULT_EXECUTE_ACTION_TIMEOUT_MS,
 } from "constants/ApiConstants";
 import axios, { AxiosPromise, CancelTokenSource } from "axios";
-
-import { Action, RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 
 export interface CreateActionRequest<T> extends APIRequest {
   datasourceId: string;
@@ -89,12 +88,12 @@ export interface ActionResponse {
 }
 
 export interface MoveActionRequest {
-  action: RestAction;
+  action: Action;
   destinationPageId: string;
 }
 
 export interface CopyActionRequest {
-  action: RestAction;
+  action: Action;
   pageId: string;
 }
 
@@ -110,7 +109,7 @@ class ActionAPI extends API {
   static apiUpdateCancelTokenSource: CancelTokenSource;
   static queryUpdateCancelTokenSource: CancelTokenSource;
 
-  static fetchAPI(id: string): AxiosPromise<GenericApiResponse<RestAction>> {
+  static fetchAPI(id: string): AxiosPromise<GenericApiResponse<Action>> {
     return API.get(`${ActionAPI.url}/${id}`);
   }
 
@@ -122,30 +121,33 @@ class ActionAPI extends API {
 
   static fetchActions(
     applicationId: string,
-  ): AxiosPromise<GenericApiResponse<RestAction[]>> {
+  ): AxiosPromise<GenericApiResponse<Action[]>> {
     return API.get(ActionAPI.url, { applicationId });
   }
 
   static fetchActionsForViewMode(
     applicationId: string,
-  ): AxiosPromise<GenericApiResponse<RestAction[]>> {
+  ): AxiosPromise<GenericApiResponse<Action[]>> {
     return API.get(`${ActionAPI.url}/view`, { applicationId });
   }
 
   static fetchActionsByPageId(
     pageId: string,
-  ): AxiosPromise<GenericApiResponse<RestAction[]>> {
+  ): AxiosPromise<GenericApiResponse<Action[]>> {
     return API.get(ActionAPI.url, { pageId });
   }
 
   static updateAPI(
-    apiConfig: Partial<RestAction>,
+    apiConfig: Partial<Action>,
   ): AxiosPromise<ActionCreateUpdateResponse> {
     if (ActionAPI.apiUpdateCancelTokenSource) {
       ActionAPI.apiUpdateCancelTokenSource.cancel();
     }
     ActionAPI.apiUpdateCancelTokenSource = axios.CancelToken.source();
-    return API.put(`${ActionAPI.url}/${apiConfig.id}`, apiConfig, undefined, {
+    const action = Object.assign({}, apiConfig);
+    // While this line is not required, name can not be changed from this endpoint
+    delete action.name;
+    return API.put(`${ActionAPI.url}/${action.id}`, action, undefined, {
       cancelToken: ActionAPI.apiUpdateCancelTokenSource.token,
     });
   }

--- a/app/client/src/api/DatasourcesApi.ts
+++ b/app/client/src/api/DatasourcesApi.ts
@@ -1,59 +1,9 @@
+import { DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS } from "constants/ApiConstants";
 import API from "./Api";
 import { GenericApiResponse } from "./ApiResponses";
 import { AxiosPromise } from "axios";
-import { DEFAULT_TEST_DATA_SOURCE_TIMEOUT_MS } from "constants/ApiConstants";
-import { Property } from "entities/Action";
 
-interface DatasourceAuthentication {
-  authType?: string;
-  username?: string;
-  password?: string;
-}
-
-export interface QueryTemplate {
-  title: string;
-  body: string;
-}
-
-export interface DatasourceColumns {
-  name: string;
-  type: string;
-}
-
-export interface DatasourceKeys {
-  name: string;
-  type: string;
-}
-
-export interface DatasourceTable {
-  type: string;
-  name: string;
-  columns: DatasourceColumns[];
-  keys: DatasourceKeys[];
-  templates: QueryTemplate[];
-}
-
-export interface DatasourceStructure {
-  tables?: DatasourceTable[];
-}
-
-export interface Datasource {
-  id: string;
-  name: string;
-  pluginId: string;
-  organizationId?: string;
-  datasourceConfiguration: {
-    url: string;
-    authentication?: DatasourceAuthentication;
-    properties?: Record<string, string>;
-    headers?: Property[];
-    databaseName?: string;
-  };
-  invalids?: string[];
-  isValid?: boolean;
-  structure?: DatasourceStructure;
-}
-
+import { DatasourceAuthentication, Datasource } from "entities/Datasource";
 export interface CreateDatasourceConfig {
   name: string;
   pluginId: string;
@@ -64,6 +14,15 @@ export interface CreateDatasourceConfig {
   };
   //Passed for logging purposes.
   appName?: string;
+}
+
+export interface EmbeddedRestDatasourceRequest {
+  datasourceConfiguration: { url: string };
+  invalids: Array<string>;
+  isValid: boolean;
+  name: string;
+  organizationId: string;
+  pluginId: string;
 }
 
 class DatasourcesApi extends API {

--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -8,7 +8,7 @@ import EditableText, {
 } from "components/editorComponents/EditableText";
 import { removeSpecialChars, isNameValid } from "utils/helpers";
 import { AppState } from "reducers";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import { getDataTree } from "selectors/dataTreeSelectors";
 import { getExistingPageNames } from "sagas/selectors";
 
@@ -49,11 +49,11 @@ export const ActionNameEditor = () => {
     return isInOnboarding && currentStep < OnboardingStep.ADD_WIDGET;
   });
 
-  const actions: RestAction[] = useSelector((state: AppState) =>
+  const actions: Action[] = useSelector((state: AppState) =>
     state.entities.actions.map((action) => action.config),
   );
 
-  const currentActionConfig: RestAction | undefined = actions.find(
+  const currentActionConfig: Action | undefined = actions.find(
     (action) => action.id === params.apiId || action.id === params.queryId,
   );
 

--- a/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
+++ b/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import { Directions } from "utils/helpers";
 import { WidgetProps } from "widgets/BaseWidget";
 import CustomizedDropdown, {
@@ -24,7 +24,7 @@ import { ReduxAction } from "constants/ReduxActionConstants";
 
 export const getApiOptions = (
   skin: Skin,
-  apis: RestAction[],
+  apis: Action[],
   pageId: string,
   dispatch: (action: ReduxAction<unknown>) => void,
   updateDynamicInputValue: (value: string, cursor?: number) => void,
@@ -73,7 +73,7 @@ export const getApiOptions = (
 
 export const getQueryOptions = (
   skin: Skin,
-  queries: RestAction[],
+  queries: Action[],
   pageId: string,
   dispatch: (action: ReduxAction<unknown>) => void,
   updateDynamicInputValue: (value: string, cursor?: number) => void,
@@ -151,8 +151,8 @@ export const getWidgetOptions = (
 });
 
 export const getLightningMenuOptions = (
-  apis: RestAction[],
-  queries: RestAction[],
+  apis: Action[],
+  queries: Action[],
   widgets: WidgetProps[],
   pageId: string,
   dispatch: (action: ReduxAction<unknown>) => void,

--- a/app/client/src/components/editorComponents/LightningMenu/hooks.ts
+++ b/app/client/src/components/editorComponents/LightningMenu/hooks.ts
@@ -1,7 +1,7 @@
 import { useSelector } from "react-redux";
 import { AppState } from "reducers";
 import { WidgetProps } from "widgets/BaseWidget";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 
 export const useWidgets = () => {
   return useSelector((state: AppState) => {
@@ -21,11 +21,11 @@ export const useActions = () => {
       (action) => action.config.pageId === currentPageId,
     );
   });
-  const apis: RestAction[] = actions
+  const apis: Action[] = actions
     .filter((action) => action.config.pluginType === "API")
     .map((action) => action.config);
 
-  const queries: RestAction[] = actions
+  const queries: Action[] = actions
     .filter((action) => action.config.pluginType === "DB")
     .map((action) => action.config);
 

--- a/app/client/src/components/editorComponents/LightningMenu/index.tsx
+++ b/app/client/src/components/editorComponents/LightningMenu/index.tsx
@@ -4,7 +4,7 @@ import CustomizedDropdown, {
 } from "pages/common/CustomizedDropdown";
 
 import { Directions } from "utils/helpers";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import { WidgetProps } from "widgets/BaseWidget";
 import { getLightningMenuOptions } from "./helpers";
 import { LightningMenuTrigger } from "./LightningMenuTrigger";
@@ -15,8 +15,8 @@ import { useDispatch } from "react-redux";
 
 const lightningMenuOptions = (
   skin: Skin,
-  apis: RestAction[],
-  queries: RestAction[],
+  apis: Action[],
+  queries: Action[],
   widgets: WidgetProps[],
   pageId: string,
   dispatch: (action: unknown) => void,

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -12,9 +12,12 @@ import CodeEditor, {
 import { API_EDITOR_FORM_NAME } from "constants/forms";
 import { AppState } from "reducers";
 import { connect } from "react-redux";
-import { Datasource } from "api/DatasourcesApi";
 import _ from "lodash";
-import { DEFAULT_DATASOURCE, EmbeddedDatasource } from "entities/Datasource";
+import {
+  DEFAULT_DATASOURCE,
+  EmbeddedRestDatasource,
+  Datasource,
+} from "entities/Datasource";
 import CodeMirror from "codemirror";
 import {
   EditorModes,
@@ -29,12 +32,12 @@ import { urlGroupsRegexExp } from "constants/ActionConstants";
 
 type ReduxStateProps = {
   orgId: string;
-  datasource: Datasource | EmbeddedDatasource;
+  datasource: Datasource | EmbeddedRestDatasource;
   datasourceList: Datasource[];
 };
 
 type ReduxDispatchProps = {
-  updateDatasource: (datasource: Datasource | EmbeddedDatasource) => void;
+  updateDatasource: (datasource: Datasource | EmbeddedRestDatasource) => void;
 };
 
 type Props = EditorProps &

--- a/app/client/src/constants/ApiEditorConstants.ts
+++ b/app/client/src/constants/ApiEditorConstants.ts
@@ -1,4 +1,4 @@
-import { RestAction } from "entities/Action";
+import { ApiActionConfig } from "entities/Action";
 import { DEFAULT_ACTION_TIMEOUT } from "constants/ApiConstants";
 import { zipObject } from "lodash";
 
@@ -23,19 +23,17 @@ export const HTTP_METHOD_OPTIONS = HTTP_METHODS.map((method) => ({
 
 export const REST_PLUGIN_PACKAGE_NAME = "restapi-plugin";
 
-export const DEFAULT_API_ACTION: Partial<RestAction> = {
-  actionConfiguration: {
-    timeoutInMillisecond: DEFAULT_ACTION_TIMEOUT,
-    httpMethod: HTTP_METHODS[0],
-    headers: [
-      { key: "", value: "" },
-      { key: "", value: "" },
-    ],
-    queryParameters: [
-      { key: "", value: "" },
-      { key: "", value: "" },
-    ],
-  },
+export const DEFAULT_API_ACTION_CONFIG: ApiActionConfig = {
+  timeoutInMillisecond: DEFAULT_ACTION_TIMEOUT,
+  httpMethod: HTTP_METHODS[0],
+  headers: [
+    { key: "", value: "" },
+    { key: "", value: "" },
+  ],
+  queryParameters: [
+    { key: "", value: "" },
+    { key: "", value: "" },
+  ],
 };
 
 export const PLUGIN_TYPE_API = "API";

--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -1,11 +1,79 @@
-import { Datasource } from "api/DatasourcesApi";
+import { Property } from "entities/Action";
+import _ from "lodash";
+export interface DatasourceAuthentication {
+  authType?: string;
+  username?: string;
+  password?: string;
+}
 
-export type EmbeddedDatasource = Omit<Datasource, "id">;
+export interface DatasourceColumns {
+  name: string;
+  type: string;
+}
+
+export interface DatasourceKeys {
+  name: string;
+  type: string;
+}
+
+export interface DatasourceStructure {
+  tables?: DatasourceTable[];
+}
+
+export interface QueryTemplate {
+  title: string;
+  body: string;
+}
+export interface DatasourceTable {
+  type: string;
+  name: string;
+  columns: DatasourceColumns[];
+  keys: DatasourceKeys[];
+  templates: QueryTemplate[];
+}
+
+// todo: check which fields are truly optional and move the common ones into base
+interface BaseDatasource {
+  pluginId: string;
+  name: string;
+  organizationId: string;
+  isValid: boolean;
+}
+
+export const isEmbeddedRestDatasource = (
+  val: any,
+): val is EmbeddedRestDatasource => {
+  if (!_.isObject(val)) return false;
+  if (!("datasourceConfiguration" in val)) return false;
+  val = <EmbeddedRestDatasource>val;
+  // Object should exist and have value
+  if (!val.datasourceConfiguration) return false;
+  //url might exist as a key but not have value, so we won't check value
+  if (!("url" in val.datasourceConfiguration)) return false;
+  return true;
+};
+
+export interface EmbeddedRestDatasource extends BaseDatasource {
+  datasourceConfiguration: { url: string };
+  invalids: Array<string>;
+}
+export interface Datasource extends BaseDatasource {
+  id: string;
+  datasourceConfiguration: {
+    url: string;
+    authentication?: DatasourceAuthentication;
+    properties?: Record<string, string>;
+    headers?: Property[];
+    databaseName?: string;
+  };
+  invalids?: string[];
+  structure?: DatasourceStructure;
+}
 
 export const DEFAULT_DATASOURCE = (
   pluginId: string,
   organizationId: string,
-): EmbeddedDatasource => ({
+): EmbeddedRestDatasource => ({
   name: "DEFAULT_REST_DATASOURCE",
   datasourceConfiguration: {
     url: "",

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -14,7 +14,7 @@ import DropdownField from "components/editorComponents/form/fields/DropdownField
 import { API_EDITOR_FORM_NAME } from "constants/forms";
 import { BaseTabbedView } from "components/designSystems/appsmith/TabbedView";
 import Pagination from "./Pagination";
-import { PaginationType, RestAction } from "entities/Action";
+import { PaginationType, Action } from "entities/Action";
 import { Icon } from "@blueprintjs/core";
 import { HelpMap, HelpBaseURL } from "constants/HelpConstants";
 import CollapsibleHelp from "components/designSystems/appsmith/help/CollapsibleHelp";
@@ -140,7 +140,7 @@ interface APIFormProps {
   apiName: string;
 }
 
-type Props = APIFormProps & InjectedFormProps<RestAction, APIFormProps>;
+type Props = APIFormProps & InjectedFormProps<Action, APIFormProps>;
 
 export const NameWrapper = styled.div`
   width: 49%;
@@ -309,7 +309,7 @@ export default connect((state: AppState) => {
     actionConfigurationHeaders,
   };
 })(
-  reduxForm<RestAction, APIFormProps>({
+  reduxForm<Action, APIFormProps>({
     form: API_EDITOR_FORM_NAME,
   })(ApiEditorForm),
 );

--- a/app/client/src/pages/Editor/APIEditor/RapidApiEditorForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/RapidApiEditorForm.tsx
@@ -15,7 +15,7 @@ import CredentialsTooltip from "components/editorComponents/form/CredentialsTool
 import { FormIcons } from "icons/FormIcons";
 import { BaseTabbedView } from "components/designSystems/appsmith/TabbedView";
 import Pagination from "./Pagination";
-import { PaginationType, RestAction } from "entities/Action";
+import { PaginationType, Action } from "entities/Action";
 import ActionNameEditor from "components/editorComponents/ActionNameEditor";
 import { NameWrapper } from "./Form";
 const Form = styled.form`
@@ -113,7 +113,7 @@ interface APIFormProps {
   dispatch: any;
 }
 
-type Props = APIFormProps & InjectedFormProps<RestAction, APIFormProps>;
+type Props = APIFormProps & InjectedFormProps<Action, APIFormProps>;
 
 const RapidApiEditorForm: React.FC<Props> = (props: Props) => {
   const {
@@ -307,7 +307,7 @@ export default connect((state) => {
     providerCredentialSteps,
   };
 })(
-  reduxForm<RestAction, APIFormProps>({
+  reduxForm<Action, APIFormProps>({
     form: API_EDITOR_FORM_NAME,
     destroyOnUnmount: false,
   })(RapidApiEditorForm),

--- a/app/client/src/pages/Editor/APIEditor/index.tsx
+++ b/app/client/src/pages/Editor/APIEditor/index.tsx
@@ -22,7 +22,7 @@ import {
   getIsEditorInitialized,
 } from "selectors/editorSelectors";
 import { Plugin } from "api/PluginApi";
-import { RapidApiAction, RestAction, PaginationType } from "entities/Action";
+import { RapidApiAction, Action, PaginationType } from "entities/Action";
 import { getApiName } from "selectors/formSelectors";
 import Spinner from "components/editorComponents/Spinner";
 import styled from "styled-components";
@@ -49,7 +49,7 @@ interface ReduxStateProps {
   pages: any;
   plugins: Plugin[];
   pluginId: any;
-  apiAction: RestAction | ActionData | RapidApiAction | undefined;
+  apiAction: Action | ActionData | RapidApiAction | undefined;
   paginationType: PaginationType;
   isEditorInitialized: boolean;
 }

--- a/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
@@ -16,7 +16,7 @@ import Connected from "./Connected";
 
 import { HelpBaseURL, HelpMap } from "constants/HelpConstants";
 import Button from "components/editorComponents/Button";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { reduxForm, InjectedFormProps } from "redux-form";
 import { BaseButton } from "components/designSystems/blueprint/ButtonComponent";
 import { APPSMITH_IP_ADDRESSES } from "constants/DatasourceEditorConstants";

--- a/app/client/src/pages/Editor/DataSourceEditor/DatasourceSection.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DatasourceSection.tsx
@@ -1,4 +1,4 @@
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import React from "react";
 import { map, get } from "lodash";
 import { Colors } from "constants/Colors";
@@ -29,16 +29,17 @@ const FieldWrapper = styled.div`
 
 export const renderDatasourceSection = (
   config: any,
-  datasource: Datasource | undefined,
+  datasource: Datasource,
 ): any => {
   return (
-    <>
+    <React.Fragment key={datasource.id}>
       {map(config.children, (section) => {
         if ("children" in section) {
           return renderDatasourceSection(section, datasource);
         } else {
           try {
             const { label, configProperty, controlType } = section;
+            const reactKey = datasource.id + "_" + label;
             let value = get(datasource, configProperty);
 
             if (controlType === "KEYVALUE_ARRAY") {
@@ -55,7 +56,7 @@ export const renderDatasourceSection = (
 
             if (controlType === "FIXED_KEY_INPUT") {
               return (
-                <FieldWrapper>
+                <FieldWrapper key={reactKey}>
                   <Key>{configProperty.key}: </Key>{" "}
                   <Value>{configProperty.value}</Value>
                 </FieldWrapper>
@@ -64,7 +65,7 @@ export const renderDatasourceSection = (
 
             if (controlType === "KEY_VAL_INPUT") {
               return (
-                <FieldWrapper>
+                <FieldWrapper key={reactKey}>
                   <Key>{label}</Key>
                   {value.map((val: { key: string; value: string }) => {
                     return (
@@ -85,13 +86,13 @@ export const renderDatasourceSection = (
             }
 
             return (
-              <FieldWrapper>
+              <FieldWrapper key={reactKey}>
                 <Key>{label}: </Key> <Value>{value}</Value>
               </FieldWrapper>
             );
           } catch (e) {}
         }
       })}
-    </>
+    </React.Fragment>
   );
 };

--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -8,7 +8,7 @@ import EditableText, {
 import { AppState } from "reducers";
 import { getDatasource } from "selectors/entitiesSelector";
 import { useSelector, useDispatch } from "react-redux";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { getDataSources } from "selectors/editorSelectors";
 import { getDataTree } from "selectors/dataTreeSelectors";
 import { isNameValid } from "utils/helpers";

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -19,7 +19,7 @@ import {
 import { DATASOURCE_DB_FORM } from "constants/forms";
 import DatasourceHome from "./DatasourceHome";
 import DataSourceEditorForm from "./DBForm";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { RouteComponentProps } from "react-router";
 
 interface ReduxStateProps {

--- a/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
@@ -12,7 +12,7 @@ import {
 
 import { Page } from "constants/ReduxActionConstants";
 import { ExplorerURLParams } from "../helpers";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Plugin } from "api/PluginApi";
 import PluginGroup from "../PluginGroup/PluginGroup";
 

--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Plugin } from "api/PluginApi";
 import DataSourceContextMenu from "./DataSourceContextMenu";
 import { getPluginIcon } from "../ExplorerIcons";
@@ -21,6 +21,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "reducers";
 import { DatasourceStructureContainer } from "./DatasourceStructureContainer";
 import { getAction } from "selectors/entitiesSelector";
+import { isStoredDatasource } from "entities/Action";
 
 type ExplorerDatasourceEntityProps = {
   plugin: Plugin;
@@ -78,6 +79,13 @@ export const ExplorerDatasourceEntity = (
     [datasourceStructure, props.datasource.id, dispatch],
   );
 
+  let isDefaultExpanded = false;
+  if (expandDatasourceId === props.datasource.id) {
+    isDefaultExpanded = true;
+  } else if (queryAction && isStoredDatasource(queryAction.datasource)) {
+    isDefaultExpanded = queryAction.datasource.id === props.datasource.id;
+  }
+
   return (
     <Entity
       entityId={`${props.datasource.id}-${props.pageId}`}
@@ -88,10 +96,7 @@ export const ExplorerDatasourceEntity = (
       active={active}
       step={props.step}
       searchKeyword={props.searchKeyword}
-      isDefaultExpanded={
-        expandDatasourceId === props.datasource.id ||
-        queryAction?.datasource.id === props.datasource.id
-      }
+      isDefaultExpanded={isDefaultExpanded}
       action={switchDatasource}
       updateEntityName={updateDatasourceName}
       contextMenu={

--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceField.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceField.tsx
@@ -6,7 +6,7 @@ import {
 } from "../ExplorerIcons";
 import styled from "styled-components";
 import { Colors } from "constants/Colors";
-import { DatasourceColumns, DatasourceKeys } from "api/DatasourcesApi";
+import { DatasourceColumns, DatasourceKeys } from "entities/Datasource";
 
 const Wrapper = styled.div<{ step: number }>`
   padding-left: ${(props) =>

--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStructure.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStructure.tsx
@@ -8,7 +8,7 @@ import { EntityTogglesWrapper } from "../ExplorerStyledComponents";
 import styled from "styled-components";
 import QueryTemplates from "./QueryTemplates";
 import DatasourceField from "./DatasourceField";
-import { DatasourceTable } from "api/DatasourcesApi";
+import { DatasourceTable } from "entities/Datasource";
 
 const Wrapper = styled(EntityTogglesWrapper)`
   &&&& {

--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStructureContainer.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStructureContainer.tsx
@@ -1,7 +1,7 @@
 import {
   DatasourceStructure as DatasourceStructureType,
   DatasourceTable,
-} from "api/DatasourcesApi";
+} from "entities/Datasource";
 import React, { memo, ReactNode } from "react";
 import EntityPlaceholder from "../Entity/Placeholder";
 import { useEntityUpdateState } from "../hooks";

--- a/app/client/src/pages/Editor/Explorer/Datasources/QueryTemplates.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/QueryTemplates.tsx
@@ -9,7 +9,7 @@ import { getCurrentPageId } from "selectors/editorSelectors";
 import { QueryAction } from "entities/Action";
 import { Classes } from "@blueprintjs/core";
 import history from "utils/history";
-import { Datasource, QueryTemplate } from "api/DatasourcesApi";
+import { Datasource, QueryTemplate } from "entities/Datasource";
 import { useParams } from "react-router";
 import { ExplorerURLParams } from "../helpers";
 import { QUERY_EDITOR_URL_WITH_SELECTED_PAGE_ID } from "constants/routes";
@@ -48,7 +48,9 @@ export const QueryTemplates = (props: QueryTemplatesProps) => {
     (template: QueryTemplate) => {
       const newQueryName = createNewQueryName(actions, currentPageId || "");
       const queryactionConfiguration: Partial<QueryAction> = {
-        actionConfiguration: { body: template.body },
+        actionConfiguration: {
+          body: template.body,
+        },
       };
 
       dispatch(

--- a/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
@@ -15,7 +15,7 @@ import { getPluginGroups } from "../Actions/helpers";
 import ExplorerWidgetGroup from "../Widgets/WidgetGroup";
 import { resolveAsSpaceChar } from "utils/helpers";
 import { CanvasStructure } from "reducers/uiReducers/pageCanvasStructure";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Plugin } from "api/PluginApi";
 
 type ExplorerPageEntityProps = {

--- a/app/client/src/pages/Editor/Explorer/Pages/PageGroup.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/PageGroup.tsx
@@ -11,7 +11,7 @@ import { Page } from "constants/ReduxActionConstants";
 import ExplorerPageEntity from "./PageEntity";
 import { AppState } from "reducers";
 import { CanvasStructure } from "reducers/uiReducers/pageCanvasStructure";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Plugin } from "api/PluginApi";
 
 type ExplorerPageGroupProps = {

--- a/app/client/src/pages/Editor/Explorer/PluginGroup/PluginGroup.tsx
+++ b/app/client/src/pages/Editor/Explorer/PluginGroup/PluginGroup.tsx
@@ -1,4 +1,4 @@
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Page } from "constants/ReduxActionConstants";
 import { keyBy } from "lodash";
 import React, { memo, useCallback, useMemo } from "react";

--- a/app/client/src/pages/Editor/Explorer/hooks.ts
+++ b/app/client/src/pages/Editor/Explorer/hooks.ts
@@ -8,7 +8,8 @@ import {
 import { useSelector } from "react-redux";
 import { AppState } from "reducers";
 import { compact, groupBy } from "lodash";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
+import { isStoredDatasource } from "entities/Action";
 import { debounce } from "lodash";
 import { WidgetProps } from "widgets/BaseWidget";
 import log from "loglevel";
@@ -46,9 +47,17 @@ export const useFilteredDatasources = (searchKeyword?: string) => {
   const datasources = useMemo(() => {
     const datasourcesPageMap: Record<string, Datasource[]> = {};
     for (const [key, value] of Object.entries(actions)) {
-      const datasourceIds = value.map((action) => action.config.datasource?.id);
+      const datasourceIds = new Set();
+      value.forEach((action) => {
+        if (
+          isStoredDatasource(action.config.datasource) &&
+          action.config.datasource.id
+        ) {
+          datasourceIds.add(action.config.datasource.id);
+        }
+      });
       const activeDatasources = reducerDatasources.filter((datasource) =>
-        datasourceIds.includes(datasource.id),
+        datasourceIds.has(datasource.id),
       );
       datasourcesPageMap[key] = activeDatasources;
     }

--- a/app/client/src/pages/Editor/QueryEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/DatasourceCard.tsx
@@ -1,10 +1,12 @@
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
+import { isStoredDatasource } from "entities/Action";
 import { BaseButton } from "components/designSystems/blueprint/ButtonComponent";
 import React from "react";
 import { isNil } from "lodash";
 import { useDispatch, useSelector } from "react-redux";
 import { Colors } from "constants/Colors";
 import { useParams } from "react-router";
+
 import {
   getPluginImages,
   getQueryActionsForCurrentPage,
@@ -89,7 +91,9 @@ const DatasourceCard = (props: DatasourceCardProps) => {
   );
   const queryActions = useSelector(getQueryActionsForCurrentPage);
   const queriesWithThisDatasource = queryActions.filter(
-    (action) => action.config.datasource.id === datasource.id,
+    (action) =>
+      isStoredDatasource(action.config.datasource) &&
+      action.config.datasource.id === datasource.id,
   ).length;
 
   const currentFormConfig: Array<any> =

--- a/app/client/src/pages/Editor/QueryEditor/Form.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Form.tsx
@@ -16,14 +16,14 @@ import Button from "components/editorComponents/Button";
 import FormRow from "components/editorComponents/FormRow";
 import DropdownField from "components/editorComponents/form/fields/DropdownField";
 import { BaseButton } from "components/designSystems/blueprint/ButtonComponent";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { BaseTabbedView } from "components/designSystems/appsmith/TabbedView";
 import { QUERY_EDITOR_FORM_NAME } from "constants/forms";
 import { Colors } from "constants/Colors";
 import JSONViewer from "./JSONViewer";
 import FormControl from "../FormControl";
 import Table from "./Table";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import { connect, useDispatch } from "react-redux";
 import { AppState } from "reducers";
 import ActionNameEditor from "components/editorComponents/ActionNameEditor";
@@ -291,8 +291,7 @@ type ReduxProps = {
 
 export type StateAndRouteProps = QueryFormProps & ReduxProps;
 
-type Props = StateAndRouteProps &
-  InjectedFormProps<RestAction, StateAndRouteProps>;
+type Props = StateAndRouteProps & InjectedFormProps<Action, StateAndRouteProps>;
 
 const QueryEditorForm: React.FC<Props> = (props: Props) => {
   const {
@@ -639,7 +638,7 @@ const mapStateToProps = (state: AppState) => {
 };
 
 export default connect(mapStateToProps)(
-  reduxForm<RestAction, StateAndRouteProps>({
+  reduxForm<Action, StateAndRouteProps>({
     form: QUERY_EDITOR_FORM_NAME,
     enableReinitialize: true,
   })(QueryEditorForm),

--- a/app/client/src/pages/Editor/QueryEditor/QueryHomeScreen.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/QueryHomeScreen.tsx
@@ -6,7 +6,7 @@ import { AppState } from "reducers";
 import { createNewQueryName } from "utils/AppsmithUtils";
 import { getPluginImages } from "selectors/entitiesSelector";
 import { ActionDataState } from "reducers/entityReducers/actionsReducer";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { createActionRequest } from "actions/actionActions";
 import { Page } from "constants/ReduxActionConstants";
 import {

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -11,7 +11,7 @@ import { AppState } from "reducers";
 import { getIsEditorInitialized } from "selectors/editorSelectors";
 import { QUERY_EDITOR_FORM_NAME } from "constants/forms";
 import { Plugin } from "api/PluginApi";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import {
   getPluginIdsOfPackageNames,
   getPlugins,
@@ -180,9 +180,15 @@ const mapStateToProps = (state: AppState, props: any): ReduxStateProps => {
 
   const { editorConfigs, loadingFormConfigs } = plugins;
   const formData = getFormValues(QUERY_EDITOR_FORM_NAME)(state) as QueryAction;
-  const queryAction = getAction(state, props.match.params.queryId);
+  const queryAction = getAction(
+    state,
+    props.match.params.queryId,
+  ) as QueryAction;
+  let pluginId;
+  if (queryAction) {
+    pluginId = queryAction.pluginId;
+  }
   let editorConfig: any;
-  const pluginId = queryAction?.datasource?.pluginId;
 
   if (editorConfigs && pluginId) {
     editorConfig = editorConfigs[pluginId];

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -7,20 +7,19 @@ import {
 import { ActionResponse } from "api/ActionAPI";
 import { ExecuteErrorPayload } from "constants/ActionConstants";
 import _ from "lodash";
-import { RapidApiAction, RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import { UpdateActionPropertyActionPayload } from "actions/actionActions";
 import produce from "immer";
-import { Datasource } from "api/DatasourcesApi";
 
 export interface ActionData {
   isLoading: boolean;
-  config: RestAction | RapidApiAction;
+  config: Action;
   data?: ActionResponse;
 }
 export type ActionDataState = ActionData[];
 export interface PartialActionData {
   isLoading: boolean;
-  config: Partial<RestAction | RapidApiAction>;
+  config: { id: string };
   data?: ActionResponse;
 }
 
@@ -29,7 +28,7 @@ const initialState: ActionDataState = [];
 const actionsReducer = createReducer(initialState, {
   [ReduxActionTypes.FETCH_ACTIONS_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction[]>,
+    action: ReduxAction<Action[]>,
   ): ActionDataState => {
     return action.payload.map((action) => {
       const foundAction = state.find((currentAction) => {
@@ -44,7 +43,7 @@ const actionsReducer = createReducer(initialState, {
   },
   [ReduxActionTypes.FETCH_ACTIONS_VIEW_MODE_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction[]>,
+    action: ReduxAction<Action[]>,
   ): ActionDataState =>
     action.payload.map((a) => ({
       isLoading: false,
@@ -52,13 +51,13 @@ const actionsReducer = createReducer(initialState, {
     })),
   [ReduxActionTypes.FETCH_ACTIONS_FOR_PAGE_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction[]>,
+    action: ReduxAction<Action[]>,
   ): ActionDataState => {
     if (action.payload.length > 0) {
       const stateActionMap = _.keyBy(state, "config.id");
       const result: ActionDataState = [];
 
-      action.payload.forEach((actionPayload: RestAction) => {
+      action.payload.forEach((actionPayload: Action) => {
         const stateAction = stateActionMap[actionPayload.id];
         if (stateAction) {
           result.push({
@@ -86,13 +85,13 @@ const actionsReducer = createReducer(initialState, {
   },
   [ReduxActionTypes.SUBMIT_CURL_FORM_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction>,
+    action: ReduxAction<Action>,
   ) => state.concat([{ config: action.payload, isLoading: false }]),
   [ReduxActionErrorTypes.FETCH_ACTIONS_ERROR]: () => initialState,
   [ReduxActionErrorTypes.FETCH_ACTIONS_VIEW_MODE_ERROR]: () => initialState,
   [ReduxActionTypes.CREATE_ACTION_INIT]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction>,
+    action: ReduxAction<Action>,
   ): ActionDataState =>
     state.concat([
       {
@@ -102,7 +101,7 @@ const actionsReducer = createReducer(initialState, {
     ]),
   [ReduxActionTypes.CREATE_ACTION_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction>,
+    action: ReduxAction<Action>,
   ): ActionDataState =>
     state.map((a) => {
       if (
@@ -115,7 +114,7 @@ const actionsReducer = createReducer(initialState, {
     }),
   [ReduxActionTypes.CREATE_ACTION_ERROR]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction>,
+    action: ReduxAction<Action>,
   ): ActionDataState =>
     state.filter(
       (a) =>
@@ -124,7 +123,7 @@ const actionsReducer = createReducer(initialState, {
     ),
   [ReduxActionTypes.UPDATE_ACTION_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<{ data: RestAction }>,
+    action: ReduxAction<{ data: Action }>,
   ): ActionDataState =>
     state.map((a) => {
       if (a.config.id === action.payload.data.id)
@@ -257,7 +256,7 @@ const actionsReducer = createReducer(initialState, {
     }),
   [ReduxActionTypes.MOVE_ACTION_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction>,
+    action: ReduxAction<Action>,
   ): ActionDataState =>
     state.map((a) => {
       if (a.config.id === action.payload.id) {
@@ -306,7 +305,7 @@ const actionsReducer = createReducer(initialState, {
     ),
   [ReduxActionTypes.COPY_ACTION_SUCCESS]: (
     state: ActionDataState,
-    action: ReduxAction<RestAction>,
+    action: ReduxAction<Action>,
   ): ActionDataState =>
     state.map((a) => {
       if (
@@ -349,52 +348,6 @@ const actionsReducer = createReducer(initialState, {
           draft[index].config.executeOnLoad = true;
         }
       });
-    });
-  },
-  [ReduxActionTypes.FETCH_DATASOURCES_SUCCESS]: (
-    state: ActionDataState,
-    action: ReduxAction<Datasource[]>,
-  ) => {
-    const datasources = action.payload;
-
-    return state.map((action) => {
-      const datasourceId = action.config.datasource.id;
-      if (datasourceId) {
-        const datasource = datasources.find(
-          (datasource) => datasource.id === datasourceId,
-        );
-
-        return {
-          ...action,
-          config: {
-            ...action.config,
-            datasource: datasource || action.config.datasource, // fallback to original datasource if datasource not available.
-          },
-        };
-      }
-
-      return action;
-    });
-  },
-  [ReduxActionTypes.UPDATE_DATASOURCE_SUCCESS]: (
-    state: ActionDataState,
-    action: ReduxAction<Datasource>,
-  ) => {
-    const datasource = action.payload;
-
-    return state.map((action) => {
-      const datasourceId = action.config.datasource.id;
-      if (datasourceId && datasource.id === datasourceId) {
-        return {
-          ...action,
-          config: {
-            ...action.config,
-            datasource: datasource,
-          },
-        };
-      }
-
-      return action;
     });
   },
 });

--- a/app/client/src/reducers/entityReducers/datasourceReducer.ts
+++ b/app/client/src/reducers/entityReducers/datasourceReducer.ts
@@ -4,7 +4,7 @@ import {
   ReduxAction,
   ReduxActionErrorTypes,
 } from "constants/ReduxActionConstants";
-import { Datasource, DatasourceStructure } from "api/DatasourcesApi";
+import { Datasource, DatasourceStructure } from "entities/Datasource";
 
 export interface DatasourceDataState {
   list: Datasource[];

--- a/app/client/src/reducers/uiReducers/apiPaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/apiPaneReducer.ts
@@ -4,7 +4,7 @@ import {
   ReduxActionErrorTypes,
   ReduxAction,
 } from "constants/ReduxActionConstants";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import { UpdateActionPropertyActionPayload } from "actions/actionActions";
 
 const initialState: ApiPaneReduxState = {
@@ -115,7 +115,7 @@ const apiPaneReducer = createReducer(initialState, {
   }),
   [ReduxActionTypes.UPDATE_ACTION_SUCCESS]: (
     state: ApiPaneReduxState,
-    action: ReduxAction<{ data: RestAction }>,
+    action: ReduxAction<{ data: Action }>,
   ) => ({
     ...state,
     isSaving: {

--- a/app/client/src/reducers/uiReducers/datasourcePaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/datasourcePaneReducer.ts
@@ -1,6 +1,6 @@
 import { createReducer } from "utils/AppsmithUtils";
 import { ReduxActionTypes, ReduxAction } from "constants/ReduxActionConstants";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import _ from "lodash";
 
 const initialState: DatasourcePaneReduxState = {

--- a/app/client/src/reducers/uiReducers/queryPaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/queryPaneReducer.ts
@@ -5,7 +5,7 @@ import {
   ReduxAction,
 } from "constants/ReduxActionConstants";
 import _ from "lodash";
-import { RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import { ActionResponse } from "api/ActionAPI";
 
 const initialState: QueryPaneReduxState = {
@@ -66,7 +66,7 @@ const queryPaneReducer = createReducer(initialState, {
   }),
   [ReduxActionTypes.UPDATE_ACTION_SUCCESS]: (
     state: QueryPaneReduxState,
-    action: ReduxAction<{ data: RestAction }>,
+    action: ReduxAction<{ data: Action }>,
   ) => ({
     ...state,
     isSaving: {

--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -47,7 +47,7 @@ import {
   showRunActionConfirmModal,
   updateAction,
 } from "actions/actionActions";
-import { Action, RestAction } from "entities/Action";
+import { Action } from "entities/Action";
 import ActionAPI, {
   ActionApiResponse,
   ActionResponse,
@@ -364,7 +364,7 @@ export function* executeActionSaga(
   );
   const appMode = yield select(getAppMode);
   try {
-    const api: RestAction = yield select(getAction, actionId);
+    const api: Action = yield select(getAction, actionId);
     const currentApp: ApplicationPayload = yield select(getCurrentApplication);
     AnalyticsUtil.logEvent("EXECUTE_ACTION", {
       type: api.pluginType,

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -14,7 +14,7 @@ import {
 import { getFormData } from "selectors/formSelectors";
 import { API_EDITOR_FORM_NAME } from "constants/forms";
 import {
-  DEFAULT_API_ACTION,
+  DEFAULT_API_ACTION_CONFIG,
   POST_BODY_FORMAT_OPTIONS,
   REST_PLUGIN_PACKAGE_NAME,
   POST_BODY_FORMATS,
@@ -44,10 +44,10 @@ import { getPluginIdOfPackageName } from "sagas/selectors";
 import { getAction, getActions, getPlugins } from "selectors/entitiesSelector";
 import { ActionData } from "reducers/entityReducers/actionsReducer";
 import { createActionRequest, setActionProperty } from "actions/actionActions";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Plugin } from "api/PluginApi";
 import { PLUGIN_PACKAGE_DBS } from "constants/QueryEditorConstants";
-import { RestAction } from "entities/Action";
+import { Action, ApiAction } from "entities/Action";
 import { getCurrentOrgId } from "selectors/organizationSelectors";
 import log from "loglevel";
 import PerformanceTracker, {
@@ -140,7 +140,7 @@ function* initializeExtraFormDataSaga() {
   const headers = get(
     values,
     "actionConfiguration.headers",
-    DEFAULT_API_ACTION.actionConfiguration?.headers,
+    DEFAULT_API_ACTION_CONFIG.headers,
   );
 
   const queryParameters = get(
@@ -157,7 +157,7 @@ function* initializeExtraFormDataSaga() {
         change(
           API_EDITOR_FORM_NAME,
           "actionConfiguration.queryParameters",
-          DEFAULT_API_ACTION.actionConfiguration?.queryParameters,
+          DEFAULT_API_ACTION_CONFIG.queryParameters,
         ),
       );
   }
@@ -302,7 +302,7 @@ function* formValueChangeSaga(
   ]);
 }
 
-function* handleActionCreatedSaga(actionPayload: ReduxAction<RestAction>) {
+function* handleActionCreatedSaga(actionPayload: ReduxAction<Action>) {
   const { id, pluginType } = actionPayload.payload;
   const action = yield select(getAction, id);
   const data = { ...action };
@@ -338,7 +338,7 @@ function* handleCreateNewApiActionSaga(
     const newActionName = createNewApiName(pageActions, pageId);
     yield put(
       createActionRequest({
-        ...DEFAULT_API_ACTION,
+        actionConfiguration: DEFAULT_API_ACTION_CONFIG,
         name: newActionName,
         datasource: {
           name: "DEFAULT_REST_DATASOURCE",
@@ -350,7 +350,7 @@ function* handleCreateNewApiActionSaga(
           from: action.payload.from,
         },
         pageId,
-      }),
+      } as ApiAction), // We don't have recursive partial in typescript for now.
     );
     history.push(
       API_EDITOR_URL_WITH_SELECTED_PAGE_ID(applicationId, pageId, pageId),

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -35,10 +35,8 @@ import {
 } from "actions/datasourceActions";
 import { fetchPluginForm } from "actions/pluginActions";
 import { GenericApiResponse } from "api/ApiResponses";
-import DatasourcesApi, {
-  CreateDatasourceConfig,
-  Datasource,
-} from "api/DatasourcesApi";
+import DatasourcesApi, { CreateDatasourceConfig } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import PluginApi, { DatasourceForm } from "api/PluginApi";
 
 import {

--- a/app/client/src/sagas/OnboardingSagas.ts
+++ b/app/client/src/sagas/OnboardingSagas.ts
@@ -1,5 +1,6 @@
 import { GenericApiResponse } from "api/ApiResponses";
-import DatasourcesApi, { Datasource } from "api/DatasourcesApi";
+import DatasourcesApi from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Plugin } from "api/PluginApi";
 import {
   ReduxActionErrorTypes,

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -34,7 +34,7 @@ import {
   getDatasource,
   getPluginTemplates,
 } from "selectors/entitiesSelector";
-import { RestAction } from "entities/Action";
+import { QueryAction } from "entities/Action";
 import { setActionProperty } from "actions/actionActions";
 import { fetchPluginForm } from "actions/pluginActions";
 import { getQueryParams } from "utils/AppsmithUtils";
@@ -138,7 +138,7 @@ function* formValueChangeSaga(
   );
 }
 
-function* handleQueryCreatedSaga(actionPayload: ReduxAction<RestAction>) {
+function* handleQueryCreatedSaga(actionPayload: ReduxAction<QueryAction>) {
   const {
     id,
     pluginType,
@@ -164,7 +164,6 @@ function* handleQueryCreatedSaga(actionPayload: ReduxAction<RestAction>) {
     const showTemplate = !(
       !!actionConfiguration.body || isEmpty(queryTemplate)
     );
-
     history.replace(
       QUERIES_EDITOR_ID_URL(applicationId, pageId, id, {
         editName: "true",

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -6,7 +6,7 @@ import {
 import { ActionResponse } from "api/ActionAPI";
 import { QUERY_CONSTANT } from "constants/QueryEditorConstants";
 import { createSelector } from "reselect";
-import { Datasource } from "api/DatasourcesApi";
+import { Datasource } from "entities/Datasource";
 import { Action } from "entities/Action";
 import { find } from "lodash";
 import ImageAlt from "assets/images/placeholder-image.svg";
@@ -205,7 +205,7 @@ export const getActionsForCurrentPage = createSelector(
 export const getQueryActionsForCurrentPage = createSelector(
   getActionsForCurrentPage,
   (actions) => {
-    return actions.filter((action: ActionData) => {
+    return actions.filter((action) => {
       return action.config.pluginType === QUERY_CONSTANT;
     });
   },

--- a/app/client/src/selectors/formSelectors.ts
+++ b/app/client/src/selectors/formSelectors.ts
@@ -1,6 +1,5 @@
 import { getFormValues, isValid, getFormInitialValues } from "redux-form";
 import { AppState } from "reducers";
-import { RestAction } from "entities/Action";
 import { ActionData } from "reducers/entityReducers/actionsReducer";
 
 type GetFormData = (
@@ -9,8 +8,8 @@ type GetFormData = (
 ) => { initialValues: any; values: any; valid: boolean };
 
 export const getFormData: GetFormData = (state, formName) => {
-  const initialValues = getFormInitialValues(formName)(state) as RestAction;
-  const values = getFormValues(formName)(state) as RestAction;
+  const initialValues = getFormInitialValues(formName)(state);
+  const values = getFormValues(formName)(state);
   const valid = isValid(formName)(state);
   return { initialValues, values, valid };
 };

--- a/app/client/src/transformers/RestActionTransformer.ts
+++ b/app/client/src/transformers/RestActionTransformer.ts
@@ -1,8 +1,8 @@
 import { HTTP_METHODS } from "constants/ApiEditorConstants";
-
+import { ApiAction } from "entities/Action";
 import _ from "lodash";
 
-export const transformRestAction = (data: any): any => {
+export const transformRestAction = (data: ApiAction): ApiAction => {
   let action = { ...data };
   // GET actions should not save body
   if (action.actionConfiguration.httpMethod === HTTP_METHODS[0]) {

--- a/app/client/src/transformers/RestActionTransformers.test.ts
+++ b/app/client/src/transformers/RestActionTransformers.test.ts
@@ -1,10 +1,10 @@
 import { transformRestAction } from "transformers/RestActionTransformer";
-import { PluginType, RestAction } from "entities/Action";
+import { PluginType, ApiAction } from "entities/Action";
 import { POST_BODY_FORMAT_OPTIONS } from "constants/ApiEditorConstants";
 
 // jest.mock("POST_");
 
-const BASE_ACTION: RestAction = {
+const BASE_ACTION: ApiAction = {
   dynamicBindingPathList: [],
   cacheResponse: "",
   executeOnLoad: false,
@@ -22,13 +22,15 @@ const BASE_ACTION: RestAction = {
   actionConfiguration: {
     httpMethod: "GET",
     path: "users",
+    headers: [],
+    timeoutInMillisecond: 5000,
   },
   jsonPathKeys: [],
 };
 
 describe("Api action transformer", () => {
   it("Removes params from path", () => {
-    const input: RestAction = {
+    const input: ApiAction = {
       ...BASE_ACTION,
       actionConfiguration: {
         ...BASE_ACTION.actionConfiguration,
@@ -110,7 +112,16 @@ describe("Api action transformer", () => {
         httpMethod: "POST",
         headers: [{ key: "content-type", value: "application/json" }],
         body: "{ name: 'test' }",
-        bodyFormData: [{ key: "key", value: "value" }],
+        bodyFormData: [
+          {
+            key: "hey",
+            value: "ho",
+            editable: true,
+            mandatory: false,
+            description: "I been tryin to do it right",
+            type: "",
+          },
+        ],
       },
     };
     const output = {
@@ -120,7 +131,16 @@ describe("Api action transformer", () => {
         httpMethod: "POST",
         headers: [{ key: "content-type", value: "application/json" }],
         body: "{ name: 'test' }",
-        bodyFormData: [{ key: "key", value: "value" }],
+        bodyFormData: [
+          {
+            key: "hey",
+            value: "ho",
+            editable: true,
+            mandatory: false,
+            description: "I been tryin to do it right",
+            type: "",
+          },
+        ],
       },
     };
     const result = transformRestAction(input);
@@ -136,7 +156,16 @@ describe("Api action transformer", () => {
         headers: [
           { key: "content-type", value: POST_BODY_FORMAT_OPTIONS[1].value },
         ],
-        bodyFormData: [{ key: "key", value: "value" }],
+        bodyFormData: [
+          {
+            key: "hey",
+            value: "ho",
+            editable: true,
+            mandatory: false,
+            description: "I been tryin to do it right",
+            type: "",
+          },
+        ],
         body: "{ name: 'test' }",
       },
     };
@@ -149,7 +178,16 @@ describe("Api action transformer", () => {
           { key: "content-type", value: POST_BODY_FORMAT_OPTIONS[1].value },
         ],
         body: "{ name: 'test' }",
-        bodyFormData: [{ key: "key", value: "value" }],
+        bodyFormData: [
+          {
+            key: "hey",
+            value: "ho",
+            editable: true,
+            mandatory: false,
+            description: "I been tryin to do it right",
+            type: "",
+          },
+        ],
       },
     };
     const result = transformRestAction(input);
@@ -165,7 +203,16 @@ describe("Api action transformer", () => {
         headers: [
           { key: "content-type", value: POST_BODY_FORMAT_OPTIONS[1].value },
         ],
-        bodyFormData: [{ key: "hey", value: "ho" }],
+        bodyFormData: [
+          {
+            key: "hey",
+            value: "ho",
+            editable: true,
+            mandatory: false,
+            description: "I been tryin to do it right",
+            type: "",
+          },
+        ],
       },
     };
     const output = {
@@ -177,7 +224,16 @@ describe("Api action transformer", () => {
           { key: "content-type", value: POST_BODY_FORMAT_OPTIONS[1].value },
         ],
         body: "",
-        bodyFormData: [{ key: "hey", value: "ho" }],
+        bodyFormData: [
+          {
+            key: "hey",
+            value: "ho",
+            editable: true,
+            mandatory: false,
+            description: "I been tryin to do it right",
+            type: "",
+          },
+        ],
       },
     };
     const result = transformRestAction(input);

--- a/app/client/src/widgets/MapWidget.tsx
+++ b/app/client/src/widgets/MapWidget.tsx
@@ -75,8 +75,7 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
     const markers: Array<MarkerProps> = [...(this.props.markers || [])].map(
       (marker, i) => {
         if (index === i) {
-          marker.lat = lat;
-          marker.long = long;
+          marker = { lat, long };
         }
         return marker;
       },


### PR DESCRIPTION
## Description
Makes `entities.datasource` separate from `entities.actions`.

Fixes #2164 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Existing tests from #2087 should not break as I undo the hotfixes from #2087 and #2134

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
