### PR TITLE
[Feature] Un-select row (#2342)

### DIFF
--- a/app/client/src/components/designSystems/appsmith/ReactTableComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/ReactTableComponent.tsx
@@ -292,7 +292,7 @@ const ReactTableComponent = (props: ReactTableComponentProps) => {
     row: { original: Record<string, unknown>; index: number },
     isSelected: boolean,
   ) => {
-    if (!isSelected || !!props.multiRowSelection) {
+    if (!isSelected || !props.multiRowSelection || props.multiRowSelection) {
       props.onRowClick(row.original, row.index);
     }
   };

--- a/app/client/src/widgets/TableWidget.tsx
+++ b/app/client/src/widgets/TableWidget.tsx
@@ -726,6 +726,12 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
         ),
       );
     } else {
+      const selectedRowIndex = isNumber(this.props.selectedRowIndex)
+        ? this.props.selectedRowIndex
+        : -1;
+      if (selectedRowIndex === index) {
+        index = -1;
+      }
       this.props.updateWidgetMetaProperty("selectedRowIndex", index);
       this.props.updateWidgetMetaProperty(
         "selectedRow",


### PR DESCRIPTION
## Description
Allow users to clear selection in widget table without multi-select option enabled.
Fixes: #2342 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually

## Checklist:
- [v] My code follows the style guidelines of this project
- [v] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [v] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [v] New and existing unit tests pass locally with my changes
