### PR TITLE
Internal Fix: Missing `currentRow` in computedValue field

### DIFF
--- a/app/client/src/utils/migrations/TableWidget.ts
+++ b/app/client/src/utils/migrations/TableWidget.ts
@@ -101,7 +101,7 @@ export const tableWidgetPropertyPaneMigrations = (
               ? columnNameMap[accessor]
               : accessor,
           // Generate computed value
-          computedValue: `{{${child.widgetName}.map((currentRow) => { return currentRow.${accessor}})}}`,
+          computedValue: `{{${child.widgetName}.tableData.map((currentRow) => { return currentRow.${accessor}})}}`,
         };
         // copy inputForma nd outputFormat for date column types
         if (columnTypeMap && columnTypeMap[accessor]) {


### PR DESCRIPTION
## Description
When tables are migrated, the computedValue for the columns do not have the  term `currentRow`

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
