### PR TITLE
Stringifying the binding name before setting in the error string

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -38,7 +38,7 @@ public enum AppsmithError {
                     "  \"widgetId\" : \"{2}\"," +
                     "  \"pageId\" : \"{4}\"," +
                     "  \"layoutId\" : \"{5}\"," +
-                    "  \"dynamicBinding\" : \"{6}\"",
+                    "  \"dynamicBinding\" : {6}",
             AppsmithErrorAction.LOG_EXTERNALLY),
     USER_ALREADY_EXISTS_IN_ORGANIZATION(400, 4021, "The user {0} has already been added to the organization with role {1}. To change the role, please navigate to `Manage Users` page.", AppsmithErrorAction.DEFAULT),
     UNAUTHORIZED_DOMAIN(401, 4019, "Invalid email domain {0} used for sign in/sign up. Please contact the administrator to configure this domain if this is unexpected.", AppsmithErrorAction.DEFAULT),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -34,7 +34,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -358,8 +357,13 @@ public class LayoutActionServiceImpl implements LayoutActionService {
 
                     // We found the path. But if the path does not have any mustache bindings, throw the error
                     if (mustacheKeysFromFields.isEmpty()) {
-                        throw new AppsmithException(AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE, widgetType,
-                                widgetName, widgetId, fieldPath, pageId, layoutId, parent);
+                        try {
+                            String bindingAsString = objectMapper.writeValueAsString(parent);
+                            throw new AppsmithException(AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE, widgetType,
+                                widgetName, widgetId, fieldPath, pageId, layoutId, bindingAsString);
+                        } catch (JsonProcessingException e) {
+                            throw new AppsmithException(AppsmithError.JSON_PROCESSING_ERROR, parent);
+                        }
                     }
 
                     dynamicBindings.addAll(mustacheKeysFromFields);


### PR DESCRIPTION
This is to ensure that the client can parse it correctly

