### PR TITLE
Hot fix redirection race in oAuth autorisation flow

### DIFF
--- a/app/client/src/actions/datasourceActions.ts
+++ b/app/client/src/actions/datasourceActions.ts
@@ -26,6 +26,21 @@ export const updateDatasource = (
   };
 };
 
+export type UpdateDatasourceSuccessAction = {
+  type: string;
+  payload: Datasource;
+  redirect: boolean;
+};
+
+export const updateDatasourceSuccess = (
+  payload: Datasource,
+  redirect = true,
+): UpdateDatasourceSuccessAction => ({
+  type: ReduxActionTypes.UPDATE_DATASOURCE_SUCCESS,
+  payload,
+  redirect,
+});
+
 export const redirectAuthorizationCode = (
   pageId: string,
   datasourceId: string,

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -33,6 +33,8 @@ import {
   expandDatasourceEntity,
   fetchDatasourceStructure,
   createDatasourceFromForm,
+  updateDatasourceSuccess,
+  UpdateDatasourceSuccessAction,
 } from "actions/datasourceActions";
 import { GenericApiResponse } from "api/ApiResponses";
 import DatasourcesApi, { CreateDatasourceConfig } from "api/DatasourcesApi";
@@ -162,10 +164,10 @@ function* updateDatasourceSaga(
       const datasourceStruture =
         state.entities.datasources.structure[response.data.id];
 
-      yield put({
-        type: ReduxActionTypes.UPDATE_DATASOURCE_SUCCESS,
-        payload: response.data,
-      });
+      // Dont redirect if action payload has an onSuccess
+      yield put(
+        updateDatasourceSuccess(response.data, !actionPayload.onSuccess),
+      );
       if (actionPayload.onSuccess) {
         yield put(actionPayload.onSuccess);
       }
@@ -452,14 +454,15 @@ function* storeAsDatasourceSaga() {
   yield put(changeDatasource(createdDatasource));
 }
 
-function* updateDatasourceSuccessSaga(action: ReduxAction<Datasource>) {
+function* updateDatasourceSuccessSaga(action: UpdateDatasourceSuccessAction) {
   const state = yield select();
   const actionRouteInfo = _.get(state, "ui.datasourcePane.actionRouteInfo");
   const updatedDatasource = action.payload;
 
   if (
     actionRouteInfo &&
-    updatedDatasource.id === actionRouteInfo.datasourceId
+    updatedDatasource.id === actionRouteInfo.datasourceId &&
+    action.redirect
   ) {
     history.push(
       API_EDITOR_ID_URL(


### PR DESCRIPTION
For Datasources created by API pane "Save as Datasource" button, we would want to redirect the user back to the API pane after saving the datasource. But if the datasource has an OAuth flow, it might need an authorisation redirection first. These two redirections would race today since the logic was not clear about redirection. 

This change is a hotfix to avoid the race and only redirect to one place depending on the flow