### PR TITLE
Expose response headers for API/DB actions

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
@@ -101,10 +101,11 @@ describe("Entity explorer tests related to query and datasource", function() {
       .find(explorer.collapse)
       .click();
     cy.get(apiwidget.propertyList).then(function($lis) {
-      expect($lis).to.have.length(3);
+      expect($lis).to.have.length(4);
       expect($lis.eq(0)).to.contain("{{Query1.isLoading}}");
       expect($lis.eq(1)).to.contain("{{Query1.data}}");
-      expect($lis.eq(2)).to.contain("{{Query1.run()}}");
+      expect($lis.eq(2)).to.contain("{{Query1.responseMeta}}");
+      expect($lis.eq(3)).to.contain("{{Query1.run()}}");
     });
     cy.Createpage(pageid);
     cy.GlobalSearchEntity("Query1");

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_API_Pane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_API_Pane_spec.js
@@ -30,8 +30,8 @@ describe("Entity explorer API pane related testcases", function() {
       expect($lis).to.have.length(4);
       expect($lis.eq(0)).to.contain("{{FirstAPI.isLoading}}");
       expect($lis.eq(1)).to.contain("{{FirstAPI.data}}");
-      expect($lis.eq(2)).to.contain("{{FirstAPI.run()}}");
-      expect($lis.eq(3)).to.contain("{{FirstAPI.responseMeta}}");
+      expect($lis.eq(2)).to.contain("{{FirstAPI.responseMeta}}");
+      expect($lis.eq(3)).to.contain("{{FirstAPI.run()}}");
     });
     cy.get(apiwidget.actionlist)
       .contains(testdata.Get)

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_API_Pane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_API_Pane_spec.js
@@ -27,10 +27,11 @@ describe("Entity explorer API pane related testcases", function() {
       .find(explorer.collapse)
       .click();
     cy.get(apiwidget.propertyList).then(function($lis) {
-      expect($lis).to.have.length(3);
+      expect($lis).to.have.length(4);
       expect($lis.eq(0)).to.contain("{{FirstAPI.isLoading}}");
       expect($lis.eq(1)).to.contain("{{FirstAPI.data}}");
       expect($lis.eq(2)).to.contain("{{FirstAPI.run()}}");
+      expect($lis.eq(3)).to.contain("{{FirstAPI.responseMeta}}");
     });
     cy.get(apiwidget.actionlist)
       .contains(testdata.Get)

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
@@ -57,8 +57,8 @@ describe("Entity explorer tests related to copy query", function() {
         expect($lis).to.have.length(4);
         expect($lis.eq(0)).to.contain("{{Query1.isLoading}}");
         expect($lis.eq(1)).to.contain("{{Query1.data}}");
-        expect($lis.eq(2)).to.contain("{{Query1.run()}}");
-        expect($lis.eq(3)).to.contain("{{Query1.responseMeta}}");
+        expect($lis.eq(2)).to.contain("{{Query1.responseMeta}}");
+        expect($lis.eq(3)).to.contain("{{Query1.run()}}");
       });
     });
   });
@@ -81,8 +81,8 @@ describe("Entity explorer tests related to copy query", function() {
       expect($lis).to.have.length(4);
       expect($lis.eq(0)).to.contain("{{Query1Copy.isLoading}}");
       expect($lis.eq(1)).to.contain("{{Query1Copy.data}}");
-      expect($lis.eq(2)).to.contain("{{Query1Copy.run()}}");
-      expect($lis.eq(3)).to.contain("{{Query1.responseMeta}}");
+      expect($lis.eq(2)).to.contain("{{Query1Copy.responseMeta}}");
+      expect($lis.eq(3)).to.contain("{{Query1Copy.run()}}");
     });
   });
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
@@ -54,10 +54,11 @@ describe("Entity explorer tests related to copy query", function() {
         .find(explorer.collapse)
         .click();
       cy.get(apiwidget.propertyList).then(function($lis) {
-        expect($lis).to.have.length(3);
+        expect($lis).to.have.length(4);
         expect($lis.eq(0)).to.contain("{{Query1.isLoading}}");
         expect($lis.eq(1)).to.contain("{{Query1.data}}");
         expect($lis.eq(2)).to.contain("{{Query1.run()}}");
+        expect($lis.eq(3)).to.contain("{{Query1.responseMeta}}");
       });
     });
   });
@@ -77,10 +78,11 @@ describe("Entity explorer tests related to copy query", function() {
       .find(explorer.collapse)
       .click();
     cy.get(apiwidget.propertyList).then(function($lis) {
-      expect($lis).to.have.length(3);
+      expect($lis).to.have.length(4);
       expect($lis.eq(0)).to.contain("{{Query1Copy.isLoading}}");
       expect($lis.eq(1)).to.contain("{{Query1Copy.data}}");
       expect($lis.eq(2)).to.contain("{{Query1Copy.run()}}");
+      expect($lis.eq(3)).to.contain("{{Query1.responseMeta}}");
     });
   });
 

