### PR TITLE
Fix Table width on drag

### DIFF
--- a/app/client/src/widgets/TableWidget/derived.js
+++ b/app/client/src/widgets/TableWidget/derived.js
@@ -225,7 +225,7 @@ export default {
       __originalIndex__: index,
     }));
 
-    const columns = props.columns;
+    const columns = props.tableColumns;
 
     let sortedTableData;
     if (props.sortedColumn) {

--- a/app/client/src/widgets/TableWidget/derived.test.js
+++ b/app/client/src/widgets/TableWidget/derived.test.js
@@ -461,7 +461,7 @@ describe("Validates Derived Properties", () => {
           isDerived: true,
         },
       },
-      columns: [
+      tableColumns: [
         {
           index: 0,
           width: 150,
@@ -608,7 +608,7 @@ describe("Validates Derived Properties", () => {
           isDerived: true,
         },
       },
-      columns: [
+      tableColumns: [
         {
           index: 0,
           width: 150,

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -83,7 +83,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       pageSize: `{{(()=>{${derivedProperties.getPageSize}})()}}`,
       triggerRowSelection: "{{!!this.onRowSelected}}",
       sanitizedTableData: `{{(()=>{${derivedProperties.getSanitizedTableData}})()}}`,
-      columns: `{{(()=>{${derivedProperties.getTableColumns}})()}}`,
+      tableColumns: `{{(()=>{${derivedProperties.getTableColumns}})()}}`,
       filteredTableData: `{{(()=>{ ${derivedProperties.getFilteredTableData}})()}}`,
     };
   }
@@ -157,7 +157,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       totalColumnSizes += columnSizeMap[i];
     }
 
-    const allColumnProperties = this.props.columns || [];
+    const allColumnProperties = this.props.tableColumns || [];
     for (let index = 0; index < allColumnProperties.length; index++) {
       const columnProperties = allColumnProperties[index];
       const isHidden = !columnProperties.isVisible;


### PR DESCRIPTION
## Description
Fix issue where table widget's dropzone (the box that appears when we drag a widget) was of width zero.
Fixes #3720 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
