### PR TITLE
fix position for table column sub-menus while scrolling

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableColumnMenu.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableColumnMenu.tsx
@@ -58,7 +58,7 @@ const TableColumnMenuPopup = (props: TableColumnMenuPopup) => {
               {option.options && (
                 <Popover
                   minimal
-                  usePortal
+                  usePortal={false}
                   enforceFocus={false}
                   interactionKind={PopoverInteractionKind.CLICK}
                   position={Position.BOTTOM_RIGHT}


### PR DESCRIPTION
## Description
We can render the submenu inline, since the parent menu is rendered within a portal

fixes #2280

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
