### PR TITLE
fix prev widget hidden when dragging new

### DIFF
--- a/app/client/src/pages/Editor/WidgetCard.tsx
+++ b/app/client/src/pages/Editor/WidgetCard.tsx
@@ -7,10 +7,13 @@ import { WidgetIcons } from "icons/WidgetIcons";
 import {
   useWidgetDragResize,
   useShowPropertyPane,
+  useWidgetSelection,
 } from "utils/hooks/dragResizeHooks";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { generateReactKey } from "utils/generators";
 import { Colors } from "constants/Colors";
+import { AppState } from "reducers";
+import { useSelector } from "react-redux";
 
 type CardProps = {
   details: WidgetCardProps;
@@ -67,6 +70,12 @@ export const IconLabel = styled.h5`
 /* eslint-disable @typescript-eslint/no-unused-vars */
 const WidgetCard = (props: CardProps) => {
   const { setIsDragging } = useWidgetDragResize();
+  const { selectWidget } = useWidgetSelection();
+
+  const selectedWidget = useSelector(
+    (state: AppState) => state.ui.widgetDragResize.selectedWidget,
+  );
+
   // Generate a new widgetId which can be used in the future for this widget.
   const [widgetId, setWidgetId] = useState(generateReactKey());
   const showPropertyPane = useShowPropertyPane();
@@ -79,6 +88,9 @@ const WidgetCard = (props: CardProps) => {
       });
       showPropertyPane && showPropertyPane(undefined);
       setIsDragging && setIsDragging(true);
+
+      // Make sure that this widget is selected
+      selectWidget && selectedWidget !== widgetId && selectWidget(widgetId);
     },
     end: (widget, monitor) => {
       AnalyticsUtil.logEvent("WIDGET_CARD_DROP", {


### PR DESCRIPTION
## Description
Unselect prev widget on the canvas when dragging a new widget from the widgets sidebar

Fixes #2209

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
