### PR TITLE
enable immer autofreeze only in development

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableColumnsVisibility.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableColumnsVisibility.tsx
@@ -132,7 +132,9 @@ const TableColumnsVisibility = (props: TableColumnsVisibilityProps) => {
             selected={!option.isHidden}
             key={index}
             onClick={() => {
-              const hiddenColumns = props.hiddenColumns || [];
+              const hiddenColumns = Array.isArray(props.hiddenColumns)
+                ? props.hiddenColumns.slice()
+                : [];
               if (!option.isHidden) {
                 hiddenColumns.push(option.accessor);
               } else {

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -17,6 +17,11 @@ import { setThemeMode } from "actions/themeActions";
 import { ThemeMode } from "reducers/uiReducers/themeReducer";
 import { StyledToastContainer } from "components/ads/Toast";
 
+// enable autofreeze only in development
+import { setAutoFreeze } from "immer";
+const shouldAutoFreeze = process.env.NODE_ENV === "development";
+setAutoFreeze(shouldAutoFreeze);
+
 import AppErrorBoundary from "./AppErrorBoundry";
 appInitializer();
 


### PR DESCRIPTION
## Description
Clone hidden columns array intead of mutating
Always freeze by default in v8.0.0 (https://github.com/immerjs/immer/releases/tag/v8.0.0)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually: toggle visibility of a table column

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
