### PR TITLE
select first when default or selected tab is not found

### DIFF
--- a/app/client/src/widgets/TabsWidget.tsx
+++ b/app/client/src/widgets/TabsWidget.tsx
@@ -185,9 +185,14 @@ class TabsWidget extends BaseWidget<
       });
 
       if (!selectedTabWithinTabs) {
+        // try to select default else select first
+        const defaultTab = _.find(this.props.tabs, {
+          label: this.props.defaultTab,
+        });
+
         this.props.updateWidgetMetaProperty(
           "selectedTabWidgetId",
-          this.props.tabs[0].widgetId,
+          (defaultTab && defaultTab.widgetId) || this.props.tabs[0].widgetId,
         );
       }
     }

--- a/app/client/src/widgets/TabsWidget.tsx
+++ b/app/client/src/widgets/TabsWidget.tsx
@@ -177,6 +177,20 @@ class TabsWidget extends BaseWidget<
         );
       }
     }
+
+    // if selected tab is deleted
+    if (this.props.selectedTabWidgetId && this.props.tabs.length > 0) {
+      const selectedTabWithinTabs = _.find(this.props.tabs, {
+        widgetId: this.props.selectedTabWidgetId,
+      });
+
+      if (!selectedTabWithinTabs) {
+        this.props.updateWidgetMetaProperty(
+          "selectedTabWidgetId",
+          this.props.tabs[0].widgetId,
+        );
+      }
+    }
   }
 
   generateTabContainers = () => {
@@ -223,7 +237,9 @@ class TabsWidget extends BaseWidget<
         label: this.props.defaultTab,
       });
       // Find the default Tab id
-      const selectedTabWidgetId = selectedTab?.widgetId;
+      const selectedTabWidgetId = selectedTab
+        ? selectedTab.widgetId
+        : this.props.tabs[0].widgetId; // in case the default tab is deleted
       // If we have a legitimate default tab Id and it is not already the selected Tab
       if (
         selectedTabWidgetId &&


### PR DESCRIPTION
## Description
- select the first tab if the default tab is not found on load
- when the selected tab is deleted try to select default or first tab
- on deleting the default tab we are currently not updating the default tab at the moment since it would need further work and might be better to test and merge independently

Fixes #1984
Fixes #1638

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
