### PR TITLE
Fix-Dropdown default value not trimming special characters

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Dropdown_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Dropdown_spec.js
@@ -15,7 +15,6 @@ describe("Dropdown Widget Functionality", function() {
 
     cy.testJsontext("options", JSON.stringify(data.input));
     cy.testJsontext("defaultoption", "{{ undefined }}");
-
     cy.get(formWidgetsPage.dropdownWidget)
       .find(widgetLocators.dropdownSingleSelect)
       .click({ force: true });
@@ -23,6 +22,13 @@ describe("Dropdown Widget Functionality", function() {
       .contains("Option 3")
       .click({ force: true });
 
+    cy.get(formWidgetsPage.dropdownWidget)
+      .find(widgetLocators.defaultSingleSelectValue)
+      .should("have.text", "Option 3");
+  });
+  it("Selects value with enter in default value", () => {
+    // cy.openPropertyPane("dropdownwidget");
+    cy.testJsontext("defaultoption", "3\n");
     cy.get(formWidgetsPage.dropdownWidget)
       .find(widgetLocators.defaultSingleSelectValue)
       .should("have.text", "Option 3");

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -750,7 +750,9 @@ export const VALIDATORS: Record<ValidationType, Validator> = {
 
     if (props) {
       if (props.selectionType === "SINGLE_SELECT") {
-        return VALIDATORS[VALIDATION_TYPES.TEXT](value, props, dataTree);
+        const defaultValue =
+          value && !Array.isArray(value) ? value.trim() : value;
+        return VALIDATORS[VALIDATION_TYPES.TEXT](defaultValue, props, dataTree);
       } else if (props.selectionType === "MULTI_SELECT") {
         if (typeof value === "string") {
           try {


### PR DESCRIPTION
## Description
Trim Dropdown default value for special characters so that dropdown selection works
 
Fixes #3111 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Cypress test to validate default dropdown selection works when default value contains special characters

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/dropdown-default-value 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 49.04 **(0)** | 29.73 **(-0.01)** | 27.23 **(0)** | 49.43 **(0)**
 :red_circle: | app/client/src/workers/validations.ts | 34.87 **(-0.1)** | 29.52 **(-0.44)** | 38.64 **(0)** | 35.33 **(-0.11)**</details>