### PR TITLE
Fix #2712 - Duplicate Property For Map Widget

### DIFF
--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -191,7 +191,6 @@ export const entityDefinitions = {
   },
   MAP_WIDGET: {
     isVisible: isVisible,
-    mapCenter: "latLong",
     center: "latLong",
     markers: "[mapMarker]",
     selectedMarker: "mapMarker",


### PR DESCRIPTION
## Description
After a Map Widget created, the text field in the Text Widget can bind the map properties. Inside the map properties, "Map center" and "Center" are duplicate value. The "MapCenter" is deleted for the adjustment.

Fixes #2712  

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual Testing

## Checklist:
- [o] My code follows the style guidelines of this project
- [o ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [o] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [o] New and existing unit tests pass locally with my changes
