### PR TITLE
Firestore plugin support for FieldValue.delete() and FieldValue.serverTimestamp() values

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/pom.xml
+++ b/app/server/appsmith-plugins/firestorePlugin/pom.xml
@@ -53,6 +53,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -235,22 +235,38 @@ public class FirestorePlugin extends BasePlugin {
                     );
                 }
 
-                //TODO: remove it.
-                System.out.println("devtest: " + deletePathsList);
-
                 deletePathsList.stream()
                         .forEach(pathList -> {
                             Map<String, Object> targetKeyValuePair = mapBody;
                             for(int i=0; i<pathList.size()-1; i++) {
-                                //TODO: remove it.
-                                System.out.println("devtest: " + pathList.get(i));
                                 targetKeyValuePair = (Map<String, Object>)targetKeyValuePair.get(pathList.get(i));
                             }
                             targetKeyValuePair.put(pathList.get(pathList.size()-1), FieldValue.delete());
                         });
+            }
 
-                //TODO: remove it.
-                System.out.println("devtest: " + deletePathsList);
+            if(!StringUtils.isEmpty(properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue())) {
+                String timestampValuePaths = properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue();
+                List<List<String>> timestampPathsList;
+                try {
+                    timestampPathsList = objectMapper.readValue(timestampValuePaths,
+                            new TypeReference<List<List<String>>>(){});
+                } catch (IOException e) {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Appsmith failed to parse the query editor form field 'Timestamp Value Path'. " +
+                                    "Please check out Appsmith's documentation to find the correct syntax."
+                    );
+                }
+
+                timestampPathsList.stream()
+                        .forEach(pathList -> {
+                            Map<String, Object> targetKeyValuePair = mapBody;
+                            for(int i=0; i<pathList.size()-1; i++) {
+                                targetKeyValuePair = (Map<String, Object>)targetKeyValuePair.get(pathList.get(i));
+                            }
+                            targetKeyValuePair.put(pathList.get(pathList.size()-1), FieldValue.serverTimestamp());
+                        });
             }
         }
 
@@ -303,6 +319,10 @@ public class FirestorePlugin extends BasePlugin {
                             }
 
                         } catch (IllegalAccessException | InvocationTargetException e) {
+                            /*
+                             * - Printing the stack because e.getMessage() returns null for FieldValue errors.
+                             */
+                            e.printStackTrace();
                             return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, e.getMessage()));
 
                         }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -198,7 +198,7 @@ public class FirestorePlugin extends BasePlugin {
                     })
                     .subscribeOn(scheduler);
         }
-
+        
         private void insertFieldValues(Map<String, Object> mapBody,
                                        List<Property> properties,
                                        Method method) throws AppsmithPluginException {
@@ -235,14 +235,16 @@ public class FirestorePlugin extends BasePlugin {
                     );
                 }
 
-                deletePathsList.stream()
+                insertFieldValueByName(mapBody, deletePathsList, "delete");
+
+                /*deletePathsList.stream()
                         .forEach(pathList -> {
                             Map<String, Object> targetKeyValuePair = mapBody;
                             for(int i=0; i<pathList.size()-1; i++) {
                                 targetKeyValuePair = (Map<String, Object>)targetKeyValuePair.get(pathList.get(i));
                             }
                             targetKeyValuePair.put(pathList.get(pathList.size()-1), FieldValue.delete());
-                        });
+                        });*/
             }
 
             if(!StringUtils.isEmpty(properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue())) {
@@ -259,15 +261,34 @@ public class FirestorePlugin extends BasePlugin {
                     );
                 }
 
-                timestampPathsList.stream()
+                insertFieldValueByName(mapBody, timestampPathsList, "serverTimestamp");
+                /*timestampPathsList.stream()
                         .forEach(pathList -> {
                             Map<String, Object> targetKeyValuePair = mapBody;
                             for(int i=0; i<pathList.size()-1; i++) {
                                 targetKeyValuePair = (Map<String, Object>)targetKeyValuePair.get(pathList.get(i));
                             }
                             targetKeyValuePair.put(pathList.get(pathList.size()-1), FieldValue.serverTimestamp());
-                        });
+                        });*/
             }
