### PR TITLE
All newly created applications now have a default published state.

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
@@ -58,4 +58,5 @@ public class FieldName {
     public static String ACTION = "action";
     public static String ASSET = "asset";
     public static String APPLICATION = "application";
+    public static String PUBLISHED_APPLICATION = "deployed application";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/PageController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/PageController.java
@@ -51,13 +51,13 @@ public class PageController {
     @Deprecated
     @GetMapping("/application/{applicationId}")
     public Mono<ResponseDTO<ApplicationPagesDTO>> getPageNamesByApplicationId(@PathVariable String applicationId) {
-        return newPageService.findNamesByApplicationIdAndViewMode(applicationId, false)
+        return newPageService.findApplicationPagesByApplicationIdAndViewMode(applicationId, false)
                 .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
     }
 
     @GetMapping("/view/application/{applicationId}")
     public Mono<ResponseDTO<ApplicationPagesDTO>> getPageNamesByApplicationIdInViewMode(@PathVariable String applicationId) {
-        return newPageService.findNamesByApplicationIdAndViewMode(applicationId, true)
+        return newPageService.findApplicationPagesByApplicationIdAndViewMode(applicationId, true)
                 .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionServiceImpl.java
@@ -552,7 +552,7 @@ public class ActionServiceImpl extends BaseService<ActionRepository, Action, Str
 
         // fetch the published pages by application
         return newPageService
-                .findNamesByApplicationIdAndViewMode(applicationId, true)
+                .findApplicationPagesByApplicationIdAndViewMode(applicationId, true)
                 .switchIfEmpty(Mono.error(new AppsmithException(
                         AppsmithError.NO_RESOURCE_FOUND, "pages for application", applicationId))
                 )
@@ -615,7 +615,7 @@ public class ActionServiceImpl extends BaseService<ActionRepository, Action, Str
             // Fetch unpublished pages because GET actions is only called during edit mode. For view mode, different
             // function call is made which takes care of returning only the essential fields of an action
             return newPageService
-                    .findNamesByApplicationIdAndViewMode(params.getFirst(FieldName.APPLICATION_ID), false)
+                    .findApplicationPagesByApplicationIdAndViewMode(params.getFirst(FieldName.APPLICATION_ID), false)
                     .switchIfEmpty(Mono.error(new AppsmithException(
                             AppsmithError.NO_RESOURCE_FOUND, "pages for application", params.getFirst(FieldName.APPLICATION_ID)))
                     )

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -226,9 +226,10 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                     return newPageService
                             .createDefault(page)
                             .flatMap(savedPage -> addPageToApplication(savedApplication, savedPage, true))
-                            // fetch the application again because the application.pages has changed post the addition of
-                            // the newly created page to the application.
-                            .then(applicationService.findById(savedApplication.getId(), READ_APPLICATIONS));
+                            // Now publish this newly created app with default states so that
+                            // launching of newly created application is possible.
+                            .flatMap(updatedApplication -> publish(savedApplication.getId())
+                                    .then(applicationService.findById(savedApplication.getId(), READ_APPLICATIONS)));
                 });
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -339,7 +339,7 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
         return sourcePageMono
                 .flatMap(page -> {
                     Mono<ApplicationPagesDTO> pageNamesMono = newPageService
-                            .findNamesByApplicationIdAndViewMode(page.getApplicationId(), false);
+                            .findApplicationPagesByApplicationIdAndViewMode(page.getApplicationId(), false);
                     return pageNamesMono
                             // If a new page name suffix is given,
                             // set a unique name for the cloned page and then create the page.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageService.java
@@ -32,7 +32,7 @@ public interface NewPageService extends CrudService<NewPage, String> {
 
     Mono<Void> deleteAll();
 
-    Mono<ApplicationPagesDTO> findNamesByApplicationIdAndViewMode(String applicationId, Boolean view);
+    Mono<ApplicationPagesDTO> findApplicationPagesByApplicationIdAndViewMode(String applicationId, Boolean view);
 
     Layout createDefaultLayout();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -29,6 +29,7 @@ import javax.validation.Validator;
 import java.util.List;
 import java.util.Set;
 
+import static com.appsmith.server.acl.AclPermission.READ_PAGES;
 import static com.appsmith.server.helpers.BeanCopyUtils.copyNewFieldValuesIntoOldObject;
 
 @Service
@@ -57,7 +58,6 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
             if (newPage.getPublishedPage() != null) {
                 page = newPage.getPublishedPage();
                 page.setName(newPage.getPublishedPage().getName());
-
             } else {
                 // We are trying to fetch published page but it doesnt exist because the page hasn't been published yet
                 return Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.PAGE, newPage.getId()));
@@ -153,13 +153,83 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
     }
 
     @Override
-    public Mono<ApplicationPagesDTO> findNamesByApplicationIdAndViewMode(String applicationId, Boolean view) {
+    public Mono<ApplicationPagesDTO> findApplicationPagesByApplicationIdAndViewMode(String applicationId, Boolean view) {
         Mono<Application> applicationMono = applicationService.findById(applicationId, AclPermission.READ_APPLICATIONS)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION, applicationId)))
+                // Throw a 404 error if the application has never been published
+                .flatMap(application -> {
+                    if (Boolean.TRUE.equals(view)) {
+                        if (application.getPublishedPages() == null || application.getPublishedPages().isEmpty()) {
+                            // We are trying to fetch published pages but they doesnt exist because the application
+                            // hasn't been published yet
+                            return Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND,
+                                    FieldName.PUBLISHED_APPLICATION, application.getId()));
+                        }
+                    }
+                    return Mono.just(application);
+                })
+                .cache();
+
+        Mono<String> defaultPageIdMono = applicationMono
+                .map(application -> {
+                    String defaultPageId = null;
+                    List<ApplicationPage> applicationPages;
+                    if (Boolean.TRUE.equals(view)) {
+                        applicationPages = application.getPublishedPages();
+                    } else {
+                        applicationPages = application.getPages();
+                    }
+
+                    for (ApplicationPage applicationPage:applicationPages)
+                    {
+                        if (Boolean.TRUE.equals(applicationPage.getIsDefault())) {
+                            defaultPageId = applicationPage.getId();
+                        }
+                    }
+                    return defaultPageId;
+                })
                 .cache();
 
         Mono<List<PageNameIdDTO>> pagesListMono = applicationMono
