### PR TITLE
Modify hint statement for 'import from curl' form

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiFlow/CurlImportFlow_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiFlow/CurlImportFlow_spec.js
@@ -9,9 +9,11 @@ describe("Test curl import flow", function() {
     cy.get("textarea").should(
       "have.attr",
       "placeholder",
-      "curl -X GET https://mock-api.appsmith.com/users",
+      "Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users",
     );
-    cy.get("textarea").type("curl -X GET https://mock-api.appsmith.com/users");
+    cy.get("textarea").type(
+      "Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users",
+    );
     cy.importCurl();
     cy.get("@curlImport").then((response) => {
       cy.expect(response.response.body.responseMeta.success).to.eq(true);

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiFlow/CurlImportFlow_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiFlow/CurlImportFlow_spec.js
@@ -11,9 +11,7 @@ describe("Test curl import flow", function() {
       "placeholder",
       "Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users",
     );
-    cy.get("textarea").type(
-      "Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users",
-    );
+    cy.get("textarea").type("curl -X GET https://mock-api.appsmith.com/users");
     cy.importCurl();
     cy.get("@curlImport").then((response) => {
       cy.expect(response.response.body.responseMeta.success).to.eq(true);

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiFlow/CurlImportFlow_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiFlow/CurlImportFlow_spec.js
@@ -6,11 +6,6 @@ describe("Test curl import flow", function() {
     localStorage.setItem("ApiPaneV2", "ApiPaneV2");
     cy.NavigateToApiEditor();
     cy.get(ApiEditor.curlImage).click({ force: true });
-    cy.get("textarea").should(
-      "have.attr",
-      "placeholder",
-      "Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users",
-    );
     cy.get("textarea").type("curl -X GET https://mock-api.appsmith.com/users");
     cy.importCurl();
     cy.get("@curlImport").then((response) => {

--- a/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
@@ -96,6 +96,11 @@ const Header = styled.div`
   }
 `;
 
+const CurlLabel = styled.div`
+  font-size: 12px;
+  color: ${Colors.SLATE_GRAY};
+`;
+
 interface ReduxStateProps {
   actions: ActionDataState;
   initialValues: Record<string, unknown>;
@@ -133,12 +138,16 @@ class CurlImportForm extends React.Component<Props> {
             </span>
             <CurlContainer>
               <label className="inputLabel">{"Paste CURL Code Here"}</label>
+              <CurlLabel>
+                {
+                  "Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users"
+                }
+              </CurlLabel>
               <CurlImportFormContainer>
                 <Field
                   name="curl"
                   component="textarea"
                   className="textAreaStyles"
-                  placeholder="Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users"
                 />
                 <Field type="hidden" name="pageId" component="input" />
                 <Field type="hidden" name="name" component="input" />

--- a/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
@@ -140,7 +140,7 @@ class CurlImportForm extends React.Component<Props> {
               <label className="inputLabel">{"Paste CURL Code Here"}</label>
               <CurlLabel>
                 {
-                  "Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users"
+                  "Hint: Try typing in the following curl command and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users"
                 }
               </CurlLabel>
               <CurlImportFormContainer>

--- a/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
@@ -138,7 +138,7 @@ class CurlImportForm extends React.Component<Props> {
                   name="curl"
                   component="textarea"
                   className="textAreaStyles"
-                  placeholder="curl -X GET https://mock-api.appsmith.com/users"
+                  placeholder="Hint: Try typing in the following curl cmd and then click on the 'Import' button: curl -X GET https://mock-api.appsmith.com/users"
                 />
                 <Field type="hidden" name="pageId" component="input" />
                 <Field type="hidden" name="name" component="input" />


### PR DESCRIPTION
## Description
Move to hint statement out of query box and put if above it - between the label and the query box - so that user's don't confuse it as a typed in statement.

Fixes #2584 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual
<img width="1078" alt="Screenshot 2021-03-01 at 6 03 03 PM" src="https://user-images.githubusercontent.com/1757421/109497924-c9043780-7ab8-11eb-96b4-f72ca141fabf.png">


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
