### PR TITLE
Use explicit Java version in RapidApi plugin pom.xml

### DIFF
--- a/app/server/appsmith-plugins/rapidApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/rapidApiPlugin/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <plugin.id>rapidapi-plugin</plugin.id>


### PR DESCRIPTION
Because of the Java version not being explicitly set
in this plugin, the build of the whole project fails
sporadically in IntelliJ since it's trying to compile the
code as Java 8, which will obviously fail.
