### PR TITLE
Fix onboarding test failure causing other tests to fail

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/Onboarding/Onboarding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Onboarding/Onboarding_spec.js
@@ -59,12 +59,4 @@ describe("Onboarding", function() {
     cy.PublishtheApp();
     cy.get(".t--continue-on-my-own").click();
   });
-
-  after(() => {
-    localStorage.removeItem("OnboardingState");
-    cy.window().then((window) => {
-      window.indexedDB.deleteDatabase("Appsmith");
-    });
-    cy.log("Cleared");
-  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/Onboarding/Onboarding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Onboarding/Onboarding_spec.js
@@ -22,7 +22,7 @@ describe("Onboarding", function() {
       "response.body.responseMeta.status",
       201,
     );
-    cy.get("#loading").should("exist");
+    cy.get("#loading").should("not.exist");
 
     //Onboarding
     cy.contains(".t--create-database", "Explore Appsmith").click();

--- a/app/client/cypress/integration/Smoke_TestSuite/Onboarding/Onboarding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/Onboarding/Onboarding_spec.js
@@ -22,7 +22,7 @@ describe("Onboarding", function() {
       "response.body.responseMeta.status",
       201,
     );
-    cy.get("#loading").should("not.exist");
+    cy.get("#loading").should("exist");
 
     //Onboarding
     cy.contains(".t--create-database", "Explore Appsmith").click();

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -59,7 +59,6 @@ before(function() {
 });
 
 beforeEach(function() {
-  cy.log("Before each");
   Cypress.Cookies.preserveOnce("SESSION", "remember_token");
   cy.startServerAndRoutes();
 });

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -43,7 +43,7 @@ before(function() {
     200,
   );
 
-  cy.generateUUID().then(id => {
+  cy.generateUUID().then((id) => {
     appId = id;
     cy.CreateApp(id);
     localStorage.setItem("AppName", appId);
@@ -60,6 +60,10 @@ beforeEach(function() {
 });
 
 after(function() {
+  // Clear indexedDB
+  cy.window().then((window) => {
+    window.indexedDB.deleteDatabase("Appsmith");
+  });
   //-- Deleting the application by Api---//
   cy.DeleteAppByApi();
   //-- LogOut Application---//

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -55,15 +55,17 @@ before(function() {
 });
 
 beforeEach(function() {
+  cy.log("Before each");
   Cypress.Cookies.preserveOnce("SESSION", "remember_token");
   cy.startServerAndRoutes();
-});
 
-after(function() {
   // Clear indexedDB
   cy.window().then((window) => {
     window.indexedDB.deleteDatabase("Appsmith");
   });
+});
+
+after(function() {
   //-- Deleting the application by Api---//
   cy.DeleteAppByApi();
   //-- LogOut Application---//

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -33,6 +33,10 @@ Cypress.on("fail", (error, runnable) => {
 
 before(function() {
   cy.startServerAndRoutes();
+  // Clear indexedDB
+  cy.window().then((window) => {
+    window.indexedDB.deleteDatabase("Appsmith");
+  });
   const username = Cypress.env("USERNAME");
   const password = Cypress.env("PASSWORD");
   cy.LoginFromAPI(username, password);
@@ -58,11 +62,6 @@ beforeEach(function() {
   cy.log("Before each");
   Cypress.Cookies.preserveOnce("SESSION", "remember_token");
   cy.startServerAndRoutes();
-
-  // Clear indexedDB
-  cy.window().then((window) => {
-    window.indexedDB.deleteDatabase("Appsmith");
-  });
 });
 
 after(function() {


### PR DESCRIPTION
## Description
`after` hook of the individual tests doesn't seem to get called when the test fails. Moving the clearing code to the  `before` hook to clear any indexeddb entries in `support/index.js` works.

Fixes #2405 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
