### PR TITLE
Always guarantee to fetch Api plugin forms

### DIFF
--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -57,7 +57,6 @@ import { createMessage, ERROR_ACTION_RENAME_FAIL } from "constants/messages";
 import { checkCurrentStep } from "./OnboardingSagas";
 import { OnboardingStep } from "constants/OnboardingConstants";
 import { getIndextoUpdate } from "utils/ApiPaneUtils";
-import { checkAndGetPluginFormConfigsSaga } from "sagas/PluginSagas";
 
 function* syncApiParamsSaga(
   actionPayload: ReduxActionWithMeta<string, { field: string }>,
@@ -401,7 +400,6 @@ function* handleCreateNewApiActionSaga(
     getPluginIdOfPackageName,
     REST_PLUGIN_PACKAGE_NAME,
   );
-  yield call(checkAndGetPluginFormConfigsSaga, pluginId);
   const applicationId = yield select(getCurrentApplicationId);
   const { pageId } = action.payload;
   if (pageId && pluginId) {


### PR DESCRIPTION
## Description
API plugin forms were not getting fetched if it did not have a saved datasource. This change guarantees that it will always be fetched during the initialisation

Fixes #3823

## Type of change

- Bug fix (non-breaking change which fixes an issue)

