### PR TITLE
Remove SSL related clicks from `fillMongoDatasourceForm` cypress command

### DIFF
--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -5,7 +5,6 @@
     "mongo-username": "cypress-test",
     "mongo-password": "RaopEmky505xYV4p",
     "mongo-authenticationAuthtype": "SCRAM-SHA-1",
-    "mongo-sslAuthtype": "No SSL",
     "postgres-host": "postgres-test-db.cz8diybf9wdj.ap-south-1.rds.amazonaws.com",
     "postgres-port": 5432,
     "postgres-databaseName": "fakeapi",

--- a/app/client/cypress/locators/DatasourcesEditor.json
+++ b/app/client/cypress/locators/DatasourcesEditor.json
@@ -6,7 +6,6 @@
   "username": "input[name='datasourceConfiguration.authentication.username']",
   "password": "input[name='datasourceConfiguration.authentication.password']",
   "authenticationAuthtype": "[data-cy=datasourceConfiguration\\.authentication\\.authType]",
-  "sslAuthtype": "[data-cy=datasourceConfiguration\\.connection\\.ssl\\.authType]",
   "url": "input[name='datasourceConfiguration.url']",
   "MongoDB": ".t--plugin-name:contains('MongoDB')",
   "RESTAPI": ".t--plugin-name:contains('REST API')",

--- a/app/client/cypress/locators/DatasourcesEditor.json
+++ b/app/client/cypress/locators/DatasourcesEditor.json
@@ -12,7 +12,6 @@
   "RESTAPI": ".t--plugin-name:contains('REST API')",
   "PostgreSQL": ".t--plugin-name:contains('PostgreSQL')",
   "sectionAuthentication": "[data-cy=section-Authentication]",
-  "sectionSSL": "[data-cy=section-SSL\\ \\(optional\\)]",
   "PostgresEntity": ".t--entity-name:contains(PostgreSQL)",
   "createQuerty": ".t--create-query",
   "editDatasource": ".t--edit-datasource",

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1424,17 +1424,6 @@ Cypress.Commands.add("fillMongoDatasourceForm", () => {
   cy.get(datasourceEditor["password"]).type(
     datasourceFormData["mongo-password"],
   );
-
-  cy.get(datasourceEditor.sectionSSL).click();
-  cy.get(datasourceEditor["authenticationAuthtype"]).click();
-  cy.contains(datasourceFormData["mongo-authenticationAuthtype"]).click({
-    force: true,
-  });
-
-  cy.get(datasourceEditor["sslAuthtype"]).click();
-  cy.contains(datasourceFormData["mongo-sslAuthtype"]).click({
-    force: true,
-  });
 });
 
 Cypress.Commands.add("fillPostgresDatasourceForm", () => {

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1424,6 +1424,10 @@ Cypress.Commands.add("fillMongoDatasourceForm", () => {
   cy.get(datasourceEditor["password"]).type(
     datasourceFormData["mongo-password"],
   );
+  cy.get(datasourceEditor["authenticationAuthtype"]).click();
+  cy.contains(datasourceFormData["mongo-authenticationAuthtype"]).click({
+    force: true,
+  });
 });
 
 Cypress.Commands.add("fillPostgresDatasourceForm", () => {


### PR DESCRIPTION
## Description

Removes SSL config from mongo test.