### PR TITLE
[Bug] Multi page applications return only a single page when fetching pages per application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -97,7 +97,8 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
         }
 
         Mono<Application> applicationMono = applicationService.findById(page.getApplicationId(), AclPermission.MANAGE_APPLICATIONS)
-                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION_ID, page.getApplicationId())));
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION_ID, page.getApplicationId())))
+                .cache();
 
         Mono<PageDTO> pageMono = applicationMono
                 .map(application -> {


### PR DESCRIPTION
## Description
Zipping flux with mono leads to mono not getting repeated and only the first emitted value of flux is processed further. This is leading to only a single page getting emitted in a multi page application.