### PR TITLE
Table primary columns in cyclic dependencies

### DIFF
--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -371,7 +371,11 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       sanitizedTableData,
       derivedColumns,
     } = this.props;
-    if (!sanitizedTableData || !sanitizedTableData.length) {
+    if (
+      !sanitizedTableData ||
+      !sanitizedTableData.length ||
+      isString(sanitizedTableData)
+    ) {
       return [];
     }
     const derivedTableData: Array<Record<string, unknown>> = [
@@ -507,7 +511,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
     | Record<string, ColumnProperties>
     | undefined => {
     const {
-      sanitizedTableData,
+      sanitizedTableData = [],
       primaryColumns = {},
       columnNameMap = {},
       columnTypeMap = {},
@@ -515,6 +519,8 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       hiddenColumns = [],
       migrated,
     } = this.props;
+    // Bail out if the data is a string. It must be an array.
+    if (isString(sanitizedTableData)) return {};
 
     const previousColumnIds = Object.keys(primaryColumns);
     const tableColumns: Record<string, ColumnProperties> = {};
@@ -647,6 +653,10 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
 
   componentDidUpdate(prevProps: TableWidgetProps) {
     const { primaryColumns = {} } = this.props;
+
+    // Donot process if the sanitizedTableData is a string
+    if (isString(this.props.sanitizedTableData)) return;
+
     // Check if data is modifed by comparing the stringified versions of the previous and next tableData
     const tableDataModified =
       JSON.stringify(this.props.sanitizedTableData) !==

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -372,11 +372,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       sanitizedTableData,
       derivedColumns,
     } = this.props;
-    if (
-      !sanitizedTableData ||
-      !sanitizedTableData.length ||
-      isString(sanitizedTableData)
-    ) {
+    if (!sanitizedTableData || !sanitizedTableData.length) {
       return [];
     }
     const derivedTableData: Array<Record<string, unknown>> = [

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -60,6 +60,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       defaultSearchText: VALIDATION_TYPES.TEXT,
       defaultSelectedRow: VALIDATION_TYPES.DEFAULT_SELECTED_ROW,
       pageSize: VALIDATION_TYPES.NUMBER,
+      sanitizedTableData: VALIDATION_TYPES.ARRAY,
     };
   }
 
@@ -519,8 +520,11 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       hiddenColumns = [],
       migrated,
     } = this.props;
-    // Bail out if the data is a string. It must be an array.
-    if (isString(sanitizedTableData)) return {};
+    // Bail out if the data doesn't exist.
+    // This is a temporary measure,
+    // to solve for the scenario where the column properties are getting reset
+    // Repurcussion: The primary columns control will never go into the "no data" state.
+    if (sanitizedTableData.length === 0) return;
 
     const previousColumnIds = Object.keys(primaryColumns);
     const tableColumns: Record<string, ColumnProperties> = {};
@@ -653,9 +657,6 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
 
   componentDidUpdate(prevProps: TableWidgetProps) {
     const { primaryColumns = {} } = this.props;
-
-    // Donot process if the sanitizedTableData is a string
-    if (isString(this.props.sanitizedTableData)) return;
 
     // Check if data is modifed by comparing the stringified versions of the previous and next tableData
     const tableDataModified =

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -60,7 +60,6 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       defaultSearchText: VALIDATION_TYPES.TEXT,
       defaultSelectedRow: VALIDATION_TYPES.DEFAULT_SELECTED_ROW,
       pageSize: VALIDATION_TYPES.NUMBER,
-      sanitizedTableData: VALIDATION_TYPES.ARRAY,
     };
   }
 
@@ -520,7 +519,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
     // This is a temporary measure,
     // to solve for the scenario where the column properties are getting reset
     // Repurcussion: The primary columns control will never go into the "no data" state.
-    if (sanitizedTableData.length === 0) return;
+    if (isString(sanitizedTableData) || sanitizedTableData.length === 0) return;
 
     const previousColumnIds = Object.keys(primaryColumns);
     const tableColumns: Record<string, ColumnProperties> = {};
@@ -653,6 +652,10 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
 
   componentDidUpdate(prevProps: TableWidgetProps) {
     const { primaryColumns = {} } = this.props;
+
+    // Bail out if santizedTableData is a string. This signifies an error in evaluations
+    // Since, it is an error in evaluations, we should not attempt to process the data
+    if (isString(this.props.sanitizedTableData)) return;
 
     // Check if data is modifed by comparing the stringified versions of the previous and next tableData
     const tableDataModified =

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -247,7 +247,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
       return {
         isValid,
         parsed: [],
-        transformed,
+        transformed: Array.isArray(transformed) ? transformed : [],
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: [{ "Col1" : "val1", "Col2" : "val2" }]`,
       };
     }

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -247,7 +247,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
       return {
         isValid,
         parsed: [],
-        transformed: Array.isArray(transformed) ? transformed : [],
+        transformed,
         message: `${WIDGET_TYPE_VALIDATION_ERROR}: [{ "Col1" : "val1", "Col2" : "val2" }]`,
       };
     }


### PR DESCRIPTION
## Description
When there is a cyclic dependency, the table data is processed as a string, leading to incorrect column computations and a render loop. Fixed this by bailing out when table data is a string, as further computations are moot

Fixes #3440 
Fixes #3291 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress test pending.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
