### PR TITLE
Allow for navigateTo urls to be of `mailto` or `tel` url schemes t

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -92,6 +92,19 @@ export enum NavigationTargetType {
   NEW_WINDOW = "NEW_WINDOW",
 }
 
+const isValidUrlScheme = (url: string): boolean => {
+  return (
+    // Standard http call
+    url.startsWith("http://") ||
+    // Secure http call
+    url.startsWith("https://") ||
+    // Mail url to directly open email app prefilled
+    url.startsWith("mailto://") ||
+    // Tel url to directly open phone app prefilled
+    url.startsWith("tel:")
+  );
+};
+
 function* navigateActionSaga(
   action: {
     pageNameOrUrl: string;
@@ -131,9 +144,9 @@ function* navigateActionSaga(
     AnalyticsUtil.logEvent("NAVIGATE", {
       navUrl: pageNameOrUrl,
     });
-    // Add a default protocol if it doesn't exist.
     let url = pageNameOrUrl + convertToQueryParams(params);
-    if (url.indexOf("://") === -1) {
+    // Add a default protocol if it doesn't exist.
+    if (!isValidUrlScheme(url)) {
       url = "https://" + url;
     }
     if (target === NavigationTargetType.SAME_WINDOW) {

--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -99,7 +99,7 @@ const isValidUrlScheme = (url: string): boolean => {
     // Secure http call
     url.startsWith("https://") ||
     // Mail url to directly open email app prefilled
-    url.startsWith("mailto://") ||
+    url.startsWith("mailto:") ||
     // Tel url to directly open phone app prefilled
     url.startsWith("tel:")
   );


### PR DESCRIPTION
## Description
Allow for navigateTo urls to be of `mailto` or `tel` url schemes to open specific apps directly with pre filled data


## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
