### PR TITLE
Fix for Table onPageSizeChange trigger executing when not defined

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -587,6 +587,12 @@ function* executeAppAction(action: ReduxAction<ExecuteActionPayload>) {
   const { dynamicString, event, responseData } = action.payload;
   log.debug({ dynamicString, responseData });
 
+  if (dynamicString === undefined) {
+    if (event.callback) event.callback({ success: false });
+    log.error("Executing undefined action", event);
+    return;
+  }
+
   const triggers = yield call(
     evaluateDynamicTrigger,
     dynamicString,

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -743,12 +743,14 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
     }
 
     if (this.props.pageSize !== prevProps.pageSize) {
-      super.executeAction({
-        dynamicString: this.props.onPageSizeChange,
-        event: {
-          type: EventType.ON_PAGE_SIZE_CHANGE,
-        },
-      });
+      if (this.props.onPageSizeChange) {
+        super.executeAction({
+          dynamicString: this.props.onPageSizeChange,
+          event: {
+            type: EventType.ON_PAGE_SIZE_CHANGE,
+          },
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Table Widget has an onPageSizeChange trigger which was getting executed even when no trigger was defined in it. This was causing `UNESCAPE_STRING_ERROR` down the line in the evaluation workflow. We should invoke trigger properties actions unless it has something defined in the field.

This PR checks adds the check around onPageSizeChange trigger before trying to execute it and also adds better handling of the error before it goes through the evaluation workflow


## Type of change

- Bug fix (non-breaking change which fixes an issue)

