### PR TITLE
Removed prod url from default config

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -66,7 +66,7 @@ admin.emails = ${APPSMITH_ADMIN_EMAILS:}
 emails.welcome.enabled = ${APPSMITH_EMAILS_WELCOME_ENABLED:true}
 
 # Appsmith Cloud Services
-appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:https://cs.appsmith.com}
+appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:}
 appsmith.cloud_services.username = ${APPSMITH_CLOUD_SERVICES_USERNAME:}
 appsmith.cloud_services.password = ${APPSMITH_CLOUD_SERVICES_PASSWORD:}
 github_repo = ${APPSMITH_GITHUB_REPO:}


### PR DESCRIPTION
Removed cloud services url from application properties. This can now only be set via an environment variable. Cypress will thus not use cloud services.