### PR TITLE
Added a migration to old rest api datasources which adds the new mandatory key `isSendSessionEnabled` with value `N`

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -2,7 +2,9 @@ package com.appsmith.server.migrations;
 
 import com.appsmith.external.models.BaseDomain;
 import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Policy;
+import com.appsmith.external.models.Property;
 import com.appsmith.server.acl.AppsmithRole;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Action;
@@ -1515,5 +1517,52 @@ public class DatabaseChangelog {
                     Datasource.class
             );
         }
+    }
+
+    @ChangeSet(order = "047", id = "add-isSendSessionEnabled-key-for-datasources", author = "")
+    public void addIsSendSessionEnabledPropertyInDatasources(MongoTemplate mongoTemplate) {
+
+        String keyName = "isSendSessionEnabled";
+
+        Plugin restApiPlugin = mongoTemplate.findOne(
+                query(where("packageName").is("restapi-plugin")),
+                Plugin.class
+        );
+
+        final org.springframework.data.mongodb.core.query.Query query = query(where("pluginId").is(restApiPlugin.getId()));
+
+        for (Datasource datasource : mongoTemplate.find(query, Datasource.class)) {
+            // Find if the datasource should be updated with the new key
+            Boolean updateRequired = false;
+            if (datasource.getDatasourceConfiguration() == null) {
+                updateRequired = true;
+                datasource.setDatasourceConfiguration(new DatasourceConfiguration());
+                datasource.getDatasourceConfiguration().setProperties(new ArrayList<>());
+            } else if (datasource.getDatasourceConfiguration().getProperties() == null) {
+                updateRequired = true;
+                datasource.getDatasourceConfiguration().setProperties(new ArrayList<>());
+            } else {
+                List<Property> properties = datasource.getDatasourceConfiguration().getProperties();
+                Optional<Property> isSendSessionEnabledOptional = properties
+                        .stream()
+                        .filter(property -> property.getKey().equals(keyName))
+                        .findFirst();
+
+                if (!isSendSessionEnabledOptional.isPresent()) {
+                    updateRequired = true;
+                }
+            }
+
+            // If the property does not exist, add the same.
+            if (updateRequired) {
+                Property newProperty = new Property();
+                newProperty.setKey(keyName);
+                newProperty.setValue("N");
+                datasource.getDatasourceConfiguration().getProperties().add(newProperty);
+                mongoTemplate.save(datasource);
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
## Description
Fixes #2371 