+        }
+        
+        private void insertFieldValueByName(Map<String, Object> mapBody,
+                                            List<List<String>> pathsList,
+                                            String fieldValueName) throws AppsmithPluginException {
+            pathsList.stream()
+                    .forEach(singlePathList -> {
+                        Map<String, Object> targetKeyValuePair = mapBody;
+                        for(int i=0; i<singlePathList.size()-1; i++) {
+                            targetKeyValuePair = (Map<String, Object>)targetKeyValuePair.get(singlePathList.get(i));
+                        }
+                        try {
+                            targetKeyValuePair.put(singlePathList.get(singlePathList.size()-1),
+                                    FieldValue.class.getMethod(fieldValueName).invoke(null));
+                        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
         }
 
         public Mono<ActionExecutionResult> handleDocumentLevelMethod(

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/Method.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/Method.java
@@ -3,10 +3,10 @@ package com.external.plugins;
 public enum Method {
     GET_DOCUMENT(true, false),
     GET_COLLECTION(false, false),
-    SET_DOCUMENT(true, true),
-    CREATE_DOCUMENT(true, true),
-    ADD_TO_COLLECTION(false, true),
-    UPDATE_DOCUMENT(true, true),
+    SET_DOCUMENT(true, false),
+    CREATE_DOCUMENT(true, false),
+    ADD_TO_COLLECTION(false, false),
+    UPDATE_DOCUMENT(true, false),
     DELETE_DOCUMENT(true, false),
     ;
 

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
@@ -86,7 +86,7 @@
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[9].value",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "",
-          "placeholderText": "[\"user\", \"name\"]",
+          "placeholderText": "[[\"user\", \"name\"]]",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "IN",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
@@ -67,7 +67,7 @@
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[8].value",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "",
-          "placeholderText": "[\"userInfo\", \"lastUpdateTs\"]",
+          "placeholderText": "[[\"userInfoKey\", \"nestedLastUpdateTsKey\"]]",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "IN",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
@@ -82,7 +82,7 @@
           "hidden": true
         },
         {
-          "label": "Delete Key Path",
+          "label": "Delete Key Value Pair Path",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[9].value",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
@@ -56,6 +56,44 @@
           "initialValue": ""
         },
         {
+          "label": "Timestamp Value Path Key",
+          "configProperty": "actionConfiguration.pluginSpecifiedTemplates[8].key",
+          "controlType": "INPUT_TEXT",
+          "initialValue": "timestampValuePath",
+          "hidden": true
+        },
+        {
+          "label": "Timestamp Value Path",
+          "configProperty": "actionConfiguration.pluginSpecifiedTemplates[8].value",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "initialValue": "",
+          "placeholderText": "[\"userInfo\", \"lastUpdateTs\"]",
+          "hidden": {
+            "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
+            "comparison": "IN",
+            "value":  ["GET_DOCUMENT", "GET_COLLECTION", "DELETE_DOCUMENT"]
+          }
+        },
+        {
+          "label": "Delete Key Value Pair Path Key",
+          "configProperty": "actionConfiguration.pluginSpecifiedTemplates[9].key",
+          "controlType": "INPUT_TEXT",
+          "initialValue": "deleteKeyValuePairPath",
+          "hidden": true
+        },
+        {
+          "label": "Delete Key Path",
+          "configProperty": "actionConfiguration.pluginSpecifiedTemplates[9].value",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "initialValue": "",
+          "placeholderText": "[\"user\", \"name\"]",
+          "hidden": {
+            "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
+            "comparison": "IN",
+            "value":  ["GET_DOCUMENT", "GET_COLLECTION", "DELETE_DOCUMENT", "CREATE_DOCUMENT", "ADD_TO_COLLECTION", "SET_DOCUMENT"]
+          }
+        },
+        {
           "label": "Order By Key",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[1].key",
           "controlType": "INPUT_TEXT",

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor.json
@@ -63,11 +63,11 @@
           "hidden": true
         },
         {
-          "label": "Timestamp Value Path",
+          "label": "Timestamp Value Path (use dot(.) notation to reference nested key e.g. [\"key1.key2\"])",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[8].value",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "",
-          "placeholderText": "[[\"userInfoKey\", \"nestedLastUpdateTsKey\"]]",
+          "placeholderText": "[\"checkinLog.timestampKey\", \"auditLog.timestampKey\"]",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "IN",
@@ -82,11 +82,11 @@
           "hidden": true
         },
         {
-          "label": "Delete Key Value Pair Path",
+          "label": "Delete Key Value Pair Path (use dot(.) notation to reference nested key e.g. [\"key1.key2\"])",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[9].value",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "",
-          "placeholderText": "[[\"user\", \"name\"]]",
+          "placeholderText": "[\"userKey.nestedNamekey\", \"cityKey.nestedPincodeKey\"]",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
             "comparison": "IN",

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -617,7 +617,7 @@ public class FirestorePluginTest {
         properties.add(null); // index 5
         properties.add(null); // index 6
         properties.add(null); // index 7
-        properties.add(new Property("key path", "[[\"value\"]]")); // index 8 - path for timestampServer fieldValue.
+        properties.add(new Property("key path", "[\"value\"]")); // index 8 - path for timestampServer fieldValue.
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setPluginSpecifiedTemplates(properties);
@@ -669,7 +669,7 @@ public class FirestorePluginTest {
         properties.add(null); // index 6
         properties.add(null); // index 7
         properties.add(null); // index 8
-        properties.add(new Property("key path", "[[\"value\"]]")); // index 9 - path for delete fieldValue.
+        properties.add(new Property("key path", "[\"value\"]")); // index 9 - path for delete fieldValue.
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setPluginSpecifiedTemplates(properties);
@@ -721,7 +721,7 @@ public class FirestorePluginTest {
         properties.add(null); // index 6
         properties.add(null); // index 7
         properties.add(null); // index 8
-        properties.add(new Property("key path", "[[\"value\"]]")); // index 9 - path for delete fieldValue.
+        properties.add(new Property("key path", "[\"value\"]")); // index 9 - path for delete fieldValue.
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setPluginSpecifiedTemplates(properties);
@@ -755,7 +755,7 @@ public class FirestorePluginTest {
         properties.add(null); // index 5
         properties.add(null); // index 6
         properties.add(null); // index 7
-        properties.add(new Property("key path", "[[\"value\"]]")); // index 8 - path for serverTimestamp fieldValue.
+        properties.add(new Property("key path", "[\"value\"]")); // index 8 - path for serverTimestamp fieldValue.
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setPluginSpecifiedTemplates(properties);
@@ -789,7 +789,7 @@ public class FirestorePluginTest {
         properties.add(null); // index 6
         properties.add(null); // index 7
         properties.add(null); // index 8
-        properties.add(new Property("key path", "[\"value\"]")); // index 9 - path for delete fieldValue.
+        properties.add(new Property("key path", "value")); // index 9 - path for delete fieldValue.
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setPluginSpecifiedTemplates(properties);
@@ -823,7 +823,7 @@ public class FirestorePluginTest {
         properties.add(null); // index 5
         properties.add(null); // index 6
         properties.add(null); // index 7
-        properties.add(new Property("key path", "[\"value\"]")); // index 8 - path for serverTimestamp fieldValue.
+        properties.add(new Property("key path", "value")); // index 8 - path for serverTimestamp fieldValue.
 
         ActionConfiguration actionConfiguration = new ActionConfiguration();
         actionConfiguration.setPluginSpecifiedTemplates(properties);
@@ -836,6 +836,7 @@ public class FirestorePluginTest {
                 .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
         StepVerifier.create(resultMono)
                 .assertNext(result -> {
+
                     assertFalse(result.getIsExecutionSuccess());
 
                     String expectedErrorMessage = "Appsmith failed to parse the query editor form field 'Timestamp " +

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.ServiceOptions;
+import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.Blob;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.DocumentSnapshot;
@@ -31,6 +32,8 @@ import reactor.test.StepVerifier;
 import reactor.util.function.Tuple3;
 
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -603,4 +606,242 @@ public class FirestorePluginTest {
                 .verifyComplete();
     }
 
+    @Test
+    public void testUpdateDocumentWithFieldValueTimestamp() {
+        List<Property> properties = new ArrayList<>();
+        properties.add(new Property("method", "UPDATE_DOCUMENT")); // index 0
+        properties.add(null); // index 1
+        properties.add(null); // index 2
+        properties.add(null); // index 3
+        properties.add(null); // index 4
+        properties.add(null); // index 5
+        properties.add(null); // index 6
+        properties.add(null); // index 7
+        properties.add(new Property("key path", "[[\"value\"]]")); // index 8 - path for timestampServer fieldValue.
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPluginSpecifiedTemplates(properties);
+        actionConfiguration.setPath("changing/to-update");
+        actionConfiguration.setBody("{\n" +
+                "    \"value\": 2\n" +
+                "}");
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor
+                .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
+
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    try {
+                        final DocumentSnapshot documentSnapshot = firestoreConnection.document("changing/to-update").get().get();
+                        assertTrue(documentSnapshot.exists());
+
+                        try {
+                            /*
+                             * - If the value against the key "value" has been replaced by a valid timestamp, then
+                             *   the getString method here must fail.
+                             */
+                            documentSnapshot.getString("value");
+                        } catch (Exception e) {
+                            assertTrue(e.getMessage().contains("Timestamp cannot be cast to class java.lang.String"));
+                        }
+                    } catch (NullPointerException | InterruptedException | ExecutionException e) {
+                        e.printStackTrace();
+                        throw new RuntimeException(e);
+                    }
+                })
+                .verifyComplete();
+    }
+
+    /*
+     * - First delete key.
+     * - Then verify that the key does not exist in the list of keys returned by reading the document.
+     */
+    @Test
+    public void testUpdateDocumentWithFieldValueDelete() {
+        List<Property> properties = new ArrayList<>();
+        properties.add(new Property("method", "UPDATE_DOCUMENT")); // index 0
+        properties.add(null); // index 1
+        properties.add(null); // index 2
+        properties.add(null); // index 3
+        properties.add(null); // index 4
+        properties.add(null); // index 5
+        properties.add(null); // index 6
+        properties.add(null); // index 7
+        properties.add(null); // index 8
+        properties.add(new Property("key path", "[[\"value\"]]")); // index 9 - path for delete fieldValue.
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPluginSpecifiedTemplates(properties);
+        actionConfiguration.setPath("changing/to-update");
+        actionConfiguration.setBody("{\n" +
+                "    \"value\": 2\n" +
+                "}");
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor
+                .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
+
+        /*
+         * - Delete key.
+         */
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                })
+                .verifyComplete();
+
+        actionConfiguration.setPath("changing/to-update");
+        actionConfiguration.setBody("");
+        actionConfiguration.setPluginSpecifiedTemplates(List.of(new Property("method", "GET_DOCUMENT")));
+
+        resultMono = pluginExecutor
+                .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
+
+        /*
+         * - Verify that the key does not exist in the list of keys returned by reading the document.
+         */
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    final Map<String, Object> doc = (Map) result.getBody();
+                    assertFalse(doc.keySet().contains("value"));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testFieldValueDeleteWithUnsupportedAction() {
+        List<Property> properties = new ArrayList<>();
+        properties.add(new Property("method", "CREATE_DOCUMENT")); // index 0
+        properties.add(null); // index 1
+        properties.add(null); // index 2
+        properties.add(null); // index 3
+        properties.add(null); // index 4
+        properties.add(null); // index 5
+        properties.add(null); // index 6
+        properties.add(null); // index 7
+        properties.add(null); // index 8
+        properties.add(new Property("key path", "[[\"value\"]]")); // index 9 - path for delete fieldValue.
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPluginSpecifiedTemplates(properties);
+        actionConfiguration.setPath("changing/to-update");
+        actionConfiguration.setBody("{\n" +
+                "    \"value\": 2\n" +
+                "}");
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor
+                .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertFalse(result.getIsExecutionSuccess());
+
+                    String expectedErrorMessage = "Appsmith has found an unexpected query form property - 'Delete Key " +
+                            "Value Pair Path'. Please reach out to Appsmith customer support to resolve this.";
+                    assertTrue(expectedErrorMessage.equals(result.getBody()));
+                })
+                .verifyComplete();
+
+    }
+
+    @Test
+    public void testFieldValueTimestampWithUnsupportedAction() {
+        List<Property> properties = new ArrayList<>();
+        properties.add(new Property("method", "GET_DOCUMENT")); // index 0
+        properties.add(null); // index 1
+        properties.add(null); // index 2
+        properties.add(null); // index 3
+        properties.add(null); // index 4
+        properties.add(null); // index 5
+        properties.add(null); // index 6
+        properties.add(null); // index 7
+        properties.add(new Property("key path", "[[\"value\"]]")); // index 8 - path for serverTimestamp fieldValue.
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPluginSpecifiedTemplates(properties);
+        actionConfiguration.setPath("changing/to-update");
+        actionConfiguration.setBody("{\n" +
+                "    \"value\": 2\n" +
+                "}");
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor
+                .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertFalse(result.getIsExecutionSuccess());
+
+                    String expectedErrorMessage = "Appsmith has found an unexpected query form property - 'Timestamp " +
+                            "Value Path'. Please reach out to Appsmith customer support to resolve this.";
+                    assertTrue(expectedErrorMessage.equals(result.getBody()));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testFieldValueDeleteWithBadArgument() {
+        List<Property> properties = new ArrayList<>();
+        properties.add(new Property("method", "UPDATE_DOCUMENT")); // index 0
+        properties.add(null); // index 1
+        properties.add(null); // index 2
+        properties.add(null); // index 3
+        properties.add(null); // index 4
+        properties.add(null); // index 5
+        properties.add(null); // index 6
+        properties.add(null); // index 7
+        properties.add(null); // index 8
+        properties.add(new Property("key path", "[\"value\"]")); // index 9 - path for delete fieldValue.
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPluginSpecifiedTemplates(properties);
+        actionConfiguration.setPath("changing/to-update");
+        actionConfiguration.setBody("{\n" +
+                "    \"value\": 2\n" +
+                "}");
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor
+                .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertFalse(result.getIsExecutionSuccess());
+
+                    String expectedErrorMessage = "Appsmith failed to parse the query editor form field 'Delete Key " +
+                            "Value Pair Path'. Please check out Appsmith's documentation to find the correct syntax.";
+                    assertTrue(expectedErrorMessage.equals(result.getBody()));
+                })
+                .verifyComplete();
+
+    }
+
+    @Test
+    public void testFieldValueTimestampWithBadArgument() {
+        List<Property> properties = new ArrayList<>();
+        properties.add(new Property("method", "UPDATE_DOCUMENT")); // index 0
+        properties.add(null); // index 1
+        properties.add(null); // index 2
+        properties.add(null); // index 3
+        properties.add(null); // index 4
+        properties.add(null); // index 5
+        properties.add(null); // index 6
+        properties.add(null); // index 7
+        properties.add(new Property("key path", "[\"value\"]")); // index 8 - path for serverTimestamp fieldValue.
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPluginSpecifiedTemplates(properties);
+        actionConfiguration.setPath("changing/to-update");
+        actionConfiguration.setBody("{\n" +
+                "    \"value\": 2\n" +
+                "}");
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor
+                .executeParameterized(firestoreConnection, null, dsConfig, actionConfiguration);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertFalse(result.getIsExecutionSuccess());
+
+                    String expectedErrorMessage = "Appsmith failed to parse the query editor form field 'Timestamp " +
+                            "Value Path'. Please check out Appsmith's documentation to find the correct syntax.";
+                    assertTrue(expectedErrorMessage.equals(result.getBody()));
+                })
+                .verifyComplete();
+    }
 }


### PR DESCRIPTION
## Description
- Allow users to define key path for FieldValue.delete() and FieldValue.serverTimestamp() values. 
- delete() value is only valid for update operation, as Firestore does not seem to support it for any other ops.
- serverTimestamp() is valid for all operations excluding get and delete operations.

### Note
- `FieldValue.delete()` value cannot be used to delete array elements. To delete array elements `FieldValue.arrayRemove()` needs to be used. https://firebase.google.com/docs/reference/android/com/google/firebase/firestore/FieldValue#arrayRemove(java.lang.Object...)
- `FieldValue.serverTimestamp()` value cannot be used inside array. It throws the following exception: 
`Caused by: com.google.cloud.firestore.FirestoreException: FieldValue.serverTimestamp() is not supported inside of an array.`
- Capturing the support for array ops here: https://github.com/appsmithorg/appsmith/issues/3770 

Fixes #3475 

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

- Added Junit TCs
- Manual


https://user-images.githubusercontent.com/1757421/112421483-1ccf0d00-8d55-11eb-92e3-8aeb6c1f1836.mov


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
