### PR TITLE
fix: script to replace local ip in case of apple m1

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -91,9 +91,9 @@ case "${uname_out}" in
         if [[ "$(uname -m)" = "arm64" ]]; then
             # if no server was passed
             if [[ -z $1 ]]; then
-                server_proxy_pass='http://"$(ipconfig getifaddr en0)":8080'
+                server_proxy_pass="http://$(ipconfig getifaddr en0):8080"
             fi
-            client_proxy_pass='http://"$(ipconfig getifaddr en0)":3000'
+            client_proxy_pass="http://$(ipconfig getifaddr en0):3000"
         fi
         echo "
     Starting nginx for MacOS...


### PR DESCRIPTION
## Description
On M1 mac, `./start-https.sh` has a different handling to use `en0` interface ip.
Currently, it doesn't replace local ip in generated `nginx.conf` file which leads to docker startup failure.

Fixes #3563 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
1. Locally by running and manually checking `nginx.conf` generated files and docker logs.

Configuration generated after this change
<img width="381" alt="Screenshot 2021-03-16 at 11 27 51 AM" src="https://user-images.githubusercontent.com/2965013/111251668-a6daef80-864a-11eb-9ca0-ab28f1bb5f22.png">

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
