### PR TITLE
Fix user email duplicated as name

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -394,10 +394,6 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
             user.setPassword(passwordEncoder.encode(user.getPassword()));
         }
 
-        if (!StringUtils.hasText(user.getName())) {
-            user.setName(user.getEmail());
-        }
-
         // Set the permissions for the user
         user.getPolicies().addAll(crudUserPolicy(user));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -43,6 +43,7 @@ import static com.appsmith.server.acl.AclPermission.READ_USERS;
 import static com.appsmith.server.acl.AclPermission.USER_MANAGE_ORGANIZATIONS;
 import static com.appsmith.server.acl.AclPermission.USER_READ_ORGANIZATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -168,7 +169,7 @@ public class UserServiceTest {
                     assertThat(user).isNotNull();
                     assertThat(user.getId()).isNotNull();
                     assertThat(user.getEmail()).isEqualTo("new-user-email@email.com");
-                    assertThat(user.getName()).isEqualTo("new-user-email@email.com");
+                    assertNull(user.getName());
                     assertThat(user.getPolicies()).isNotEmpty();
                     assertThat(user.getPolicies()).containsAll(Set.of(manageUserPolicy, manageUserOrgPolicy, readUserPolicy, readUserOrgPolicy));
                     // Since there is a template organization, the user won't have an empty default organization. They
@@ -396,4 +397,3 @@ public class UserServiceTest {
         }
     }
 }
-

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -43,7 +43,6 @@ import static com.appsmith.server.acl.AclPermission.READ_USERS;
 import static com.appsmith.server.acl.AclPermission.USER_MANAGE_ORGANIZATIONS;
 import static com.appsmith.server.acl.AclPermission.USER_READ_ORGANIZATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -169,7 +168,7 @@ public class UserServiceTest {
                     assertThat(user).isNotNull();
                     assertThat(user.getId()).isNotNull();
                     assertThat(user.getEmail()).isEqualTo("new-user-email@email.com");
-                    assertNull(user.getName());
+                    assertThat(user.getName()).isNullOrEmpty();
                     assertThat(user.getPolicies()).isNotEmpty();
                     assertThat(user.getPolicies()).containsAll(Set.of(manageUserPolicy, manageUserOrgPolicy, readUserPolicy, readUserOrgPolicy));
                     // Since there is a template organization, the user won't have an empty default organization. They

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -103,7 +102,7 @@ public class UserServiceWithDisabledSignupTest {
                     assertThat(user).isNotNull();
                     assertThat(user.getId()).isNotNull();
                     assertThat(user.getEmail()).isEqualTo("dummy_admin@appsmith.com");
-                    assertNull(user.getName());
+                    assertThat(user.getName()).isNullOrEmpty();
                     assertThat(user.getPolicies()).isNotEmpty();
                     assertThat(user.getOrganizationIds()).isNullOrEmpty();
                 })
@@ -124,7 +123,7 @@ public class UserServiceWithDisabledSignupTest {
                     assertThat(user).isNotNull();
                     assertThat(user.getId()).isNotNull();
                     assertThat(user.getEmail()).isEqualTo("dummy2@appsmith.com");
-                    assertNull(user.getName());
+                    assertThat(user.getName()).isNullOrEmpty();
                     assertThat(user.getPolicies()).isNotEmpty();
                     assertThat(user.getOrganizationIds()).isNullOrEmpty();
                 })

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -102,7 +103,7 @@ public class UserServiceWithDisabledSignupTest {
                     assertThat(user).isNotNull();
                     assertThat(user.getId()).isNotNull();
                     assertThat(user.getEmail()).isEqualTo("dummy_admin@appsmith.com");
-                    assertThat(user.getName()).isEqualTo("dummy_admin@appsmith.com");
+                    assertNull(user.getName());
                     assertThat(user.getPolicies()).isNotEmpty();
                     assertThat(user.getOrganizationIds()).isNullOrEmpty();
                 })
@@ -123,7 +124,7 @@ public class UserServiceWithDisabledSignupTest {
                     assertThat(user).isNotNull();
                     assertThat(user.getId()).isNotNull();
                     assertThat(user.getEmail()).isEqualTo("dummy2@appsmith.com");
-                    assertThat(user.getName()).isEqualTo("dummy2@appsmith.com");
+                    assertNull(user.getName());
                     assertThat(user.getPolicies()).isNotEmpty();
                     assertThat(user.getOrganizationIds()).isNullOrEmpty();
                 })


### PR DESCRIPTION
## Description
Fix an issue with a user's email being duplicated as the user's name when inviting a new user.

Fixes #595 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Run Appsmith with the changes made in this PR
2. Navigate to Manage Users
3. Invite a new user
4. Observe the Name column

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
