### PR TITLE
Correctly parse query params when there are dynamic bindings in the api url

### DIFF
--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -101,7 +101,7 @@ export interface ExecuteErrorPayload extends ErrorActionPayload {
 // Group 1 = datasource (https://www.domain.com)
 // Group 2 = path (/nested/path)
 // Group 3 = params (?param=123&param2=12)
-export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/\S*?)(\?\S*)?$/;
+export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/[\s\S]*?)(\?(?![^{]*})[\s\S]*)?$/;
 
 export const EXECUTION_PARAM_KEY = "executionParams";
 export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params/g;


### PR DESCRIPTION
## Description
Fix to correctly parse query params when there are dynamic bindings in the api url

Fixes #1957 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/ternary_ops_api_pane 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 48.69 **(0)** | 29.6 **(-0.02)** | 27.23 **(0)** | 49.14 **(0)**
 :red_circle: | app/client/src/sagas/ApiPaneSagas.ts | 13.84 **(-0.12)** | 1.74 **(-0.09)** | 7.14 **(0)** | 15.46 **(-0.17)**</details>