### PR TITLE
Make first eval after page change happen with new layout first

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -216,7 +216,6 @@ const EVALUATE_REDUX_ACTIONS = [
   // App Data
   ReduxActionTypes.SET_APP_MODE,
   ReduxActionTypes.FETCH_USER_DETAILS_SUCCESS,
-  ReduxActionTypes.SET_URL_DATA,
   ReduxActionTypes.UPDATE_APP_STORE,
   // Widgets
   ReduxActionTypes.UPDATE_LAYOUT,


### PR DESCRIPTION
Whenever we load a new page, we want to clear all cache and re evaluate after new page layout is loaded into the state.
This was not happening because URL_DATA was getting set and triggering an evaluation before new layout is loaded.

This PR unsubscribes to the `SET_URL_DATA` event to avoid evaluating with new url data and old layout
