### PR TITLE
Migrate renamed canvas widgets to the correct name

### DIFF
--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -278,6 +278,27 @@ const canvasNameConflictMigration = (
   return currentDSL;
 };
 
+const renamedCanvasNameConflictMigration = (
+  currentDSL: ContainerWidgetProps<WidgetProps>,
+  props = { counter: 1 },
+): ContainerWidgetProps<WidgetProps> => {
+  // Rename all canvas widgets except for MainContainer
+  if (
+    currentDSL.type === WidgetTypes.CANVAS_WIDGET &&
+    currentDSL.widgetName !== "MainContainer"
+  ) {
+    currentDSL.widgetName = `Canvas${props.counter}`;
+    // Canvases inside tabs have `name` property as well
+    if (currentDSL.name) {
+      currentDSL.name = currentDSL.widgetName;
+    }
+    props.counter++;
+  }
+  currentDSL.children?.forEach((c) => canvasNameConflictMigration(c, props));
+
+  return currentDSL;
+};
+
 // A rudimentary transform function which updates the DSL based on its version.
 // A more modular approach needs to be designed.
 const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
@@ -333,6 +354,11 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
   if (currentDSL.version === 7) {
     currentDSL = canvasNameConflictMigration(currentDSL);
     currentDSL.version = 8;
+  }
+
+  if (currentDSL.version === 8) {
+    currentDSL = renamedCanvasNameConflictMigration(currentDSL);
+    currentDSL.version = 9;
   }
 
   return currentDSL;

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -580,9 +580,10 @@ export const generateWidgetProps = (
   parentRowSpace: number,
   parentColumnSpace: number,
   widgetName: string,
-  widgetConfig: { widgetId: string; renderMode: RenderMode } & Partial<
-    WidgetProps
-  >,
+  widgetConfig: {
+    widgetId: string;
+    renderMode: RenderMode;
+  } & Partial<WidgetProps>,
 ): ContainerWidgetProps<WidgetProps> => {
   if (parent) {
     const sizes = {


### PR DESCRIPTION
## Description
Set correct canvas names for renamed canvas widgets.
Should be merged only after #2778 & #2779

Fixes #2772 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
