### PR TITLE
Fix: Drop overlay widgets anywhere and add them as main container child

### DIFF
--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -165,7 +165,7 @@ export const DropTargetComponent = memo((props: DropTargetComponentProps) => {
           dropTargetOffset,
           props.snapColumnSpace,
           props.snapRowSpace,
-          widget.overlayWidget ? MAIN_CONTAINER_WIDGET_ID : props.widgetId,
+          widget.detachFromLayout ? MAIN_CONTAINER_WIDGET_ID : props.widgetId,
         );
 
         // const widgetBottomRow = getWidgetBottomRow(widget, updateWidgetParams);

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -165,7 +165,7 @@ export const DropTargetComponent = memo((props: DropTargetComponentProps) => {
           dropTargetOffset,
           props.snapColumnSpace,
           props.snapRowSpace,
-          props.widgetId,
+          widget.overlayWidget ? MAIN_CONTAINER_WIDGET_ID : props.widgetId,
         );
 
         // const widgetBottomRow = getWidgetBottomRow(widget, updateWidgetParams);

--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -259,6 +259,7 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       canEscapeKeyClose: true,
       detachFromLayout: true,
       canOutsideClickClose: true,
+      overlayWidget: true,
       shouldScrollContents: true,
       widgetName: "Modal",
       children: [],

--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -257,9 +257,10 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       columns: 6,
       size: "MODAL_SMALL",
       canEscapeKeyClose: true,
+      // detachFromLayout is set true for widgets that are not bound to the widgets within the layout.
+      // setting it to true will only render the widgets(from sidebar) on the main container without any collision check.
       detachFromLayout: true,
       canOutsideClickClose: true,
-      overlayWidget: true,
       shouldScrollContents: true,
       widgetName: "Modal",
       children: [],

--- a/app/client/src/selectors/editorSelectors.tsx
+++ b/app/client/src/selectors/editorSelectors.tsx
@@ -122,8 +122,12 @@ export const getWidgetCards = createSelector(
     const cards = widgetCards.cards;
     return cards
       .map((widget: WidgetCardProps) => {
-        const { rows, columns } = widgetConfigs.config[widget.type];
-        return { ...widget, rows, columns };
+        const {
+          rows,
+          columns,
+          overlayWidget = false,
+        }: any = widgetConfigs.config[widget.type];
+        return { ...widget, rows, columns, overlayWidget };
       })
       .sort(
         (

--- a/app/client/src/selectors/editorSelectors.tsx
+++ b/app/client/src/selectors/editorSelectors.tsx
@@ -125,9 +125,9 @@ export const getWidgetCards = createSelector(
         const {
           rows,
           columns,
-          overlayWidget = false,
+          detachFromLayout = false,
         }: any = widgetConfigs.config[widget.type];
-        return { ...widget, rows, columns, overlayWidget };
+        return { ...widget, rows, columns, detachFromLayout };
       })
       .sort(
         (

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -470,6 +470,9 @@ export const noCollision = (
   cols?: number,
 ): boolean => {
   if (clientOffset && dropTargetOffset && widget) {
+    if (widget.overlayWidget) {
+      return true;
+    }
     const [left, top] = getDropZoneOffsets(
       colWidth,
       rowHeight,

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -470,7 +470,7 @@ export const noCollision = (
   cols?: number,
 ): boolean => {
   if (clientOffset && dropTargetOffset && widget) {
-    if (widget.overlayWidget) {
+    if (widget.detachFromLayout) {
       return true;
     }
     const [left, top] = getDropZoneOffsets(


### PR DESCRIPTION

## Description
Added new flag to set for overlay widgets that can be dropped anywhere but will be rendered on the maincontainer.

Fixes #3304 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce. 
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
