### PR TITLE
Fix Firestore datasources not encrypting secret key JSON when editing

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -24,22 +24,30 @@ import java.util.Set;
         @JsonSubTypes.Type(value = OAuth2.class, name = AuthType.OAUTH2)
 })
 public class AuthenticationDTO {
+    // In principle, this class should've been abstract. However, when this class is abstract, Spring's deserialization
+    // routines choke on identifying the correct class to instantiate and ends up trying to instantiate this abstract
+    // class and fails.
 
     @JsonIgnore
-    private boolean isEncrypted;
+    private Boolean isEncrypted;
 
     @JsonIgnore
     public Map<String, String> getEncryptionFields() {
         return Collections.emptyMap();
     }
 
-    @JsonIgnore
     public void setEncryptionFields(Map<String, String> encryptedFields) {
+        // This is supposed to be overridden by implementations.
     }
 
     @JsonIgnore
     public Set<String> getEmptyEncryptionFields() {
         return Collections.emptySet();
+    }
+
+    @JsonIgnore
+    public boolean isEncrypted() {
+        return Boolean.TRUE.equals(isEncrypted);
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -178,7 +178,7 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
                             Map.Entry::getKey,
                             e -> encryptionService.decryptString(e.getValue())));
             authentication.setEncryptionFields(decryptedFields);
-            authentication.setEncrypted(false);
+            authentication.setIsEncrypted(false);
         }
         return authentication;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -158,13 +158,15 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
 
     @Override
     public AuthenticationDTO encryptAuthenticationFields(AuthenticationDTO authentication) {
-        if (authentication != null && authentication.getEmptyEncryptionFields().isEmpty() && !authentication.isEncrypted()) {
+        if (authentication != null
+                && CollectionUtils.isEmpty(authentication.getEmptyEncryptionFields())
+                && !authentication.isEncrypted()) {
             Map<String, String> encryptedFields = authentication.getEncryptionFields().entrySet().stream()
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
                             e -> encryptionService.encryptString(e.getValue())));
             authentication.setEncryptionFields(encryptedFields);
-            authentication.setEncrypted(true);
+            authentication.setIsEncrypted(true);
         }
         return authentication;
     }
@@ -263,7 +265,7 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
                                                     Map.Entry::getKey,
                                                     e -> encryptionService.decryptString(e.getValue())));
                                     datasource.getDatasourceConfiguration().getAuthentication().setEncryptionFields(decryptedFields);
-                                    datasource.getDatasourceConfiguration().getAuthentication().setEncrypted(false);
+                                    datasource.getDatasourceConfiguration().getAuthentication().setIsEncrypted(false);
                                 }
 
                             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EncryptionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EncryptionServiceImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.services;
 
 import com.appsmith.server.configurations.EncryptionConfig;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.encrypt.Encryptors;
@@ -8,17 +9,14 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class EncryptionServiceImpl implements EncryptionService {
-    private final EncryptionConfig encryptionConfig;
-
-    private TextEncryptor textEncryptor;
+    private final TextEncryptor textEncryptor;
 
     @Autowired
     public EncryptionServiceImpl(EncryptionConfig encryptionConfig) {
-        this.encryptionConfig = encryptionConfig;
         String saltInHex = Hex.encodeHexString(encryptionConfig.getSalt().getBytes());
-        this.textEncryptor = Encryptors.queryableText(encryptionConfig.getPassword(),
-                saltInHex);
+        this.textEncryptor = Encryptors.queryableText(encryptionConfig.getPassword(), saltInHex);
     }
 
     @Override
@@ -28,6 +26,11 @@ public class EncryptionServiceImpl implements EncryptionService {
 
     @Override
     public String decryptString(String encryptedText) {
-        return textEncryptor.decrypt(encryptedText);
+        try {
+            return textEncryptor.decrypt(encryptedText);
+        } catch (IllegalArgumentException e) {
+            log.error("Error trying to decrypt an incorrectly encrypted or non-encrypted string '{}'.", encryptedText);
+            return encryptedText;
+        }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EncryptionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EncryptionServiceImpl.java
@@ -9,12 +9,16 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class EncryptionServiceImpl implements EncryptionService {
-    private final TextEncryptor textEncryptor;
+    private final EncryptionConfig encryptionConfig;
+
+    private TextEncryptor textEncryptor;
 
     @Autowired
     public EncryptionServiceImpl(EncryptionConfig encryptionConfig) {
+        this.encryptionConfig = encryptionConfig;
         String saltInHex = Hex.encodeHexString(encryptionConfig.getSalt().getBytes());
-        this.textEncryptor = Encryptors.queryableText(encryptionConfig.getPassword(), saltInHex);
+        this.textEncryptor = Encryptors.queryableText(encryptionConfig.getPassword(),
+                saltInHex);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EncryptionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/EncryptionServiceImpl.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.services;
 
 import com.appsmith.server.configurations.EncryptionConfig;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Hex;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.encrypt.Encryptors;
@@ -9,7 +8,6 @@ import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.stereotype.Service;
 
 @Service
-@Slf4j
 public class EncryptionServiceImpl implements EncryptionService {
     private final TextEncryptor textEncryptor;
 
@@ -26,11 +24,6 @@ public class EncryptionServiceImpl implements EncryptionService {
 
     @Override
     public String decryptString(String encryptedText) {
-        try {
-            return textEncryptor.decrypt(encryptedText);
-        } catch (IllegalArgumentException e) {
-            log.error("Error trying to decrypt an incorrectly encrypted or non-encrypted string '{}'.", encryptedText);
-            return encryptedText;
-        }
+        return textEncryptor.decrypt(encryptedText);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
@@ -95,7 +95,7 @@ public class DatasourceStructureSolution {
                                 Map.Entry::getKey,
                                 e -> encryptionService.decryptString(e.getValue())));
                 authentication.setEncryptionFields(decryptedFields);
-                authentication.setEncrypted(false);
+                authentication.setIsEncrypted(false);
             }
         }
 


### PR DESCRIPTION
The `isEncrypted` field of `AuthenticationDTO` was not being ignored when serializing to JSON and sending to client. This is causing an incorrect value for this field being sent by the client, which shouldn't happen.
