### PR TITLE
Add an option to set reset the input widget's value on submit

### DIFF
--- a/app/client/src/mockResponses/PropertyPaneConfigResponse.tsx
+++ b/app/client/src/mockResponses/PropertyPaneConfigResponse.tsx
@@ -711,6 +711,14 @@ const PropertyPaneConfigResponse: PropertyPaneConfigsResponse["data"] = {
             controlType: "SWITCH",
             isJSConvertible: true,
           },
+          {
+            id: "4.2.0",
+            helpText: "Clears the input value after submit",
+            propertyName: "resetOnSubmit",
+            label: "Reset on submit",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+          },
         ],
       },
       {

--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -139,7 +139,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
   };
 
   onSubmitSuccess = (result: ExecutionResult) => {
-    if (result && this.props.resetOnSubmit) {
+    if (result.success && this.props.resetOnSubmit) {
       this.props.updateWidgetMetaProperty("text", "", {
         dynamicString: this.props.onTextChanged,
         event: {

--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -4,7 +4,7 @@ import { WidgetType } from "constants/WidgetConstants";
 import InputComponent, {
   InputComponentProps,
 } from "components/designSystems/blueprint/InputComponent";
-import { EventType } from "constants/ActionConstants";
+import { EventType, ExecutionResult } from "constants/ActionConstants";
 import {
   WidgetPropertyValidationType,
   BASE_WIDGET_VALIDATION,
@@ -138,8 +138,8 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
     this.props.updateWidgetMetaProperty("isFocused", focusState);
   };
 
-  onSubmitSuccess = () => {
-    if (this.props.resetOnSubmit) {
+  onSubmitSuccess = (result: ExecutionResult) => {
+    if (result && this.props.resetOnSubmit) {
       this.props.updateWidgetMetaProperty("text", "", {
         dynamicString: this.props.onTextChanged,
         event: {

--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -39,6 +39,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
       // onTextChanged: VALIDATION_TYPES.ACTION_SELECTOR,
       isRequired: VALIDATION_TYPES.BOOLEAN,
       isValid: VALIDATION_TYPES.BOOLEAN,
+      resetOnSubmit: VALIDATION_TYPES.BOOLEAN,
     };
   }
   static getTriggerPropertyMap(): TriggerPropertiesMap {
@@ -137,6 +138,17 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
     this.props.updateWidgetMetaProperty("isFocused", focusState);
   };
 
+  onSubmitSuccess = () => {
+    if (this.props.resetOnSubmit) {
+      this.props.updateWidgetMetaProperty("text", "", {
+        dynamicString: this.props.onTextChanged,
+        event: {
+          type: EventType.ON_TEXT_CHANGE,
+        },
+      });
+    }
+  };
+
   handleKeyDown = (
     e:
       | React.KeyboardEvent<HTMLTextAreaElement>
@@ -148,6 +160,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
         dynamicString: this.props.onSubmit,
         event: {
           type: EventType.ON_SUBMIT,
+          callback: this.onSubmitSuccess,
         },
       });
     }


### PR DESCRIPTION
## Description
Add option to reset input text after submitting

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
