### PR TITLE
stop logging datasource argument error externally.

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -543,7 +543,8 @@ public class FirestorePlugin extends BasePlugin {
                         } catch (IOException e) {
                             throw Exceptions.propagate(new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
-                                    e.getMessage()
+                                    "Validation failed for field 'Service Account Credentials'. Please check the " +
+                                            "value provided in the 'Service Account Credentials' field."
                             ));
                         }
 

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -542,7 +542,7 @@ public class FirestorePlugin extends BasePlugin {
                             credentials = GoogleCredentials.fromStream(serviceAccount);
                         } catch (IOException e) {
                             throw Exceptions.propagate(new AppsmithPluginException(
-                                    AppsmithPluginError.PLUGIN_ERROR,
+                                    AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
                                     e.getMessage()
                             ));
                         }

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -1,6 +1,8 @@
 package com.external.plugins;
 
 import com.appsmith.external.dtos.ExecuteActionDTO;
+import com.appsmith.external.exceptions.AppsmithErrorAction;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.DBAuth;
@@ -481,6 +483,32 @@ public class FirestorePluginTest {
 
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    public void testDatasourceCreateErrorOnBadServiceAccountCredentials() {
+        DBAuth dbAuth = new DBAuth();
+        dbAuth.setUsername("username");
+        dbAuth.setPassword("password");
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(dbAuth);
+        datasourceConfiguration.setUrl("https://url");
+
+        StepVerifier.create(pluginExecutor.datasourceCreate(datasourceConfiguration))
+                .expectErrorSatisfies(error -> {
+                    // Check that error is caught and returned as plugin error.
+                    assertTrue(error instanceof AppsmithPluginException);
+
+                    // Check error message.
+                    assertEquals(
+                            "Validation failed for field 'Service Account Credentials'. Please check the " +
+                                    "value provided in the 'Service Account Credentials' field.",
+                            error.getMessage());
+
+                    // Check that the error does not get logged externally.
+                    assertTrue(((AppsmithPluginException)error).getError().getErrorAction().equals(AppsmithErrorAction.DEFAULT));
+                })
+                .verify();
     }
 
 }

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -506,7 +506,7 @@ public class FirestorePluginTest {
                             error.getMessage());
 
                     // Check that the error does not get logged externally.
-                    assertTrue(((AppsmithPluginException)error).getError().getErrorAction().equals(AppsmithErrorAction.DEFAULT));
+                    assertFalse(AppsmithErrorAction.LOG_EXTERNALLY.equals(((AppsmithPluginException)error).getError().getErrorAction()));
                 })
                 .verify();
     }


### PR DESCRIPTION
## Description
- Stop logging datasource argument error externally. The error described in the linked GitHub issue arises due to bad service account credentials provided as arg.
- Update error msg to make it clear.
- Add TC.

Fixes #3138 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- verified that that the source of error indeed is the bad argument. 
<img width="1528" alt="Screenshot 2021-03-01 at 6 57 58 AM" src="https://user-images.githubusercontent.com/1757421/109442052-1357cb00-7a5d-11eb-9258-96aa4ebef678.png">

- new message:
<img width="1534" alt="Screenshot 2021-03-01 at 7 48 54 AM" src="https://user-images.githubusercontent.com/1757421/109444275-e3abc180-7a62-11eb-95cc-f2ea09123292.png">

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
