### PR TITLE
change response data format for AmazonS3 Plugin

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -433,10 +433,10 @@ public class AmazonS3Plugin extends BasePlugin {
                                 listOfFilesAndUrls.add(fileUrlPair);
                             }
 
-                            actionResult = Map.of("Files", listOfFilesAndUrls);
+                            actionResult = Map.of("files", listOfFilesAndUrls);
                         }
                         else {
-                            actionResult = Map.of("Files", listOfFiles);
+                            actionResult = Map.of("files", listOfFiles);
                         }
                         break;
                     case UPLOAD_FILE_FROM_BODY:
@@ -477,7 +477,7 @@ public class AmazonS3Plugin extends BasePlugin {
                             signedUrl = uploadFileFromBody(connection, bucketName, path, body, false,
                                     durationInMilliseconds);
                         }
-                        actionResult = signedUrl;
+                        actionResult = Map.of("signed_url", signedUrl);
                         break;
                     case READ_FILE:
                         String result = null;
@@ -489,11 +489,11 @@ public class AmazonS3Plugin extends BasePlugin {
                         else {
                             result = readFile(connection, bucketName, path, false);
                         }
-                        actionResult = result;
+                        actionResult = Map.of("data", result);
                         break;
                     case DELETE_FILE:
                         connection.deleteObject(bucketName, path);
-                        actionResult = Map.of("Status", "File deleted successfully");
+                        actionResult = Map.of("status", "File deleted successfully");
                         break;
                     default:
                         throw new AppsmithPluginException(

--- a/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
@@ -215,7 +215,7 @@ public class AmazonS3PluginTest {
                                     dummyKey1,
                                     dummyKey2
                             },
-                            node.get("Files").toArray()
+                            node.get("files").toArray()
                     );
                 })
                 .verifyComplete();
@@ -376,7 +376,8 @@ public class AmazonS3PluginTest {
         StepVerifier.create(resultMono)
                 .assertNext(result -> {
                     assertTrue(result.getIsExecutionSuccess());
-                    assertEquals(dummyContent, result.getBody());
+                    Map<String, Object> body = (Map<String, Object>) result.getBody();
+                    assertEquals(dummyContent, body.get("data"));
                 })
                 .verifyComplete();
     }
@@ -419,7 +420,8 @@ public class AmazonS3PluginTest {
         StepVerifier.create(resultMono)
                 .assertNext(result -> {
                     assertTrue(result.getIsExecutionSuccess());
-                    assertEquals(new String(Base64.encode(dummyContent.getBytes())), result.getBody());
+                    Map<String, Object> body = (Map<String, Object>) result.getBody();
+                    assertEquals(new String(Base64.encode(dummyContent.getBytes())), body.get("data"));
                 })
                 .verifyComplete();
     }
@@ -453,7 +455,7 @@ public class AmazonS3PluginTest {
                     assertTrue(result.getIsExecutionSuccess());
 
                     Map<String, String> node = (Map<String, String>) result.getBody();
-                    assertEquals("File deleted successfully", node.get("Status"));
+                    assertEquals("File deleted successfully", node.get("status"));
                 })
                 .verifyComplete();
     }
@@ -510,7 +512,7 @@ public class AmazonS3PluginTest {
                                     dummyKey1,
                                     dummyKey2
                             },
-                            node.get("Files").toArray()
+                            node.get("files").toArray()
                     );
                 })
                 .verifyComplete();
@@ -582,7 +584,7 @@ public class AmazonS3PluginTest {
                             (Map<String, ArrayList<ArrayList<String>>>)result.getBody();
                     assertArrayEquals(
                             expectedResult.toArray(),
-                            node.get("Files").toArray()
+                            node.get("files").toArray()
                     );
                 })
                 .verifyComplete();


### PR DESCRIPTION
## Description
Change reponse format. Earlier some responses could be accessed as query.data (based on some early feedback) but it shows up with an error label on UI. So changing it to a valid format. 

Fixes #3022 
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
