### PR TITLE
RPC-like layer with graceful startup and shutdown around a webworker

### DIFF
--- a/app/client/cypress/plugins/index.js
+++ b/app/client/cypress/plugins/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const dotenv = require("dotenv");
 const chalk = require("chalk");
+const cypressLogToOutput = require("cypress-log-to-output");
 
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins
@@ -22,21 +23,24 @@ const chalk = require("chalk");
  * @type {Cypress.PluginConfig}
  */
 module.exports = (on, config) => {
+  // Todo: maybe raise a PR instead of overwriting `on("before:browser:launch", ...)` twice.
+  cypressLogToOutput.install(on, (type, event) => {
+    if (event.level === "error" || event.type === "error") {
+      return true;
+    }
+    return false;
+  });
+
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   on("before:browser:launch", (browser = {}, launchOptions) => {
     /*
       Uncomment below to get console log printed in cypress output
     */
-    launchOptions.args = require("cypress-log-to-output").browserLaunchHandler(
+
+    launchOptions.args = cypressLogToOutput.browserLaunchHandler(
       browser,
       launchOptions.args,
-      (type, event) => {
-        if (event.level === "error" || event.type === "error") {
-          return true;
-        }
-        return false;
-      },
     );
     if (browser.name === "chrome") {
       launchOptions.args.push("--disable-dev-shm-usage");

--- a/app/client/src/utils/WorkerUtil.test.ts
+++ b/app/client/src/utils/WorkerUtil.test.ts
@@ -1,0 +1,171 @@
+import { GracefulWorkerService } from "./WorkerUtil";
+import { runSaga } from "redux-saga";
+
+const MessageType = "message";
+class MockWorker {
+  callback: CallableFunction;
+  noop: CallableFunction;
+  messages: Array<any>;
+  delayMilliSeconds: number;
+  static instance: MockWorker | undefined;
+  responses: Set<number>;
+  running: boolean;
+
+  static resetInstance() {
+    MockWorker.instance = undefined;
+  }
+
+  constructor() {
+    /* eslint-disable @typescript-eslint/no-empty-function */
+    this.noop = () => {};
+    this.callback = this.noop;
+    this.messages = [];
+    this.delayMilliSeconds = 0;
+    this.responses = new Set<number>();
+    MockWorker.instance = this;
+    this.running = true;
+  }
+
+  addEventListener(msgType: string, callback: CallableFunction) {
+    expect(msgType).toEqual(MessageType);
+    this.callback = callback;
+  }
+
+  removeEventListener(msgType: string, callback: CallableFunction) {
+    expect(msgType).toEqual(MessageType);
+    expect(callback).toEqual(this.callback);
+    this.callback = this.noop;
+  }
+
+  postMessage(message: any) {
+    expect(this.running).toEqual(true);
+    expect(this.callback).not.toEqual(this.noop);
+    this.messages.push(message);
+    const counter = setTimeout(() => {
+      const response = {
+        requestId: message.requestId,
+        responseData: message.requestData,
+      };
+      this.sendEvent({ data: response });
+      this.responses.delete(counter);
+    }, this.delayMilliSeconds);
+    this.responses.add(counter);
+  }
+
+  sendEvent(ev: any) {
+    expect(this.running).toEqual(true);
+    expect(this.callback).not.toEqual(this.noop);
+    this.callback(ev);
+  }
+
+  terminate() {
+    this.running = false;
+    expect(this.callback).toEqual(this.noop);
+    this.responses.forEach(counter => {
+      clearTimeout(counter);
+    });
+    this.responses = new Set<number>();
+  }
+}
+
+describe("GracefulWorkerService", () => {
+  beforeEach(() => {
+    MockWorker.resetInstance();
+    // Assert we don't have an instance from before
+    expect(MockWorker.instance).toBeUndefined();
+  });
+
+  test("Worker should start", async () => {
+    const w = new GracefulWorkerService(MockWorker);
+
+    // wait for worker to start
+    await runSaga({}, w.start);
+    if (MockWorker.instance === undefined) {
+      expect(MockWorker.instance).toBeDefined();
+      return;
+    }
+    expect(MockWorker.instance.callback).not.toEqual(MockWorker.instance.noop);
+  });
+
+  test("Independent requests should respond independently irrespective of order", async () => {
+    const w = new GracefulWorkerService(MockWorker);
+    await runSaga({}, w.start);
+    const message1 = { tree: "hello" };
+    const message2 = { tree: "world" };
+    // Send requests in order
+    const result1 = await runSaga({}, w.request, "test", message1);
+    const result2 = await runSaga({}, w.request, "test", message2);
+    // wait for responses out of order
+    const resp2 = await result2.toPromise();
+    const resp1 = await result1.toPromise();
+    expect(resp1).toEqual(message1);
+    expect(resp2).toEqual(message2);
+  });
+
+  test("Request should wait for ready", async () => {
+    const w = new GracefulWorkerService(MockWorker);
+    const message = { hello: "world" };
+    // Send a request before starting
+    const result = await runSaga({}, w.request, "test", message);
+    // trigger start after the worker is already waiting
+    runSaga({}, w.start);
+    const resp = await result.toPromise();
+    expect(resp).toEqual(message);
+  });
+
+  test("Worker should wait to drain in-flight requests before shutdown", async () => {
+    const w = new GracefulWorkerService(MockWorker);
+    const message = { hello: "world" };
+    await runSaga({}, w.start);
+    const start = performance.now();
+    // Need this to work with eslint
+    if (MockWorker.instance === undefined) {
+      expect(MockWorker.instance).toBeDefined();
+      return;
+    }
+    // Typical run takes less than 10ms
+    // we add a delay of 100ms to check if shutdown waited for pending requests.
+    MockWorker.instance.delayMilliSeconds = 100;
+
+    const result = await runSaga({}, w.request, "test", message);
+    // wait for shutdown
+    await (await runSaga({}, w.shutdown)).toPromise();
+    // Shutdown shouldn't happen till we get a response
+    expect(performance.now() - start).toBeGreaterThanOrEqual(
+      MockWorker.instance.delayMilliSeconds,
+    );
+    const resp = await result.toPromise();
+    expect(resp).toEqual(message);
+  });
+
+  test("Worker restart should work", async () => {
+    const w = new GracefulWorkerService(MockWorker);
+    const message1 = { tree: "hello" };
+    await runSaga({}, w.start);
+
+    // Need this to work with eslint
+    if (MockWorker.instance === undefined) {
+      expect(MockWorker.instance).toBeDefined();
+      return;
+    }
+    // Keep a reference to the old instance to check later
+    const oldInstance = MockWorker.instance;
+    const result1 = await runSaga({}, w.request, "test", message1);
+    expect(await result1.toPromise()).toEqual(message1);
+    // stop the worker
+    await (await runSaga({}, w.shutdown)).toPromise();
+    // Should have called terminate on worker
+    expect(oldInstance.running).toEqual(false);
+
+    // Send a message to the new worker before starting it
+    const message2 = { tree: "world" };
+    const result2 = await runSaga({}, w.request, "test", message2);
+
+    await runSaga({}, w.start);
+
+    // We should have a new instance of the worker
+    expect(MockWorker.instance).not.toEqual(oldInstance);
+    // The new worker should get the correct message
+    expect(await result2.toPromise()).toEqual(message2);
+  });
+});

--- a/app/client/src/utils/WorkerUtil.test.ts
+++ b/app/client/src/utils/WorkerUtil.test.ts
@@ -61,7 +61,7 @@ class MockWorker {
   terminate() {
     this.running = false;
     expect(this.callback).toEqual(this.noop);
-    this.responses.forEach(counter => {
+    this.responses.forEach((counter) => {
       clearTimeout(counter);
     });
     this.responses = new Set<number>();

--- a/app/client/src/utils/WorkerUtil.ts
+++ b/app/client/src/utils/WorkerUtil.ts
@@ -1,0 +1,164 @@
+import { all, put, take, takeEvery } from "redux-saga/effects";
+import {
+  eventChannel,
+  EventChannel,
+  channel,
+  Channel,
+  END,
+  buffers,
+} from "redux-saga";
+import _ from "lodash";
+
+/**
+ * Wrap a webworker to provide a synchronous request-response semantic.
+ *
+ * Usage on main thread:
+ * w = GracefulWorkerService(Worker);
+ * yield w.start(); // Start the worker
+ * const workerResponse = yield w.request("my_action", { hello: "world" }); // Send a request, wait for response
+ *
+ * Worker will receive:
+ * {
+ *   method: "my_action",
+ *   requestId: "<unique request id>",
+ *   requestData: { hello: "world" },
+ * }
+ *
+ * Worker is expected to respond with an object with exactly the `requestId` and `responseData` keys:
+ * {
+ *   requestId: "<the id it received>",
+ *   responseData: 42
+ * }
+ * All other keys will be ignored.
+ * We make no assumptions about data type of `requestData` or `responseData`.
+ *
+ * Note: The worker will hold ALL requests, even in case of restarts.
+ * If we do not want that behaviour, we should create a new GracefulWorkerService.
+ */
+// TODO: Add a compatible listener layer on the worker to complete the framework.
+// TODO: Extract the worker wrapper into a library to be useful to anyone with WebWorkers + redux-saga.
+// TODO: Add support for timeouts on requests and shutdown.
+// TODO: Add a readiness + liveness probes.
+// TODO: Add telemetry.
+export class GracefulWorkerService {
+  // We keep track of all in-flight requests with these channels.
+  private _channels: {
+    [requestId: string]: Channel<any>;
+  };
+  // Redux-saga's channel subscriber for our worker.
+  private _workerChannel: EventChannel<any> | undefined;
+  // The actual WebWorker
+  private _evaluationWorker: Worker | undefined;
+
+  // Channels in redux-saga are NOT like signals.
+  // They operate in `pulse` mode of a signal. But `readiness` is more like a continuous signal.
+  // This variable provides the equivalent of the `hold` state signal.
+  // If isReady is false, wait on `this._readyChan` to get the pulse signal.
+  private _isReady: boolean;
+  // Channel to signal all waiters that we're ready. Always use it with `this._isReady`.
+  private _readyChan: Channel<any>;
+
+  private _workerClass: any;
+
+  constructor(workerClass: any) {
+    this.shutdown = this.shutdown.bind(this);
+    this.start = this.start.bind(this);
+    this.request = this.request.bind(this);
+    this._broker = this._broker.bind(this);
+
+    // Do not buffer messages on this channel
+    this._readyChan = channel(buffers.none());
+    this._isReady = false;
+    this._channels = {};
+    this._workerClass = workerClass;
+  }
+
+  /**
+   * Start a new worker and registers our broker.
+   * Note: Shuts down the old worker, if one exists.
+   */
+  *start() {
+    //TODO: call this on editor unmount as part of a separate PR
+    yield this.shutdown();
+    this._evaluationWorker = new this._workerClass();
+    this._workerChannel = eventChannel(emitter => {
+      if (!this._evaluationWorker) {
+        // Impossible case unless something really went wrong
+        // END the channel in that case
+        emitter(END);
+        return _.noop;
+      }
+
+      this._evaluationWorker.addEventListener("message", emitter);
+      // The subscriber must return an unsubscribe function
+      return () => {
+        if (!this._evaluationWorker) return;
+        this._evaluationWorker.removeEventListener("message", emitter);
+        this._evaluationWorker.terminate();
+        this._evaluationWorker = undefined;
+      };
+    });
+
+    // Listen to all messages from the channel and send it to our broker
+    yield takeEvery(this._workerChannel, this._broker);
+
+    // Inform all pending requests that we're good to go!
+    this._isReady = true;
+    yield put(this._readyChan, true);
+  }
+
+  /**
+   * Gracefully shutdown the worker.
+   */
+  *shutdown() {
+    // Ignore if already shutdown/shutting down
+    if (!this._isReady) return;
+    // stop accepting new requests
+    this._isReady = false;
+    // wait for current responses to drain
+    yield all(Object.values(this._channels).map(c => take(c)));
+    // close the worker
+    yield this._workerChannel?.close();
+  }
+
+  /**
+   * Send a request to the worker for processing.
+   * If the worker has not started yet, we wait for it to become ready.
+   *
+   * @param method identifier for a rpc method
+   * @param requestData data that we want to send over to the worker
+   *
+   * @returns response from the worker
+   */
+  *request(method: string, requestData = {}): any {
+    if (!this._evaluationWorker || !this._isReady) {
+      // Block requests till the worker is ready.
+      yield take(this._readyChan);
+      // Impossible case, but helps avoid `?` later in code and makes it clearer.
+      if (!this._evaluationWorker) return;
+    }
+    /**
+     * We create a unique channel to wait for a response of this specific request.
+     */
+    const requestId = `${method}__${_.uniqueId()}`;
+    this._channels[requestId] = channel();
+    this._evaluationWorker.postMessage({
+      method,
+      requestData,
+      requestId,
+    });
+    // The `this._broker` method is listening to events and will pass response to us over this channel.
+    const response = yield take(this._channels[requestId]);
+    yield this._channels[requestId].close(); // cleanup
+    delete this._channels[requestId];
+    return response;
+  }
+
+  private *_broker(event: MessageEvent) {
+    if (!event || !event.data) {
+      return;
+    }
+    const { requestId, responseData } = event.data;
+    yield put(this._channels[requestId], responseData);
+  }
+}

--- a/app/client/src/utils/WorkerUtil.ts
+++ b/app/client/src/utils/WorkerUtil.ts
@@ -81,7 +81,7 @@ export class GracefulWorkerService {
     //TODO: call this on editor unmount as part of a separate PR
     yield this.shutdown();
     this._evaluationWorker = new this._workerClass();
-    this._workerChannel = eventChannel(emitter => {
+    this._workerChannel = eventChannel((emitter) => {
       if (!this._evaluationWorker) {
         // Impossible case unless something really went wrong
         // END the channel in that case
@@ -116,7 +116,7 @@ export class GracefulWorkerService {
     // stop accepting new requests
     this._isReady = false;
     // wait for current responses to drain
-    yield all(Object.values(this._channels).map(c => take(c)));
+    yield all(Object.values(this._channels).map((c) => take(c)));
     // close the worker
     yield this._workerChannel?.close();
   }

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -52,83 +52,89 @@ const ctx: Worker = self as any;
 let ERRORS: EvalError[] = [];
 let WIDGET_TYPE_CONFIG_MAP: WidgetTypeConfigMap = {};
 
-ctx.addEventListener("message", (e) => {
-  const { action, ...rest } = e.data;
+//TODO: Create a more complete RPC setup in the subtree-eval branch.
+function messageEventListener(fn: any) {
+  return (e: MessageEvent) => {
+    const { method, requestId, requestData } = e.data;
+    const responseData = fn(method, requestData);
+    ctx.postMessage({ requestId, responseData });
+    ERRORS = [];
+  };
+}
 
-  switch (action as EVAL_WORKER_ACTIONS) {
-    case EVAL_WORKER_ACTIONS.EVAL_TREE: {
-      const { widgetTypeConfigMap, dataTree } = rest;
-      WIDGET_TYPE_CONFIG_MAP = widgetTypeConfigMap;
-      const response = getEvaluatedDataTree(dataTree);
-      // We need to clean it to remove any possible functions inside the tree.
-      // If functions exist, it will crash the web worker
-      try {
-        const cleanDataTree = JSON.stringify(response);
-        ctx.postMessage({ dataTree: cleanDataTree, errors: ERRORS });
-      } catch (e) {
-        ERRORS.push({
-          type: EvalErrorTypes.DEPENDENCY_ERROR,
-          message: e.message,
-        });
-        const cleanDataTree = JSON.stringify(getValidatedTree(dataTree));
-        ctx.postMessage({ dataTree: cleanDataTree, errors: ERRORS });
+ctx.addEventListener(
+  "message",
+  messageEventListener((method: string, requestData: any) => {
+    switch (method as EVAL_WORKER_ACTIONS) {
+      case EVAL_WORKER_ACTIONS.EVAL_TREE: {
+        const { widgetTypeConfigMap, dataTree } = requestData;
+        WIDGET_TYPE_CONFIG_MAP = widgetTypeConfigMap;
+        const response = getEvaluatedDataTree(dataTree);
+        try {
+          // We need to clean it to remove any possible functions inside the tree.
+          // If functions exist, it will crash the web worker
+          const cleanDataTree = JSON.stringify(response);
+          return { dataTree: cleanDataTree, errors: ERRORS };
+        } catch (e) {
+          ERRORS.push({
+            type: EvalErrorTypes.EVAL_TREE_ERROR,
+            message: e.message,
+          });
+          const cleanDataTree = JSON.stringify(getValidatedTree(dataTree));
+          return { dataTree: cleanDataTree, errors: ERRORS };
+        }
       }
-      ERRORS = [];
-      break;
+      case EVAL_WORKER_ACTIONS.EVAL_SINGLE: {
+        const { binding, dataTree } = requestData;
+        const withFunctions = addFunctions(dataTree);
+        const value = getDynamicValue(binding, withFunctions, false);
+        const cleanedResponse = removeFunctions(value);
+        return { value: cleanedResponse, errors: ERRORS };
+      }
+      case EVAL_WORKER_ACTIONS.EVAL_TRIGGER: {
+        const { dynamicTrigger, callbackData, dataTree } = requestData;
+        const evalTree = getEvaluatedDataTree(dataTree);
+        const withFunctions = addFunctions(evalTree);
+        const triggers = getDynamicValue(
+          dynamicTrigger,
+          withFunctions,
+          true,
+          callbackData,
+        );
+        const cleanedResponse = removeFunctions(triggers);
+        return { triggers: cleanedResponse, errors: ERRORS };
+      }
+      case EVAL_WORKER_ACTIONS.CLEAR_CACHE: {
+        clearCaches();
+        return true;
+      }
+      case EVAL_WORKER_ACTIONS.CLEAR_PROPERTY_CACHE: {
+        const { propertyPath } = requestData;
+        clearPropertyCache(propertyPath);
+        return true;
+      }
+      case EVAL_WORKER_ACTIONS.CLEAR_PROPERTY_CACHE_OF_WIDGET: {
+        const { widgetName } = requestData;
+        clearPropertyCacheOfWidget(widgetName);
+        return true;
+      }
+      case EVAL_WORKER_ACTIONS.VALIDATE_PROPERTY: {
+        const { widgetType, property, value, props } = requestData;
+        const result = validateWidgetProperty(
+          widgetType,
+          property,
+          value,
+          props,
+        );
+        const cleanedResponse = removeFunctions(result);
+        return cleanedResponse;
+      }
+      default: {
+        console.error("Action not registered on worker", method, requestData);
+      }
     }
-    case EVAL_WORKER_ACTIONS.EVAL_SINGLE: {
-      const { binding, dataTree } = rest;
-      const withFunctions = addFunctions(dataTree);
-      const value = getDynamicValue(binding, withFunctions, false);
-      const cleanedResponse = removeFunctions(value);
-      ctx.postMessage({ value: cleanedResponse, errors: ERRORS });
-      ERRORS = [];
-      break;
-    }
-    case EVAL_WORKER_ACTIONS.EVAL_TRIGGER: {
-      const { dynamicTrigger, callbackData, dataTree } = rest;
-      const evalTree = getEvaluatedDataTree(dataTree);
-      const withFunctions = addFunctions(evalTree);
-      const triggers = getDynamicValue(
-        dynamicTrigger,
-        withFunctions,
-        true,
-        callbackData,
-      );
-      const cleanedResponse = removeFunctions(triggers);
-      ctx.postMessage({ triggers: cleanedResponse, errors: ERRORS });
-      ERRORS = [];
-      break;
-    }
-    case EVAL_WORKER_ACTIONS.CLEAR_CACHE: {
-      clearCaches();
-      ctx.postMessage(true);
-      break;
-    }
-    case EVAL_WORKER_ACTIONS.CLEAR_PROPERTY_CACHE: {
-      const { propertyPath } = rest;
-      clearPropertyCache(propertyPath);
-      ctx.postMessage(true);
-      break;
-    }
-    case EVAL_WORKER_ACTIONS.CLEAR_PROPERTY_CACHE_OF_WIDGET: {
-      const { widgetName } = rest;
-      clearPropertyCacheOfWidget(widgetName);
-      ctx.postMessage(true);
-      break;
-    }
-    case EVAL_WORKER_ACTIONS.VALIDATE_PROPERTY: {
-      const { widgetType, property, value, props } = rest;
-      const result = validateWidgetProperty(widgetType, property, value, props);
-      const cleanedResponse = removeFunctions(result);
-      ctx.postMessage(cleanedResponse);
-      break;
-    }
-    default: {
-      console.error("Action not registered on worker", action);
-    }
-  }
-});
+  }),
+);
 
 let dependencyTreeCache: any = {};
 let cachedDataTreeString = "";
@@ -190,7 +196,7 @@ function getEvaluatedDataTree(dataTree: DataTree): DataTree {
 
 const addFunctions = (dataTree: DataTree): DataTree => {
   dataTree.actionPaths = [];
-  Object.keys(dataTree).forEach((entityName) => {
+  Object.keys(dataTree).forEach(entityName => {
     const entity = dataTree[entityName];
     if (
       entity &&
@@ -271,7 +277,7 @@ const addFunctions = (dataTree: DataTree): DataTree => {
 };
 
 const removeFunctionsFromDataTree = (dataTree: DataTree) => {
-  dataTree.actionPaths?.forEach((functionPath) => {
+  dataTree.actionPaths?.forEach(functionPath => {
     _.set(dataTree, functionPath, {});
   });
   delete dataTree.actionPaths;
@@ -300,7 +306,7 @@ const createDependencyTree = (
 } => {
   let dependencyMap: DynamicDependencyMap = {};
   const allKeys = getAllPaths(dataTree);
-  Object.keys(dataTree).forEach((entityKey) => {
+  Object.keys(dataTree).forEach(entityKey => {
     const entity = dataTree[entityKey];
     if (entity && "ENTITY_TYPE" in entity) {
       if (
@@ -309,14 +315,14 @@ const createDependencyTree = (
       ) {
         const dynamicBindingPathList = getEntityDynamicBindingPathList(entity);
         if (dynamicBindingPathList.length) {
-          dynamicBindingPathList.forEach((dynamicPath) => {
+          dynamicBindingPathList.forEach(dynamicPath => {
             const propertyPath = dynamicPath.key;
             const unevalPropValue = _.get(entity, propertyPath);
             const { jsSnippets } = getDynamicBindings(unevalPropValue);
             const existingDeps =
               dependencyMap[`${entityKey}.${propertyPath}`] || [];
             dependencyMap[`${entityKey}.${propertyPath}`] = existingDeps.concat(
-              jsSnippets.filter((jsSnippet) => !!jsSnippet),
+              jsSnippets.filter(jsSnippet => !!jsSnippet),
             );
           });
         }
@@ -324,7 +330,7 @@ const createDependencyTree = (
           // Set default property dependency
           const defaultProperties =
             WIDGET_TYPE_CONFIG_MAP[entity.type].defaultProperties;
-          Object.keys(defaultProperties).forEach((property) => {
+          Object.keys(defaultProperties).forEach(property => {
             dependencyMap[`${entityKey}.${property}`] = [
               `${entityKey}.${defaultProperties[property]}`,
             ];
@@ -333,7 +339,7 @@ const createDependencyTree = (
             entity,
           );
           if (dynamicTriggerPathList.length) {
-            dynamicTriggerPathList.forEach((dynamicPath) => {
+            dynamicTriggerPathList.forEach(dynamicPath => {
               dependencyMap[`${entityKey}.${dynamicPath.key}`] = [];
             });
           }
@@ -341,16 +347,16 @@ const createDependencyTree = (
       }
     }
   });
-  Object.keys(dependencyMap).forEach((key) => {
+  Object.keys(dependencyMap).forEach(key => {
     dependencyMap[key] = _.flatten(
-      dependencyMap[key].map((path) => calculateSubDependencies(path, allKeys)),
+      dependencyMap[key].map(path => calculateSubDependencies(path, allKeys)),
     );
   });
   dependencyMap = makeParentsDependOnChildren(dependencyMap);
   const dependencyTree: Array<[string, string]> = [];
   Object.keys(dependencyMap).forEach((key: string) => {
     if (dependencyMap[key].length) {
-      dependencyMap[key].forEach((dep) => dependencyTree.push([key, dep]));
+      dependencyMap[key].forEach(dep => dependencyTree.push([key, dep]));
     } else {
       // Set no dependency
       dependencyTree.push([key, ""]);
@@ -361,7 +367,7 @@ const createDependencyTree = (
     // sort dependencies and remove empty dependencies
     const sortedDependencies = toposort(dependencyTree)
       .reverse()
-      .filter((d) => !!d);
+      .filter(d => !!d);
 
     return { sortedDependencies, dependencyMap, dependencyTree };
   } catch (e) {
@@ -408,7 +414,7 @@ const setTreeLoading = (
   const isLoadingActions: string[] = [];
 
   // Fetch all actions that are in loading state
-  Object.keys(dataTree).forEach((e) => {
+  Object.keys(dataTree).forEach(e => {
     const entity = dataTree[e];
     if (entity && "ENTITY_TYPE" in entity) {
       if (entity.ENTITY_TYPE === ENTITY_TYPE.WIDGET) {
@@ -430,7 +436,7 @@ const setTreeLoading = (
       [],
     )
     // set loading to true for those widgets
-    .forEach((w) => {
+    .forEach(w => {
       const entity = dataTree[w] as DataTreeWidget;
       entity.isLoading = true;
     });
@@ -443,8 +449,8 @@ const getEntityDependencies = (
   entities: string[],
 ): Array<string> => {
   const entityDeps: Record<string, string[]> = dependencyMap
-    .map((d) => [d[1].split(".")[0], d[0].split(".")[0]])
-    .filter((d) => d[0] !== d[1])
+    .map(d => [d[1].split(".")[0], d[0].split(".")[0]])
+    .filter(d => d[0] !== d[1])
     .reduce((deps: Record<string, string[]>, dep) => {
       const key: string = dep[0];
       const value: string = dep[1];
@@ -462,8 +468,8 @@ const getEntityDependencies = (
     ): Array<string> => {
       let allDeps: string[] = [];
       keys
-        .filter((k) => entities.includes(k))
-        .forEach((e) => {
+        .filter(k => entities.includes(k))
+        .forEach(e => {
           if (visited.has(e)) {
             return;
           }
@@ -693,7 +699,7 @@ const getDynamicBindings = (
   // Get the {{binding}} bound values
   const stringSegments = getDynamicStringSegments(sanitisedString);
   // Get the "binding" path values
-  const paths = stringSegments.map((segment) => {
+  const paths = stringSegments.map(segment => {
     const length = segment.length;
     const matches = isDynamicValue(segment);
     if (matches) {
@@ -956,7 +962,7 @@ const evaluate = (
       ///// Adding callback data
       GLOBAL_DATA.CALLBACK_DATA = callbackData;
       ///// Adding Data tree
-      Object.keys(data).forEach((datum) => {
+      Object.keys(data).forEach(datum => {
         GLOBAL_DATA[datum] = data[datum];
       });
       ///// Fixing action paths and capturing their execution response
@@ -980,21 +986,21 @@ const evaluate = (
       }
 
       // Set it to self
-      Object.keys(GLOBAL_DATA).forEach((key) => {
+      Object.keys(GLOBAL_DATA).forEach(key => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         self[key] = GLOBAL_DATA[key];
       });
 
       ///// Adding extra libraries separately
-      extraLibraries.forEach((library) => {
+      extraLibraries.forEach(library => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         self[library.accessor] = library.lib;
       });
 
       ///// Remove all unsafe functions
-      unsafeFunctionForEval.forEach((func) => {
+      unsafeFunctionForEval.forEach(func => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         self[func] = undefined;
@@ -1004,7 +1010,7 @@ const evaluate = (
 
       // Remove it from self
       // This is needed so that next eval can have a clean sheet
-      Object.keys(GLOBAL_DATA).forEach((key) => {
+      Object.keys(GLOBAL_DATA).forEach(key => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         delete self[key];
@@ -1320,7 +1326,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
         parsed,
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Tabs Data`,
       };
-    } else if (!every(parsed, (datum) => isObject(datum))) {
+    } else if (!every(parsed, datum => isObject(datum))) {
       return {
         isValid: false,
         parsed: [],
@@ -1347,10 +1353,10 @@ const VALIDATORS: Record<ValidationType, Validator> = {
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: [{ "Col1" : "val1", "Col2" : "val2" }]`,
       };
     }
-    const isValidTableData = every(parsed, (datum) => {
+    const isValidTableData = every(parsed, datum => {
       return (
         isPlainObject(datum) &&
-        Object.keys(datum).filter((key) => isString(key) && key.length === 0)
+        Object.keys(datum).filter(key => isString(key) && key.length === 0)
           .length === 0
       );
     });
@@ -1437,7 +1443,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
         parsed,
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Marker Data`,
       };
-    } else if (!every(parsed, (datum) => isObject(datum))) {
+    } else if (!every(parsed, datum => isObject(datum))) {
       return {
         isValid: false,
         parsed: [],
@@ -1697,7 +1703,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
           } catch {
             values = value.length ? value.split(",") : [];
             if (values.length > 0) {
-              values = values.map((value) => value.trim());
+              values = values.map(value => value.trim());
             }
           }
         }
@@ -1731,7 +1737,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
           } catch {
             values = value.length ? value.split(",") : [];
             if (values.length > 0) {
-              let numbericValues = values.map((value) => {
+              let numbericValues = values.map(value => {
                 return isNumber(value.trim()) ? -1 : Number(value.trim());
               });
               numbericValues = _.uniq(numbericValues);
@@ -1775,9 +1781,9 @@ export const makeParentsDependOnChildren = (
 ): DynamicDependencyMap => {
   //return depMap;
   // Make all parents depend on child
-  Object.keys(depMap).forEach((key) => {
+  Object.keys(depMap).forEach(key => {
     depMap = makeParentsDependOnChild(depMap, key);
-    depMap[key].forEach((path) => {
+    depMap[key].forEach(path => {
       depMap = makeParentsDependOnChild(depMap, path);
     });
   });

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -196,7 +196,7 @@ function getEvaluatedDataTree(dataTree: DataTree): DataTree {
 
 const addFunctions = (dataTree: DataTree): DataTree => {
   dataTree.actionPaths = [];
-  Object.keys(dataTree).forEach(entityName => {
+  Object.keys(dataTree).forEach((entityName) => {
     const entity = dataTree[entityName];
     if (
       entity &&
@@ -277,7 +277,7 @@ const addFunctions = (dataTree: DataTree): DataTree => {
 };
 
 const removeFunctionsFromDataTree = (dataTree: DataTree) => {
-  dataTree.actionPaths?.forEach(functionPath => {
+  dataTree.actionPaths?.forEach((functionPath) => {
     _.set(dataTree, functionPath, {});
   });
   delete dataTree.actionPaths;
@@ -306,7 +306,7 @@ const createDependencyTree = (
 } => {
   let dependencyMap: DynamicDependencyMap = {};
   const allKeys = getAllPaths(dataTree);
-  Object.keys(dataTree).forEach(entityKey => {
+  Object.keys(dataTree).forEach((entityKey) => {
     const entity = dataTree[entityKey];
     if (entity && "ENTITY_TYPE" in entity) {
       if (
@@ -315,14 +315,14 @@ const createDependencyTree = (
       ) {
         const dynamicBindingPathList = getEntityDynamicBindingPathList(entity);
         if (dynamicBindingPathList.length) {
-          dynamicBindingPathList.forEach(dynamicPath => {
+          dynamicBindingPathList.forEach((dynamicPath) => {
             const propertyPath = dynamicPath.key;
             const unevalPropValue = _.get(entity, propertyPath);
             const { jsSnippets } = getDynamicBindings(unevalPropValue);
             const existingDeps =
               dependencyMap[`${entityKey}.${propertyPath}`] || [];
             dependencyMap[`${entityKey}.${propertyPath}`] = existingDeps.concat(
-              jsSnippets.filter(jsSnippet => !!jsSnippet),
+              jsSnippets.filter((jsSnippet) => !!jsSnippet),
             );
           });
         }
@@ -330,7 +330,7 @@ const createDependencyTree = (
           // Set default property dependency
           const defaultProperties =
             WIDGET_TYPE_CONFIG_MAP[entity.type].defaultProperties;
-          Object.keys(defaultProperties).forEach(property => {
+          Object.keys(defaultProperties).forEach((property) => {
             dependencyMap[`${entityKey}.${property}`] = [
               `${entityKey}.${defaultProperties[property]}`,
             ];
@@ -339,7 +339,7 @@ const createDependencyTree = (
             entity,
           );
           if (dynamicTriggerPathList.length) {
-            dynamicTriggerPathList.forEach(dynamicPath => {
+            dynamicTriggerPathList.forEach((dynamicPath) => {
               dependencyMap[`${entityKey}.${dynamicPath.key}`] = [];
             });
           }
@@ -347,16 +347,16 @@ const createDependencyTree = (
       }
     }
   });
-  Object.keys(dependencyMap).forEach(key => {
+  Object.keys(dependencyMap).forEach((key) => {
     dependencyMap[key] = _.flatten(
-      dependencyMap[key].map(path => calculateSubDependencies(path, allKeys)),
+      dependencyMap[key].map((path) => calculateSubDependencies(path, allKeys)),
     );
   });
   dependencyMap = makeParentsDependOnChildren(dependencyMap);
   const dependencyTree: Array<[string, string]> = [];
   Object.keys(dependencyMap).forEach((key: string) => {
     if (dependencyMap[key].length) {
-      dependencyMap[key].forEach(dep => dependencyTree.push([key, dep]));
+      dependencyMap[key].forEach((dep) => dependencyTree.push([key, dep]));
     } else {
       // Set no dependency
       dependencyTree.push([key, ""]);
@@ -367,7 +367,7 @@ const createDependencyTree = (
     // sort dependencies and remove empty dependencies
     const sortedDependencies = toposort(dependencyTree)
       .reverse()
-      .filter(d => !!d);
+      .filter((d) => !!d);
 
     return { sortedDependencies, dependencyMap, dependencyTree };
   } catch (e) {
@@ -414,7 +414,7 @@ const setTreeLoading = (
   const isLoadingActions: string[] = [];
 
   // Fetch all actions that are in loading state
-  Object.keys(dataTree).forEach(e => {
+  Object.keys(dataTree).forEach((e) => {
     const entity = dataTree[e];
     if (entity && "ENTITY_TYPE" in entity) {
       if (entity.ENTITY_TYPE === ENTITY_TYPE.WIDGET) {
@@ -436,7 +436,7 @@ const setTreeLoading = (
       [],
     )
     // set loading to true for those widgets
-    .forEach(w => {
+    .forEach((w) => {
       const entity = dataTree[w] as DataTreeWidget;
       entity.isLoading = true;
     });
@@ -449,8 +449,8 @@ const getEntityDependencies = (
   entities: string[],
 ): Array<string> => {
   const entityDeps: Record<string, string[]> = dependencyMap
-    .map(d => [d[1].split(".")[0], d[0].split(".")[0]])
-    .filter(d => d[0] !== d[1])
+    .map((d) => [d[1].split(".")[0], d[0].split(".")[0]])
+    .filter((d) => d[0] !== d[1])
     .reduce((deps: Record<string, string[]>, dep) => {
       const key: string = dep[0];
       const value: string = dep[1];
@@ -468,8 +468,8 @@ const getEntityDependencies = (
     ): Array<string> => {
       let allDeps: string[] = [];
       keys
-        .filter(k => entities.includes(k))
-        .forEach(e => {
+        .filter((k) => entities.includes(k))
+        .forEach((e) => {
           if (visited.has(e)) {
             return;
           }
@@ -699,7 +699,7 @@ const getDynamicBindings = (
   // Get the {{binding}} bound values
   const stringSegments = getDynamicStringSegments(sanitisedString);
   // Get the "binding" path values
-  const paths = stringSegments.map(segment => {
+  const paths = stringSegments.map((segment) => {
     const length = segment.length;
     const matches = isDynamicValue(segment);
     if (matches) {
@@ -962,7 +962,7 @@ const evaluate = (
       ///// Adding callback data
       GLOBAL_DATA.CALLBACK_DATA = callbackData;
       ///// Adding Data tree
-      Object.keys(data).forEach(datum => {
+      Object.keys(data).forEach((datum) => {
         GLOBAL_DATA[datum] = data[datum];
       });
       ///// Fixing action paths and capturing their execution response
@@ -986,21 +986,21 @@ const evaluate = (
       }
 
       // Set it to self
-      Object.keys(GLOBAL_DATA).forEach(key => {
+      Object.keys(GLOBAL_DATA).forEach((key) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         self[key] = GLOBAL_DATA[key];
       });
 
       ///// Adding extra libraries separately
-      extraLibraries.forEach(library => {
+      extraLibraries.forEach((library) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         self[library.accessor] = library.lib;
       });
 
       ///// Remove all unsafe functions
-      unsafeFunctionForEval.forEach(func => {
+      unsafeFunctionForEval.forEach((func) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         self[func] = undefined;
@@ -1010,7 +1010,7 @@ const evaluate = (
 
       // Remove it from self
       // This is needed so that next eval can have a clean sheet
-      Object.keys(GLOBAL_DATA).forEach(key => {
+      Object.keys(GLOBAL_DATA).forEach((key) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available
         delete self[key];
@@ -1326,7 +1326,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
         parsed,
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Tabs Data`,
       };
-    } else if (!every(parsed, datum => isObject(datum))) {
+    } else if (!every(parsed, (datum) => isObject(datum))) {
       return {
         isValid: false,
         parsed: [],
@@ -1353,10 +1353,10 @@ const VALIDATORS: Record<ValidationType, Validator> = {
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: [{ "Col1" : "val1", "Col2" : "val2" }]`,
       };
     }
-    const isValidTableData = every(parsed, datum => {
+    const isValidTableData = every(parsed, (datum) => {
       return (
         isPlainObject(datum) &&
-        Object.keys(datum).filter(key => isString(key) && key.length === 0)
+        Object.keys(datum).filter((key) => isString(key) && key.length === 0)
           .length === 0
       );
     });
@@ -1443,7 +1443,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
         parsed,
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: Marker Data`,
       };
-    } else if (!every(parsed, datum => isObject(datum))) {
+    } else if (!every(parsed, (datum) => isObject(datum))) {
       return {
         isValid: false,
         parsed: [],
@@ -1703,7 +1703,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
           } catch {
             values = value.length ? value.split(",") : [];
             if (values.length > 0) {
-              values = values.map(value => value.trim());
+              values = values.map((value) => value.trim());
             }
           }
         }
@@ -1737,7 +1737,7 @@ const VALIDATORS: Record<ValidationType, Validator> = {
           } catch {
             values = value.length ? value.split(",") : [];
             if (values.length > 0) {
-              let numbericValues = values.map(value => {
+              let numbericValues = values.map((value) => {
                 return isNumber(value.trim()) ? -1 : Number(value.trim());
               });
               numbericValues = _.uniq(numbericValues);
@@ -1781,9 +1781,9 @@ export const makeParentsDependOnChildren = (
 ): DynamicDependencyMap => {
   //return depMap;
   // Make all parents depend on child
-  Object.keys(depMap).forEach(key => {
+  Object.keys(depMap).forEach((key) => {
     depMap = makeParentsDependOnChild(depMap, key);
-    depMap[key].forEach(path => {
+    depMap[key].forEach((path) => {
       depMap = makeParentsDependOnChild(depMap, path);
     });
   });


### PR DESCRIPTION
## Description
- Create a rpc-like layer to communicate with our worker.
- Wrap messages from worker to also contain the `requestId`.

This is a tentative fix of an issue that can happen because of race between worker messages.
Fixes #2169

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
