### PR TITLE
Fix build failure on Maven 3.8

### DIFF
--- a/app/server/appsmith-plugins/redshiftPlugin/pom.xml
+++ b/app/server/appsmith-plugins/redshiftPlugin/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <version>2.0.0.1</version>
+            <version>2.0.0.4</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Maven 3.8 now blocks HTTP repositories and only allows HTTPS. However, the version redshift jdbc dependency we are using connects to a separate repository that runs on HTTP. The latest version has switched to using HTTPS instead.

So this PR upgrades redshift dependency from version 2.0.0.1 to 2.0.0.4.

Ref: <https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291>.
