### PR TITLE
Fixed unreferenced actions not being triggered for execute on load

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepository.java
@@ -20,6 +20,8 @@ public interface CustomNewActionRepository extends AppsmithRepository<NewAction>
 
     Flux<NewAction> findUnpublishedActionsByNameInAndPageId(Set<String> names, String pageId, AclPermission permission);
 
+    Flux<NewAction> findUnpublishedActionsByPageIdAndExecuteOnLoadSetByUserTrue(String pageId, AclPermission permission);
+
     Flux<NewAction> findUnpublishedActionsForRestApiOnLoad(Set<String> names,
                                                            String pageId,
                                                            String httpMethod,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
@@ -35,20 +35,20 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
 
     @Override
     public Mono<NewAction> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission aclPermission) {
-        Criteria nameCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.name)).is(name);
-        Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
+        Criteria nameCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.name)).is(name);
+        Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
 
         return queryOne(List.of(nameCriteria, pageCriteria), aclPermission);
     }
 
     @Override
     public Flux<NewAction> findByPageId(String pageId, AclPermission aclPermission) {
-        String unpublishedPage = fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.pageId);
-        String publishedPage = fieldName(QNewAction.newAction.publishedAction)+"."+fieldName(QNewAction.newAction.publishedAction.pageId);
+        String unpublishedPage = fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId);
+        String publishedPage = fieldName(QNewAction.newAction.publishedAction) + "." + fieldName(QNewAction.newAction.publishedAction.pageId);
 
         Criteria pageCriteria = new Criteria().orOperator(
-        where(unpublishedPage).is(pageId),
-        where(publishedPage).is(pageId)
+                where(unpublishedPage).is(pageId),
+                where(publishedPage).is(pageId)
         );
 
         return ReactiveSecurityContextHolder.getContext()
@@ -81,11 +81,11 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
 
         // Fetch published actions
         if (Boolean.TRUE.equals(viewMode)) {
-            pageCriteria = where(fieldName(QNewAction.newAction.publishedAction)+"."+fieldName(QNewAction.newAction.publishedAction.pageId)).is(pageId);
+            pageCriteria = where(fieldName(QNewAction.newAction.publishedAction) + "." + fieldName(QNewAction.newAction.publishedAction.pageId)).is(pageId);
         }
         // Fetch unpublished actions
         else {
-            pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
+            pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
         }
         return queryAll(List.of(pageCriteria), aclPermission);
     }
@@ -98,18 +98,18 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
             Boolean userSetOnLoad,
             AclPermission aclPermission) {
         Criteria namesCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)
-                        + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.name))
+                + "."
+                + fieldName(QNewAction.newAction.unpublishedAction.name))
                 .in(names);
 
         Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)
-                        + "."
-                        + fieldName(QNewAction.newAction.unpublishedAction.pageId))
+                + "."
+                + fieldName(QNewAction.newAction.unpublishedAction.pageId))
                 .is(pageId);
 
         Criteria userSetOnLoadCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)
-                        + "."
-                        +fieldName(QNewAction.newAction.unpublishedAction.userSetOnLoad))
+                + "."
+                + fieldName(QNewAction.newAction.unpublishedAction.userSetOnLoad))
                 .is(userSetOnLoad);
 
         String httpMethodQueryKey = fieldName(QNewAction.newAction.unpublishedAction)
@@ -142,12 +142,12 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
         if (Boolean.TRUE.equals(viewMode)) {
 
             if (name != null) {
-                Criteria nameCriteria = where(fieldName(QNewAction.newAction.publishedAction)+"."+fieldName(QNewAction.newAction.publishedAction.name)).is(name);
+                Criteria nameCriteria = where(fieldName(QNewAction.newAction.publishedAction) + "." + fieldName(QNewAction.newAction.publishedAction.name)).is(name);
                 criteriaList.add(nameCriteria);
             }
 
             if (pageIds != null && !pageIds.isEmpty()) {
-                Criteria pageCriteria = where(fieldName(QNewAction.newAction.publishedAction)+"."+fieldName(QNewAction.newAction.publishedAction.pageId)).in(pageIds);
+                Criteria pageCriteria = where(fieldName(QNewAction.newAction.publishedAction) + "." + fieldName(QNewAction.newAction.publishedAction.pageId)).in(pageIds);
                 criteriaList.add(pageCriteria);
             }
         }
@@ -155,12 +155,12 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
         else {
 
             if (name != null) {
-                Criteria nameCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.name)).is(name);
+                Criteria nameCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.name)).is(name);
                 criteriaList.add(nameCriteria);
             }
 
             if (pageIds != null && !pageIds.isEmpty()) {
-                Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.pageId)).in(pageIds);
+                Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId)).in(pageIds);
                 criteriaList.add(pageCriteria);
             }
         }
