### PR TITLE
Null check for empty pagination next url

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -684,7 +684,11 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
                                                                                DatasourceConfiguration datasourceConfiguration,
                                                                                PaginationField paginationField) {
         if (PaginationField.NEXT.equals(paginationField)) {
-            datasourceConfiguration.setUrl(URLDecoder.decode(actionConfiguration.getNext(), StandardCharsets.UTF_8));
+            if (actionConfiguration.getNext() == null) {
+                datasourceConfiguration.setUrl(null);
+            } else {
+                datasourceConfiguration.setUrl(URLDecoder.decode(actionConfiguration.getNext(), StandardCharsets.UTF_8));
+            }
         } else if (PaginationField.PREV.equals(paginationField)) {
             datasourceConfiguration.setUrl(actionConfiguration.getPrev());
         }


### PR DESCRIPTION
When a user tried to test the "next url" for pagination without entering any input, the server throws a null pointer exception. This change adds a null check for this scenario.

Fixes #2424 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Added a JUnit test case

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
