### PR TITLE
check dynamodb connection validity using listTables cmd.

### DIFF
--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
@@ -399,14 +399,28 @@ public class DynamoPlugin extends BasePlugin {
         public Mono<DatasourceTestResult> testDatasource(DatasourceConfiguration datasourceConfiguration) {
             return datasourceCreate(datasourceConfiguration)
                     .map(client -> {
-                        client.close();
+
+                        /*
+                         * - Creating a connection with false credentials does not throw an error. Hence,
+                         *   calling listTables() method to check validity.
+                         */
+                        client.listTables();
+
+                        try {
+                            client.close();
+                        } catch (Exception e) {
+                            System.out.println("Error closing Dynamodb connection that was made for testing." + e);
+                            return false;
+                        }
+
                         return true;
                     })
                     .defaultIfEmpty(false)
                     .map(isValid -> BooleanUtils.isTrue(isValid)
                             ? new DatasourceTestResult()
-                            : new DatasourceTestResult("Unable to create DynamoDB Client.")
+                            : new DatasourceTestResult("Invalid Access Key / Secret Key")
                     )
+                    .onErrorResume(error -> Mono.just(new DatasourceTestResult("Invalid Access Key / Secret Key")))
                     .subscribeOn(scheduler);
         }
 

--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
@@ -418,9 +418,9 @@ public class DynamoPlugin extends BasePlugin {
                     .defaultIfEmpty(false)
                     .map(isValid -> BooleanUtils.isTrue(isValid)
                             ? new DatasourceTestResult()
-                            : new DatasourceTestResult("Invalid Access Key / Secret Key")
+                            : new DatasourceTestResult("Invalid Access Key / Secret Key / Region")
                     )
-                    .onErrorResume(error -> Mono.just(new DatasourceTestResult("Invalid Access Key / Secret Key")))
+                    .onErrorResume(error -> Mono.just(new DatasourceTestResult(error.getMessage())))
                     .subscribeOn(scheduler);
         }
 

--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
@@ -9,7 +9,7 @@
           "configProperty": "datasourceConfiguration.authentication.databaseName",
           "controlType": "DROP_DOWN",
           "isRequired": true,
-          "initialValue": "AP_SOUTH_1",
+          "initialValue": "ap-south-1",
           "options": [
             {
               "label": "ap-south-1",
@@ -167,9 +167,9 @@
           "label": "AWS Secret Access Key",
           "configProperty": "datasourceConfiguration.authentication.password",
           "controlType": "INPUT_TEXT",
-          "isRequired": true,
-          "placeholderText": "",
-          "initialValue": ""
+          "dataType": "PASSWORD",
+          "initialValue": "",
+          "encrypted": true
         }
       ]
     }

--- a/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
@@ -448,7 +448,7 @@ public class DynamoPluginTest {
                     assertEquals(1, datasourceTestResult.getInvalids().size());
 
                     List<String> errorList = new ArrayList<>(datasourceTestResult.getInvalids());
-                    assertTrue(errorList.get(0).contains("Invalid Access Key / Secret Key"));
+                    assertTrue(errorList.get(0).contains("The security token included in the request is invalid."));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
@@ -29,7 +29,6 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +37,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 

--- a/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -428,6 +429,26 @@ public class DynamoPluginTest {
                             ((Map<String, Object>)transformedItemMap.get("MapType")).get("mapKey").toString());
                     assertEquals("listValue1", ((ArrayList<String>)transformedItemMap.get("ListType")).get(0));
                     assertEquals("listValue2", ((ArrayList<String>)transformedItemMap.get("ListType")).get(1));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testTestDatasourceWithFalseCredentials() {
+        DBAuth auth = new DBAuth();
+        auth.setUsername("dummy");
+        auth.setPassword("dummy");
+        auth.setDatabaseName(Region.AP_SOUTH_1.toString());
+
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        dsConfig.setAuthentication(auth);
+
+        StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
+                .assertNext(datasourceTestResult -> {
+                    assertEquals(1, datasourceTestResult.getInvalids().size());
+
+                    List<String> errorList = new ArrayList<>(datasourceTestResult.getInvalids());
+                    assertTrue(errorList.get(0).contains("Invalid Access Key / Secret Key"));
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
- creating connection with false creds does not throw error. Hence, using listTables() method to check connection validity.
- add TC to test this feature.
- add encrypted logo to password field
- rectify the default value of region dropdown

Fixes #2813 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
