### PR TITLE
fix modal entity not renamed through property pane when closed by clicking on the overlay

### DIFF
--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -31,6 +31,7 @@ type EditableTextProps = {
   hideEditIcon?: boolean;
   minimal?: boolean;
   onBlur?: (value?: string) => void;
+  beforeUnmount?: (value?: string) => void;
 };
 
 const EditPen = styled.img`
@@ -91,7 +92,7 @@ export const EditableText = (props: EditableTextProps) => {
   const [isEditing, setIsEditing] = useState(!!props.isEditingDefault);
   const [value, _setValue] = useState(props.defaultValue);
   const inputValRef = useRef("");
-  const { onTextChanged } = props;
+  const { beforeUnmount } = props;
 
   const setValue = useCallback(_value => {
     inputValRef.current = _value;
@@ -107,11 +108,14 @@ export const EditableText = (props: EditableTextProps) => {
     if (props.forceDefault === true) setValue(props.defaultValue);
   }, [props.forceDefault, props.defaultValue, setValue]);
 
+  // in some cases onTextChange is not fired
+  // for example when the modal is closed on clicking the overlay
   useEffect(() => {
     return () => {
-      onTextChanged(inputValRef.current);
+      if (typeof beforeUnmount === "function")
+        beforeUnmount(inputValRef.current);
     };
-  }, [onTextChanged]);
+  }, [beforeUnmount]);
 
   const edit = (e: any) => {
     setIsEditing(true);
@@ -122,7 +126,7 @@ export const EditableText = (props: EditableTextProps) => {
     props.onBlur && props.onBlur();
     const isInvalid = props.isInvalid ? props.isInvalid(_value) : false;
     if (!isInvalid) {
-      onTextChanged(_value);
+      props.onTextChanged(_value);
       setIsEditing(false);
     } else {
       Toaster.show({

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -110,7 +110,7 @@ export const EditableText = (props: EditableTextProps) => {
     return () => {
       props.onTextChanged(inputValRef.current);
     };
-  });
+  }, [props.onTextChanged]);
 
   const edit = (e: any) => {
     setIsEditing(true);

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -90,13 +90,13 @@ const TextContainer = styled.div<{ isValid: boolean; minimal: boolean }>`
 
 export const EditableText = (props: EditableTextProps) => {
   const [isEditing, setIsEditing] = useState(!!props.isEditingDefault);
-  const [value, _setValue] = useState(props.defaultValue);
+  const [value, setStateValue] = useState(props.defaultValue);
   const inputValRef = useRef("");
   const { beforeUnmount } = props;
 
   const setValue = useCallback(_value => {
     inputValRef.current = _value;
-    _setValue(_value);
+    setStateValue(_value);
   }, []);
 
   useEffect(() => {

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -100,17 +100,17 @@ export const EditableText = (props: EditableTextProps) => {
   useEffect(() => {
     setValue(props.defaultValue);
     setIsEditing(!!props.isEditingDefault);
-  }, [props.defaultValue, props.isEditingDefault]);
+  }, [props.defaultValue, props.isEditingDefault, setValue]);
 
   useEffect(() => {
     if (props.forceDefault === true) setValue(props.defaultValue);
-  }, [props.forceDefault, props.defaultValue]);
+  }, [props.forceDefault, props.defaultValue, setValue]);
 
   useEffect(() => {
     return () => {
       props.onTextChanged(inputValRef.current);
     };
-  }, []);
+  });
 
   const edit = (e: any) => {
     setIsEditing(true);

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -91,6 +91,7 @@ export const EditableText = (props: EditableTextProps) => {
   const [isEditing, setIsEditing] = useState(!!props.isEditingDefault);
   const [value, _setValue] = useState(props.defaultValue);
   const inputValRef = useRef("");
+  const { onTextChanged } = props;
 
   const setValue = useCallback(_value => {
     inputValRef.current = _value;
@@ -108,9 +109,9 @@ export const EditableText = (props: EditableTextProps) => {
 
   useEffect(() => {
     return () => {
-      props.onTextChanged(inputValRef.current);
+      onTextChanged(inputValRef.current);
     };
-  }, [props.onTextChanged]);
+  }, [onTextChanged]);
 
   const edit = (e: any) => {
     setIsEditing(true);
@@ -121,7 +122,7 @@ export const EditableText = (props: EditableTextProps) => {
     props.onBlur && props.onBlur();
     const isInvalid = props.isInvalid ? props.isInvalid(_value) : false;
     if (!isInvalid) {
-      props.onTextChanged(_value);
+      onTextChanged(_value);
       setIsEditing(false);
     } else {
       Toaster.show({

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   EditableText as BlueprintEditableText,
   Classes,
@@ -89,7 +89,13 @@ const TextContainer = styled.div<{ isValid: boolean; minimal: boolean }>`
 
 export const EditableText = (props: EditableTextProps) => {
   const [isEditing, setIsEditing] = useState(!!props.isEditingDefault);
-  const [value, setValue] = useState(props.defaultValue);
+  const [value, _setValue] = useState(props.defaultValue);
+  const inputValRef = useRef("");
+
+  const setValue = useCallback(_value => {
+    inputValRef.current = _value;
+    _setValue(_value);
+  }, []);
 
   useEffect(() => {
     setValue(props.defaultValue);
@@ -99,6 +105,12 @@ export const EditableText = (props: EditableTextProps) => {
   useEffect(() => {
     if (props.forceDefault === true) setValue(props.defaultValue);
   }, [props.forceDefault, props.defaultValue]);
+
+  useEffect(() => {
+    return () => {
+      props.onTextChanged(inputValRef.current);
+    };
+  }, []);
 
   const edit = (e: any) => {
     setIsEditing(true);

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useEffect, useCallback } from "react";
+import React, { useState, memo, useEffect, useCallback, useRef } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import EditableText, {
@@ -71,6 +71,7 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
   const widgets = useSelector(getExistingWidgetNames);
   const toggleEditWidgetName = useToggleEditWidgetName();
   const [name, setName] = useState(props.title);
+  const valueRef = useRef("");
 
   const updateTitle = useCallback(
     (value?: string) => {
@@ -78,8 +79,10 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
         value &&
         value.trim().length > 0 &&
         value.trim() !== props.title.trim() &&
+        valueRef.current !== value.trim() &&
         props.widgetId
       ) {
+        valueRef.current = value.trim();
         if (widgets.indexOf(value.trim()) > -1) {
           setName(props.title);
         }

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useEffect, useCallback, useRef } from "react";
+import React, { useState, memo, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import EditableText, {

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useEffect, useCallback } from "react";
+import React, { useState, memo, useEffect, useCallback, useRef } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import EditableText, {
@@ -71,6 +71,8 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
   const widgets = useSelector(getExistingWidgetNames);
   const toggleEditWidgetName = useToggleEditWidgetName();
   const [name, setName] = useState(props.title);
+  const titleValueRef = useRef("");
+
   const updateTitle = useCallback(
     (value: string) => {
       if (
@@ -79,6 +81,8 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
         value.trim() !== props.title.trim() &&
         props.widgetId
       ) {
+        titleValueRef.current = value.trim();
+
         if (widgets.indexOf(value.trim()) > -1) {
           setName(props.title);
         }
@@ -101,6 +105,15 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
     props.widgetId && toggleEditWidgetName(props.widgetId, false);
   }, [toggleEditWidgetName, props.widgetId]);
 
+  const beforeUnmount = useCallback(
+    _value => {
+      if (_value && _value.trim() !== titleValueRef.current) {
+        updateTitle(_value);
+      }
+    },
+    [updateTitle],
+  );
+
   return props.widgetId ? (
     <Wrapper>
       <NameWrapper>
@@ -117,6 +130,7 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
           hideEditIcon
           minimal
           className="t--propery-page-title"
+          beforeUnmount={beforeUnmount}
         />
         {updating && <Spinner size={16} />}
       </NameWrapper>

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -71,18 +71,15 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
   const widgets = useSelector(getExistingWidgetNames);
   const toggleEditWidgetName = useToggleEditWidgetName();
   const [name, setName] = useState(props.title);
-  const titleValueRef = useRef("");
 
   const updateTitle = useCallback(
-    (value: string) => {
+    (value?: string) => {
       if (
         value &&
         value.trim().length > 0 &&
         value.trim() !== props.title.trim() &&
         props.widgetId
       ) {
-        titleValueRef.current = value.trim();
-
         if (widgets.indexOf(value.trim()) > -1) {
           setName(props.title);
         }
@@ -105,15 +102,6 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
     props.widgetId && toggleEditWidgetName(props.widgetId, false);
   }, [toggleEditWidgetName, props.widgetId]);
 
-  const beforeUnmount = useCallback(
-    _value => {
-      if (_value && _value.trim() !== titleValueRef.current) {
-        updateTitle(_value);
-      }
-    },
-    [updateTitle],
-  );
-
   return props.widgetId ? (
     <Wrapper>
       <NameWrapper>
@@ -130,7 +118,7 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
           hideEditIcon
           minimal
           className="t--propery-page-title"
-          beforeUnmount={beforeUnmount}
+          beforeUnmount={updateTitle}
         />
         {updating && <Spinner size={16} />}
       </NameWrapper>


### PR DESCRIPTION
## Description
When the modal is closed by clicking the overlay the corresponding change method is not triggered.
Trigger change when the editable text unmounts

Fixes #992 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
manually
deferred to adding tests once the new tests for the table widget are merged (#2184)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
