### PR TITLE
br instead of p on enter within rte

### DIFF
--- a/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
@@ -57,6 +57,7 @@ export const RichtextEditorComponent = (
     }, 200);
     const selector = `textarea#rte-${props.widgetId}`;
     (window as any).tinyMCE.init({
+      forced_root_block: false,
       height: "100%",
       selector: selector,
       menubar: false,


### PR DESCRIPTION
## Description
Config to not force root element selected on press enter key

Fixes # (issue)
fixes #2048

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually:
- enter should insert <br>
- shift+enter should insert <p>

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