--- a/app/client/src/entities/DataTree/dataTreeAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeAction.ts
@@ -36,6 +36,11 @@ export const generateDataTreeAction = (
     config: action.config.actionConfiguration,
     dynamicBindingPathList,
     data: action.data ? action.data.body : {},
+    responseMeta: {
+      statusCode: action.data?.statusCode,
+      isExecutionSuccess: action.data?.isExecutionSuccess || false,
+      headers: action.data?.headers,
+    },
     ENTITY_TYPE: ENTITY_TYPE.ACTION,
     isLoading: action.isLoading,
     bindingPaths: getBindingPathsOfAction(action.config, editorConfig),

--- a/app/client/src/entities/DataTree/dataTreeFactory.ts
+++ b/app/client/src/entities/DataTree/dataTreeFactory.ts
@@ -1,6 +1,6 @@
 import {
-  ActionData,
   ActionDataState,
+  ActionDataWithMeta,
 } from "reducers/entityReducers/actionsReducer";
 import { WidgetProps } from "widgets/BaseWidget";
 import { ActionResponse } from "api/ActionAPI";
@@ -42,7 +42,8 @@ export enum EvaluationSubstitutionType {
   SMART_SUBSTITUTE = "SMART_SUBSTITUTE",
 }
 
-export interface DataTreeAction extends Omit<ActionData, "data" | "config"> {
+export interface DataTreeAction
+  extends Omit<ActionDataWithMeta, "data" | "config"> {
   data: ActionResponse["body"];
   actionId: string;
   config: Partial<ActionConfig>;

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -16,6 +16,15 @@ export interface ActionData {
   config: Action;
   data?: ActionResponse;
 }
+
+export interface ActionDataWithMeta extends ActionData {
+  responseMeta: {
+    headers?: unknown;
+    isExecutionSuccess: boolean;
+    statusCode?: string;
+  };
+}
+
 export type ActionDataState = ActionData[];
 export interface PartialActionData {
   isLoading: boolean;

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -14,6 +14,7 @@ const isVisible = {
 export const entityDefinitions = {
   ACTION: (entity: DataTreeAction) => {
     const dataDef = generateTypeDef(entity.data);
+    const responseMetaDef = generateTypeDef(entity.responseMeta);
     let data: Record<string, any> = {
       "!doc": "The response of the action",
     };
@@ -22,12 +23,21 @@ export const entityDefinitions = {
     } else {
       data = { ...data, ...dataDef };
     }
+    let responseMeta: Record<string, any> = {
+      "!doc": "The response meta of the action",
+    };
+    if (_.isString(responseMetaDef)) {
+      responseMeta["!type"] = responseMetaDef;
+    } else {
+      responseMeta = { ...responseMeta, ...responseMetaDef };
+    }
     return {
       "!doc":
         "Actions allow you to connect your widgets to your backend data in a secure manner.",
       "!url": "https://docs.appsmith.com/v/v1.2.1/framework-reference/run",
       isLoading: "bool",
       data,
+      responseMeta,
       run: "fn(onSuccess: fn() -> void, onError: fn() -> void) -> void",
     };
   },

--- a/app/client/src/workers/evaluation.test.ts
+++ b/app/client/src/workers/evaluation.test.ts
@@ -237,6 +237,7 @@ const BASE_ACTION: DataTreeAction = {
   pluginType: PluginType.API,
   run: {},
   data: {},
+  responseMeta: { isExecutionSuccess: false },
   ENTITY_TYPE: ENTITY_TYPE.ACTION,
   bindingPaths: {
     isLoading: EvaluationSubstitutionType.TEMPLATE,

--- a/app/client/src/workers/evaluationUtils.test.ts
+++ b/app/client/src/workers/evaluationUtils.test.ts
@@ -55,6 +55,7 @@ describe("Add functions", () => {
         bindingPaths: {},
         isLoading: false,
         run: {},
+        responseMeta: { isExecutionSuccess: false },
         ENTITY_TYPE: ENTITY_TYPE.ACTION,
         dependencyMap: {},
       },


### PR DESCRIPTION
## Description
Expose response headers/meta in API/DB actions

Fixes #3643 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/bind_response_meta_to_actions 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 48.93 **(-0.01)** | 28.61 **(-0.04)** | 26.78 **(0)** | 49.29 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/EntityDefinitions.ts | 35 **(-11.67)** | 0 **(0)** | 25 **(0)** | 35 **(-11.67)**</details>