### PR TITLE
Fix DEFAULT_OPTION_VALUE validations which were breaking evaluations

### DIFF
--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -2,6 +2,7 @@ import { VALIDATORS, validateDateString } from "workers/validations";
 import { WidgetProps } from "widgets/BaseWidget";
 import { RenderModes, WidgetTypes } from "constants/WidgetConstants";
 import moment from "moment";
+import { VALIDATION_TYPES } from "constants/WidgetValidation";
 
 const DUMMY_WIDGET: WidgetProps = {
   bottomRow: 0,
@@ -553,5 +554,29 @@ describe("List data validator", () => {
       const response = validator(testCase.input, DUMMY_WIDGET, {});
       expect(response).toStrictEqual(testCase.output);
     }
+  });
+
+  it("Validates DEFAULT_OPTION_VALUE correctly (string trim and integers)", () => {
+    const validator = VALIDATORS[VALIDATION_TYPES.DEFAULT_OPTION_VALUE];
+    const widgetProps = { ...DUMMY_WIDGET, selectionType: "SINGLE_SELECT" };
+    const inputs = [100, "something ", "something\n"];
+    const expected = [
+      {
+        isValid: true,
+        parsed: "100",
+      },
+      {
+        isValid: true,
+        parsed: "something",
+      },
+      {
+        isValid: true,
+        parsed: "something",
+      },
+    ];
+    inputs.forEach((input, index) => {
+      const response = validator(input, widgetProps);
+      expect(response).toStrictEqual(expected[index]);
+    });
   });
 });

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -761,8 +761,7 @@ export const VALIDATORS: Record<VALIDATION_TYPES, Validator> = {
 
     if (props) {
       if (props.selectionType === "SINGLE_SELECT") {
-        const defaultValue =
-          value && !Array.isArray(value) ? value.trim() : value;
+        const defaultValue = value && _.isString(value) ? value.trim() : value;
         return VALIDATORS[VALIDATION_TYPES.TEXT](defaultValue, props, dataTree);
       } else if (props.selectionType === "MULTI_SELECT") {
         if (typeof value === "string") {


### PR DESCRIPTION

## Description
Evaluations break when one of the evaluations fail

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/defaultoption-validation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 50.09 **(0.03)** | 30.64 **(0.05)** | 28.99 **(0.02)** | 50.51 **(0.04)**
 :green_circle: | app/client/src/workers/validations.ts | 37.26 **(2.19)** | 32.51 **(2.47)** | 42.22 **(2.22)** | 37.91 **(2.39)**</details>