### PR TITLE
BUG-1610 : Text gets cropped in the text widget even when there is go…

### DIFF
--- a/app/client/src/components/designSystems/blueprint/TextComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/TextComponent.tsx
@@ -57,6 +57,7 @@ export const StyledText = styled(Text)<{
   font-size: ${(props) => props?.fontSize && TEXT_SIZES[props?.fontSize]};
   span {
     width: 100%;
+    line-height: 1.2;
   }
 `;
 


### PR DESCRIPTION
## Description
Change css line-height property into 1.2
Fixes #1610 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>