### PR TITLE
Internal Fix: Property panel doesn't scroll to top when opened

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/index.tsx
@@ -82,6 +82,7 @@ const PropertyPaneView = (
 };
 
 class PropertyPane extends Component<PropertyPaneProps, PropertyPaneState> {
+  private panelWrapperRef = React.createRef<HTMLDivElement>();
   render() {
     if (this.props.isVisible) {
       log.debug("Property pane rendered");
@@ -109,11 +110,16 @@ class PropertyPane extends Component<PropertyPaneProps, PropertyPaneState> {
     if (!widgetProperties) return <PropertyPaneWrapper />;
     return (
       <PropertyPaneWrapper
+        ref={this.panelWrapperRef}
         onClick={(e: any) => {
           e.stopPropagation();
         }}
       >
         <StyledPanelStack
+          onOpen={() => {
+            const parent = this.panelWrapperRef.current;
+            parent?.scrollTo(0, 0);
+          }}
           initialPanel={{
             component: PropertyPaneView,
             props: {


### PR DESCRIPTION
## Description
Fix issue where the panel isn't scrolled to top when opening it

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
