### PR TITLE
Fail the build script if some command fails

### DIFF
--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# exit when any command fails
+set -e
+
 GIT_SHA=$(eval git rev-parse HEAD)
 echo $GIT_SHA
 echo "Sentry Auth Token: $SENTRY_AUTH_TOKEN"


### PR DESCRIPTION
## Description
Currently the build script (build.sh) can never fail since it ends with an echo command. This change will make the script fail for any command sending a non-zero exit code.

