### PR TITLE
Fix success message for single user invite and multiple user invite

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
@@ -19,6 +19,16 @@ describe("Create new org and share with a user", function() {
         Cypress.env("TESTUSERNAME1"),
         homePage.viewerRole,
       );
+      // check that the error message is correct
+      cy.checkSuccessMessageForOneUserInvite(
+        orgid,
+        "The user has been invited successfully",
+      );
+      cy.get(homePage.manageUsers).click({ force: true });
+      cy.xpath(homePage.appHome)
+        .first()
+        .should("be.visible")
+        .click();
       cy.CheckShareIcon(orgid, 2);
       cy.CreateAppForOrg(orgid, appid);
     });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
@@ -19,7 +19,7 @@ describe("Create new org and share with a user", function() {
         Cypress.env("TESTUSERNAME1"),
         homePage.viewerRole,
       );
-      // check that the error message is correct
+      // check that the success message is correct
       cy.checkSuccessMessageForOneUserInvite(
         orgid,
         "The user has been invited successfully",

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
@@ -20,10 +20,8 @@ describe("Create new org and share with a user", function() {
         homePage.viewerRole,
       );
       // check that the success message is correct
-      cy.checkSuccessMessageForOneUserInvite(
-        orgid,
-        "The user has been invited successfully",
-      );
+      const successMessage = "The user has been invited successfully";
+      cy.contains(message);
       cy.get(homePage.manageUsers).click({ force: true });
       cy.xpath(homePage.appHome)
         .first()

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/CreateOrgTests_spec.js
@@ -21,7 +21,7 @@ describe("Create new org and share with a user", function() {
       );
       // check that the success message is correct
       const successMessage = "The user has been invited successfully";
-      cy.contains(message);
+      cy.contains(successMessage);
       cy.get(homePage.manageUsers).click({ force: true });
       cy.xpath(homePage.appHome)
         .first()

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -85,12 +85,14 @@ Cypress.Commands.add("inviteUserForOrg", (orgName, email, role) => {
     200,
   );
   cy.contains(email);
-  cy.get(homePage.manageUsers).click({ force: true });
-  cy.xpath(homePage.appHome)
-    .first()
-    .should("be.visible")
-    .click();
 });
+
+Cypress.Commands.add(
+  "checkSuccessMessageForOneUserInvite",
+  (orgName, message) => {
+    cy.contains(message);
+  },
+);
 
 Cypress.Commands.add("CheckShareIcon", (orgName, count) => {
   cy.get(homePage.orgList.concat(orgName).concat(")"))

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -87,13 +87,6 @@ Cypress.Commands.add("inviteUserForOrg", (orgName, email, role) => {
   cy.contains(email);
 });
 
-Cypress.Commands.add(
-  "checkSuccessMessageForOneUserInvite",
-  (orgName, message) => {
-    cy.contains(message);
-  },
-);
-
 Cypress.Commands.add("CheckShareIcon", (orgName, count) => {
   cy.get(homePage.orgList.concat(orgName).concat(")"))
     .scrollIntoView()

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -129,6 +129,8 @@ export const INVITE_USERS_SUBMIT_ERROR = () =>
   `We were unable to invite the users, please try again later`;
 export const INVITE_USERS_SUBMIT_SUCCESS = () =>
   `The users have been invited successfully`;
+export const INVITE_USER_SUBMIT_SUCCESS = () =>
+  `The user has been invited successfully`;
 export const INVITE_USERS_VALIDATION_EMAILS_EMPTY = () =>
   `Please enter the user emails`;
 

--- a/app/client/src/pages/organization/OrgInviteUsersForm.tsx
+++ b/app/client/src/pages/organization/OrgInviteUsersForm.tsx
@@ -18,6 +18,7 @@ import { INVITE_USERS_TO_ORG_FORM } from "constants/forms";
 import {
   createMessage,
   INVITE_USERS_SUBMIT_SUCCESS,
+  INVITE_USER_SUBMIT_SUCCESS,
   INVITE_USERS_VALIDATION_EMAILS_EMPTY,
   INVITE_USERS_VALIDATION_EMAIL_LIST,
   INVITE_USERS_VALIDATION_ROLE_EMPTY,
@@ -362,7 +363,11 @@ const OrgInviteUsersForm = (props: any) => {
             <Callout
               variant={Variant.success}
               fill
-              text={createMessage(INVITE_USERS_SUBMIT_SUCCESS)}
+              text={
+                allUsers > 1
+                  ? createMessage(INVITE_USERS_SUBMIT_SUCCESS)
+                  : createMessage(INVITE_USER_SUBMIT_SUCCESS)
+              }
             />
           )}
           {((submitFailed && error) || emailError) && (

--- a/app/client/src/pages/organization/OrgInviteUsersForm.tsx
+++ b/app/client/src/pages/organization/OrgInviteUsersForm.tsx
@@ -221,6 +221,10 @@ const OrgInviteUsersForm = (props: any) => {
     isLoading,
   } = props;
 
+  // set state for checking number of users invited
+  const [numberOfUsersInvited, updateNumberOfUsersInvited] = useState(0);
+
+  console.log("INVITING USERS:", allUsers, props);
   const currentOrg = useSelector(getCurrentAppOrg);
 
   const userOrgPermissions = currentOrg?.userPermissions ?? [];
@@ -276,6 +280,9 @@ const OrgInviteUsersForm = (props: any) => {
         onSubmit={handleSubmit((values: any, dispatch: any) => {
           validateFormValues(values);
           AnalyticsUtil.logEvent("INVITE_USER", values);
+          const usersAsStringsArray = values.users.split(",");
+          // update state to show success message correctly
+          updateNumberOfUsersInvited(usersAsStringsArray.length);
           return inviteUsersToOrg({ ...values, orgId: props.orgId }, dispatch);
         })}
       >
@@ -364,9 +371,9 @@ const OrgInviteUsersForm = (props: any) => {
               variant={Variant.success}
               fill
               text={
-                allUsers > 1
-                  ? createMessage(INVITE_USERS_SUBMIT_SUCCESS)
-                  : createMessage(INVITE_USER_SUBMIT_SUCCESS)
+                numberOfUsersInvited > 1
+                  ? INVITE_USERS_SUBMIT_SUCCESS()
+                  : INVITE_USER_SUBMIT_SUCCESS()
               }
             />
           )}

--- a/app/client/src/pages/organization/OrgInviteUsersForm.tsx
+++ b/app/client/src/pages/organization/OrgInviteUsersForm.tsx
@@ -223,8 +223,6 @@ const OrgInviteUsersForm = (props: any) => {
 
   // set state for checking number of users invited
   const [numberOfUsersInvited, updateNumberOfUsersInvited] = useState(0);
-
-  console.log("INVITING USERS:", allUsers, props);
   const currentOrg = useSelector(getCurrentAppOrg);
 
   const userOrgPermissions = currentOrg?.userPermissions ?? [];


### PR DESCRIPTION
## Description
The invite text says: "Users have been invited." when I invited only one user. It should say, 'The user has been invited successfully' for one email and 'Users have been invited' for multiple emails.

Fixes #3542 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test 1: invited a single user, used cypress to check if the error message is correct.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
