### PR TITLE
Better handling of action error response

### DIFF
--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -98,7 +98,7 @@ interface ReduxStateProps {
 
 type Props = ReduxStateProps & RouteComponentProps<APIEditorRouteParams>;
 
-const EMPTY_RESPONSE: ActionResponse = {
+export const EMPTY_RESPONSE: ActionResponse = {
   statusCode: "",
   duration: "",
   body: {},

--- a/app/client/src/constants/ActionConstants.tsx
+++ b/app/client/src/constants/ActionConstants.tsx
@@ -1,3 +1,6 @@
+import { ErrorActionPayload } from "../sagas/ErrorSagas";
+import { ActionResponse } from "../api/ActionAPI";
+
 export type ExecuteActionPayloadEvent = {
   type: EventType;
   callback?: (result: ExecutionResult) => void;
@@ -63,11 +66,10 @@ export interface PageAction {
   timeoutInMillisecond: number;
 }
 
-export interface ExecuteErrorPayload {
+export interface ExecuteErrorPayload extends ErrorActionPayload {
   actionId: string;
-  error: any;
   isPageLoad?: boolean;
-  show?: boolean;
+  data: ActionResponse;
 }
 
 // Group 1 = datasource (https://www.domain.com)

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -190,9 +190,8 @@ const actionsReducer = createReducer(initialState, {
   ): ActionDataState =>
     state.map((a) => {
       if (a.config.id === action.payload.actionId) {
-        return { ...a, isLoading: false, data: action.payload.error };
+        return { ...a, isLoading: false, data: action.payload.data };
       }
-
       return a;
     }),
   [ReduxActionTypes.RUN_ACTION_REQUEST]: (

--- a/app/client/src/sagas/ErrorSagas.tsx
+++ b/app/client/src/sagas/ErrorSagas.tsx
@@ -127,13 +127,13 @@ enum ErrorEffectTypes {
   LOG_ERROR = "LOG_ERROR",
 }
 
-export function* errorSaga(
-  errorAction: ReduxAction<{
-    error: ErrorPayloadType;
-    show?: boolean;
-    crash?: boolean;
-  }>,
-) {
+export interface ErrorActionPayload {
+  error: ErrorPayloadType;
+  show?: boolean;
+  crash?: boolean;
+}
+
+export function* errorSaga(errorAction: ReduxAction<ErrorActionPayload>) {
   const effects = [ErrorEffectTypes.LOG_ERROR];
   const { type, payload } = errorAction;
   const { show = true, error } = payload || {};


### PR DESCRIPTION
## Description
Actions with error responses were setting an undefined value inside the data tree. We need instead have a separate handling of the error messaging and the actual data getting set inside the data tree.

Fixes #2838 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
