### PR TITLE
use script loader for tinymce

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -160,7 +160,6 @@
     };
 
   </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.4.0/tinymce.min.js" referrerpolicy="origin"></script>
 </body>
 
 </html>

--- a/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { debounce } from "lodash";
 import styled from "styled-components";
+import { useScript, ScriptStatus } from "utils/hooks/useScript";
 const StyledRTEditor = styled.div`
   && {
     width: 100%;
@@ -22,6 +23,10 @@ export interface RichtextEditorComponentProps {
 export const RichtextEditorComponent = (
   props: RichtextEditorComponentProps,
 ) => {
+  const status = useScript(
+    "https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.4.0/tinymce.min.js",
+  );
+
   const [editorInstance, setEditorInstance] = useState(null as any);
   /* Using editorContent as a variable to save editor content locally to verify against new content*/
   const editorContent = useRef("");
@@ -32,7 +37,7 @@ export const RichtextEditorComponent = (
         props.isDisabled === true ? "readonly" : "design",
       );
     }
-  }, [props.isDisabled]);
+  }, [props.isDisabled, editorInstance, status]);
 
   useEffect(() => {
     if (
@@ -49,8 +54,9 @@ export const RichtextEditorComponent = (
         });
       }, 200);
     }
-  }, [props.defaultValue]);
+  }, [props.defaultValue, editorInstance, status]);
   useEffect(() => {
+    if (status !== ScriptStatus.READY) return;
     const onChange = debounce((content: string) => {
       editorContent.current = content;
       props.onValueChange(content);
@@ -100,7 +106,10 @@ export const RichtextEditorComponent = (
       (window as any).tinyMCE.EditorManager.remove(selector);
       editorInstance !== null && editorInstance.remove();
     };
-  }, []);
+  }, [status]);
+
+  if (status !== ScriptStatus.READY) return null;
+
   return (
     <StyledRTEditor>
       <textarea id={`rte-${props.widgetId}`}></textarea>


### PR DESCRIPTION
## Description
Using `useScript` hook to load tinymce, also re-run effect to set value when `editorInstance` is created
This should fix the `RichTextEditor_spec`, where it seemed like a race condition b/w setting default value and tinymce instantiation

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- existing RichTextEditor_spec should pass

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
