### PR TITLE
Fix: Modal Size gets cut in smaller screens.

### DIFF
--- a/app/client/src/components/designSystems/blueprint/ModalComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/ModalComponent.tsx
@@ -26,6 +26,7 @@ const Container = styled.div<{
       justify-content: center;
       align-items: center;
       & .${Classes.OVERLAY_CONTENT} {
+        max-width: 95%;
         width: ${(props) => props.width}px;
         min-height: ${(props) => props.height}px;
         background: white;

--- a/app/client/src/widgets/ModalWidget.tsx
+++ b/app/client/src/widgets/ModalWidget.tsx
@@ -9,10 +9,13 @@ import {
   WidgetTypes,
   RenderMode,
   GridDefaults,
+  MAIN_CONTAINER_WIDGET_ID,
 } from "constants/WidgetConstants";
 import { generateClassName } from "utils/generators";
 import * as Sentry from "@sentry/react";
 import withMeta, { WithMeta } from "./MetaHOC";
+import { AppState } from "reducers";
+import { getWidget } from "sagas/selectors";
 
 const MODAL_SIZE: { [id: string]: { width: number; height: number } } = {
   MODAL_SMALL: {
@@ -72,6 +75,14 @@ export class ModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
     canEscapeKeyClose: false,
   };
 
+  getModalWidth() {
+    const widthFromOverlay = this.props.mainContainer.rightColumn * 0.95;
+    const defaultModalWidth = MODAL_SIZE[this.props.size].width;
+    return widthFromOverlay < defaultModalWidth
+      ? widthFromOverlay
+      : defaultModalWidth;
+  }
+
   renderChildWidget = (childWidgetData: WidgetProps): ReactNode => {
     childWidgetData.parentId = this.props.widgetId;
     childWidgetData.shouldScrollContents = false;
@@ -82,7 +93,7 @@ export class ModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
     childWidgetData.isVisible = this.props.isVisible;
     childWidgetData.containerStyle = "none";
     childWidgetData.minHeight = MODAL_SIZE[this.props.size].height;
-    childWidgetData.rightColumn = MODAL_SIZE[this.props.size].width;
+    childWidgetData.rightColumn = this.getModalWidth();
     return WidgetFactory.createWidget(childWidgetData, this.props.renderMode);
   };
 
@@ -108,7 +119,7 @@ export class ModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
         <ModalComponent
           isOpen={!!this.props.isVisible}
           onClose={this.closeModal}
-          width={MODAL_SIZE[this.props.size].width}
+          width={this.getModalWidth()}
           height={MODAL_SIZE[this.props.size].height}
           className={`t--modal-widget ${generateClassName(
             this.props.widgetId,
@@ -150,6 +161,7 @@ export interface ModalWidgetProps extends WidgetProps, WithMeta {
   canEscapeKeyClose?: boolean;
   shouldScrollContents?: boolean;
   size: string;
+  mainContainer: WidgetProps;
 }
 
 const mapDispatchToProps = (dispatch: any) => ({
@@ -169,8 +181,15 @@ const mapDispatchToProps = (dispatch: any) => ({
     });
   },
 });
+
+const mapStateToProps = (state: AppState) => {
+  const props = {
+    mainContainer: getWidget(state, MAIN_CONTAINER_WIDGET_ID),
+  };
+  return props;
+};
 export default ModalWidget;
 export const ProfiledModalWidget = connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(Sentry.withProfiler(withMeta(ModalWidget)));


### PR DESCRIPTION

Modal Resizing based on canvas size.

Fixes # #3416 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
