### PR TITLE
Fix: Paste functionality fails when there is no parent available. 

### DIFF
--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -51,7 +51,7 @@ export const handleIfParentIsListWidgetWhilePasting = (
 ): { [widgetId: string]: FlattenedWidgetProps } => {
   let root = get(widgets, `${widget.parentId}`);
 
-  while (root.parentId && root.widgetId !== MAIN_CONTAINER_WIDGET_ID) {
+  while (root && root.parentId && root.widgetId !== MAIN_CONTAINER_WIDGET_ID) {
     if (root.type === WidgetTypes.LIST_WIDGET) {
       const listWidget = root;
       const currentWidget = cloneDeep(widget);


### PR DESCRIPTION
Fixes the test failing in cypress Entity_Explorer_Widgets_Copy_Paste_Delete_Undo_Keyboard_Event_spec.js for listwidget

Fixes #1427 

## Type of change
- Bug fix

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
