### PR TITLE
Fixed escaped layout being used for update

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -320,12 +320,12 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
         Mono<PageDTO> sourcePageMono = newPageService.findPageById(pageId, MANAGE_PAGES, false)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.PAGE, pageId)))
                 .flatMap(page -> Flux.fromIterable(page.getLayouts())
-                        .map(layout -> layout.getDsl())
-                        .map(dsl -> {
+                        .map(layout -> {
                             Layout newLayout = new Layout();
                             String id = new ObjectId().toString();
                             newLayout.setId(id);
-                            newLayout.setDsl(dsl);
+                            newLayout.setMongoEscapedWidgetNames(layout.getMongoEscapedWidgetNames());
+                            newLayout.setDsl(layout.getDsl());
                             return newLayout;
                         })
                         .collectList()
@@ -398,7 +398,10 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                     List<Layout> layouts = savedPage.getLayouts();
 
                     return Flux.fromIterable(layouts)
-                            .flatMap(layout -> layoutActionService.updateLayout(savedPage.getId(), layout.getId(), layout))
+                            .flatMap(layout -> {
+                                layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
+                                return layoutActionService.updateLayout(savedPage.getId(), layout.getId(), layout);
+                            })
                             .collectList()
                             .thenReturn(savedPage);
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -531,7 +531,10 @@ public class LayoutActionServiceImpl implements LayoutActionService {
                         return Mono.empty();
                     }
                     return Flux.fromIterable(page.getLayouts())
-                            .flatMap(layout -> updateLayout(page.getId(), layout.getId(), layout));
+                            .flatMap(layout -> {
+                                //layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
+                                return updateLayout(page.getId(), layout.getId(), layout);
+                            });
                 })
                 .collectList()
                 .then(Mono.just(pageId));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -113,7 +113,10 @@ public class LayoutActionServiceImpl implements LayoutActionService {
 
                                     // 2. Run updateLayout on the old page
                                     return Flux.fromIterable(page.getLayouts())
-                                            .flatMap(layout -> updateLayout(oldPageId, layout.getId(), layout))
+                                            .flatMap(layout -> {
+                                                layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
+                                                return updateLayout(page.getId(), layout.getId(), layout);
+                                            })
                                             .collect(toSet());
                                 })
                                 // fetch the unpublished destination page
@@ -125,7 +128,10 @@ public class LayoutActionServiceImpl implements LayoutActionService {
 
                                     // 3. Run updateLayout on the new page.
                                     return Flux.fromIterable(page.getLayouts())
-                                            .flatMap(layout -> updateLayout(actionMoveDTO.getDestinationPageId(), layout.getId(), layout))
+                                            .flatMap(layout -> {
+                                                layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
+                                                return updateLayout(page.getId(), layout.getId(), layout);
+                                            })
                                             .collect(toSet());
                                 })
                                 // 4. Return the saved action.
