### PR TITLE
Fix: Allow the same dates to be used in Default & Min/Max fields

### DIFF
--- a/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
+++ b/app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx
@@ -168,6 +168,7 @@ class DatePickerComponent extends React.Component<
       if (
         this.props.minDate &&
         parsedMinDate.isValid() &&
+        !parsedCurrentDate.isSame(parsedMinDate, "day") &&
         parsedCurrentDate.isBefore(parsedMinDate)
       ) {
         isValid = false;
@@ -179,6 +180,7 @@ class DatePickerComponent extends React.Component<
         isValid &&
         this.props.maxDate &&
         parsedMaxDate.isValid() &&
+        !parsedCurrentDate.isSame(parsedMaxDate, "day") &&
         parsedCurrentDate.isAfter(parsedMaxDate)
       ) {
         isValid = false;


### PR DESCRIPTION
## Description
> Fixed: If the same date is selected in the Default and Min/Max date field then “Date out of range error”.

Fixes #4407

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ]  I have commented on my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: bug/datepicker-max-date-validation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/designSystems/blueprint/DatePickerComponent2.tsx | 28.99 **(0)** | 3.28 **(-0.11)** | 5.88 **(0)** | 28.36 **(0)**</details>