### PR TITLE
size change for raw and editor in API editor

### DIFF
--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -102,8 +102,3 @@ div.bp3-popover-arrow {
   background: white !important;
   border-bottom: 1px solid #E7E7E7 !important;
 }
-
-.width-65 {
-  width: 65%;
-}
-

--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -103,3 +103,7 @@ div.bp3-popover-arrow {
   border-bottom: 1px solid #E7E7E7 !important;
 }
 
+.width-65 {
+  width: 65%;
+}
+

--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -29,12 +29,10 @@ const PostBodyContainer = styled.div`
 
 const JSONEditorFieldWrapper = styled.div`
   margin: 0 30px;
+  width: 65%;
   .CodeMirror {
     height: auto;
     min-height: 250px;
-  }
-  &.width-65 {
-    width: 65%;
   }
 `;
 
@@ -64,7 +62,7 @@ const PostBodyData = (props: Props) => {
         tabs={POST_BODY_FORMAT_TITLES_NO_MULTI_PART.map((el) => {
           let component = (
             <JSONEditorFieldWrapper
-              className={"t--apiFormPostBody width-65"}
+              className={"t--apiFormPostBody"}
               key={el.key}
             >
               <DynamicTextField
@@ -94,7 +92,7 @@ const PostBodyData = (props: Props) => {
             );
           } else if (el.title === ApiContentTypes.RAW) {
             component = (
-              <JSONEditorFieldWrapper key={el.key} className={"width-65"}>
+              <JSONEditorFieldWrapper key={el.key}>
                 <DynamicTextField
                   name="actionConfiguration.body"
                   tabBehaviour={TabBehaviour.INDENT}

--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -61,7 +61,7 @@ const PostBodyData = (props: Props) => {
         tabs={POST_BODY_FORMAT_TITLES_NO_MULTI_PART.map((el) => {
           let component = (
             <JSONEditorFieldWrapper
-              className={"t--apiFormPostBody"}
+              className={"t--apiFormPostBody width-65"}
               key={el.key}
             >
               <DynamicTextField
@@ -91,7 +91,7 @@ const PostBodyData = (props: Props) => {
             );
           } else if (el.title === ApiContentTypes.RAW) {
             component = (
-              <JSONEditorFieldWrapper key={el.key}>
+              <JSONEditorFieldWrapper key={el.key} className={"width-65"}>
                 <DynamicTextField
                   name="actionConfiguration.body"
                   tabBehaviour={TabBehaviour.INDENT}

--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -33,6 +33,9 @@ const JSONEditorFieldWrapper = styled.div`
     height: auto;
     min-height: 250px;
   }
+  &.width-65 {
+    width: 65%;
+  }
 `;
 
 interface PostDataProps {


### PR DESCRIPTION
## Description
The Evaluated values popover hinders the API Editor when in "Raw" and "JSON" mode so resized for just these 2 modes. 

Fixes #3254 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
