### PR TITLE
Fix app viewer's bottom border when the tabs arent rendered

### DIFF
--- a/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
+++ b/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
@@ -82,6 +82,8 @@ const HeaderRow = styled.div<{ justify: string }>`
   flex-direction: row;
   justify-content: ${(props) => props.justify};
   height: ${(props) => `calc(${props.theme.smallHeaderHeight})`};
+  border-bottom: 1px solid
+    ${(props) => props.theme.colors.header.tabsHorizontalSeparator};
 `;
 
 const HeaderSection = styled.div<{ justify: string }>`

--- a/app/client/src/pages/AppViewer/viewer/PageTabsContainer.tsx
+++ b/app/client/src/pages/AppViewer/viewer/PageTabsContainer.tsx
@@ -20,8 +20,6 @@ const Container = styled.div`
       stroke: ${(props) => props.theme.colors.header.tabText};
     }
   }
-  border-top: 1px solid
-    ${(props) => props.theme.colors.header.tabsHorizontalSeparator};
   border-bottom: 1px solid
     ${(props) => props.theme.colors.header.tabsHorizontalSeparator};
 `;


### PR DESCRIPTION
## Description
Fix app viewer's bottom border when the tabs arent rendered

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