@@ -174,13 +174,13 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
                                                                                        AclPermission permission) {
         List<Criteria> criteriaList = new ArrayList<>();
         if (names != null) {
-            Criteria namesCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.name)).in(names);
+            Criteria namesCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.name)).in(names);
             criteriaList.add(namesCriteria);
         }
-        Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
+        Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
         criteriaList.add(pageCriteria);
 
-        Criteria executeOnLoadCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.executeOnLoad)).is(Boolean.TRUE);
+        Criteria executeOnLoadCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.executeOnLoad)).is(Boolean.TRUE);
         criteriaList.add(executeOnLoadCriteria);
 
         return queryAll(criteriaList, permission);
@@ -190,10 +190,26 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
     public Flux<NewAction> findUnpublishedActionsByNameInAndPageId(Set<String> names, String pageId, AclPermission permission) {
         List<Criteria> criteriaList = new ArrayList<>();
         if (names != null) {
-            Criteria namesCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.name)).in(names);
+            Criteria namesCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.name)).in(names);
             criteriaList.add(namesCriteria);
         }
-        Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)+"."+fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
+        Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
+        criteriaList.add(pageCriteria);
+
+        return queryAll(criteriaList, permission);
+    }
+
+    @Override
+    public Flux<NewAction> findUnpublishedActionsByPageIdAndExecuteOnLoadSetByUserTrue(String pageId, AclPermission permission) {
+        List<Criteria> criteriaList = new ArrayList<>();
+
+        Criteria executeOnLoadCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.executeOnLoad)).is(Boolean.TRUE);
+        criteriaList.add(executeOnLoadCriteria);
+
+        Criteria setByUserCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.userSetOnLoad)).is(Boolean.TRUE);
+        criteriaList.add(setByUserCriteria);
+
+        Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);
         criteriaList.add(pageCriteria);
 
         return queryAll(criteriaList, permission);
