### PR TITLE
Add arbitrary wait on onboarding test

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
@@ -14,60 +14,49 @@ describe("Onboarding", function() {
       "response.body.responseMeta.status",
       201,
     );
-    cy.wait("@getDataSources");
 
-    cy.window()
-      .its("store")
-      .invoke("getState")
-      .then((state) => {
-        const datasources = state.entities.datasources.list;
-        let onboardingDatasource = datasources.find((datasource) => {
-          const name = datasource.name;
-          return name === "Super Updates DB";
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000);
+
+    cy.get(".t--start-building")
+      .should("be.visible")
+      .click({ force: true });
+
+    // Create and run query
+    cy.get(".t--onboarding-indicator").should("be.visible");
+    cy.get(".t--create-query").click();
+    cy.runQuery();
+
+    // Add widget
+    cy.get(".t--add-widget").click();
+    cy.dragAndDropToCanvas("tablewidget", { x: 30, y: -30 });
+
+    // Click on "Show me how" and then copy hint
+    cy.get(".t--onboarding-action").click();
+    cy.get(".t--onboarding-snippet").click({ force: true });
+
+    cy.get(".t--property-control-tabledata" + " .CodeMirror textarea")
+      .first()
+      .focus({ force: true })
+      .type("{uparrow}", { force: true })
+      .type("{ctrl}{shift}{downarrow}", { force: true });
+    cy.focused().then(() => {
+      cy.get(".t--property-control-tabledata" + " .CodeMirror")
+        .first()
+        .then((editor) => {
+          editor[0].CodeMirror.setValue("{{fetch_standup_updates.data}}");
         });
+    });
+    cy.closePropertyPane();
+    cy.get(explorer.closeWidgets).click();
 
-        if (!onboardingDatasource) {
-          cy.wait("@createDatasource");
-        }
+    cy.openPropertyPane("tablewidget");
+    cy.closePropertyPane();
+    cy.get(".t--application-feedback-btn").should("not.exist");
 
-        cy.get(".t--start-building").click();
-
-        // Create and run query
-        cy.get(".t--onboarding-indicator").should("be.visible");
-        cy.get(".t--create-query").click();
-        cy.runQuery();
-    
-        // Add widget
-        cy.get(".t--add-widget").click();
-        cy.dragAndDropToCanvas("tablewidget", { x: 30, y: -30 });
-    
-        // Click on "Show me how" and then copy hint
-        cy.get(".t--onboarding-action").click();
-        cy.get(".t--onboarding-snippet").click({ force: true });
-    
-        cy.get(".t--property-control-tabledata" + " .CodeMirror textarea")
-          .first()
-          .focus({ force: true })
-          .type("{uparrow}", { force: true })
-          .type("{ctrl}{shift}{downarrow}", { force: true });
-        cy.focused().then(() => {
-          cy.get(".t--property-control-tabledata" + " .CodeMirror")
-            .first()
-            .then((editor) => {
-              editor[0].CodeMirror.setValue("{{fetch_standup_updates.data}}");
-            });
-        });
-        cy.closePropertyPane();
-        cy.get(explorer.closeWidgets).click();
-    
-        cy.openPropertyPane("tablewidget");
-        cy.closePropertyPane();
-        cy.get(".t--application-feedback-btn").should("not.exist");
-    
-        cy.contains(".t--onboarding-helper-title", "Capture Hero Updates");
-        cy.get(".t--onboarding-cheat-action").click();
-        cy.contains(".t--onboarding-helper-title", "Deploy the Standup Dashboard");
-      });
+    cy.contains(".t--onboarding-helper-title", "Capture Hero Updates");
+    cy.get(".t--onboarding-cheat-action").click();
+    cy.contains(".t--onboarding-helper-title", "Deploy the Standup Dashboard");
   });
 
   // Similar to PublishtheApp command with little changes


### PR DESCRIPTION
We recently changed the test to make sure we wait for the client to create an onboarding data source if it did not exist. This kind of check was also happening on the source code, and the complexity was not getting translated properly in the tests. 

To improve the reliability of the test, I added an arbitrary wait time before we start the building