### PR TITLE
[Bug Fix] : Removal of cyclical dependencies due to action relationships being added to dependency map

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Text_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Text_spec.js
@@ -61,33 +61,33 @@ describe("Text Widget Functionality", function() {
       .should("have.css", "font-size", "18px");
   });
 
-  // it("Text widget depends on itself", function() {
-  //   cy.getCodeMirror().then(($cm) => {
-  //     if ($cm.val() !== "") {
-  //       cy.get(".CodeMirror textarea")
-  //         .first()
-  //         .clear({
-  //           force: true,
-  //         });
-  //     }
-  //
-  //     cy.get(".CodeMirror textarea")
-  //       .first()
-  //       .type(`{{${this.data.TextName}}}`, {
-  //         force: true,
-  //         parseSpecialCharSequences: false,
-  //       });
-  //   });
-  //   cy.get(commonlocators.toastBody)
-  //     .first()
-  //     .contains("Cyclic");
-  //
-  //   cy.PublishtheApp();
-  //   cy.get(commonlocators.bodyTextStyle).should(
-  //     "have.text",
-  //     `{{${this.data.TextName}}}`,
-  //   );
-  // });
+  it("Text widget depends on itself", function() {
+    cy.getCodeMirror().then(($cm) => {
+      if ($cm.val() !== "") {
+        cy.get(".CodeMirror textarea")
+          .first()
+          .clear({
+            force: true,
+          });
+      }
+
+      cy.get(".CodeMirror textarea")
+        .first()
+        .type(`{{${this.data.TextName}}}`, {
+          force: true,
+          parseSpecialCharSequences: false,
+        });
+    });
+    cy.get(commonlocators.toastBody)
+      .first()
+      .contains("Cyclic");
+
+    cy.PublishtheApp();
+    cy.get(commonlocators.bodyTextStyle).should(
+      "have.text",
+      `{{${this.data.TextName}}}`,
+    );
+  });
 
   afterEach(() => {
     cy.get(publishPage.backToEditor).click({ force: true });

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -872,14 +872,11 @@ export default class DataTreeEvaluator {
                       ].map((dep) => `${entityName}.${dep}`);
 
                       // Filter only the paths which exist in the appsmith world to avoid cyclical dependencies
-                      const filteredEntityDependencies: Array<string> = [];
-                      for (const path of entityDependenciesName) {
-                        if (this.allKeys.hasOwnProperty(path)) {
-                          filteredEntityDependencies.push(path);
-                        }
-                      }
+                      const filteredEntityDependencies = entityDependenciesName.filter(
+                        (path) => this.allKeys.hasOwnProperty(path),
+                      );
 
-                      // Now assign these existing depedent paths to the property path in dependencyMap
+                      // Now assign these existing dependent paths to the property path in dependencyMap
                       if (fullPropertyPath in this.dependencyMap) {
                         this.dependencyMap[
                           fullPropertyPath

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -305,7 +305,7 @@ export default class DataTreeEvaluator {
     Object.keys(dependencyMap).forEach((key) => {
       dependencyMap[key] = _.flatten(
         dependencyMap[key].map((path) =>
-          extractReferencesFromBinding(key, path, this.allKeys),
+          extractReferencesFromBinding(path, this.allKeys),
         ),
       );
     });
@@ -911,7 +911,7 @@ export default class DataTreeEvaluator {
         this.dependencyMap[key] = _.uniq(
           _.flatten(
             this.dependencyMap[key].map((path) =>
-              extractReferencesFromBinding(key, path, this.allKeys),
+              extractReferencesFromBinding(path, this.allKeys),
             ),
           ),
         );
@@ -1048,7 +1048,7 @@ export default class DataTreeEvaluator {
           const propertyBindings = entityPropertyBindings[path];
           const references = _.flatten(
             propertyBindings.map((binding) =>
-              extractReferencesFromBinding(path, binding, this.allKeys),
+              extractReferencesFromBinding(binding, this.allKeys),
             ),
           );
           references.forEach((value) => {

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -126,7 +126,6 @@ export default class DataTreeEvaluator {
   }
 
   updateDataTree(unEvalTree: DataTree) {
-    debugger;
     const totalStart = performance.now();
     // Calculate diff
     const diffCheckTimeStart = performance.now();
@@ -346,18 +345,22 @@ export default class DataTreeEvaluator {
     }
     if (isAction(entity)) {
       Object.entries(entity.dependencyMap).forEach(
-        ([dependent, entityDependencies]) => {
+        ([path, entityDependencies]) => {
           const actionDependentPaths: Array<string> = [];
-          // Only add dependent paths which exist in the data tree. Skip all the other paths to avoid creating
-          // a cyclical dependency.
-          entityDependencies.forEach((dependentPath) => {
-            debugger;
-            const completePath = `${entityName}.${dependentPath}`;
-            if (this.allKeys.hasOwnProperty(completePath)) {
-              actionDependentPaths.push(completePath);
-            }
-          });
-          dependencies[`${entityName}.${dependent}`] = actionDependentPaths;
+          const mainPath = `${entityName}.${path}`;
+          // Only add dependencies for paths which exist at the moment in appsmith world
+          if (this.allKeys.hasOwnProperty(mainPath)) {
+            // Only add dependent paths which exist in the data tree. Skip all the other paths to avoid creating
+            // a cyclical dependency.
+            entityDependencies.forEach((dependentPath) => {
+              debugger;
+              const completePath = `${entityName}.${dependentPath}`;
+              if (this.allKeys.hasOwnProperty(completePath)) {
+                actionDependentPaths.push(completePath);
+              }
+            });
+            dependencies[mainPath] = actionDependentPaths;
+          }
         },
       );
     }

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -1120,7 +1120,7 @@ const extractReferencesFromBinding = (
   identifiers.forEach((identifier: string) => {
     // If the identifier exists directly, add it and return
     if (all.hasOwnProperty(identifier)) {
-      subDeps.push(dependentPath);
+      subDeps.push(identifier);
       return;
     }
     const subpaths = _.toPath(identifier);
@@ -1133,7 +1133,7 @@ const extractReferencesFromBinding = (
       current = convertPathToString(subpaths);
       // We've found the dep, add it and return
       if (all.hasOwnProperty(current)) {
-        subDeps.push(dependentPath);
+        subDeps.push(current);
         return;
       }
       subpaths.pop();

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -353,7 +353,6 @@ export default class DataTreeEvaluator {
             // Only add dependent paths which exist in the data tree. Skip all the other paths to avoid creating
             // a cyclical dependency.
             entityDependencies.forEach((dependentPath) => {
-              debugger;
               const completePath = `${entityName}.${dependentPath}`;
               if (this.allKeys.hasOwnProperty(completePath)) {
                 actionDependentPaths.push(completePath);
@@ -830,7 +829,6 @@ export default class DataTreeEvaluator {
             }
 
             case DataTreeDiffEvent.EDIT: {
-              debugger;
               // We only care if the difference is in dynamic bindings since static values do not need
               // an evaluation.
               if (
@@ -867,18 +865,21 @@ export default class DataTreeEvaluator {
                     delete this.dependencyMap[fullPropertyPath];
                   }
                   if (isAction(entity)) {
-                    debugger;
                     // Actions have a defined dependency map that should always be maintained
                     if (entityPropertyPath in entity.dependencyMap) {
                       const entityDependenciesName = entity.dependencyMap[
                         entityPropertyPath
                       ].map((dep) => `${entityName}.${dep}`);
+
+                      // Filter only the paths which exist in the appsmith world to avoid cyclical dependencies
                       const filteredEntityDependencies: Array<string> = [];
                       for (const path of entityDependenciesName) {
                         if (this.allKeys.hasOwnProperty(path)) {
                           filteredEntityDependencies.push(path);
                         }
                       }
+
+                      // Now assign these existing depedent paths to the property path in dependencyMap
                       if (fullPropertyPath in this.dependencyMap) {
                         this.dependencyMap[
                           fullPropertyPath
@@ -905,7 +906,6 @@ export default class DataTreeEvaluator {
     const diffCalcEnd = performance.now();
     const subDepCalcStart = performance.now();
     if (didUpdateDependencyMap) {
-      debugger;
       // TODO Optimise
       Object.keys(this.dependencyMap).forEach((key) => {
         this.dependencyMap[key] = _.uniq(

--- a/app/server/appsmith-plugins/rapidApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/rapidApiPlugin/pom.xml
@@ -93,8 +93,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>10</source>
+                    <target>10</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/app/server/appsmith-plugins/rapidApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/rapidApiPlugin/pom.xml
@@ -93,8 +93,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>10</source>
-                    <target>10</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This fix does the following :
1. Reverts the patch fix made to production to get the users unblocked ASAP.
2. Removes the cyclical dependencies being added during create action and update action

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: bug/no-cyclical-dependency-direct 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 48.94 **(0.01)** | 28.75 **(0)** | 26.78 **(0)** | 49.32 **(0.01)**
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 88.68 **(0.12)** | 78.38 **(-0.31)** | 87.32 **(0)** | 88.86 **(0.1)**</details>