### PR TITLE
Selective data tree update

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -124,7 +124,9 @@ export default class DataTreeEvaluator {
     return relativePropertyPath in entity.bindingPaths;
   }
 
-  updateDataTree(unEvalTree: DataTree) {
+  updateDataTree(
+    unEvalTree: DataTree,
+  ): { dataTree: DataTree; changedEntities: string[] } {
     const totalStart = performance.now();
     // Calculate diff
     const diffCheckTimeStart = performance.now();
@@ -132,7 +134,7 @@ export default class DataTreeEvaluator {
     // Since eval tree is listening to possible events that dont cause differences
     // We want to check if no diffs are present and bail out early
     if (differences.length === 0) {
-      return this.evalTree;
+      return { dataTree: this.evalTree, changedEntities: [] };
     }
     const diffCheckTimeStop = performance.now();
     // Check if dependencies have changed
@@ -203,7 +205,16 @@ export default class DataTreeEvaluator {
       evaluate: (evalStop - evalStart).toFixed(2),
     };
     this.logs.push({ timeTakenForSubTreeEval });
-    return this.evalTree;
+    return {
+      dataTree: this.evalTree,
+      changedEntities: Array.from(
+        new Set(
+          evaluationOrder.map((propertyPath) =>
+            propertyPath.substring(0, propertyPath.indexOf(".")),
+          ),
+        ),
+      ),
+    };
   }
 
   getCompleteSortOrder(

--- a/app/client/src/workers/evaluation.test.ts
+++ b/app/client/src/workers/evaluation.test.ts
@@ -378,7 +378,8 @@ describe("DataTreeEvaluator", () => {
         text: "Hey there",
       },
     };
-    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree);
+    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree)
+      .dataTree;
     expect(updatedEvalTree).toHaveProperty("Text2.text", "Hey there");
     expect(updatedEvalTree).toHaveProperty("Text3.text", "Hey there");
   });
@@ -391,7 +392,8 @@ describe("DataTreeEvaluator", () => {
         text: "Label 3",
       },
     };
-    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree);
+    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree)
+      .dataTree;
     const updatedDependencyMap = evaluator.dependencyMap;
     expect(updatedEvalTree).toHaveProperty("Text2.text", "Label");
     expect(updatedEvalTree).toHaveProperty("Text3.text", "Label 3");
@@ -439,7 +441,8 @@ describe("DataTreeEvaluator", () => {
       },
     };
 
-    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree);
+    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree)
+      .dataTree;
     expect(updatedEvalTree).toHaveProperty("Input1.text", "Default value");
   });
 
@@ -475,7 +478,8 @@ describe("DataTreeEvaluator", () => {
         },
       },
     };
-    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree);
+    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree)
+      .dataTree;
     expect(updatedEvalTree).toHaveProperty(
       "Dropdown2.options.0.label",
       "newValue",
@@ -498,7 +502,8 @@ describe("DataTreeEvaluator", () => {
         ],
       },
     };
-    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree);
+    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree)
+      .dataTree;
     const updatedDependencyMap = evaluator.dependencyMap;
     expect(updatedEvalTree).toHaveProperty("Table1.tableData", [
       {
@@ -562,7 +567,8 @@ describe("DataTreeEvaluator", () => {
         ],
       },
     };
-    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree);
+    const updatedEvalTree = evaluator.updateDataTree(updatedUnEvalTree)
+      .dataTree;
     const updatedDependencyMap = evaluator.dependencyMap;
     expect(updatedEvalTree).toHaveProperty("Table1.tableData", [
       {

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -44,13 +44,16 @@ ctx.addEventListener(
         let errors: EvalError[] = [];
         let logs: any[] = [];
         let dependencies: DependencyMap = {};
+        let changedEntities: string[] = [];
         try {
           if (!dataTreeEvaluator) {
             dataTreeEvaluator = new DataTreeEvaluator(widgetTypeConfigMap);
             dataTreeEvaluator.createFirstTree(unevalTree);
             dataTree = dataTreeEvaluator.evalTree;
           } else {
-            dataTree = dataTreeEvaluator.updateDataTree(unevalTree);
+            const updateResponse = dataTreeEvaluator.updateDataTree(unevalTree);
+            dataTree = updateResponse.dataTree;
+            changedEntities = updateResponse.changedEntities;
           }
 
           // We need to clean it to remove any possible functions inside the tree.
@@ -81,6 +84,7 @@ ctx.addEventListener(
           dependencies,
           errors,
           logs,
+          changedEntities,
         };
       }
       case EVAL_WORKER_ACTIONS.EVAL_ACTION_BINDINGS: {
@@ -105,7 +109,9 @@ ctx.addEventListener(
         if (!dataTreeEvaluator) {
           return { triggers: [], errors: [] };
         }
-        const evalTree = dataTreeEvaluator.updateDataTree(dataTree);
+        const { dataTree: evalTree } = dataTreeEvaluator.updateDataTree(
+          dataTree,
+        );
         const triggers = dataTreeEvaluator.getDynamicValue(
           dynamicTrigger,
           evalTree,


### PR DESCRIPTION
Updating the whole data tree after evaluation causes the whole app to rerender. Instead, if we only update the state of the entities that have been updated, the render time should be shorter

