### PR TITLE
Fix order of roles in share modal

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/RoleGraph.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/RoleGraph.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static com.appsmith.server.acl.AppsmithRole.APPLICATION_ADMIN;
@@ -43,7 +43,7 @@ public class RoleGraph {
     public Set<AppsmithRole> generateHierarchicalRoles(String roleName) {
         AppsmithRole role = AppsmithRole.generateAppsmithRoleFromName(roleName);
 
-        Set<AppsmithRole> childrenRoles = new HashSet<>();
+        Set<AppsmithRole> childrenRoles = new LinkedHashSet<>();
         childrenRoles.add(role);
         BreadthFirstIterator<AppsmithRole, DefaultEdge> breadthFirstIterator = new BreadthFirstIterator<>(hierarchyGraph, role);
         while(breadthFirstIterator.hasNext()) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
@@ -34,6 +34,7 @@ import reactor.core.scheduler.Scheduler;
 
 import javax.validation.Validator;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,7 +44,6 @@ import static com.appsmith.server.acl.AclPermission.MANAGE_ORGANIZATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_INVITE_USERS;
 import static com.appsmith.server.acl.AclPermission.READ_USERS;
 import static com.appsmith.server.acl.AclPermission.USER_MANAGE_ORGANIZATIONS;
-import static java.util.stream.Collectors.toMap;
 
 @Slf4j
 @Service
@@ -268,9 +268,10 @@ public class OrganizationServiceImpl extends BaseService<OrganizationRepository,
 
                     Set<AppsmithRole> appsmithRoles = roleGraph.generateHierarchicalRoles(roleName);
 
-                    Map<String, String> appsmithRolesMap = appsmithRoles
-                            .stream()
-                            .collect(toMap(AppsmithRole::getName, AppsmithRole::getDescription));
+                    final Map<String, String> appsmithRolesMap = new LinkedHashMap<>();
+                    for (final AppsmithRole role : appsmithRoles) {
+                        appsmithRolesMap.put(role.getName(), role.getDescription());
+                    }
 
                     return Mono.just(appsmithRolesMap);
                 });


### PR DESCRIPTION
The order in the roles dropdown in the Share modal is unpredictable and often counter-intuitive. They are not ordered in increasing or decreasing privileges which makes it very confusing when trying to make a choice by reading the descriptions. This PR fixes the order and makes it predictable.

Screenshot with counter-intuitive order of roles:
![Screenshot 2021-02-12 at 15 01 20](https://user-images.githubusercontent.com/120119/107751411-620a2300-6d43-11eb-8e31-1814f3e1946d.png)
