### PR TITLE
Remove isFromSignup param to prevent duplicate hits

### DIFF
--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -26,7 +26,11 @@ import AppErrorBoundary from "./AppErrorBoundry";
 import GlobalStyles from "globalStyles";
 appInitializer();
 
+import useRemoveSignUpCompleteParam from "utils/hooks/useRemoveSignUpCompleteParam";
+
 function App() {
+  useRemoveSignUpCompleteParam();
+
   return (
     <Sentry.ErrorBoundary fallback={"An error has occured"}>
       <Provider store={store}>

--- a/app/client/src/utils/hooks/useRemoveSignUpCompleteParam.ts
+++ b/app/client/src/utils/hooks/useRemoveSignUpCompleteParam.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import history from "utils/history";
+
+const useRemoveSignUpCompleteParam = () => {
+  useEffect(() => {
+    if (window.location.href) {
+      const url = new URL(window.location.href);
+      const searchParams = url.searchParams;
+      if (searchParams.get("isFromSignup")) {
+        searchParams.delete("isFromSignup");
+        history.replace({
+          pathname: url.pathname,
+          search: url.search,
+          hash: url.hash,
+        });
+      }
+    }
+  }, []);
+};
+
+export default useRemoveSignUpCompleteParam;


### PR DESCRIPTION
## Description
Remove `isFromSignup` param from the URL to prevent duplicate analytics hits 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>