### PR TITLE
fix default override same value

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -345,6 +345,7 @@ export default class DataTreeEvaluator {
   ): DataTree {
     const tree = _.cloneDeep(oldUnevalTree);
     try {
+      debugger;
       return sortedDependencies.reduce(
         (currentTree: DataTree, propertyPath: string) => {
           this.logs.push(`evaluating ${propertyPath}`);
@@ -387,6 +388,13 @@ export default class DataTreeEvaluator {
             // The following line will calculated the property name to be selectedRow
             // instead of selectedRow.email
             const propertyName = propertyPath.split(".")[1];
+            const defaultPropertyMap = this.widgetConfigMap[widgetEntity.type]
+              .defaultProperties;
+            const isDefaultProperty = !!Object.values(
+              defaultPropertyMap,
+            ).filter(
+              (defaultPropertyName) => propertyName === defaultPropertyName,
+            ).length;
             if (propertyName) {
               let parsedValue = this.validateAndParseWidgetProperty(
                 propertyPath,
@@ -394,9 +402,8 @@ export default class DataTreeEvaluator {
                 currentTree,
                 evalPropertyValue,
                 unEvalPropertyValue,
+                isDefaultProperty,
               );
-              const defaultPropertyMap = this.widgetConfigMap[widgetEntity.type]
-                .defaultProperties;
               const hasDefaultProperty = propertyName in defaultPropertyMap;
               if (hasDefaultProperty) {
                 const defaultProperty = defaultPropertyMap[propertyName];
@@ -576,6 +583,7 @@ export default class DataTreeEvaluator {
     currentTree: DataTree,
     evalPropertyValue: any,
     unEvalPropertyValue: string,
+    isDefaultProperty: boolean,
   ): any {
     const entityPropertyName = _.drop(propertyPath.split(".")).join(".");
     let valueToValidate = evalPropertyValue;
@@ -615,7 +623,7 @@ export default class DataTreeEvaluator {
       return unEvalPropertyValue;
     } else {
       const parsedCache = this.getParsedValueCache(propertyPath);
-      if (!equal(parsedCache.value, parsed)) {
+      if (!equal(parsedCache.value, parsed) || isDefaultProperty) {
         this.parsedValueCache.set(propertyPath, {
           value: parsed,
           version: Date.now(),

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -622,6 +622,8 @@ export default class DataTreeEvaluator {
       return unEvalPropertyValue;
     } else {
       const parsedCache = this.getParsedValueCache(propertyPath);
+      // In case this is a default property, always set the cache even in the value remains the same so that the version 
+      // in cache gets updated and the property dependent on default property updates accordingly.
       if (!equal(parsedCache.value, parsed) || isDefaultProperty) {
         this.parsedValueCache.set(propertyPath, {
           value: parsed,

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -622,7 +622,7 @@ export default class DataTreeEvaluator {
       return unEvalPropertyValue;
     } else {
       const parsedCache = this.getParsedValueCache(propertyPath);
-      // In case this is a default property, always set the cache even in the value remains the same so that the version 
+      // In case this is a default property, always set the cache even if the value remains the same so that the version
       // in cache gets updated and the property dependent on default property updates accordingly.
       if (!equal(parsedCache.value, parsed) || isDefaultProperty) {
         this.parsedValueCache.set(propertyPath, {

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -345,7 +345,6 @@ export default class DataTreeEvaluator {
   ): DataTree {
     const tree = _.cloneDeep(oldUnevalTree);
     try {
-      debugger;
       return sortedDependencies.reduce(
         (currentTree: DataTree, propertyPath: string) => {
           this.logs.push(`evaluating ${propertyPath}`);


### PR DESCRIPTION
## Description
Default value overrides happen by tracking value changes of their paths. Post our subtree optimisations, this can be improved by always updating the version of the default value property if it gets evaluated. That way, we make sure that the values are overridden any time the default property value changes

Fixes #3443 