### PR TITLE
Provide option for only one endpoint and port in the dynamodb plugin datasource form 

### DIFF
--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/resources/form.json
@@ -143,15 +143,17 @@
             {
               "label": "Host Address (for overriding endpoint only)",
               "configProperty": "datasourceConfiguration.endpoints[*].host",
-              "controlType": "KEYVALUE_ARRAY",
               "validationMessage": "Please enter a valid host",
-              "validationRegex": "^((?![/:]).)*$"
+              "validationRegex": "^((?![/:]).)*$",
+              "controlType": "KEYVALUE_ARRAY",
+              "maxLength": 1
             },
             {
               "label": "Port",
               "configProperty": "datasourceConfiguration.endpoints[*].port",
               "dataType": "NUMBER",
-              "controlType": "KEYVALUE_ARRAY"
+              "controlType": "KEYVALUE_ARRAY",
+              "maxLength": 1
             }
           ]
         },


### PR DESCRIPTION
## Description
- provide a max length to keyvalue_array type. If the max length is set to 1, then the "+" button will not appear.
- front end changes are pending. A new github issue will be opened to track the same : https://github.com/appsmithorg/appsmith/issues/3315 

Fixes #2854 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- can only be tested once the front end changes are added.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
