### PR TITLE
Fix input's onSubmit action being triggered if its validation is failing

### DIFF
--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -154,10 +154,11 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
       | React.KeyboardEvent<HTMLTextAreaElement>
       | React.KeyboardEvent<HTMLInputElement>,
   ) => {
+    const { isValid, onSubmit } = this.props;
     const isEnterKey = e.key === "Enter" || e.keyCode === 13;
-    if (isEnterKey && this.props.onSubmit) {
+    if (isEnterKey && onSubmit && isValid) {
       super.executeAction({
-        dynamicString: this.props.onSubmit,
+        dynamicString: onSubmit,
         event: {
           type: EventType.ON_SUBMIT,
           callback: this.onSubmitSuccess,


### PR DESCRIPTION
## Description
Do not trigger input on submit action if the input's state is invalid

Fixes #2928

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
