### PR TITLE
Fix #2342 Un-select row

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/index.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/index.tsx
@@ -163,7 +163,7 @@ const ReactTableComponent = (props: ReactTableComponentProps) => {
     row: { original: Record<string, unknown>; index: number },
     isSelected: boolean,
   ) => {
-    if (!isSelected || !!props.multiRowSelection) {
+    if (!isSelected || props.multiRowSelection || !props.multiRowSelection) {
       props.onRowClick(row.original, row.index);
     }
   };

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -949,6 +949,12 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
         ),
       );
     } else {
+      const selectedRowIndex = isNumber(this.props.selectedRowIndex)
+        ? this.props.selectedRowIndex
+        : -1;
+      if (selectedRowIndex === index) {
+        index = -1;
+      }
       this.props.updateWidgetMetaProperty("selectedRowIndex", index);
       this.props.updateWidgetMetaProperty(
         "selectedRow",

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -954,18 +954,19 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
         : -1;
       if (selectedRowIndex === index) {
         index = -1;
+      } else {
+        this.props.updateWidgetMetaProperty(
+          "selectedRow",
+          this.props.filteredTableData[index],
+          {
+            dynamicString: this.props.onRowSelected,
+            event: {
+              type: EventType.ON_ROW_SELECTED,
+            },
+          },
+        );
       }
       this.props.updateWidgetMetaProperty("selectedRowIndex", index);
-      this.props.updateWidgetMetaProperty(
-        "selectedRow",
-        this.props.filteredTableData[index],
-        {
-          dynamicString: this.props.onRowSelected,
-          event: {
-            type: EventType.ON_ROW_SELECTED,
-          },
-        },
-      );
     }
   };
 


### PR DESCRIPTION
## Description
Allow Appsmith users to clear selection in a widget table without multi-select option enabled.

Fixes #2342 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manually

## Checklist:
- [o] My code follows the style guidelines of this project
- [o] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [o] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [o] New and existing unit tests pass locally with my changes
