### PR TITLE
CSS fix to wrap long urls/text in json viewer

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/JSONViewer.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/JSONViewer.tsx
@@ -17,6 +17,9 @@ const ResponseContent = styled.div`
 
 const Record = styled(Card)`
   margin: 5px;
+  span.string-value {
+    overflow-wrap: anywhere;
+  }
 `;
 
 type JSONOutputProps = {


### PR DESCRIPTION
## Description
Fix to wrap long texts/urls in json viewer

Fixes #4007 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>