### PR TITLE
Array support hidden field

### DIFF
--- a/app/client/src/components/formControls/BaseControl.tsx
+++ b/app/client/src/components/formControls/BaseControl.tsx
@@ -50,4 +50,45 @@ export interface ControlFunctions {
   onPropertyChange?: (propertyName: string, propertyValue: string) => void;
 }
 
+export const hidden = {
+  conditionType: "AND",
+  conditions: [
+    {
+      conditionType: "AND",
+      conditions: [
+        {
+          path: 2,
+          value: 2,
+          comparison: "EQUALS",
+        },
+        {
+          path: 2,
+          value: 2,
+          comparison: "EQUALS",
+        },
+      ],
+    },
+    {
+      conditionType: "AND",
+      conditions: [
+        {
+          conditionType: "OR",
+          conditions: [
+            {
+              path: 2,
+              value: 3,
+              comparison: "EQUALS",
+            },
+          ],
+        },
+        {
+          path: 3,
+          value: 3,
+          comparison: "EQUALS",
+        },
+      ],
+    },
+  ],
+};
+
 export default BaseControl;

--- a/app/client/src/components/formControls/BaseControl.tsx
+++ b/app/client/src/components/formControls/BaseControl.tsx
@@ -17,10 +17,17 @@ export type ComparisonOperations =
   | "IN"
   | "NOT_IN";
 
-export type HiddenType =
-  | boolean
-  | { path: string; comparison: ComparisonOperations; value: any };
+export type HiddenType = boolean | Condition | ConditionObject;
 
+export type ConditionObject = { conditionType: string; conditions: Conditions };
+
+export type Condition = {
+  path: string;
+  comparison: ComparisonOperations;
+  value: any;
+};
+
+export type Conditions = Array<Condition> | ConditionObject;
 export interface ControlBuilder<T extends ControlProps> {
   buildPropertyControl(controlProps: T): JSX.Element;
 }