@@ -270,7 +276,8 @@ public class LayoutActionServiceImpl implements LayoutActionService {
                     List<Layout> layouts = page.getLayouts();
                     for (Layout layout : layouts) {
                         if (layout.getId().equals(layoutId)) {
-                            return updateLayout(pageId, layout.getId(), layout);
+                            layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
+                            return updateLayout(page.getId(), layout.getId(), layout);
                         }
                     }
                     return Mono.empty();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -532,7 +532,7 @@ public class LayoutActionServiceImpl implements LayoutActionService {
                     }
                     return Flux.fromIterable(page.getLayouts())
                             .flatMap(layout -> {
-                                //layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
+                                layout.setDsl(this.unescapeMongoSpecialCharacters(layout));
                                 return updateLayout(page.getId(), layout.getId(), layout);
                             });
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutServiceImpl.java
@@ -48,6 +48,7 @@ public class LayoutServiceImpl implements LayoutService {
                     }
                     //Adding an Id to the layout to ensure that a layout can be referred to by its ID as well.
                     layout.setId(new ObjectId().toString());
+
                     layoutList.add(layout);
                     page.setLayouts(layoutList);
                     return page;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionServiceTest.java
@@ -38,6 +38,7 @@ import com.appsmith.server.repositories.OrganizationRepository;
 import com.appsmith.server.repositories.PluginRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -55,6 +56,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -146,13 +149,29 @@ public class ActionServiceTest {
             testApp = applicationPageService.createApplication(application, organization.getId()).block();
 
             final String pageId = testApp.getPages().get(0).getId();
-            Layout layout = new Layout();
-            JSONObject dsl = new JSONObject(Map.of("text", "{{ query1.data }}"));
-            layout.setDsl(dsl);
-            layout.setPublishedDsl(dsl);
-            layoutService.createLayout(pageId, layout).block();
 
             testPage = newPageService.findPageById(pageId, READ_PAGES, false).block();
+
+            Layout layout = testPage.getLayouts().get(0);
+            JSONObject dsl = new JSONObject(Map.of("text", "{{ query1.data }}"));
+
+            JSONObject dsl2 = new JSONObject();
+            dsl2.put("widgetName", "Table1");
+            dsl2.put("type", "TABLE_WIDGET");
+            Map<String, Object> primaryColumns = new HashMap<>();
+            JSONObject jsonObject = new JSONObject(Map.of("key", "value"));
+            primaryColumns.put("_id", "{{ query1.data }}");
+            primaryColumns.put("_class", jsonObject);
+            dsl2.put("primaryColumns", primaryColumns);
+            final ArrayList<Object> objects = new ArrayList<>();
+            JSONArray temp2 = new JSONArray();
+            temp2.addAll(List.of(new JSONObject(Map.of("key", "primaryColumns._id"))));
+            dsl2.put("dynamicBindingPathList", temp2);
+            objects.add(dsl2);
+            dsl.put("children", objects);
+
+            layout.setDsl(dsl);
+            layout.setPublishedDsl(dsl);
         }
 
         Organization testOrg = organizationRepository.findByName("Another Test Organization", AclPermission.READ_ORGANIZATIONS).block();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,6 +118,22 @@ public class LayoutActionServiceTest {
             temp.addAll(List.of(new JSONObject(Map.of("key", "testField"))));
             dsl.put("dynamicBindingPathList", temp);
             dsl.put("testField", "{{ query1.data }}");
+
+            JSONObject dsl2 = new JSONObject();
+            dsl2.put("widgetName", "Table1");
+            dsl2.put("type", "TABLE_WIDGET");
+            Map<String, Object> primaryColumns = new HashMap<>();
+            JSONObject jsonObject = new JSONObject(Map.of("key", "value"));
+            primaryColumns.put("_id", "{{ query1.data }}");
+            primaryColumns.put("_class", jsonObject);
+            dsl2.put("primaryColumns", primaryColumns);
+            final ArrayList<Object> objects = new ArrayList<>();
+            JSONArray temp2 = new JSONArray();
+            temp2.addAll(List.of(new JSONObject(Map.of("key", "primaryColumns._id"))));
+            dsl2.put("dynamicBindingPathList", temp2);
+            objects.add(dsl2);
+            dsl.put("children", objects);
+
             layout.setDsl(dsl);
             layout.setPublishedDsl(dsl);
             layoutActionService.updateLayout(pageId, layout.getId(), layout).block();
@@ -267,6 +284,7 @@ public class LayoutActionServiceTest {
 
         ActionDTO firstAction = newActionService.createAction(action).block();
 
+        layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
         LayoutDTO firstLayout = layoutActionService.updateLayout(testPage.getId(), layout.getId(), layout).block();
 
         applicationPageService.publish(testPage.getApplicationId()).block();


### PR DESCRIPTION
On updating actions, any layout updates required use the escaped primary columns to do so. This breaks the expectation of dynamic bindings. This fix unescapes the layout before update.

In draft state because I need to add test cases for this.