### PR TITLE
Make sure Table selected row is not set to undefined on mount

### DIFF
--- a/app/client/src/widgets/TableWidget.tsx
+++ b/app/client/src/widgets/TableWidget.tsx
@@ -353,7 +353,11 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
     filteredTableData: Array<Record<string, unknown>>,
     selectedRowIndex?: number,
   ) => {
-    if (selectedRowIndex === undefined || selectedRowIndex === -1) {
+    if (
+      selectedRowIndex === undefined ||
+      selectedRowIndex === null ||
+      selectedRowIndex === -1
+    ) {
       const columnKeys: string[] = getAllTableColumnKeys(this.props.tableData);
       const selectedRow: { [key: string]: any } = {};
       for (let i = 0; i < columnKeys.length; i++) {


### PR DESCRIPTION
Fixes the `navigateTo` tests failing. 

This PR fixes table widget's selectedRow property getting set to undefined on mount by checking for null value in selectedRowIndex