### PR TITLE
modify hint message to include a fix

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -171,8 +171,10 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
             }
 
             if(usingLocalhostUrl) {
-                messages.add("You may not able to access your localhost if Appsmith is running inside a docker " +
-                        "container or on the cloud. Please check out Appsmith's documentation to understand more.");
+                messages.add("You may not be able to access your localhost if Appsmith is running inside a docker " +
+                        "container or on the cloud. To enable access to your localhost you may use ngrok to expose " +
+                        "your local endpoint to the internet. Please check out Appsmith's documentation to understand more" +
+                        ".");
             }
         }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -807,9 +807,10 @@ public class DatasourceServiceTest {
                     assertThat(testResult.getInvalids()).isEmpty();
                     assertThat(testResult.getMessages()).isNotEmpty();
 
-                    String expectedMessage = "You may not able to access your localhost if Appsmith is running inside" +
-                            " a docker container or on the cloud. Please check out Appsmith's documentation to " +
-                            "understand more.";
+                    String expectedMessage = "You may not be able to access your localhost if Appsmith is running " +
+                            "inside a docker container or on the cloud. To enable access to your localhost you may use " +
+                            "ngrok to expose your local endpoint to the internet. Please check out Appsmith's " +
+                            "documentation to understand more.";
                     assertThat(
                             testResult.getMessages().stream()
                                     .anyMatch(message -> expectedMessage.equals(message))
@@ -841,9 +842,10 @@ public class DatasourceServiceTest {
                 .assertNext(createdDatasource -> {
                     assertThat(createdDatasource.getMessages()).isNotEmpty();
 
-                    String expectedMessage = "You may not able to access your localhost if Appsmith is running inside" +
-                            " a docker container or on the cloud. Please check out Appsmith's documentation to " +
-                            "understand more.";
+                    String expectedMessage = "You may not be able to access your localhost if Appsmith is running " +
+                            "inside a docker container or on the cloud. To enable access to your localhost you may " +
+                            "use ngrok to expose your local endpoint to the internet. Please check out Appsmith's " +
+                            "documentation to understand more.";
                     assertThat(
                             createdDatasource.getMessages().stream()
                                     .anyMatch(message -> expectedMessage.equals(message))
@@ -891,9 +893,10 @@ public class DatasourceServiceTest {
                 .create(datasourceMono)
                 .assertNext(updatedDatasource -> {
                     assertThat(updatedDatasource.getMessages().size()).isNotZero();
-                    String expectedMessage = "You may not able to access your localhost if Appsmith is running inside" +
-                            " a docker container or on the cloud. Please check out Appsmith's documentation to " +
-                            "understand more.";
+                    String expectedMessage = "You may not be able to access your localhost if Appsmith is running " +
+                            "inside a docker container or on the cloud. To enable access to your localhost you may " +
+                            "use ngrok to expose your local endpoint to the internet. Please check out Appsmith's " +
+                            "documentation to understand more.";
                     assertThat(
                             updatedDatasource.getMessages().stream()
                                     .anyMatch(message -> expectedMessage.equals(message))
@@ -928,9 +931,10 @@ public class DatasourceServiceTest {
                 .assertNext(createdDatasource -> {
                     assertThat(createdDatasource.getMessages()).isNotEmpty();
 
-                    String expectedMessage = "You may not able to access your localhost if Appsmith is running inside" +
-                            " a docker container or on the cloud. Please check out Appsmith's documentation to " +
-                            "understand more.";
+                    String expectedMessage = "You may not be able to access your localhost if Appsmith is running " +
+                            "inside a docker container or on the cloud. To enable access to your localhost you may " +
+                            "use ngrok to expose your local endpoint to the internet. Please check out Appsmith's " +
+                            "documentation to understand more.";
                     assertThat(
                             createdDatasource.getMessages().stream()
                                     .anyMatch(message -> expectedMessage.equals(message))
@@ -980,9 +984,10 @@ public class DatasourceServiceTest {
                 .create(datasourceMono)
                 .assertNext(updatedDatasource -> {
                     assertThat(updatedDatasource.getMessages().size()).isNotZero();
-                    String expectedMessage = "You may not able to access your localhost if Appsmith is running inside" +
-                            " a docker container or on the cloud. Please check out Appsmith's documentation to " +
-                            "understand more.";
+                    String expectedMessage = "You may not be able to access your localhost if Appsmith is running " +
+                            "inside a docker container or on the cloud. To enable access to your localhost you may " +
+                            "use ngrok to expose your local endpoint to the internet. Please check out " +
+                            "Appsmith's documentation to understand more.";
                     assertThat(
                             updatedDatasource.getMessages().stream()
                                     .anyMatch(message -> expectedMessage.equals(message))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -434,9 +434,10 @@ public class LayoutActionServiceTest {
                 .assertNext(resultAction -> {
                     assertThat(resultAction.getDatasource().getMessages().size()).isNotZero();
 
-                    String expectedMessage = "You may not able to access your localhost if Appsmith is running inside" +
-                            " a docker container or on the cloud. Please check out Appsmith's documentation to " +
-                            "understand more.";
+                    String expectedMessage = "You may not be able to access your localhost if Appsmith is running " +
+                            "inside a docker container or on the cloud. To enable access to your localhost you may " +
+                            "use ngrok to expose your local endpoint to the internet. Please check out " +
+                            "Appsmith's documentation to understand more.";
                     assertThat(resultAction.getDatasource().getMessages().stream()
                             .anyMatch(message -> expectedMessage.equals(message))
                     ).isTrue();


### PR DESCRIPTION
## Description
Modify hint message
from: 
`
You may not be able to access your localhost if Appsmith is running inside a docker container or on the cloud. Please check out Appsmith's documentation to understand more.
`

to:
`
You may not be able to access your localhost if Appsmith is running inside a docker container or on the cloud. To enable access to your localhost you may use ngrok to expose your local endpoint to the internet. Please check out Appsmith's documentation to understand more.
`


Fixes #3725 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
