### PR TITLE
Fix: TypeError: e.widgetName is undefined and TypeError: Cannot read property 'toUpperCase' of undefined

### DIFF
--- a/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
+++ b/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
@@ -194,7 +194,7 @@ export const getLightningMenuOptions = (
   ];
   if (widgets.length > 0) {
     widgets = widgets.sort((a: WidgetProps, b: WidgetProps) => {
-      return a.widgetName.toUpperCase() > b.widgetName.toUpperCase() ? 1 : -1;
+      return a.widgetName?.toUpperCase() > b.widgetName?.toUpperCase() ? 1 : -1;
     });
     options.push({
       content: (

--- a/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
+++ b/app/client/src/components/editorComponents/LightningMenu/helpers.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { toUpper, get } from "lodash";
 import { Action } from "entities/Action";
 import { Directions } from "utils/helpers";
 import { WidgetProps } from "widgets/BaseWidget";
@@ -194,7 +195,9 @@ export const getLightningMenuOptions = (
   ];
   if (widgets.length > 0) {
     widgets = widgets.sort((a: WidgetProps, b: WidgetProps) => {
-      return a.widgetName?.toUpperCase() > b.widgetName?.toUpperCase() ? 1 : -1;
+      return toUpper(get(a, "widgetName")) > toUpper(get(b, "widgetName"))
+        ? 1
+        : -1;
     });
     options.push({
       content: (


### PR DESCRIPTION
toUpperCase() on undefined was failing. Using lodash instead of native string functions.


Fixes #3672 #3673 

## Type of change

- Bug fix


## How Has This Been Tested?

- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
