### PR TITLE
Add migration to remove template organization config

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -26,6 +26,7 @@ import com.appsmith.server.domains.Permission;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.PluginType;
 import com.appsmith.server.domains.QApplication;
+import com.appsmith.server.domains.QConfig;
 import com.appsmith.server.domains.QDatasource;
 import com.appsmith.server.domains.QNewAction;
 import com.appsmith.server.domains.QOrganization;
@@ -1991,6 +1992,15 @@ public class DatabaseChangelog {
             );
 
         }
+    }
+
+    @ChangeSet(order = "060", id = "clear-example-apps", author = "")
+    public void clearExampleApps(MongoTemplate mongoTemplate) {
+        mongoTemplate.updateFirst(
+                query(where(fieldName(QConfig.config1.name)).is("template-organization")),
+                update("config.applicationIds", Collections.emptyList()).set("config.organizationId", null),
+                Config.class
+        );
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigServiceImpl.java
@@ -19,6 +19,8 @@ import javax.validation.Validator;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
 @Slf4j
 @Service
 public class ConfigServiceImpl extends BaseService<ConfigRepository, Config, String> implements ConfigService {
@@ -74,15 +76,19 @@ public class ConfigServiceImpl extends BaseService<ConfigRepository, Config, Str
     @Override
     public Mono<String> getTemplateOrganizationId() {
         return repository.findByName(TEMPLATE_ORGANIZATION_CONFIG_NAME)
-                .map(config -> config.getConfig().getAsString(FieldName.ORGANIZATION_ID))
-                .doOnError(error -> log.warn("Error getting template organization ID", error))
-                .onErrorReturn("");
+                .filter(config -> config.getConfig() != null)
+                .flatMap(config -> Mono.justOrEmpty(config.getConfig().getAsString(FieldName.ORGANIZATION_ID)))
+                .doOnError(error -> log.warn("Error getting template organization ID", error));
     }
 
     @Override
     public Flux<Application> getTemplateApplications() {
         return repository.findByName(TEMPLATE_ORGANIZATION_CONFIG_NAME)
-                .map(config -> config.getConfig().getOrDefault("applicationIds", Collections.emptyList()))
+                .filter(config -> config.getConfig() != null)
+                .map(config -> defaultIfNull(
+                        config.getConfig().getOrDefault("applicationIds", null),
+                        Collections.emptyList()
+                ))
                 .cast(List.class)
                 .onErrorReturn(Collections.emptyList())
                 .flatMapMany(applicationRepository::findByIdIn);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationForkingService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationForkingService.java
@@ -52,7 +52,6 @@ public class ApplicationForkingService {
                     }
 
                     return examplesOrganizationCloner.cloneApplications(
-                            application.getOrganizationId(),
                             targetOrganization.getId(),
                             Flux.fromIterable(Collections.singletonList(application))
                     );

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -136,27 +136,26 @@ public class ExamplesOrganizationCloner {
                             .when(
                                     userService.update(user.getId(), userUpdate),
                                     applicationsFlux == null
-                                            ? cloneApplications(templateOrganizationId, newOrganization.getId())
-                                            : cloneApplications(templateOrganizationId, newOrganization.getId(), applicationsFlux)
+                                            ? cloneApplications(newOrganization.getId())
+                                            : cloneApplications(newOrganization.getId(), applicationsFlux)
                             )
                             .thenReturn(newOrganization);
                 })
                 .doOnError(error -> log.error("Error cloning examples organization.", error));
     }
 
-    private Mono<List<String>> cloneApplications(String fromOrganizationId, String toOrganizationId) {
-        return cloneApplications(fromOrganizationId, toOrganizationId, configService.getTemplateApplications());
+    private Mono<List<String>> cloneApplications(String toOrganizationId) {
+        return cloneApplications(toOrganizationId, configService.getTemplateApplications());
     }
 
     /**
      * Clone all applications (except deleted ones), including it's pages and actions from one organization into
      * another. Also clones all datasources (not just the ones used by any applications) in the given organizations.
      *
-     * @param fromOrganizationId ID of the organization that is the source to copy objects from.
      * @param toOrganizationId   ID of the organization that is the target to copy objects to.
      * @return Empty Mono.
      */
-    public Mono<List<String>> cloneApplications(String fromOrganizationId, String toOrganizationId, Flux<Application> applicationsFlux) {
+    public Mono<List<String>> cloneApplications(String toOrganizationId, Flux<Application> applicationsFlux) {
         final List<NewPage> clonedPages = new ArrayList<>();
         final List<String> newApplicationIds = new ArrayList<>();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -175,7 +175,7 @@ public class UserServiceTest {
                     // Since there is a template organization, the user won't have an empty default organization. They
                     // will get a clone of the default organization when they first login. So, we expect it to be
                     // empty here.
-                    assertThat(user.getOrganizationIds()).isNullOrEmpty();
+                    assertThat(user.getOrganizationIds()).hasSize(1);
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceWithDisabledSignupTest.java
@@ -104,7 +104,7 @@ public class UserServiceWithDisabledSignupTest {
                     assertThat(user.getEmail()).isEqualTo("dummy_admin@appsmith.com");
                     assertThat(user.getName()).isNullOrEmpty();
                     assertThat(user.getPolicies()).isNotEmpty();
-                    assertThat(user.getOrganizationIds()).isNullOrEmpty();
+                    assertThat(user.getOrganizationIds()).hasSize(1);
                 })
                 .verifyComplete();
     }
@@ -125,7 +125,7 @@ public class UserServiceWithDisabledSignupTest {
                     assertThat(user.getEmail()).isEqualTo("dummy2@appsmith.com");
                     assertThat(user.getName()).isNullOrEmpty();
                     assertThat(user.getPolicies()).isNotEmpty();
-                    assertThat(user.getOrganizationIds()).isNullOrEmpty();
+                    assertThat(user.getOrganizationIds()).hasSize(1);
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -382,7 +382,7 @@ public class ExamplesOrganizationClonerTests {
                                 app.setName(originalName);
                                 return app;
                             })
-                            .flatMap(app -> examplesOrganizationCloner.cloneApplications(app.getOrganizationId(), orgId, Flux.fromArray(new Application[]{ app })))
+                            .flatMap(app -> examplesOrganizationCloner.cloneApplications(orgId, Flux.fromArray(new Application[]{ app })))
                             .then();
                     // Clone this application into the same organization thrice.
                     return cloneMono
@@ -851,7 +851,6 @@ public class ExamplesOrganizationClonerTests {
                                             return app;
                                         })
                                         .flatMap(app -> examplesOrganizationCloner.cloneApplications(
-                                                app.getOrganizationId(),
                                                 targetOrg1.getId(),
                                                 Flux.fromArray(new Application[]{ app })
                                         ))


### PR DESCRIPTION
This PR:

1. Adds a migration to remove the configuration of template organization. So, after this, self-hosted instances won't have example applications being cloned for new users who sign up.
2. Add a few null checks around getting template organizations since it's now very possible to be `null` (and does indeed throw a few NPEs around).
3. Update tests accordingly.
