### PR TITLE
change default value of s3 file data type on create file action

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
@@ -51,14 +51,14 @@
           "label": "File Data Type: Base64/Text",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[6].value",
           "controlType": "DROP_DOWN",
-          "initialValue": "NO",
+          "initialValue": "YES",
           "options": [
             {
-              "label": "Yes",
+              "label": "Base64",
               "value": "YES"
             },
             {
-              "label": "No",
+              "label": "Text",
               "value": "NO"
             }
           ],

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
@@ -58,7 +58,7 @@
               "value": "YES"
             },
             {
-              "label": "Text",
+              "label": "Text / Binary",
               "value": "NO"
             }
           ],

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
@@ -48,7 +48,7 @@
           }
         },
         {
-          "label": "File Data Type: Base64/Text",
+          "label": "File Data Type",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[6].value",
           "controlType": "DROP_DOWN",
           "initialValue": "YES",


### PR DESCRIPTION
## Description
- modify default value for s3 on file create to Yes.
- change dropdown option names to base64, text from yes, no.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## How Has This Been Tested?
![Screenshot 2021-03-24 at 11 43 28 AM](https://user-images.githubusercontent.com/1757421/112264350-c56a6780-8c96-11eb-900f-6ee433e3ffc8.png)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
