### PR TITLE
Fix-Hide table filters delete icon when there is no filters

### DIFF
--- a/app/client/src/components/designSystems/appsmith/CascadeFields.tsx
+++ b/app/client/src/components/designSystems/appsmith/CascadeFields.tsx
@@ -29,7 +29,7 @@ const StyledRemoveIcon = styled(
   position: relative;
   cursor: pointer;
   &.hide-icon {
-    opacity: 0;
+    display: none;
   }
 `;
 

--- a/app/client/src/components/designSystems/appsmith/CascadeFields.tsx
+++ b/app/client/src/components/designSystems/appsmith/CascadeFields.tsx
@@ -28,6 +28,9 @@ const StyledRemoveIcon = styled(
   padding: 0;
   position: relative;
   cursor: pointer;
+  &.hide-icon {
+    opacity: 0;
+  }
 `;
 
 const LabelWrapper = styled.div`
@@ -246,7 +249,7 @@ const RenderOptions = (props: {
         (i) => i.value === props.value,
       );
       if (selectedOptions && selectedOptions.length) {
-        selectValue(selectedOptions[0].value);
+        selectValue(selectedOptions[0].label);
       } else {
         selectValue(props.placeholder);
       }
@@ -290,6 +293,7 @@ type CascadeFieldProps = {
   value: any;
   operator: Operator;
   index: number;
+  hasAnyFilters: boolean;
   applyFilter: (filter: ReactTableFilter, index: number) => void;
   removeFilter: (index: number) => void;
 };
@@ -447,7 +451,7 @@ const CascadeField = (props: CascadeFieldProps) => {
 };
 
 const Fields = (props: CascadeFieldProps & { state: CascadeFieldState }) => {
-  const { index, removeFilter, applyFilter } = props;
+  const { index, removeFilter, applyFilter, hasAnyFilters } = props;
   const [state, dispatch] = React.useReducer(CaseCaseFieldReducer, props.state);
   const handleRemoveFilter = () => {
     dispatch({ type: CascadeFieldActionTypes.DELETE_FILTER });
@@ -515,7 +519,9 @@ const Fields = (props: CascadeFieldProps & { state: CascadeFieldState }) => {
         height={16}
         width={16}
         color={Colors.RIVER_BED}
-        className="t--table-filter-remove-btn"
+        className={`t--table-filter-remove-btn ${
+          hasAnyFilters ? "" : "hide-icon"
+        }`}
       />
       {index === 1 ? (
         <DropdownWrapper width={75}>

--- a/app/client/src/components/designSystems/appsmith/TableFilters.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableFilters.tsx
@@ -151,8 +151,11 @@ const TableFilters = (props: TableFilterProps) => {
       };
     },
   );
-  const showAddFilter =
-    filters.length >= 1 && filters[0].column && filters[0].condition;
+  const hasAnyFilters = !!(
+    filters.length >= 1 &&
+    filters[0].column &&
+    filters[0].condition
+  );
   return (
     <Popover
       minimal
@@ -170,7 +173,7 @@ const TableFilters = (props: TableFilterProps) => {
         className="t--table-filter-toggle-btn"
         selected={selected}
         icon={
-          showAddFilter ? (
+          hasAnyFilters ? (
             <SelectedFilterWrapper>{filters.length}</SelectedFilterWrapper>
           ) : null
         }
@@ -194,6 +197,7 @@ const TableFilters = (props: TableFilterProps) => {
                 condition={filter.condition}
                 value={filter.value}
                 columns={columns}
+                hasAnyFilters={hasAnyFilters}
                 applyFilter={(filter: ReactTableFilter, index: number) => {
                   const updatedFilters = props.filters
                     ? [...props.filters]
@@ -215,7 +219,7 @@ const TableFilters = (props: TableFilterProps) => {
               />
             );
           })}
-          {showAddFilter ? (
+          {hasAnyFilters ? (
             <ButtonWrapper className={Classes.POPOVER_DISMISS}>
               <Button
                 intent="primary"


### PR DESCRIPTION

## Description
Hide table filters delete icon when there is no filters

Fixes #2135 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
