### PR TITLE
Use columnName to render table header column

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
@@ -264,7 +264,7 @@ const AscendingIcon = styled(ControlIcons.SORT_CONTROL as AnyStyledComponent)`
   top: 18px;
   cursor: pointer;
   transform: rotate(180deg);
-  svg {
+  && svg {
     path {
       fill: ${(props) => props.theme.colors.secondary};
     }
@@ -276,7 +276,7 @@ const DescendingIcon = styled(ControlIcons.SORT_CONTROL as AnyStyledComponent)`
   position: relative;
   top: 3px;
   cursor: pointer;
-  svg {
+  && svg {
     path {
       fill: ${(props) => props.theme.colors.secondary};
     }
@@ -328,7 +328,7 @@ export const TableHeaderCell = (props: {
             : "hidden-header"
         }
       >
-        {column.render("Header")}
+        {props.columnName}
       </div>
       <div
         {...column.getResizerProps()}


### PR DESCRIPTION
## Description
Fix renderer error by using columnName to render instead of column.render function

Fixes #3645 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
