### PR TITLE
Fix Application crash on widget delete undo

### DIFF
--- a/app/client/src/components/ads/Toast.tsx
+++ b/app/client/src/components/ads/Toast.tsx
@@ -168,7 +168,8 @@ export const Toaster = {
       />,
       {
         toastId: toastId,
-        pauseOnHover: true,
+        pauseOnHover: !config.dispatchableAction && !config.hideProgressBar,
+        pauseOnFocusLoss: !config.dispatchableAction && !config.hideProgressBar,
         autoClose: false,
         closeOnClick: false,
         hideProgressBar: config.hideProgressBar,

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -463,21 +463,21 @@ export function* undoDeleteSaga(action: ReduxAction<{ widgetId: string }>) {
   const deletedWidgets: FlattenedWidgetProps[] = yield getDeletedWidgets(
     action.payload.widgetId,
   );
-  // Find the parent in the list of deleted widgets
-  const deletedWidget = deletedWidgets.find(
-    (widget) => widget.widgetId === action.payload.widgetId,
-  );
+  if (deletedWidgets && Array.isArray(deletedWidgets)) {
+    // Find the parent in the list of deleted widgets
+    const deletedWidget = deletedWidgets.find(
+      (widget) => widget.widgetId === action.payload.widgetId,
+    );
 
-  // If the deleted widget is in fact available.
-  if (deletedWidget) {
-    // Log an undo event
-    AnalyticsUtil.logEvent("WIDGET_DELETE_UNDO", {
-      widgetName: deletedWidget.widgetName,
-      widgetType: deletedWidget.type,
-    });
-  }
+    // If the deleted widget is in fact available.
+    if (deletedWidget) {
+      // Log an undo event
+      AnalyticsUtil.logEvent("WIDGET_DELETE_UNDO", {
+        widgetName: deletedWidget.widgetName,
+        widgetType: deletedWidget.type,
+      });
+    }
 
-  if (deletedWidgets) {
     // Get the current list of widgets from reducer
     const stateWidgets = yield select(getWidgets);
     let widgets = { ...stateWidgets };


### PR DESCRIPTION
## Description
Fixes issue where users could undo delete long after the timeout has expired

Fixes #2714 
## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
