### PR TITLE
Safe handling of alias

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/documenttype/DocumentTypeMapper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/documenttype/DocumentTypeMapper.java
@@ -7,7 +7,6 @@ import org.springframework.data.convert.TypeInformationMapper;
 import org.springframework.data.mapping.Alias;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
-import org.springframework.lang.NonNullApi;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/documenttype/DocumentTypeMapper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/documenttype/DocumentTypeMapper.java
@@ -7,6 +7,7 @@ import org.springframework.data.convert.TypeInformationMapper;
 import org.springframework.data.mapping.Alias;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.NonNullApi;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,8 +59,9 @@ public class DocumentTypeMapper implements TypeInformationMapper {
 
     @Override
     public TypeInformation<?> resolveTypeFrom(Alias alias) {
-        if (aliasToTypeMap.containsKey((String) alias.getValue())) {
-            return aliasToTypeMap.get(alias.getValue());
+        final String aliasAsString = alias.mapTyped(String.class);
+        if (aliasAsString != null && aliasToTypeMap.containsKey(aliasAsString)) {
+            return aliasToTypeMap.get(aliasAsString);
         }
         return null;
     }


### PR DESCRIPTION
Fixes #4003 

Unable to repro the issue itself, but this mapper is a bottleneck that has failed multiple times in the past for other errors as well. Fixed this by replicating default type mapper's logic.