### PR TITLE
Fix #3752 Datepicker defaultDate auto parse

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
@@ -60,7 +60,7 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
 
   it("Datepicker default date validation message", function() {
     cy.openPropertyPane("datepickerwidget2");
-    cy.testJsontext("defaultdate", "2020-02-01");
+    cy.testJsontext("defaultdate", "24-12-2021");
     cy.evaluateErrorMessage(
       "Value does not match ISO 8601 standard date string",
     );

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -1,6 +1,7 @@
 import { VALIDATORS, validateDateString } from "workers/validations";
 import { WidgetProps } from "widgets/BaseWidget";
 import { RenderModes, WidgetTypes } from "constants/WidgetConstants";
+import moment from "moment";
 
 const DUMMY_WIDGET: WidgetProps = {
   bottomRow: 0,
@@ -12,7 +13,7 @@ const DUMMY_WIDGET: WidgetProps = {
   rightColumn: 0,
   topRow: 0,
   type: WidgetTypes.SKELETON_WIDGET,
-  version: 0,
+  version: 2,
   widgetId: "",
   widgetName: "",
 };
@@ -474,6 +475,11 @@ describe("validateDateString test", () => {
         format: "YYYY-MM-DD",
         version: 1,
       },
+      {
+        date: "2021-03-12",
+        format: "YYYY-MM-DD",
+        version: 2,
+      },
     ];
 
     validDateStrings.forEach((item) => {
@@ -506,6 +512,28 @@ describe("validateDateString test", () => {
       expect(
         validateDateString(item.date, item.format, item.version),
       ).toBeFalsy();
+    });
+  });
+
+  it("Checks whether a valid value is returned even if a valid date is not an ISO string", () => {
+    const validator = VALIDATORS.DEFAULT_DATE;
+    const inputs = [
+      "12/12/2014",
+      "12-12-2014",
+      "01/13/2014",
+      "01-13-2014",
+      moment().toISOString(),
+    ];
+    inputs.forEach((item) => {
+      const dateString = moment(item).toISOString(true);
+      const result = validator(item, DUMMY_WIDGET);
+
+      const expected = {
+        parsed: dateString,
+        isValid: true,
+        message: "",
+      };
+      expect(result).toStrictEqual(expected);
     });
   });
 });

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -523,6 +523,7 @@ describe("validateDateString test", () => {
       "01/13/2014",
       "01-13-2014",
       moment().toISOString(),
+      moment().toISOString(true),
     ];
     inputs.forEach((item) => {
       const dateString = moment(item).toISOString(true);

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -518,8 +518,8 @@ describe("validateDateString test", () => {
   it("Checks whether a valid value is returned even if a valid date is not an ISO string", () => {
     const validator = VALIDATORS.DEFAULT_DATE;
     const inputs = [
-      "12/12/2014",
-      "12-12-2014",
+      "2014/12/01",
+      "2014-12-01",
       "01/13/2014",
       "01-13-2014",
       moment().toISOString(),

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -31,6 +31,10 @@ export function validateDateString(
     try {
       const d = new Date(dateString);
       isValid = d.toISOString() === dateString;
+      if (!isValid) {
+        const parsedDate = moment(dateString);
+        isValid = parsedDate.isValid();
+      }
     } catch (e) {
       isValid = false;
     }
@@ -498,6 +502,16 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
       };
     }
     const isValid = validateDateString(dateString, dateFormat, props.version);
+    let parsedDate = dateString;
+
+    try {
+      if (isValid && props.version === 2) {
+        parsedDate = moment(dateString).toISOString(true);
+      }
+    } catch (e) {
+      console.error("Could not parse date", parsedDate, e);
+    }
+
     if (!isValid) {
       return {
         isValid: isValid,
@@ -507,7 +521,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
     }
     return {
       isValid,
-      parsed: dateString,
+      parsed: parsedDate,
       message: isValid ? "" : `${WIDGET_TYPE_VALIDATION_ERROR}: Date`,
     };
   },
@@ -536,7 +550,17 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
             : "",
       };
     }
+
     const isValid = validateDateString(dateString, dateFormat, props.version);
+    let parsedDate = dateString;
+
+    try {
+      if (isValid && props.version === 2) {
+        parsedDate = moment(dateString).toISOString(true);
+      }
+    } catch (e) {
+      console.error("Could not parse date", parsedDate, e);
+    }
     if (!isValid) {
       return {
         isValid: isValid,
@@ -546,7 +570,7 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
     }
     return {
       isValid: isValid,
-      parsed: dateString,
+      parsed: parsedDate,
       message: "",
     };
   },

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -29,8 +29,9 @@ export function validateDateString(
   let isValid = true;
   if (version === 2) {
     try {
-      const d = new Date(dateString);
-      isValid = d.toISOString() === dateString;
+      const d = moment(dateString);
+      isValid =
+        d.toISOString(true) === dateString || d.toISOString() === dateString;
       if (!isValid) {
         const parsedDate = moment(dateString);
         isValid = parsedDate.isValid();


### PR DESCRIPTION
## Description
Tries to auto parse the given date string in the `defaultDate` input of the date picker widget. This tries to retain the timezone of the user.

Fixes #3752 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Unit tests added for validation

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
