### PR TITLE
Disable uninvited signups via environment variable

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -25,6 +25,9 @@ public class CommonConfig {
 
     private static final String ELASTIC_THREAD_POOL_NAME = "appsmith-elastic-pool";
 
+    @Value("${signup.disabled}")
+    private boolean isSignupDisabled;
+
     @Value("${oauth2.allowed-domains}")
     private String allowedDomainList;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
@@ -50,6 +50,7 @@ public class UserController extends BaseController<UserService, User, String> {
     }
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE})
+    @ResponseStatus(HttpStatus.CREATED)
     public Mono<ResponseDTO<User>> create(@Valid @RequestBody User resource,
                                           @RequestHeader(name = "Origin", required = false) String originHeader,
                                           ServerWebExchange exchange) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.controllers;
 
-import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.Url;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.InviteUsersDTO;
@@ -38,29 +37,22 @@ public class UserController extends BaseController<UserService, User, String> {
     private final SessionUserService sessionUserService;
     private final UserOrganizationService userOrganizationService;
     private final UserSignup userSignup;
-    private final CommonConfig commonConfig;
 
     @Autowired
     public UserController(UserService service,
                           SessionUserService sessionUserService,
                           UserOrganizationService userOrganizationService,
-                          UserSignup userSignup,
-                          CommonConfig commonConfig) {
+                          UserSignup userSignup) {
         super(service);
         this.sessionUserService = sessionUserService;
         this.userOrganizationService = userOrganizationService;
         this.userSignup = userSignup;
-        this.commonConfig = commonConfig;
     }
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE})
     public Mono<ResponseDTO<User>> create(@Valid @RequestBody User resource,
                                           @RequestHeader(name = "Origin", required = false) String originHeader,
                                           ServerWebExchange exchange) {
-        if (commonConfig.isSignupDisabled()) {
-            return Mono.just(new ResponseDTO<>(HttpStatus.FORBIDDEN.value(), null, null));
-        }
-
         return userSignup.signupAndLogin(resource, exchange)
                 .map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -69,7 +69,8 @@ public enum AppsmithError {
     INVALID_CURL_METHOD(400, 4032, "Invalid method in cURL command: {0}.", AppsmithErrorAction.DEFAULT),
     OAUTH_NOT_AVAILABLE(500, 5006, "Login with {0} is not supported.", AppsmithErrorAction.LOG_EXTERNALLY),
     MARKETPLACE_NOT_CONFIGURED(500, 5007, "Marketplace is not configured.", AppsmithErrorAction.DEFAULT),
-    PAYLOAD_TOO_LARGE(413, 4028, "The request payload is too large. Max allowed size for request payload is {0} KB", AppsmithErrorAction.DEFAULT)
+    PAYLOAD_TOO_LARGE(413, 4028, "The request payload is too large. Max allowed size for request payload is {0} KB", AppsmithErrorAction.DEFAULT),
+    SIGNUP_DISABLED(403, 4033, "Signing up is disabled on this instance of Appsmith. Please contact the administrator for more details.", AppsmithErrorAction.DEFAULT),
     ;
 
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -70,7 +70,7 @@ public enum AppsmithError {
     OAUTH_NOT_AVAILABLE(500, 5006, "Login with {0} is not supported.", AppsmithErrorAction.LOG_EXTERNALLY),
     MARKETPLACE_NOT_CONFIGURED(500, 5007, "Marketplace is not configured.", AppsmithErrorAction.DEFAULT),
     PAYLOAD_TOO_LARGE(413, 4028, "The request payload is too large. Max allowed size for request payload is {0} KB", AppsmithErrorAction.DEFAULT),
-    SIGNUP_DISABLED(403, 4033, "Signing up is disabled on this instance of Appsmith. Please contact the administrator for more details.", AppsmithErrorAction.DEFAULT),
+    SIGNUP_DISABLED(403, 4033, "Signup is restricted on this instance of Appsmith. Please contact the administrator to get an invite.", AppsmithErrorAction.DEFAULT),
     ;
 
 

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -77,3 +77,6 @@ management.metrics.web.server.request.ignore-trailing-slash=true
 management.metrics.web.server.request.autotime.percentiles=0.5, 0.9, 0.95, 0.99
 management.metrics.web.server.request.autotime.percentiles-histogram=true
 management.metrics.distribution.sla.[http.server.requests]=1s
+
+# Support disabling signup with an environment variable
+signup.disabled = ${APPSMITH_SIGNUP_DISABLED:false}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -265,30 +265,6 @@ public class UserServiceTest {
 
     @Test
     @WithMockAppsmithUser
-    public void confirmInviteTokenFlow() {
-        User newUser = new User();
-        newUser.setEmail("newEmail@newEmail.com");
-        newUser.setIsEnabled(false);
-        newUser.setInviteToken("inviteToken");
-
-        userRepository.save(newUser).block();
-
-        newUser.setPassword("newPassword");
-
-        Mono<User> afterConfirmationUserMono = userService.confirmInviteUser(newUser, "http://localhost:8080")
-                .then(userRepository.findByEmail("newEmail@newEmail.com"));
-
-        StepVerifier.create(afterConfirmationUserMono)
-                .assertNext(user -> {
-                    assertThat(user).isNotNull();
-                    assertThat(user.getIsEnabled()).isTrue();
-                })
-                .verifyComplete();
-
-    }
-
-    @Test
-    @WithMockAppsmithUser
     public void signUpViaFormLoginIfAlreadyInvited() {
         User newUser = new User();
         newUser.setEmail("alreadyInvited@alreadyInvited.com");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
@@ -1,0 +1,104 @@
+package com.appsmith.server.services;
+
+import com.appsmith.external.models.Policy;
+import com.appsmith.server.configurations.CommonConfig;
+import com.appsmith.server.configurations.WithMockAppsmithUser;
+import com.appsmith.server.domains.Organization;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.repositories.UserRepository;
+import com.appsmith.server.solutions.UserSignup;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Set;
+
+import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
+import static com.appsmith.server.acl.AclPermission.READ_USERS;
+import static com.appsmith.server.acl.AclPermission.USER_MANAGE_ORGANIZATIONS;
+import static com.appsmith.server.acl.AclPermission.USER_READ_ORGANIZATIONS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = { "signup.disabled = true" })
+@DirtiesContext
+public class UserServiceWithDisabledSignupTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    OrganizationService organizationService;
+
+    @Autowired
+    ApplicationService applicationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    CommonConfig commonConfig;
+
+    Mono<User> userMono;
+
+    Mono<Organization> organizationMono;
+
+    @Autowired
+    UserSignup userSignup;
+
+    @Before
+    public void setup() {
+        userMono = userService.findByEmail("usertest@usertest.com");
+        organizationMono = organizationService.getBySlug("spring-test-organization");
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void createNewUserValidWhenDisabled() {
+        User newUser = new User();
+        newUser.setEmail("new-user-email@email.com");
+        newUser.setPassword("new-user-test-password");
+
+        Policy manageUserPolicy = Policy.builder()
+                .permission(MANAGE_USERS.getValue())
+                .users(Set.of(newUser.getUsername())).build();
+
+        Policy manageUserOrgPolicy = Policy.builder()
+                .permission(USER_MANAGE_ORGANIZATIONS.getValue())
+                .users(Set.of(newUser.getUsername())).build();
+
+        Policy readUserPolicy = Policy.builder()
+                .permission(READ_USERS.getValue())
+                .users(Set.of(newUser.getUsername())).build();
+
+        Policy readUserOrgPolicy = Policy.builder()
+                .permission(USER_READ_ORGANIZATIONS.getValue())
+                .users(Set.of(newUser.getUsername())).build();
+
+        Mono<User> userMono = userService.create(newUser);
+
+        StepVerifier.create(userMono)
+                .expectErrorMatches(error -> {
+                    assertThat(error).isInstanceOf(AppsmithException.class);
+                    assertThat(((AppsmithException) error).getError()).isEqualTo(AppsmithError.SIGNUP_DISABLED);
+                    return true;
+                })
+                .verify();
+    }
+
+}
+

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
@@ -174,30 +174,6 @@ public class UserServiceWithDisabledSignupTest {
 
     @Test
     @WithMockAppsmithUser
-    public void confirmInviteTokenFlow() {
-        User newUser = new User();
-        newUser.setEmail("newEmail@newEmail.com");
-        newUser.setIsEnabled(false);
-        newUser.setInviteToken("inviteToken");
-
-        userRepository.save(newUser).block();
-
-        newUser.setPassword("newPassword");
-
-        Mono<User> afterConfirmationUserMono = userService.confirmInviteUser(newUser, "http://localhost:8080")
-                .then(userRepository.findByEmail("newEmail@newEmail.com"));
-
-        StepVerifier.create(afterConfirmationUserMono)
-                .assertNext(user -> {
-                    assertThat(user).isNotNull();
-                    assertThat(user.getIsEnabled()).isTrue();
-                })
-                .verifyComplete();
-
-    }
-
-    @Test
-    @WithMockAppsmithUser
     public void signUpViaFormLoginIfAlreadyInvited() {
         User newUser = new User();
         newUser.setEmail("alreadyInvited@alreadyInvited.com");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
@@ -1,8 +1,12 @@
 package com.appsmith.server.services;
 
 import com.appsmith.external.models.Policy;
+import com.appsmith.server.acl.AppsmithRole;
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.WithMockAppsmithUser;
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.domains.InviteUser;
+import com.appsmith.server.domains.LoginSource;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.exceptions.AppsmithError;
@@ -16,17 +20,17 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.HashSet;
 import java.util.Set;
 
-import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
-import static com.appsmith.server.acl.AclPermission.READ_USERS;
-import static com.appsmith.server.acl.AclPermission.USER_MANAGE_ORGANIZATIONS;
-import static com.appsmith.server.acl.AclPermission.USER_READ_ORGANIZATIONS;
+import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
+import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
@@ -73,22 +77,6 @@ public class UserServiceWithDisabledSignupTest {
         newUser.setEmail("new-user-email@email.com");
         newUser.setPassword("new-user-test-password");
 
-        Policy manageUserPolicy = Policy.builder()
-                .permission(MANAGE_USERS.getValue())
-                .users(Set.of(newUser.getUsername())).build();
-
-        Policy manageUserOrgPolicy = Policy.builder()
-                .permission(USER_MANAGE_ORGANIZATIONS.getValue())
-                .users(Set.of(newUser.getUsername())).build();
-
-        Policy readUserPolicy = Policy.builder()
-                .permission(READ_USERS.getValue())
-                .users(Set.of(newUser.getUsername())).build();
-
-        Policy readUserOrgPolicy = Policy.builder()
-                .permission(USER_READ_ORGANIZATIONS.getValue())
-                .users(Set.of(newUser.getUsername())).build();
-
         Mono<User> userMono = userService.create(newUser);
 
         StepVerifier.create(userMono)
@@ -100,5 +88,136 @@ public class UserServiceWithDisabledSignupTest {
                 .verify();
     }
 
-}
+    @Test
+    @DirtiesContext
+    @WithUserDetails(value = "api_user")
+    public void inviteUserToApplicationValidAsAdmin() {
+        InviteUser inviteUser = new InviteUser();
+        inviteUser.setEmail("inviteUserToApplication@test.com");
+        inviteUser.setRole(AppsmithRole.APPLICATION_ADMIN);
 
+        Mono<Application> applicationMono = applicationService.findByName("LayoutServiceTest TestApplications", MANAGE_APPLICATIONS)
+                .switchIfEmpty(Mono.error(new Exception("No such app")));
+
+        Mono<User> userMono = applicationMono.flatMap(application -> userService
+                .inviteUserToApplication(inviteUser, "http://localhost:8080", application.getId())).cache();
+
+        Mono<Application> updatedApplication = userMono.then(applicationService.findByName("LayoutServiceTest TestApplications", MANAGE_APPLICATIONS));
+
+        StepVerifier.create(Mono.zip(updatedApplication, userMono))
+                .assertNext(tuple -> {
+                    Application application = tuple.getT1();
+                    User user = tuple.getT2();
+
+                    Policy manageAppPolicy = Policy.builder()
+                            .permission(MANAGE_APPLICATIONS.getValue())
+                            .users(Set.of("api_user", user.getUsername()))
+                            .groups(new HashSet<>())
+                            .build();
+
+                    Policy readAppPolicy = Policy.builder()
+                            .permission(READ_APPLICATIONS.getValue())
+                            .users(Set.of("api_user", user.getUsername()))
+                            .groups(new HashSet<>())
+                            .build();
+
+
+                    assertThat(application).isNotNull();
+                    assertThat(application.getPolicies()).isNotEmpty();
+                    assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
+
+                    assertThat(user).isNotNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void inviteUserToApplicationValidAsViewer() {
+        InviteUser inviteUser = new InviteUser();
+        inviteUser.setEmail("inviteUserToApplication@test.com");
+        inviteUser.setRole(AppsmithRole.APPLICATION_VIEWER);
+
+        Mono<Application> applicationMono = applicationService.findByName("LayoutServiceTest TestApplications", READ_APPLICATIONS)
+                .switchIfEmpty(Mono.error(new Exception("No such app")));
+
+        Mono<User> userMono = applicationMono.flatMap(application -> userService
+                .inviteUserToApplication(inviteUser, "http://localhost:8080", application.getId())).cache();
+
+        Mono<Application> updatedApplication = userMono.then(applicationService.findByName("LayoutServiceTest TestApplications", READ_APPLICATIONS));
+
+
+        StepVerifier.create(Mono.zip(updatedApplication, userMono))
+                .assertNext(tuple -> {
+                    Application application = tuple.getT1();
+                    User user = tuple.getT2();
+
+                    Policy readAppPolicy = Policy.builder()
+                            .permission(READ_APPLICATIONS.getValue())
+                            .users(Set.of("api_user", user.getUsername()))
+                            .groups(new HashSet<>())
+                            .build();
+
+                    Policy manageAppPolicy = Policy.builder()
+                            .permission(MANAGE_APPLICATIONS.getValue())
+                            .users(Set.of("api_user"))
+                            .build();
+
+                    assertThat(application).isNotNull();
+                    assertThat(application.getPolicies()).isNotEmpty();
+                    assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
+
+                    assertThat(user).isNotNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void confirmInviteTokenFlow() {
+        User newUser = new User();
+        newUser.setEmail("newEmail@newEmail.com");
+        newUser.setIsEnabled(false);
+        newUser.setInviteToken("inviteToken");
+
+        userRepository.save(newUser).block();
+
+        newUser.setPassword("newPassword");
+
+        Mono<User> afterConfirmationUserMono = userService.confirmInviteUser(newUser, "http://localhost:8080")
+                .then(userRepository.findByEmail("newEmail@newEmail.com"));
+
+        StepVerifier.create(afterConfirmationUserMono)
+                .assertNext(user -> {
+                    assertThat(user).isNotNull();
+                    assertThat(user.getIsEnabled()).isTrue();
+                })
+                .verifyComplete();
+
+    }
+
+    @Test
+    @WithMockAppsmithUser
+    public void signUpViaFormLoginIfAlreadyInvited() {
+        User newUser = new User();
+        newUser.setEmail("alreadyInvited@alreadyInvited.com");
+        newUser.setIsEnabled(false);
+
+        userRepository.save(newUser).block();
+
+        User signupUser = new User();
+        signupUser.setEmail(newUser.getEmail());
+        signupUser.setPassword("password");
+        signupUser.setSource(LoginSource.FORM);
+
+        Mono<User> userMono = userService.create(signupUser);
+
+        StepVerifier.create(userMono)
+                .assertNext(user -> {
+                    assertThat(user.getEmail().equals(newUser.getEmail()));
+                    assertThat(user.getSource().equals(LoginSource.FORM));
+                    assertThat(user.getIsEnabled()).isTrue();
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
Sign up can be disabled by setting `APPSMITH_SIGNUP_DISABLED` environment variable to `true`. It defaults to `false` so signup is not disabled unless this environment variable is set.

![Screenshot 2021-01-11 at 16 16 20](https://user-images.githubusercontent.com/120119/104171290-68496e80-5428-11eb-86b7-bed1130ab73d.png)

