### PR TITLE
Add support for setting.json

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -40,7 +40,6 @@ import Callout from "components/ads/Callout";
 import { useLocalStorage } from "utils/hooks/localstorage";
 import TooltipComponent from "components/ads/Tooltip";
 import { Position } from "@blueprintjs/core";
-import { getAction, getPlugin } from "selectors/entitiesSelector";
 
 const Form = styled.form`
   display: flex;

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -40,6 +40,7 @@ import Callout from "components/ads/Callout";
 import { useLocalStorage } from "utils/hooks/localstorage";
 import TooltipComponent from "components/ads/Tooltip";
 import { Position } from "@blueprintjs/core";
+import { getAction, getPlugin } from "selectors/entitiesSelector";
 
 const Form = styled.form`
   display: flex;

--- a/app/client/src/pages/Editor/QueryEditor/Form.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Form.tsx
@@ -35,7 +35,6 @@ import {
 import { ControlProps } from "components/formControls/BaseControl";
 import CenteredWrapper from "components/designSystems/appsmith/CenteredWrapper";
 import ActionSettings from "pages/Editor/ActionSettings";
-import { queryActionSettingsConfig } from "mockResponses/ActionSettings";
 import { addTableWidgetFromQuery } from "actions/widgetActions";
 import { OnboardingStep } from "constants/OnboardingConstants";
 import Boxed from "components/editorComponents/Onboarding/Boxed";
@@ -279,6 +278,7 @@ type QueryFormProps = {
     state: any;
   };
   editorConfig?: any;
+  settingConfig: any;
   loadingFormConfigs: boolean;
 };
 
