### PR TITLE
change data-time format 'YYYY-MM-DD hh:mm:ss A' to 'YYYY-MM-DD hh:mm:ss'

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2.tsx
+++ b/app/client/src/widgets/DatePickerWidget2.tsx
@@ -34,7 +34,7 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
             label: "Date Format",
             controlType: "DROP_DOWN",
             isJSConvertible: true,
-            optionWidth: "320px",
+            optionWidth: "340px",
             options: [
               {
                 label: moment().format("YYYY-MM-DDTHH:mm:ss.sssZ"),
@@ -62,9 +62,9 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
                 value: "YYYY-MM-DDTHH:mm:ss",
               },
               {
-                label: moment().format("YYYY-MM-DD hh:mm:ss"),
-                subText: "YYYY-MM-DD hh:mm:ss",
-                value: "YYYY-MM-DD hh:mm:ss",
+                label: moment().format("YYYY-MM-DD hh:mm:ss A"),
+                subText: "YYYY-MM-DD hh:mm:ss A",
+                value: "YYYY-MM-DD hh:mm:ss A",
               },
               {
                 label: moment().format("DD/MM/YYYY HH:mm"),


### PR DESCRIPTION
## Description

-  While using date picker in YYYY:MM:DD HH:MM:SS format, the input field resets to 11:00 when the user chooses 23:00
-  Here optionWidth increase because of a design issue

Fixes #4278 

## Type of change
- UI Performance improvements (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

![image](https://user-images.githubusercontent.com/58818598/116995610-e68f9080-acf7-11eb-8e83-85968fe28ff0.png)
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>