@@ -220,10 +236,10 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
     @Override
     public Mono<Long> countByDatasourceId(String datasourceId) {
         Criteria unpublishedDatasourceCriteria = where(fieldName(QNewAction.newAction.unpublishedAction)
-                    + ".datasource._id")
+                + ".datasource._id")
                 .is(new ObjectId(datasourceId));
         Criteria publishedDatasourceCriteria = where(fieldName(QNewAction.newAction.publishedAction)
-                    + ".datasource._id")
+                + ".datasource._id")
                 .is(new ObjectId(datasourceId));
 
         Criteria datasourceCriteria = new Criteria().orOperator(unpublishedDatasourceCriteria, publishedDatasourceCriteria);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -147,6 +147,9 @@ public class LayoutActionServiceImpl implements LayoutActionService {
     public Mono<List<HashSet<DslActionDTO>>> findAndUpdateOnLoadActionsInPage(Set<String> dynamicBindingNames, String pageId) {
         Mono<List<HashSet<DslActionDTO>>> referencedActions = findAndUpdateOnLoadActionsInPage(new ArrayList<>(), dynamicBindingNames, pageId);
         return referencedActions
+                // Currently, we do not pick action dependencies for actions that users have set to run
+                // on page load but haven't used on their application page.
+                // If such actions exist, they will inevitably fail because these actions are executed before any other
                 .zipWith(newActionService.findUnpublishedOnLoadActionsInPage(pageId)
                         .flatMap(newAction -> {
                             ActionDTO action = newAction.getUnpublishedAction();
@@ -164,7 +167,7 @@ public class LayoutActionServiceImpl implements LayoutActionService {
                 .map(tuple -> {
                     List<HashSet<DslActionDTO>> actionList = tuple.getT1();
                     if (!tuple.getT2().isEmpty()) {
-                        actionList.add(tuple.getT2());
+                        actionList.add(0, tuple.getT2());
                     }
                     return actionList;
                 });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionService.java
@@ -33,7 +33,7 @@ public interface NewActionService extends CrudService<NewAction, String> {
 
     Flux<NewAction> findUnpublishedOnLoadActionsInPage(String pageId);
 
-    Flux<NewAction> findUnpublishedOnLoadActionsInPageByName(Set<String> names, String pageId);
+    Flux<NewAction> findUnpublishedActionsInPageByNames(Set<String> names, String pageId);
 
     Mono<NewAction> findById(String id);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionService.java
@@ -31,7 +31,9 @@ public interface NewActionService extends CrudService<NewAction, String> {
 
     Mono<ActionDTO> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission permission);
 
-    Flux<NewAction> findUnpublishedOnLoadActionsInPage(Set<String> names, String pageId);
+    Flux<NewAction> findUnpublishedOnLoadActionsInPage(String pageId);
+
+    Flux<NewAction> findUnpublishedOnLoadActionsInPageByName(Set<String> names, String pageId);
 
     Mono<NewAction> findById(String id);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -702,7 +702,7 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
      * @return A Flux of Actions that are identified to be executed on page-load.
      */
     @Override
-    public Flux<NewAction> findUnpublishedOnLoadActionsInPageByName(Set<String> names, String pageId) {
+    public Flux<NewAction> findUnpublishedActionsInPageByNames(Set<String> names, String pageId) {
         return repository
                 .findUnpublishedActionsByNameInAndPageId(names, pageId, MANAGE_ACTIONS);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -688,6 +688,12 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
                 .flatMap(action -> generateActionByViewMode(action, false));
     }
 
+    @Override
+    public Flux<NewAction> findUnpublishedOnLoadActionsInPage(String pageId) {
+        return repository
+                .findUnpublishedActionsByPageIdAndExecuteOnLoadSetByUserTrue(pageId, MANAGE_ACTIONS);
+    }
+
     /**
      * Given a list of names of actions and pageId, find all the actions matching this criteria of names and pageId
      *
@@ -696,8 +702,9 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
      * @return A Flux of Actions that are identified to be executed on page-load.
      */
     @Override
-    public Flux<NewAction> findUnpublishedOnLoadActionsInPage(Set<String> names, String pageId) {
-        return repository.findUnpublishedActionsByNameInAndPageId(names, pageId, MANAGE_ACTIONS);
+    public Flux<NewAction> findUnpublishedOnLoadActionsInPageByName(Set<String> names, String pageId) {
+        return repository
+                .findUnpublishedActionsByNameInAndPageId(names, pageId, MANAGE_ACTIONS);
     }
 
     @Override

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -181,8 +181,8 @@ public class LayoutActionServiceTest {
                     assertThat(page.getLayouts()).hasSize(1);
                     assertThat(page.getLayouts().get(0).getLayoutOnLoadActions()).hasSize(2);
                     assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(0)).hasSize(1);
-                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(0).stream().anyMatch(x -> x.getName().equalsIgnoreCase("query1"))).isTrue();
-                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(1).stream().anyMatch(x -> x.getName().equalsIgnoreCase("query2"))).isTrue();
+                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(0).stream().anyMatch(x -> x.getName().equalsIgnoreCase("query2"))).isTrue();
+                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(1).stream().anyMatch(x -> x.getName().equalsIgnoreCase("query1"))).isTrue();
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -146,8 +146,25 @@ public class LayoutActionServiceTest {
         action.setActionConfiguration(actionConfiguration);
         action.setDatasource(datasource);
 
+        ActionDTO unreferencedAction = new ActionDTO();
+        unreferencedAction.setName("query2");
+        unreferencedAction.setPageId(testPage.getId());
+        unreferencedAction.setUserSetOnLoad(true);
+        ActionConfiguration actionConfiguration2 = new ActionConfiguration();
+        actionConfiguration2.setHttpMethod(HttpMethod.GET);
+        unreferencedAction.setActionConfiguration(actionConfiguration2);
+        unreferencedAction.setDatasource(datasource);
+
         Mono<PageDTO> resultMono = newActionService
                 .createAction(action)
+                .flatMap(savedAction -> {
+                    ActionDTO updates = new ActionDTO();
+                    updates.setExecuteOnLoad(true);
+                    updates.setPolicies(null);
+                    updates.setUserPermissions(null);
+                    return layoutActionService.updateAction(savedAction.getId(), updates);
+                })
+                .flatMap(savedAction -> newActionService.createAction(unreferencedAction))
                 .flatMap(savedAction -> {
                     ActionDTO updates = new ActionDTO();
                     updates.setExecuteOnLoad(true);
@@ -162,8 +179,10 @@ public class LayoutActionServiceTest {
                 .create(resultMono)
                 .assertNext(page -> {
                     assertThat(page.getLayouts()).hasSize(1);
-                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions()).hasSize(1);
-                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(0).iterator().next().getName()).isEqualTo("query1");
+                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions()).hasSize(2);
+                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(0)).hasSize(1);
+                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(0).stream().anyMatch(x -> x.getName().equalsIgnoreCase("query1"))).isTrue();
+                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions().get(1).stream().anyMatch(x -> x.getName().equalsIgnoreCase("query2"))).isTrue();
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
During the process of updating a page's layout, this fix adds a query to pick actions that are associated to the page, and marked to be executed on load by the user. This set of actions will exist in a separate list.

Fixes #2217 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Added JUnit tests to check for actions that are not referenced in the dsl, but have been set to execute on load by the user

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
