### PR TITLE
Fix dropdown option validation to allow null or empty string as value

### DIFF
--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -394,9 +394,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
       const isValidOption = (option: { label: any; value: any }) =>
         _.isObject(option) &&
         _.isString(option.label) &&
-        _.isString(option.value) &&
-        !_.isEmpty(option.label) &&
-        !_.isEmpty(option.value);
+        !_.isEmpty(option.label);
 
       const hasOptions = every(parsed, isValidOption);
       const validOptions = parsed.filter(isValidOption);


### PR DESCRIPTION
## Description
Fix dropdown option validation to allow null or empty string as value

Fixes #3330 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
