### PR TITLE
fix: datepicker popover adjust height and width.

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
@@ -74,9 +74,9 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
     cy.get(".t--property-control-defaultdate .bp3-input").type("2020-02-01");
     cy.closePropertyPane();
     cy.openPropertyPane("datepickerwidget2");
-    cy.get(formWidgetsPage.toggleJsMinDate).click();
+    cy.get(formWidgetsPage.toggleJsMinDate).click({ force: true });
     cy.get(".t--property-control-mindate .bp3-input").type("2020-01-01");
-    cy.get(formWidgetsPage.toggleJsMaxDate).click();
+    cy.get(formWidgetsPage.toggleJsMaxDate).click({ force: true });
     cy.get(".t--property-control-maxdate .bp3-input").type("2020-02-10");
     cy.closePropertyPane();
   });

--- a/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
+++ b/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
@@ -150,6 +150,7 @@ class DatePickerComponent extends React.Component<
               onChange={this.onDateSelected}
               parseDate={this.parseDate}
               placeholder={"Select Date"}
+              popoverProps={{ position: "bottom" }}
               showActionsBar
               timePrecision={TimePrecision.MINUTE}
               value={value}

--- a/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
+++ b/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
@@ -150,7 +150,6 @@ class DatePickerComponent extends React.Component<
               onChange={this.onDateSelected}
               parseDate={this.parseDate}
               placeholder={"Select Date"}
-              popoverProps={{ position: "bottom" }}
               showActionsBar
               timePrecision={TimePrecision.MINUTE}
               value={value}

--- a/app/client/src/globalStyles/popover.ts
+++ b/app/client/src/globalStyles/popover.ts
@@ -5,4 +5,11 @@ export const PopoverStyles = createGlobalStyle`
   .${Classes.POPOVER} {
     box-shadow: 0px 0px 2px rgb(0 0 0 / 20%), 0px 2px 10px rgb(0 0 0 / 10%);
   }
+
+  .bp3-datepicker {
+    .DayPicker {
+      min-height: 251px !important ;
+      min-width: 233px !important ;
+    }
+  }
 `;


### PR DESCRIPTION
## Description
>  DatePicker calendar popover postion set bottom.

Fixes # (#4290) , (#4410)

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>