### PR TITLE
Clone explicitly set datasource for new users

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/DatasourceRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/DatasourceRepository.java
@@ -4,8 +4,12 @@ import com.appsmith.server.domains.Datasource;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
+import java.util.List;
+
 @Repository
 public interface DatasourceRepository extends BaseRepository<Datasource, String>, CustomDatasourceRepository {
+
+    Flux<Datasource> findByIdIn(List<String> ids);
 
     Flux<Datasource> findAllByOrganizationId(String organizationId);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigService.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services;
 
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.Config;
+import com.appsmith.server.domains.Datasource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -15,4 +16,6 @@ public interface ConfigService extends CrudService<Config, String> {
     Mono<String> getTemplateOrganizationId();
 
     Flux<Application> getTemplateApplications();
+
+    Flux<Datasource> getTemplateDatasources();
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -167,7 +167,7 @@ public class ExamplesOrganizationClonerTests {
         final Mono<OrganizationData> resultMono = organizationService.create(newOrganization)
                 .zipWith(sessionUserService.getCurrentUser())
                 .flatMap(tuple ->
-                        examplesOrganizationCloner.cloneOrganizationForUser(tuple.getT1().getId(), tuple.getT2(), Flux.empty()))
+                        examplesOrganizationCloner.cloneOrganizationForUser(tuple.getT1().getId(), tuple.getT2(), Flux.empty(), Flux.empty()))
                 .flatMap(this::loadOrganizationData);
 
         StepVerifier.create(resultMono)
@@ -213,7 +213,8 @@ public class ExamplesOrganizationClonerTests {
                                     examplesOrganizationCloner.cloneOrganizationForUser(
                                             organization.getId(),
                                             tuple.getT2(),
-                                            Flux.fromArray(new Application[]{tuple1.getT1()})
+                                            Flux.fromArray(new Application[]{tuple1.getT1()}),
+                                            Flux.empty()
                                     )
                             );
                 })
@@ -272,7 +273,8 @@ public class ExamplesOrganizationClonerTests {
                                     examplesOrganizationCloner.cloneOrganizationForUser(
                                             organization.getId(),
                                             tuple.getT2(),
-                                            Flux.fromArray(new Application[]{tuple1.getT1(), tuple1.getT2()})
+                                            Flux.fromArray(new Application[]{tuple1.getT1(), tuple1.getT2()}),
+                                            Flux.empty()
                                     )
                             );
                 })
@@ -329,7 +331,7 @@ public class ExamplesOrganizationClonerTests {
                     return Mono.when(
                             applicationPageService.createApplication(app1),
                             applicationPageService.createApplication(app2)
-                    ).then(examplesOrganizationCloner.cloneOrganizationForUser(organization.getId(), tuple.getT2(), Flux.empty()));
+                    ).then(examplesOrganizationCloner.cloneOrganizationForUser(organization.getId(), tuple.getT2(), Flux.empty(), Flux.empty()));
                 })
                 .flatMap(this::loadOrganizationData);
 
@@ -437,7 +439,7 @@ public class ExamplesOrganizationClonerTests {
                     return Mono.when(
                             datasourceService.create(ds1),
                             datasourceService.create(ds2)
-                    ).then(examplesOrganizationCloner.cloneOrganizationForUser(organization.getId(), tuple.getT2(), Flux.empty()));
+                    ).then(examplesOrganizationCloner.cloneOrganizationForUser(organization.getId(), tuple.getT2(), Flux.empty(), Flux.empty()));
                 })
                 .flatMap(this::loadOrganizationData);
 
