### PR TITLE
APIs for adding and removing reactions on comments

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
@@ -85,4 +85,24 @@ public class CommentController extends BaseController<CommentService, Comment, S
                 .map(deletedResource -> new ResponseDTO<>(HttpStatus.OK.value(), deletedResource, null));
     }
 
+    @PostMapping("/{commentId}/reactions")
+    public Mono<ResponseDTO<Boolean>> createReaction(
+            @PathVariable String commentId,
+            @Valid @RequestBody Comment.Reaction reaction
+    ) {
+        log.debug("Going to create reaction on comment with id: {}", commentId);
+        return service.createReaction(commentId, reaction)
+                .map(isSaved -> new ResponseDTO<>(HttpStatus.OK.value(), isSaved, null));
+    }
+
+    @DeleteMapping("/{commentId}/reactions")
+    public Mono<ResponseDTO<Boolean>> deleteReaction(
+            @PathVariable String commentId,
+            @Valid @RequestBody Comment.Reaction reaction
+    ) {
+        log.debug("Going to create reaction on comment with id: {}", commentId);
+        return service.deleteReaction(commentId, reaction)
+                .map(isSaved -> new ResponseDTO<>(HttpStatus.OK.value(), isSaved, null));
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
@@ -100,7 +100,7 @@ public class CommentController extends BaseController<CommentService, Comment, S
             @PathVariable String commentId,
             @Valid @RequestBody Comment.Reaction reaction
     ) {
-        log.debug("Going to create reaction on comment with id: {}", commentId);
+        log.debug("Going to delete reaction on comment with id: {}", commentId);
         return service.deleteReaction(commentId, reaction)
                 .map(isSaved -> new ResponseDTO<>(HttpStatus.OK.value(), isSaved, null));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
@@ -1,12 +1,14 @@
 package com.appsmith.server.domains;
 
 import com.appsmith.external.models.BaseDomain;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +33,8 @@ public class Comment extends BaseDomain {
     String authorName;
 
     Body body;
+
+    List<Reaction> reactions;
 
     @Data
     public static class Body {
@@ -77,6 +81,15 @@ public class Comment extends BaseDomain {
             String username;
             String roleName;
         }
+    }
+
+    @Data
+    public static class Reaction {
+        String emoji;
+        String byUsername;
+        String byName;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssX", timezone = "UTC")
+        Date createdAt;
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepository.java
@@ -1,7 +1,13 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.domains.Comment;
+import com.mongodb.client.result.UpdateResult;
+import reactor.core.publisher.Mono;
 
 public interface CustomCommentRepository extends AppsmithRepository<Comment> {
+
+    Mono<UpdateResult> pushReaction(String commentId, Comment.Reaction reaction);
+
+    Mono<UpdateResult> deleteReaction(String commentId, Comment.Reaction reaction);
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepositoryImpl.java
@@ -1,10 +1,18 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.domains.Comment;
+import com.appsmith.server.domains.QComment;
+import com.mongodb.client.result.UpdateResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @Component
 @Slf4j
@@ -12,6 +20,45 @@ public class CustomCommentRepositoryImpl extends BaseAppsmithRepositoryImpl<Comm
 
     public CustomCommentRepositoryImpl(ReactiveMongoOperations mongoOperations, MongoConverter mongoConverter) {
         super(mongoOperations, mongoConverter);
+    }
+
+    /**
+     * Add a reaction, by a user, if the reaction by that user already doesn't exist on this comment.
+     * @param commentId UUID string of the comment to add the reaction to.
+     * @param reaction The reaction object to add to the comment.
+     * @return Mono that publishes an UpdateResult that will contain the number of reactions added. It's only ever 0 or 1.
+     */
+    @Override
+    public Mono<UpdateResult> pushReaction(String commentId, Comment.Reaction reaction) {
+        final String reactionsField = fieldName(QComment.comment.reactions);
+        return mongoOperations.updateFirst(
+                Query.query(new Criteria().andOperator(
+                        where("id").is(commentId),
+                        Criteria
+                                .where(reactionsField)
+                                .not()
+                                .elemMatch(where("emoji").is(reaction.getEmoji()).and("byUsername").is(reaction.getByUsername()))
+                )),
+                new Update().addToSet(reactionsField, reaction),
+                Comment.class
+        );
+    }
+
+    /**
+     * Atomically delete a reaction, by a user, if the reaction by that user exists on this comment.
+     * @param commentId UUID string of the comment on which to delete a reaction.
+     * @param reaction The reaction object to be deleted.
+     * @return Mono that publishes an UpdateResult that will contain the number of reactions deleted. It's usually 0 or 1, but can theoretically be more.
+     */
+    @Override
+    public Mono<UpdateResult> deleteReaction(String commentId, Comment.Reaction reaction) {
+        reaction.setByName(null);
+        reaction.setCreatedAt(null);
+        return mongoOperations.updateFirst(
+                Query.query(where("id").is(commentId)),
+                new Update().pull(fieldName(QComment.comment.reactions), reaction),
+                Comment.class
+        );
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentService.java
@@ -20,4 +20,7 @@ public interface CommentService extends CrudService<Comment, String> {
 
     Mono<CommentThread> deleteThread(String threadId);
 
+    Mono<Boolean> createReaction(String commentId, Comment.Reaction reaction);
+
+    Mono<Boolean> deleteReaction(String commentId, Comment.Reaction reaction);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -14,13 +14,13 @@ import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.repositories.CommentRepository;
 import com.appsmith.server.repositories.CommentThreadRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -28,6 +28,7 @@ import reactor.core.scheduler.Scheduler;
 import javax.validation.Validator;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -269,6 +270,38 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
         return threadRepository.findById(threadId, AclPermission.MANAGE_THREAD)
                 .flatMap(threadRepository::archive)
                 .flatMap(analyticsService::sendDeleteEvent);
+    }
+
+    @Override
+    public Mono<Boolean> createReaction(String commentId, Comment.Reaction reaction) {
+        return Mono.zip(
+                repository.findById(commentId, AclPermission.READ_COMMENT),
+                sessionUserService.getCurrentUser()
+        )
+                .flatMap(tuple -> {
+                    final User user = tuple.getT2();
+
+                    reaction.setByUsername(user.getUsername());
+                    reaction.setByName(user.getName());
+                    reaction.setCreatedAt(new Date(Instant.now().toEpochMilli()));
+
+                    return repository.pushReaction(commentId, reaction)
+                            .map(result -> result.getModifiedCount() == 1L);
+                });
+    }
+
+    @Override
+    public Mono<Boolean> deleteReaction(String commentId, Comment.Reaction reaction) {
+        return Mono.zip(
+                repository.findById(commentId, AclPermission.READ_COMMENT),
+                sessionUserService.getCurrentUser()
+        )
+                .flatMap(tuple -> {
+                    final User user = tuple.getT2();
+                    reaction.setByUsername(user.getUsername());
+                    return repository.deleteReaction(commentId, reaction)
+                            .map(result -> result.getModifiedCount() == 1L);
+                });
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -300,7 +300,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                     final User user = tuple.getT2();
                     reaction.setByUsername(user.getUsername());
                     return repository.deleteReaction(commentId, reaction)
-                            .map(result -> result.getModifiedCount() == 1L);
+                            .map(result -> result.getModifiedCount() > 0);
                 });
     }
 


### PR DESCRIPTION
Introduces two API endpoints:

- `POST /comments/{commentId}/reactions` with body looking like `{"emoji": "a"}` to add a reaction on a comment, given by the ID.
- `DELETE /comments/{commentId}/reactions` with body looking like `{"emoji": "a"}` to remove a reaction on a comment, given by the ID.
