### PR TITLE
Fix navigation to modal widget's children from the entity explorer

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Widgets/WidgetEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Widgets/WidgetEntity.tsx
@@ -111,6 +111,11 @@ export const WidgetEntity = memo((props: WidgetEntityProps) => {
     props.parentModalId,
   );
 
+  const { widgetType, widgetId, parentModalId } = props;
+  const parentModalIdForChildren = useMemo(() => {
+    return widgetType === "MODAL_WIDGET" ? widgetId : parentModalId;
+  }, [widgetType, widgetId, parentModalId]);
+
   if (UNREGISTERED_WIDGETS.indexOf(props.widgetType) > -1)
     return <React.Fragment />;
 
@@ -153,6 +158,7 @@ export const WidgetEntity = memo((props: WidgetEntityProps) => {
             key={child.widgetId}
             searchKeyword={props.searchKeyword}
             pageId={props.pageId}
+            parentModalId={parentModalIdForChildren}
           />
         ))}
       {!(props.childWidgets && props.childWidgets.length > 0) &&

--- a/app/client/src/pages/Editor/Explorer/Widgets/WidgetEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Widgets/WidgetEntity.tsx
@@ -112,6 +112,11 @@ export const WidgetEntity = memo((props: WidgetEntityProps) => {
   );
 
   const { widgetType, widgetId, parentModalId } = props;
+  /**
+   * While navigating to a widget we need to show a modal if the widget is nested within it
+   * Since the immediate parent for the widget would be a canvas instead of the modal,
+   * so we track the immediate modal parent for the widget
+   */
   const parentModalIdForChildren = useMemo(() => {
     return widgetType === "MODAL_WIDGET" ? widgetId : parentModalId;
   }, [widgetType, widgetId, parentModalId]);


### PR DESCRIPTION
## Description
Fix navigation to modal widget's children from the entity explorer by passing `parentModalId` to non-immediate descendents as well.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
