### PR TITLE
Avoid double validation

### DIFF
--- a/app/client/src/utils/DynamicBindingUtils.test.ts
+++ b/app/client/src/utils/DynamicBindingUtils.test.ts
@@ -43,6 +43,9 @@ describe("isChildPropertyPath function", () => {
       ["Table1.selectedRow", "1Table1.selectedRow", false],
       ["Table1.selectedRow", "Table11selectedRow", false],
       ["Table1.selectedRow", "Table1.selectedRow", true],
+      ["Dropdown1.options", "Dropdown1.options[1]", true],
+      ["Dropdown1.options[1]", "Dropdown1.options[1].value", true],
+      ["Dropdown1", "Dropdown1.options[1].value", true],
     ];
     cases.forEach((testCase) => {
       const result = isChildPropertyPath(testCase[0], testCase[1]);

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -249,12 +249,11 @@ export const unsafeFunctionForEval = [
   "setInterval",
   "Promise",
 ];
+
 export const isChildPropertyPath = (
   parentPropertyPath: string,
   childPropertyPath: string,
-): boolean => {
-  const regexTest = new RegExp(
-    `^${parentPropertyPath.replace(".", "\\.")}(\\.\\S+)?$`,
-  );
-  return regexTest.test(childPropertyPath);
-};
+): boolean =>
+  parentPropertyPath === childPropertyPath ||
+  childPropertyPath.startsWith(`${parentPropertyPath}.`) ||
+  childPropertyPath.startsWith(`${parentPropertyPath}[`);

--- a/app/client/src/workers/evaluation.test.ts
+++ b/app/client/src/workers/evaluation.test.ts
@@ -436,7 +436,7 @@ const WIDGET_CONFIG_MAP: WidgetTypeConfigMap = {
 
 const BASE_WIDGET: DataTreeWidget = {
   widgetId: "randomID",
-  widgetName: "randomName",
+  widgetName: "randomWidgetName",
   bottomRow: 0,
   isLoading: false,
   leftColumn: 0,
@@ -452,7 +452,7 @@ const BASE_WIDGET: DataTreeWidget = {
 
 const BASE_ACTION: DataTreeAction = {
   actionId: "randomId",
-  name: "randomName",
+  name: "randomActionName",
   config: {
     timeoutInMillisecond: 10,
   },
@@ -645,6 +645,7 @@ describe("DataTreeEvaluator", () => {
       ...unEvalTree,
       Api1: {
         ...BASE_ACTION,
+        name: "Api1",
         data: [
           {
             test: "Hey",
@@ -708,6 +709,7 @@ describe("DataTreeEvaluator", () => {
       },
       Api1: {
         ...BASE_ACTION,
+        name: "Api1",
         data: [
           {
             test: "Hey",

--- a/app/client/src/workers/evaluation.test.ts
+++ b/app/client/src/workers/evaluation.test.ts
@@ -669,7 +669,6 @@ describe("DataTreeEvaluator", () => {
     ]);
     expect(updatedDependencyMap).toStrictEqual({
       Api1: ["Api1.data"],
-      Input1: ["Input1.text"],
       Text1: ["Text1.text"],
       Text2: ["Text2.text"],
       Text3: ["Text3.text"],
@@ -693,7 +692,6 @@ describe("DataTreeEvaluator", () => {
       "Table1.selectedRowIndex": [],
       "Table1.selectedRowIndices": [],
       "Text4.text": [],
-      "Input1.text": [],
     });
   });
 
@@ -751,7 +749,6 @@ describe("DataTreeEvaluator", () => {
         "Dropdown1.selectedOptionValue",
         "Dropdown1.selectedOptionValueArr",
       ],
-      Input1: ["Input1.text"],
       "Text2.text": ["Text1.text"],
       "Text3.text": ["Text1.text"],
       "Dropdown1.selectedOptionValue": [],
@@ -761,7 +758,6 @@ describe("DataTreeEvaluator", () => {
       "Table1.selectedRowIndex": [],
       "Table1.selectedRowIndices": [],
       "Text4.text": ["Table1.selectedRow.test"],
-      "Input1.text": [],
     });
   });
 });

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -39,6 +39,7 @@ import {
   removeFunctionsFromDataTree,
   translateDiffEventToDataTreeDiffEvent,
   validateWidgetProperty,
+  getImmediateParentsOfPropertyPaths,
 } from "./evaluationUtils";
 import {
   EXECUTION_PARAM_KEY,
@@ -368,7 +369,7 @@ export class DataTreeEvaluator {
       // Add all the sorted nodes in the final list
       finalSortOrder = [...finalSortOrder, ...subSortOrderArray];
 
-      parents = this.getImmediateParentsOfPropertyPaths(subSortOrderArray);
+      parents = getImmediateParentsOfPropertyPaths(subSortOrderArray);
       // If we find parents of the property paths in the sorted array, we should continue finding all the nodes dependent
       // on the parents
       computeSortOrder = parents.length > 0;
@@ -391,28 +392,6 @@ export class DataTreeEvaluator {
     });
 
     return finalSortOrderArray;
-  }
-
-  // The idea is to find the immediate parents of the property paths
-  // e.g. For Table1.selectedRow.email, the parent is Table1.selectedRow
-  getImmediateParentsOfPropertyPaths(
-    propertyPaths: Array<string>,
-  ): Array<string> {
-    // Use a set to ensure that we dont have duplicates
-    const parents: Set<string> = new Set();
-    const rgx = /^(.*)(\..*|\[.*\])$/;
-
-    propertyPaths.forEach((path) => {
-      const matches = path.match(rgx);
-
-      if (matches !== null) {
-        parents.add(matches[1]);
-      } else {
-        // We have reached the top of the path. No parent exists
-      }
-    });
-
-    return Array.from(parents);
   }
 
   getEvaluationSortOrder(

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -1090,7 +1090,7 @@ export class DataTreeEvaluator {
   ) {
     const changePaths: Set<string> = new Set(dependenciesOfRemovedPaths);
     for (const d of differences) {
-      if (!Array.isArray(d.path) || d.path.length === 0) continue;
+      if (!Array.isArray(d.path) || d.path.length === 0) continue; // Null check for typescript
       // Apply the changes into the evalTree so that it gets the latest changes
       applyChange(this.evalTree, undefined, d);
 

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -268,14 +268,8 @@ export function validateWidgetProperty(
 export function getValidatedTree(
   widgetConfigMap: WidgetTypeConfigMap,
   tree: DataTree,
-  only?: Set<string>,
 ) {
   return Object.keys(tree).reduce((tree, entityKey: string) => {
-    if (only && only.size) {
-      if (!only.has(entityKey)) {
-        return tree;
-      }
-    }
     const entity = tree[entityKey] as DataTreeWidget;
     if (!isWidget(entity)) {
       return tree;

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -6,6 +6,7 @@ import { VALIDATORS } from "./validations";
 import { Diff } from "deep-diff";
 import {
   DataTree,
+  DataTreeAction,
   DataTreeEntity,
   DataTreeWidget,
   ENTITY_TYPE,
@@ -119,7 +120,11 @@ export const isPropertyPathOrNestedPath = (
   path: string,
   comparePath: string,
 ): boolean => {
-  return path === comparePath || comparePath.startsWith(`${path}.`);
+  return (
+    path === comparePath ||
+    comparePath.startsWith(`${path}.`) ||
+    comparePath.startsWith(`${path}[`)
+  );
 };
 
 /*
@@ -148,7 +153,7 @@ export const addDependantsOfNestedPropertyPaths = (
   return [...withNestedPaths.values()];
 };
 
-export function isWidget(entity: DataTreeEntity): boolean {
+export function isWidget(entity: DataTreeEntity): entity is DataTreeWidget {
   return (
     typeof entity === "object" &&
     "ENTITY_TYPE" in entity &&
@@ -156,7 +161,7 @@ export function isWidget(entity: DataTreeEntity): boolean {
   );
 }
 
-export function isAction(entity: DataTreeEntity): boolean {
+export function isAction(entity: DataTreeEntity): entity is DataTreeAction {
   return (
     typeof entity === "object" &&
     "ENTITY_TYPE" in entity &&
@@ -203,7 +208,7 @@ export const makeParentsDependOnChild = (
 ): DependencyMap => {
   const result: DependencyMap = depMap;
   let curKey = child;
-  const rgx = /^(.*)\..*$/;
+  const rgx = /^(.*)(\..*|\[.*\])$/;
   let matches: Array<string> | null;
   // Note: The `=` is intentional
   // Stops looping when match is null


### PR DESCRIPTION
## Description

We were running multiple validation on the same properties. The first one would trigger a validation failure, the second one would clear it.

This PR attempts to remove the 2nd validation altogether and adds fixes for tests that started failing as a result.

Fixes #2701
Fixes #2758 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually (Needs Automated tests to prevent future regression)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
