### PR TITLE
Fix RestAPI plugin not starting up

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/restApiPlugin/pom.xml
@@ -4,13 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.2.RELEASE</version>
-        <relativePath/> <!-- lookup parent from repository -->
-    </parent>
-
     <groupId>com.external.plugins</groupId>
     <artifactId>restApiPlugin</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -47,20 +40,49 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>5.2.3.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
-            <version>5.1.13.RELEASE</version>
+            <version>5.2.3.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.projectreactor</groupId>
+                    <artifactId>reactor-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-web</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.4</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.10.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.10.2</version>
         </dependency>
 
         <dependency>
@@ -72,13 +94,11 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
             <version>0.11.2</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if Gson is preferred -->
             <version>0.11.2</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Test dependencies -->
@@ -106,6 +126,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>3.13.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -125,33 +146,42 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>2.2.4.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
-    <!--
-        This doesn't use the maven-shade-plugin because it inherits from spring-boot-starter-parent
-        for it's dependency on webclient. This is a normal compile.
-    -->
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
                 <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Plugin-Id>${plugin.id}</Plugin-Id>
-                            <Plugin-Class>${plugin.class}</Plugin-Class>
-                            <Plugin-Version>${plugin.version}</Plugin-Version>
-                            <Plugin-Provider>${plugin.provider}</Plugin-Provider>
-                            <Plugin-Dependencies>${plugin.dependencies}</Plugin-Dependencies>
-                        </manifestEntries>
-                    </archive>
+                    <minimizeJar>false</minimizeJar>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Plugin-Id>${plugin.id}</Plugin-Id>
+                                <Plugin-Class>${plugin.class}</Plugin-Class>
+                                <Plugin-Version>${plugin.version}</Plugin-Version>
+                                <Plugin-Provider>${plugin.provider}</Plugin-Provider>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -165,6 +195,10 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                             <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.springframework</groupId>
+                                    <artifactId>spring-webflux</artifactId>
+                                </artifactItem>
                                 <artifactItem>
                                     <groupId>io.jsonwebtoken</groupId>
                                     <artifactId>jjwt-api</artifactId>

--- a/app/server/appsmith-plugins/restApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/restApiPlugin/pom.xml
@@ -42,6 +42,14 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>5.2.3.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.2.3.RELEASE</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -52,6 +60,10 @@
                 <exclusion>
                     <groupId>io.projectreactor</groupId>
                     <artifactId>reactor-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -195,10 +207,6 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                             <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.springframework</groupId>
-                                    <artifactId>spring-webflux</artifactId>
-                                </artifactItem>
                                 <artifactItem>
                                     <groupId>io.jsonwebtoken</groupId>
                                     <artifactId>jjwt-api</artifactId>


### PR DESCRIPTION
### Tests done to ensure release doesn't go down like with the last PR:

1. Run the server from IntelliJ, execute two Rest API actions, one with a signature and the other without.
2. Run the server from command line after building with Maven, execute two Rest API actions, on with a signature and the other without.
3. Run all tests from IntelliJ.
4. Run all tests from command line with Maven.

I've also ran the server as well as ran the tests after deleting the `~/.m2` folder.

### How is this fix different from the previous one:

1. Two dependencies needed a `provided` scope on them.
2. Added additional jackson datatype dependencies with explicitly mentioned version number, because their version was not being computed correctly by Maven.
3. Don't use `spring-boot-starter-webflux`, instead use `spring-webflux` directly and explicitly specify exclusions on libraries that need scope to be `provided`.
4. Added `spring-boot-starter-webflux` within `test` scope since the tests don't seem to run at all without this. Likely because of some testing specific configuration that it provides makes a difference.

### What can you (the reviewer) can do to help (if time permits)?

1. Please run all tests from the command line, using Maven. Verify that they pass.
2. Please run the server from the command line, using `java -jar` and execute a REST API action (preferably with signature configured). Verify that it executes well.
3. Delete your `~/.m2` folder and perform the above two steps again.