### PR TITLE
Fix issue while deleting a tab from explorer 

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -40,6 +40,7 @@ import {
   SetWidgetDynamicPropertyPayload,
   updateWidgetProperty,
   UpdateWidgetPropertyPayload,
+  updateWidgetPropertyRequest,
   UpdateWidgetPropertyRequestPayload,
 } from "actions/controlActions";
 import {
@@ -431,6 +432,23 @@ export function* deleteSaga(deleteAction: ReduxAction<WidgetDelete>) {
       // SPECIAL HANDLING FOR TABS IN A TABS WIDGET
       if (parent.type === WidgetTypes.TABS_WIDGET && widget.tabName) {
         widgetName = widget.tabName;
+        // Deleting a tab from the explorer doesn't remove the same
+        // from the "tabs" property of the widget.
+        // So updating the widget property here when the children length doesn't match
+        // `tabs` length
+        if (parent.children?.length !== parent.tabs.length) {
+          const filteredTabs = parent.tabs.filter(
+            (tab: any) => tab.widgetId !== widgetId,
+          );
+          yield put(
+            updateWidgetPropertyRequest(
+              parentId,
+              "tabs",
+              filteredTabs,
+              RenderModes.CANVAS,
+            ),
+          );
+        }
       }
       if (saveStatus && !disallowUndo) {
         Toaster.show({


### PR DESCRIPTION

## Description
Deleting from the explorer doesn't update the widgets `tab` property. So doing the same as a special case for tabs in a tab widget in the delete widget saga.

Fixes #2885 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
