### PR TITLE
Handle for scenarios scrollTo is not available in browser

### DIFF
--- a/app/client/src/components/designSystems/appsmith/ContainerComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/ContainerComponent.tsx
@@ -40,7 +40,15 @@ const ContainerComponent = (props: ContainerComponentProps) => {
   const containerRef: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!props.shouldScrollContents) {
-      containerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+      const supportsNativeSmoothScroll =
+        "scrollBehavior" in document.documentElement.style;
+      if (supportsNativeSmoothScroll) {
+        containerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+      } else {
+        if (containerRef.current) {
+          containerRef.current.scrollTop = 0;
+        }
+      }
     }
   }, [props.shouldScrollContents]);
   return (


### PR DESCRIPTION
## Description
Old Edge does not have scroll behaviour functionality 
https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior
This PR will fallback to the old way of scrolling when this functionality does not exist

Fixes #2431 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Not been tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
