### PR TITLE
use dynamic input text in plugin editor forms

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
@@ -32,14 +32,14 @@
         {
           "label": "Bucket Name",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[1].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "isRequired": true,
           "initialValue": ""
         },
         {
           "label": "File Path",
           "configProperty": "actionConfiguration.path",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
@@ -71,7 +71,7 @@
         {
           "label": "Expiry Duration of Signed URL (Minutes)",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[7].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "5",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
@@ -93,7 +93,7 @@
         {
           "label": "Prefix",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[4].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
@@ -125,7 +125,7 @@
         {
           "label": "Expiry Duration of Signed URL (Minutes)",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[3].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "5",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[2].value",

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/editor.json
@@ -32,7 +32,7 @@
         {
           "label": "Path",
           "configProperty": "actionConfiguration.path",
-          "controlType": "INPUT_TEXT"
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT"
         },
         {
           "label": "Body",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
@@ -51,7 +51,7 @@
         {
           "label": "Document/Collection Path",
           "configProperty": "actionConfiguration.path",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "isRequired": true,
           "initialValue": ""
         },
@@ -65,7 +65,7 @@
         {
           "label": "Order By (JSON array of field names to order by)",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[1].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "NOT_EQUALS",
@@ -84,7 +84,7 @@
         {
           "label": "Start After",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[6].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "NOT_EQUALS",
@@ -102,7 +102,7 @@
         {
           "label": "End Before",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[7].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "NOT_EQUALS",
@@ -120,7 +120,7 @@
         {
           "label": "Limit Documents",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[2].value",
-          "controlType": "INPUT_TEXT",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "NOT_EQUALS",
@@ -142,7 +142,7 @@
             {
               "label": "Where Condition: Field Path (leave empty to not apply any conditions)",
               "configProperty": "actionConfiguration.pluginSpecifiedTemplates[3].value",
-              "controlType": "INPUT_TEXT",
+              "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
               "hidden": {
                 "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 "comparison": "NOT_EQUALS",
@@ -212,7 +212,7 @@
             {
               "label": "Where Condition: Value",
               "configProperty": "actionConfiguration.pluginSpecifiedTemplates[5].value",
-              "controlType": "INPUT_TEXT",
+              "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
               "hidden": {
                 "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
                 "comparison": "NOT_EQUALS",


### PR DESCRIPTION
## Description
- Use dynamic input text for plugin editor forms so that the evaluated value of mustache expression is visible.
- Those fields which are meant to store Key only - i.e. they are not visible to the user and are only meant to provide key for key value pair in db have been skipped. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual
![Screenshot 2021-03-10 at 10 59 31 AM](https://user-images.githubusercontent.com/1757421/110581130-f5dadd80-818f-11eb-9504-ec4065c279d4.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
