### PR TITLE
Use replace instead of replaceAll for wider support

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
@@ -109,7 +109,7 @@ export const useDefaultDocumentationResults = () => {
           const response = await fetch(doc.link);
           let document = await response.text();
           const assetRegex = new RegExp("[../]*?/.gitbook", "g");
-          document = document.replaceAll(assetRegex, githubDocsAssetsPath);
+          document = document.replace(assetRegex, githubDocsAssetsPath);
           return {
             _highlightResult: {
               document: {


### PR DESCRIPTION
## Description
`replace` has more support than `replaceAll`, including android browser 81, which does not support `replace`

Fixes #3529

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
