### PR TITLE
fix viewer tabs arrow btns on mobile

### DIFF
--- a/app/client/src/pages/AppViewer/viewer/PageTabsContainer.tsx
+++ b/app/client/src/pages/AppViewer/viewer/PageTabsContainer.tsx
@@ -122,6 +122,8 @@ export const PageTabsContainer = (props: AppViewerHeaderProps) => {
         onMouseDown={() => startScrolling(true)}
         onMouseUp={stopScrolling}
         onMouseLeave={stopScrolling}
+        onTouchStart={() => startScrolling(true)}
+        onTouchEnd={stopScrolling}
         visible={shouldShowLeftArrow}
       >
         <Icon name="chevron-left" />
@@ -137,6 +139,8 @@ export const PageTabsContainer = (props: AppViewerHeaderProps) => {
         onMouseDown={() => startScrolling(false)}
         onMouseUp={stopScrolling}
         onMouseLeave={stopScrolling}
+        onTouchStart={() => startScrolling(false)}
+        onTouchEnd={stopScrolling}
         visible={shouldShowRightArrow}
       >
         <Icon name="chevron-right" />


### PR DESCRIPTION
## Description
Handle `touchStart/touchEnd` events so that the tab navigation buttons work on mobile 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
