### PR TITLE
fix undo delete tab

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -486,6 +486,7 @@ export function* undoDeleteSaga(action: ReduxAction<{ widgetId: string }>) {
         if (widget.tabId && widget.type === WidgetTypes.CANVAS_WIDGET) {
           const parent = { ...widgets[widget.parentId] };
           if (parent.tabs) {
+            parent.tabs = parent.tabs.slice();
             try {
               parent.tabs.push({
                 id: widget.tabId,


### PR DESCRIPTION
## Description
Since tabs array is an immutable we're not allowed to push objects. Create a copy of tabs to fix this.

fixes #2034

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
