### PR TITLE
Sort order fix if property path gets updated via multiple start nodes

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -251,12 +251,19 @@ export default class DataTreeEvaluator {
     this.sortedDependencies.forEach((path) => {
       if (uniqueKeysInSortOrder.has(path)) {
         sortOrderPropertyPaths.push(path);
+        // remove from the uniqueKeysInSortOrder
+        uniqueKeysInSortOrder.delete(path);
       }
     });
+    // Add any remaining paths in the uniqueKeysInSortOrder
+    const completeSortOrder = [
+      ...Array.from(uniqueKeysInSortOrder),
+      ...sortOrderPropertyPaths,
+    ];
 
     //Trim this list to now remove the property paths which are simply entity names
     const finalSortOrderArray: Array<string> = [];
-    sortOrderPropertyPaths.forEach((propertyPath) => {
+    completeSortOrder.forEach((propertyPath) => {
       const lastIndexOfDot = propertyPath.lastIndexOf(".");
       // Only do this for property paths and not the entity themselves
       if (lastIndexOfDot !== -1) {

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -243,9 +243,16 @@ export default class DataTreeEvaluator {
 
     // Remove duplicates from this list. Since we explicitly walk down the tree and implicitly (by fetching parents) walk
     // up the tree, there are bound to be many duplicates.
-    const uniqueKeysInSortOrder = [...new Set(finalSortOrder)];
+    const uniqueKeysInSortOrder = new Set(finalSortOrder);
 
-    const sortOrderPropertyPaths = Array.from(uniqueKeysInSortOrder);
+    // if a property path evaluation gets triggered by diff top order changes
+    // this could lead to incorrect sort order in spite of the bfs traversal
+    const sortOrderPropertyPaths: string[] = [];
+    this.sortedDependencies.forEach((path) => {
+      if (uniqueKeysInSortOrder.has(path)) {
+        sortOrderPropertyPaths.push(path);
+      }
+    });
 
     //Trim this list to now remove the property paths which are simply entity names
     const finalSortOrderArray: Array<string> = [];


### PR DESCRIPTION
## Description
Sort order fix if property path gets updated via multiple start nodes

Fixes #3172 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
