### PR TITLE
Adding support for multipart form data

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiPaneTests/API_CurlPOSTImport_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiPaneTests/API_CurlPOSTImport_spec.js
@@ -2,7 +2,7 @@ const ApiEditor = require("../../../../locators/ApiEditor.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 
 describe("Test curl import flow", function() {
-  it("Test curl import flow for POST action", function() {
+  it("Test curl import flow for POST action with JSON body", function() {
     localStorage.setItem("ApiPaneV2", "ApiPaneV2");
     cy.NavigateToApiEditor();
     cy.get(ApiEditor.curlImage).click({ force: true });
@@ -24,6 +24,35 @@ describe("Test curl import flow", function() {
           const someText = text;
           expect(someText).to.equal(response.response.body.data.name);
         });
+    });
+  });
+
+  it("Test curl import flow for POST action with multipart form data", function() {
+    localStorage.setItem("ApiPaneV2", "ApiPaneV2");
+    cy.NavigateToApiEditor();
+    cy.get(ApiEditor.curlImage).click({ force: true });
+    cy.get("textarea").type(
+      "curl --request POST http://httpbin.org/post -F 'randomKey=randomValue' --form 'randomKey2=\"randomValue2\"'",
+      {
+        force: true,
+        parseSpecialCharSequences: false,
+      },
+    );
+    cy.importCurl();
+    cy.RunAPI();
+    cy.ResponseStatusCheck("200 OK");
+    cy.log("Ran the API successfully");
+    cy.get("@postExecute").then((response) => {
+      cy.log(response.response.body);
+      cy.expect(response.response.body.responseMeta.success).to.eq(true);
+      // Asserting if the form key value are returned in the response
+      cy.expect(response.response.body.data.body.form.randomKey).to.eq(
+        "randomValue",
+      );
+      // Asserting the content type header set in curl import is multipart/form-data
+      cy.expect(
+        response.response.body.data.body.headers["Content-Type"],
+      ).contains("multipart/form-data;boundary");
     });
   });
 });

--- a/app/client/src/constants/ApiEditorConstants.ts
+++ b/app/client/src/constants/ApiEditorConstants.ts
@@ -65,17 +65,11 @@ export const POST_BODY_FORMAT_OPTIONS: Array<{
   { label: ApiContentTypes.RAW, value: "raw" },
 ];
 
-export const POST_BODY_FORMAT_OPTIONS_NO_MULTI_PART = POST_BODY_FORMAT_OPTIONS.filter(
-  (option) => {
-    return option.value !== "multipart/form-data";
-  },
-);
-
 export const POST_BODY_FORMATS = POST_BODY_FORMAT_OPTIONS.map((option) => {
   return option.value;
 });
 
-export const POST_BODY_FORMAT_TITLES_NO_MULTI_PART = POST_BODY_FORMAT_OPTIONS_NO_MULTI_PART.map(
+export const POST_BODY_FORMAT_TITLES = POST_BODY_FORMAT_OPTIONS.map(
   (option) => {
     return { title: option.label, key: option.value };
   },

--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -5,7 +5,7 @@ import { formValueSelector } from "redux-form";
 import {
   ApiContentTypes,
   POST_BODY_FORMAT_OPTIONS,
-  POST_BODY_FORMAT_TITLES_NO_MULTI_PART,
+  POST_BODY_FORMAT_TITLES,
 } from "constants/ApiEditorConstants";
 import { API_EDITOR_FORM_NAME } from "constants/forms";
 import KeyValueFieldArray from "components/editorComponents/form/fields/KeyValueFieldArray";
@@ -62,7 +62,7 @@ function PostBodyData(props: Props) {
           updateBodyContentType(title, apiId)
         }
         selected={displayFormat}
-        tabs={POST_BODY_FORMAT_TITLES_NO_MULTI_PART.map((el) => {
+        tabs={POST_BODY_FORMAT_TITLES.map((el) => {
           let component = (
             <JSONEditorFieldWrapper
               className={"t--apiFormPostBody"}
@@ -83,7 +83,10 @@ function PostBodyData(props: Props) {
               />
             </JSONEditorFieldWrapper>
           );
-          if (el.title === ApiContentTypes.FORM_URLENCODED) {
+          if (
+            el.title === ApiContentTypes.FORM_URLENCODED ||
+            el.title === ApiContentTypes.MULTIPART_FORM_DATA
+          ) {
             component = (
               <KeyValueFieldArray
                 dataTreePath={`${dataTreePath}.bodyFormData`}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang.StringUtils;
 import org.bson.internal.Base64;
 import org.pf4j.Extension;
 import org.pf4j.PluginWrapper;
+import org.springframework.data.util.StreamUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -40,6 +41,7 @@ import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -133,9 +135,9 @@ public class RestApiPlugin extends BasePlugin {
                 smartJsonSubstitution = false;
 
                 // Since properties is not empty, we are guaranteed to find the first property.
-            } else if (properties.get(SMART_JSON_SUBSTITUTION_INDEX) != null){
+            } else if (properties.get(SMART_JSON_SUBSTITUTION_INDEX) != null) {
                 Object ssubValue = properties.get(SMART_JSON_SUBSTITUTION_INDEX).getValue();
-                if (ssubValue instanceof  Boolean) {
+                if (ssubValue instanceof Boolean) {
                     smartJsonSubstitution = (Boolean) ssubValue;
                 } else if (ssubValue instanceof String) {
                     smartJsonSubstitution = Boolean.parseBoolean((String) ssubValue);
@@ -265,16 +267,16 @@ public class RestApiPlugin extends BasePlugin {
                 return Mono.just(errorResult);
             }
 
-            String requestBodyAsString = "";
+            Object requestBodyObj = null;
 
             // Add request body only for non GET calls.
             if (!HttpMethod.GET.equals(httpMethod)) {
                 // Adding request body
-                requestBodyAsString = (actionConfiguration.getBody() == null) ? "" : actionConfiguration.getBody();
+                requestBodyObj = (actionConfiguration.getBody() == null) ? "" : actionConfiguration.getBody();
 
                 if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType)
                         || MediaType.MULTIPART_FORM_DATA_VALUE.equals(reqContentType)) {
-                    requestBodyAsString = convertPropertyListToReqBody(actionConfiguration.getBodyFormData(),
+                    requestBodyObj = convertPropertyListToReqBody(actionConfiguration.getBodyFormData(),
                             reqContentType,
                             encodeParamsToggle);
                 }
@@ -309,7 +311,7 @@ public class RestApiPlugin extends BasePlugin {
             WebClient client = webClientBuilder.exchangeStrategies(EXCHANGE_STRATEGIES).build();
 
             // Triggering the actual REST API call
-            return httpCall(client, httpMethod, uri, requestBodyAsString, 0, reqContentType)
+            return httpCall(client, httpMethod, uri, requestBodyObj, 0, reqContentType)
                     .flatMap(clientResponse -> clientResponse.toEntity(byte[].class))
                     .map(stringResponseEntity -> {
                         HttpHeaders headers = stringResponseEntity.getHeaders();
@@ -380,7 +382,7 @@ public class RestApiPlugin extends BasePlugin {
 
                         return result;
                     })
-                    .onErrorResume(error  -> {
+                    .onErrorResume(error -> {
                         errorResult.setIsExecutionSuccess(false);
                         errorResult.setErrorInfo(error);
                         return Mono.just(errorResult);
@@ -415,32 +417,42 @@ public class RestApiPlugin extends BasePlugin {
             return null;
         }
 
-        public String convertPropertyListToReqBody(List<Property> bodyFormData,
+        public Object convertPropertyListToReqBody(List<Property> bodyFormData,
                                                    String reqContentType,
                                                    Boolean encodeParamsToggle) {
             if (bodyFormData == null || bodyFormData.isEmpty()) {
-                return "";
+                return null;
             }
 
-            String reqBody = bodyFormData.stream()
-                    .map(property -> {
-                        String key = property.getKey();
-                        String value = (String) property.getValue();
+            Object requestBody = null;
 
-                        if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType)
-                                && encodeParamsToggle == true) {
-                            try {
-                                value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
-                            } catch (UnsupportedEncodingException e) {
-                                throw new UnsupportedOperationException(e);
-                            }
-                        }
+            switch (reqContentType) {
+                case MediaType.APPLICATION_FORM_URLENCODED_VALUE:
+                    requestBody = bodyFormData.stream()
+                            .map(property -> {
+                                String key = property.getKey();
+                                String value = (String) property.getValue();
 
-                        return key + "=" + value;
-                    })
-                    .collect(Collectors.joining("&"));
+                                if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType)
+                                        && encodeParamsToggle == true) {
+                                    try {
+                                        value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+                                    } catch (UnsupportedEncodingException e) {
+                                        throw new UnsupportedOperationException(e);
+                                    }
+                                }
 
-            return reqBody;
+                                return key + "=" + value;
+                            })
+                            .collect(Collectors.joining("&"));
+                    break;
+                    
+                case MediaType.MULTIPART_FORM_DATA_VALUE:
+                    requestBody = bodyFormData.stream()
+                            .collect(StreamUtils.toMultiMap(Property::getKey, Property::getValue));
+                    break;
+            }
+            return requestBody;
         }
 
         /**
@@ -510,7 +522,7 @@ public class RestApiPlugin extends BasePlugin {
             return webClient
                     .method(httpMethod)
                     .uri(uri)
-                    .body(BodyInserters.fromObject(requestBody))
+                    .body(BodyInserters.fromValue(requestBody))
                     .exchange()
                     .doOnError(e -> Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, e)))
                     .flatMap(response -> {

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -71,7 +71,7 @@ public class RestApiPluginTest {
 
     @Test
     public void testEncodingFunctionWithEncodeParamsToggleTrue() throws UnsupportedEncodingException {
-        String encoded_value = pluginExecutor.convertPropertyListToReqBody(List.of(new Property("key", "valüe")),
+        Object encoded_value = pluginExecutor.convertPropertyListToReqBody(List.of(new Property("key", "valüe")),
                 "application/x-www-form-urlencoded",
                 true);
         String expected_value = null;
@@ -85,7 +85,7 @@ public class RestApiPluginTest {
 
     @Test
     public void testEncodingFunctionWithEncodeParamsToggleFalse() throws UnsupportedEncodingException {
-        String encoded_value = pluginExecutor.convertPropertyListToReqBody(List.of(new Property("key", "valüe")),
+        Object encoded_value = pluginExecutor.convertPropertyListToReqBody(List.of(new Property("key", "valüe")),
                 "application/x-www-form-urlencoded",
                 false);
         String expected_value = null;
@@ -404,4 +404,29 @@ public class RestApiPluginTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    public void testMultipartFormData() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        dsConfig.setUrl("http://httpbin.org/post");
+
+        ActionConfiguration actionConfig = new ActionConfiguration();
+        actionConfig.setHeaders(List.of(new Property("content-type", "multipart/form-data")));
+
+        actionConfig.setHttpMethod(HttpMethod.POST);
+        String requestBody = "{\"key\":\"skdjfh&kjsd\"}";
+        List<Property> formData = List.of(new Property("key", "skdjfh&kjsd"));
+        actionConfig.setBodyFormData(formData);
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+                    JsonNode data = ((ObjectNode) result.getBody()).get("form");
+                    assertEquals(requestBody, data.toString());
+                })
+                .verifyComplete();
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CurlImporterService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CurlImporterService.java
@@ -387,7 +387,7 @@ public class CurlImporterService extends BaseApiImporter {
                     final String[] parts = part.split("=", 2);
                     // Multipart form values are double quoted. Eg: "value"
                     // We trim the quotes from the beginning & end of the string
-                    String formValue = (parts.length > 1) ? parts[1].substring(1, parts[1].length() - 1) : "";
+                    String formValue = (parts.length > 1) ? parts[1].replaceAll("^\"|\"$", "") : "";
                     formPairs.add(new Property(parts[0], formValue));
                 }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CurlImporterService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CurlImporterService.java
@@ -13,7 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -33,22 +35,18 @@ public class CurlImporterService extends BaseApiImporter {
     private static final String RESTAPI_PLUGIN = "restapi-plugin";
 
     private static final String ARG_DATA = "--data";
+    private static final String ARG_FORM = "--form";
     private static final String ARG_HEADER = "--header";
     private static final String ARG_REQUEST = "--request";
     private static final String ARG_COOKIE = "--cookie";
     private static final String ARG_USER = "--user";
     private static final String ARG_USER_AGENT = "--user-agent";
 
-    private static final String CONTENT_TYPE_URLENCODED = "application/x-www-form-urlencoded";
-
-    private final NewActionService newActionService;
     private final PluginService pluginService;
     private final LayoutActionService layoutActionService;
 
-    public CurlImporterService(NewActionService newActionService,
-                               PluginService pluginService,
+    public CurlImporterService(PluginService pluginService,
                                LayoutActionService layoutActionService) {
-        this.newActionService = newActionService;
         this.pluginService = pluginService;
         this.layoutActionService = layoutActionService;
     }
@@ -215,6 +213,9 @@ public class CurlImporterService extends BaseApiImporter {
                     normalizedTokens.add(token.substring(2));
                 }
 
+            } else if ("-F".equals(token)) {
+                normalizedTokens.add(ARG_FORM);
+
             } else if ("-H".equals(token)) {
                 normalizedTokens.add(ARG_HEADER);
 
@@ -276,6 +277,7 @@ public class CurlImporterService extends BaseApiImporter {
         final List<Property> headers = new ArrayList<>();
         String contentType = null;
         final List<String> dataParts = new ArrayList<>();
+        final List<String> formParts = new ArrayList<>();
 
         String state = null;
 
@@ -309,6 +311,10 @@ public class CurlImporterService extends BaseApiImporter {
             } else if ("--data-urlencode".equals(state)) {
                 // The `token` is next to `--data-urlencode`.
                 dataParts.add(token);
+
+            } else if (ARG_FORM.equals(state)) {
+                // The token is next to --form
+                formParts.add(token);
 
             } else if (ARG_COOKIE.equals(state)) {
                 // The `token` is next to `--data-cookie`.
@@ -347,8 +353,12 @@ public class CurlImporterService extends BaseApiImporter {
         }
 
         if (contentType == null && !dataParts.isEmpty()) {
-            contentType = CONTENT_TYPE_URLENCODED;
-            headers.add(new Property("Content-Type", contentType));
+            contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+            headers.add(new Property(HttpHeaders.CONTENT_TYPE, contentType));
+
+        } else if (contentType == null && !formParts.isEmpty()) {
+            contentType = MediaType.MULTIPART_FORM_DATA_VALUE;
+            headers.add(new Property(HttpHeaders.CONTENT_TYPE, contentType));
         }
 
         if (!headers.isEmpty()) {
@@ -356,7 +366,7 @@ public class CurlImporterService extends BaseApiImporter {
         }
 
         if (!dataParts.isEmpty()) {
-            if (CONTENT_TYPE_URLENCODED.equals(contentType)) {
+            if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(contentType)) {
                 final ArrayList<Property> formPairs = new ArrayList<>();
                 actionConfiguration.setBodyFormData(formPairs);
                 for (String part : dataParts) {
@@ -367,6 +377,22 @@ public class CurlImporterService extends BaseApiImporter {
             } else {
                 actionConfiguration.setBody(StringUtils.join(dataParts, '&'));
 
+            }
+        }
+        if (!formParts.isEmpty()) {
+            if (MediaType.MULTIPART_FORM_DATA_VALUE.equals(contentType)) {
+                final ArrayList<Property> formPairs = new ArrayList<>();
+                actionConfiguration.setBodyFormData(formPairs);
+                for (String part : formParts) {
+                    final String[] parts = part.split("=", 2);
+                    // Multipart form values are double quoted. Eg: "value"
+                    // We trim the quotes from the beginning & end of the string
+                    String formValue = (parts.length > 1) ? parts[1].substring(1, parts[1].length() - 1) : "";
+                    formPairs.add(new Property(parts[0], formValue));
+                }
+
+            } else {
+                actionConfiguration.setBody(StringUtils.join(formParts, '&'));
             }
         }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -55,9 +55,6 @@ public class CurlImporterServiceTest {
     @Autowired
     UserService userService;
 
-    @Autowired
-    OrganizationService organizationService;
-
     String orgId;
 
     @Before
@@ -661,6 +658,33 @@ public class CurlImporterServiceTest {
                 action,
                 new Property("payment_intent", "pi_Aabcxyz01aDfoo"),
                 new Property("amount", "1000")
+        );
+    }
+
+    @Test
+    public void parseMultiFormData() throws AppsmithException {
+        ActionDTO action = curlImporterService.curlToAction("curl --request POST 'http://httpbin.org/post' --form 'somekey=\"value\"' --form 'anotherKey=\"anotherValue\"'");
+        assertMethod(action, HttpMethod.POST);
+        assertUrl(action, "http://httpbin.org");
+        assertPath(action, "/post");
+        assertHeaders(action, new Property("Content-Type", "multipart/form-data"));
+        assertEmptyBody(action);
+        assertBodyFormData(
+                action,
+                new Property("somekey", "value"),
+                new Property("anotherKey", "anotherValue")
+        );
+
+        action = curlImporterService.curlToAction("curl --request POST 'http://httpbin.org/post' -F 'somekey=\"value\"' -F 'anotherKey=\"anotherValue\"'");
+        assertMethod(action, HttpMethod.POST);
+        assertUrl(action, "http://httpbin.org");
+        assertPath(action, "/post");
+        assertHeaders(action, new Property("Content-Type", "multipart/form-data"));
+        assertEmptyBody(action);
+        assertBodyFormData(
+                action,
+                new Property("somekey", "value"),
+                new Property("anotherKey", "anotherValue")
         );
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -663,19 +663,9 @@ public class CurlImporterServiceTest {
 
     @Test
     public void parseMultiFormData() throws AppsmithException {
-        ActionDTO action = curlImporterService.curlToAction("curl --request POST 'http://httpbin.org/post' --form 'somekey=\"value\"' --form 'anotherKey=\"anotherValue\"'");
-        assertMethod(action, HttpMethod.POST);
-        assertUrl(action, "http://httpbin.org");
-        assertPath(action, "/post");
-        assertHeaders(action, new Property("Content-Type", "multipart/form-data"));
-        assertEmptyBody(action);
-        assertBodyFormData(
-                action,
-                new Property("somekey", "value"),
-                new Property("anotherKey", "anotherValue")
-        );
-
-        action = curlImporterService.curlToAction("curl --request POST 'http://httpbin.org/post' -F 'somekey=\"value\"' -F 'anotherKey=\"anotherValue\"'");
+        // In the curl command, we test for a combination of --form and -F
+        // Also some values are double-quoted while some aren't. This tests a permutation of all such fields
+        ActionDTO action = curlImporterService.curlToAction("curl --request POST 'http://httpbin.org/post' -F 'somekey=value' --form 'anotherKey=\"anotherValue\"'");
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://httpbin.org");
         assertPath(action, "/post");


### PR DESCRIPTION
## Description

This PR adds the functionality of `multipart/form-data` to Appsmith's API pane section. A user can now select the tab "Form-Data" in the data types under "Body". Appsmith will send a multipart form data request to the backend API.

Fixes #1586

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

For now, this has been tested manually. Will add Cypress tests as well. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/multipart-form 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 48.92 **(-0.01)** | 28.63 **(0)** | 26.76 **(-0.01)** | 49.29 **(-0.01)**
 :red_circle: | app/client/src/pages/Editor/APIEditor/PostBodyData.tsx | 51.52 **(0)** | 28.57 **(-4.76)** | 0 **(0)** | 53.13 **(0)**</details>