### PR TITLE
show pre-filled values for autocomplete

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicInput/autocomplete_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicInput/autocomplete_spec.js
@@ -36,8 +36,8 @@ describe("Dynamic input autocomplete", () => {
 
         // Tests if data tree entities are sorted
         cy.get(`${dynamicInputLocators.hints} li`)
-          .first()
-          .should("have.text", "Aditya");
+          .eq(1)
+          .should("have.text", "Aditya.backgroundColor");
 
         // Tests if "No suggestions" message will pop if you type any garbage
         cy.get(dynamicInputLocators.input)

--- a/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
@@ -44,10 +44,9 @@ export type HintHelper = (
   editor: CodeMirror.Editor,
   data: DataTree,
   additionalData?: Record<string, Record<string, unknown>>,
-  expected?: string,
 ) => Hinter;
 export type Hinter = {
-  showHint: (editor: CodeMirror.Editor) => void;
+  showHint: (editor: CodeMirror.Editor, expected: string) => void;
   update?: (data: DataTree) => void;
   trigger?: (editor: CodeMirror.Editor) => void;
 };

--- a/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
@@ -44,6 +44,7 @@ export type HintHelper = (
   editor: CodeMirror.Editor,
   data: DataTree,
   additionalData?: Record<string, Record<string, unknown>>,
+  expected?: string,
 ) => Hinter;
 export type Hinter = {
   showHint: (editor: CodeMirror.Editor) => void;

--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
@@ -7,19 +7,16 @@ import { getDynamicStringSegments } from "utils/DynamicBindingUtils";
 import { HintHelper } from "components/editorComponents/CodeEditor/EditorConfig";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 //TODO : add currentRow to data ?? currentRow: Object of columns ie first row
-export const bindingHint: HintHelper = (
-  editor,
-  data,
-  additionalData,
-  expected,
-) => {
-  const ternServer = new TernServer(data, additionalData, expected);
+export const bindingHint: HintHelper = (editor, data, additionalData) => {
+  const ternServer = new TernServer(data, additionalData);
   editor.setOption("extraKeys", {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: No types available
     ...editor.options.extraKeys,
-    [KeyboardShortcuts.CodeEditor.OpenAutocomplete]: (cm: CodeMirror.Editor) =>
-      ternServer.complete(cm),
+    [KeyboardShortcuts.CodeEditor.OpenAutocomplete]: (
+      cm: CodeMirror.Editor,
+      expected: string,
+    ) => ternServer.complete(cm, expected),
     [KeyboardShortcuts.CodeEditor.ShowTypeAndInfo]: (cm: CodeMirror.Editor) => {
       ternServer.showType(cm);
     },
@@ -32,7 +29,7 @@ export const bindingHint: HintHelper = (
       const dataTreeDef = dataTreeTypeDefCreator(data);
       ternServer.updateDef("dataTree", dataTreeDef);
     },
-    showHint: (editor: CodeMirror.Editor) => {
+    showHint: (editor: CodeMirror.Editor, expected: string) => {
       let cursorBetweenBinding = false;
       const cursor = editor.getCursor();
       const value = editor.getValue();
@@ -69,7 +66,7 @@ export const bindingHint: HintHelper = (
       const shouldShow = cursorBetweenBinding;
       if (shouldShow) {
         AnalyticsUtil.logEvent("AUTO_COMPELTE_SHOW", {});
-        ternServer.complete(editor);
+        ternServer.complete(editor, expected);
       } else {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: No types available

--- a/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/hintHelpers.ts
@@ -7,8 +7,13 @@ import { getDynamicStringSegments } from "utils/DynamicBindingUtils";
 import { HintHelper } from "components/editorComponents/CodeEditor/EditorConfig";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 //TODO : add currentRow to data ?? currentRow: Object of columns ie first row
-export const bindingHint: HintHelper = (editor, data, additionalData) => {
-  const ternServer = new TernServer(data, additionalData);
+export const bindingHint: HintHelper = (
+  editor,
+  data,
+  additionalData,
+  expected,
+) => {
+  const ternServer = new TernServer(data, additionalData, expected);
   editor.setOption("extraKeys", {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: No types available

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -55,13 +55,7 @@ const LightningMenu = lazy(() =>
   retryPromise(() => import("components/editorComponents/LightningMenu")),
 );
 
-const AUTOCOMPLETE_CLOSE_KEY_CODES = [
-  "Enter",
-  "Tab",
-  "Escape",
-  "Backspace",
-  "Comma",
-];
+const AUTOCOMPLETE_CLOSE_KEY_CODES = ["Enter", "Tab", "Escape", "Comma"];
 
 interface ReduxStateProps {
   dynamicData: DataTree;

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -223,6 +223,7 @@ class CodeEditor extends Component<Props, State> {
         this.editor,
         this.props.dynamicData,
         this.props.additionalDynamicData,
+        this.props.expected,
       );
     });
   }

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -288,9 +288,6 @@ class CodeEditor extends Component<Props, State> {
       AnalyticsUtil.logEvent("AUTO_COMPLETE_SELECT", {
         searchString: changeObj.text[0],
       });
-      const cursor = this.editor.getCursor().ch;
-      const val = [value.slice(0, cursor), ".", value.slice(cursor)].join("");
-      this.updatePropertyValue(val, cursor + 1);
     }
     const inputValue = this.props.input.value;
     if (

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -223,7 +223,6 @@ class CodeEditor extends Component<Props, State> {
         this.editor,
         this.props.dynamicData,
         this.props.additionalDynamicData,
-        this.props.expected,
       );
     });
   }
@@ -296,7 +295,8 @@ class CodeEditor extends Component<Props, State> {
   };
 
   handleAutocompleteVisibility = (cm: CodeMirror.Editor) => {
-    this.hinters.forEach((hinter) => hinter.showHint(cm));
+    const expected = this.props.expected ? this.props.expected : "";
+    this.hinters.forEach((hinter) => hinter.showHint(cm, expected));
   };
 
   handleAutocompleteHide = (cm: any, event: KeyboardEvent) => {

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -288,6 +288,9 @@ class CodeEditor extends Component<Props, State> {
       AnalyticsUtil.logEvent("AUTO_COMPLETE_SELECT", {
         searchString: changeObj.text[0],
       });
+      const cursor = this.editor.getCursor().ch;
+      const val = [value.slice(0, cursor), ".", value.slice(cursor)].join("");
+      this.updatePropertyValue(val, cursor + 1);
     }
     const inputValue = this.props.input.value;
     if (

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -14,7 +14,7 @@ export const HintStyles = createGlobalStyle<{
   .CodeMirror-hints {
     position: absolute;
     z-index: 20;
-    // overflow: hidden;
+    overflow: hidden;
     list-style: none;
     margin-top: ${(props) => props.theme.spaces[3]}px;
     padding: 0px 0px;
@@ -35,6 +35,7 @@ export const HintStyles = createGlobalStyle<{
     cursor: pointer;
     display: flex;
     min-width: 220px;
+    width: auto;
     align-items: center;
     font-size: 12px;
     line-height: 15px;
@@ -64,6 +65,7 @@ export const HintStyles = createGlobalStyle<{
     }
   }
   .CodeMirror-Tern-completion {
+    display: flex;
     padding-left: ${(props) => props.theme.spaces[11]}px !important;
     &:hover{
       background: ${(props) =>
@@ -99,9 +101,10 @@ export const HintStyles = createGlobalStyle<{
     background: ${(props) => props.theme.colors.dataTypeBg.number};
   }
   .CodeMirror-Tern-completion:after {
-    position: absolute;
-    right: 8px;
-    bottom: 6px;
+    display: flex;
+    justify-content: flex-end;
+    flex: 1;
+    padding-right: 10px;
     font-style: italic;
     font-weight: normal;
     font-size: 10px;

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -51,6 +51,10 @@ export const HintStyles = createGlobalStyle<{
     }
   }
 
+  .CodeMirror-Tern-expected {
+    background-color: #d8ffd8;
+  }
+
   .datasource-hint {
     padding: 10px;
     display: block;

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -14,7 +14,7 @@ export const HintStyles = createGlobalStyle<{
   .CodeMirror-hints {
     position: absolute;
     z-index: 20;
-    overflow: hidden;
+    // overflow: hidden;
     list-style: none;
     margin-top: ${(props) => props.theme.spaces[3]}px;
     padding: 0px 0px;
@@ -34,7 +34,7 @@ export const HintStyles = createGlobalStyle<{
       props.editorTheme === EditorTheme.LIGHT ? "#090707" : "#FFFFFF"};
     cursor: pointer;
     display: flex;
-    width: 220px;
+    min-width: 220px;
     align-items: center;
     font-size: 12px;
     line-height: 15px;

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -117,6 +117,7 @@ export const HintStyles = createGlobalStyle<{
     font-size: 10px;
     line-height: 13px;
     letter-spacing: -0.24px;
+    padding-left: 10px;
     color: ${(props) => props.theme.colors.codeMirror.dataType.fullForm};
   }
   .CodeMirror-Tern-completion-fn:after {

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -51,8 +51,11 @@ export const HintStyles = createGlobalStyle<{
     }
   }
 
-  .CodeMirror-Tern-expected {
-    background-color: #d8ffd8;
+  .CodeMirror-hint-header {
+    padding-left: 8px;
+    color: #4B4848;
+    pointer-events: none !important;
+    font-weight: 600;
   }
 
   .datasource-hint {

--- a/app/client/src/utils/autocomplete/TernServer.ts
+++ b/app/client/src/utils/autocomplete/TernServer.ts
@@ -65,10 +65,8 @@ class TernServer {
   constructor(
     dataTree: DataTree,
     additionalDataTree?: Record<string, Record<string, unknown>>,
-    expected?: string,
   ) {
     const dataTreeDef = dataTreeTypeDefCreator(dataTree);
-    this.expected = expected;
     let customDataTreeDef = undefined;
     if (additionalDataTree) {
       customDataTreeDef = customTreeTypeDefCreator(additionalDataTree);
@@ -81,7 +79,8 @@ class TernServer {
     });
   }
 
-  complete(cm: CodeMirror.Editor) {
+  complete(cm: CodeMirror.Editor, expected: string) {
+    this.expected = expected;
     cm.showHint({
       hint: this.getHint.bind(this),
       completeSingle: false,
@@ -297,6 +296,7 @@ class TernServer {
     if (type === "boolean") return "BOOLEAN";
     if (type === "string") return "STRING";
     if (type === "number") return "NUMBER";
+    if (type === "object" || type === "JSON") return "OBJECT";
     if (type === undefined) return "UNKNOWN";
     return undefined;
   }

--- a/app/client/src/utils/autocomplete/TernServer.ts
+++ b/app/client/src/utils/autocomplete/TernServer.ts
@@ -26,6 +26,8 @@ type Completion = Hint & {
   data: {
     doc: string;
   };
+  render?: any;
+  isHeader?: boolean;
 };
 
 type TernDocs = Record<string, TernDoc>;
@@ -57,6 +59,7 @@ class TernServer {
   server: Server;
   docs: TernDocs = Object.create(null);
   cachedArgHints: ArgHints | null = null;
+  active: any;
   expected?: string;
 
   constructor(
@@ -79,7 +82,24 @@ class TernServer {
   }
 
   complete(cm: CodeMirror.Editor) {
-    cm.showHint({ hint: this.getHint.bind(this), completeSingle: false });
+    cm.showHint({
+      hint: this.getHint.bind(this),
+      completeSingle: false,
+      extraKeys: {
+        Up: (cm: CodeMirror.Editor, handle: any) => {
+          handle.moveFocus(-1);
+          if (this.active.isHeader === true) {
+            handle.moveFocus(-1);
+          }
+        },
+        Down: (cm: CodeMirror.Editor, handle: any) => {
+          handle.moveFocus(1);
+          if (this.active.isHeader === true) {
+            handle.moveFocus(1);
+          }
+        },
+      },
+    });
   }
 
   showType(cm: CodeMirror.Editor) {
@@ -110,7 +130,6 @@ class TernServer {
     const lineValue = this.lineValue(doc);
     const focusedValue = this.getFocusedDynamicValue(doc);
     const index = lineValue.indexOf(focusedValue);
-    const expectedDataType = this.getExpectedDataType();
     let completions: Completion[] = [];
     let after = "";
     const { start, end } = data;
@@ -134,7 +153,6 @@ class TernServer {
       const completion = data.completions[i];
       let className = this.typeToIcon(completion.type);
       const dataType = this.getDataType(completion.type);
-      if (dataType === expectedDataType) className += " " + cls + "expected";
       if (data.guess) className += " " + cls + "guess";
       completions.push({
         text: completion.name + after,
@@ -146,8 +164,13 @@ class TernServer {
       });
     }
     completions = this.sortCompletions(completions);
-
-    const obj = { from: from, to: to, list: completions };
+    const indexToBeSelected = completions.length > 1 ? 1 : 0;
+    const obj = {
+      from: from,
+      to: to,
+      list: completions,
+      selectedHint: indexToBeSelected,
+    };
     let tooltip: HTMLElement | undefined = undefined;
     CodeMirror.on(obj, "close", () => this.remove(tooltip));
     CodeMirror.on(obj, "update", () => this.remove(tooltip));
@@ -155,6 +178,7 @@ class TernServer {
       obj,
       "select",
       (cur: { data: { doc: string } }, node: any) => {
+        this.active = cur;
         this.remove(tooltip);
         const content = cur.data.doc;
         if (content) {
@@ -205,6 +229,7 @@ class TernServer {
 
   sortCompletions(completions: Completion[]) {
     // Add data tree completions before others
+    const expectedDataType = this.getExpectedDataType();
     const dataTreeCompletions = completions
       .filter((c) => c.origin === "dataTree")
       .sort((a: Completion, b: Completion) => {
@@ -215,11 +240,44 @@ class TernServer {
         }
         return a.text.toLowerCase().localeCompare(b.text.toLowerCase());
       });
+    const sameDataType = dataTreeCompletions.filter(
+      (c) => c.type === expectedDataType,
+    );
+    const otherDataType = dataTreeCompletions.filter(
+      (c) => c.type !== expectedDataType,
+    );
+    if (otherDataType.length && sameDataType.length) {
+      const otherDataTitle: Completion = {
+        text: "Search results",
+        displayText: "Search results",
+        className: "CodeMirror-hint-header",
+        data: { doc: "" },
+        origin: "",
+        type: "UNKNOWN",
+        isHeader: true,
+      };
+      const sameDataTitle: Completion = {
+        text: "Best Match",
+        displayText: "Best Match",
+        className: "CodeMirror-hint-header",
+        data: { doc: "" },
+        origin: "",
+        type: "UNKNOWN",
+        isHeader: true,
+      };
+      sameDataType.unshift(sameDataTitle);
+      otherDataType.unshift(otherDataTitle);
+    }
     const docCompletetions = completions.filter((c) => c.origin === "[doc]");
     const otherCompletions = completions.filter(
       (c) => c.origin !== "dataTree" && c.origin !== "[doc]",
     );
-    return [...docCompletetions, ...dataTreeCompletions, ...otherCompletions];
+    return [
+      ...docCompletetions,
+      ...sameDataType,
+      ...otherDataType,
+      ...otherCompletions,
+    ];
   }
 
   getDataType(type: string): DataType {

--- a/app/client/src/utils/autocomplete/TernServer.ts
+++ b/app/client/src/utils/autocomplete/TernServer.ts
@@ -436,8 +436,7 @@ class TernServer {
         if (query.start) {
           query.start = Pos(query.start.line - -offsetLines, query.start.ch);
         }
-        // query.end = Pos(query.end.line - offsetLines, query.end.ch);
-        query.end = 20;
+        query.end = Pos(query.end.line - offsetLines, query.end.ch);
       } else {
         files.push({
           type: "full",

--- a/app/client/src/utils/autocomplete/dataTreeTypeDefCreator.test.ts
+++ b/app/client/src/utils/autocomplete/dataTreeTypeDefCreator.test.ts
@@ -1,6 +1,7 @@
 import {
   generateTypeDef,
   dataTreeTypeDefCreator,
+  flattenObjKeys,
 } from "utils/autocomplete/dataTreeTypeDefCreator";
 import {
   DataTree,
@@ -43,6 +44,7 @@ describe("dataTreeTypeDefCreator", () => {
     // instead of testing each widget maybe we can test to ensure
     // that defs are in a correct format
     expect(def.Input1).toBe(entityDefinitions.INPUT_WIDGET);
+    expect(def).toHaveProperty("Input1.isDisabled");
   });
 
   it("creates a correct def for an object", () => {
@@ -69,5 +71,29 @@ describe("dataTreeTypeDefCreator", () => {
 
     const objType = generateTypeDef(obj);
     expect(objType).toStrictEqual(expected);
+  });
+
+  it("flatten object", () => {
+    const options = {
+      someNumber: "number",
+      someString: "string",
+      someBool: "bool",
+      nested: {
+        someExtraNested: "string",
+      },
+    };
+
+    const expected = {
+      "entity1.someNumber": "number",
+      "entity1.someString": "string",
+      "entity1.someBool": "bool",
+      "entity1.nested": {
+        someExtraNested: "string",
+      },
+      "entity1.nested.someExtraNested": "string",
+    };
+
+    const value = flattenObjKeys(options, "entity1");
+    expect(value).toStrictEqual(expected);
   });
 });

--- a/app/client/src/utils/autocomplete/dataTreeTypeDefCreator.ts
+++ b/app/client/src/utils/autocomplete/dataTreeTypeDefCreator.ts
@@ -7,7 +7,6 @@ import {
   GLOBAL_FUNCTIONS,
 } from "utils/autocomplete/EntityDefinitions";
 import { getType, Types } from "utils/TypeHelpers";
-import options from "pages/common/CustomizedDropdown/HeaderDropdownData";
 
 let extraDefs: any = {};
 const skipProperties = ["!doc", "!url", "!type"];
@@ -49,7 +48,7 @@ export const dataTreeTypeDefCreator = (dataTree: DataTree) => {
       }
       if (entity.ENTITY_TYPE === ENTITY_TYPE.APPSMITH) {
         const options: any = generateTypeDef(_.omit(entity, "ENTITY_TYPE"));
-        // def.appsmith = options;
+        def.appsmith = options;
         const flattenedObjects = flattenObjKeys(options, "appsmith");
         for (const [key, value] of Object.entries(flattenedObjects)) {
           def[key] = value;


### PR DESCRIPTION
## Description
Autocomplete needs to show the next list even when the user hasn't type a '.'

Fixes #1844 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes










## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: invisble-dot 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.6 **(-0.01)** | 32.51 **(0.08)** | 29.83 **(0.01)** | 52.09 **(0)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 73.68 **(0.14)** | 53.98 **(0.83)** | 56.67 **(0)** | 73.74 **(0.14)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 44.78 **(0.3)** | 30 **(3.26)** | 31.48 **(-1.17)** | 49.84 **(0.37)**
 :red_circle: | app/client/src/utils/autocomplete/dataTreeTypeDefCreator.ts | 62.37 **(-18.58)** | 67.86 **(8.77)** | 100 **(0)** | 69.7 **(-10.79)**</details>