### PR TITLE
Fix table text pagination

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/Binding/Bind_TableTextPagination_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Binding/Bind_TableTextPagination_spec.js
@@ -23,7 +23,7 @@ describe("Test Create Api and Bind to Table widget", function() {
     /**Bind Table with Textwidget with selected row */
     cy.SearchEntityandOpen("Text1");
     cy.testJsontext("text", "{{Table1.selectedRow.url}}");
-    cy.SearchEntityandOpen("Table1");
+    cy.get(commonlocators.editPropCrossButton).click();
     cy.readTabledata("0", "0").then(tabData => {
       const tableData = tabData;
       localStorage.setItem("tableDataPage1", tableData);


### PR DESCRIPTION
Autocomplete was getting a bad data tree only when using tests. Keeping the property pane close to bypass the issue