-                .flatMapMany(application -> findNamesByApplication(application, view))
+                .map(application -> {
+                    List<ApplicationPage> pages;
+                    if (Boolean.TRUE.equals(view)) {
+                        pages = application.getPublishedPages();
+                    } else {
+                        pages = application.getPages();
+                    }
+                    return pages;
+                })
+                .flatMapMany(Flux::fromIterable)
+                .flatMap(page -> this.findById(page.getId(), READ_PAGES))
+                .zipWith(defaultPageIdMono)
+                .flatMap(tuple -> {
+                    NewPage pageFromDb = tuple.getT1();
+                    String defaultPageId = tuple.getT2();
+
+                    PageNameIdDTO pageNameIdDTO = new PageNameIdDTO();
+
+                    pageNameIdDTO.setId(pageFromDb.getId());
+
+                    if (Boolean.TRUE.equals(view)) {
+                        if (pageFromDb.getPublishedPage() == null) {
+                            // We are trying to fetch published page but it doesnt exist because the page hasn't been published yet
+                            return Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND,
+                                    FieldName.PAGE, pageFromDb.getId()));
+                        }
+                        pageNameIdDTO.setName(pageFromDb.getPublishedPage().getName());
+                    } else {
+                        pageNameIdDTO.setName(pageFromDb.getUnpublishedPage().getName());
+                    }
+
+                    if (pageNameIdDTO.getId().equals(defaultPageId)) {
+                        pageNameIdDTO.setIsDefault(true);
+                    } else {
+                        pageNameIdDTO.setIsDefault(false);
+                    }
+
+                    return Mono.just(pageNameIdDTO);
+                })
                 .collectList();
 
         return Mono.zip(applicationMono, pagesListMono)
@@ -195,9 +265,15 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
     }
 
     private Flux<PageNameIdDTO> findNamesByApplication(Application application, Boolean viewMode) {
-        List<ApplicationPage> pages = application.getPages();
+        List<ApplicationPage> pages;
 
-        return findByApplicationId(application.getId(), AclPermission.READ_PAGES, viewMode)
+        if (Boolean.TRUE.equals(viewMode)) {
+            pages = application.getPublishedPages();
+        } else {
+            pages = application.getPages();
+        }
+
+        return findByApplicationId(application.getId(), READ_PAGES, viewMode)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.PAGE + " by application id", application.getId())))
                 .map(page -> {
                     PageNameIdDTO pageNameIdDTO = new PageNameIdDTO();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -60,7 +60,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
 
             } else {
                 // We are trying to fetch published page but it doesnt exist because the page hasn't been published yet
-                page = new PageDTO();
+                return Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.PAGE, newPage.getId()));
             }
         } else {
             if (newPage.getUnpublishedPage() != null) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -963,7 +963,7 @@ public class ApplicationServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
-    public void createApplicationShouldHavePublishedState() {
+    public void newApplicationShouldHavePublishedState() {
         Application testApplication = new Application();
         testApplication.setName("ApplicationServiceTest NewApp PublishedState");
         Mono<Application> applicationMono = applicationPageService.createApplication(testApplication, orgId).cache();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -960,4 +960,35 @@ public class ApplicationServiceTest {
                 .verifyComplete();
 
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createApplicationShouldHavePublishedState() {
+        Application testApplication = new Application();
+        testApplication.setName("ApplicationServiceTest NewApp PublishedState");
+        Mono<Application> applicationMono = applicationPageService.createApplication(testApplication, orgId).cache();
+
+        Mono<PageDTO> publishedPageMono = applicationMono
+                .flatMap(application -> {
+                    List<ApplicationPage> publishedPages = application.getPublishedPages();
+                    return applicationPageService.getPage(publishedPages.get(0).getId(), true);
+                });
+
+        StepVerifier
+                .create(Mono.zip(applicationMono, publishedPageMono))
+                .assertNext(tuple -> {
+                    Application application = tuple.getT1();
+                    PageDTO publishedPage = tuple.getT2();
+
+                    // Assert that the application has 1 published page
+                    assertThat(application.getPublishedPages()).hasSize(1);
+
+                    // Assert that the published page and the unpublished page are one and the same
+                    assertThat(application.getPages().get(0).getId()).isEqualTo(application.getPublishedPages().get(0).getId());
+
+                    // Assert that the published page has 1 layout
+                    assertThat(publishedPage.getLayouts()).hasSize(1);
+                })
+                .verifyComplete();
+    }
 }


### PR DESCRIPTION
## Description
When an application is created, after creating a default page, just publish this application to ensure that both the application and the newly created default page have a published state before returning this to the user. This supports the launching of an application till this new application is deployed for the first time.

Fixes #1899 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
