### PR TITLE
Add feature to simultaneously modify and remove property paths in a widget

### DIFF
--- a/app/client/src/actions/controlActions.tsx
+++ b/app/client/src/actions/controlActions.tsx
@@ -1,5 +1,8 @@
 import { ReduxActionTypes, ReduxAction } from "constants/ReduxActionConstants";
-import { RenderMode } from "constants/WidgetConstants";
+import {
+  BatchPropertyUpdatePayload,
+  RenderMode,
+} from "constants/WidgetConstants";
 import { BatchAction, batchAction } from "actions/batchActions";
 import { DynamicPath } from "utils/DynamicBindingUtils";
 
@@ -40,7 +43,7 @@ export const updateWidgetProperty = (
 
 export const batchUpdateWidgetProperty = (
   widgetId: string,
-  updates: Record<string, unknown>,
+  updates: BatchPropertyUpdatePayload,
 ): ReduxAction<UpdateWidgetPropertyPayload> => ({
   type: ReduxActionTypes.BATCH_UPDATE_WIDGET_PROPERTY,
   payload: {
@@ -84,7 +87,7 @@ export interface UpdateWidgetPropertyRequestPayload {
 
 export interface UpdateWidgetPropertyPayload {
   widgetId: string;
-  updates: Record<string, unknown>;
+  updates: BatchPropertyUpdatePayload;
   dynamicUpdates?: {
     dynamicBindingPathList: DynamicPath[];
     dynamicTriggerPathList: DynamicPath[];

--- a/app/client/src/actions/controlActions.tsx
+++ b/app/client/src/actions/controlActions.tsx
@@ -1,8 +1,5 @@
 import { ReduxActionTypes, ReduxAction } from "constants/ReduxActionConstants";
-import {
-  BatchPropertyUpdatePayload,
-  RenderMode,
-} from "constants/WidgetConstants";
+import { RenderMode } from "constants/WidgetConstants";
 import { BatchAction, batchAction } from "actions/batchActions";
 import { DynamicPath } from "utils/DynamicBindingUtils";
 
@@ -40,6 +37,11 @@ export const updateWidgetProperty = (
     },
   });
 };
+
+export interface BatchPropertyUpdatePayload {
+  modify?: Record<string, unknown>; //Key value pairs of paths and values to update
+  remove?: string[]; //Array of paths to delete
+}
 
 export const batchUpdateWidgetProperty = (
   widgetId: string,

--- a/app/client/src/components/editorComponents/EditorContextProvider.tsx
+++ b/app/client/src/components/editorComponents/EditorContextProvider.tsx
@@ -12,7 +12,10 @@ import {
 } from "actions/controlActions";
 
 import { ExecuteActionPayload } from "constants/ActionConstants";
-import { RenderModes } from "constants/WidgetConstants";
+import {
+  BatchPropertyUpdatePayload,
+  RenderModes,
+} from "constants/WidgetConstants";
 import { OccupiedSpace } from "constants/editorConstants";
 
 import {
@@ -43,7 +46,7 @@ export type EditorContextType = {
   deleteWidgetProperty?: (widgetId: string, propertyPaths: string[]) => void;
   batchUpdateWidgetProperty?: (
     widgetId: string,
-    updates: Record<string, unknown>,
+    updates: BatchPropertyUpdatePayload,
   ) => void;
 };
 export const EditorContext: Context<EditorContextType> = createContext({});
@@ -119,7 +122,7 @@ const mapDispatchToProps = (dispatch: any) => {
       dispatch(deletePropertyAction(widgetId, propertyPaths)),
     batchUpdateWidgetProperty: (
       widgetId: string,
-      updates: Record<string, unknown>,
+      updates: BatchPropertyUpdatePayload,
     ) => {
       dispatch(batchUpdatePropertyAction(widgetId, updates));
     },

--- a/app/client/src/components/editorComponents/EditorContextProvider.tsx
+++ b/app/client/src/components/editorComponents/EditorContextProvider.tsx
@@ -9,13 +9,11 @@ import {
   updateWidgetPropertyRequest,
   deleteWidgetProperty as deletePropertyAction,
   batchUpdateWidgetProperty as batchUpdatePropertyAction,
+  BatchPropertyUpdatePayload,
 } from "actions/controlActions";
 
 import { ExecuteActionPayload } from "constants/ActionConstants";
-import {
-  BatchPropertyUpdatePayload,
-  RenderModes,
-} from "constants/WidgetConstants";
+import { RenderModes } from "constants/WidgetConstants";
 import { OccupiedSpace } from "constants/editorConstants";
 
 import {

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -92,8 +92,3 @@ export const MAIN_CONTAINER_WIDGET_NAME = "MainContainer";
 export const WIDGET_DELETE_UNDO_TIMEOUT = 7000;
 
 export const DEFAULT_CENTER = { lat: -34.397, lng: 150.644 };
-
-export interface BatchPropertyUpdatePayload {
-  modify?: Record<string, unknown>; //Key value pairs of paths and values to update
-  remove?: string[]; //Array of paths to delete
-}

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -92,3 +92,8 @@ export const MAIN_CONTAINER_WIDGET_NAME = "MainContainer";
 export const WIDGET_DELETE_UNDO_TIMEOUT = 7000;
 
 export const DEFAULT_CENTER = { lat: -34.397, lng: 150.644 };
+
+export interface BatchPropertyUpdatePayload {
+  modify?: Record<string, unknown>; //Key value pairs of paths and values to update
+  remove?: string[]; //Array of paths to delete
+}

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -71,7 +71,9 @@ const PropertyControl = memo((props: Props) => {
   const onBatchUpdateProperties = useCallback(
     (allUpdates: Record<string, unknown>) =>
       dispatch(
-        batchUpdateWidgetProperty(widgetProperties.widgetId, allUpdates),
+        batchUpdateWidgetProperty(widgetProperties.widgetId, {
+          modify: allUpdates,
+        }),
       ),
     [widgetProperties.widgetId, dispatch],
   );

--- a/app/client/src/sagas/OnboardingSagas.ts
+++ b/app/client/src/sagas/OnboardingSagas.ts
@@ -152,6 +152,7 @@ function* listenForWidgetAdditions() {
               avatar: 20,
               name: 30,
             },
+            migrated: false,
             ...getStandupTableDimensions(),
           }),
         );

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -4,7 +4,6 @@ import {
   ReduxActionTypes,
 } from "constants/ReduxActionConstants";
 import {
-  saveLayout,
   updateAndSaveLayout,
   WidgetAddChild,
   WidgetAddChildren,
@@ -54,7 +53,7 @@ import {
   isPathADynamicTrigger,
 } from "utils/DynamicBindingUtils";
 import { WidgetProps } from "widgets/BaseWidget";
-import _, { cloneDeep, isString, set } from "lodash";
+import _, { cloneDeep, isString, set, uniqBy } from "lodash";
 import WidgetFactory from "utils/WidgetFactory";
 import {
   buildWidgetBlueprint,
@@ -767,7 +766,7 @@ function* updateWidgetPropertySaga(
   // Push these updates via the batch update
   yield call(
     batchUpdateWidgetPropertySaga,
-    batchUpdateWidgetProperty(widgetId, updates),
+    batchUpdateWidgetProperty(widgetId, { modify: updates }),
   );
 }
 
@@ -808,14 +807,10 @@ function* setWidgetDynamicPropertySaga(
   yield put(updateAndSaveLayout(widgets));
 }
 
-function* batchUpdateWidgetPropertySaga(
-  action: ReduxAction<UpdateWidgetPropertyPayload>,
+function* getPropertiesToUpdate(
+  widgetId: string,
+  updates: Record<string, unknown>,
 ) {
-  const { updates, widgetId } = action.payload;
-  if (!widgetId) {
-    // Handling the case where sometimes widget id is not passed through here
-    return;
-  }
   const widget: WidgetProps = yield select(getWidget, widgetId);
 
   // Create a
@@ -874,16 +869,96 @@ function* batchUpdateWidgetPropertySaga(
     currentDynamicBindingPathList,
   );
 
-  // Send the updates
-  yield put(
-    updateWidgetProperty(widgetId, propertyUpdates, {
+  return {
+    propertyUpdates,
+    dynamicTriggerPathList,
+    dynamicBindingPathList,
+  };
+}
+
+function* batchUpdateWidgetPropertySaga(
+  action: ReduxAction<UpdateWidgetPropertyPayload>,
+) {
+  const start = performance.now();
+  const { updates, widgetId } = action.payload;
+  if (!widgetId) {
+    // Handling the case where sometimes widget id is not passed through here
+    return;
+  }
+  const { modify = {}, remove = [] } = updates;
+
+  const stateWidget: WidgetProps = yield select(getWidget, widgetId);
+  let widget = cloneDeep(stateWidget);
+  if (Object.keys(modify).length > 0) {
+    const {
+      propertyUpdates,
       dynamicTriggerPathList,
       dynamicBindingPathList,
-    }),
+    } = yield getPropertiesToUpdate(widgetId, modify);
+
+    // We loop over all updates
+    Object.entries(propertyUpdates).forEach(([propertyPath, propertyValue]) => {
+      // since property paths could be nested, we use lodash set method
+      widget = set(widget, propertyPath, propertyValue);
+    });
+
+    if (dynamicBindingPathList?.length) {
+      const currentList = widget.dynamicBindingPathList || [];
+      widget.dynamicBindingPathList = uniqBy(
+        [...currentList, ...dynamicBindingPathList],
+        "key",
+      );
+    }
+    if (dynamicTriggerPathList?.length) {
+      const currentList = widget.dynamicTriggerPathList || [];
+      widget.dynamicTriggerPathList = uniqBy(
+        [...currentList, ...dynamicTriggerPathList],
+        "key",
+      );
+    }
+  }
+
+  if (Array.isArray(remove) && remove.length > 0) {
+    widget = yield removeWidgetProperties(widget, remove);
+  }
+
+  const stateWidgets = yield select(getWidgets);
+  const widgets = { ...stateWidgets, [widgetId]: widget };
+
+  log.debug(
+    "Batch widget property update calculations took: ",
+    performance.now() - start,
+    "ms",
+  );
+  // Save the layout
+  yield put(updateAndSaveLayout(widgets));
+}
+
+function* removeWidgetProperties(widget: WidgetProps, paths: string[]) {
+  let dynamicTriggerPathList: DynamicPath[] = getWidgetDynamicTriggerPathList(
+    widget,
+  );
+  let dynamicBindingPathList: DynamicPath[] = getEntityDynamicBindingPathList(
+    widget,
   );
 
-  // Save the layout
-  yield put(saveLayout());
+  paths.forEach((propertyPath) => {
+    dynamicTriggerPathList = dynamicTriggerPathList.filter((dynamicPath) => {
+      return !isChildPropertyPath(propertyPath, dynamicPath.key);
+    });
+
+    dynamicBindingPathList = dynamicBindingPathList.filter((dynamicPath) => {
+      return !isChildPropertyPath(propertyPath, dynamicPath.key);
+    });
+  });
+
+  widget.dynamicBindingPathList = dynamicBindingPathList;
+  widget.dynamicTriggerPathList = dynamicTriggerPathList;
+  paths.forEach((propertyPath) => {
+    widget = unsetPropertyPath(widget, propertyPath) as WidgetProps;
+  });
+
+  return widget;
 }
 
 function* deleteWidgetPropertySaga(
@@ -894,43 +969,15 @@ function* deleteWidgetPropertySaga(
     // Handling the case where sometimes widget id is not passed through here
     return;
   }
+
   const stateWidget: WidgetProps = yield select(getWidget, widgetId);
-  let dynamicTriggerPathList: DynamicPath[] = getWidgetDynamicTriggerPathList(
-    stateWidget,
+  const widget = yield removeWidgetProperties(
+    cloneDeep(stateWidget),
+    propertyPaths,
   );
-  let dynamicBindingPathList: DynamicPath[] = getEntityDynamicBindingPathList(
-    stateWidget,
-  );
-
-  propertyPaths.forEach((propertyPath) => {
-    dynamicTriggerPathList = dynamicTriggerPathList.filter((dynamicPath) => {
-      return !isChildPropertyPath(propertyPath, dynamicPath.key);
-    });
-
-    dynamicBindingPathList = dynamicBindingPathList.filter((dynamicPath) => {
-      return !isChildPropertyPath(propertyPath, dynamicPath.key);
-    });
-  });
-
-  // yield put(
-  //   updateWidgetProperty(widgetId, {
-  //     dynamicTriggerPathList,
-  //     dynamicBindingPathList,
-  //   }),
-  // );
 
   const stateWidgets = yield select(getWidgets);
-  // Cloning because we probably froze the properties earlier
-  // TODO(abhinav): Check if we need to use immer to handle this.
-  let widget = _.cloneDeep(stateWidget);
-  widget.dynamicBindingPathList = dynamicBindingPathList;
-  widget.dynamicTriggerPathList = dynamicTriggerPathList;
-  propertyPaths.forEach((propertyPath) => {
-    widget = unsetPropertyPath(widget, propertyPath) as WidgetProps;
-  });
-
   const widgets = { ...stateWidgets, [widgetId]: widget };
-
   // Save the layout
   yield put(updateAndSaveLayout(widgets));
 }

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -8,6 +8,7 @@ import {
   RenderMode,
   RenderModes,
   CSSUnits,
+  BatchPropertyUpdatePayload,
 } from "constants/WidgetConstants";
 import React, { Component, ReactNode } from "react";
 import {
@@ -111,7 +112,7 @@ abstract class BaseWidget<
     }
   }
 
-  batchUpdateWidgetProperty(updates: Record<string, unknown>): void {
+  batchUpdateWidgetProperty(updates: BatchPropertyUpdatePayload): void {
     const { batchUpdateWidgetProperty } = this.context;
     const { widgetId } = this.props;
     if (batchUpdateWidgetProperty && widgetId) {

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -8,7 +8,6 @@ import {
   RenderMode,
   RenderModes,
   CSSUnits,
-  BatchPropertyUpdatePayload,
 } from "constants/WidgetConstants";
 import React, { Component, ReactNode } from "react";
 import {
@@ -34,6 +33,7 @@ import {
   WidgetDynamicPathListProps,
   WidgetEvaluatedProps,
 } from "../utils/DynamicBindingUtils";
+import { BatchPropertyUpdatePayload } from "actions/controlActions";
 
 /***
  * BaseWidget

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -1,10 +1,6 @@
 import React, { lazy, Suspense } from "react";
 import BaseWidget, { WidgetState } from "../BaseWidget";
-import {
-  BatchPropertyUpdatePayload,
-  RenderModes,
-  WidgetType,
-} from "constants/WidgetConstants";
+import { RenderModes, WidgetType } from "constants/WidgetConstants";
 import { EventType } from "constants/ActionConstants";
 import {
   compare,
@@ -45,6 +41,7 @@ import {
   CompactMode,
 } from "components/designSystems/appsmith/TableComponent/Constants";
 import tablePropertyPaneConfig from "./TablePropertyPaneConfig";
+import { BatchPropertyUpdatePayload } from "actions/controlActions";
 const ReactTableComponent = lazy(() =>
   retryPromise(() =>
     import("components/designSystems/appsmith/TableComponent"),

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -1,6 +1,10 @@
 import React, { lazy, Suspense } from "react";
 import BaseWidget, { WidgetState } from "../BaseWidget";
-import { RenderModes, WidgetType } from "constants/WidgetConstants";
+import {
+  BatchPropertyUpdatePayload,
+  RenderModes,
+  WidgetType,
+} from "constants/WidgetConstants";
 import { EventType } from "constants/ActionConstants";
 import {
   compare,
@@ -607,19 +611,19 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
         if (migrated === false) {
           propertiesToAdd["migrated"] = true;
         }
+        const propertiesToUpdate: BatchPropertyUpdatePayload = {
+          modify: propertiesToAdd,
+        };
 
         const columnsIdsToDelete = without(previousColumnIds, ...newColumnIds);
         if (columnsIdsToDelete.length > 0) {
           columnsIdsToDelete.forEach((id: string) => {
             pathsToDelete.push(`primaryColumns.${id}`);
           });
-
-          super.deleteWidgetProperty(pathsToDelete);
+          propertiesToUpdate.remove = pathsToDelete;
         }
 
-        setTimeout(() => {
-          super.batchUpdateWidgetProperty(propertiesToAdd);
-        }, 1000);
+        super.batchUpdateWidgetProperty(propertiesToUpdate);
       }
     }
   };


### PR DESCRIPTION

## Description
Add feature to simultaneously modify and remove property paths in a widget

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
