### PR TITLE
Add a memory based fallback for `localstorage` for scripts within index.html

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -34,6 +34,18 @@
   <div id="header-root"></div>
   <div id="root"></div>
   <script type="text/javascript">
+    // Memory based localstorage fallback for cases where we need a basic store
+    // similar to a shared object
+    if (!window.localStorage) {
+      window.localStorage = {
+        _data       : {},
+        setItem     : function(id, val) { return this._data[id] = typeof val === "string" ? val : JSON.stringify(val); },
+        getItem     : function(id) { return this._data.hasOwnProperty(id) ? this._data[id] : undefined; },
+        removeItem  : function(id) { return delete this._data[id]; },
+        clear       : function() { return this._data = {}; }
+      };
+    }
+
     // Note: The following handler is necessary for when we have a new deployment.
 
     // What happens?


### PR DESCRIPTION
## Description
Add a memory based fallback for `localstorage` scripts within index.html

Fixes #3671

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
