### PR TITLE
Handle scenario where columnOrder was unavailable in Table widget

### DIFF
--- a/app/client/src/components/propertyControls/PrimaryColumnsControl.tsx
+++ b/app/client/src/components/propertyControls/PrimaryColumnsControl.tsx
@@ -273,12 +273,9 @@ class PrimaryColumnsControl extends BaseControl<ControlProps> {
     const columns: Record<string, ColumnProperties> =
       this.props.propertyValue || {};
     const derivedColumns = this.props.widgetProperties.derivedColumns || {};
+    const columnOrder = this.props.widgetProperties.columnOrder || [];
 
-    const originalColumn = getOriginalColumn(
-      columns,
-      index,
-      this.props.widgetProperties.columnOrder,
-    );
+    const originalColumn = getOriginalColumn(columns, index, columnOrder);
 
     if (originalColumn) {
       const propertiesToDelete = [
@@ -287,7 +284,7 @@ class PrimaryColumnsControl extends BaseControl<ControlProps> {
       if (derivedColumns[originalColumn.id])
         propertiesToDelete.push(`derivedColumns.${originalColumn.id}`);
 
-      const columnOrderIndex = this.props.widgetProperties.columnOrder.findIndex(
+      const columnOrderIndex = columnOrder.findIndex(
         (column: string) => column === originalColumn.id,
       );
       if (columnOrderIndex > -1)


### PR DESCRIPTION
## Description
Handle scenario where columnOrder was unavailable in Table widget

Fixes #3298 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
