### PR TITLE
Consistent handling of signup configuration over FORM and OAUTH

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/AuthenticationFailureHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/AuthenticationFailureHandler.java
@@ -5,6 +5,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.server.DefaultServerRedirectStrategy;
 import org.springframework.security.web.server.ServerRedirectStrategy;
 import org.springframework.security.web.server.WebFilterExchange;
@@ -68,13 +69,14 @@ public class AuthenticationFailureHandler implements ServerAuthenticationFailure
         // Authentication failure message can hold sensitive information, directly or indirectly. So we don't show all
         // possible error messages. Only the ones we know are okay to be read by the user. Like a whitelist.
         URI defaultRedirectLocation;
-        if (AppsmithError.SIGNUP_DISABLED.getMessage().equals(exception.getMessage())) {
+        if (exception instanceof OAuth2AuthenticationException
+                && AppsmithError.SIGNUP_DISABLED.getAppErrorCode().toString().equals(((OAuth2AuthenticationException) exception).getError().getErrorCode())) {
             defaultRedirectLocation = URI.create("/user/signup?error=" + URLEncoder.encode(exception.getMessage(), StandardCharsets.UTF_8));
         } else {
             defaultRedirectLocation = URI.create(originHeader + "/user/login?error=true");
         }
 
         return this.redirectStrategy.sendRedirect(exchange, defaultRedirectLocation);
-
     }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomOidcUserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomOidcUserServiceImpl.java
@@ -3,6 +3,7 @@ package com.appsmith.server.authentication.handlers;
 import com.appsmith.server.domains.LoginSource;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserState;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +12,7 @@ import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAut
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -73,6 +75,12 @@ public class CustomOidcUserServiceImpl extends OidcReactiveOAuth2UserService
                         return repository.save(user);
                     }
                     return Mono.just(user);
-                });
+                })
+                .onErrorMap(
+                        AppsmithException.class,
+                        error -> new OAuth2AuthenticationException(
+                                new OAuth2Error(error.getAppErrorCode().toString(), error.getMessage(), "")
+                        )
+                );
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomServerOAuth2AuthorizationRequestResolver.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomServerOAuth2AuthorizationRequestResolver.java
@@ -155,14 +155,14 @@ public class CustomServerOAuth2AuthorizationRequestResolver implements ServerOAu
             if (ClientAuthenticationMethod.NONE.equals(clientRegistration.getClientAuthenticationMethod())) {
                 addPkceParameters(attributes, additionalParameters);
             }
