### PR TITLE
scroll while dragged component is outside droptarget

### DIFF
--- a/app/client/src/components/editorComponents/DragLayerComponent.tsx
+++ b/app/client/src/components/editorComponents/DragLayerComponent.tsx
@@ -147,21 +147,18 @@ const DragLayerComponent = (props: DragLayerProps) => {
       rowHeight={props.parentRowHeight}
       ref={dropTargetMask}
     >
-      {props.visible &&
-        props.isOver &&
-        currentOffset &&
-        isParentOffsetCalculated && (
-          <DropZone
-            parentOffset={dropTargetOffset.current}
-            parentRowHeight={props.parentRowHeight}
-            parentColumnWidth={props.parentColumnWidth}
-            width={widgetWidth}
-            height={widgetHeight}
-            currentOffset={currentOffset as XYCoord}
-            canDrop={canDrop}
-            ref={dropZoneRef}
-          />
-        )}
+      {currentOffset && isParentOffsetCalculated && (
+        <DropZone
+          parentOffset={dropTargetOffset.current}
+          parentRowHeight={props.parentRowHeight}
+          parentColumnWidth={props.parentColumnWidth}
+          width={widgetWidth}
+          height={widgetHeight}
+          currentOffset={currentOffset as XYCoord}
+          canDrop={canDrop}
+          ref={dropZoneRef}
+        />
+      )}
     </WrappedDragLayer>
   );
 };

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -43,7 +43,7 @@ export const Directions: { [id: string]: string } = {
 };
 
 export type Direction = typeof Directions[keyof typeof Directions];
-const SCROLL_THESHOLD = 10;
+// const SCROLL_THESHOLD = 10;
 
 export const getScrollByPixels = function(
   elem: Element,

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -54,16 +54,12 @@ export const getScrollByPixels = function(
   const scrollAmount =
     GridDefaults.CANVAS_EXTENSION_OFFSET * GridDefaults.DEFAULT_GRID_ROW_HEIGHT;
 
-  if (
-    bounding.top > 0 &&
-    bounding.top - scrollParentBounds.top < SCROLL_THESHOLD
-  )
-    return -scrollAmount;
-  if (scrollParentBounds.bottom - bounding.bottom < SCROLL_THESHOLD)
-    return scrollAmount;
+  if (bounding.top < scrollParentBounds.top) return -scrollAmount;
+  if (scrollParentBounds.bottom < bounding.bottom) return scrollAmount;
   return 0;
 };
 
+const interval: any = {};
 export const scrollElementIntoParentCanvasView = (
   el: Element | null,
   parent: Element | null,
@@ -71,13 +67,23 @@ export const scrollElementIntoParentCanvasView = (
   if (el) {
     const scrollParent = parent;
     if (scrollParent) {
-      const scrollBy: number = getScrollByPixels(el, scrollParent);
-      if (scrollBy < 0 && scrollParent.scrollTop > 0) {
-        scrollParent.scrollBy({ top: scrollBy, behavior: "smooth" });
+      if (interval.current) {
+        clearInterval(interval.current);
       }
-      if (scrollBy > 0) {
-        scrollParent.scrollBy({ top: scrollBy, behavior: "smooth" });
-      }
+      interval.current = setInterval(() => {
+        const scrollBy: number = getScrollByPixels(el, scrollParent);
+        const bounding = el.getBoundingClientRect();
+        const elNotDragged = bounding.top === bounding.bottom;
+        if (!scrollBy || elNotDragged) {
+          clearInterval(interval.current);
+        }
+        if (scrollBy < 0 && scrollParent.scrollTop > 0) {
+          scrollParent.scrollBy({ top: scrollBy, behavior: "smooth" });
+        }
+        if (scrollBy > 0) {
+          scrollParent.scrollBy({ top: scrollBy, behavior: "smooth" });
+        }
+      }, 200);
     }
   }
 };


### PR DESCRIPTION
## Description
Currently the editor page doesn't scroll while the dragged element is outside the drop zone.

Fixes #2035

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
