### PR TITLE
Fix cyclic dependency making the table widget crash the app. #4209

### DIFF
--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -493,7 +493,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
     // When we have tableData, the primaryColumns order is unlikely to change
     // When we don't have tableData primaryColumns will not be available, so let's let it be.
 
-    if (sanitizedTableData.length > 0) {
+    if (Array.isArray(sanitizedTableData) && sanitizedTableData.length > 0) {
       newPrimaryColumns = this.createTablePrimaryColumns();
       if (newPrimaryColumns) this.updateColumnProperties(newPrimaryColumns);
     }


### PR DESCRIPTION
## Description
Fix cyclic dependency making the table widget crash the app. 

- Check if sanitizedTableData is array

Fixes #4209

## Type of change


- Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>