-            if (!commonConfig.getAllowedDomains().isEmpty()) {
-                if (commonConfig.getAllowedDomains().size() == 1) {
+            if (!commonConfig.getOauthAllowedDomains().isEmpty()) {
+                if (commonConfig.getOauthAllowedDomains().size() == 1) {
                     // Incase there's only 1 domain, we can do a further optimization to let the user select a specific one
                     // from the list
-                    additionalParameters.put("hd", commonConfig.getAllowedDomains().get(0));
+                    additionalParameters.put("hd", commonConfig.getOauthAllowedDomains().get(0));
                 } else {
                     // Add multiple domains to the list of allowed domains
-                    additionalParameters.put("hd", commonConfig.getAllowedDomains());
+                    additionalParameters.put("hd", commonConfig.getOauthAllowedDomains());
                 }
             }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ClientUserRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ClientUserRepository.java
@@ -77,13 +77,13 @@ public class ClientUserRepository implements ServerOAuth2AuthorizedClientReposit
         // Check if the list of configured custom domains match the authenticated principal.
         // This is to provide more control over which accounts can be used to access the application.
         // TODO: This is not a good way to do this. Ideally, we should pass "hd=example.com" to OAuth2 provider to list relevant accounts only
-        if (!commonConfig.getAllowedDomains().isEmpty()) {
+        if (!commonConfig.getOauthAllowedDomains().isEmpty()) {
             String domain = null;
             log.debug("Got the principal class as: {}", principal.getPrincipal().getClass().getName());
             if (principal.getPrincipal() instanceof DefaultOidcUser) {
                 DefaultOidcUser userPrincipal = (DefaultOidcUser) principal.getPrincipal();
                 domain = (String) userPrincipal.getAttributes().getOrDefault("hd", "");
-                if (!commonConfig.getAllowedDomains().contains(domain)) {
+                if (!commonConfig.getOauthAllowedDomains().contains(domain)) {
                     return Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_DOMAIN, domain));
                 }
             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -14,6 +14,7 @@ import reactor.core.scheduler.Schedulers;
 
 import javax.validation.Validation;
 import javax.validation.Validator;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,9 +34,14 @@ public class CommonConfig {
     private Set<String> adminEmails = Collections.emptySet();
 
     @Value("${oauth2.allowed-domains}")
-    private String allowedDomainList;
+    private String allowedDomainsForOauthString;
 
-    private List<String> domainList;
+    private List<String> allowedDomainsForOauth;
+
+    @Value("${signup.allowed-domains}")
+    private String allowedDomainsString;
+
+    private List<String> allowedDomains;
 
     @Bean
     public Scheduler scheduler() {
@@ -55,13 +61,25 @@ public class CommonConfig {
         return objectMapper;
     }
 
+    public List<String> getOauthAllowedDomains() {
+        if (allowedDomainsForOauth == null) {
+            allowedDomainsForOauth = StringUtils.hasText(allowedDomainsForOauthString)
+                    ? Arrays.asList(allowedDomainsForOauthString.trim().split("\\s*,[,\\s]*"))
+                    : new ArrayList<>();
+            allowedDomainsForOauth.addAll(getAllowedDomains());
+        }
+
+        return allowedDomainsForOauth;
+    }
+
     public List<String> getAllowedDomains() {
-        if (domainList == null) {
-            domainList = StringUtils.hasText(allowedDomainList)
-                    ? Arrays.asList(allowedDomainList.trim().split("\\s*,[,\\s]*"))
+        if (allowedDomains == null) {
+            allowedDomains = StringUtils.hasText(allowedDomainsString)
+                    ? Arrays.asList(allowedDomainsString.trim().split("\\s*,[,\\s]*"))
                     : Collections.emptyList();
         }
 
-        return domainList;
+        return allowedDomains;
     }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -474,7 +474,10 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
             final List<String> allowedDomains = user.getSource() == LoginSource.FORM
                     ? commonConfig.getAllowedDomains()
                     : commonConfig.getOauthAllowedDomains();
-            if (!CollectionUtils.isEmpty(allowedDomains) && !allowedDomains.contains(user.getEmail().split("@")[1])) {
+            if (!CollectionUtils.isEmpty(allowedDomains)
+                    && StringUtils.hasText(user.getEmail())
+                    && user.getEmail().contains("@")
+                    && !allowedDomains.contains(user.getEmail().split("@")[1])) {
                 // There is an explicit whitelist of email address domains that should be allowed. If the new email is
                 // of a different domain, reject.
                 return Mono.error(new AppsmithException(AppsmithError.SIGNUP_DISABLED));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -31,6 +31,7 @@ import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import reactor.core.Exceptions;
@@ -385,14 +386,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
 
     @Override
     public Mono<User> userCreate(User user) {
-
-        // Only encode the password if it's a form signup. For OAuth signups, we don't need password
-        if (user.isEnabled() && LoginSource.FORM.equals(user.getSource())) {
-            if (user.getPassword() == null || user.getPassword().isBlank()) {
-                return Mono.error(new AppsmithException(AppsmithError.INVALID_CREDENTIALS));
-            }
-            user.setPassword(passwordEncoder.encode(user.getPassword()));
-        }
+        // It is assumed here that the user's password has already been encoded.
 
         // Set the permissions for the user
         user.getPolicies().addAll(crudUserPolicy(user));
@@ -438,6 +432,14 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
 
         final String finalOriginHeader = originHeader;
 
+        // Only encode the password if it's a form signup. For OAuth signups, we don't need password
+        if (LoginSource.FORM.equals(user.getSource())) {
+            if (user.getPassword() == null || user.getPassword().isBlank()) {
+                return Mono.error(new AppsmithException(AppsmithError.INVALID_CREDENTIALS));
+            }
+            user.setPassword(passwordEncoder.encode(user.getPassword()));
+        }
+
         // If the user doesn't exist, create the user. If the user exists, return a duplicate key exception
         return repository.findByEmail(user.getUsername())
                 .flatMap(savedUser -> {
@@ -445,35 +447,42 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                         // First enable the user
                         savedUser.setIsEnabled(true);
 
-                        // In case of form login, store the password
-                        if (LoginSource.FORM.equals(user.getSource())) {
-                            if (user.getPassword() == null || user.getPassword().isBlank()) {
-                                return Mono.error(new AppsmithException(AppsmithError.INVALID_CREDENTIALS));
-                            }
-
-                            /**
-                             * At this point, the user's password is encoded (not sure why). So no need to
-                             * double encode the password while setting it. Set it directly.
-                             * TODO : Figure out why after entering this flatMap that the password stored in the
-                             * user changes from simple string to encoded string.
-                             */
-                            savedUser.setPassword(user.getPassword());
-                        }
+                        // In case of form login, store the encrypted password.
+                        savedUser.setPassword(user.getPassword());
                         return repository.save(savedUser);
                     }
                     return Mono.error(new AppsmithException(AppsmithError.USER_ALREADY_EXISTS_SIGNUP, user.getUsername()));
                 })
-                .switchIfEmpty(
-                        commonConfig.isSignupDisabled() && !commonConfig.getAdminEmails().contains(user.getEmail())
-                                ? Mono.error(new AppsmithException(AppsmithError.SIGNUP_DISABLED))
-                                : userCreate(user)
-                )
+                .switchIfEmpty(Mono.defer(() -> signupIfAllowed(user)))
                 .flatMap(savedUser ->
                         emailConfig.isWelcomeEmailEnabled()
                                 ? sendWelcomeEmail(savedUser, finalOriginHeader)
                                 : Mono.just(savedUser)
                 );
+    }
 
+    private Mono<User> signupIfAllowed(User user) {
+        if (!commonConfig.getAdminEmails().contains(user.getEmail())) {
+            // If this is not an admin email address, only then do we check if signup should be allowed or not. Being an
+            // explicitly set admin email address trumps all everything and signup for this email can never be disabled.
+
+            if (commonConfig.isSignupDisabled()) {
+                // Signing up has been globally disabled. Reject.
+                return Mono.error(new AppsmithException(AppsmithError.SIGNUP_DISABLED));
+            }
+
+            final List<String> allowedDomains = user.getSource() == LoginSource.FORM
+                    ? commonConfig.getAllowedDomains()
+                    : commonConfig.getOauthAllowedDomains();
+            if (!CollectionUtils.isEmpty(allowedDomains) && !allowedDomains.contains(user.getEmail().split("@")[1])) {
+                // There is an explicit whitelist of email address domains that should be allowed. If the new email is
+                // of a different domain, reject.
+                return Mono.error(new AppsmithException(AppsmithError.SIGNUP_DISABLED));
+            }
+        }
+
+        // No special configurations found, allow signup for the new user.
+        return userCreate(user);
     }
 
     public Mono<User> sendWelcomeEmail(User user, String originHeader) {

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -23,6 +23,7 @@ spring.security.oauth2.client.registration.github.client-secret=${APPSMITH_OAUTH
 spring.security.oauth2.client.provider.github.userNameAttribute=login
 
 # Accounts from specific domains are allowed to login
+# DEPRECATED, in favor of signup.allowed-domains
 oauth2.allowed-domains=${APPSMITH_OAUTH2_ALLOWED_DOMAINS:}
 
 # Segment
@@ -85,3 +86,4 @@ management.metrics.distribution.sla.[http.server.requests]=1s
 
 # Support disabling signup with an environment variable
 signup.disabled = ${APPSMITH_SIGNUP_DISABLED:false}
+signup.allowed-domains=${APPSMITH_SIGNUP_ALLOWED_DOMAINS:}


### PR DESCRIPTION
## This PR achieves the following:

1. When signup is disabled with `APPSMITH_SIGNUP_DISABLED=true`, signing up is disabled from form as well as from OAuth.
2. When email domains that can sign up are restricted using `APPSMITH_SIGNUP_ALLOWED_DOMAINS=appsmith.com,example.com`, then any email with a domain other than these will not be allowed to sign up, from form or OAuth.

## However, the following facts still hold:

1. Any existing user can login using any method. A user who signed up with the form, can later login using OAuth, irrespective of the above two settings.
2. Any new user who has been *invited* by an existing user, can sign up using form or OAuth, irrespective of the above two settings.

## Tests done:

1. Signup from form with a new appsmith.com address.
2. Signup from form with a new gmail.com address.
3. Signup from form with an invited appsmith.com address.
4. Signup from form with an invited gmail.com address.
1. Signup from OAuth with a new appsmith.com address.
2. Signup from OAuth with a new gmail.com address.
3. Signup from OAuth with an invited appsmith.com address.
4. Signup from OAuth with an invited gmail.com address.

### These tests have been run once for each situation below:

1. Vanilla settings. No `APPSMITH_SIGNUP_DISABLED` or `APPSMITH_SIGNUP_ALLOWED_DOMAINS`.
2. Just `APPSMITH_SIGNUP_DISABLED=true`.
3. Just `APPSMITH_SIGNUP_ALLOWED_DOMAINS=appsmith.com`.
4. Both `APPSMITH_SIGNUP_DISABLED=true` and `APPSMITH_SIGNUP_ALLOWED_DOMAINS=appsmith.com`.

All tests resulted in expected results.

## Additional Notes

We have kept backwards compatible support for `APPSMITH_OAUTH2_ALLOWED_DOMAINS`, but have marked it as deprecated. However, we don't show any warning that this has been deprecated. This list of domains behaves the same as the other, but doesn't affect form-based signups.
