### PR TITLE
Deprecate UPDATE_WIDGET_PROPERTY action

### DIFF
--- a/app/client/src/actions/controlActions.tsx
+++ b/app/client/src/actions/controlActions.tsx
@@ -1,6 +1,5 @@
 import { ReduxActionTypes, ReduxAction } from "constants/ReduxActionConstants";
 import { RenderMode } from "constants/WidgetConstants";
-import { BatchAction, batchAction } from "actions/batchActions";
 import { DynamicPath } from "utils/DynamicBindingUtils";
 
 export const updateWidgetPropertyRequest = (
@@ -18,24 +17,6 @@ export const updateWidgetPropertyRequest = (
       renderMode,
     },
   };
-};
-
-export const updateWidgetProperty = (
-  widgetId: string,
-  updates: Record<string, unknown>,
-  dynamicUpdates?: {
-    dynamicBindingPathList: DynamicPath[];
-    dynamicTriggerPathList: DynamicPath[];
-  },
-): BatchAction<UpdateWidgetPropertyPayload> => {
-  return batchAction({
-    type: ReduxActionTypes.UPDATE_WIDGET_PROPERTY,
-    payload: {
-      widgetId,
-      updates,
-      dynamicUpdates,
-    },
-  });
 };
 
 export interface BatchPropertyUpdatePayload {

--- a/app/client/src/reducers/entityReducers/canvasWidgetsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/canvasWidgetsReducer.tsx
@@ -5,11 +5,8 @@ import {
   ReduxAction,
 } from "constants/ReduxActionConstants";
 import { WidgetProps } from "widgets/BaseWidget";
-import {
-  UpdateCanvasLayout,
-  UpdateWidgetPropertyPayload,
-} from "actions/controlActions";
-import { set, uniqBy } from "lodash";
+import { UpdateCanvasLayout } from "actions/controlActions";
+import { set } from "lodash";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 
 const initialState: CanvasWidgetsReduxState = {};
@@ -36,32 +33,6 @@ const canvasWidgetsReducer = createImmerReducer(initialState, {
     action: ReduxAction<UpdateCanvasLayout>,
   ) => {
     set(state[MAIN_CONTAINER_WIDGET_ID], "rightColumn", action.payload.width);
-  },
-  [ReduxActionTypes.UPDATE_WIDGET_PROPERTY]: (
-    state: CanvasWidgetsReduxState,
-    action: ReduxAction<UpdateWidgetPropertyPayload>,
-  ) => {
-    const { dynamicUpdates, updates, widgetId } = action.payload;
-    // We loop over all updates
-    Object.entries(updates).forEach(([propertyPath, propertyValue]) => {
-      // since property paths could be nested, we use lodash set method
-      set(state[widgetId], propertyPath, propertyValue);
-    });
-
-    if (dynamicUpdates && dynamicUpdates.dynamicBindingPathList.length) {
-      const currentList = state[widgetId].dynamicBindingPathList || [];
-      state[widgetId].dynamicBindingPathList = uniqBy(
-        [...currentList, ...dynamicUpdates.dynamicBindingPathList],
-        "key",
-      );
-    }
-    if (dynamicUpdates && dynamicUpdates.dynamicTriggerPathList.length) {
-      const currentList = state[widgetId].dynamicTriggerPathList || [];
-      state[widgetId].dynamicTriggerPathList = uniqBy(
-        [...currentList, ...dynamicUpdates.dynamicTriggerPathList],
-        "key",
-      );
-    }
   },
 });
 

--- a/app/client/src/sagas/OnboardingSagas.ts
+++ b/app/client/src/sagas/OnboardingSagas.ts
@@ -84,7 +84,7 @@ import { generateReactKey } from "utils/generators";
 import { forceOpenPropertyPane } from "actions/widgetActions";
 import { navigateToCanvas } from "pages/Editor/Explorer/Widgets/WidgetEntity";
 import {
-  updateWidgetProperty,
+  batchUpdateWidgetProperty,
   updateWidgetPropertyRequest,
 } from "../actions/controlActions";
 import OnSubmitGif from "assets/gifs/onsubmit.gif";
