### PR TITLE
Fix invalid templates and API breaking on invalid templates

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/templates/meta.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/templates/meta.json
@@ -1,16 +1,16 @@
 {
   "templates": [
     {
-      "filename": "CREATE.sql"
+      "file": "CREATE.sql"
     },
     {
-      "filename": "SELECT.sql"
+      "file": "SELECT.sql"
     },
     {
-      "filename": "UPDATE.sql"
+      "file": "UPDATE.sql"
     },
     {
-      "filename": "DELETE.sql"
+      "file": "DELETE.sql"
     }
   ]
 }


### PR DESCRIPTION
Two major things this PR fixes:

1. The meta.json files and the implementation of the reader were not in sync. This was a refactoring mistake. Fixed now.
2. When a meta.json file is not as expected, the whole plugins API breaks. This PR also fixes this by gracefully recovering when such a rogue meta.json file is present in any plugin.
