### PR TITLE
Set build.sh to fail on any failure

### DIFF
--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 GIT_SHA=$(eval git rev-parse HEAD)
 echo $GIT_SHA
 echo "Sentry Auth Token: $SENTRY_AUTH_TOKEN"


### PR DESCRIPTION
## Description
A script's return code is the return code of it's last line. This hides issues when there's an error in the middle of the script.

As a result, our builds were passing even when there was an error. 

This PR changes build to fail immediately on any failure in the script.