### PR TITLE
Fix: New widget and action name conflicts

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -288,8 +288,11 @@ export function* addChildrenSaga(
     const widgets = { ...stateWidgets };
     const widgetNames = Object.keys(widgets).map((w) => widgets[w].widgetName);
     const stateActions = yield select(getActions);
-    const actionNames = stateActions.map(
-      (action: ActionData) => action.config.name,
+    const currentPageId = yield select(getCurrentPageId);
+    const actionNames = compact(
+      stateActions.map((action: ActionData) =>
+        action.config.pageId === currentPageId ? action.config.name : undefined,
+      ),
     );
 
     children.forEach((child) => {

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -285,8 +285,7 @@ export function* addChildrenSaga(
     const stateWidgets = yield select(getWidgets);
     const widgets = { ...stateWidgets };
     const widgetNames = Object.keys(widgets).map((w) => widgets[w].widgetName);
-    const evalTree = yield select(getDataTree);
-    const entityNames = Object.keys(evalTree);
+    const entityNames = yield call(getEntityNames);
 
     children.forEach((child) => {
       // Create only if it doesn't already exist


### PR DESCRIPTION
Fix widget add scenarios to make sure there are not conflicts between widget names and action names

## Description
When adding a new widget, the new widget's name should not conflict with an existing action name

Fixes #2773 
## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
