### PR TITLE
Fix date string parsing for date from input field

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
@@ -81,12 +81,26 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
     cy.closePropertyPane();
   });
 
-  it("Datepicker value to work with selected date formats", function() {
+  it("Datepicker input value changes to work with selected date formats", function() {
     cy.openPropertyPane("datepickerwidget2");
-    cy.testJsontext("defaultdate", "04/05/2021 05:25");
-    cy.selectDateFormat("YYYY-MM-DD HH:mm");
+    cy.get(".t--property-control-defaultdate .bp3-input").clear();
+    cy.get(formWidgetsPage.toggleJsDefaultDate).click();
+    cy.selectDateFormat("DD/MM/YYYY HH:mm");
+    cy.testJsontext(
+      "defaultdate",
+      '{{moment("04/05/2021 05:25", "DD/MM/YYYY HH:mm").toISOString()}}',
+    );
+    cy.get(".t--draggable-datepickerwidget2 .bp3-input")
+      .clear({
+        force: true,
+      })
+      .type("04/05/2021 06:25");
+    cy.selectDateFormat("LLL");
     cy.SearchEntityandOpen("Text1");
     cy.testJsontext("text", "{{DatePicker1.formattedDate}}");
+    cy.get(".t--draggable-textwidget .bp3-ui-text")
+      .first()
+      .should("have.text", "May 4, 2021 6:25 AM");
   });
 
   it("Datepicker default date validation with js binding", function() {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
@@ -106,8 +106,6 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
       })
       .type("04/05/2021 06:25");
     cy.selectDateFormat("LLL");
-    cy.SearchEntityandOpen("Text1");
-    cy.testJsontext("text", "{{DatePicker1.formattedDate}}");
     cy.wait("@updateLayout");
     cy.get(".t--draggable-textwidget .bp3-ui-text")
       .first()

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
@@ -83,9 +83,19 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
 
   it("Datepicker input value changes to work with selected date formats", function() {
     cy.openPropertyPane("datepickerwidget2");
+    cy.get(".t--property-control-mindate .bp3-input")
+      .clear()
+      .type("2021-01-01");
+    cy.closePropertyPane();
+    cy.openPropertyPane("datepickerwidget2");
+    cy.get(".t--property-control-maxdate .bp3-input")
+      .clear()
+      .type("2021-10-10");
+    cy.closePropertyPane();
+    cy.openPropertyPane("datepickerwidget2");
     cy.get(".t--property-control-defaultdate .bp3-input").clear();
-    cy.get(formWidgetsPage.toggleJsDefaultDate).click();
     cy.selectDateFormat("DD/MM/YYYY HH:mm");
+    cy.get(formWidgetsPage.toggleJsDefaultDate).click();
     cy.testJsontext(
       "defaultdate",
       '{{moment("04/05/2021 05:25", "DD/MM/YYYY HH:mm").toISOString()}}',
@@ -98,6 +108,7 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
     cy.selectDateFormat("LLL");
     cy.SearchEntityandOpen("Text1");
     cy.testJsontext("text", "{{DatePicker1.formattedDate}}");
+    cy.wait("@updateLayout");
     cy.get(".t--draggable-textwidget .bp3-ui-text")
       .first()
       .should("have.text", "May 4, 2021 6:25 AM");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
@@ -81,6 +81,14 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
     cy.closePropertyPane();
   });
 
+  it("Datepicker value to work with selected date formats", function() {
+    cy.openPropertyPane("datepickerwidget2");
+    cy.testJsontext("defaultdate", "04/05/2021 05:25");
+    cy.selectDateFormat("YYYY-MM-DD HH:mm");
+    cy.SearchEntityandOpen("Text1");
+    cy.testJsontext("text", "{{DatePicker1.formattedDate}}");
+  });
+
   it("Datepicker default date validation with js binding", function() {
     cy.PublishtheApp();
     // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
+++ b/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
@@ -194,8 +194,8 @@ class DatePickerComponent extends React.Component<
 
   parseDate = (dateStr: string): Date => {
     const date = moment(dateStr);
-
-    if (date.isValid()) return moment(dateStr).toDate();
+    const dateFormat = this.props.dateFormat || ISO_DATE_FORMAT;
+    if (date.isValid()) return moment(dateStr, dateFormat).toDate();
     else return moment().toDate();
   };
 


### PR DESCRIPTION
## Description
Fix date string parsing for date from input field

Fixes #3957 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Added cypress test case to validate issue fix

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/date-input-edit 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 49.04 **(0)** | 29.73 **(-0.01)** | 27.23 **(0)** | 49.43 **(0)**
 :red_circle: | app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx | 28.99 **(-0.42)** | 3.39 **(-0.12)** | 5.88 **(0)** | 28.36 **(-0.43)**</details>