### PR TITLE
Added type parameter for REST API plugin, and changes for no auth

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnection.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnection.java
@@ -1,0 +1,7 @@
+package com.external.connections;
+
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+
+// Parent type for all API connections that need to be created during datasource create method.
+public abstract class APIConnection implements ExchangeFilterFunction {
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
@@ -2,15 +2,16 @@ package com.external.connections;
 
 import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.OAuth2;
+import reactor.core.publisher.Mono;
 
 
 public class APIConnectionFactory {
 
-    public static APIConnection createConnection(AuthenticationDTO authenticationType) {
+    public static Mono<APIConnection> createConnection(AuthenticationDTO authenticationType) {
         if (authenticationType instanceof OAuth2) {
-            return OAuth2Connection.create((OAuth2) authenticationType);
+            return Mono.from(OAuth2Connection.create((OAuth2) authenticationType));
         } else {
-            return null;
+            return Mono.empty();
         }
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
@@ -1,0 +1,16 @@
+package com.external.connections;
+
+import com.appsmith.external.models.AuthenticationDTO;
+import com.appsmith.external.models.OAuth2;
+
+
+public class APIConnectionFactory {
+
+    public static APIConnection createConnection(AuthenticationDTO authenticationType) {
+        if (authenticationType instanceof OAuth2) {
+            return OAuth2Connection.create((OAuth2) authenticationType);
+        } else {
+            return null;
+        }
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2Connection.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2Connection.java
@@ -11,7 +11,7 @@ public class OAuth2Connection extends APIConnection {
     private OAuth2Connection() {
     }
 
-    public static OAuth2Connection create(OAuth2 oAuth2) {
+    public static Mono<OAuth2Connection> create(OAuth2 oAuth2) {
 //        if (oAuth2.getToken() == null || !isValid(oAuth2)) {
 //
 //        }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2Connection.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2Connection.java
@@ -1,0 +1,28 @@
+package com.external.connections;
+
+import com.appsmith.external.models.OAuth2;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+public class OAuth2Connection extends APIConnection {
+
+    private OAuth2Connection() {
+    }
+
+    public static OAuth2Connection create(OAuth2 oAuth2) {
+//        if (oAuth2.getToken() == null || !isValid(oAuth2)) {
+//
+//        }
+
+        return null;
+    }
+
+    @Override
+    public Mono<ClientResponse> filter(ClientRequest clientRequest, ExchangeFunction exchangeFunction) {
+//        return getValidToken().map(token -> bearer(clientRequest, token)).flatMap(exchangeFunction::exchange)
+//                .switchIfEmpty(exchangeFunction.exchange(clientRequest));
+        return null;
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -105,10 +105,7 @@ public class RestApiPlugin extends BasePlugin {
                 return Mono.just(errorResult);
             }
 
-//            log.debug("Final URL is: " + uri.toString());
-
             ActionExecutionRequest actionExecutionRequest = populateRequestFields(actionConfiguration, uri);
-//            log.debug("request is : {}", actionExecutionRequest);
 
             if (httpMethod == null) {
                 errorResult.setBody(AppsmithPluginError.PLUGIN_ERROR.getMessage("HTTPMethod must be set."));

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -394,7 +394,7 @@ public class RestApiPlugin extends BasePlugin {
 
         @Override
         public Mono<APIConnection> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
-            return Mono.justOrEmpty(APIConnectionFactory.createConnection(datasourceConfiguration.getAuthentication()));
+            return APIConnectionFactory.createConnection(datasourceConfiguration.getAuthentication());
         }
 
         @Override

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -10,6 +10,8 @@ import com.appsmith.external.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
+import com.external.connections.APIConnection;
+import com.external.connections.APIConnectionFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
@@ -69,21 +71,23 @@ public class RestApiPlugin extends BasePlugin {
 
     @Slf4j
     @Extension
-    public static class RestApiPluginExecutor implements PluginExecutor<Void> {
+    public static class RestApiPluginExecutor implements PluginExecutor<APIConnection> {
 
         private final String IS_SEND_SESSION_ENABLED_KEY = "isSendSessionEnabled";
         private final String SESSION_SIGNATURE_KEY_KEY = "sessionSignatureKey";
         private final String SIGNATURE_HEADER_NAME = "X-APPSMITH-SIGNATURE";
 
         @Override
-        public Mono<ActionExecutionResult> execute(Void ignored,
+        public Mono<ActionExecutionResult> execute(APIConnection apiConnection,
                                                    DatasourceConfiguration datasourceConfiguration,
                                                    ActionConfiguration actionConfiguration) {
 
+            // Initializing object for error condition
             ActionExecutionResult errorResult = new ActionExecutionResult();
             errorResult.setStatusCode(AppsmithPluginError.PLUGIN_ERROR.getAppErrorCode().toString());
             errorResult.setIsExecutionSuccess(false);
 
+            // Initializing request URL
             String path = (actionConfiguration.getPath() == null) ? "" : actionConfiguration.getPath();
             String url = datasourceConfiguration.getUrl() + path;
             String reqContentType = "";
@@ -101,10 +105,10 @@ public class RestApiPlugin extends BasePlugin {
                 return Mono.just(errorResult);
             }
 
-            log.debug("Final URL is: " + uri.toString());
+//            log.debug("Final URL is: " + uri.toString());
 
             ActionExecutionRequest actionExecutionRequest = populateRequestFields(actionConfiguration, uri);
-            log.debug("request is : {}", actionExecutionRequest);
+//            log.debug("request is : {}", actionExecutionRequest);
 
             if (httpMethod == null) {
                 errorResult.setBody(AppsmithPluginError.PLUGIN_ERROR.getMessage("HTTPMethod must be set."));
@@ -112,8 +116,10 @@ public class RestApiPlugin extends BasePlugin {
                 return Mono.just(errorResult);
             }
 
+            // Initializing webClient to be used for http call
             WebClient.Builder webClientBuilder = WebClient.builder();
 
+            // Adding headers from datasource
             if (datasourceConfiguration.getHeaders() != null) {
                 reqContentType = addHeadersToRequestAndGetContentType(
                         webClientBuilder, datasourceConfiguration.getHeaders());
@@ -124,6 +130,7 @@ public class RestApiPlugin extends BasePlugin {
                         webClientBuilder, actionConfiguration.getHeaders());
             }
 
+            // Check for content type
             final String contentTypeError = verifyContentType(actionConfiguration.getHeaders());
             if (contentTypeError != null) {
                 errorResult.setBody(AppsmithPluginError.PLUGIN_ERROR.getMessage("Invalid value for Content-Type."));
@@ -131,6 +138,7 @@ public class RestApiPlugin extends BasePlugin {
                 return Mono.just(errorResult);
             }
 
+            // Adding request body
             String requestBodyAsString = (actionConfiguration.getBody() == null) ? "" : actionConfiguration.getBody();
 
             if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType)
@@ -138,6 +146,7 @@ public class RestApiPlugin extends BasePlugin {
                 requestBodyAsString = convertPropertyListToReqBody(actionConfiguration.getBodyFormData(), reqContentType);
             }
 
+            // If users have chosen to share the Appsmith signature in the header, calculate and add that
             String secretKey;
             try {
                 secretKey = getSignatureKey(datasourceConfiguration);
@@ -158,8 +167,14 @@ public class RestApiPlugin extends BasePlugin {
                 webClientBuilder.defaultHeader(SIGNATURE_HEADER_NAME, token);
             }
 
+            // Right before building the webclient object, we populate it with whatever mutation the APIConnection object demands
+            if (apiConnection != null) {
+                webClientBuilder.filter(apiConnection);
+            }
+
             WebClient client = webClientBuilder.exchangeStrategies(EXCHANGE_STRATEGIES).build();
 
+            // Triggering the actual REST API call
             return httpCall(client, httpMethod, uri, requestBodyAsString, 0, reqContentType)
                     .flatMap(clientResponse -> clientResponse.toEntity(byte[].class))
                     .map(stringResponseEntity -> {
@@ -264,7 +279,7 @@ public class RestApiPlugin extends BasePlugin {
                         String key = property.getKey();
                         String value = property.getValue();
 
-                        if(MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType)) {
+                        if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType)) {
                             try {
                                 value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
                             } catch (UnsupportedEncodingException e) {
@@ -272,7 +287,7 @@ public class RestApiPlugin extends BasePlugin {
                             }
                         }
 
-                        return key + "="+ value;
+                        return key + "=" + value;
                     })
                     .collect(Collectors.joining("&"));
 
@@ -381,12 +396,12 @@ public class RestApiPlugin extends BasePlugin {
         }
 
         @Override
-        public Mono<Void> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
-            return Mono.empty();
+        public Mono<APIConnection> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
+            return Mono.justOrEmpty(APIConnectionFactory.createConnection(datasourceConfiguration.getAuthentication()));
         }
 
         @Override
-        public void datasourceDestroy(Void connection) {
+        public void datasourceDestroy(APIConnection connection) {
             // REST API plugin doesn't have a datasource.
         }
 


### PR DESCRIPTION
This change uses an [ExchangeFilterFunction](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/reactive/function/client/ExchangeFilterFunction.html) type as a type parameter for REST APIs so that any mutations that need to be performed on the webclient during plugin execution can be recorded and created in the datasource create step in the future.

This change also contains the necessary changes to implement the status quo of REST APIs with no authentication.

Fixes #2255 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Existing JUnit tests are all that is required since the change only introduces a new way of doing things
- Manual testing with existing datasource + API action (no auth):

![image](https://user-images.githubusercontent.com/5298848/103646347-8a05aa00-4f7f-11eb-9a6a-68343f225610.png)

![image](https://user-images.githubusercontent.com/5298848/103646308-7bb78e00-4f7f-11eb-83d3-d42164cb948d.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
