### PR TITLE
Fix #3381: Table column properties now map correctly when filtering, sorting or searching

### DIFF
--- a/app/client/src/widgets/TableWidget/derived.js
+++ b/app/client/src/widgets/TableWidget/derived.js
@@ -182,7 +182,7 @@ export default {
     if (!props.sanitizedTableData || !props.sanitizedTableData.length) {
       return [];
     }
-    const derivedTableData = [...props.sanitizedTableData];
+    let derivedTableData = [...props.sanitizedTableData];
     if (props.primaryColumns && _.isPlainObject(props.primaryColumns)) {
       const primaryColumns = props.primaryColumns;
       const columnIds = Object.keys(props.primaryColumns);
@@ -219,6 +219,11 @@ export default {
         }
       });
     }
+
+    derivedTableData = derivedTableData.map((item, index) => ({
+      ...item,
+      __originalIndex__: index,
+    }));
 
     const columns = props.columns;
 
@@ -280,9 +285,7 @@ export default {
       isExactly: (a, b) => {
         return a.toString() === b.toString();
       },
-      empty: (a) => {
-        return a === "" || a === undefined || a === null;
-      },
+      empty: _.isEmpty,
       notEmpty: (a) => {
         return a !== "" && a !== undefined && a !== null;
       },
@@ -313,28 +316,35 @@ export default {
         return numericA >= numericB;
       },
       contains: (a, b) => {
-        if (_.isString(a) && _.isString(b)) {
-          return a.includes(b);
+        try {
+          return a.toString().includes(b.toString());
+        } catch (e) {
+          return false;
         }
-        return false;
       },
       doesNotContain: (a, b) => {
-        if (_.isString(a) && _.isString(b)) {
-          return !a.includes(b);
+        try {
+          return !this.contains(a, b);
+        } catch (e) {
+          return false;
         }
-        return false;
       },
       startsWith: (a, b) => {
-        if (_.isString(a) && _.isString(b)) {
-          return a.indexOf(b) === 0;
+        try {
+          return a.toString().indexOf(b.toString()) === 0;
+        } catch (e) {
+          return false;
         }
-        return false;
       },
       endsWith: (a, b) => {
-        if (_.isString(a) && _.isString(b)) {
-          return a.length === a.indexOf(b) + b.length;
+        try {
+          const _a = a.toString();
+          const _b = b.toString();
+
+          return _a.length === _a.indexOf(_b) + _b.length;
+        } catch (e) {
+          return false;
         }
-        return false;
       },
       is: (a, b) => {
         return moment(a).isSame(moment(b), "d");

--- a/app/client/src/widgets/TableWidget/derived.test.js
+++ b/app/client/src/widgets/TableWidget/derived.test.js
@@ -519,8 +519,8 @@ describe("Validates Derived Properties", () => {
       ],
     };
     const expected = [
-      { id: 234, name: "Jane Doe", extra: "Extra2" },
-      { id: 123, name: "John Doe", extra: "Extra1" },
+      { id: 234, name: "Jane Doe", extra: "Extra2", __originalIndex__: 1 },
+      { id: 123, name: "John Doe", extra: "Extra1", __originalIndex__: 0 },
     ];
 
     let result = getFilteredTableData(input, moment, _);
@@ -666,9 +666,9 @@ describe("Validates Derived Properties", () => {
       ],
     };
     const expected = [
-      { id: 1234, name: "Jim Doe", extra: "" },
-      { id: 234, name: "Jane Doe", extra: "Extra2" },
-      { id: 123, name: "John Doe", extra: "Extra1" },
+      { id: 1234, name: "Jim Doe", extra: "", __originalIndex__: 0 },
+      { id: 234, name: "Jane Doe", extra: "Extra2", __originalIndex__: 2 },
+      { id: 123, name: "John Doe", extra: "Extra1", __originalIndex__: 1 },
     ];
 
     let result = getFilteredTableData(input, moment, _);

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -182,7 +182,10 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
         },
         columnProperties: columnProperties,
         Cell: (props: any) => {
-          const rowIndex: number = props.cell.row.index;
+          let rowIndex: number = props.cell.row.index;
+          const data = this.props.filteredTableData[rowIndex];
+          if (data && data.__originalIndex__) rowIndex = data.__originalIndex__;
+
           const cellProperties = this.getCellProperties(
             columnProperties,
             rowIndex,


### PR DESCRIPTION

## Description
- Fix: Some comparison functions were not working correctly for non-string data
- Fix: Column properties were not updating based on the filter, sort and search values

Fixes #3381

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Updated unit tests
- Cypress test pending

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
