### PR TITLE
Disable client side search when server side search is enabled in table widget

### DIFF
--- a/app/client/cypress/fixtures/tableWidgetDsl.json
+++ b/app/client/cypress/fixtures/tableWidgetDsl.json
@@ -67,7 +67,11 @@
                 "bottomRow": 10,
                 "parentId": "tyiwk4xuq0",
                 "widgetId": "5up3r2iuvs",
-                "dynamicBindingPathList": []
+                "dynamicTriggerPathList": [{
+                  "key": "onSearchTextChanged"
+                }],
+                "onSearchTextChanged": "{{Api1.run()}}",
+                "selectedRow": "{{Table1.tableData[Table1.selectedRowIndex]}}"
               }
             ],
             "widgetId": "tyiwk4xuq0",

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_tableApi_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_tableApi_spec.js
@@ -3,6 +3,7 @@ const dsl = require("../../../../fixtures/tableWidgetDsl.json");
 const pages = require("../../../../locators/Pages.json");
 const apiPage = require("../../../../locators/ApiEditor.json");
 const publishPage = require("../../../../locators/publishWidgetspage.json");
+const widgetsPage = require("../../../../locators/Widgets.json");
 
 describe("Test Create Api and Bind to Table widget", function() {
   let apiData;
@@ -40,6 +41,18 @@ describe("Test Create Api and Bind to Table widget", function() {
       expect(apiData).to.eq(`\"${tabData}\"`);
     });
     cy.PublishtheApp();
+    cy.readTabledataPublish("0", "1").then((tabData) => {
+      expect(apiData).to.eq(`\"${tabData}\"`);
+    });
+    cy.get(commonlocators.backToEditor).click();
+  });
+
+  it("Validate onSearchTextChanged function is called when configured for search text", function() {
+    cy.SearchEntityandOpen("Table1");
+    cy.get(".t--widget-tablewidget .t--search-input")
+      .first()
+      .type("Currey");
+    cy.wait(5000);
     cy.readTabledataPublish("0", "1").then((tabData) => {
       expect(apiData).to.eq(`\"${tabData}\"`);
     });

--- a/app/client/cypress/locators/Widgets.json
+++ b/app/client/cypress/locators/Widgets.json
@@ -38,6 +38,8 @@
     "textInputval": ".t--draggable-textwidget span.t--widget-name",
     "textCenterAlign": ".t--property-control-textalign .t--icon-tab-CENTER",
     "ColumnAction": ".t--property-control-rowbutton button",
+    "SearchTextChangeAction": ".t--property-control-onsearchtextchanged button",
+    "tableSearchTextChangeSelected": ".t--property-control-onsearchtextchanged",
     "videoWidget": ".t--draggable-videowidget",
     "autoPlay": ".t--property-control-autoplay > .bp3-control > .bp3-control-indicator",
     "defaultOption": ".t--property-control-defaultoption .CodeMirror-code",

--- a/app/client/src/components/designSystems/appsmith/SearchComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/SearchComponent.tsx
@@ -52,6 +52,7 @@ class SearchComponent extends React.Component<
   render() {
     return (
       <SearchInputWrapper
+        className="t--search-input"
         leftIcon="search"
         onChange={this.handleSearch}
         placeholder={this.props.placeholder}

--- a/app/client/src/widgets/TableWidget/derived.js
+++ b/app/client/src/widgets/TableWidget/derived.js
@@ -360,7 +360,10 @@ export default {
       },
     };
 
-    const searchKey = props.searchText ? props.searchText.toLowerCase() : "";
+    const searchKey =
+      props.searchText && !props.onSearchTextChanged
+        ? props.searchText.toLowerCase()
+        : "";
 
     const finalTableData = sortedTableData.filter((item) => {
       const searchFound = searchKey


### PR DESCRIPTION
## Description
Disable client side search when server side search is enabled in table widget

Fixes #4039 

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Added cypress test case to validate onSearchTextChange function if configured in table widget

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>