### PR TITLE
fix: select disabled option popover overflow

### DIFF
--- a/app/client/src/components/designSystems/blueprint/DropdownComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/DropdownComponent.tsx
@@ -267,6 +267,11 @@ class DropDownComponent extends React.Component<DropDownComponentProps> {
               popoverProps={{
                 minimal: true,
                 usePortal: true,
+                modifiers: {
+                  preventOverflow: {
+                    enabled: false,
+                  },
+                },
                 popoverClassName: "select-popover-wrapper",
               }}
             >
@@ -294,6 +299,11 @@ class DropDownComponent extends React.Component<DropDownComponentProps> {
               popoverProps={{
                 minimal: true,
                 usePortal: true,
+                modifiers: {
+                  preventOverflow: {
+                    enabled: false,
+                  },
+                },
                 popoverClassName: "select-popover-wrapper",
               }}
               resetOnSelect


### PR DESCRIPTION
## Description
> In dropdown component option popover is scroll issue fixed. here we disabled `preventOverflow`.

Fixes # (#2356)

## Type of change

> Please delete options that are not relevant.

- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ]  I have commented on my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>