### PR TITLE
fix: set default format in table date type cell

### DIFF
--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -6,7 +6,7 @@ import { DropdownOption } from "components/ads/Dropdown";
 class DropDownControl extends BaseControl<DropDownControlProps> {
   render() {
     let defaultSelected: DropdownOption = {
-      label: "No results.",
+      label: "No selection.",
       value: undefined,
     };
     if (this.props.defaultValue) {

--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -9,6 +9,11 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
       label: "No results.",
       value: undefined,
     };
+    if (this.props.defaultValue) {
+      defaultSelected = this.props.options.find(
+        (option) => option.value === this.props.defaultValue,
+      );
+    }
 
     const selected: DropdownOption = this.props.options.find(
       (option) => option.value === this.props.propertyValue,
@@ -51,6 +56,7 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
 
 export interface DropDownControlProps extends ControlProps {
   options: any[];
+  defaultValue?: string;
   placeholderText: string;
   propertyValue: string;
   optionWidth?: string;

--- a/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
+++ b/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
@@ -224,10 +224,6 @@ export default [
                   controlType: "DROP_DOWN",
                   options: [
                     {
-                      label: "No Selection",
-                      value: "",
-                    },
-                    {
                       label: "UNIX timestamp (s)",
                       value: "Epoch",
                     },
@@ -331,10 +327,6 @@ export default [
                   customJSControl: "COMPUTE_VALUE",
                   isJSConvertible: true,
                   options: [
-                    {
-                      label: "No Selection",
-                      value: "",
-                    },
                     {
                       label: "UNIX timestamp (s)",
                       value: "Epoch",

--- a/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
+++ b/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
@@ -224,6 +224,10 @@ export default [
                   controlType: "DROP_DOWN",
                   options: [
                     {
+                      label: "No Selection",
+                      value: "",
+                    },
+                    {
                       label: "UNIX timestamp (s)",
                       value: "Epoch",
                     },
@@ -304,6 +308,7 @@ export default [
                       value: "MM/DD/YY",
                     },
                   ],
+                  defaultValue: "YYYY-MM-DD HH:mm",
                   customJSControl: "COMPUTE_VALUE",
                   isJSConvertible: true,
                   updateHook: updateDerivedColumnsHook,
@@ -327,6 +332,10 @@ export default [
                   isJSConvertible: true,
                   options: [
                     {
+                      label: "No Selection",
+                      value: "",
+                    },
+                    {
                       label: "UNIX timestamp (s)",
                       value: "Epoch",
                     },
@@ -407,6 +416,7 @@ export default [
                       value: "MM/DD/YY",
                     },
                   ],
+                  defaultValue: "YYYY-MM-DD HH:mm",
                   updateHook: updateDerivedColumnsHook,
                   hidden: (props: TableWidgetProps, propertyPath: string) => {
                     const baseProperty = getBasePropertyPath(propertyPath);


### PR DESCRIPTION
## Description
> set default format `YYYY-MM-DD HH:mm` in `Orignal Date Format` and `Display Date Format` in table widget cell type **Date**. 
add `No Selection` additional option in date format 


>  In DropDownControl add support for set defaultValue.

Fixes # (#3318)


## Type of change

> Please delete options that are not relevant.

- Bugfix (non-breaking change which fixes an issue)
- Breaking change (fix that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/dropdown-default-value 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.43 **(0)** | 32.1 **(0.01)** | 30.01 **(-0.01)** | 51.92 **(0)**
 :red_circle: | app/client/src/components/propertyControls/DropDownControl.tsx | 76.92 **(-5.69)** | 45.45 **(1.01)** | 57.14 **(-9.53)** | 73.91 **(-6.09)**</details>