### PR TITLE
Correcting the display message for query actions based on isExecutionSuccess flag

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/Form.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Form.tsx
@@ -9,7 +9,7 @@ import {
   OptionTypeBase,
   SingleValueProps,
 } from "react-select";
-import { isString } from "lodash";
+import { isString, isArray } from "lodash";
 import history from "utils/history";
 import { DATA_SOURCES_EDITOR_URL } from "constants/routes";
 import Button from "components/editorComponents/Button";
@@ -270,6 +270,7 @@ type QueryFormProps = {
   DATASOURCES_OPTIONS: any;
   executedQueryData: {
     body: Record<string, any>[] | string;
+    isExecutionSuccess: boolean;
   };
   applicationId: string;
   runErrorMessage: string | undefined;
@@ -314,16 +315,32 @@ const QueryEditorForm: React.FC<Props> = (props: Props) => {
 
   let error = runErrorMessage;
   let output: Record<string, any>[] | null = null;
+  let displayMessage = "";
 
   if (executedQueryData) {
-    if (isString(executedQueryData.body)) {
-      error = executedQueryData.body;
+    if (!executedQueryData.isExecutionSuccess) {
+      error = String(executedQueryData.body);
+    } else if (isString(executedQueryData.body)) {
+      output = JSON.parse(executedQueryData.body);
     } else {
       output = executedQueryData.body;
     }
   }
 
-  const isSQL = responseType === "TABLE";
+  // Constructing the header of the response based on the response
+  if (!output) {
+    displayMessage = "No data records to display";
+  } else if (isArray(output)) {
+    // The returned output is an array
+    displayMessage = output.length
+      ? "Query response"
+      : "No data records to display";
+  } else {
+    // Output is a JSON object. We can display a single object
+    displayMessage = "Query response";
+  }
+
+  const isTableResponse = responseType === "TABLE";
 
   const dispatch = useDispatch();
   const onAddWidget = () => {
@@ -534,11 +551,7 @@ const QueryEditorForm: React.FC<Props> = (props: Props) => {
                   {!error && output && dataSources.length && (
                     <OutputWrapper>
                       <OutputHeader>
-                        <p className="statementTextArea">
-                          {output.length
-                            ? "Query response"
-                            : "No data records to display"}
-                        </p>
+                        <p className="statementTextArea">{displayMessage}</p>
                         {!!output.length && (
                           <Boxed step={OnboardingStep.SUCCESSFUL_BINDING}>
                             <AddWidgetButton
@@ -550,7 +563,7 @@ const QueryEditorForm: React.FC<Props> = (props: Props) => {
                           </Boxed>
                         )}
                       </OutputHeader>
-                      {isSQL ? (
+                      {isTableResponse ? (
                         <Table data={output} />
                       ) : (
                         <JSONViewer src={output} />

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -1,5 +1,8 @@
 package com.external.plugins;
 
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.exceptions.pluginExceptions.StaleConnectionException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.Connection;
@@ -9,9 +12,6 @@ import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.SSLDetails;
-import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
-import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
-import com.appsmith.external.exceptions.pluginExceptions.StaleConnectionException;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.mongodb.MongoCommandException;
@@ -84,7 +84,7 @@ public class MongoPlugin extends BasePlugin {
          * https://docs.huihoo.com/mongodb/3.4/reference/command/index.html
          *
          * @param mongoClient             : This is the connection that is established to the data source. This connection is according
-         *                                  to the parameters in Datasource Configuration
+         *                                to the parameters in Datasource Configuration
          * @param datasourceConfiguration : These are the configurations which have been used to create a Datasource from a Plugin
          * @param actionConfiguration     : These are the configurations which have been used to create an Action from a Datasource.
          * @return Result data from executing the action's query.
@@ -105,9 +105,17 @@ public class MongoPlugin extends BasePlugin {
             ActionExecutionResult result = new ActionExecutionResult();
 
             return mongoOutputMono
+                    .onErrorMap(
+                            MongoCommandException.class,
+                            error -> new AppsmithPluginException(
+                                    AppsmithPluginError.PLUGIN_ERROR,
+                                    error.getErrorMessage()
+                            )
+                    )
                     .flatMap(mongoOutput -> {
                         try {
                             JSONObject outputJson = new JSONObject(mongoOutput.toJson());
+                            System.out.println(outputJson);
                             //The output json contains the key "ok". This is the status of the command
                             BigInteger status = outputJson.getBigInteger("ok");
                             JSONArray headerArray = new JSONArray();
@@ -206,7 +214,7 @@ public class MongoPlugin extends BasePlugin {
                                     )
                     )
                     .onErrorMap(e -> {
-                        if(!(e instanceof AppsmithPluginException)) {
+                        if (!(e instanceof AppsmithPluginException)) {
                             return new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, e.getMessage());
                         }
 
@@ -341,12 +349,12 @@ public class MongoPlugin extends BasePlugin {
                     .flatMap(mongoClient -> {
                         return Mono.zip(Mono.just(mongoClient),
                                 Mono.from(mongoClient.getDatabase("admin").runCommand(new Document(
-                                "listDatabases", 1))));
+                                        "listDatabases", 1))));
                     })
                     .doOnSuccess(tuple -> {
                         MongoClient mongoClient = tuple.getT1();
 
-                        if(mongoClient != null) {
+                        if (mongoClient != null) {
                             mongoClient.close();
                         }
                     })
@@ -358,7 +366,7 @@ public class MongoPlugin extends BasePlugin {
                          *    the MongoDB instance is valid. It also means we don't have access to the admin database,
                          *    but that's okay for our purposes here.
                          */
-                        if(error instanceof MongoCommandException &&
+                        if (error instanceof MongoCommandException &&
                                 ((MongoCommandException) error).getErrorCodeName().equals("Unauthorized")) {
                             return Mono.just(new DatasourceTestResult());
                         }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -115,7 +115,7 @@ public class MongoPlugin extends BasePlugin {
                     .flatMap(mongoOutput -> {
                         try {
                             JSONObject outputJson = new JSONObject(mongoOutput.toJson());
-                            System.out.println(outputJson);
+
                             //The output json contains the key "ok". This is the status of the command
                             BigInteger status = outputJson.getBigInteger("ok");
                             JSONArray headerArray = new JSONArray();

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -179,7 +179,7 @@ public class MongoPluginTest {
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("{\n" +
                 "      find: \"users\",\n" +
-                "      filter: { $is: {} },\n" +
+                "      filter: { age: { $gte: 30 } },\n" +
                 "      sort: { id: 1 },\n" +
                 "      limit: 10,\n" +
                 "    }");

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -1,5 +1,6 @@
 package com.external.plugins;
 
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.Connection;
@@ -36,8 +37,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for MongoPlugin
@@ -178,7 +179,7 @@ public class MongoPluginTest {
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setBody("{\n" +
                 "      find: \"users\",\n" +
-                "      filter: { age: { $gte: 30 } },\n" +
+                "      filter: { $is: {} },\n" +
                 "      sort: { id: 1 },\n" +
                 "      limit: 10,\n" +
                 "    }");
@@ -194,6 +195,29 @@ public class MongoPluginTest {
                     assertEquals(2, ((ArrayNode) result.getBody()).size());
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    public void testExecuteInvalidReadQuery() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        Mono<MongoClient> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setBody("{\n" +
+                "      find: \"users\",\n" +
+                "      filter: { $is: {} },\n" +
+                "      sort: { id: 1 },\n" +
+                "      limit: 10,\n" +
+                "    }");
+
+        Mono<Object> executeMono = dsConnectionMono.flatMap(conn -> pluginExecutor.execute(conn, dsConfig, actionConfiguration));
+
+        StepVerifier.create(executeMono)
+                .expectErrorMatches(throwable ->
+                        throwable instanceof AppsmithPluginException &&
+                        throwable.getMessage().equals("unknown top level operator: $is")
+                )
+                .verify();
     }
 
     @Test


### PR DESCRIPTION
Also improving the mongo error response string. Now we only send the error message instead of the entire stack trace back.

## Description

Fixes #2732 
Fixes #3046

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual
- Junit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
