### PR TITLE
Added Oauth2 functionality for REST APIs

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/FieldName.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/FieldName.java
@@ -3,6 +3,7 @@ package com.appsmith.external.constants;
 public class FieldName {
     public static final String CLIENT_SECRET = "clientSecret";
     public static final String TOKEN = "token";
+    public static final String TOKEN_RESPONSE = "tokenResponse";
 
     public static final String PASSWORD = "password";
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -29,7 +29,7 @@ public class AuthenticationDTO {
     // class and fails.
 
     @JsonIgnore
-    private Boolean isEncrypted;
+    private Boolean isEncrypted = false;
 
     @JsonIgnore
     public Map<String, String> getEncryptionFields() {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -6,11 +6,13 @@ import com.appsmith.external.constants.FieldName;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,13 +24,16 @@ import java.util.Set;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @DocumentType(AuthType.OAUTH2)
-public class OAuth2 extends AuthenticationDTO {
+public class OAuth2 extends AuthenticationDTO implements Serializable {
     public enum Type {
         CLIENT_CREDENTIALS,
     }
 
     Type authType;
+
+    Boolean isHeader;
 
     String clientId;
 
@@ -37,13 +42,35 @@ public class OAuth2 extends AuthenticationDTO {
 
     String accessTokenUrl;
 
-    String scope;
+    Set<String> scope;
+
+    String headerPrefix = "Bearer";
+
+    @JsonIgnore
+    Object tokenResponse;
 
     @JsonIgnore
     String token;
 
     @JsonIgnore
+    Instant issuedAt;
+
+    @JsonIgnore
     Instant expiresAt;
+
+    public OAuth2(OAuth2 oAuth2) {
+        this.authType = oAuth2.authType;
+        this.isHeader = oAuth2.isHeader;
+        this.clientId = oAuth2.clientId;
+        this.clientSecret = oAuth2.clientSecret;
+        this.accessTokenUrl = oAuth2.accessTokenUrl;
+        this.scope = oAuth2.scope;
+        this.headerPrefix = oAuth2.headerPrefix;
+        this.tokenResponse = oAuth2.tokenResponse;
+        this.token = oAuth2.token;
+        this.issuedAt = oAuth2.issuedAt;
+        this.expiresAt = oAuth2.expiresAt;
+    }
 
     @Override
     public Map<String, String> getEncryptionFields() {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -6,13 +6,11 @@ import com.appsmith.external.constants.FieldName;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -24,9 +22,8 @@ import java.util.Set;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @DocumentType(AuthType.OAUTH2)
-public class OAuth2 extends AuthenticationDTO implements Serializable {
+public class OAuth2 extends AuthenticationDTO {
     public enum Type {
         CLIENT_CREDENTIALS,
     }
@@ -58,20 +55,6 @@ public class OAuth2 extends AuthenticationDTO implements Serializable {
     @JsonIgnore
     Instant expiresAt;
 
-    public OAuth2(OAuth2 oAuth2) {
-        this.authType = oAuth2.authType;
-        this.isHeader = oAuth2.isHeader;
-        this.clientId = oAuth2.clientId;
-        this.clientSecret = oAuth2.clientSecret;
-        this.accessTokenUrl = oAuth2.accessTokenUrl;
-        this.scope = oAuth2.scope;
-        this.headerPrefix = oAuth2.headerPrefix;
-        this.tokenResponse = oAuth2.tokenResponse;
-        this.token = oAuth2.token;
-        this.issuedAt = oAuth2.issuedAt;
-        this.expiresAt = oAuth2.expiresAt;
-    }
-
     @Override
     public Map<String, String> getEncryptionFields() {
         Map<String, String> map = new HashMap<>();
@@ -80,6 +63,9 @@ public class OAuth2 extends AuthenticationDTO implements Serializable {
         }
         if (this.token != null) {
             map.put(FieldName.TOKEN, this.token);
+        }
+        if (this.tokenResponse != null) {
+            map.put(FieldName.TOKEN_RESPONSE, String.valueOf(this.tokenResponse));
         }
         return map;
     }
@@ -93,6 +79,9 @@ public class OAuth2 extends AuthenticationDTO implements Serializable {
             if (encryptedFields.containsKey(FieldName.TOKEN)) {
                 this.token = encryptedFields.get(FieldName.TOKEN);
             }
+            if (encryptedFields.containsKey(FieldName.TOKEN_RESPONSE)) {
+                this.tokenResponse = encryptedFields.get(FieldName.TOKEN_RESPONSE);
+            }
         }
     }
 
@@ -104,6 +93,9 @@ public class OAuth2 extends AuthenticationDTO implements Serializable {
         }
         if (this.token == null || this.token.isEmpty()) {
             set.add(FieldName.TOKEN);
+        }
+        if (this.tokenResponse == null || (String.valueOf(this.token)).isEmpty()) {
+            set.add(FieldName.TOKEN_RESPONSE);
         }
         return set;
     }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/UpdatableConnection.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/UpdatableConnection.java
@@ -1,9 +1,5 @@
 package com.appsmith.external.models;
 
 public interface UpdatableConnection {
-    void updateDatasource(DatasourceConfiguration datasourceConfiguration);
-
-    default boolean isUpdated() {
-        return false;
-    }
+    public AuthenticationDTO getAuthenticationDTO(AuthenticationDTO authenticationDTO);
 }

--- a/app/server/appsmith-plugins/restApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/restApiPlugin/pom.xml
@@ -103,6 +103,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!--

--- a/app/server/appsmith-plugins/restApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/restApiPlugin/pom.xml
@@ -108,6 +108,23 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <!--

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2Connection.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2Connection.java
@@ -1,28 +1,174 @@
 package com.external.connections;
 
+import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.OAuth2;
+import com.appsmith.external.models.UpdatableConnection;
+import com.appsmith.external.pluginExceptions.StaleConnectionException;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.BodyExtractors;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
-public class OAuth2Connection extends APIConnection {
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+@Setter
+@Getter
+public class OAuth2Connection extends APIConnection implements UpdatableConnection {
+
+    private final Clock clock = Clock.systemUTC();
+    private String token;
+    private String headerPrefix;
+    private boolean isHeader;
+    private Instant expiresAt;
 
     private OAuth2Connection() {
     }
 
     public static Mono<OAuth2Connection> create(OAuth2 oAuth2) {
-//        if (oAuth2.getToken() == null || !isValid(oAuth2)) {
-//
-//        }
+        if (oAuth2 == null) {
+            return Mono.empty();
+        }
+        // Create OAuth2Connection
+        OAuth2Connection connection = new OAuth2Connection();
 
-        return null;
+        return Mono.just(oAuth2)
+                // Validate existing token
+                .filter(x -> x.getToken() != null && !x.getToken().isBlank())
+                .filter(x -> x.getExpiresAt() != null)
+                .filter(x -> {
+                    Instant now = connection.clock.instant();
+                    Instant expiresAt = x.getExpiresAt();
+                    return now.isBefore(expiresAt.minus(Duration.ofMinutes(1)));
+                })
+                // If invalid, regenerate token
+                .switchIfEmpty(connection.generateOAuth2Token(oAuth2))
+                // Store valid token
+                .flatMap(token -> {
+                    connection.setToken(token.getToken());
+                    connection.setHeader(token.getIsHeader());
+                    connection.setHeaderPrefix(token.getHeaderPrefix());
+                    connection.setExpiresAt(token.getExpiresAt());
+                    return Mono.just(connection);
+                });
+    }
+
+    private Mono<OAuth2> generateOAuth2Token(OAuth2 oAuth2) {
+        // Webclient
+        WebClient webClient = WebClient.builder()
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .exchangeStrategies(ExchangeStrategies
+                        .builder()
+                        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(/* 10MB */ 10 * 1024 * 1024))
+                        .build())
+                .build();
+
+        // Send oauth2 generic request
+        return webClient
+                .method(HttpMethod.POST)
+                .uri(oAuth2.getAccessTokenUrl())
+                .body(clientCredentialsTokenBody(oAuth2))
+                .exchange()
+                .flatMap(response -> response.body(BodyExtractors.toMono(Map.class)))
+                // Receive and parse response
+                .map(mappedResponse -> {
+                    // Store received response as is for reference
+                    oAuth2.setTokenResponse(mappedResponse);
+                    // Parse useful fields for quick access
+                    Object issuedAtResponse = mappedResponse.get("issued_at");
+                    // Default issuedAt to current time
+                    Instant issuedAt = Instant.now();
+                    if (issuedAtResponse != null) {
+                        issuedAt = Instant.ofEpochMilli(Long.parseLong((String) issuedAtResponse));
+                    }
+
+                    // We expect at least one of the following to be present
+                    Object expiresAtResponse = mappedResponse.get("expires_at");
+                    Object expiresInResponse = mappedResponse.get("expires_in");
+                    Instant expiresAt = null;
+                    if (expiresAtResponse != null) {
+                        expiresAt = Instant.ofEpochMilli(Long.parseLong((String) expiresAtResponse));
+                    } else if (expiresInResponse != null) {
+                        expiresAt = issuedAt.plusMillis(Long.parseLong((String) expiresInResponse));
+                    }
+                    oAuth2.setExpiresAt(expiresAt);
+                    oAuth2.setIssuedAt(issuedAt);
+                    oAuth2.setToken(String.valueOf(mappedResponse.get("access_token")));
+
+                    return oAuth2;
+                });
     }
 
     @Override
     public Mono<ClientResponse> filter(ClientRequest clientRequest, ExchangeFunction exchangeFunction) {
-//        return getValidToken().map(token -> bearer(clientRequest, token)).flatMap(exchangeFunction::exchange)
-//                .switchIfEmpty(exchangeFunction.exchange(clientRequest));
-        return null;
+        // Validate token before execution
+        Instant now = this.clock.instant();
+        Instant expiresAt = this.expiresAt;
+        if (this.expiresAt != null && now.isBefore(expiresAt.minus(Duration.ofMinutes(1)))) {
+            return Mono.error(new StaleConnectionException("The access token has expired"));
+        }
+        // Pick the token that has been created/retrieved
+        return addTokenToRequest(clientRequest)
+                // Carry on to next exchange function
+                .flatMap(exchangeFunction::exchange)
+                // Default to next exchange function if something went wrong
+                .switchIfEmpty(exchangeFunction.exchange(clientRequest));
+    }
+
+    private Mono<ClientRequest> addTokenToRequest(ClientRequest clientRequest) {
+        // Check to see where the token needs to be added
+        if (this.isHeader()) {
+            final String finalHeaderPrefix = this.getHeaderPrefix() != null && !this.getHeaderPrefix().isBlank() ?
+                    this.getHeaderPrefix() + " "
+                    : "Bearer ";
+            return Mono.justOrEmpty(ClientRequest.from(clientRequest)
+                    .headers(headers -> headers.set("Authorization", finalHeaderPrefix + this.getToken()))
+                    .build());
+        } else {
+            final URI url = UriComponentsBuilder.fromUri(clientRequest.url())
+                    .queryParam("access_token", this.getToken())
+                    .build()
+                    .toUri();
+            return Mono.justOrEmpty(ClientRequest.from(clientRequest)
+                    .url(url)
+                    .build());
+        }
+    }
+
+    private BodyInserters.FormInserter<String> clientCredentialsTokenBody(OAuth2 oAuth2) {
+        BodyInserters.FormInserter<String> body = BodyInserters
+                .fromFormData("grant_type", "client_credentials")
+                .with("client_id", oAuth2.getClientId())
+                .with("client_secret", oAuth2.getClientSecret());
+        // Optionally add scope, if applicable
+        if (!CollectionUtils.isEmpty(oAuth2.getScope())) {
+            body.with("scope", StringUtils.collectionToDelimitedString(oAuth2.getScope(), " "));
+        }
+        return body;
+    }
+
+    @Override
+    public AuthenticationDTO getAuthenticationDTO(AuthenticationDTO authenticationDTO) {
+        OAuth2 oAuth2 = (OAuth2) authenticationDTO;
+        oAuth2.setToken(this.token);
+        oAuth2.setHeaderPrefix(this.headerPrefix);
+        oAuth2.setIsHeader(this.isHeader);
+
+        return oAuth2;
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ConnectionTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ConnectionTest.java
@@ -44,35 +44,6 @@ public class OAuth2ConnectionTest {
         assertThat(connection.getToken()).isEqualTo("SomeToken");
     }
 
-//    @Test
-//    public void testExpiredConnection() throws Exception {
-//        // Setting up an expired token object
-//        OAuth2 oAuth2 = new OAuth2();
-//        oAuth2.setIsHeader(true);
-//        oAuth2.setToken("SomeToken");
-//        oAuth2.setIsEncrypted(false);
-//        oAuth2.setExpiresAt(Instant.now());
-//
-//        // Setting up the sample token to be returned
-//        OAuth2 newOauth2 = new OAuth2();
-//        newOauth2.setToken("Generated token");
-//        newOauth2.setHeaderPrefix("ManualPrefix");
-//        Mono<OAuth2> generatedOauth2 = Mono.just(newOauth2);
-//        PowerMockito.mockStatic(OAuth2Connection.class);
-//
-//        OAuth2Connection oAuth2Connection = PowerMockito.mock(OAuth2Connection.class);
-//        PowerMockito.spy(oAuth2Connection);
-//        PowerMockito
-//                .when(oAuth2Connection, OAuth2Connection.class.getDeclaredMethod("generateOAuth2Token", OAuth2.class))
-//                .withArguments(oAuth2)
-//                .thenReturn(generatedOauth2);
-//        OAuth2Connection connection = oAuth2Connection.create(oAuth2).block(Duration.ofMillis(100));
-//
-//        assertThat(connection).isNotNull();
-//        assertThat(connection.getHeaderPrefix()).isEqualTo("ManualPrefix");
-//        assertThat(connection.getToken()).isEqualTo("Generated token");
-//    }
-
     @Test
     public void testStaleFilter() {
         OAuth2 oAuth2 = new OAuth2();

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ConnectionTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ConnectionTest.java
@@ -1,17 +1,92 @@
 package com.external.connections;
 
+import com.appsmith.external.models.OAuth2;
+import com.appsmith.external.pluginExceptions.StaleConnectionException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(OAuth2Connection.class)
 public class OAuth2ConnectionTest {
 
     @Test
     public void testNullConnection() {
         APIConnection connection = OAuth2Connection.create(null).block(Duration.ofMillis(100));
         assertThat(connection).isNull();
+    }
+
+    @Test
+    public void testValidConnection() {
+        OAuth2 oAuth2 = new OAuth2();
+        oAuth2.setIsHeader(true);
+        oAuth2.setToken("SomeToken");
+        oAuth2.setIsEncrypted(false);
+        oAuth2.setExpiresAt(Instant.now().plusSeconds(1200));
+        OAuth2Connection connection = OAuth2Connection.create(oAuth2).block(Duration.ofMillis(100));
+        assertThat(connection).isNotNull();
+        assertThat(connection.getExpiresAt()).isEqualTo(oAuth2.getExpiresAt());
+        assertThat(connection.getHeaderPrefix()).isEqualTo("Bearer");
+        assertThat(connection.getToken()).isEqualTo("SomeToken");
+    }
+
+//    @Test
+//    public void testExpiredConnection() throws Exception {
+//        // Setting up an expired token object
+//        OAuth2 oAuth2 = new OAuth2();
+//        oAuth2.setIsHeader(true);
+//        oAuth2.setToken("SomeToken");
+//        oAuth2.setIsEncrypted(false);
+//        oAuth2.setExpiresAt(Instant.now());
+//
+//        // Setting up the sample token to be returned
+//        OAuth2 newOauth2 = new OAuth2();
+//        newOauth2.setToken("Generated token");
+//        newOauth2.setHeaderPrefix("ManualPrefix");
+//        Mono<OAuth2> generatedOauth2 = Mono.just(newOauth2);
+//        PowerMockito.mockStatic(OAuth2Connection.class);
+//
+//        OAuth2Connection oAuth2Connection = PowerMockito.mock(OAuth2Connection.class);
+//        PowerMockito.spy(oAuth2Connection);
+//        PowerMockito
+//                .when(oAuth2Connection, OAuth2Connection.class.getDeclaredMethod("generateOAuth2Token", OAuth2.class))
+//                .withArguments(oAuth2)
+//                .thenReturn(generatedOauth2);
+//        OAuth2Connection connection = oAuth2Connection.create(oAuth2).block(Duration.ofMillis(100));
+//
+//        assertThat(connection).isNotNull();
+//        assertThat(connection.getHeaderPrefix()).isEqualTo("ManualPrefix");
+//        assertThat(connection.getToken()).isEqualTo("Generated token");
+//    }
+
+    @Test
+    public void testStaleFilter() {
+        OAuth2 oAuth2 = new OAuth2();
+        oAuth2.setIsHeader(true);
+        oAuth2.setToken("SomeToken");
+        oAuth2.setIsEncrypted(false);
+        oAuth2.setExpiresAt(Instant.now().plusSeconds(1200));
+        OAuth2Connection connection = OAuth2Connection.create(oAuth2).block(Duration.ofMillis(100));
+        connection.setExpiresAt(Instant.now());
+
+        Mono<ClientResponse> response = connection.filter(Mockito.mock(ClientRequest.class), Mockito.mock(ExchangeFunction.class));
+
+        StepVerifier.create(response)
+                .expectError(StaleConnectionException.class);
     }
 
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ConnectionTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ConnectionTest.java
@@ -1,0 +1,17 @@
+package com.external.connections;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OAuth2ConnectionTest {
+
+    @Test
+    public void testNullConnection() {
+        APIConnection connection = OAuth2Connection.create(null).block(Duration.ofMillis(100));
+        assertThat(connection).isNull();
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.services;
 
 import com.appsmith.external.models.AuthenticationDTO;
+import com.appsmith.external.models.UpdatableConnection;
 import com.appsmith.external.pluginExceptions.StaleConnectionException;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.server.domains.Datasource;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -60,7 +62,7 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
                 // the reactive flow interrupts, resulting in the destroy operation not completing.
                 && datasourceContextMap.get(datasourceId).getConnection() != null
                 && !isStale) {
-            log.debug("resource context exists. Returning the same.");
+            log.debug("Resource context exists. Returning the same.");
             return Mono.just(datasourceContextMap.get(datasourceId));
         }
 
@@ -115,6 +117,19 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
 
                     Mono<Object> connectionMono = pluginExecutor.datasourceCreate(datasource1.getDatasourceConfiguration());
                     return connectionMono
+                            .flatMap(connection -> {
+                                Mono<Datasource> datasourceMono1 = Mono.just(datasource1);
+                                if (connection instanceof UpdatableConnection) {
+                                    datasource1.setUpdatedAt(Instant.now());
+                                    datasource1
+                                            .getDatasourceConfiguration()
+                                            .setAuthentication(
+                                                    ((UpdatableConnection) connection).getAuthenticationDTO(
+                                                            datasource1.getDatasourceConfiguration().getAuthentication()));
+                                    datasourceMono1 = datasourceService.update(datasource1.getId(), datasource1);
+                                }
+                                return datasourceMono1.thenReturn(connection);
+                            })
                             .map(connection -> {
                                 // When a connection object exists and makes sense for the plugin, we put it in the
                                 // context. Example, DB plugins.
@@ -174,6 +189,7 @@ public class DatasourceContextServiceImpl implements DatasourceContextService {
     public AuthenticationDTO decryptSensitiveFields(AuthenticationDTO authentication) {
         if (authentication != null && authentication.isEncrypted()) {
             Map<String, String> decryptedFields = authentication.getEncryptionFields().entrySet().stream()
+                    .filter(e -> e.getValue() != null)
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
                             e -> encryptionService.decryptString(e.getValue())));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -159,14 +159,16 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
     @Override
     public AuthenticationDTO encryptAuthenticationFields(AuthenticationDTO authentication) {
         if (authentication != null
-                && CollectionUtils.isEmpty(authentication.getEmptyEncryptionFields())
                 && !authentication.isEncrypted()) {
             Map<String, String> encryptedFields = authentication.getEncryptionFields().entrySet().stream()
+                    .filter(e -> e.getValue() != null)
                     .collect(Collectors.toMap(
                             Map.Entry::getKey,
                             e -> encryptionService.encryptString(e.getValue())));
-            authentication.setEncryptionFields(encryptedFields);
-            authentication.setIsEncrypted(true);
+            if (!encryptedFields.isEmpty()) {
+                authentication.setEncryptionFields(encryptedFields);
+                authentication.setIsEncrypted(true);
+            }
         }
         return authentication;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
@@ -89,8 +89,9 @@ public class DatasourceStructureSolution {
         // If datasource has encrypted fields, decrypt and set it in the datasource.
         if (datasource.getDatasourceConfiguration() != null) {
             AuthenticationDTO authentication = datasource.getDatasourceConfiguration().getAuthentication();
-            if (authentication != null && authentication.getEmptyEncryptionFields().isEmpty() && authentication.isEncrypted()) {
+            if (authentication != null && authentication.isEncrypted()) {
                 Map<String, String> decryptedFields = authentication.getEncryptionFields().entrySet().stream()
+                        .filter(e -> e.getValue() != null)
                         .collect(Collectors.toMap(
                                 Map.Entry::getKey,
                                 e -> encryptionService.decryptString(e.getValue())));


### PR DESCRIPTION
OAuth2 is inherently part of the API plugin. The following functionality has been added to the plugin as part of this PR:

1. Client credentials flow for OAuth2. Users can now connect to APIs that require long-lived or short lived access tokens. Since the automated flow for API plugins cannot be interrupted, this change only supports 2LO. 3LO will remain a front end feature for now.
2. All client secrets are encrypted on the backend. This also means that they are not editable once configured. Users will need to re-enter their authentication details.
3. Customizable Header prefix (defaults to Bearer)
4. Choice to include access token in either header or query params (Official documentation recommends using headers)
5. Auto refresh of credentials on expiry. The client credentials flow typically requests for a new token on every request. However, for cases where the token response supports an expiry datetime instant, this change allows token reuse. The relevant fields that are tracked are:
- expires_at
- issued_at and expires_in
6. Configurable scopes
7. Extensible OAuth2 type to allow customizations over the default OAuth2 behaviour
8. Authentication types can be swapped out in case an API configuration needs to be changed. The request can simply start using the new type to do so. Note that previous configurations will not be saved.
 
Refer to [this Notion document](https://www.notion.so/appsmith/Datasource-and-plugin-execution-related-changes-8282acbd4e334bc5aea6a757bc669ccd#c1733db392ea42a2b03f52ca8e0c0d60) for context

Fixes #934

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?
- JUnit for edge cases
- Manually tested on local since credentials cannot be shared on JUnit

*Creating datasource of OAuth2 type*
![image](https://user-images.githubusercontent.com/5298848/104146810-04a44e80-53f2-11eb-9d2e-4d653f23a9f0.png)

![image](https://user-images.githubusercontent.com/5298848/104146743-c149e000-53f1-11eb-8a22-91da1f69cd5c.png)

*Creating action for this datasource*
![image](https://user-images.githubusercontent.com/5298848/104146769-df174500-53f1-11eb-92cf-da9ba11145df.png)
![image](https://user-images.githubusercontent.com/5298848/104146771-e0e10880-53f1-11eb-9175-8f47c324f290.png)

*Executing action (2LO against Facebook API)*
![image](https://user-images.githubusercontent.com/5298848/104146792-f3f3d880-53f1-11eb-93c9-7b4c73d9f034.png)
![image](https://user-images.githubusercontent.com/5298848/104146795-f5bd9c00-53f1-11eb-9228-e5b17740e3e0.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