@@ -146,14 +146,16 @@ function* listenForWidgetAdditions() {
         selectedWidget.tableData === initialTableData
       ) {
         yield put(
-          updateWidgetProperty(selectedWidget.widgetId, {
-            tableData: [],
-            columnSizeMap: {
-              avatar: 20,
-              name: 30,
+          batchUpdateWidgetProperty(selectedWidget.widgetId, {
+            modify: {
+              tableData: [],
+              columnSizeMap: {
+                avatar: 20,
+                name: 30,
+              },
+              migrated: false,
+              ...getStandupTableDimensions(),
             },
-            migrated: false,
-            ...getStandupTableDimensions(),
           }),
         );
       }
@@ -209,9 +211,11 @@ function* listenForAddInputWidget() {
           ),
         );
         yield put(
-          updateWidgetProperty(inputWidget.widgetId, {
-            ...getStandupInputDimensions(),
-            ...getStandupInputProps(),
+          batchUpdateWidgetProperty(inputWidget.widgetId, {
+            modify: {
+              ...getStandupInputDimensions(),
+              ...getStandupInputProps(),
+            },
           }),
         );
         yield put(setCurrentSubstep(2));
@@ -306,11 +310,13 @@ function* listenForSuccessfulBinding() {
 
         if (bindSuccessful) {
           yield put(
-            updateWidgetProperty(selectedWidget.widgetId, {
-              columnTypeMap: {
-                avatar: {
-                  type: "image",
-                  format: "",
+            batchUpdateWidgetProperty(selectedWidget.widgetId, {
+              modify: {
+                columnTypeMap: {
+                  avatar: {
+                    type: "image",
+                    format: "",
+                  },
                 },
               },
             }),

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -38,7 +38,6 @@ import {
   batchUpdateWidgetProperty,
   DeleteWidgetPropertyPayload,
   SetWidgetDynamicPropertyPayload,
-  updateWidgetProperty,
   UpdateWidgetPropertyPayload,
   UpdateWidgetPropertyRequestPayload,
 } from "actions/controlActions";
@@ -804,7 +803,7 @@ function* setWidgetDynamicPropertySaga(
   }
   propertyUpdates.dynamicPropertyPathList = dynamicPropertyPathList;
 
-  yield put(updateWidgetProperty(widgetId, propertyUpdates));
+  yield put(batchUpdateWidgetProperty(widgetId, propertyUpdates));
 
   const stateWidgets = yield select(getWidgets);
   const widgets = { ...stateWidgets, [widgetId]: widget };
@@ -1063,7 +1062,9 @@ function* updateCanvasSize(
     // Check this out when non canvas widgets are updating snapRows
     // erstwhile: Math.round((rows * props.snapRowSpace) / props.parentRowSpace),
     yield put(
-      updateWidgetProperty(canvasWidgetId, { bottomRow: newBottomRow }),
+      batchUpdateWidgetProperty(canvasWidgetId, {
+        modify: { bottomRow: newBottomRow },
+      }),
     );
   }
 }

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -121,11 +121,9 @@ abstract class BaseWidget<
   }
 
   updateWidgetProperty(propertyName: string, propertyValue: any): void {
-    const { updateWidgetProperty } = this.context;
-    const { widgetId } = this.props;
-    if (updateWidgetProperty && widgetId) {
-      updateWidgetProperty(widgetId, propertyName, propertyValue);
-    }
+    this.batchUpdateWidgetProperty({
+      modify: { [propertyName]: propertyValue },
+    });
   }
 
   resetChildrenMetaProperty(widgetId: string) {


### PR DESCRIPTION

## Description
With the BATCH_UPDATE_WIDGET_PROPERTY action UPDATE_WIDGET_PROPERTY is no longer required.

Fixes #3288
Fixes #3246


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

If this change works, all the existing tests should pass.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