@@ -579,7 +579,7 @@ const QueryEditorForm: React.FC<Props> = (props: Props) => {
               panelComponent: (
                 <SettingsWrapper>
                   <ActionSettings
-                    actionSettingsConfig={queryActionSettingsConfig}
+                    actionSettingsConfig={props.settingConfig}
                     formName={QUERY_EDITOR_FORM_NAME}
                   />
                 </SettingsWrapper>

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -29,6 +29,7 @@ import PerformanceTracker, {
   PerformanceTransactionName,
 } from "utils/PerformanceTracker";
 import AnalyticsUtil from "utils/AnalyticsUtil";
+import { queryActionSettingsConfig } from "mockResponses/ActionSettings";
 
 const EmptyStateContainer = styled.div`
   display: flex;
@@ -58,6 +59,7 @@ type ReduxStateProps = {
   isCreating: boolean;
   pluginImages: Record<string, string>;
   editorConfig: any;
+  settingConfig: any;
   loadingFormConfigs: boolean;
   isEditorInitialized: boolean;
 };
@@ -118,6 +120,7 @@ class QueryEditor extends React.Component<Props> {
       runErrorMessage,
       loadingFormConfigs,
       editorConfig,
+      settingConfig,
       isEditorInitialized,
     } = this.props;
     const { applicationId, pageId } = this.props.match.params;
@@ -154,6 +157,7 @@ class QueryEditor extends React.Component<Props> {
             onRunClick={this.handleRunClick}
             dataSources={dataSources}
             editorConfig={editorConfig}
+            settingConfig={settingConfig}
             loadingFormConfigs={loadingFormConfigs}
             DATASOURCES_OPTIONS={DATASOURCES_OPTIONS}
             executedQueryData={responses[queryId]}
@@ -178,7 +182,7 @@ const mapStateToProps = (state: AppState, props: any): ReduxStateProps => {
   const { runErrorMessage } = state.ui.queryPane;
   const { plugins } = state.entities;
 
-  const { editorConfigs, loadingFormConfigs } = plugins;
+  const { editorConfigs, loadingFormConfigs, settingConfigs } = plugins;
   const formData = getFormValues(QUERY_EDITOR_FORM_NAME)(state) as QueryAction;
   const queryAction = getAction(
     state,
@@ -194,6 +198,15 @@ const mapStateToProps = (state: AppState, props: any): ReduxStateProps => {
     editorConfig = editorConfigs[pluginId];
   }
 
+  let settingConfig: any;
+
+  if (settingConfigs && pluginId) {
+    settingConfig = settingConfigs[pluginId];
+  }
+  if (!settingConfig) {
+    settingConfig = queryActionSettingsConfig;
+  }
+
   return {
     pluginImages: getPluginImages(state),
     plugins: getPlugins(state),
@@ -205,6 +218,7 @@ const mapStateToProps = (state: AppState, props: any): ReduxStateProps => {
     isDeleting: state.ui.queryPane.isDeleting[props.match.params.queryId],
     formData,
     editorConfig,
+    settingConfig,
     loadingFormConfigs,
     isCreating: state.ui.apiPane.isCreating,
     isEditorInitialized: getIsEditorInitialized(state),

--- a/app/client/src/reducers/entityReducers/pluginsReducer.ts
+++ b/app/client/src/reducers/entityReducers/pluginsReducer.ts
@@ -10,6 +10,7 @@ export interface PluginFormPayload {
   id: string;
   form: any[];
   editor: any[];
+  setting: any[];
 }
 
 export interface PluginDataState {
@@ -17,6 +18,7 @@ export interface PluginDataState {
   loading: boolean;
   formConfigs: Record<string, any[]>;
   editorConfigs: Record<string, any[]>;
+  settingConfigs: Record<string, any[]>;
   loadingFormConfigs: boolean;
   loadingDBFormConfigs: boolean;
 }
@@ -26,6 +28,7 @@ const initialState: PluginDataState = {
   loading: false,
   formConfigs: {},
   editorConfigs: {},
+  settingConfigs: {},
   loadingFormConfigs: false,
   loadingDBFormConfigs: false,
 };
@@ -70,6 +73,10 @@ const pluginsReducer = createReducer(initialState, {
       editorConfigs: {
         ...state.editorConfigs,
         [action.payload.id]: action.payload.editor,
+      },
+      settingConfigs: {
+        ...state.settingConfigs,
+        [action.payload.id]: action.payload.setting,
       },
     };
   },

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -49,6 +49,7 @@ import {
   getAction,
   getCurrentPageNameByActionId,
   getPageNameByPageId,
+  getSettingConfig,
 } from "selectors/entitiesSelector";
 import { getDataSources } from "selectors/editorSelectors";
 import { PLUGIN_TYPE_API } from "constants/ApiEditorConstants";
@@ -77,13 +78,13 @@ export function* createActionSaga(
   try {
     let payload = actionPayload.payload;
     if (actionPayload.payload.pluginId) {
-      let formConfig;
-      formConfig = yield select(
+      let editorConfig;
+      editorConfig = yield select(
         getEditorConfig,
         actionPayload.payload.pluginId,
       );
 
-      if (!formConfig) {
+      if (!editorConfig) {
         const formConfigResponse: GenericApiResponse<any> = yield PluginsApi.fetchFormConfig(
           actionPayload.payload.pluginId,
         );
@@ -96,13 +97,24 @@ export function* createActionSaga(
           },
         });
 
-        formConfig = yield select(
+        editorConfig = yield select(
           getEditorConfig,
           actionPayload.payload.pluginId,
         );
       }
+      const settingConfig = yield select(
+        getSettingConfig,
+        actionPayload.payload.pluginId,
+      );
 
-      const initialValues = yield call(getConfigInitialValues, formConfig);
+      let initialValues = yield call(getConfigInitialValues, editorConfig);
+      if (settingConfig) {
+        const settingInitialValues = yield call(
+          getConfigInitialValues,
+          settingConfig,
+        );
+        initialValues = merge(initialValues, settingInitialValues);
+      }
       payload = merge(initialValues, actionPayload.payload);
     }
 

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -48,6 +48,7 @@ function* changeQuerySaga(actionPayload: ReduxAction<{ id: string }>) {
   const { id } = actionPayload.payload;
   const state = yield select();
   const editorConfigs = state.entities.plugins.editorConfigs;
+  const settingConfigs = state.entities.plugins.settingConfigs;
   let configInitialValues = {};
   // // Typescript says Element does not have blur function but it does;
   // document.activeElement &&
@@ -82,6 +83,7 @@ function* changeQuerySaga(actionPayload: ReduxAction<{ id: string }>) {
       currentEditorConfig = success.payload.editor;
     }
   }
+  const currentSettingConfig = settingConfigs[action.datasource.pluginId];
 
   // If config exists
   if (currentEditorConfig) {
@@ -90,6 +92,14 @@ function* changeQuerySaga(actionPayload: ReduxAction<{ id: string }>) {
       getConfigInitialValues,
       currentEditorConfig,
     );
+  }
+
+  if (currentSettingConfig) {
+    const settingInitialValues = yield call(
+      getConfigInitialValues,
+      currentSettingConfig,
+    );
+    configInitialValues = merge(configInitialValues, settingInitialValues);
   }
 
   // Merge the initial values and action.

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -101,6 +101,10 @@ export const getEditorConfig = (state: AppState, pluginId: string): any[] => {
   return state.entities.plugins.editorConfigs[pluginId];
 };
 
+export const getSettingConfig = (state: AppState, pluginId: string): any[] => {
+  return state.entities.plugins.settingConfigs[pluginId];
+};
+
 export const getActions = (state: AppState): ActionDataState =>
   state.entities.actions;
 

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/editor.json
@@ -5,13 +5,6 @@
       "id": 1,
       "children": [
         {
-          "label": "Use Prepared Statement",
-          "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-          "controlType": "SWITCH",
-          "isRequired": true,
-          "initialValue": true
-        },
-        {
           "label": "",
           "configProperty": "actionConfiguration.body",
           "controlType": "QUERY_DYNAMIC_TEXT"

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
@@ -1,0 +1,36 @@
+{
+  "setting": [
+    {
+      "sectionName": "",
+      "id": 1,
+      "children": [
+        {
+          "label": "Run query on page load",
+          "configProperty": "executeOnLoad",
+          "controlType": "SWITCH",
+          "info": "Will refresh data each time the page is loaded"
+        },
+        {
+          "label": "Request confirmation before running query",
+          "configProperty": "confirmBeforeExecute",
+          "controlType": "SWITCH",
+          "info": "Ask confirmation from the user each time before refreshing data"
+        },
+        {
+          "label": "Use Prepared Statement",
+          "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
+          "controlType": "SWITCH",
+          "isRequired": true,
+          "initialValue": true
+        },
+        {
+          "label": "Query timeout (in milliseconds)",
+          "info": "Maximum time after which the query will return",
+          "configProperty": "actionConfiguration.timeoutInMillisecond",
+          "controlType": "INPUT_TEXT",
+          "dataType": "NUMBER"
+        }
+      ]
+    }
+  ]
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PluginServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PluginServiceTest.java
@@ -97,7 +97,7 @@ public class PluginServiceTest {
                     assertThat(form).isNotNull();
                     assertThat(form.get("form")).isNotNull();
                     assertThat(form.get("editor")).isNull();
-                    assertThat(form.get("editor")).isNull();
+                    assertThat(form.get("setting")).isNull();
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PluginServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PluginServiceTest.java
@@ -68,6 +68,8 @@ public class PluginServiceTest {
                 .thenReturn(Mono.error(new AppsmithException(AppsmithError.PLUGIN_LOAD_FORM_JSON_FAIL)));
         Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("editor.json")))
                 .thenReturn(Mono.error(new AppsmithException(AppsmithError.PLUGIN_LOAD_FORM_JSON_FAIL)));
+        Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("setting.json")))
+                .thenReturn(Mono.error(new AppsmithException(AppsmithError.PLUGIN_LOAD_FORM_JSON_FAIL)));
 
         Mono<Map> formConfig = pluginService.getFormConfig("random-plugin-id");
 
@@ -86,12 +88,15 @@ public class PluginServiceTest {
                 .thenReturn(Mono.just(formMap));
         Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("editor.json")))
                 .thenReturn(Mono.error(new AppsmithException(AppsmithError.PLUGIN_LOAD_FORM_JSON_FAIL)));
+        Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("setting.json")))
+                .thenReturn(Mono.error(new AppsmithException(AppsmithError.PLUGIN_LOAD_FORM_JSON_FAIL)));
 
         Mono<Map> formConfig = pluginService.getFormConfig("random-plugin-id");
         StepVerifier.create(formConfig)
                 .assertNext(form -> {
                     assertThat(form).isNotNull();
                     assertThat(form.get("form")).isNotNull();
+                    assertThat(form.get("editor")).isNull();
                     assertThat(form.get("editor")).isNull();
                 })
                 .verifyComplete();
@@ -105,10 +110,15 @@ public class PluginServiceTest {
         Map editorMap = new HashMap();
         editorMap.put("editor", new Object());
 
+        Map settingMap = new HashMap();
+        settingMap.put("setting", new Object());
+
         Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("form.json")))
                 .thenReturn(Mono.just(formMap));
         Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("editor.json")))
                 .thenReturn(Mono.just(editorMap));
+        Mockito.when(pluginService.loadPluginResource(Mockito.anyString(), eq("setting.json")))
+                .thenReturn(Mono.just(settingMap));
 
         Mono<Map> formConfig = pluginService.getFormConfig("random-plugin-id");
         StepVerifier.create(formConfig)
@@ -116,6 +126,7 @@ public class PluginServiceTest {
                     assertThat(form).isNotNull();
                     assertThat(form.get("form")).isNotNull();
                     assertThat(form.get("editor")).isNotNull();
+                    assertThat(form.get("setting")).isNotNull();
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

Adds support for `setting.json` in plugins.


Todo: 
- [x] Add on query settings page
- [x] ~Add on API pane~ We've decided to keep API settings purely client side.

Fixes #3157

## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Manually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
