### PR TITLE
Added defaultText property for text type validations

### DIFF
--- a/app/client/src/widgets/RichTextEditorWidget.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget.tsx
@@ -78,6 +78,7 @@ class RichTextEditorWidget extends BaseWidget<
       text: VALIDATION_TYPES.TEXT,
       placeholder: VALIDATION_TYPES.TEXT,
       defaultValue: VALIDATION_TYPES.TEXT,
+      defaultText: VALIDATION_TYPES.TEXT,
       isDisabled: VALIDATION_TYPES.BOOLEAN,
       isVisible: VALIDATION_TYPES.BOOLEAN,
     };

--- a/app/client/src/widgets/RichTextEditorWidget.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget.tsx
@@ -75,9 +75,7 @@ class RichTextEditorWidget extends BaseWidget<
   }
   static getPropertyValidationMap(): WidgetPropertyValidationType {
     return {
-      text: VALIDATION_TYPES.TEXT,
       placeholder: VALIDATION_TYPES.TEXT,
-      defaultValue: VALIDATION_TYPES.TEXT,
       defaultText: VALIDATION_TYPES.TEXT,
       isDisabled: VALIDATION_TYPES.BOOLEAN,
       isVisible: VALIDATION_TYPES.BOOLEAN,


### PR DESCRIPTION
## Description
Added defaultText property for text type validations

Fixes #3384 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