@@ -49,46 +56,5 @@ export interface ControlData {
 export interface ControlFunctions {
   onPropertyChange?: (propertyName: string, propertyValue: string) => void;
 }
-
-export const hidden = {
-  conditionType: "AND",
-  conditions: [
-    {
-      conditionType: "AND",
-      conditions: [
-        {
-          path: 2,
-          value: 2,
-          comparison: "EQUALS",
-        },
-        {
-          path: 2,
-          value: 2,
-          comparison: "EQUALS",
-        },
-      ],
-    },
-    {
-      conditionType: "AND",
-      conditions: [
-        {
-          conditionType: "OR",
-          conditions: [
-            {
-              path: 2,
-              value: 3,
-              comparison: "EQUALS",
-            },
-          ],
-        },
-        {
-          path: 3,
-          value: 3,
-          comparison: "EQUALS",
-        },
-      ],
-    },
-  ],
-};
 
 export default BaseControl;

--- a/app/client/src/components/formControls/utils.test.ts
+++ b/app/client/src/components/formControls/utils.test.ts
@@ -1,4 +1,10 @@
-import { isHidden, getConfigInitialValues } from "./utils";
+import {
+  isHidden,
+  getConfigInitialValues,
+  caculateIsHidden,
+  evaluateCondtionWithType,
+} from "./utils";
+import { HiddenType } from "./BaseControl";
 
 describe("isHidden test", () => {
   it("Test for isHidden true", () => {
@@ -243,5 +249,38 @@ describe("getConfigInitialValues test", () => {
     testCases.forEach((testCase) => {
       expect(getConfigInitialValues(testCase.input)).toEqual(testCase.output);
     });
+  });
+});
+
+describe("caculateIsHidden test", () => {
+  it("calcualte hidden field value", () => {
+    const values = { name: "Name" };
+    const hiddenTruthy: HiddenType = {
+      path: "name",
+      comparison: "EQUALS",
+      value: "Name",
+    };
+    const hiddenFalsy: HiddenType = {
+      path: "name",
+      comparison: "EQUALS",
+      value: "Different Name",
+    };
+    expect(caculateIsHidden(values, hiddenTruthy)).toBeTruthy();
+    expect(caculateIsHidden(values, hiddenFalsy)).toBeFalsy();
+  });
+});
+
+describe("evaluateCondtionWithType test", () => {
+  it("accumulate boolean of array into one based on conditionType", () => {
+    const andConditionType = "AND";
+    const orConditionType = "OR";
+    const booleanArray = [true, false, true];
+
+    expect(
+      evaluateCondtionWithType(booleanArray, andConditionType),
+    ).toBeFalsy();
+    expect(
+      evaluateCondtionWithType(booleanArray, orConditionType),
+    ).toBeTruthy();
   });
 });

--- a/app/client/src/components/formControls/utils.test.ts
+++ b/app/client/src/components/formControls/utils.test.ts
@@ -5,6 +5,34 @@ describe("isHidden test", () => {
     const hiddenTrueInputs: any = [
       { values: { name: "Name" }, hidden: true },
       {
+        values: { name: "Name", number: 2, email: "temp@temp.com" },
+        hidden: {
+          conditionType: "AND",
+          conditions: [
+            {
+              path: "name",
+              value: "Name",
+              comparison: "EQUALS",
+            },
+            {
+              conditionType: "AND",
+              conditions: [
+                {
+                  path: "number",
+                  value: 2,
+                  comparison: "EQUALS",
+                },
+                {
+                  path: "email",
+                  value: "temp@temp.com",
+                  comparison: "EQUALS",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
         values: { name: "Name" },
         hidden: {
           path: "name",
@@ -83,6 +111,48 @@ describe("isHidden test", () => {
       },
       {
         values: { name: "Name" },
+      },
+      {
+        values: {
+          name: "Name",
+          config: { type: "EMAIL", name: "TEMP" },
+          contact: { number: 1234, address: "abcd" },
+        },
+        hidden: {
+          conditionType: "AND",
+          conditions: [
+            {
+              path: "contact.number",
+              value: 1234,
+              comparison: "NOT_EQUALS",
+            },
+            {
+              conditionType: "OR",
+              conditions: [
+                {
+                  conditionType: "AND",
+                  conditions: [
+                    {
+                      path: "config.name",
+                      value: "TEMP",
+                      comparison: "EQUALS",
+                    },
+                    {
+                      path: "config.name",
+                      value: "HELLO",
+                      comparison: "EQUALS",
+                    },
+                  ],
+                },
+                {
+                  path: "config.type",
+                  value: "EMAIL",
+                  comparison: "NOT_EQUALS",
+                },
+              ],
+            },
+          ],
+        },
       },
     ];
 

--- a/app/client/src/components/formControls/utils.ts
+++ b/app/client/src/components/formControls/utils.ts
@@ -1,7 +1,64 @@
 import { isBoolean, get, map, set } from "lodash";
-import { HiddenType } from "./BaseControl";
+import { HiddenType, hidden } from "./BaseControl";
+
+export const isHiddenForArray = (hiddenConfig: any) => {
+  if (!!hiddenConfig) {
+    const valueAtPath = hiddenConfig.path;
+    const value = hiddenConfig.value;
+
+    switch (hiddenConfig.comparison) {
+      case "EQUALS":
+        return valueAtPath === value;
+      case "NOT_EQUALS":
+        return valueAtPath !== value;
+      case "GREATER":
+        return valueAtPath > value;
+      case "LESSER":
+        return valueAtPath < value;
+      case "IN":
+        return Array.isArray(value) && value.includes(valueAtPath);
+      case "NOT_IN":
+        return Array.isArray(value) && !value.includes(valueAtPath);
+      default:
+        return true;
+    }
+  }
+  return !!hiddenConfig;
+};
+
+export const evaluateCondtionsWithType = (conditions: any, type: string) => {
+  let flag;
+  if (conditions.length > 1) {
+    if (type === "AND") {
+      flag = conditions.reduce((acc: any, item: boolean) => {
+        return acc && item;
+      }, conditions[0]);
+    } else if (type === "OR") {
+      flag = conditions.reduce((acc: any, item: boolean) => {
+        return acc || item;
+      }, undefined);
+    }
+  } else {
+    flag = conditions[0];
+  }
+  return flag;
+};
+
+export const isHiddenEvaluation = (hidden: any) => {
+  const conditionType = hidden.conditionType;
+  let conditions = hidden.conditions;
+  if (conditions) {
+    conditions = conditions.map((rule: any) => {
+      return isHiddenEvaluation(rule);
+    });
+  } else {
+    return isHiddenForArray(hidden);
+  }
+  return evaluateCondtionsWithType(conditions, conditionType);
+};
 
 export const isHidden = (values: any, hiddenConfig?: HiddenType) => {
+  console.log(isHiddenEvaluation(hidden));
   if (!!hiddenConfig && !isBoolean(hiddenConfig)) {
     const valueAtPath = get(values, hiddenConfig.path);
     const value = hiddenConfig.value;


### PR DESCRIPTION
## Description
Added capability for hidden field to support  for an array that ANDs(OR) all clauses so that the more complicated forms can be rendered with checks for multiple conditions. 

Fixes #3687 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
