### PR TITLE
Fix: Make contents of tab selectable

### DIFF
--- a/app/client/src/components/ads/Tabs.tsx
+++ b/app/client/src/components/ads/Tabs.tsx
@@ -14,7 +14,6 @@ export type TabProp = {
 };
 
 const TabsWrapper = styled.div<{ shouldOverflow?: boolean }>`
-  user-select: none;
   border-radius: 0px;
   height: 100%;
   .react-tabs {


### PR DESCRIPTION
## Description
Remove user-select: none from the tabs component

Fixes #4335 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Text can be selected from the tabs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>