### PR TITLE
Added selectedOptionLabel property in dropdown widget

### DIFF
--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -84,9 +84,19 @@ export const entityDefinitions = {
       "!doc": "The value selected in a single select dropdown",
       "!url": "https://docs.appsmith.com/widget-reference/dropdown",
     },
+    selectedOptionLabel: {
+      "!type": "string",
+      "!doc": "The selected option label in a single select dropdown",
+      "!url": "https://docs.appsmith.com/widget-reference/dropdown",
+    },
     selectedOptionValues: {
       "!type": "[string]",
       "!doc": "The array of values selected in a multi select dropdown",
+      "!url": "https://docs.appsmith.com/widget-reference/dropdown",
+    },
+    selectedOptionLabels: {
+      "!type": "[string]",
+      "!doc": "The array of selected option labels in a multi select dropdown",
       "!url": "https://docs.appsmith.com/widget-reference/dropdown",
     },
     isDisabled: "bool",

--- a/app/client/src/widgets/DropdownWidget.tsx
+++ b/app/client/src/widgets/DropdownWidget.tsx
@@ -114,6 +114,8 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
       isRequired: VALIDATION_TYPES.BOOLEAN,
       // onOptionChange: VALIDATION_TYPES.ACTION_SELECTOR,
       selectedOptionValues: VALIDATION_TYPES.ARRAY,
+      selectedOptionLabels: VALIDATION_TYPES.ARRAY,
+      selectedOptionLabel: VALIDATION_TYPES.TEXT,
       defaultOptionValue: VALIDATION_TYPES.DEFAULT_OPTION_VALUE,
     };
   }
@@ -127,6 +129,8 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
       selectedIndexArr: `{{ this.selectedOptionValueArr.map(o => _.findIndex(this.options, { value: o })) }}`,
       value: `{{ this.selectionType === 'SINGLE_SELECT' ? this.selectedOptionValue : this.selectedOptionValueArr }}`,
       selectedOptionValues: `{{ this.selectedOptionValueArr }}`,
+      selectedOptionLabels: `{{ this.selectionType === "MULTI_SELECT" ? this.selectedOptionValueArr.map(o => { const index = _.findIndex(this.options, { value: o }); return this.options[index]?.label; }) : [] }}`,
+      selectedOptionLabel: `{{(()=>{const index = _.findIndex(this.options, { value: this.selectedOptionValue }); return this.selectionType === "SINGLE_SELECT" ? this.options[index]?.label : ""; })()}}`,
     };
   }
 
@@ -282,6 +286,8 @@ export interface DropdownWidgetProps extends WidgetProps, WithMeta {
   isRequired: boolean;
   selectedOptionValue: string;
   selectedOptionValueArr: string[];
+  selectedOptionLabels: string[];
+  selectedOptionLabel: string;
 }
 
 export default DropdownWidget;


### PR DESCRIPTION
## Description
Allow access to selectedOptionLabel property in dropdown widget

Fixes #3115 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
