### PR TITLE
Fix help modal overlapping with close button

### DIFF
--- a/app/client/src/components/designSystems/appsmith/help/HelpModal.tsx
+++ b/app/client/src/components/designSystems/appsmith/help/HelpModal.tsx
@@ -49,8 +49,8 @@ const HelpButton = styled.button<{
 
 const MODAL_WIDTH = 240;
 const MODAL_HEIGHT = 206;
-const MODAL_BOTTOM_DISTANCE = 45;
-const MODAL_RIGHT_DISTANCE = 30;
+const MODAL_BOTTOM_DISTANCE = 100;
+const MODAL_RIGHT_DISTANCE = 27;
 
 const HelpIcon = HelpIcons.HELP_ICON;
 const CloseIcon = HelpIcons.CLOSE_ICON;


### PR DESCRIPTION
## Description
Fix help modal overlapping with close button
Fixes #3286

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
