### PR TITLE
use editor init event intead of setup to check if initialised

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/FormWidgets/RichTextEditor_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/FormWidgets/RichTextEditor_spec.js
@@ -31,6 +31,15 @@ describe("RichTextEditor Widget Functionality", function() {
       "This is a Heading",
     );
 
+    // validate after reload
+    cy.reload(true);
+    cy.wait(2000);
+    cy.validateHTMLText(
+      formWidgetsPage.richTextEditorWidget,
+      "h1",
+      "This is a Heading",
+    );
+
     cy.PublishtheApp();
     cy.validateHTMLText(
       publishPage.richTextEditorWidget,

--- a/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
@@ -90,7 +90,7 @@ export const RichtextEditorComponent = (
             onChange(editor.getContent());
           });
         setEditorInstance(editor);
-        editor.on("init", function() {
+        editor.on("init", () => {
           setIsEditorInitialised(true);
         });
       },

--- a/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
@@ -27,6 +27,8 @@ export const RichtextEditorComponent = (
     "https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.4.0/tinymce.min.js",
   );
 
+  const [isEditorInitialised, setIsEditorInitialised] = useState(false);
+
   const [editorInstance, setEditorInstance] = useState(null as any);
   /* Using editorContent as a variable to save editor content locally to verify against new content*/
   const editorContent = useRef("");
@@ -37,7 +39,7 @@ export const RichtextEditorComponent = (
         props.isDisabled === true ? "readonly" : "design",
       );
     }
-  }, [props.isDisabled, editorInstance, status]);
+  }, [props.isDisabled, editorInstance, isEditorInitialised]);
 
   useEffect(() => {
     if (
@@ -45,16 +47,15 @@ export const RichtextEditorComponent = (
       (editorContent.current.length === 0 ||
         editorContent.current !== props.defaultValue)
     ) {
-      setTimeout(() => {
-        const content = props.defaultValue
-          ? props.defaultValue.replace(/\n/g, "<br/>")
-          : props.defaultValue;
-        editorInstance.setContent(content, {
-          format: "html",
-        });
-      }, 200);
+      const content = props.defaultValue
+        ? props.defaultValue.replace(/\n/g, "<br/>")
+        : props.defaultValue;
+
+      editorInstance.setContent(content, {
+        format: "html",
+      });
     }
-  }, [props.defaultValue, editorInstance, status]);
+  }, [props.defaultValue, editorInstance, isEditorInitialised]);
   useEffect(() => {
     if (status !== ScriptStatus.READY) return;
     const onChange = debounce((content: string) => {
@@ -71,13 +72,10 @@ export const RichtextEditorComponent = (
       resize: false,
       setup: (editor: any) => {
         editor.mode.set(props.isDisabled === true ? "readonly" : "design");
-        // Without timeout default value is not set on browser refresh.
-        setTimeout(() => {
-          const content = props.defaultValue
-            ? props.defaultValue.replace(/\n/g, "<br/>")
-            : props.defaultValue;
-          editor.setContent(content, { format: "html" });
-        }, 300);
+        const content = props.defaultValue
+          ? props.defaultValue.replace(/\n/g, "<br/>")
+          : props.defaultValue;
+        editor.setContent(content, { format: "html" });
         editor
           .on("Change", () => {
             onChange(editor.getContent());
@@ -92,6 +90,9 @@ export const RichtextEditorComponent = (
             onChange(editor.getContent());
           });
         setEditorInstance(editor);
+        editor.on("init", function() {
+          setIsEditorInitialised(true);
+        });
       },
       plugins: [
         "advlist autolink lists link image charmap print preview anchor",


### PR DESCRIPTION
## Description
Use `editor.on("init")` to set initialized status for RTE
ref: https://www.tiny.cloud/docs/advanced/events/#editorcoreevents

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually: on refresh `RTE` should render default value

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
