### PR TITLE
[Issue #2093]-show last used organizations first in home page

### DIFF
--- a/app/server/.run/ServerApplication.run.xml
+++ b/app/server/.run/ServerApplication.run.xml
@@ -19,4 +19,4 @@
       <option name="Make" enabled="true" />
     </method>
   </configuration>
-</component> 
+</component>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
@@ -6,6 +6,7 @@ public class FieldName {
     public static final String DELETED = "deleted";
     public static final String CREATED_AT = "createdAt";
     public static final String DELETED_AT = "deletedAt";
+    public static final String UPDATED_AT = "updatedAt";
     public static final String CURL_CODE = "curlCode";
     public static String ORGANIZATION = "organization";
     public static String ID = "id";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/PageController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/PageController.java
@@ -6,6 +6,7 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.services.ApplicationPageService;
 import com.appsmith.server.services.NewPageService;
+import com.appsmith.server.services.UserDataService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -30,12 +31,14 @@ import javax.validation.Valid;
 public class PageController {
     private final ApplicationPageService applicationPageService;
     private final NewPageService newPageService;
+    private final UserDataService userDataService;
 
     @Autowired
     public PageController(ApplicationPageService applicationPageService,
-                          NewPageService newPageService) {
+                          NewPageService newPageService, UserDataService userDataService) {
         this.applicationPageService = applicationPageService;
         this.newPageService = newPageService;
+        this.userDataService = userDataService;
     }
 
     @PostMapping
@@ -52,12 +55,18 @@ public class PageController {
     @GetMapping("/application/{applicationId}")
     public Mono<ResponseDTO<ApplicationPagesDTO>> getPageNamesByApplicationId(@PathVariable String applicationId) {
         return newPageService.findApplicationPagesByApplicationIdAndViewMode(applicationId, false)
+                .flatMap(applicationPagesDTO ->
+                        userDataService.updateLastUsedOrgList(applicationPagesDTO.getOrganizationId())
+                        .thenReturn(applicationPagesDTO))
                 .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
     }
 
     @GetMapping("/view/application/{applicationId}")
     public Mono<ResponseDTO<ApplicationPagesDTO>> getPageNamesByApplicationIdInViewMode(@PathVariable String applicationId) {
         return newPageService.findApplicationPagesByApplicationIdAndViewMode(applicationId, true)
+                .flatMap(applicationPagesDTO ->
+                        userDataService.updateLastUsedOrgList(applicationPagesDTO.getOrganizationId())
+                                .thenReturn(applicationPagesDTO))
                 .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/PageController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/PageController.java
@@ -6,7 +6,6 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.services.ApplicationPageService;
 import com.appsmith.server.services.NewPageService;
-import com.appsmith.server.services.UserDataService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -31,14 +30,11 @@ import javax.validation.Valid;
 public class PageController {
     private final ApplicationPageService applicationPageService;
     private final NewPageService newPageService;
-    private final UserDataService userDataService;
 
     @Autowired
-    public PageController(ApplicationPageService applicationPageService,
-                          NewPageService newPageService, UserDataService userDataService) {
+    public PageController(ApplicationPageService applicationPageService, NewPageService newPageService) {
         this.applicationPageService = applicationPageService;
         this.newPageService = newPageService;
-        this.userDataService = userDataService;
     }
 
     @PostMapping
@@ -55,18 +51,12 @@ public class PageController {
     @GetMapping("/application/{applicationId}")
     public Mono<ResponseDTO<ApplicationPagesDTO>> getPageNamesByApplicationId(@PathVariable String applicationId) {
         return newPageService.findApplicationPagesByApplicationIdAndViewMode(applicationId, false)
-                .flatMap(applicationPagesDTO ->
-                        userDataService.updateLastUsedOrgList(applicationPagesDTO.getOrganizationId())
-                        .thenReturn(applicationPagesDTO))
                 .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
     }
 
     @GetMapping("/view/application/{applicationId}")
     public Mono<ResponseDTO<ApplicationPagesDTO>> getPageNamesByApplicationIdInViewMode(@PathVariable String applicationId) {
         return newPageService.findApplicationPagesByApplicationIdAndViewMode(applicationId, true)
-                .flatMap(applicationPagesDTO ->
-                        userDataService.updateLastUsedOrgList(applicationPagesDTO.getOrganizationId())
-                                .thenReturn(applicationPagesDTO))
                 .map(resources -> new ResponseDTO<>(HttpStatus.OK.value(), resources, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
@@ -8,6 +8,8 @@ import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.List;
+
 /**
  * This model is intended to hold any user-specific information that is not directly about the user's authentication.
  */
@@ -26,6 +28,9 @@ public class UserData extends BaseDomain {
 
     // The version where this user has last viewed the release notes.
     private String releaseNotesViewedVersion;
+
+    // list of organisation ids that were recently accessed by the user
+    private List<String> recentlyUsedOrgIds;
 
     public UserData(String userId) {
         this.userId = userId;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CollectionUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CollectionUtils.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.helpers;
 
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 
 public class CollectionUtils {
 
@@ -23,6 +22,42 @@ public class CollectionUtils {
      */
     public static boolean isNullOrEmpty(final Map<?, ?> m) {
         return (m == null || m.isEmpty());
+    }
+
+    /**
+     * Puts an item at the beginning of the list. If the item already exists in other position, it'll move it to first
+     * @param list
+     * @param item
+     * @param <E>
+     */
+    public static <E> void putAtFirst(List<E> list, E item) {
+        // check if item already exists
+        int index = list.indexOf(item);
+        if(index == -1) {  // does not exist so put it at first
+            list.add(0, item);
+        } else if(index > 0) {
+            list.remove(item);
+            list.add(0, item);
+        }
+    }
+
+    /**
+     * Removes duplicate items from an array list
+     * @param list
+     * @param <T>
+     * @return
+     */
+    public static <T> void removeDuplicates(List<T> list)
+    {
+        // Create a new LinkedHashSet
+        Set<T> set = new LinkedHashSet<T>(list);
+
+        // Clear the list
+        list.clear();
+
+        // add the elements of set
+        // with no duplicates to the list
+        list.addAll(set);
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CollectionUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CollectionUtils.java
@@ -1,6 +1,11 @@
 package com.appsmith.server.helpers;
 
-import java.util.*;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class CollectionUtils {
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepository.java
@@ -7,5 +7,5 @@ import reactor.core.publisher.Mono;
 public interface CustomUserDataRepository extends AppsmithRepository<UserData> {
 
     Mono<UpdateResult> saveReleaseNotesViewedVersion(String userId, String version);
-
+    Mono<UpdateResult> removeOrgFromRecentlyUsedList(String userId, String organizationId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserDataRepositoryImpl.java
@@ -31,4 +31,12 @@ public class CustomUserDataRepositoryImpl extends BaseAppsmithRepositoryImpl<Use
                 );
     }
 
+    @Override
+    public Mono<UpdateResult> removeOrgFromRecentlyUsedList(String userId, String organizationId) {
+        return mongoOperations.updateFirst(
+                query(where(fieldName(QUserData.userData.userId)).is(userId)),
+                new Update().pull(fieldName(QUserData.userData.recentlyUsedOrgIds), organizationId),
+                UserData.class
+                );
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataService.java
@@ -31,4 +31,5 @@ public interface UserDataService {
 
     Mono<Void> makeProfilePhotoResponse(ServerWebExchange exchange);
 
+    Mono<UserData> updateLastUsedOrgList(String currentOrgId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationFetcher.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationFetcher.java
@@ -18,13 +18,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.READ_ORGANIZATIONS;
@@ -64,11 +60,23 @@ public class ApplicationFetcher {
                 .cache();
 
         return userMono
-                .flatMap(user -> {
+                .zipWith(userDataService.getForCurrentUser().defaultIfEmpty(new UserData()))
+                .flatMap(userAndUserDataTuple -> {
+                    User user = userAndUserDataTuple.getT1();
+                    UserData userData = userAndUserDataTuple.getT2();
+
                     Set<String> orgIds = user.getOrganizationIds();
 
-                    // Collect all the applications as a map with organization id as a key
+                    // create a set of org id where recently used ones will be at the beginning
+                    List<String> recentlyUsedOrgIds = userData.getRecentlyUsedOrgIds();
+                    Set<String> orgIdSortedSet = new LinkedHashSet<>(orgIds.size());
+                    if(recentlyUsedOrgIds != null && recentlyUsedOrgIds.size() > 0) {
+                        // user has a recently used list, add them to the beginning
+                        orgIdSortedSet.addAll(recentlyUsedOrgIds);
+                    }
+                    orgIdSortedSet.addAll(orgIds); // add all other if not added already
 
+                    // Collect all the applications as a map with organization id as a key
                     Mono<Map<String, Collection<Application>>> applicationsMapMono = applicationRepository
                             .findByMultipleOrganizationIds(orgIds, READ_APPLICATIONS)
                             .collectMultimap(Application::getOrganizationId, Function.identity());
@@ -78,29 +86,34 @@ public class ApplicationFetcher {
 
                     return organizationService
                             .findByIdsIn(orgIds, READ_ORGANIZATIONS)
-                            .collectList()
+                            .collectMap(Organization::getId, v -> v)
                             .zipWith(applicationsMapMono)
                             .map(tuple -> {
-                                List<Organization> organizations = tuple.getT1();
+                                Map<String, Organization> organizations = tuple.getT1();
+
                                 Map<String, Collection<Application>> applicationsCollectionByOrgId = tuple.getT2();
 
                                 List<OrganizationApplicationsDTO> organizationApplicationsDTOS = new ArrayList<>();
 
-                                for (Organization organization : organizations) {
-                                    Collection<Application> applicationCollection = applicationsCollectionByOrgId.get(organization.getId());
+                                for(String orgId : orgIdSortedSet) {
+                                    Organization organization = organizations.get(orgId);
+                                    if(organization != null) {
+                                        Collection<Application> applicationCollection = applicationsCollectionByOrgId.get(organization.getId());
 
-                                    final List<Application> applicationList = new ArrayList<>();
-                                    if (!CollectionUtils.isEmpty(applicationCollection)) {
-                                        applicationList.addAll(applicationCollection);
+                                        final List<Application> applicationList = new ArrayList<>();
+                                        if (!CollectionUtils.isEmpty(applicationCollection)) {
+                                            applicationList.addAll(applicationCollection);
+                                        }
+
+                                        OrganizationApplicationsDTO organizationApplicationsDTO = new OrganizationApplicationsDTO();
+                                        organizationApplicationsDTO.setOrganization(organization);
+                                        organizationApplicationsDTO.setApplications(applicationList);
+                                        organizationApplicationsDTO.setUserRoles(organization.getUserRoles());
+
+                                        organizationApplicationsDTOS.add(organizationApplicationsDTO);
                                     }
-
-                                    OrganizationApplicationsDTO organizationApplicationsDTO = new OrganizationApplicationsDTO();
-                                    organizationApplicationsDTO.setOrganization(organization);
-                                    organizationApplicationsDTO.setApplications(applicationList);
-                                    organizationApplicationsDTO.setUserRoles(organization.getUserRoles());
-
-                                    organizationApplicationsDTOS.add(organizationApplicationsDTO);
                                 }
+
                                 userHomepageDTO.setOrganizationApplications(organizationApplicationsDTOS);
                                 return userHomepageDTO;
                             });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationFetcher.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationFetcher.java
@@ -18,9 +18,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Mono;
 
-import java.util.*;
+import java.util.Set;
+import java.util.Collection;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Collections;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.READ_ORGANIZATIONS;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CollectionUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CollectionUtilsTest.java
@@ -1,0 +1,83 @@
+package com.appsmith.server.helpers;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionUtilsTest {
+
+    @Test
+    public void testPutAtFirstWhenItemDoesNotExist() {
+        List<String> sampleList = new ArrayList<>(3);
+        sampleList.add("a");
+        sampleList.add("b");
+        sampleList.add("c");
+        CollectionUtils.putAtFirst(sampleList, "d");
+        Assert.assertEquals(4, sampleList.size());
+        Assert.assertArrayEquals(new String[]{ "d", "a", "b", "c" }, sampleList.toArray());
+    }
+
+    @Test
+    public void testPutAtFirstWhenItemAlreadyAtFirst() {
+        List<String> sampleList = new ArrayList<>(3);
+        sampleList.add("a");
+        sampleList.add("b");
+        sampleList.add("c");
+        CollectionUtils.putAtFirst(sampleList, "a");
+        Assert.assertEquals(3, sampleList.size());
+        Assert.assertArrayEquals(new String[]{ "a", "b", "c" }, sampleList.toArray());
+    }
+
+    @Test
+    public void testPutAtFirstWhenItemExistsButNotAtFirst() {
+        List<String> sampleList = new ArrayList<>(3);
+        sampleList.add("a");
+        sampleList.add("b");
+        sampleList.add("c");
+        CollectionUtils.putAtFirst(sampleList, "b");
+        Assert.assertEquals(3, sampleList.size());
+        Assert.assertArrayEquals(new String[]{ "b", "a", "c" }, sampleList.toArray());
+    }
+
+    @Test
+    public void testRemoveDuplicatesWhenThereAreDuplicates() {
+        List<String> sampleList = new ArrayList<>(4);
+        sampleList.add("a");
+        sampleList.add("b");
+        sampleList.add("c");
+        sampleList.add("c");
+
+        CollectionUtils.removeDuplicates(sampleList);
+        Assert.assertEquals(3, sampleList.size());
+        Assert.assertArrayEquals(new String[]{ "a", "b", "c" }, sampleList.toArray());
+    }
+
+    @Test
+    public void testRemoveDuplicatesWhenThereAreNoDuplicates() {
+        List<String> sampleList = new ArrayList<>(4);
+        sampleList.add("a");
+        sampleList.add("b");
+        sampleList.add("c");
+
+        CollectionUtils.removeDuplicates(sampleList);
+        Assert.assertEquals(3, sampleList.size());
+        Assert.assertArrayEquals(new String[]{ "a", "b", "c" }, sampleList.toArray());
+    }
+
+    @Test
+    public void testRemoveDuplicatesWhenThereAreMulipleDuplicates() {
+        List<String> sampleList = new ArrayList<>(5);
+        sampleList.add("a");
+        sampleList.add("b");
+        sampleList.add("c");
+        sampleList.add("c");
+        sampleList.add("b");
+
+        CollectionUtils.removeDuplicates(sampleList);
+        Assert.assertEquals(3, sampleList.size());
+        Assert.assertArrayEquals(new String[]{ "a", "b", "c" }, sampleList.toArray());
+    }
+
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomUserDataRepositoryImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomUserDataRepositoryImplTest.java
@@ -1,0 +1,81 @@
+package com.appsmith.server.repositories;
+
+import com.appsmith.server.domains.UserData;
+import com.mongodb.client.result.UpdateResult;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Slf4j
+class CustomUserDataRepositoryImplTest {
+
+    @Autowired
+    private UserDataRepository userDataRepository;
+
+    private Mono<UserData> createUser(String userId, List<String> orgIds) {
+        String sampleUserId = userId;
+        UserData sampleUserData = new UserData();
+        sampleUserData.setUserId(sampleUserId);
+        sampleUserData.setRecentlyUsedOrgIds(List.of("123", "234", "345"));
+        return userDataRepository.save(sampleUserData);
+    }
+
+    @Test
+    void removeOrgFromRecentlyUsedList_WhenOrgIdAlreadyExists_OrgIdRemoved() {
+        // create an user data with 3 org id in the recently used orgid list
+        String sampleUserId = "abcd";
+        Mono<UserData> createUserDataMono = createUser(sampleUserId, List.of("123", "234", "345"));
+
+        // remove the 345 org id from the recently used orgid list
+        Mono<UpdateResult> updateResultMono = createUserDataMono.flatMap(
+                userData -> userDataRepository.removeOrgFromRecentlyUsedList(userData.getUserId(), "345")
+        );
+
+        // read the userdata
+        Mono<UserData> readUserDataMono = userDataRepository.findByUserId(sampleUserId);
+
+        // add the read user data mono after the update mono
+        Mono<UserData> userDataAfterUpdateMono = updateResultMono.then(readUserDataMono);
+
+        StepVerifier.create(userDataAfterUpdateMono).assertNext(userData -> {
+            Assert.assertEquals(2, userData.getRecentlyUsedOrgIds().size());
+            Assert.assertArrayEquals(List.of("123", "234").toArray(), userData.getRecentlyUsedOrgIds().toArray());
+        }).verifyComplete();
+    }
+
+    @Test
+    void removeOrgFromRecentlyUsedList_WhenOrgIdDoesNotExist_NothingRemoved() {
+        // create an user data with 3 org id in the recently used orgid list
+        String sampleUserId = "efgh";
+        Mono<UserData> createUserDataMono = createUser(sampleUserId, List.of("123", "234", "345"));
+
+        // remove the 345 org id from the recently used orgid list
+        Mono<UpdateResult> updateResultMono = createUserDataMono.flatMap(
+                userData -> userDataRepository.removeOrgFromRecentlyUsedList(userData.getUserId(), "678")
+        );
+
+        // read the userdata
+        Mono<UserData> readUserDataMono = userDataRepository.findByUserId(sampleUserId);
+
+        // add the read user data mono after the update mono
+        Mono<UserData> userDataAfterUpdateMono = updateResultMono.then(readUserDataMono);
+
+        StepVerifier.create(userDataAfterUpdateMono).assertNext(userData -> {
+            Assert.assertEquals(3, userData.getRecentlyUsedOrgIds().size());
+            Assert.assertArrayEquals(List.of("123", "234", "345").toArray(), userData.getRecentlyUsedOrgIds().toArray());
+        }).verifyComplete();
+    }
+}


### PR DESCRIPTION
## Description
When user visits their home page, they can see the list of organization and list of applications under each organization. The list of organization are sorted alphabetically. This PR will change this behavior. The organizations will now be sorted based on usage - the last used one is shown at first. So if user has 3 organization A, B, C and she opens an app under the C, then organization list will be shown in order C, A, B in her home page. If she opens an app from A now, the order will change to A, C, B

Fixes # (issue)
Issue #2093

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Integration tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
