### PR TITLE
Fix/datasource name conflict issue

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -38,8 +38,8 @@ const FormTitle = (props: FormTitleProps) => {
     | undefined = useSelector((state: AppState) =>
     getDatasource(state, params.datasourceId),
   );
+
   const datasources: Datasource[] = useSelector(getDataSources);
-  const evalTree = useSelector(getDataTree);
   const [forceUpdate, setForceUpdate] = useState(false);
   const dispatch = useDispatch();
   const saveStatus: {
@@ -68,7 +68,7 @@ const FormTitle = (props: FormTitleProps) => {
           datasourcesNames[datasource.name] = datasource;
         });
 
-      return !isNameValid(name, { ...datasourcesNames, ...evalTree });
+      return !isNameValid(name, { ...datasourcesNames });
     },
     [datasources, currentDatasource],
   );

--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -10,7 +10,6 @@ import { getDatasource } from "selectors/entitiesSelector";
 import { useSelector, useDispatch } from "react-redux";
 import { Datasource } from "entities/Datasource";
 import { getDataSources } from "selectors/editorSelectors";
-import { getDataTree } from "selectors/dataTreeSelectors";
 import { isNameValid } from "utils/helpers";
 import { saveDatasourceName } from "actions/datasourceActions";
 import { Spinner } from "@blueprintjs/core";


### PR DESCRIPTION
## Description
Removes `evalTree` check for name conflicts on datasources

Fixes #3108

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
