### PR TITLE
Fixed handling of validation errors and structured error types

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/pluginExceptions/AppsmithPluginError.java
@@ -10,6 +10,8 @@ public enum AppsmithPluginError {
     PLUGIN_ERROR(500, 5000, "{0}"),
     PLUGIN_STRUCTURE_ERROR(500, 5001, "Failed to get database structure with error {0}"),
     PLUGIN_TIMEOUT_ERROR(504, 5002, "{0} timed out in {1} milliseconds. Please increase timeout. This can be found in Settings tab of {0}."),
+    PLUGIN_DATASOURCE_CREATE_ERROR(500, 5003, "Error creating datasource: {0}"),
+    PLUGIN_DATASOURCE_TEST_ERROR(500, 5004, "Error testing datasource: {0}"),
     ;
 
     private final Integer httpErrorCode;

--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
@@ -1,14 +1,13 @@
 {
   "form": [
     {
-      "sectionName": "Details",
+      "sectionName": "Connection",
       "id": 1,
       "children": [
         {
           "label": "Region",
           "configProperty": "datasourceConfiguration.authentication.databaseName",
           "controlType": "DROP_DOWN",
-          "isRequired": true,
           "initialValue": "AP_SOUTH_1",
           "options": [
             {
@@ -138,23 +137,25 @@
           ]
         },
         {
-          "sectionName": "Endpoint Override (Overrides above region)",
-          "children": [
-            {
-              "label": "Host Address (for overriding endpoint only)",
-              "configProperty": "datasourceConfiguration.endpoints[*].host",
-              "controlType": "KEYVALUE_ARRAY",
-              "validationMessage": "Please enter a valid host",
-              "validationRegex": "^((?![/:]).)*$"
-            },
-            {
-              "label": "Port",
-              "configProperty": "datasourceConfiguration.endpoints[*].port",
-              "dataType": "NUMBER",
-              "controlType": "KEYVALUE_ARRAY"
-            }
-          ]
+          "label": "Host Address (for overriding endpoint only)",
+          "configProperty": "datasourceConfiguration.endpoints[*].host",
+          "controlType": "KEYVALUE_ARRAY",
+          "isRequired": true,
+          "validationMessage": "Please enter a valid host",
+          "validationRegex": "^((?![/:]).)*$"
         },
+        {
+          "label": "Port",
+          "configProperty": "datasourceConfiguration.endpoints[*].port",
+          "dataType": "NUMBER",
+          "controlType": "KEYVALUE_ARRAY"
+        }
+      ]
+    },
+    {
+      "sectionName": "Authentication",
+      "id": 2,
+      "children": [
         {
           "label": "AWS Access Key ID",
           "configProperty": "datasourceConfiguration.authentication.username",
@@ -169,7 +170,8 @@
           "controlType": "INPUT_TEXT",
           "isRequired": true,
           "placeholderText": "",
-          "initialValue": ""
+          "initialValue": "",
+          "dataType": "PASSWORD"
         }
       ]
     }

--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
@@ -8,7 +8,7 @@
           "label": "Region",
           "configProperty": "datasourceConfiguration.authentication.databaseName",
           "controlType": "DROP_DOWN",
-          "initialValue": "AP_SOUTH_1",
+          "initialValue": "ap-south-1",
           "options": [
             {
               "label": "ap-south-1",
@@ -137,18 +137,22 @@
           ]
         },
         {
-          "label": "Host Address (for overriding endpoint only)",
-          "configProperty": "datasourceConfiguration.endpoints[*].host",
-          "controlType": "KEYVALUE_ARRAY",
-          "isRequired": true,
-          "validationMessage": "Please enter a valid host",
-          "validationRegex": "^((?![/:]).)*$"
-        },
-        {
-          "label": "Port",
-          "configProperty": "datasourceConfiguration.endpoints[*].port",
-          "dataType": "NUMBER",
-          "controlType": "KEYVALUE_ARRAY"
+          "sectionName": "",
+          "children": [
+            {
+              "label": "Host Address (for overriding endpoint only)",
+              "configProperty": "datasourceConfiguration.endpoints[*].host",
+              "controlType": "KEYVALUE_ARRAY",
+              "validationMessage": "Please enter a valid host",
+              "validationRegex": "^((?![/:]).)*$"
+            },
+            {
+              "label": "Port",
+              "configProperty": "datasourceConfiguration.endpoints[*].port",
+              "dataType": "NUMBER",
+              "controlType": "KEYVALUE_ARRAY"
+            }
+          ]
         }
       ]
     },

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/form.json
@@ -2,30 +2,27 @@
   "form": [
     {
       "sectionName": "Connection",
+      "id": 1,
       "children": [
         {
-          "sectionName": null,
-          "children": [
-            {
-              "label": "Host URL",
-              "configProperty": "datasourceConfiguration.endpoints[*].host",
-              "controlType": "KEYVALUE_ARRAY",
-              "validationMessage": "Please enter a valid host URL",
-              "validationRegex": "^(http|https)://"
-            },
-            {
-              "label": "Port",
-              "configProperty": "datasourceConfiguration.endpoints[*].port",
-              "dataType": "NUMBER",
-              "controlType": "KEYVALUE_ARRAY"
-            }
-          ]
+          "label": "Host URL",
+          "configProperty": "datasourceConfiguration.endpoints[*].host",
+          "controlType": "KEYVALUE_ARRAY",
+          "validationMessage": "Please enter a valid host URL",
+          "validationRegex": "^(http|https)://"
+        },
+        {
+          "label": "Port",
+          "configProperty": "datasourceConfiguration.endpoints[*].port",
+          "dataType": "NUMBER",
+          "controlType": "KEYVALUE_ARRAY"
         }
       ]
     },
     {
       "sectionName": "Authentication",
-       "children": [
+      "id": 2,
+      "children": [
         {
           "label": "Username for Basic Auth",
           "configProperty": "datasourceConfiguration.authentication.username",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
@@ -103,7 +103,7 @@
               "initialValue": "fieldPath"
             },
             {
-              "label": "Where Condition: Field Path (leave emtpy to not apply any conditions)",
+              "label": "Where Condition: Field Path",
               "configProperty": "actionConfiguration.pluginSpecifiedTemplates[3].value",
               "controlType": "INPUT_TEXT",
               "hidden": {
@@ -111,7 +111,8 @@
                 "comparison": "NOT_EQUALS",
                 "value": "GET_COLLECTION"
               },
-              "initialValue": ""
+              "initialValue": "",
+              "placeHolder": "Leave empty to not apply any conditions"
             },
             {
               "label": "Operator Key",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/form.json
@@ -1,7 +1,7 @@
 {
   "form": [
     {
-      "sectionName": "Details",
+      "sectionName": "Connection",
       "id": 1,
       "children": [
         {

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/form.json
@@ -92,23 +92,18 @@
           ]
         },
         {
-          "sectionName": null,
-          "children": [
-            {
-              "label": "Username",
-              "configProperty": "datasourceConfiguration.authentication.username",
-              "controlType": "INPUT_TEXT",
-              "placeholderText": "Username"
-            },
-            {
-              "label": "Password",
-              "configProperty": "datasourceConfiguration.authentication.password",
-              "dataType": "PASSWORD",
-              "controlType": "INPUT_TEXT",
-              "placeholderText": "Password",
-              "encrypted": true
-            }
-          ]
+          "label": "Username",
+          "configProperty": "datasourceConfiguration.authentication.username",
+          "controlType": "INPUT_TEXT",
+          "placeholderText": "Username"
+        },
+        {
+          "label": "Password",
+          "configProperty": "datasourceConfiguration.authentication.password",
+          "dataType": "PASSWORD",
+          "controlType": "INPUT_TEXT",
+          "placeholderText": "Password",
+          "encrypted": true
         }
       ]
     }

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -71,13 +71,13 @@ public class MssqlPlugin extends BasePlugin {
             return (Mono<ActionExecutionResult>) Mono.fromCallable(() -> {
                 try {
                     if (connection == null || connection.isClosed() || !connection.isValid(VALIDITY_CHECK_TIMEOUT)) {
-                        log.info("Encountered stale connection in MsSQL plugin. Reporting back.");
+                        System.out.println("Encountered stale connection in MsSQL plugin. Reporting back.");
                         return Mono.error(new StaleConnectionException());
                     }
                 } catch (SQLException error) {
                     // This exception is thrown only when the timeout to `isValid` is negative. Since, that's not the case,
                     // here, this should never happen.
-                    log.error("Error checking validity of MsSQL connection.", error);
+                    System.out.println("Error checking validity of MsSQL connection." + error);
                 }
 
                 String query = actionConfiguration.getBody();
@@ -159,7 +159,7 @@ public class MssqlPlugin extends BasePlugin {
                         try {
                             resultSet.close();
                         } catch (SQLException e) {
-                            log.warn("Error closing MsSQL ResultSet", e);
+                            System.out.println("Error closing MsSQL ResultSet. " + e);
                         }
                     }
 
@@ -167,7 +167,7 @@ public class MssqlPlugin extends BasePlugin {
                         try {
                             statement.close();
                         } catch (SQLException e) {
-                            log.warn("Error closing MsSQL Statement", e);
+                            System.out.println("Error closing MsSQL Statement. " + e);
                         }
                     }
 
@@ -191,7 +191,7 @@ public class MssqlPlugin extends BasePlugin {
                     Class.forName(JDBC_DRIVER);
                 } catch (ClassNotFoundException e) {
                     return Mono.error(new AppsmithPluginException(
-                            AppsmithPluginError.PLUGIN_ERROR,
+                            AppsmithPluginError.PLUGIN_DATASOURCE_CREATE_ERROR,
                             "Error loading MsSQL JDBC Driver class."
                     ));
                 }
@@ -248,8 +248,8 @@ public class MssqlPlugin extends BasePlugin {
 
                 } catch (SQLException e) {
                     return Mono.error(new AppsmithPluginException(
-                            AppsmithPluginError.PLUGIN_ERROR,
-                            "Error connecting to MsSQL: " + e.getMessage()
+                            AppsmithPluginError.PLUGIN_DATASOURCE_CREATE_ERROR,
+                            e.getMessage()
                     ));
 
                 }
@@ -265,7 +265,7 @@ public class MssqlPlugin extends BasePlugin {
                     connection.close();
                 }
             } catch (SQLException e) {
-                log.error("Error closing MsSQL Connection.", e);
+                System.out.println("Error closing MsSQL Connection." + e);
             }
         }
 
@@ -309,7 +309,7 @@ public class MssqlPlugin extends BasePlugin {
                                 connection.close();
                             }
                         } catch (SQLException e) {
-                            log.warn("Error closing MsSQL connection that was made for testing.", e);
+                            System.out.println("Error closing MsSQL connection that was made for testing." + e);
                         }
 
                         return new DatasourceTestResult();

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/form.json
@@ -112,41 +112,31 @@
           ]
         },
         {
-          "sectionName": null,
-          "children": [
-            {
-              "label": "Key File",
-              "configProperty": "datasourceConfiguration.connection.ssl.keyFile",
-              "controlType": "FILE_PICKER"
-            },
-            {
-              "label": "Certificate",
-              "configProperty": "datasourceConfiguration.connection.ssl.certificateFile",
-              "controlType": "FILE_PICKER"
-            }
-          ]
+          "label": "Key File",
+          "configProperty": "datasourceConfiguration.connection.ssl.keyFile",
+          "controlType": "FILE_PICKER"
         },
         {
-          "sectionName": null,
-          "children": [
-            {
-              "label": "CA Certificate",
-              "configProperty": "datasourceConfiguration.connection.ssl.caCertificateFile",
-              "controlType": "FILE_PICKER"
-            },
-            {
-              "label": "PEM Certificate",
-              "configProperty": "datasourceConfiguration.connection.ssl.pemCertificate.file",
-              "controlType": "FILE_PICKER"
-            },
-            {
-              "label": "PEM Passphrase",
-              "configProperty": "datasourceConfiguration.connection.ssl.pemCertificate.password",
-              "dataType": "PASSWORD",
-              "controlType": "INPUT_TEXT",
-              "placeholderText": "PEM Passphrase"
-            }
-          ]
+          "label": "Certificate",
+          "configProperty": "datasourceConfiguration.connection.ssl.certificateFile",
+          "controlType": "FILE_PICKER"
+        },
+        {
+          "label": "CA Certificate",
+          "configProperty": "datasourceConfiguration.connection.ssl.caCertificateFile",
+          "controlType": "FILE_PICKER"
+        },
+        {
+          "label": "PEM Certificate",
+          "configProperty": "datasourceConfiguration.connection.ssl.pemCertificate.file",
+          "controlType": "FILE_PICKER"
+        },
+        {
+          "label": "PEM Passphrase",
+          "configProperty": "datasourceConfiguration.connection.ssl.pemCertificate.password",
+          "dataType": "PASSWORD",
+          "controlType": "INPUT_TEXT",
+          "placeholderText": "PEM Passphrase"
         }
       ]
     }

--- a/app/server/appsmith-plugins/redshiftPlugin/src/test/java/com/external/plugins/RedshiftPluginTest.java
+++ b/app/server/appsmith-plugins/redshiftPlugin/src/test/java/com/external/plugins/RedshiftPluginTest.java
@@ -88,7 +88,7 @@ public class RedshiftPluginTest {
 
         StepVerifier.create(dsConnectionMono)
                 .expectErrorMatches(throwable -> throwable instanceof AppsmithPluginException && throwable.getMessage()
-                        .equals(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, "Error connecting" +
+                        .equals(new AppsmithPluginException(AppsmithPluginError.PLUGIN_DATASOURCE_CREATE_ERROR, "Error connecting" +
                         " to Redshift.").getMessage()))
                 .verify();
     }


### PR DESCRIPTION
Minor issues with consistency between plugins. Not all of the exceptions have been tested for lack of datasources, but most of them are cosmetic changes. Still have a few open questions:
- Mongodb times out and cancels request on the client side without displaying any error message for invalid inputs
- Elastic search expects http in url, while dynamo db explicitly adds it. None of the others handle the field.
- Dynamodb allows datasourc test to pass with any random values

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
