### PR TITLE
[Cypress Test Fix] Updated the DSL to change table's primary columns from an array to a map structure in the DSL

### DIFF
--- a/app/client/cypress/fixtures/tableNewDsl.json
+++ b/app/client/cypress/fixtures/tableNewDsl.json
@@ -36,8 +36,8 @@
         "parentId": "0",
         "widgetId": "sb070qr2ir",
         "dynamicBindingPathList": [],
-        "primaryColumns": [
-          {
+        "primaryColumns": {
+          "id": {
             "index": 0,
             "width": 150,
             "id": "id",
@@ -54,7 +54,7 @@
             "label": "id",
             "computedValue": ""
           },
-          {
+          "email": {
             "index": 1,
             "width": 150,
             "id": "email",
@@ -71,7 +71,7 @@
             "label": "email",
             "computedValue": ""
           },
-          {
+          "userName": {
             "index": 2,
             "width": 150,
             "id": "userName",
@@ -88,7 +88,7 @@
             "label": "userName",
             "computedValue": ""
           },
-          {
+          "productName": {
             "index": 3,
             "width": 150,
             "id": "productName",
@@ -105,7 +105,7 @@
             "label": "productName",
             "computedValue": ""
           },
-          {
+          "orderAmount": {
             "index": 4,
             "width": 150,
             "id": "orderAmount",
@@ -122,7 +122,7 @@
             "label": "orderAmount",
             "computedValue": ""
           }
-        ]
+        }
       }
     ]
   }


### PR DESCRIPTION
This DSL required update because server parses through all the Table widget jsons and expects the primary columns to be of the type Map. Earlier the table json was being dumped without being parsed and hence this is a new issue.