### PR TITLE
Add REACT_APP_GOOGLE_ANALYTICS_ID as a build time env var

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -115,6 +115,7 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_ID=${{ steps.vars.outputs.version }} \
             REACT_APP_VERSION_RELEASE_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ') \
+            REACT_APP_GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_TAG_MANAGER_ID }} \
             yarn build
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow


### PR DESCRIPTION
Add REACT_APP_GOOGLE_ANALYTICS_ID as a build time env var.
To be used here, within `index.html`:
``` 
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=%REACT_APP_GOOGLE_ANALYTICS_ID%"
  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
  ```

~~Also, @mohanarpit  just to confirm: we're using it in the above format, not as `process.env.REACT_APP_GOOGLE_ANALYTICS_ID`~~