### PR TITLE
Add timeout failure for mongo plugin test datasource

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -21,6 +21,7 @@ public enum AppsmithPluginError {
             AppsmithErrorAction.DEFAULT),
     PLUGIN_DATASOURCE_TEST_GENERIC_ERROR(500, 5007, "Plugin failed to test with the given configuration. Please reach out to Appsmith customer support to report this",
             AppsmithErrorAction.LOG_EXTERNALLY),
+    PLUGIN_DATASOURCE_TIMEOUT_ERROR(504, 5008, "{0}", AppsmithErrorAction.DEFAULT),
     ;
 
     private final Integer httpErrorCode;

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -207,7 +207,11 @@ public class MongoPlugin extends BasePlugin {
 
             return Mono.just(datasourceConfiguration)
                     .map(MongoPluginExecutor::buildClientURI)
-                    .map(MongoClients::create)
+                    .map(uri -> {
+                        //TODO: remove it.
+                        System.out.println("devtest: going to create mongo client");
+                        return MongoClients.create(uri);
+                    })
                     .onErrorMap(
                             IllegalArgumentException.class,
                             error ->
@@ -353,11 +357,20 @@ public class MongoPlugin extends BasePlugin {
             return Mono.just(datasourceConfiguration)
                     .flatMap(dsConfig -> datasourceCreate(dsConfig))
                     .flatMap(mongoClient -> {
+                        //TODO: remove it.
+                        System.out.println("=============================================");
+                        System.out.println("devtest: got mongoClient, calling listDb");
+                        System.out.println("=============================================");
                         return Mono.zip(Mono.just(mongoClient),
                                 Mono.from(mongoClient.getDatabase("admin").runCommand(new Document(
                                         "listDatabases", 1))));
                     })
                     .doOnSuccess(tuple -> {
+                        //TODO: remove it.
+                        System.out.println("=============================================");
+                        System.out.println("devtest: closing conn");
+                        System.out.println("=============================================");
+
                         MongoClient mongoClient = tuple.getT1();
 
                         if (mongoClient != null) {
@@ -366,6 +379,10 @@ public class MongoPlugin extends BasePlugin {
                     })
                     .then(Mono.just(new DatasourceTestResult()))
                     .onErrorResume(error -> {
+                        //TODO: remove it.
+                        System.out.println("=============================================");
+                        System.out.println("devtest: got error");
+                        System.out.println("=============================================");
                         /**
                          * 1. Return OK response on "Unauthorized" exception.
                          * 2. If we get an exception with error code "Unauthorized" then it means that the connection to

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -6,6 +6,7 @@ import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.Connection;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStructure;
+import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -399,6 +400,29 @@ public class MongoPluginTest {
                             },
                             possessionsTable.getTemplates().toArray()
                     );
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testTestDatasourceTimeoutError() {
+        String badHost = "mongo-bad-url.mongodb.net";
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        dsConfig.getEndpoints().get(0).setHost(badHost);
+
+        Mono<DatasourceTestResult> datasourceTestResult = pluginExecutor.testDatasource(dsConfig);
+
+        StepVerifier.create(datasourceTestResult)
+                .assertNext(result -> {
+                    assertFalse(result.isSuccess());
+                    assertTrue(result.getInvalids().size() == 1);
+                    assertTrue(result
+                            .getInvalids()
+                            .stream()
+                            .anyMatch(error -> error.contains(
+                                    "Connection timed out. Please check if the datasource configuration fields have " +
+                                            "been filled correctly."
+                            )));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
@@ -174,6 +174,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler
     @ResponseBody
     public Mono<ResponseDTO<ErrorDTO>> catchException(Exception e, ServerWebExchange exchange) {
+        //TODO: remove it.
+        System.out.println("devtest: no handler for exception");
         AppsmithError appsmithError = AppsmithError.INTERNAL_SERVER_ERROR;
         exchange.getResponse().setStatusCode(HttpStatus.resolve(appsmithError.getHttpErrorCode()));
         doLog(e);


### PR DESCRIPTION
## Description
- Mongo plugin client driver does not return with exception upon first failure - instead it keeps retrying. Hence, adding timeout error to report failure on timeout.

Fixes #2295 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually
- JUnit TC 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
