### PR TITLE
Null handling for bad state in OAuth2 callback

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
@@ -186,10 +186,12 @@ public class AuthenticationService {
                 })
                 // We have no use of the datasource object during redirection, we merely send the response as a success state
                 .flatMap((datasource -> this.getPageRedirectUrl(state, null)))
-                .onErrorResume(e -> {
-                    log.debug("Error while retrieving access token: ", e);
-                    return this.getPageRedirectUrl(state, "appsmith_error");
-                });
+                .onErrorResume(
+                        e -> !(AppsmithError.UNAUTHORIZED_ACCESS.equals(((AppsmithException) e).getError())),
+                        e -> {
+                            log.debug("Error while retrieving access token: ", e);
+                            return this.getPageRedirectUrl(state, "appsmith_error");
+                        });
     }
 
     private Mono<String> getPageRedirectUrl(String state, String error) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
@@ -119,7 +119,14 @@ public class AuthenticationService {
             return this.getPageRedirectUrl(state, error);
         }
         // Otherwise, proceed to retrieve the access token from the authorization server
-        return datasourceService.getById(state.split(",")[1])
+        return Mono.just(state)
+                .flatMap(localState -> {
+                    if (localState == null || localState.split(",").length != 3) {
+                        return Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS));
+                    } else
+                        return Mono.just(localState.split(",")[1]);
+                })
+                .flatMap(datasourceService::getById)
                 .flatMap(datasource -> {
                     OAuth2 oAuth2 = (OAuth2) datasource.getDatasourceConfiguration().getAuthentication();
                     WebClient.Builder builder = WebClient.builder();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
@@ -119,9 +119,10 @@ public class AuthenticationService {
             return this.getPageRedirectUrl(state, error);
         }
         // Otherwise, proceed to retrieve the access token from the authorization server
-        return Mono.just(state)
+        return Mono.justOrEmpty(state)
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS)))
                 .flatMap(localState -> {
-                    if (localState == null || localState.split(",").length != 3) {
+                    if (localState.split(",").length != 3) {
                         return Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS));
                     } else
                         return Mono.just(localState.split(",")[1]);


### PR DESCRIPTION
Really weird error to receive. I'm concerned about why this would ever arise. This PR fixes the NPE to make it prettier, but we should ideally never hit this state.

Tested this by hitting the server manually on that endpoint. This could be possible when there is no state provided at all, and a variation when state is not the same as the one we shared. I am guessing the authorization server is at fault, or someone was trying to hit our endpoint manually. :D

Fixes #3803 

The way to handle this is to still show a JSON error on the web page. All we have done with this change is to change the error type so that it does not get flagged by Sentry. Sample response:
```
{"responseMeta":{"status":403,"success":false,"error":{"code":4025,"message":"Unauthorized access"}}}
```
