### PR TITLE
fix options drop-down scrolling to top on selection and reset query for multi-select

### DIFF
--- a/app/client/src/components/designSystems/blueprint/DropdownComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/DropdownComponent.tsx
@@ -278,6 +278,8 @@ class DropDownComponent extends React.Component<DropDownComponentProps> {
             </StyledSingleDropDown>
           ) : (
             <StyledMultiDropDown
+              resetOnSelect
+              scrollToActiveItem={false}
               className={this.props.isLoading ? Classes.SKELETON : ""}
               items={this.props.options}
               itemListPredicate={this.itemListPredicate}


### PR DESCRIPTION
## Description
Added props `resetOnSelect`, `scrollToActiveItem` (is set as true this scrolls the list to the top selected item in list)

Fixes #2132
Fixes #998

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
