### PR TITLE
Fix app title widths for both viewer and editor

### DIFF
--- a/app/client/src/components/ads/EditableText.tsx
+++ b/app/client/src/components/ads/EditableText.tsx
@@ -45,7 +45,7 @@ export type EditableTextProps = CommonComponentProps & {
   underline?: boolean;
 };
 
-const EditableTextWrapper = styled.div<{
+export const EditableTextWrapper = styled.div<{
   filled: boolean;
 }>`
   width: ${(props) => (!props.filled ? "234px" : "100%")};

--- a/app/client/src/components/ads/EditableText.tsx
+++ b/app/client/src/components/ads/EditableText.tsx
@@ -48,7 +48,15 @@ export type EditableTextProps = CommonComponentProps & {
 export const EditableTextWrapper = styled.div<{
   filled: boolean;
 }>`
-  width: ${(props) => (!props.filled ? "234px" : "100%")};
+  ${(props) =>
+    !props.filled
+      ? `
+    width: 243px;
+  `
+      : `
+    width: 100%;
+    flex: 1;
+  `}
   .error-message {
     margin-left: ${(props) => props.theme.spaces[5]}px;
     color: ${(props) => props.theme.colors.danger.main};

--- a/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
+++ b/app/client/src/pages/AppViewer/viewer/AppViewerHeader.tsx
@@ -46,7 +46,6 @@ const HeaderWrapper = styled(StyledHeader)<{ hasPages: boolean }>`
   color: white;
   flex-direction: column;
   .${Classes.TEXT} {
-    max-width: 194px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -73,6 +72,10 @@ const HeaderWrapper = styled(StyledHeader)<{ hasPages: boolean }>`
   & ${Profile} {
     width: 24px;
     height: 24px;
+  }
+
+  & .current-app-name {
+    overflow: auto;
   }
 `;
 

--- a/app/client/src/pages/Editor/EditableAppName.tsx
+++ b/app/client/src/pages/Editor/EditableAppName.tsx
@@ -1,4 +1,7 @@
-import EditableText, { EditableTextProps } from "components/ads/EditableText";
+import EditableText, {
+  EditableTextProps,
+  EditableTextWrapper as AdsEditableTextWrapper,
+} from "components/ads/EditableText";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { Variant } from "components/ads/common";
@@ -34,6 +37,11 @@ const Container = styled.div`
   }
   &&&& .${Classes.EDITABLE_TEXT_CONTENT} {
     min-width: 0;
+  }
+  flex: 1;
+  overflow: auto;
+  ${AdsEditableTextWrapper} {
+    flex: 1;
   }
 `;
 

--- a/app/client/src/pages/Editor/EditableAppName.tsx
+++ b/app/client/src/pages/Editor/EditableAppName.tsx
@@ -1,7 +1,4 @@
-import EditableText, {
-  EditableTextProps,
-  EditableTextWrapper as AdsEditableTextWrapper,
-} from "components/ads/EditableText";
+import EditableText, { EditableTextProps } from "components/ads/EditableText";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { Variant } from "components/ads/common";
@@ -40,9 +37,6 @@ const Container = styled.div`
   }
   flex: 1;
   overflow: auto;
-  ${AdsEditableTextWrapper} {
-    flex: 1;
-  }
 `;
 
 export default function EditableTextWrapper(props: EditableTextWrapperProps) {

--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -50,6 +50,7 @@ import OnboardingIndicator from "components/editorComponents/Onboarding/Indicato
 import { getThemeDetails, ThemeMode } from "selectors/themeSelectors";
 
 const HeaderWrapper = styled(StyledHeader)`
+  width: 100%;
   padding-right: 0;
   padding-left: ${(props) => props.theme.spaces[7]}px;
   background-color: ${(props) => props.theme.colors.header.background};
@@ -83,6 +84,7 @@ const HeaderWrapper = styled(StyledHeader)`
 const HeaderSection = styled.div`
   display: flex;
   flex: 1;
+  overflow: auto;
   align-items: center;
   :nth-child(1) {
     justify-content: flex-start;
@@ -211,7 +213,7 @@ export const EditorHeader = (props: EditorHeaderProps) => {
                 defaultValue={currentApplication.name || ""}
                 editInteractionKind={EditInteractionKind.SINGLE}
                 className="t--application-name editable-application-name"
-                fill={false}
+                fill={true}
                 savingState={
                   isSavingName ? SavingState.STARTED : SavingState.NOT_STARTED
                 }


### PR DESCRIPTION
## Description
Increase allowed width for app title for both viewer and editor

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
