### PR TITLE
[Bug Fix] : Chart Series not getting evaluated if the chart series id starts with a number

### DIFF
--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -57,8 +57,7 @@ export const convertPathToString = (arrPath: Array<string | number>) => {
 // Todo: improve the logic here
 // Right now NaN, Infinity, floats, everything works
 function isInt(val: string | number): boolean {
-  if (typeof val === "number") return true;
-  return !isNaN(parseInt(val));
+  return Number.isInteger(val) || (_.isString(val) && /^\d+$/.test(val));
 }
 
 // Removes the entity name from the property path


### PR DESCRIPTION
In case the chart series data id starts with a number, it was incorrectly identified as a number instead of a string which led to incorrect path computed to check in binding paths

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: bug/chart-data-eval-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 48.93 **(0)** | 28.75 **(0.01)** | 26.77 **(0)** | 49.31 **(0)**
 :green_circle: | app/client/src/workers/evaluationUtils.ts | 88.7 **(-0.09)** | 77.45 **(0.22)** | 90.48 **(0)** | 88.44 **(-0.06)**</details>