### PR TITLE
use popover for ads dropdown options

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -3,6 +3,7 @@ import Icon, { IconName, IconSize } from "./Icon";
 import { CommonComponentProps, Classes } from "./common";
 import styled from "styled-components";
 import Text, { TextType } from "./Text";
+import { Popover, Position } from "@blueprintjs/core";
 
 type DropdownOption = {
   label?: string;
@@ -57,14 +58,11 @@ const Selected = styled.div<{ isOpen: boolean; disabled?: boolean }>`
 `;
 
 const DropdownWrapper = styled.div`
-  position: absolute;
-  top: 38px;
-  left: 0px;
+  width: 260px;
   z-index: 1;
   margin-top: ${(props) => props.theme.spaces[2] - 1}px;
   background: ${(props) => props.theme.colors.dropdown.menuBg};
   box-shadow: 0px 12px 28px ${(props) => props.theme.colors.dropdown.menuShadow};
-  width: 100%;
 `;
 
 const OptionWrapper = styled.div<{ selected: boolean }>`
@@ -144,21 +142,23 @@ export default function Dropdown(props: DropdownProps) {
   );
 
   return (
-    <DropdownContainer
-      tabIndex={0}
-      onBlur={() => setIsOpen(false)}
-      data-cy={props.cypressSelector}
-    >
-      <Selected
-        isOpen={isOpen}
-        disabled={props.disabled}
-        onClick={() => setIsOpen(!isOpen)}
+    <DropdownContainer data-cy={props.cypressSelector}>
+      <Popover
+        minimal
+        position={Position.BOTTOM_RIGHT}
+        data-cy={props.cypressSelector}
+        isOpen={isOpen && !props.disabled}
+        onInteraction={(state) => setIsOpen(state)}
+        boundary="viewport"
       >
-        <Text type={TextType.P1}>{selected.value}</Text>
-        <Icon name="downArrow" size={IconSize.XXS} />
-      </Selected>
-
-      {isOpen && !props.disabled ? (
+        <Selected
+          isOpen={isOpen}
+          disabled={props.disabled}
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          <Text type={TextType.P1}>{selected.value}</Text>
+          <Icon name="downArrow" size={IconSize.XXS} />
+        </Selected>
         <DropdownWrapper>
           {props.options.map((option: DropdownOption, index: number) => {
             return (
@@ -186,7 +186,7 @@ export default function Dropdown(props: DropdownProps) {
             );
           })}
         </DropdownWrapper>
-      ) : null}
+      </Popover>
     </DropdownContainer>
   );
 }

--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Icon, { IconName, IconSize } from "./Icon";
 import { CommonComponentProps, Classes } from "./common";
 import styled from "styled-components";
@@ -126,6 +126,7 @@ export default function Dropdown(props: DropdownProps) {
   const { onSelect } = { ...props };
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState<DropdownOption>(props.selected);
+  const [containerWidth, setContainerWidth] = useState(0);
 
   useEffect(() => {
     setSelected(props.selected);
@@ -141,15 +142,14 @@ export default function Dropdown(props: DropdownProps) {
     [onSelect],
   );
 
-  const containerRef = useRef<HTMLInputElement>(null);
-
-  const getContainerWidth = useCallback(() => {
-    if (!containerRef) return undefined;
-    return containerRef.current?.offsetWidth;
+  const measuredRef = useCallback((node) => {
+    if (node !== null) {
+      setContainerWidth(node.getBoundingClientRect().width);
+    }
   }, []);
 
   return (
-    <DropdownContainer data-cy={props.cypressSelector} ref={containerRef}>
+    <DropdownContainer data-cy={props.cypressSelector} ref={measuredRef}>
       <Popover
         minimal
         position={Position.BOTTOM_RIGHT}
@@ -165,7 +165,7 @@ export default function Dropdown(props: DropdownProps) {
           <Text type={TextType.P1}>{selected.value}</Text>
           <Icon name="downArrow" size={IconSize.XXS} />
         </Selected>
-        <DropdownWrapper width={getContainerWidth()}>
+        <DropdownWrapper width={containerWidth}>
           {props.options.map((option: DropdownOption, index: number) => {
             return (
               <OptionWrapper

--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import Icon, { IconName, IconSize } from "./Icon";
 import { CommonComponentProps, Classes } from "./common";
 import styled from "styled-components";
@@ -57,8 +57,8 @@ const Selected = styled.div<{ isOpen: boolean; disabled?: boolean }>`
   }
 `;
 
-const DropdownWrapper = styled.div`
-  width: 260px;
+const DropdownWrapper = styled.div<{ width?: number }>`
+  width: ${(props) => props.width || 260}px;
   z-index: 1;
   margin-top: ${(props) => props.theme.spaces[2] - 1}px;
   background: ${(props) => props.theme.colors.dropdown.menuBg};
@@ -141,12 +141,18 @@ export default function Dropdown(props: DropdownProps) {
     [onSelect],
   );
 
+  const containerRef = useRef<HTMLInputElement>(null);
+
+  const getContainerWidth = useCallback(() => {
+    if (!containerRef) return undefined;
+    return containerRef.current?.offsetWidth;
+  }, []);
+
   return (
-    <DropdownContainer data-cy={props.cypressSelector}>
+    <DropdownContainer data-cy={props.cypressSelector} ref={containerRef}>
       <Popover
         minimal
         position={Position.BOTTOM_RIGHT}
-        data-cy={props.cypressSelector}
         isOpen={isOpen && !props.disabled}
         onInteraction={(state) => setIsOpen(state)}
         boundary="viewport"
@@ -159,7 +165,7 @@ export default function Dropdown(props: DropdownProps) {
           <Text type={TextType.P1}>{selected.value}</Text>
           <Icon name="downArrow" size={IconSize.XXS} />
         </Selected>
-        <DropdownWrapper>
+        <DropdownWrapper width={getContainerWidth()}>
           {props.options.map((option: DropdownOption, index: number) => {
             return (
               <OptionWrapper


### PR DESCRIPTION
## Description
Use popover for dropdown options to prevent overflow issues.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually: invite modal, `select a role` styles

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
