### PR TITLE
Fix #2829 When resetting form meta properties widget is undefined

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -921,7 +921,13 @@ function* deleteWidgetPropertySaga(
 function* getWidgetChildren(widgetId: string): any {
   const childrenIds: string[] = [];
   const widget = yield select(getWidget, widgetId);
-  const { children } = widget;
+  // When a form widget tries to resetChildrenMetaProperties
+  // But one or more of its container like children
+  // have just been deleted, widget can be undefined
+  if (widget === undefined) {
+    return [];
+  }
+  const { children = [] } = widget;
   if (children && children.length) {
     for (const childIndex in children) {
       if (children.hasOwnProperty(childIndex)) {


### PR DESCRIPTION
## Description
When a form widget tries to reset the children's meta properties. Some container like widgets within it might not be available
This results in the `widget` being `undefined`

Fixes #2829


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Difficult to reproduce. Fixed by handling the erroneous path in the code.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
