### PR TITLE
Fix for timeout being sent in a different location in view mode

### DIFF
--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -5,7 +5,7 @@ import {
   DEFAULT_EXECUTE_ACTION_TIMEOUT_MS,
 } from "constants/ApiConstants";
 import axios, { AxiosPromise, CancelTokenSource } from "axios";
-import { Action } from "entities/Action";
+import { Action, ActionViewMode } from "entities/Action";
 
 export interface CreateActionRequest<T> extends APIRequest {
   datasourceId: string;
@@ -127,7 +127,7 @@ class ActionAPI extends API {
 
   static fetchActionsForViewMode(
     applicationId: string,
-  ): AxiosPromise<GenericApiResponse<Action[]>> {
+  ): AxiosPromise<GenericApiResponse<ActionViewMode[]>> {
     return API.get(`${ActionAPI.url}/view`, { applicationId });
   }
 

--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -108,4 +108,13 @@ export interface QueryAction extends BaseAction {
   datasource: StoredDatasource;
 }
 
+export type ActionViewMode = {
+  id: string;
+  name: string;
+  pageId: string;
+  jsonPathKeys: string[];
+  confirmBeforeExecute?: boolean;
+  timeoutInMillisecond?: number;
+};
+
 export type Action = ApiAction | QueryAction;

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -44,7 +44,7 @@ import {
 } from "selectors/editorSelectors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { QUERY_CONSTANT } from "constants/QueryEditorConstants";
-import { Action } from "entities/Action";
+import { Action, ActionViewMode } from "entities/Action";
 import { ActionData } from "reducers/entityReducers/actionsReducer";
 import {
   getAction,
@@ -145,14 +145,22 @@ export function* fetchActionsForViewModeSaga(
     { mode: "VIEWER", appId: applicationId },
   );
   try {
-    const response: GenericApiResponse<Action[]> = yield ActionAPI.fetchActionsForViewMode(
+    const response: GenericApiResponse<ActionViewMode[]> = yield ActionAPI.fetchActionsForViewMode(
       applicationId,
     );
+    const correctFormatResponse = response.data.map((action) => {
+      return {
+        ...action,
+        actionConfiguration: {
+          timeoutInMillisecond: action.timeoutInMillisecond,
+        },
+      };
+    });
     const isValidResponse = yield validateResponse(response);
     if (isValidResponse) {
       yield put({
         type: ReduxActionTypes.FETCH_ACTIONS_VIEW_MODE_SUCCESS,
-        payload: response.data,
+        payload: correctFormatResponse,
       });
       PerformanceTracker.stopAsyncTracking(
         PerformanceTransactionName.FETCH_ACTIONS_API,


### PR DESCRIPTION
## Description
Action structure is different in view mode. This was causing issues setting the correct timeout actions with long timeouts were getting cancelled in the default 20s time. This PR will fix the structure when storing this response in the view mode to fix the issue

Fixes #2553

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
