### PR TITLE
Handle false (type: string) as falsy for the switch control (internal forms)

### DIFF
--- a/app/client/src/components/formControls/SwitchControl.tsx
+++ b/app/client/src/components/formControls/SwitchControl.tsx
@@ -32,6 +32,15 @@ const Info = styled.div`
 `;
 
 export class SwitchField extends React.Component<Props, any> {
+  get value() {
+    const { input } = this.props;
+    if (typeof input.value !== "string") return !!input.value;
+    else {
+      if (input.value.toLocaleLowerCase() === "false") return false;
+      else return !!input.value;
+    }
+  }
+
   render() {
     const { label, isRequired, input, info } = this.props;
 
@@ -42,7 +51,7 @@ export class SwitchField extends React.Component<Props, any> {
             {label} {isRequired && "*"}
           </StyledFormLabel>
           <StyledSwitch
-            checked={input.value}
+            checked={this.value}
             onChange={(value) => input.onChange(value)}
             large
           />


### PR DESCRIPTION
## Description
Handle false strings as falsy for the switch widget 
We need to handle this case since we have some limitations with the data type

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