@@ -449,6 +451,65 @@ public class ExamplesOrganizationClonerTests {
                     assertThat(data.organization.getPolicies()).isNotEmpty();
 
                     assertThat(data.datasources).isEmpty();
+                    assertThat(data.applications).isEmpty();
+                    assertThat(data.actions).isEmpty();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void cloneOrganizationWithOnlyDatasourcesSpecifiedExplicitly() {
+        Organization newOrganization = new Organization();
+        newOrganization.setName("Template Organization 2");
+        final Mono<OrganizationData> resultMono = Mono
+                .zip(
+                        organizationService.create(newOrganization),
+                        sessionUserService.getCurrentUser()
+                )
+                .flatMap(tuple -> {
+                    final Organization organization = tuple.getT1();
+
+                    final Datasource ds1 = new Datasource();
+                    ds1.setName("datasource 1");
+                    ds1.setOrganizationId(organization.getId());
+                    final DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+                    ds1.setDatasourceConfiguration(datasourceConfiguration);
+                    datasourceConfiguration.setUrl("http://httpbin.org/get");
+                    datasourceConfiguration.setHeaders(List.of(
+                            new Property("X-Answer", "42")
+                    ));
+
+                    final Datasource ds2 = new Datasource();
+                    ds2.setName("datasource 2");
+                    ds2.setOrganizationId(organization.getId());
+                    ds2.setDatasourceConfiguration(new DatasourceConfiguration());
+                    DBAuth auth = new DBAuth();
+                    auth.setPassword("answer-to-life");
+                    ds2.getDatasourceConfiguration().setAuthentication(auth);
+
+                    return Mono.zip(
+                            datasourceService.create(ds1),
+                            datasourceService.create(ds2)
+                    ).flatMap(tuple1 -> examplesOrganizationCloner.cloneOrganizationForUser(
+                            organization.getId(),
+                            tuple.getT2(),
+                            Flux.empty(),
+                            Flux.just(tuple1.getT1())
+                    ));
+                })
+                .flatMap(this::loadOrganizationData);
+
+        StepVerifier.create(resultMono)
+                .assertNext(data -> {
+                    assertThat(data.organization).isNotNull();
+                    assertThat(data.organization.getId()).isNotNull();
+                    assertThat(data.organization.getName()).isEqualTo("api_user's apps");
+                    assertThat(data.organization.getPolicies()).isNotEmpty();
+
+                    assertThat(data.datasources).hasSize(1);
+                    assertThat(data.datasources.get(0).getName()).isEqualTo("datasource 1");
+
                     assertThat(data.applications).isEmpty();
                     assertThat(data.actions).isEmpty();
                 })
@@ -497,7 +558,8 @@ public class ExamplesOrganizationClonerTests {
                                     examplesOrganizationCloner.cloneOrganizationForUser(
                                             organization.getId(),
                                             tuple.getT2(),
-                                            Flux.fromArray(new Application[]{tuple1.getT1(), tuple1.getT2()})
+                                            Flux.fromArray(new Application[]{tuple1.getT1(), tuple1.getT2()}),
+                                            Flux.empty()
                                     )
                             );
                 })
@@ -651,7 +713,8 @@ public class ExamplesOrganizationClonerTests {
                                     examplesOrganizationCloner.cloneOrganizationForUser(
                                             organization.getId(),
                                             tuple.getT2(),
-                                            Flux.fromIterable(applications)
+                                            Flux.fromIterable(applications),
+                                            Flux.empty()
                                     )
                             );
                 })


### PR DESCRIPTION
This PR enables setting an explicit list of datasources from the template organization, that will be cloned for any new user that signs up.

Today, only those datasources are cloned that are used by any of the example apps that are being cloned. If a datasource in the template org is not used by any example apps, it will *not* be cloned.

This PR provides a way to set a list of datasources, that will be cloned, even if there's no example app that uses this datasource.

To configure that list of datasources, the following MongoDB command can be used:

```javascript
db.config.updateOne({name: "template-organization"}, {$set: {"config.datasourceIds": ["datasourceId1", "datasourceId2"]}})
```

Note that this assumes, the organization ID is already set. If not, that can be done with the following:

```javascript
db.config.updateOne({name: "template-organization"}, {$set: {"config.organizationId": "organizationId"}})
```
