### PR TITLE
null check on renderCell value

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableUtilities.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableUtilities.tsx
@@ -464,11 +464,12 @@ export const renderCell = (
   columnType: string,
   isHidden: boolean,
 ) => {
+  if (!value) {
+    return <CellWrapper isHidden={isHidden}></CellWrapper>;
+  }
   switch (columnType) {
     case ColumnTypes.IMAGE:
-      if (!value) {
-        return <CellWrapper isHidden={isHidden}></CellWrapper>;
-      } else if (!isString(value)) {
+      if (!isString(value)) {
         return (
           <CellWrapper isHidden={isHidden}>
             <div>Invalid Image </div>
@@ -505,9 +506,7 @@ export const renderCell = (
       );
     case ColumnTypes.VIDEO:
       const youtubeRegex = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=|\?v=)([^#&?]*).*/;
-      if (!value) {
-        return <CellWrapper isHidden={isHidden}></CellWrapper>;
-      } else if (isString(value) && youtubeRegex.test(value)) {
+      if (isString(value) && youtubeRegex.test(value)) {
         return (
           <CellWrapper isHidden={isHidden} className="video-cell">
             <PopoverVideo url={value} />


### PR DESCRIPTION
## Description
All other cases in the switch had a null check, default case was missing one

Fixes #2182 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

@vicky-primathon can you reason about this and help with a way to test this out? I tried setting cell data in table to be undefined and it still worked.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
