### PR TITLE
Fix popover position for editor header popovers

### DIFF
--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -84,7 +84,7 @@ const HeaderWrapper = styled(StyledHeader)`
 const HeaderSection = styled.div`
   display: flex;
   flex: 1;
-  overflow: auto;
+  overflow: hidden;
   align-items: center;
   :nth-child(1) {
     justify-content: flex-start;


### PR DESCRIPTION
## Description
Fix popover position for editor header popovers

[Ref](https://github.com/popperjs/popper-core/issues/248): `preventOverflow` by default will keep the popper between its scroll parent boundaries

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
