### PR TITLE
Fix: Return helpful error message when get structure fails for mongo db due to lack of read permission.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-    <a href="https://app.appsmith.com/signup"><strong>Try Online Sandbox</strong></a>
+    <a href="https://app.appsmith.com/signup?utm_source=github&utm_medium=social&utm_content=website&utm_campaign=null&utm_term=website"><strong>Try Online Sandbox</strong></a>
 </p>
 <p align="center">
   <a href="https://docs.appsmith.com/">Documentation</a>
@@ -63,7 +63,7 @@ But if you’d rather check out some real applications that can be built with Ap
 
 The following steps introduce you to building a simple user-list dashboard on Appsmith.
 
-1. [Sign up on Appsmith Cloud](https://bit.ly/appsmith-signup-github) or [Deploy Appsmith](https://docs.appsmith.com/setup).
+1. [Sign up on Appsmith Cloud](https://app.appsmith.com/signup?utm_source=github&utm_medium=social&utm_content=website&utm_campaign=null&utm_term=website) or [Deploy Appsmith](https://docs.appsmith.com/setup).
 2. Create a new app within the organization that has already been created for you.
 3. Click on the `+` icon next to the `Queries` section to add a new query in the mock database
    1. Name the query `usersQuery`.
@@ -79,12 +79,12 @@ Connect your own data to build apps for your team. [Read more here.](https://doc
 ## 📚 Tutorials
 
 1. [Building an Admin Panel on MongoDB using Appsmith](https://blog.appsmith.com/building-an-admin-panel-with-mongodb-using-appsmith) ([Video](https://www.youtube.com/watch?v=tisUaIgI86k))
-2. [Building a customer support dashboard in Appsmith](https://www.youtube.com/watch?v=-O_6OLREEzo&t=272s)
-3. [Running CI/CD jobs manually using Appsmith](https://blog.appsmith.com/how-to-run-manual-jobs-in-gitlab-cicd) ([Video](https://www.youtube.com/watch?v=CYdeJcD4I8A))
-4. [Building a calendly clone in Appsmith](https://blog.appsmith.com/how-to-build-a-calendly-clone-in-30-minutes)
-5. [Building Internal Tools with Appsmith](https://youtu.be/eYYYfuW-kEE) `Community`
-6. [Building an Issue Tracker with Appsmith](https://dev.to/pjmantoss/how-to-build-an-issue-tracker-with-appsmith-204e) `Community`
-
+2. [Building a Customer Support Dashboard in Appsmith](https://www.youtube.com/watch?v=-O_6OLREEzo&t=272s)
+3. [Building a Store Catalogue Management System using Appsmith and GraphQL](https://blog.appsmith.com/building-a-store-catalogue-management-system-using-appsmith-and-graphql)
+4. [Running CI/CD Jobs Manually using Appsmith](https://blog.appsmith.com/how-to-run-manual-jobs-in-gitlab-cicd) ([Video](https://www.youtube.com/watch?v=CYdeJcD4I8A))
+5. [Building a Calendly Clone in Appsmith](https://blog.appsmith.com/how-to-build-a-calendly-clone-in-30-minutes)
+6. [Building Internal Tools with Appsmith](https://youtu.be/eYYYfuW-kEE) `Community`
+7. [Building an Issue Tracker with Appsmith](https://dev.to/pjmantoss/how-to-build-an-issue-tracker-with-appsmith-204e) `Community`
 
 ## 📕 Support & Troubleshooting
 

--- a/app/client/cypress/fixtures/example.json
+++ b/app/client/cypress/fixtures/example.json
@@ -102,6 +102,7 @@
   "AlertModalName": "Alert_Modal",
   "FormModalName": "Form_Modal",
   "TextLabelValue": "Test Text Label",
+  "TextLabelValueScrollable": "Test Text Label to check scroll feature",
   "TextName": "TestTextBox",
   "TextLabel": "Paragraph",
   "TextBody": "Heading 2",

--- a/app/client/cypress/fixtures/textDsl.json
+++ b/app/client/cypress/fixtures/textDsl.json
@@ -1,0 +1,45 @@
+{
+    "dsl": {
+        "widgetName": "MainContainer",
+        "backgroundColor": "none",
+        "rightColumn": 966,
+        "snapColumns": 16,
+        "detachFromLayout": true,
+        "widgetId": "0",
+        "topRow": 0,
+        "bottomRow": 240,
+        "containerStyle": "none",
+        "snapRows": 33,
+        "parentRowSpace": 1,
+        "type": "CANVAS_WIDGET",
+        "canExtend": true,
+        "version": 16,
+        "minHeight": 280,
+        "parentColumnSpace": 1,
+        "dynamicTriggerPathList": [],
+        "dynamicBindingPathList": [],
+        "leftColumn": 0,
+        "children": [
+            {
+                "isVisible": true,
+                "text": "Label",
+                "fontSize": "PARAGRAPH",
+                "fontStyle": "BOLD",
+                "textAlign": "LEFT",
+                "textColor": "#231F20",
+                "widgetName": "Text1",
+                "version": 1,
+                "type": "TEXT_WIDGET",
+                "isLoading": false,
+                "parentColumnSpace": 57.875,
+                "parentRowSpace": 40,
+                "leftColumn": 4,
+                "rightColumn": 8,
+                "topRow": 1,
+                "bottomRow": 2,
+                "parentId": "0",
+                "widgetId": "266vj9u1mr"
+            }
+        ]
+    }
+}

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_PropertyPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_PropertyPane_spec.js
@@ -10,21 +10,8 @@ describe("Table Widget property pane feature validation", function() {
     cy.addDsl(dsl);
   });
 
-  it("Check collapse section feature in property pane", function() {
-    cy.openPropertyPane("tablewidget");
-    //check open and collapse
-    cy.get(commonlocators.collapsesection)
-      .first()
-      .should("be.visible")
-      .click();
-    cy.assertControlVisibility("tabledata");
-  });
-
   it("Check open section and column data in property pane", function() {
-    cy.get(commonlocators.collapsesection)
-      .scrollIntoView()
-      .first()
-      .click();
+    cy.openPropertyPane("tablewidget");
     cy.tableColumnDataValidation("id");
     cy.tableColumnDataValidation("email");
     cy.tableColumnDataValidation("userName");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Text_new_feature_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Text_new_feature_spec.js
@@ -1,0 +1,109 @@
+const commonlocators = require("../../../../locators/commonlocators.json");
+const widgetsPage = require("../../../../locators/Widgets.json");
+const publishPage = require("../../../../locators/publishWidgetspage.json");
+const dsl = require("../../../../fixtures/textDsl.json");
+const pages = require("../../../../locators/Pages.json");
+
+describe("Text Widget color/font/alignment Functionality", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  beforeEach(() => {
+    cy.openPropertyPane("textwidget");
+  });
+
+  it("Text-TextStyle Heading, Text Name Validation", function() {
+    //changing the Text Name and verifying
+    cy.widgetText(
+      this.data.TextName,
+      widgetsPage.textWidget,
+      widgetsPage.textWidget + " " + commonlocators.widgetNameTag,
+    );
+
+    //Changing the text label
+    cy.testCodeMirror(this.data.TextLabelValueScrollable);
+
+    cy.ChangeTextStyle(
+      this.data.TextHeading,
+      commonlocators.headingTextStyle,
+      this.data.TextLabelValueScrollable,
+    );
+    cy.wait("@updateLayout");
+    cy.PublishtheApp();
+    cy.get(commonlocators.headingTextStyle)
+      .should("have.text", this.data.TextLabelValueScrollable)
+      .should("have.css", "font-size", "24px");
+    cy.get(publishPage.backToEditor).click({ force: true });
+  });
+
+  it("Test to validate text format", function() {
+    //Changing the Text Style's and validating
+    cy.get(widgetsPage.italics).click({ force: true });
+    cy.readTextDataValidateCSS("font-style", "italic");
+    cy.get(widgetsPage.bold).click({ force: true });
+    cy.readTextDataValidateCSS("font-weight", "400");
+    cy.get(widgetsPage.bold).click({ force: true });
+    cy.readTextDataValidateCSS("font-weight", "700");
+    cy.get(widgetsPage.italics).click({ force: true });
+    cy.readTextDataValidateCSS("font-style", "normal");
+    cy.closePropertyPane();
+  });
+
+  it("Test to validate color changes in text and background", function() {
+    //Changing the Text Style's and validating
+    cy.get(widgetsPage.textColor)
+      .first()
+      .click({ force: true });
+    cy.xpath(widgetsPage.greenColor).click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500);
+    cy.wait("@updateLayout");
+    cy.readTextDataValidateCSS("color", "rgb(3, 179, 101)");
+    cy.get(widgetsPage.textColor)
+      .clear({ force: true })
+      .type("purple", { force: true });
+    cy.wait("@updateLayout");
+    cy.readTextDataValidateCSS("color", "rgb(128, 0, 128)");
+    cy.get(widgetsPage.backgroundColor)
+      .first()
+      .click({ force: true });
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500);
+    cy.xpath(widgetsPage.greenColor)
+      .first()
+      .click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500);
+    cy.wait("@updateLayout");
+    cy.PublishtheApp();
+    cy.get(publishPage.backToEditor).click({ force: true });
+  });
+
+  it("Test to validate text alignment", function() {
+    cy.get(widgetsPage.centerAlign)
+      .first()
+      .click({ force: true });
+    cy.readTextDataValidateCSS("text-align", "center");
+    cy.get(widgetsPage.rightAlign)
+      .first()
+      .click({ force: true });
+    cy.readTextDataValidateCSS("text-align", "right");
+    cy.get(widgetsPage.leftAlign)
+      .first()
+      .click({ force: true });
+    cy.readTextDataValidateCSS("text-align", "left");
+    cy.closePropertyPane();
+  });
+
+  it("Test to validate enable scroll feature", function() {
+    cy.get(".t--property-control-enablescroll .bp3-switch").click({
+      force: true,
+    });
+    cy.wait("@updateLayout");
+    cy.get(commonlocators.headingTextStyle).trigger("mouseover", {
+      force: true,
+    });
+    cy.get(commonlocators.headingTextStyle).scrollIntoView({ duration: 2000 });
+  });
+});

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1409,6 +1409,14 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add("readTextDataValidateCSS", (cssProperty, cssValue) => {
+  cy.get(commonlocators.headingTextStyle).should(
+    "have.css",
+    cssProperty,
+    cssValue,
+  );
+});
+
 Cypress.Commands.add("evaluateErrorMessage", (value) => {
   cy.get(commonlocators.evaluateMsg)
     .first()

--- a/app/client/src/components/designSystems/appsmith/TableComponent/CommonUtilities.test.ts
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/CommonUtilities.test.ts
@@ -1,5 +1,11 @@
-import { sortTableFunction } from "components/designSystems/appsmith/TableComponent/CommonUtilities";
-import { ColumnTypes } from "components/designSystems/appsmith/TableComponent/Constants";
+import {
+  sortTableFunction,
+  transformTableDataIntoCsv,
+} from "components/designSystems/appsmith/TableComponent/CommonUtilities";
+import {
+  ColumnTypes,
+  TableColumnProps,
+} from "components/designSystems/appsmith/TableComponent/Constants";
 
 describe("TableUtilities", () => {
   it("works as expected for sort table rows", () => {
@@ -27,5 +33,84 @@ describe("TableUtilities", () => {
     );
     // console.log(JSON.stringify(sortedTableData));
     expect(sortedTableData).toStrictEqual(expected);
+  });
+});
+
+describe("TransformTableDataIntoArrayOfArray", () => {
+  const columns: TableColumnProps[] = [
+    {
+      Header: "Id",
+      accessor: "id",
+      minWidth: 60,
+      draggable: true,
+      metaProperties: {
+        isHidden: false,
+        type: "string",
+      },
+      columnProperties: {
+        id: "id",
+        label: "Id",
+        columnType: "string",
+        isVisible: true,
+        index: 0,
+        width: 60,
+        isDerived: false,
+        computedValue: "",
+      },
+    },
+  ];
+  it("work as expected", () => {
+    const data = [
+      {
+        id: "abc",
+      },
+      {
+        id: "xyz",
+      },
+    ];
+    const csvData = transformTableDataIntoCsv({
+      columns,
+      data,
+    });
+    const expectedCsvData = [["Id"], ["abc"], ["xyz"]];
+    expect(JSON.stringify(csvData)).toStrictEqual(
+      JSON.stringify(expectedCsvData),
+    );
+  });
+  it("work as expected with newline", () => {
+    const data = [
+      {
+        id: "abc\ntest",
+      },
+      {
+        id: "xyz",
+      },
+    ];
+    const csvData = transformTableDataIntoCsv({
+      columns,
+      data,
+    });
+    const expectedCsvData = [["Id"], ["abc test"], ["xyz"]];
+    expect(JSON.stringify(csvData)).toStrictEqual(
+      JSON.stringify(expectedCsvData),
+    );
+  });
+  it("work as expected with comma", () => {
+    const data = [
+      {
+        id: "abc,test",
+      },
+      {
+        id: "xyz",
+      },
+    ];
+    const csvData = transformTableDataIntoCsv({
+      columns,
+      data,
+    });
+    const expectedCsvData = [["Id"], ['"abc,test"'], ["xyz"]];
+    expect(JSON.stringify(csvData)).toStrictEqual(
+      JSON.stringify(expectedCsvData),
+    );
   });
 });

--- a/app/client/src/components/designSystems/appsmith/TableComponent/CommonUtilities.ts
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/CommonUtilities.ts
@@ -1,5 +1,8 @@
-import { ColumnTypes } from "components/designSystems/appsmith/TableComponent/Constants";
-import { isPlainObject, isNil } from "lodash";
+import {
+  ColumnTypes,
+  TableColumnProps,
+} from "components/designSystems/appsmith/TableComponent/Constants";
+import { isPlainObject, isNil, isString } from "lodash";
 import moment from "moment";
 
 export function sortTableFunction(
@@ -51,3 +54,41 @@ export function sortTableFunction(
     },
   );
 }
+
+export const transformTableDataIntoCsv = (props: {
+  columns: TableColumnProps[];
+  data: Array<Record<string, unknown>>;
+}) => {
+  const csvData = [];
+  csvData.push(
+    props.columns
+      .map((column: TableColumnProps) => {
+        if (column.metaProperties && !column.metaProperties.isHidden) {
+          return column.Header;
+        }
+        return null;
+      })
+      .filter((i) => !!i),
+  );
+  for (let row = 0; row < props.data.length; row++) {
+    const data: { [key: string]: any } = props.data[row];
+    const csvDataRow = [];
+    for (let colIndex = 0; colIndex < props.columns.length; colIndex++) {
+      const column = props.columns[colIndex];
+      let value = data[column.accessor];
+      if (column.metaProperties && !column.metaProperties.isHidden) {
+        value =
+          isString(value) && value.includes("\n")
+            ? value.replace("\n", " ")
+            : value;
+        if (isString(value) && value.includes(",")) {
+          csvDataRow.push(`"${value}"`);
+        } else {
+          csvDataRow.push(value);
+        }
+      }
+    }
+    csvData.push(csvDataRow);
+  }
+  return csvData;
+};

--- a/app/client/src/components/designSystems/appsmith/TableComponent/Constants.ts
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/Constants.ts
@@ -103,7 +103,7 @@ export interface TableColumnMetaProps {
   type: string;
 }
 
-export interface ReactTableColumnProps {
+export interface TableColumnProps {
   Header: string;
   accessor: string;
   width?: number;
@@ -114,6 +114,8 @@ export interface ReactTableColumnProps {
   metaProperties?: TableColumnMetaProps;
   isDerived?: boolean;
   columnProperties: ColumnProperties;
+}
+export interface ReactTableColumnProps extends TableColumnProps {
   Cell: (props: any) => JSX.Element;
 }
 

--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableDataDownload.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableDataDownload.tsx
@@ -5,7 +5,7 @@ import { ReactComponent as DownloadIcon } from "assets/icons/control/download-ta
 import { ReactTableColumnProps } from "components/designSystems/appsmith/TableComponent/Constants";
 import { TableIconWrapper } from "components/designSystems/appsmith/TableComponent/TableStyledWrappers";
 import TableActionIcon from "components/designSystems/appsmith/TableComponent/TableActionIcon";
-import { isString } from "lodash";
+import { transformTableDataIntoCsv } from "./CommonUtilities";
 
 interface TableDataDownloadProps {
   data: Array<Record<string, unknown>>;
@@ -13,63 +13,49 @@ interface TableDataDownloadProps {
   widgetName: string;
 }
 
+const downloadDataAsCSV = (props: {
+  csvData: Array<Array<any>>;
+  fileName: string;
+}) => {
+  let csvContent = "";
+  props.csvData.forEach((infoArray: Array<any>, index: number) => {
+    const dataString = infoArray.join(",");
+    csvContent += index < props.csvData.length ? dataString + "\n" : dataString;
+  });
+  const anchor = document.createElement("a");
+  const mimeType = "application/octet-stream";
+  if (navigator.msSaveBlob) {
+    navigator.msSaveBlob(
+      new Blob([csvContent], {
+        type: mimeType,
+      }),
+      props.fileName,
+    );
+  } else if (URL && "download" in anchor) {
+    anchor.href = URL.createObjectURL(
+      new Blob([csvContent], {
+        type: mimeType,
+      }),
+    );
+    anchor.setAttribute("download", props.fileName);
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  }
+};
+
 const TableDataDownload = (props: TableDataDownloadProps) => {
   const [selected, toggleButtonClick] = React.useState(false);
   const downloadTableData = () => {
     toggleButtonClick(true);
-    const csvData = [];
-    csvData.push(
-      props.columns
-        .map((column: ReactTableColumnProps) => {
-          if (column.metaProperties && !column.metaProperties.isHidden) {
-            return column.Header;
-          }
-          return null;
-        })
-        .filter((i) => !!i),
-    );
-    for (let row = 0; row < props.data.length; row++) {
-      const data: { [key: string]: any } = props.data[row];
-      const csvDataRow = [];
-      for (let colIndex = 0; colIndex < props.columns.length; colIndex++) {
-        const column = props.columns[colIndex];
-        const value = data[column.accessor];
-        if (column.metaProperties && !column.metaProperties.isHidden) {
-          if (isString(value) && value.includes(",")) {
-            csvDataRow.push(`"${value}"`);
-          } else {
-            csvDataRow.push(value);
-          }
-        }
-      }
-      csvData.push(csvDataRow);
-    }
-    let csvContent = "";
-    csvData.forEach(function(infoArray, index) {
-      const dataString = infoArray.join(",");
-      csvContent += index < csvData.length ? dataString + "\n" : dataString;
+    const csvData = transformTableDataIntoCsv({
+      columns: props.columns,
+      data: props.data,
     });
-    const fileName = `${props.widgetName}.csv`;
-    const anchor = document.createElement("a");
-    const mimeType = "application/octet-stream";
-    if (navigator.msSaveBlob) {
-      navigator.msSaveBlob(
-        new Blob([csvContent], {
-          type: mimeType,
-        }),
-        fileName,
-      );
-    } else if (URL && "download" in anchor) {
-      anchor.href = URL.createObjectURL(
-        new Blob([csvContent], {
-          type: mimeType,
-        }),
-      );
-      anchor.setAttribute("download", fileName);
-      document.body.appendChild(anchor);
-      anchor.click();
-      document.body.removeChild(anchor);
-    }
+    downloadDataAsCSV({
+      csvData: csvData,
+      fileName: `${props.widgetName}.csv`,
+    });
     toggleButtonClick(false);
   };
 

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -239,6 +239,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
           <StoreAsDatasource enable={!!displayValue} />
         ) : datasource && "id" in datasource ? (
           <DatasourceIcon
+            enable={true}
             onClick={() =>
               history.push(
                 DATA_SOURCES_EDITOR_ID_URL(

--- a/app/client/src/constants/AppsmithActionConstants/formConfig/ApiSettingsConfig.ts
+++ b/app/client/src/constants/AppsmithActionConstants/formConfig/ApiSettingsConfig.ts
@@ -28,7 +28,7 @@ export default [
         controlType: "CHECKBOX",
         info:
           "Turning on this property fixes the JSON substitution of bindings in API body by adding/removing quotes intelligently and reduces developer errors",
-        initialValue: "false",
+        initialValue: false,
       },
       // {
       //   label: "Cache response",

--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -102,4 +102,3 @@ div.bp3-popover-arrow {
   background: white !important;
   border-bottom: 1px solid #E7E7E7 !important;
 }
-

--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -29,6 +29,7 @@ const PostBodyContainer = styled.div`
 
 const JSONEditorFieldWrapper = styled.div`
   margin: 0 30px;
+  width: 65%;
   .CodeMirror {
     height: auto;
     min-height: 250px;

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -121,7 +121,11 @@ const PropertyPaneTitle = memo((props: PropertyPaneTitleProps) => {
   const { title, updatePropertyTitle } = props;
   const updateNewTitle = useCallback(
     (value: string) => {
-      if (value && value.trim().length > 0 && value.trim() !== title.trim()) {
+      if (
+        value &&
+        value.trim().length > 0 &&
+        value.trim() !== (title && title.trim())
+      ) {
         updatePropertyTitle && updatePropertyTitle(value.trim());
       }
     },

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -508,12 +508,12 @@ function* handleApiNameChangeSuccessSaga(
   if (!actionObj) {
     // Error case, log to sentry
     Toaster.show({
-      text: createMessage(ERROR_ACTION_RENAME_FAIL, actionObj.name),
+      text: createMessage(ERROR_ACTION_RENAME_FAIL, ""),
       variant: Variant.danger,
     });
 
     Sentry.captureException(
-      new Error(createMessage(ERROR_ACTION_RENAME_FAIL, actionObj.name)),
+      new Error(createMessage(ERROR_ACTION_RENAME_FAIL, "")),
       {
         extra: {
           actionId: actionId,

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -160,12 +160,12 @@ function* handleNameChangeSuccessSaga(
   if (!actionObj) {
     // Error case, log to sentry
     Toaster.show({
-      text: createMessage(ERROR_ACTION_RENAME_FAIL, actionObj.name),
+      text: createMessage(ERROR_ACTION_RENAME_FAIL, ""),
       variant: Variant.danger,
     });
 
     Sentry.captureException(
-      new Error(createMessage(ERROR_ACTION_RENAME_FAIL, actionObj.name)),
+      new Error(createMessage(ERROR_ACTION_RENAME_FAIL, "")),
       {
         extra: {
           actionId: actionId,

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -3504,11 +3504,6 @@
   dependencies:
     "@types/tern" "*"
 
-"@types/component-emitter@^1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.10.tgz#ef5b1589b9f16544642e473db5ea5639107ef3ea"
-  integrity sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==
-
 "@types/cookie@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.0.tgz#14f854c0f93d326e39da6e3b6f34f7d37513d108"
@@ -6920,7 +6915,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.0, debug@~4.3.1:
+debug@^4.3.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -8197,6 +8192,7 @@ fd-slicer@~1.1.0:
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
+  integrity sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==
 
 figures@^1.7.0:
   version "1.7.0"
@@ -11106,7 +11102,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.x:
+lodash@4.x, lodash@^4.6.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11114,11 +11110,6 @@ lodash@4.x:
 "lodash@>=3.5 <5", lodash@^4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.16.2, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-
-lodash@^4.6.1:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"
@@ -15666,8 +15657,9 @@ sshpk@^1.7.0:
     tweetnacl "~0.14.0"
 
 ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
+  integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/encryption/EncryptionHandler.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/encryption/EncryptionHandler.java
@@ -38,6 +38,9 @@ public class EncryptionHandler {
         // At this point source class represents the true polymorphic type of the document
         Class<?> sourceClass = source.getClass();
 
+        // Lock a thread wanting to find information about the same type
+        // So that this information retrieval is only done once
+        // Ignore this warning, this class reference will be on the heap
         List<CandidateField> candidateFields = this.encryptedFieldsMap.get(sourceClass);
 
         if (candidateFields != null) {
@@ -192,6 +195,7 @@ public class EncryptionHandler {
         encryptedFieldsMap.put(sourceClass, finalCandidateFields);
 
         return finalCandidateFields;
+        
     }
 
     boolean convertEncryption(Object source, Function<String, String> transformer) {
@@ -243,7 +247,6 @@ public class EncryptionHandler {
                         // unknown types as polymorphic candidates over time
                         // If that is the case then do we need to store the candidate field type by
                         // known, unknown or polymorphic types at all?
-                        // TODO Discuss w/ reviewer
                     }
                 } else {
                     final Type[] typeNames = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/ErrorDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/ErrorDTO.java
@@ -1,8 +1,9 @@
-package com.appsmith.server.exceptions;
+package com.appsmith.external.exceptions;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
@@ -10,6 +11,7 @@ import java.io.Serializable;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class ErrorDTO implements Serializable {
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -9,13 +9,13 @@ import java.text.MessageFormat;
 public enum AppsmithPluginError {
 
     PLUGIN_ERROR(500, 5000, "{0}", AppsmithErrorAction.LOG_EXTERNALLY, "Query execution error"),
-    PLUGIN_GET_STRUCTURE_ERROR(500, 5001, "Failed to get database structure with error: {0}",
-            AppsmithErrorAction.LOG_EXTERNALLY, "Failed to get datasource structure"),
+    PLUGIN_GET_STRUCTURE_ERROR(500, 5001, "{0}", AppsmithErrorAction.DEFAULT, "Failed to get datasource " +
+            "structure"),
     PLUGIN_QUERY_TIMEOUT_ERROR(504, 5002, "{0} timed out in {1} milliseconds. " +
             "Please increase timeout. This can be found in Settings tab of {0}.", AppsmithErrorAction.DEFAULT, "Timed" +
             " out on query execution"),
     PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR(504, 5003, "Plugin timed out when fetching structure.",
-            AppsmithErrorAction.DEFAULT, "Timed out when fetching datasource structure"),
+            AppsmithErrorAction.LOG_EXTERNALLY, "Timed out when fetching datasource structure"),
     PLUGIN_DATASOURCE_ARGUMENT_ERROR(500, 5004, "{0}", AppsmithErrorAction.DEFAULT, "Datasource configuration is " +
             "invalid"),
     PLUGIN_EXECUTE_ARGUMENT_ERROR(500, 5005, "{0}", AppsmithErrorAction.DEFAULT, "Query configuration is invalid"),

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -14,8 +14,8 @@ public enum AppsmithPluginError {
     PLUGIN_QUERY_TIMEOUT_ERROR(504, 5002, "{0} timed out in {1} milliseconds. " +
             "Please increase timeout. This can be found in Settings tab of {0}.", AppsmithErrorAction.DEFAULT, "Timed" +
             " out on query execution"),
-    PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR(504, 5003, "Plugin timed out when fetching structure.",
-            AppsmithErrorAction.LOG_EXTERNALLY, "Timed out when fetching datasource structure"),
+    PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR(504, 5003, "{0}", AppsmithErrorAction.LOG_EXTERNALLY, "Timed out when fetching" +
+            " datasource structure"),
     PLUGIN_DATASOURCE_ARGUMENT_ERROR(500, 5004, "{0}", AppsmithErrorAction.DEFAULT, "Datasource configuration is " +
             "invalid"),
     PLUGIN_EXECUTE_ARGUMENT_ERROR(500, 5005, "{0}", AppsmithErrorAction.DEFAULT, "Query configuration is invalid"),

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
@@ -14,6 +14,10 @@ public class DatasourceStructure {
 
     List<Table> tables;
 
+    public DatasourceStructure(List<Table> tables) {
+        this.tables = tables;
+    }
+
     public enum TableType {
         TABLE,
         VIEW,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
@@ -106,9 +106,10 @@ public class DatasourceStructure {
         String body;
     }
 
-    ErrorDTO error = new ErrorDTO();
+    ErrorDTO error;
 
     public void setErrorInfo(Throwable error) {
+        this.error = new ErrorDTO();
         this.error.setMessage(error.getMessage());
 
         if (error instanceof BaseException) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
@@ -1,5 +1,6 @@
 package com.appsmith.external.models;
 
+import com.appsmith.external.exceptions.BaseException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -100,4 +101,14 @@ public class DatasourceStructure {
         String body;
     }
 
+    String errorMessage;
+    String errorStatusCode;
+
+    public void setErrorInfo(Throwable error) {
+        this.errorMessage = error.getMessage();
+
+        if (error instanceof BaseException) {
+            this.errorStatusCode = ((BaseException)error).getAppErrorCode().toString();
+        }
+    }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStructure.java
@@ -1,6 +1,7 @@
 package com.appsmith.external.models;
 
 import com.appsmith.external.exceptions.BaseException;
+import com.appsmith.external.exceptions.ErrorDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -105,14 +106,13 @@ public class DatasourceStructure {
         String body;
     }
 
-    String errorMessage;
-    String errorStatusCode;
+    ErrorDTO error = new ErrorDTO();
 
     public void setErrorInfo(Throwable error) {
-        this.errorMessage = error.getMessage();
+        this.error.setMessage(error.getMessage());
 
         if (error instanceof BaseException) {
-            this.errorStatusCode = ((BaseException)error).getAppErrorCode().toString();
+            this.error.setCode(((BaseException)error).getAppErrorCode());
         }
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
@@ -16,14 +16,14 @@ public class Property {
     /*
      * A convenience constructor to create a Property object with just a key and a value.
      */
-    public Property(String key, String value) {
+    public Property(String key, Object value) {
         this.key = key;
         this.value = value;
     }
 
     String key;
 
-    String value;
+    Object value;
 
     Boolean editable;
 

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -315,7 +315,7 @@ public class AmazonS3Plugin extends BasePlugin {
                 }
 
 
-                AmazonS3Action s3Action = AmazonS3Action.valueOf(properties.get(ACTION_PROPERTY_INDEX).getValue());
+                AmazonS3Action s3Action = AmazonS3Action.valueOf((String) properties.get(ACTION_PROPERTY_INDEX).getValue());
                 query[0] = s3Action.name();
 
                 if (properties.size() < (1 + BUCKET_NAME_PROPERTY_INDEX)
@@ -329,7 +329,7 @@ public class AmazonS3Plugin extends BasePlugin {
                     );
                 }
 
-                final String bucketName = properties.get(BUCKET_NAME_PROPERTY_INDEX).getValue();
+                final String bucketName = (String) properties.get(BUCKET_NAME_PROPERTY_INDEX).getValue();
                 requestProperties.put("bucket", bucketName == null ? "" : bucketName);
 
                 if (StringUtils.isEmpty(bucketName)) {
@@ -378,7 +378,7 @@ public class AmazonS3Plugin extends BasePlugin {
                         if (properties.size() > PREFIX_PROPERTY_INDEX
                                 && properties.get(PREFIX_PROPERTY_INDEX) != null
                                 && properties.get(PREFIX_PROPERTY_INDEX).getValue() != null) {
-                            prefix = properties.get(PREFIX_PROPERTY_INDEX).getValue();
+                            prefix = (String) properties.get(PREFIX_PROPERTY_INDEX).getValue();
                         }
 
                         ArrayList<String> listOfFiles = listAllFilesInBucket(connection, bucketName, prefix);
@@ -390,13 +390,13 @@ public class AmazonS3Plugin extends BasePlugin {
                             int durationInMinutes;
                             if (properties.size() < (1 + URL_EXPIRY_DURATION_PROPERTY_INDEX)
                                     || properties.get(URL_EXPIRY_DURATION_PROPERTY_INDEX) == null
-                                    || StringUtils.isEmpty(properties.get(URL_EXPIRY_DURATION_PROPERTY_INDEX).getValue())) {
+                                    || StringUtils.isEmpty((String) properties.get(URL_EXPIRY_DURATION_PROPERTY_INDEX).getValue())) {
                                 durationInMinutes = DEFAULT_URL_EXPIRY_IN_MINUTES;
                             } else {
                                 try {
                                     durationInMinutes = Integer
                                             .parseInt(
-                                                    properties
+                                                    (String) properties
                                                             .get(URL_EXPIRY_DURATION_PROPERTY_INDEX)
                                                             .getValue()
                                             );
@@ -451,13 +451,13 @@ public class AmazonS3Plugin extends BasePlugin {
                         int durationInMinutes;
                         if (properties.size() < (1 + URL_EXPIRY_DURATION_FOR_UPLOAD_PROPERTY_INDEX)
                                 || properties.get(URL_EXPIRY_DURATION_FOR_UPLOAD_PROPERTY_INDEX) == null
-                                || StringUtils.isEmpty(properties.get(URL_EXPIRY_DURATION_FOR_UPLOAD_PROPERTY_INDEX).getValue())) {
+                                || StringUtils.isEmpty((String) properties.get(URL_EXPIRY_DURATION_FOR_UPLOAD_PROPERTY_INDEX).getValue())) {
                             durationInMinutes = DEFAULT_URL_EXPIRY_IN_MINUTES;
                         } else {
                             try {
                                 durationInMinutes = Integer
                                         .parseInt(
-                                                properties
+                                                (String) properties
                                                         .get(URL_EXPIRY_DURATION_FOR_UPLOAD_PROPERTY_INDEX)
                                                         .getValue()
                                         );
@@ -591,7 +591,7 @@ public class AmazonS3Plugin extends BasePlugin {
                  */
                 if (properties == null
                         || properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX) == null
-                        || StringUtils.isEmpty(properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX).getValue())) {
+                        || StringUtils.isEmpty((String) properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX).getValue())) {
                     return Mono.error(
                             new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
@@ -607,7 +607,7 @@ public class AmazonS3Plugin extends BasePlugin {
                 if (!usingCustomEndpoint
                         && (properties.size() < (AWS_S3_REGION_PROPERTY_INDEX + 1)
                         || properties.get(AWS_S3_REGION_PROPERTY_INDEX) == null
-                        || StringUtils.isEmpty(properties.get(AWS_S3_REGION_PROPERTY_INDEX).getValue()))) {
+                        || StringUtils.isEmpty((String) properties.get(AWS_S3_REGION_PROPERTY_INDEX).getValue()))) {
                     return Mono.error(
                             new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
@@ -636,7 +636,7 @@ public class AmazonS3Plugin extends BasePlugin {
                 if (usingCustomEndpoint
                         && (properties.size() < (CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX + 1)
                         || properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX) == null
-                        || StringUtils.isEmpty(properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX).getValue()))) {
+                        || StringUtils.isEmpty((String) properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX).getValue()))) {
                     return Mono.error(
                             new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
@@ -647,9 +647,9 @@ public class AmazonS3Plugin extends BasePlugin {
                     );
                 }
 
-                final String region = usingCustomEndpoint ?
-                        properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX).getValue() :
-                        properties.get(AWS_S3_REGION_PROPERTY_INDEX).getValue();
+                final String region = (String) (usingCustomEndpoint ?
+                                        properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX).getValue() :
+                                        properties.get(AWS_S3_REGION_PROPERTY_INDEX).getValue());
 
                 DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
                 if (authentication == null
@@ -776,7 +776,7 @@ public class AmazonS3Plugin extends BasePlugin {
              */
             if (properties == null
                     || properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX) == null
-                    || StringUtils.isEmpty(properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX).getValue())) {
+                    || StringUtils.isEmpty((String) properties.get(S3_SERVICE_PROVIDER_PROPERTY_INDEX).getValue())) {
                 invalids.add("Appsmith has failed to fetch the 'S3 Service Provider' field properties. Please " +
                         "reach out to Appsmith customer support to resolve this.");
             }
@@ -786,7 +786,7 @@ public class AmazonS3Plugin extends BasePlugin {
             if (!usingCustomEndpoint
                     && (properties.size() < (AWS_S3_REGION_PROPERTY_INDEX + 1)
                     || properties.get(AWS_S3_REGION_PROPERTY_INDEX) == null
-                    || StringUtils.isEmpty(properties.get(AWS_S3_REGION_PROPERTY_INDEX).getValue()))) {
+                    || StringUtils.isEmpty((String) properties.get(AWS_S3_REGION_PROPERTY_INDEX).getValue()))) {
                 invalids.add("Required parameter 'Region' is empty. Did you forget to edit the 'Region' field" +
                         " in the datasource creation form ? You need to fill it with the region where " +
                         "your AWS S3 instance is hosted.");
@@ -805,7 +805,7 @@ public class AmazonS3Plugin extends BasePlugin {
             if (usingCustomEndpoint
                     && (properties.size() < (CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX + 1)
                     || properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX) == null
-                    || StringUtils.isEmpty(properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX).getValue()))) {
+                    || StringUtils.isEmpty((String) properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX).getValue()))) {
                 invalids.add("Required parameter 'Region' is empty. Did you forget to edit the 'Region' field" +
                         " in the datasource creation form ? You need to fill it with the region where " +
                         "your S3 instance is hosted.");

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/main/java/com/external/plugins/ElasticSearchPlugin.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/main/java/com/external/plugins/ElasticSearchPlugin.java
@@ -187,7 +187,7 @@ public class ElasticSearchPlugin extends BasePlugin {
                     clientBuilder.setDefaultHeaders(
                             (Header[]) datasourceConfiguration.getHeaders()
                                     .stream()
-                                    .map(h -> new BasicHeader(h.getKey(), h.getValue()))
+                                    .map(h -> new BasicHeader(h.getKey(), (String) h.getValue()))
                                     .toArray()
                     );
                 }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -114,7 +113,7 @@ public class FirestorePlugin extends BasePlugin {
             final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
             final com.external.plugins.Method method = CollectionUtils.isEmpty(properties)
                     ? null
-                    : com.external.plugins.Method.valueOf(properties.get(0).getValue());
+                    : com.external.plugins.Method.valueOf((String) properties.get(0).getValue());
             requestData.put("method", method == null ? "" : method.toString());
 
             final PaginationField paginationField = executeActionDTO == null ? null : executeActionDTO.getPaginationField();
@@ -189,10 +188,10 @@ public class FirestorePlugin extends BasePlugin {
                                     || Method.CREATE_DOCUMENT.equals(method) || Method.ADD_TO_COLLECTION.equals(method))
                                     && (properties == null || ((properties.size() < FIELDVALUE_TIMESTAMP_PROPERTY_INDEX + 1
                                     || properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX) == null
-                                    || StringUtils.isEmpty(properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue()))
+                                    || StringUtils.isEmpty((String) properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue()))
                                     && (properties.size() < FIELDVALUE_DELETE_PROPERTY_INDEX
                                     || properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX) == null
-                                    || StringUtils.isEmpty(properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue()))))) {
+                                    || StringUtils.isEmpty((String) properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue()))))) {
                                 return Mono.error(new AppsmithPluginException(
                                         AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
                                         "The method " + method.toString() + " needs at least one of the following " +
@@ -250,7 +249,7 @@ public class FirestorePlugin extends BasePlugin {
             if(!Method.UPDATE_DOCUMENT.equals(method)
                     && properties.size() > FIELDVALUE_DELETE_PROPERTY_INDEX
                     && properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX) != null
-                    && !StringUtils.isEmpty(properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue())) {
+                    && !StringUtils.isEmpty((String) properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue())) {
                 throw new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_ERROR,
                         "Appsmith has found an unexpected query form property - 'Delete Key Value Pair Path'. Please " +
@@ -263,8 +262,8 @@ public class FirestorePlugin extends BasePlugin {
              */
             if( properties.size() > FIELDVALUE_DELETE_PROPERTY_INDEX
                     && properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX) != null
-                    && !StringUtils.isEmpty(properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue())) {
-                String deletePaths = properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue();
+                    && !StringUtils.isEmpty((String) properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue())) {
+                String deletePaths = (String) properties.get(FIELDVALUE_DELETE_PROPERTY_INDEX).getValue();
                 List<String> deletePathsList;
                 try {
                     deletePathsList = objectMapper.readValue(deletePaths, new TypeReference<List<String>>(){});
@@ -297,7 +296,7 @@ public class FirestorePlugin extends BasePlugin {
                     || Method.DELETE_DOCUMENT.equals(method))
                     && properties.size() > FIELDVALUE_TIMESTAMP_PROPERTY_INDEX
                     && properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX) != null
-                    && !StringUtils.isEmpty(properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue())) {
+                    && !StringUtils.isEmpty((String) properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue())) {
                 throw new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_ERROR,
                         "Appsmith has found an unexpected query form property - 'Timestamp Value Path'. Please reach " +
@@ -310,8 +309,8 @@ public class FirestorePlugin extends BasePlugin {
              */
             if(properties.size() > FIELDVALUE_TIMESTAMP_PROPERTY_INDEX
                     && properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX) != null
-                    && !StringUtils.isEmpty(properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue())) {
-                String timestampValuePaths = properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue();
+                    && !StringUtils.isEmpty((String) properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue())) {
+                String timestampValuePaths = (String) properties.get(FIELDVALUE_TIMESTAMP_PROPERTY_INDEX).getValue();
                 List<String> timestampPathsStringList; // ["key1.key2", "key3.key4"]
                 try {
                     timestampPathsStringList = objectMapper.readValue(timestampValuePaths,
@@ -511,7 +510,7 @@ public class FirestorePlugin extends BasePlugin {
                 return defaultValue;
             }
 
-            final String value = property.getValue();
+            final String value = (String) property.getValue();
             return value != null ? value : defaultValue;
         }
 

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -129,7 +129,14 @@ public class MongoPlugin extends BasePlugin {
 
                 // Since properties is not empty, we are guaranteed to find the first property.
             } else if (properties.get(SMART_BSON_SUBSTITUTION_INDEX) != null){
-                smartBsonSubstitution = Boolean.parseBoolean(properties.get(SMART_BSON_SUBSTITUTION_INDEX).getValue());
+                Object ssubValue = properties.get(SMART_BSON_SUBSTITUTION_INDEX).getValue();
+                if (ssubValue instanceof  Boolean) {
+                    smartBsonSubstitution = (Boolean) ssubValue;
+                } else if (ssubValue instanceof String) {
+                    smartBsonSubstitution = Boolean.parseBoolean((String) ssubValue);
+                } else {
+                    smartBsonSubstitution = false;
+                }
             } else {
                 smartBsonSubstitution = false;
             }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -606,6 +606,14 @@ public class MongoPlugin extends BasePlugin {
                     })
                     .collectList()
                     .thenReturn(structure)
+                    .onErrorMap(
+                            MongoCommandException.class,
+                            error -> new AppsmithPluginException(
+                                    AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR,
+                                    "Appsmith has failed to get database structure. Please provide read permission on" +
+                                            " the database to fix this."
+                            )
+                    )
                     .subscribeOn(scheduler);
         }
 

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -87,6 +87,8 @@ public class MongoPlugin extends BasePlugin {
 
     private static final int SMART_BSON_SUBSTITUTION_INDEX = 0;
 
+    private static final Integer MONGO_COMMAND_EXCEPTION_UNAUTHORIZED_ERROR_CODE = 13;
+
     public MongoPlugin(PluginWrapper wrapper) {
         super(wrapper);
     }
@@ -608,11 +610,17 @@ public class MongoPlugin extends BasePlugin {
                     .thenReturn(structure)
                     .onErrorMap(
                             MongoCommandException.class,
-                            error -> new AppsmithPluginException(
-                                    AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR,
-                                    "Appsmith has failed to get database structure. Please provide read permission on" +
-                                            " the database to fix this."
-                            )
+                            error -> {
+                                if (MONGO_COMMAND_EXCEPTION_UNAUTHORIZED_ERROR_CODE.equals(error.getErrorCode())) {
+                                    return new AppsmithPluginException(
+                                            AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR,
+                                            "Appsmith has failed to get database structure. Please provide read permission on" +
+                                                    " the database to fix this."
+                                    );
+                                }
+
+                                return error;
+                            }
                     )
                     .subscribeOn(scheduler);
         }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor.json
@@ -11,8 +11,11 @@
           "evaluationSubstitutionType": "SMART_SUBSTITUTE",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "false"
+            "comparison": "IN",
+            "value": [
+              "false",
+              false
+            ]
           }
         },
         {
@@ -22,8 +25,11 @@
           "evaluationSubstitutionType": "TEMPLATE",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "true"
+            "comparison": "IN",
+            "value": [
+              "true",
+              true
+            ]
           }
         }
       ]

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/setting.json
@@ -21,7 +21,7 @@
           "info": "Turning on this property fixes the BSON substitution of bindings in the Mongo BSON document by adding/removing quotes intelligently and reduces developer errors",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
-          "initialValue": "false"
+          "initialValue": false
         },
         {
           "label": "Query timeout (in milliseconds)",

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -682,6 +682,7 @@ public class MongoPluginTest {
 
         MongoCommandException mockMongoCmdException = mock(MongoCommandException.class);
         when(mockDatabase.listCollectionNames()).thenReturn(Mono.error(mockMongoCmdException));
+        when(mockMongoCmdException.getErrorCode()).thenReturn(13);
 
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         Mono<DatasourceStructure> structureMono = pluginExecutor.datasourceCreate(dsConfig)

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -2,6 +2,7 @@ package com.external.plugins;
 
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.dtos.ExecuteActionDTO;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionRequest;
 import com.appsmith.external.models.ActionExecutionResult;
@@ -19,9 +20,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoGridFSException;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
 import org.bson.Document;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -670,5 +673,27 @@ public class MongoPluginTest {
                     );
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    public void testGetStructureReadPermissionError() {
+        MongoClient mockConnection = mock(MongoClient.class);
+        MongoDatabase mockDatabase = mock(MongoDatabase.class);
+        when(mockConnection.getDatabase(any())).thenReturn(mockDatabase);
+
+        MongoCommandException mockMongoCmdException = mock(MongoCommandException.class);
+        when(mockDatabase.listCollectionNames()).thenReturn(Mono.error(mockMongoCmdException));
+
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        Mono<DatasourceStructure> structureMono = pluginExecutor.datasourceCreate(dsConfig)
+                .flatMap(connection -> pluginExecutor.getStructure(mockConnection, dsConfig));
+
+        StepVerifier.create(structureMono)
+                .verifyErrorSatisfies(error -> {
+                   assertTrue(error instanceof AppsmithPluginException);
+                   String expectedMessage = "Appsmith has failed to get database structure. Please provide read permission on" +
+                           " the database to fix this.";
+                   assertTrue(expectedMessage.equals(error.getMessage()));
+                });
     }
 }

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.MongoCommandException;
-import com.mongodb.MongoGridFSException;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoCollection;

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -123,7 +123,14 @@ public class MssqlPlugin extends BasePlugin {
                  */
                 isPreparedStatement = false;
             } else if (properties.get(PREPARED_STATEMENT_INDEX) != null){
-                isPreparedStatement = Boolean.parseBoolean(properties.get(PREPARED_STATEMENT_INDEX).getValue());
+                Object psValue = properties.get(PREPARED_STATEMENT_INDEX).getValue();
+                if (psValue instanceof  Boolean) {
+                    isPreparedStatement = (Boolean) psValue;
+                } else if (psValue instanceof String) {
+                    isPreparedStatement = Boolean.parseBoolean((String) psValue);
+                } else {
+                    isPreparedStatement = false;
+                }
             } else {
                 isPreparedStatement = false;
             }

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/editor.json
@@ -11,8 +11,11 @@
           "evaluationSubstitutionType": "PARAMETER",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "false"
+            "comparison": "IN",
+            "value": [
+              "false",
+              false
+            ]
           }
         },
         {
@@ -22,8 +25,11 @@
           "evaluationSubstitutionType": "TEMPLATE",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "true"
+            "comparison": "IN",
+            "value": [
+              "true",
+              true
+            ]
           }
         }
       ]

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/setting.json
@@ -21,7 +21,7 @@
           "info": "Turning on Prepared Statement makes the query parametrized. This in turn makes it resilient against SQL injections",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
-          "initialValue": "false"
+          "initialValue": false
         },
         {
           "label": "Query timeout (in milliseconds)",

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -166,7 +166,14 @@ public class MySqlPlugin extends BasePlugin {
                  */
                 isPreparedStatement = false;
             } else if (properties.get(PREPARED_STATEMENT_INDEX) != null){
-                isPreparedStatement = Boolean.parseBoolean(properties.get(PREPARED_STATEMENT_INDEX).getValue());
+                Object psValue = properties.get(PREPARED_STATEMENT_INDEX).getValue();
+                if (psValue instanceof  Boolean) {
+                    isPreparedStatement = (Boolean) psValue;
+                } else if (psValue instanceof String) {
+                    isPreparedStatement = Boolean.parseBoolean((String) psValue);
+                } else {
+                    isPreparedStatement = false;
+                }
             } else {
                 isPreparedStatement = false;
             }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/editor.json
@@ -11,8 +11,11 @@
           "evaluationSubstitutionType": "PARAMETER",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "false"
+            "comparison": "IN",
+            "value": [
+              "false",
+              false
+            ]
           }
         },
         {
@@ -22,8 +25,11 @@
           "evaluationSubstitutionType": "TEMPLATE",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "true"
+            "comparison": "IN",
+            "value": [
+              "true",
+              true
+            ]
           }
         }
       ]

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/setting.json
@@ -21,7 +21,7 @@
           "info": "Turning on Prepared Statement makes the query parametrized. This in turn makes it resilient against SQL injections",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
-          "initialValue": "false"
+          "initialValue": false
         },
         {
           "label": "Query timeout (in milliseconds)",

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -172,7 +172,14 @@ public class PostgresPlugin extends BasePlugin {
                  */
                 isPreparedStatement = false;
             } else if (properties.get(PREPARED_STATEMENT_INDEX) != null){
-                isPreparedStatement = Boolean.parseBoolean(properties.get(PREPARED_STATEMENT_INDEX).getValue());
+                Object psValue = properties.get(PREPARED_STATEMENT_INDEX).getValue();
+                if (psValue instanceof  Boolean) {
+                    isPreparedStatement = (Boolean) psValue;
+                } else if (psValue instanceof String) {
+                    isPreparedStatement = Boolean.parseBoolean((String) psValue);
+                } else {
+                    isPreparedStatement = false;
+                }
             } else {
                 isPreparedStatement = false;
             }

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/editor.json
@@ -11,8 +11,11 @@
           "evaluationSubstitutionType": "PARAMETER",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "false"
+            "comparison": "IN",
+            "value": [
+              "false",
+              false
+            ]
           }
         },
         {
@@ -22,8 +25,11 @@
           "evaluationSubstitutionType": "TEMPLATE",
           "hidden": {
             "path": "actionConfiguration.pluginSpecifiedTemplates[0].value",
-            "comparison": "EQUALS",
-            "value": "true"
+            "comparison": "IN",
+            "value": [
+              "true",
+              true
+            ]
           }
         }
       ]

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/setting.json
@@ -21,7 +21,7 @@
           "info": "Turning on Prepared Statement makes the query parametrized. This in turn makes it resilient against SQL injections",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[0].value",
           "controlType": "SWITCH",
-          "initialValue": "false"
+          "initialValue": false
         },
         {
           "label": "Query timeout (in milliseconds)",

--- a/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
+++ b/app/server/appsmith-plugins/rapidApiPlugin/src/main/java/com/external/plugins/RapidApiPlugin.java
@@ -94,11 +94,11 @@ public class RapidApiPlugin extends BasePlugin {
                 for (Property property : actionConfiguration.getRouteParameters()) {
                     // If either the key or the value is empty, skip
                     if (property.getKey() != null && !property.getKey().isEmpty() &&
-                            property.getValue() != null && !property.getValue().isEmpty()) {
+                            property.getValue() != null && !((String) property.getValue()).isEmpty()) {
 
                         Pattern pattern = Pattern.compile("\\{" + property.getKey() + "\\}");
                         Matcher matcher = pattern.matcher(url);
-                        url = matcher.replaceAll(URLEncoder.encode(property.getValue()));
+                        url = matcher.replaceAll(URLEncoder.encode((String) property.getValue()));
                     }
                 }
             }
@@ -126,11 +126,11 @@ public class RapidApiPlugin extends BasePlugin {
 
                     if (property.getValue() != null) {
                         if (!property.getType().equals(JSON_TYPE)) {
-                            keyValueMap.put(property.getKey(), property.getValue());
+                            keyValueMap.put(property.getKey(), (String) property.getValue());
                         } else {
                             // This is actually supposed to be the body and should not be in key-value format. No need to
                             // convert the same.
-                            jsonString = property.getValue();
+                            jsonString = (String) property.getValue();
                             break;
                         }
                     }
@@ -285,7 +285,7 @@ public class RapidApiPlugin extends BasePlugin {
         private void addHeadersToRequest(WebClient.Builder webClientBuilder, List<Property> headers) {
             for (Property header : headers) {
                 if (header.getKey() != null && !header.getKey().isEmpty()) {
-                    webClientBuilder.defaultHeader(header.getKey(), header.getValue());
+                    webClientBuilder.defaultHeader(header.getKey(), (String) header.getValue());
                 }
             }
         }
@@ -305,8 +305,8 @@ public class RapidApiPlugin extends BasePlugin {
                 for (Property queryParam : queryParams) {
                     // If either the key or the value is empty, skip
                     if (queryParam.getKey() != null && !queryParam.getKey().isEmpty() &&
-                            queryParam.getValue() != null && !queryParam.getValue().isEmpty()) {
-                        uriBuilder.queryParam(queryParam.getKey(), URLEncoder.encode(queryParam.getValue(),
+                            queryParam.getValue() != null && !((String) queryParam.getValue()).isEmpty()) {
+                        uriBuilder.queryParam(queryParam.getKey(), URLEncoder.encode((String) queryParam.getValue(),
                                 StandardCharsets.UTF_8));
                     }
                 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -135,7 +135,14 @@ public class RestApiPlugin extends BasePlugin {
 
                 // Since properties is not empty, we are guaranteed to find the first property.
             } else if (properties.get(SMART_JSON_SUBSTITUTION_INDEX) != null){
-                smartJsonSubstitution = Boolean.parseBoolean(properties.get(SMART_JSON_SUBSTITUTION_INDEX).getValue());
+                Object ssubValue = properties.get(SMART_JSON_SUBSTITUTION_INDEX).getValue();
+                if (ssubValue instanceof  Boolean) {
+                    smartJsonSubstitution = (Boolean) ssubValue;
+                } else if (ssubValue instanceof String) {
+                    smartJsonSubstitution = Boolean.parseBoolean((String) ssubValue);
+                } else {
+                    smartJsonSubstitution = false;
+                }
             } else {
                 smartJsonSubstitution = false;
             }
@@ -400,7 +407,7 @@ public class RestApiPlugin extends BasePlugin {
                     if (IS_SEND_SESSION_ENABLED_KEY.equals(property.getKey())) {
                         isSendSessionEnabled = "Y".equals(property.getValue());
                     } else if (SESSION_SIGNATURE_KEY_KEY.equals(property.getKey())) {
-                        secretKey = property.getValue();
+                        secretKey = (String) property.getValue();
                     }
                 }
 
@@ -429,7 +436,7 @@ public class RestApiPlugin extends BasePlugin {
             String reqBody = bodyFormData.stream()
                     .map(property -> {
                         String key = property.getKey();
-                        String value = property.getValue();
+                        String value = (String) property.getValue();
 
                         if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType)
                                 && encodeParamsToggle == true) {
@@ -462,7 +469,7 @@ public class RestApiPlugin extends BasePlugin {
             for (Property header : headers) {
                 if (header.getKey().equalsIgnoreCase(HttpHeaders.CONTENT_TYPE)) {
                     try {
-                        MediaType.valueOf(header.getValue());
+                        MediaType.valueOf((String) header.getValue());
                     } catch (InvalidMediaTypeException e) {
                         return e.getMessage();
                     }
@@ -609,7 +616,7 @@ public class RestApiPlugin extends BasePlugin {
                     if ("isSendSessionEnabled".equals(property.getKey())) {
                         isSendSessionEnabled = "Y".equals(property.getValue());
                     } else if ("sessionSignatureKey".equals(property.getKey())) {
-                        secretKey = property.getValue();
+                        secretKey = (String) property.getValue();
                     }
                 }
 
@@ -647,7 +654,7 @@ public class RestApiPlugin extends BasePlugin {
             for (Property header : headers) {
                 String key = header.getKey();
                 if (StringUtils.isNotEmpty(key)) {
-                    String value = header.getValue();
+                    String value = (String) header.getValue();
                     webClientBuilder.defaultHeader(key, value);
 
                     if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(key)) {
@@ -678,7 +685,7 @@ public class RestApiPlugin extends BasePlugin {
                         if (encodeParamsToggle == true) {
                             uriBuilder.queryParam(
                                     URLEncoder.encode(key, StandardCharsets.UTF_8),
-                                    URLEncoder.encode(queryParam.getValue(), StandardCharsets.UTF_8)
+                                    URLEncoder.encode((String) queryParam.getValue(), StandardCharsets.UTF_8)
                             );
                         } else {
                             uriBuilder.queryParam(
@@ -708,7 +715,7 @@ public class RestApiPlugin extends BasePlugin {
                 MultiValueMap<String, String> reqMultiMap = CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
 
                 actionConfiguration.getHeaders().stream()
-                        .forEach(header -> reqMultiMap.put(header.getKey(), Arrays.asList(header.getValue())));
+                        .forEach(header -> reqMultiMap.put(header.getKey(), Arrays.asList((String) header.getValue())));
                 actionExecutionRequest.setHeaders(objectMapper.valueToTree(reqMultiMap));
             }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
@@ -79,9 +79,9 @@ public class MongoConfig {
         return converter;
     }
 
-    @Bean
-    public EncryptionMongoEventListener encryptionMongoEventListener(EncryptionService encryptionService) {
-        return new EncryptionMongoEventListener(encryptionService);
-    }
+//    @Bean
+//    public EncryptionMongoEventListener encryptionMongoEventListener(EncryptionService encryptionService) {
+//        return new EncryptionMongoEventListener(encryptionService);
+//    }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseDTO.java
@@ -1,6 +1,6 @@
 package com.appsmith.server.dtos;
 
-import com.appsmith.server.exceptions.ErrorDTO;
+import com.appsmith.external.exceptions.ErrorDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseMetaDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ResponseMetaDTO.java
@@ -1,6 +1,6 @@
 package com.appsmith.server.dtos;
 
-import com.appsmith.server.exceptions.ErrorDTO;
+import com.appsmith.external.exceptions.ErrorDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.exceptions;
 
+import com.appsmith.external.exceptions.ErrorDTO;
 import com.appsmith.server.dtos.ResponseDTO;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.appsmith.server.exceptions;
 
 import com.appsmith.external.exceptions.AppsmithErrorAction;
 import com.appsmith.external.exceptions.BaseException;
+import com.appsmith.external.exceptions.ErrorDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.server.dtos.ResponseDTO;
 import io.sentry.Sentry;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -287,7 +287,9 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
         if (datasource.getDatasourceConfiguration() != null
                 && !CollectionUtils.isEmpty(datasource.getDatasourceConfiguration().getEndpoints())) {
             for (final Endpoint endpoint : datasource.getDatasourceConfiguration().getEndpoints()) {
-                endpoint.setHost(endpoint.getHost().trim());
+                if (endpoint != null && endpoint.getHost() != null) {
+                    endpoint.setHost(endpoint.getHost().trim());
+                }
             }
         }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
@@ -91,14 +91,16 @@ public class DatasourceStructureSolution {
                         TimeoutException.class,
                         error -> new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR,
-                                "Timed out when fetching structure"
+                                "Appsmith server timed out when fetching structure. Please reach out to appsmith " +
+                                        "customer support to resolve this."
                         )
                 )
                 .onErrorMap(
                         StaleConnectionException.class,
                         error -> new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_ERROR,
-                                "Secondary stale connection error."
+                                "Appsmith server found a secondary stale connection. Please reach out to appsmith " +
+                                        "customer support to resolve this."
                         )
                 )
                 .onErrorMap(
@@ -117,6 +119,11 @@ public class DatasourceStructureSolution {
                     }
 
                     return e;
+                })
+                .onErrorResume(error -> {
+                    DatasourceStructure dsStructure = new DatasourceStructure();
+                    dsStructure.setErrorInfo(error);
+                    return Mono.just(dsStructure);
                 })
                 .flatMap(structure -> datasource.getId() == null
                         ? Mono.empty()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
@@ -97,7 +97,7 @@ public class DatasourceStructureSolution {
                 .onErrorMap(
                         StaleConnectionException.class,
                         error -> new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_GET_STRUCTURE_ERROR,
+                                AppsmithPluginError.PLUGIN_ERROR,
                                 "Secondary stale connection error."
                         )
                 )

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
@@ -59,6 +59,11 @@ public class DatasourceStructureSolution {
                     }
 
                     return e;
+                })
+                .onErrorResume(error -> {
+                    DatasourceStructure dsStructure = new DatasourceStructure();
+                    dsStructure.setErrorInfo(error);
+                    return Mono.just(dsStructure);
                 });
     }
 
@@ -119,11 +124,6 @@ public class DatasourceStructureSolution {
                     }
 
                     return e;
-                })
-                .onErrorResume(error -> {
-                    DatasourceStructure dsStructure = new DatasourceStructure();
-                    dsStructure.setErrorInfo(error);
-                    return Mono.just(dsStructure);
                 })
                 .flatMap(structure -> datasource.getId() == null
                         ? Mono.empty()


### PR DESCRIPTION
## Description
- return helpful error message when get structure fails for mongo db due to lack of read permission. The message returned is: `Appsmith has failed to get database structure. Please provide read permission on the database to fix this.`
- any get structure error is also generically being caught by the `getStrucuture` method in `DatasourceStructureSolution.java`
- error msg and status code is now returned as part of `DatasourceStructure` object.
  - `ErrorDTO` is used to store error info. 
  - `ErrorDTO` definition is moved to `appsmith-interfaces` package so that it can be used all packages. 
- Other changes:
  - stop logging `PLUGIN_GET_STRUCTURE_ERROR` externally, as this error is mostly triggered by credentials error or lack of read permission. 
  - start logging `PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR` externally, because this is not a user error. 

Fixes 1479

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually 
- Test case

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
