### PR TITLE
Fix onboarding test spec: check res instead of req to validate

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
@@ -27,7 +27,7 @@ describe("Onboarding", function() {
 
         if (!onboardingDatasource) {
           cy.wait("@createDatasource").then((httpRequest) => {
-            const createdDbName = httpRequest.request.body.name;
+            const createdDbName = httpRequest.response.body.data.name;
             expect(createdDbName).to.be.equal("Super Updates DB");
           });
         }


### PR DESCRIPTION
Fix onboarding test spec: check res instead of req to validate

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Test spec

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
