### PR TITLE
Fix: cypress test failing for chart-text binding

### DIFF
--- a/app/client/cypress/fixtures/ChartTextDsl.json
+++ b/app/client/cypress/fixtures/ChartTextDsl.json
@@ -58,7 +58,9 @@
                             "chartType": "LINE_CHART",
                             "chartName": "Sales on working days",
                             "allowHorizontalScroll": false,
-                            "chartData": [{"seriesName":"Sales","data":""}],
+                            "chartData": {
+                              "some-random-id": {"seriesName":"Sales","data": []}
+                            },
                             "xAxisName": "Last Week",
                             "yAxisName": "Total Order Revenue $",
                             "type": "CHART_WIDGET",


### PR DESCRIPTION
The cypress test for chart and text binding was failing due to recent change. Updated the DSL to fix the test.

<img width="444" alt="screenshot_2021-04-27_at_3 12 09_pm" src="https://user-images.githubusercontent.com/6636360/116228227-9bfb9a80-a772-11eb-945a-bb4acdc6ebec.png">

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/chart-widget-binding-test 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 49.08 **(0.01)** | 29.8 **(0.04)** | 27.28 **(0.03)** | 49.47 **(0.02)**
 :green_circle: | app/client/src/pages/Applications/ForkApplicationModal.tsx | 94.64 **(7.14)** | 96 **(20)** | 70 **(20)** | 94.44 **(7.4)**</details>