### PR TITLE
Fix/table eval

### DIFF
--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -281,10 +281,13 @@ export class DataTreeEvaluator {
     if (!isAction(entity) && !isWidget(entity)) return false;
 
     // TODO: this is not a complete requirement
-    const dynamicPaths = new Set(
-      getEntityDynamicBindingPathList(entity).map((e) => e.key),
-    );
-    if (dynamicPaths.has(convertPathToString(propPathEls))) return true;
+    const dynamicPaths = getEntityDynamicBindingPathList(entity);
+    const relativePropPath = convertPathToString(propPathEls);
+    for (const path of dynamicPaths) {
+      if (path.key === relativePropPath) {
+        return true;
+      }
+    }
     if (!(entityName in this.validationPaths)) return false;
     return this.validationPaths[entityName].has(propertyPath);
   }

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -284,7 +284,9 @@ export class DataTreeEvaluator {
     const dynamicPaths = new Set(
       getEntityDynamicBindingPathList(entity).map((e) => e.key),
     );
-    return dynamicPaths.has(convertPathToString(propPathEls));
+    if (dynamicPaths.has(convertPathToString(propPathEls))) return true;
+    if (!(entityName in this.validationPaths)) return false;
+    return this.validationPaths[entityName].has(propertyPath);
   }
 
   updateDataTree(unEvalTree: DataTree) {

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -42,17 +42,24 @@ export class CrashingError extends Error {}
 export const convertPathToString = (arrPath: Array<string | number>) => {
   let string = "";
   arrPath.forEach((segment) => {
-    if (typeof segment === "string") {
+    if (isInt(segment)) {
+      string = string + "[" + segment + "]";
+    } else {
       if (string.length !== 0) {
         string = string + ".";
       }
       string = string + segment;
-    } else {
-      string = string + "[" + segment + "]";
     }
   });
   return string;
 };
+
+// Todo: improve the logic here
+// Right now NaN, Infinity, floats, everything works
+function isInt(val: string | number): boolean {
+  if (typeof val === "number") return true;
+  return !isNaN(parseInt(val));
+}
 
 export const translateDiffEventToDataTreeDiffEvent = (
   difference: Diff<any, any>,


### PR DESCRIPTION
## Description
We had a faulty logic of resetting properties, where we'd reset the complete parent object if it appeared in the sort order.

This led to bugs like `Table1.primaryColumns[0].buttonLabel` getting reset to it's raw dynamic binding (but not evaluated) if  `Table1.primaryColumns[0].onClick` ever got updated.

With this PR, we check if the property path is a leaf before resetting it for eval.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

With new table widget.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
