### PR TITLE
Add toast for trigger errors

### DIFF
--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -5,7 +5,7 @@ import {
 } from "constants/BindingsConstants";
 import { Action } from "entities/Action";
 import moment from "moment-timezone";
-import { WidgetProps } from "../widgets/BaseWidget";
+import { WidgetProps } from "widgets/BaseWidget";
 import parser from "fast-xml-parser";
 
 export type DependencyMap = Record<string, Array<string>>;
@@ -91,6 +91,7 @@ export enum EvalErrorTypes {
   EVAL_ERROR = "EVAL_ERROR",
   UNKNOWN_ERROR = "UNKNOWN_ERROR",
   BAD_UNEVAL_TREE_ERROR = "BAD_UNEVAL_TREE_ERROR",
+  EVAL_TRIGGER_ERROR = "EVAL_TRIGGER_ERROR",
 }
 
 export type EvalError = {

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -19,11 +19,11 @@ import {
   isPathADynamicBinding,
   isPathADynamicTrigger,
   unsafeFunctionForEval,
-} from "../utils/DynamicBindingUtils";
+} from "utils/DynamicBindingUtils";
 import _ from "lodash";
-import { WidgetTypeConfigMap } from "../utils/WidgetFactory";
+import { WidgetTypeConfigMap } from "utils/WidgetFactory";
 import toposort from "toposort";
-import { DATA_BIND_REGEX } from "../constants/BindingsConstants";
+import { DATA_BIND_REGEX } from "constants/BindingsConstants";
 import equal from "fast-deep-equal/es6";
 import unescapeJS from "unescape-js";
 
@@ -46,7 +46,7 @@ import {
 import {
   EXECUTION_PARAM_KEY,
   EXECUTION_PARAM_REFERENCE_REGEX,
-} from "../constants/ActionConstants";
+} from "constants/ActionConstants";
 
 const ctx: Worker = self as any;
 
@@ -152,7 +152,17 @@ ctx.addEventListener(
           callbackData,
         );
         const cleanTriggers = removeFunctions(triggers);
-        const errors = dataTreeEvaluator.errors;
+        // Transforming eval errors into eval trigger errors. Since trigger
+        // errors occur less, we want to treat it separately
+        const errors = dataTreeEvaluator.errors.map((error) => {
+          if (error.type === EvalErrorTypes.EVAL_ERROR) {
+            return {
+              ...error,
+              type: EvalErrorTypes.EVAL_TRIGGER_ERROR,
+            };
+          }
+          return error;
+        });
         dataTreeEvaluator.clearErrors();
         return { triggers: cleanTriggers, errors };
       }


### PR DESCRIPTION
## Description
Evaluation errors are failed silently today and only shown in the browser console. This PR will add a toast if any evaluation error occurs when executing a trigger since those are more timely errors and harder to debug.


https://user-images.githubusercontent.com/12022471/108458982-c9702780-729b-11eb-9154-fdbeac140b92.mov



Fixes #1956

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
