### PR TITLE
Reducing the probability of getting pages out of order (Expected orde…

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepository.java
@@ -5,6 +5,8 @@ import com.appsmith.server.domains.NewPage;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
 public interface CustomNewPageRepository extends AppsmithRepository<NewPage> {
     Flux<NewPage> findByApplicationId(String applicationId, AclPermission aclPermission);
 
@@ -13,4 +15,6 @@ public interface CustomNewPageRepository extends AppsmithRepository<NewPage> {
     Mono<NewPage> findByNameAndViewMode(String name, AclPermission aclPermission, Boolean viewMode);
 
     Mono<NewPage> findByNameAndApplicationIdAndViewMode(String name, String applicationId, AclPermission aclPermission, Boolean viewMode);
+
+    Flux<NewPage> findAllByIds(List<String> ids, AclPermission aclPermission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
@@ -66,6 +66,14 @@ public class CustomNewPageRepositoryImpl extends BaseAppsmithRepositoryImpl<NewP
         return queryOne(List.of(nameCriterion, applicationIdCriterion), aclPermission);
     }
 
+    @Override
+    public Flux<NewPage> findAllByIds(List<String> ids, AclPermission aclPermission) {
+        Criteria idsCriterion = where("id")
+                .in(ids);
+
+        return queryAll(List.of(idsCriterion), aclPermission);
+    }
+
     private Criteria getNameCriterion(String name, Boolean viewMode) {
         String nameKey;
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -1034,8 +1034,8 @@ public class ApplicationServiceTest {
                 .create(applicationPagesDTOMono)
                 .assertNext(applicationPagesDTO -> {
                     assertThat(applicationPagesDTO.getPages().size()).isEqualTo(4);
-                    Set<String> pageNames = applicationPagesDTO.getPages().stream().map(pageNameIdDTO -> pageNameIdDTO.getName()).collect(Collectors.toSet());
-                    assertThat(pageNames).containsExactlyInAnyOrder("Page1", "Page2", "Page3", "Page4");
+                    List<String> pageNames = applicationPagesDTO.getPages().stream().map(pageNameIdDTO -> pageNameIdDTO.getName()).collect(Collectors.toList());
+                    assertThat(pageNames).containsExactly("Page1", "Page2", "Page3", "Page4");
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
…r is the order in which the pages were created and added to the application). This should :

1. Get rid of cypress test failures which asserts a certain order till the cypress test case is fixed and unblocks the frontend team.
2. Uses a bulk API to fetch all the pages instead of fetching each page sequentially over different network calls with the database.

