### PR TITLE
Handle snapshot versions as special

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
@@ -1,9 +1,9 @@
 package com.appsmith.server.services;
 
-import com.appsmith.server.configurations.ProjectProperties;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserData;
 import com.appsmith.server.repositories.UserDataRepository;
+import com.appsmith.server.solutions.ReleaseNotesService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -19,7 +19,7 @@ public class UserDataServiceImpl extends BaseService<UserDataRepository, UserDat
 
     private final UserService userService;
 
-    private final ProjectProperties projectProperties;
+    private final ReleaseNotesService releaseNotesService;
 
     @Autowired
     public UserDataServiceImpl(Scheduler scheduler,
@@ -29,11 +29,11 @@ public class UserDataServiceImpl extends BaseService<UserDataRepository, UserDat
                                UserDataRepository repository,
                                AnalyticsService analyticsService,
                                UserService userService,
-                               ProjectProperties projectProperties
+                               ReleaseNotesService releaseNotesService
     ) {
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
         this.userService = userService;
-        this.projectProperties = projectProperties;
+        this.releaseNotesService = releaseNotesService;
     }
 
     @Override
@@ -52,7 +52,7 @@ public class UserDataServiceImpl extends BaseService<UserDataRepository, UserDat
 
     @Override
     public Mono<User> setViewedCurrentVersionReleaseNotes(User user) {
-        final String version = projectProperties.getVersion();
+        final String version = releaseNotesService.getReleasedVersion();
         if (StringUtils.isEmpty(version)) {
             return Mono.just(user);
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ReleaseNotesService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ReleaseNotesService.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.solutions;
 
 import com.appsmith.server.configurations.CloudServicesConfig;
+import com.appsmith.server.configurations.ProjectProperties;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.services.ConfigService;
 import lombok.Data;
@@ -27,6 +28,8 @@ public class ReleaseNotesService {
     private final CloudServicesConfig cloudServicesConfig;
 
     private final ConfigService configService;
+
+    private final ProjectProperties projectProperties;
 
     public final List<ReleaseNode> releaseNodesCache = new ArrayList<>();
 
@@ -88,14 +91,14 @@ public class ReleaseNotesService {
     }
 
     public String computeNewFrom(String version) {
-        if (CollectionUtils.isEmpty(releaseNodesCache)) {
+        if (CollectionUtils.isEmpty(releaseNodesCache) || StringUtils.isEmpty(version)) {
             return "0";
         }
 
         int newCount = 0;
 
         for (ReleaseNode node : releaseNodesCache) {
-            if (version == null || version.equals(node.getTagName())) {
+            if (version.equals(node.getTagName())) {
                 break;
             } else {
                 ++newCount;
@@ -103,6 +106,20 @@ public class ReleaseNotesService {
         }
 
         return newCount == releaseNodesCache.size() ? ((newCount - 1) + "+") : String.valueOf(newCount);
+    }
+
+    public String getReleasedVersion() {
+        final String version = projectProperties.getVersion();
+
+        if (!version.endsWith("-SNAPSHOT")) {
+            return version;
+        }
+
+        if (CollectionUtils.isEmpty(releaseNodesCache)) {
+            return "";
+        }
+
+        return releaseNodesCache.get(0).getTagName();
     }
 
 }


### PR DESCRIPTION
This is needed for remembering when a user has viewed
release notes. Snapshot versions aren't a tagged marker
on the version timeline so aren't useful for this purpose.