### PR TITLE
change java version to 11.0.10 to allow TLSv1 for mysql

### DIFF
--- a/app/server/Dockerfile
+++ b/app/server/Dockerfile
@@ -1,6 +1,6 @@
 #When you are building, name it appsmith-server which is how it is referenced in docker-compose.yml
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 
 LABEL maintainer="tech@appsmith.com"
 


### PR DESCRIPTION
## Description
- Change docker image java version to 11.0.10 to allow TLSv1 for mysql.

Fixes #4462 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Via EC2 deployment

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
