### PR TITLE
Null check in getConfigInitialValues

### DIFF
--- a/app/client/src/components/formControls/utils.ts
+++ b/app/client/src/components/formControls/utils.ts
@@ -29,6 +29,8 @@ export const isHidden = (values: any, hiddenConfig?: HiddenType) => {
 
 export const getConfigInitialValues = (config: Record<string, any>[]) => {
   const configInitialValues = {};
+  if (!Array.isArray(config)) return configInitialValues;
+
   const parseConfig = (section: any): any => {
     return map(section.children, (subSection: any) => {
       if ("children" in subSection) {

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -101,10 +101,9 @@ export function* createActionSaga(
           actionPayload.payload.pluginId,
         );
       }
-      if (formConfig) {
-        const initialValues = yield call(getConfigInitialValues, formConfig);
-        payload = merge(initialValues, actionPayload.payload);
-      }
+
+      const initialValues = yield call(getConfigInitialValues, formConfig);
+      payload = merge(initialValues, actionPayload.payload);
     }
 
     const response: ActionCreateUpdateResponse = yield ActionAPI.createAPI(

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -101,8 +101,10 @@ export function* createActionSaga(
           actionPayload.payload.pluginId,
         );
       }
-      const initialValues = yield call(getConfigInitialValues, formConfig);
-      payload = merge(initialValues, actionPayload.payload);
+      if (formConfig) {
+        const initialValues = yield call(getConfigInitialValues, formConfig);
+        payload = merge(initialValues, actionPayload.payload);
+      }
     }
 
     const response: ActionCreateUpdateResponse = yield ActionAPI.createAPI(


### PR DESCRIPTION
There was a bug introduced in #2976

Editor config doesn't exist in all plugins, undefined broke `getConfigInitialValues`. Added null check there.