### PR TITLE
Fixed query params parsing in API pane

### DIFF
--- a/app/client/cypress/fixtures/testdata.json
+++ b/app/client/cypress/fixtures/testdata.json
@@ -122,5 +122,6 @@
   "accessTokenUrl": "https://oauth.mocklab.io/oauth/token",
   "oauthResponse": "169444434892406",
   "authorizationURL": "https://oauth.mocklab.io/oauth/authorize",
-  "basicURl": "https://envyenksqii9nf3.m.pipedream.net"
+  "basicURl": "https://envyenksqii9nf3.m.pipedream.net",
+  "methodWithQueryParam": "users?q=mimeType='application/vnd.google-apps.spreadsheet'"
 }

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
@@ -39,4 +39,16 @@ describe("API Panel Test Functionality", function() {
     cy.xpath(apiwidget.headerKey).should("be.visible");
     cy.xpath(apiwidget.headerKey).should("have.value", "");
   });
+
+  it("Should correctly parse query params", function() {
+    cy.NavigateToAPI_Panel();
+    cy.CreateAPI("APIWithQueryParams");
+    cy.get("textarea").should(
+      "have.attr",
+      "placeholder",
+      "https://mock-api.appsmith.com/users",
+    );
+    cy.enterDatasourceAndPath(testdata.baseUrl, testdata.methodWithQueryParam);
+    cy.ValidateQueryParams({ key: "q", value:"mimeType='application/vnd.google-apps.spreadsheet'" });
+  });
 });

--- a/app/client/cypress/locators/apiWidgetslocator.json
+++ b/app/client/cypress/locators/apiWidgetslocator.json
@@ -52,5 +52,8 @@
   "actionlist": ".action div div",
   "settings": "li:contains('Settings')",
   "onPageLoad": "[data-cy=executeOnLoad]",
-  "renameEntity": ".single-select >div:contains('Edit Name')"
+  "renameEntity": ".single-select >div:contains('Edit Name')",
+  "paramsTab": "//li//span[text()='Params']",
+  "paramKey": "(//div[contains(@class,'t--actionConfiguration.queryParameters[0].key.0')]//textarea)[1]",
+  "paramValue": "(//div[contains(@class,'t--actionConfiguration.queryParameters[0].value.0')]//textarea)[1]"
 }

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -2342,3 +2342,11 @@ Cypress.Commands.add("callApi", (apiname) => {
 Cypress.Commands.add("assertPageSave", () => {
   cy.get(commonlocators.saveStatusSuccess);
 });
+
+Cypress.Commands.add("ValidateQueryParams", (param) => {
+  cy.xpath(apiwidget.paramsTab)
+      .should("be.visible")
+      .click({ force: true });
+  cy.xpath(apiwidget.paramKey).first().contains(param.key);
+  cy.xpath(apiwidget.paramValue).first().contains(param.value);
+});

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -84,7 +84,11 @@ function* syncApiParamsSaga(
     if (value.indexOf("?") > -1) {
       const paramsString = value.substr(value.indexOf("?") + 1);
       const params = paramsString.split("&").map((p) => {
-        const keyValue = p.split("=");
+        const firstEqualPos = p.indexOf("=");
+        const keyValue =
+          firstEqualPos > -1
+            ? [p.substring(0, firstEqualPos), p.substring(firstEqualPos + 1)]
+            : [];
         return { key: keyValue[0], value: keyValue[1] || "" };
       });
       if (params.length < 2) {


### PR DESCRIPTION
## Description
Fixed query params parsing when there are multiple "="s in the URL

Fixes #3585 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/query_params_parsing_api_pane 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 48.92 **(-0.01)** | 28.63 **(0)** | 26.78 **(0)** | 49.3 **(0)**
 :red_circle: | app/client/src/sagas/ApiPaneSagas.ts | 13.66 **(-1.06)** | 1.67 **(0)** | 7.14 **(0)** | 15.23 **(-1.19)**</details>