### PR TITLE
Never show the redux action type in toast errors

### DIFF
--- a/app/client/src/constants/errors.ts
+++ b/app/client/src/constants/errors.ts
@@ -1,3 +1,0 @@
-export const DEFAULT_ERROR_MESSAGE = "There was an error";
-export const DEFAULT_ACTION_ERROR = (action: string) =>
-  `Incurred an error when ${action}`;

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -171,3 +171,6 @@ export const GOOGLE_RECAPTCHA_DOMAIN_ERROR =
 
 export const SERVER_API_TIMEOUT_ERROR =
   "Appsmith server is taking too long to respond. Please try again after some time";
+export const DEFAULT_ERROR_MESSAGE = "There was an unexpected error";
+export const DEFAULT_ACTION_ERROR = (action: string) =>
+  `Incurred an error when ${action}`;

--- a/app/client/src/sagas/ErrorSagas.tsx
+++ b/app/client/src/sagas/ErrorSagas.tsx
@@ -16,8 +16,13 @@ import { getSafeCrash } from "selectors/errorSelectors";
 import { getCurrentUser } from "selectors/usersSelectors";
 import { ANONYMOUS_USERNAME } from "constants/userConstants";
 import { put, takeLatest, call, select } from "redux-saga/effects";
-import { ERROR_401, ERROR_500, ERROR_0 } from "constants/messages";
-import { DEFAULT_ERROR_MESSAGE, DEFAULT_ACTION_ERROR } from "constants/errors";
+import {
+  ERROR_401,
+  ERROR_500,
+  ERROR_0,
+  DEFAULT_ERROR_MESSAGE,
+  DEFAULT_ACTION_ERROR,
+} from "constants/messages";
 
 export function* callAPI(apiCall: any, requestPayload: any) {
   try {
@@ -72,23 +77,25 @@ type ErrorPayloadType = {
   message?: string;
   crash?: boolean;
 };
-let ActionErrorDisplayMap: {
+const ActionErrorDisplayMap: {
   [key: string]: (error: ErrorPayloadType) => string;
-} = {};
-
-Object.keys(ReduxActionErrorTypes).forEach((type: string) => {
-  ActionErrorDisplayMap[type] = () =>
-    DEFAULT_ERROR_MESSAGE + " action: " + type;
-});
-
-ActionErrorDisplayMap = {
-  ...ActionErrorDisplayMap,
+} = {
   [ReduxActionErrorTypes.API_ERROR]: (error) =>
     get(error, "message", DEFAULT_ERROR_MESSAGE),
   [ReduxActionErrorTypes.FETCH_PAGE_ERROR]: () =>
     DEFAULT_ACTION_ERROR("fetching the page"),
   [ReduxActionErrorTypes.SAVE_PAGE_ERROR]: () =>
     DEFAULT_ACTION_ERROR("saving the page"),
+};
+
+const getErrorMessageFromActionType = (
+  type: string,
+  error: ErrorPayloadType,
+): string => {
+  if (type in ActionErrorDisplayMap) {
+    return ActionErrorDisplayMap[type](error);
+  }
+  return DEFAULT_ERROR_MESSAGE;
 };
 
 enum ErrorEffectTypes {
@@ -107,7 +114,7 @@ export function* errorSaga(
   const effects = [ErrorEffectTypes.LOG_ERROR];
   const { type, payload } = errorAction;
   const { show = true, error } = payload || {};
-  const message = get(error, "message", ActionErrorDisplayMap[type](error));
+  const message = getErrorMessageFromActionType(type, error);
 
   if (show) {
     effects.push(ErrorEffectTypes.SHOW_ALERT);

--- a/app/client/src/sagas/ErrorSagas.tsx
+++ b/app/client/src/sagas/ErrorSagas.tsx
@@ -92,10 +92,14 @@ const getErrorMessageFromActionType = (
   type: string,
   error: ErrorPayloadType,
 ): string => {
-  if (type in ActionErrorDisplayMap) {
-    return ActionErrorDisplayMap[type](error);
+  const actionErrorMessage = get(error, "message");
+  if (actionErrorMessage === undefined) {
+    if (type in ActionErrorDisplayMap) {
+      return ActionErrorDisplayMap[type](error);
+    }
+    return DEFAULT_ERROR_MESSAGE;
   }
-  return DEFAULT_ERROR_MESSAGE;
+  return actionErrorMessage;
 };
 
 enum ErrorEffectTypes {


### PR DESCRIPTION
## Description
Don't expose app redux action types in toast errors

Fixes: #2642
Fixes: #2656 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Could not be reproduced

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
