### PR TITLE
Disable sort by Delete column in Members page

### DIFF
--- a/app/client/src/pages/organization/Members.tsx
+++ b/app/client/src/pages/organization/Members.tsx
@@ -128,6 +128,7 @@ export default function MemberSettings(props: PageProps) {
     {
       Header: "Delete",
       accessor: "delete",
+      disableSortBy: true,
       Cell: function DeleteCell(cellProps: any) {
         if (
           cellProps.cell.row.values.username ===


### PR DESCRIPTION
## Description

Disabled the ability to sort by the `Delete` column on the `Members` page. This functionality is not necessary.

Fixes #597 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Run Appsmith with the changes made in [this commit](https://github.com/trdillon/appsmith/commit/b08b2b081b59645e200fd41401fdc4c7cd73a9ec)
2. Navigate to Manage Users
3. Click the Delete column
4. Observe the data not being sorted

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
