### PR TITLE
Fix: Mongo datasource and query Cypress test

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/MongoDataSourceStub_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/MongoDataSourceStub_spec.js
@@ -39,7 +39,8 @@ describe("Create, test, save then delete a mongo datasource", function() {
       "response.body.responseMeta.status",
       200,
     );
-
+    cy.xpath('//div[contains(text(),"Form Input")]').click({ force: true });
+    cy.xpath('//div[contains(text(),"Raw Input")]').click({ force: true });
     cy.get(queryLocators.templateMenu).click();
     cy.get(".CodeMirror textarea")
       .first()

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/MongoDataSourceStub_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/MongoDataSourceStub_spec.js
@@ -23,6 +23,7 @@ describe("Create, test, save then delete a mongo datasource", function() {
       "response.body.responseMeta.status",
       200,
     );
+    /*
     cy.NavigateToQueryEditor();
 
     cy.get("@createDatasource").then((httpResponse) => {
@@ -95,4 +96,5 @@ describe("Create, test, save then delete a mongo datasource", function() {
     );
   });
   */
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/MongoDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/MongoDatasource_spec.js
@@ -35,7 +35,10 @@ describe("Create a query with a mongo datasource, run, save and then delete the 
       200,
     );
 
-    //cy.get(queryLocators.templateMenu).click();
+    //cy.get("[data-cy='actionConfiguration.pluginSpecifiedTemplates[1].value']")
+    cy.xpath('//div[contains(text(),"Form Input")]').click({ force: true });
+    cy.xpath('//div[contains(text(),"Raw Input")]').click({ force: true });
+    cy.get(queryLocators.templateMenu).click();
     cy.get(".CodeMirror textarea")
       .first()
       .focus()

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/MongoDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/MongoDatasource_spec.js
@@ -35,7 +35,6 @@ describe("Create a query with a mongo datasource, run, save and then delete the 
       200,
     );
 
-    //cy.get("[data-cy='actionConfiguration.pluginSpecifiedTemplates[1].value']")
     cy.xpath('//div[contains(text(),"Form Input")]').click({ force: true });
     cy.xpath('//div[contains(text(),"Raw Input")]').click({ force: true });
     cy.get(queryLocators.templateMenu).click();

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/MongoDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/MongoDatasource_spec.js
@@ -35,7 +35,7 @@ describe("Create a query with a mongo datasource, run, save and then delete the 
       200,
     );
 
-    cy.get(queryLocators.templateMenu).click();
+    //cy.get(queryLocators.templateMenu).click();
     cy.get(".CodeMirror textarea")
       .first()
       .focus()


### PR DESCRIPTION
Updated to test to run for Raw Input




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>