### PR TITLE
Fixes a small syntax issue with ./start-https.sh

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -65,16 +65,16 @@ case "${uname_out}" in
     Linux*)     machine=Linux
 	
         source ../util/is_wsl.sh
-	      if [ $IS_WSL ]; then
-            # ignore to continue using host.docker.internal
-	      else
+        if [ $IS_WSL ]; then
+            : # ignore to continue using host.docker.internal
+        else
             network_mode="host"
             client_proxy_pass=$default_linux_client_proxy
             # if no server was passed
             if [[ -z $1 ]]; then
                 server_proxy_pass=$default_linux_server_proxy
             fi
-	      fi
+        fi
                 echo "
     Starting nginx for Linux...
     "


### PR DESCRIPTION
## Description
I introduced a small bug in this script in https://github.com/appsmithorg/appsmith/pull/2729 when I didn't account for the swap to bash's `if` logic.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the script without issues

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
