### PR TITLE
Add Linux Mint support to install.sh

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -138,6 +138,11 @@ check_os() {
             os="debian"
             package_manager="apt-get"
             ;;
+        Linux\ Mint*)
+            desired_os=1
+            os="linux mint"
+            package_manager="apt-get"
+            ;;
         Red\ Hat*)
             desired_os=1
             os="red hat"
@@ -426,7 +431,7 @@ curl -s --location --request POST 'https://hook.integromat.com/dkwb6i52am93pi30o
 
 if [[ $desired_os -eq 0 ]];then
     echo ""
-    echo "This script is currently meant to install Appsmith on Mac OS X, Ubuntu, SLES or openSUSE machines."
+    echo "This script is currently meant to install Appsmith on Mac OS X, Ubuntu, Debian, Linux Mint, Red Hat, CentOS, SLES or openSUSE machines."
     echo_contact_support " if you wish to extend this support."
     curl -s --location --request POST 'https://hook.integromat.com/dkwb6i52am93pi30ojeboktvj32iw0fa' \
     --header 'Content-Type: text/plain' \


### PR DESCRIPTION
## Description
Add support for Linux Mint to `install.sh` to allow users to install Appsmith on Mint.

Fixes #2693

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Launch Linux Mint 20.1
2. Run `./install.sh` with modifications made in [this commit](https://github.com/trdillon/appsmith/commit/98c945adc92af65a16e32779be91ec0f64250f82)
3. Run command `docker ps` after installation and observe running containers
4. Access Appsmith at `http://localhost`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
