### PR TITLE
Fix: TypeError: t.match is not a function

### DIFF
--- a/app/client/src/widgets/ListWidget/ListWidget.tsx
+++ b/app/client/src/widgets/ListWidget/ListWidget.tsx
@@ -226,6 +226,8 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
           const evaluatedValue = evaluatedProperty[itemIndex];
           if (isPlainObject(evaluatedValue) || Array.isArray(evaluatedValue))
             set(widget, path, JSON.stringify(evaluatedValue));
+          if (isNumber(evaluatedValue))
+            set(widget, path, evaluatedValue.toString());
           else set(widget, path, evaluatedValue);
         }
       });

--- a/app/client/src/widgets/ListWidget/ListWidget.tsx
+++ b/app/client/src/widgets/ListWidget/ListWidget.tsx
@@ -1,6 +1,15 @@
 import React from "react";
 import log from "loglevel";
-import { compact, get, set, xor, isPlainObject, isNumber, round } from "lodash";
+import {
+  compact,
+  get,
+  set,
+  xor,
+  isPlainObject,
+  isNumber,
+  round,
+  toString,
+} from "lodash";
 import * as Sentry from "@sentry/react";
 
 import WidgetFactory from "utils/WidgetFactory";
@@ -226,9 +235,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
           const evaluatedValue = evaluatedProperty[itemIndex];
           if (isPlainObject(evaluatedValue) || Array.isArray(evaluatedValue))
             set(widget, path, JSON.stringify(evaluatedValue));
-          if (isNumber(evaluatedValue))
-            set(widget, path, evaluatedValue.toString());
-          else set(widget, path, evaluatedValue);
+          else set(widget, path, toString(evaluatedValue));
         }
       });
     }


### PR DESCRIPTION
Numbers in the text widget in list widget were failing because we were directly passing to text widget component. So using toString before passing the numbers too.

Fixes #4402 

## Type of change
- Bugfix


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>