### PR TITLE
Feature/user leave organization

### DIFF
--- a/app/client/src/components/editorComponents/EditorContextProvider.tsx
+++ b/app/client/src/components/editorComponents/EditorContextProvider.tsx
@@ -1,4 +1,4 @@
-import React, { Context, createContext, ReactNode } from "react";
+import React, { Context, createContext, ReactNode, useMemo } from "react";
 import { connect } from "react-redux";
 
 import { WidgetOperation } from "widgets/BaseWidget";
@@ -65,66 +65,58 @@ function EditorContextProvider(props: EditorContextProviderProps) {
     updateWidgetMetaProperty,
     updateWidgetProperty,
   } = props;
+
+  // Memoize the context provider to prevent
+  // unnecessary renders
+  const contextValue = useMemo(
+    () => ({
+      executeAction,
+      updateWidget,
+      updateWidgetProperty,
+      updateWidgetMetaProperty,
+      disableDrag,
+      resetChildrenMetaProperty,
+      deleteWidgetProperty,
+      batchUpdateWidgetProperty,
+    }),
+    [
+      executeAction,
+      updateWidget,
+      updateWidgetProperty,
+      updateWidgetMetaProperty,
+      disableDrag,
+      resetChildrenMetaProperty,
+      deleteWidgetProperty,
+      batchUpdateWidgetProperty,
+    ],
+  );
   return (
-    <EditorContext.Provider
-      value={{
-        executeAction,
-        updateWidget,
-        updateWidgetProperty,
-        updateWidgetMetaProperty,
-        disableDrag,
-        resetChildrenMetaProperty,
-        deleteWidgetProperty,
-        batchUpdateWidgetProperty,
-      }}
-    >
+    <EditorContext.Provider value={contextValue}>
       {children}
     </EditorContext.Provider>
   );
 }
 
-const mapDispatchToProps = (dispatch: any) => {
-  return {
-    updateWidgetProperty: (
-      widgetId: string,
-      propertyName: string,
-      propertyValue: any,
-    ) =>
-      dispatch(
-        updateWidgetPropertyRequest(
-          widgetId,
-          propertyName,
-          propertyValue,
-          RenderModes.CANVAS,
-        ),
-      ),
-    executeAction: (actionPayload: ExecuteActionPayload) =>
-      dispatch(executeAction(actionPayload)),
-    updateWidget: (
-      operation: WidgetOperation,
-      widgetId: string,
-      payload: any,
-    ) => dispatch(updateWidget(operation, widgetId, payload)),
-    updateWidgetMetaProperty: (
-      widgetId: string,
-      propertyName: string,
-      propertyValue: any,
-    ) =>
-      dispatch(updateWidgetMetaProperty(widgetId, propertyName, propertyValue)),
-    resetChildrenMetaProperty: (widgetId: string) =>
-      dispatch(resetChildrenMetaProperty(widgetId)),
-    disableDrag: (disable: boolean) => {
-      dispatch(disableDragAction(disable));
-    },
-    deleteWidgetProperty: (widgetId: string, propertyPaths: string[]) =>
-      dispatch(deletePropertyAction(widgetId, propertyPaths)),
-    batchUpdateWidgetProperty: (
-      widgetId: string,
-      updates: BatchPropertyUpdatePayload,
-    ) => {
-      dispatch(batchUpdatePropertyAction(widgetId, updates));
-    },
-  };
+const mapDispatchToProps = {
+  updateWidgetProperty: (
+    widgetId: string,
+    propertyName: string,
+    propertyValue: any,
+  ) =>
+    updateWidgetPropertyRequest(
+      widgetId,
+      propertyName,
+      propertyValue,
+      RenderModes.CANVAS,
+    ),
+
+  executeAction,
+  updateWidget,
+  updateWidgetMetaProperty,
+  resetChildrenMetaProperty,
+  disableDrag: disableDragAction,
+  deleteWidgetProperty: deletePropertyAction,
+  batchUpdateWidgetProperty: batchUpdatePropertyAction,
 };
 
 export default connect(null, mapDispatchToProps)(EditorContextProvider);

--- a/app/client/src/components/editorComponents/ResizableComponent.tsx
+++ b/app/client/src/components/editorComponents/ResizableComponent.tsx
@@ -43,8 +43,9 @@ export type ResizableComponentProps = WidgetProps & {
   paddingOffset: number;
 };
 
-/* eslint-disable react/display-name */
-export const ResizableComponent = memo((props: ResizableComponentProps) => {
+export const ResizableComponent = memo(function ResizableComponent(
+  props: ResizableComponentProps,
+) {
   const resizableRef = useRef<HTMLDivElement>(null);
   // Fetch information from the context
   const { updateWidget } = useContext(EditorContext);

--- a/app/client/src/components/editorComponents/ResizableComponent.tsx
+++ b/app/client/src/components/editorComponents/ResizableComponent.tsx
@@ -110,15 +110,18 @@ export const ResizableComponent = memo(function ResizableComponent(
     possibleBoundingElements.length > 0
       ? possibleBoundingElements[0]
       : undefined;
-  const boundingElementClientRect = boundingElement
-    ? boundingElement.getBoundingClientRect()
-    : undefined;
 
   // onResize handler
   // Checks if the current resize position has any collisions
   // If yes, set isColliding flag to true.
   // If no, set isColliding flag to false.
   const isColliding = (newDimensions: UIElementSize, position: XYCoord) => {
+    // Moving the bounding element calculations inside
+    // to make this expensive operation only whne
+    const boundingElementClientRect = boundingElement
+      ? boundingElement.getBoundingClientRect()
+      : undefined;
+
     const bottom =
       props.topRow +
       position.y / props.parentRowSpace +

--- a/app/client/src/pages/organization/Members.tsx
+++ b/app/client/src/pages/organization/Members.tsx
@@ -130,12 +130,6 @@ export default function MemberSettings(props: PageProps) {
       accessor: "delete",
       disableSortBy: true,
       Cell: function DeleteCell(cellProps: any) {
-        if (
-          cellProps.cell.row.values.username ===
-          useSelector(getCurrentUser)?.username
-        ) {
-          return null;
-        }
         return (
           <Icon
             cypressSelector="t--deleteUser"

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
@@ -90,6 +90,12 @@ public class UserController extends BaseController<UserService, User, String> {
                 .map(user -> new ResponseDTO<>(HttpStatus.OK.value(), user, null));
     }
 
+    @DeleteMapping("/organization/{orgId}")
+    public Mono<ResponseDTO<User>> leaveOrganization(@PathVariable String orgId) {
+        return userOrganizationService.leaveOrganization(orgId)
+                .map(user -> new ResponseDTO<>(HttpStatus.OK.value(), user, null));
+    }
+
     /**
      * This function initiates the process to reset a user's password. We require the Origin header from the request
      * in order to construct client facing URLs that will be sent to the user over email.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -61,6 +61,7 @@ public enum AppsmithError {
     GENERIC_BAD_REQUEST(400, 4028, "Bad Request: {0}", AppsmithErrorAction.DEFAULT, null),
     VALIDATION_FAILURE(400, 4028, "Validation Failure(s): {0}", AppsmithErrorAction.DEFAULT, null),
     INVALID_CURL_COMMAND(400, 4029, "Invalid cURL command, couldn't import.", AppsmithErrorAction.DEFAULT, null),
+    REMOVE_LAST_ORG_ADMIN_ERROR(400, 4037, "The last admin can not be removed from an organization", AppsmithErrorAction.DEFAULT, null),
     INTERNAL_SERVER_ERROR(500, 5000, "Internal server error while processing request", AppsmithErrorAction.LOG_EXTERNALLY, null),
     REPOSITORY_SAVE_FAILED(500, 5001, "Failed to save the repository. Try again.", AppsmithErrorAction.DEFAULT, null),
     PLUGIN_INSTALLATION_FAILED_DOWNLOAD_ERROR(500, 5002, "Plugin installation failed due to an error while " +

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationService.java
@@ -16,7 +16,7 @@ public interface UserOrganizationService {
 
     Mono<Organization> addUserToOrganizationGivenUserObject(Organization organization, User user, UserRole userRole);
 
-    Mono<Organization> removeUserRoleFromOrganization(String orgId, UserRole userRole);
+    Mono<User> leaveOrganization(String orgId);
 
     Mono<Organization> removeUserRoleFromOrganizationGivenUserObject(Organization organization, User user);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationServiceImpl.java
@@ -20,7 +20,6 @@ import com.appsmith.server.notifications.EmailSender;
 import com.appsmith.server.repositories.OrganizationRepository;
 import com.appsmith.server.repositories.UserDataRepository;
 import com.appsmith.server.repositories.UserRepository;
-import com.mongodb.client.result.UpdateResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
@@ -53,7 +52,8 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
     public UserOrganizationServiceImpl(SessionUserService sessionUserService,
                                        OrganizationRepository organizationRepository,
                                        UserRepository userRepository,
-                                       UserDataRepository userDataRepository, PolicyUtils policyUtils,
+                                       UserDataRepository userDataRepository,
+                                       PolicyUtils policyUtils,
                                        EmailSender emailSender) {
         this.sessionUserService = sessionUserService;
         this.organizationRepository = organizationRepository;
@@ -191,15 +191,23 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
     }
 
     @Override
-    public Mono<Organization> removeUserRoleFromOrganization(String orgId, UserRole userRole) {
-        Mono<Organization> organizationMono = organizationRepository.findById(orgId, MANAGE_ORGANIZATIONS);
-        Mono<User> userMono = userRepository.findByEmail(userRole.getUsername());
+    public Mono<User> leaveOrganization(String orgId) {
+        Mono<Organization> organizationMono = organizationRepository.findById(orgId);
+        Mono<User> userMono = sessionUserService.getCurrentUser()
+                    .flatMap(user1 -> userRepository.findByEmail(user1.getUsername()));
 
         return Mono.zip(organizationMono, userMono)
                 .flatMap(tuple -> {
                     Organization organization = tuple.getT1();
                     User user = tuple.getT2();
-                    return removeUserRoleFromOrganizationGivenUserObject(organization, user);
+
+                    UserRole userRole = new UserRole();
+                    userRole.setUsername(user.getUsername());
+
+                    user.getOrganizationIds().remove(organization.getId());
+                    return this.updateMemberRole(
+                            organization, user, userRole, user, null
+                    ).thenReturn(user);
                 });
     }
 
@@ -254,6 +262,83 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
                 });
     }
 
+    private Mono<UserRole> updateMemberRole(Organization organization, User user, UserRole userRole, User currentUser, String originHeader) {
+        List<UserRole> userRoles = organization.getUserRoles();
+
+        // count how many admins are there is this organization
+        long orgAdminCount = userRoles.stream().filter(
+                userRole1 -> userRole1.getRole() == AppsmithRole.ORGANIZATION_ADMIN
+        ).count();
+
+        for (UserRole role : userRoles) {
+            if (role.getUsername().equals(userRole.getUsername())) {
+                // User found in the organization.
+
+                if (role.getRole().equals(userRole.getRole())) {
+                    // No change in the role. Do nothing.
+                    return Mono.just(userRole);
+                } else if(role.getRole().equals(AppsmithRole.ORGANIZATION_ADMIN)) {
+                    // user is currently admin, check if this user is the only admin
+                    if(orgAdminCount == 1) {
+                        return Mono.error(new AppsmithException(AppsmithError.REMOVE_LAST_ORG_ADMIN_ERROR));
+                    }
+                }
+
+                // Step 1. Remove the existing role of the user from the organization
+                Mono<Organization> userRemovedOrganizationMono = this.removeUserRoleFromOrganizationGivenUserObject(organization, user);
+
+                // Step 2. Add the new role (if present) to the organization for the user
+                Mono<Organization> finalUpdatedOrganizationMono = userRemovedOrganizationMono;
+                if (userRole.getRoleName() != null) {
+                    // If a userRole name has been specified, then it means that the user's role has been modified.
+                    Mono<Organization> userAddedToOrganizationMono = userRemovedOrganizationMono
+                            .flatMap(organization1 -> this.addUserToOrganizationGivenUserObject(organization1, user, userRole));
+                    finalUpdatedOrganizationMono = userAddedToOrganizationMono.flatMap(addedOrganization -> {
+
+                        Map<String, String> params = new HashMap<>();
+                        params.put("Inviter_First_Name", currentUser.getName());
+                        params.put("inviter_org_name", organization.getName());
+                        params.put("inviteUrl", originHeader);
+                        params.put("user_role_name", userRole.getRoleName());
+
+                        Mono<Boolean> emailMono = emailSender.sendMail(user.getEmail(),
+                                "Appsmith: Your Role has been changed",
+                                UPDATE_ROLE_EXISTING_USER_TEMPLATE, params);
+                        return emailMono
+                                .thenReturn(addedOrganization);
+                    });
+                } else {
+                    // If the roleName was not present, then it implies that the user is being removed from the org.
+                    // Since at this point we have already removed the user from the organization,
+                    // remove the organization from recent org list of UserData
+                    // we also need to remove the org id from User.orgIdList
+                    finalUpdatedOrganizationMono = userRemovedOrganizationMono.flatMap(userDataRepository
+                            .removeOrgFromRecentlyUsedList(user.getId(), organization.getId())::thenReturn)
+                            .flatMap(organization1 -> {
+                                    if(user.getOrganizationIds() != null) {
+                                        user.getOrganizationIds().remove(organization.getId());
+                                        return userRepository.save(user).thenReturn(organization1);
+                                    }
+                                    return Mono.just(user).thenReturn(organization1);
+                            });
+                }
+
+                return finalUpdatedOrganizationMono.thenReturn(userRole);
+            }
+        }
+        // The user was not found in the organization. Return an error
+        return Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.USER, user.getUsername()
+                + " in the organization " + organization.getName()));
+    }
+
+    /**
+     * This method is used when an admin of an organization changes the role or removes a member.
+     * Admin user can also remove himself from the organization, if there is another admin there in the organization.
+     * @param orgId ID of the organization
+     * @param userRole updated role of the target member. userRole.roleName will be null when removing a member
+     * @param originHeader
+     * @return The updated UserRole
+     */
     @Override
     public Mono<UserRole> updateRoleForMember(String orgId, UserRole userRole, String originHeader) {
         if (userRole.getUsername() == null) {
@@ -272,58 +357,7 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
                     Organization organization = tuple.getT1();
                     User user = tuple.getT2();
                     User currentUser = tuple.getT3();
-
-                    if (user.getUsername().equals(currentUser.getUsername())) {
-                        // The user is trying to change its own role. Disallow the same.
-                        return Mono.error(new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION));
-                    }
-
-                    List<UserRole> userRoles = organization.getUserRoles();
-                    for (UserRole role : userRoles) {
-                        if (role.getUsername().equals(userRole.getUsername())) {
-                            // User found in the organization.
-
-                            if (role.getRole().equals(userRole)) {
-                                // No change in the role. Do nothing.
-                                Mono.just(userRole);
-                            }
-
-                            // Step 1. Remove the existing role of the user from the organization
-                            Mono<Organization> userRemovedOrganizationMono = this.removeUserRoleFromOrganizationGivenUserObject(organization, user);
-                            // Step 2. Add the new role (if present) to the organization for the user
-                            Mono<Organization> finalUpdatedOrganizationMono = userRemovedOrganizationMono;
-                            if (userRole.getRoleName() != null) {
-                                // If a userRole name has been specified, then it means that the user's role has been modified.
-                                Mono<Organization> userAddedToOrganizationMono = userRemovedOrganizationMono
-                                        .flatMap(organization1 -> this.addUserToOrganizationGivenUserObject(organization1, user, userRole));
-                                finalUpdatedOrganizationMono = userAddedToOrganizationMono.flatMap(addedOrganization -> {
-                                    
-                                    Map<String, String> params = new HashMap<>();
-                                    params.put("Inviter_First_Name", currentUser.getName());
-                                    params.put("inviter_org_name", organization.getName());
-                                    params.put("inviteUrl", originHeader);
-                                    params.put("user_role_name", userRole.getRoleName());
-
-                                    Mono<Boolean> emailMono = emailSender.sendMail(user.getEmail(),
-                                        "Appsmith: Your Role has been changed",
-                                        UPDATE_ROLE_EXISTING_USER_TEMPLATE, params);
-                                    return emailMono
-                                           .thenReturn(addedOrganization);
-                                });
-                            } else {
-                                // If the roleName was not present, then it implies that the user is being removed from the org.
-                                // Since at this point we have already removed the user from the organization, we dont need to do anything else.
-                                // remove the organization from recent org list of UserData
-                                finalUpdatedOrganizationMono = userRemovedOrganizationMono.flatMap(userDataRepository
-                                        .removeOrgFromRecentlyUsedList(user.getId(), organization.getId())::thenReturn);
-                            }
-
-                            return finalUpdatedOrganizationMono.thenReturn(userRole);
-                        }
-                    }
-                    // The user was not found in the organization. Return an error
-                    return Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.USER, user.getUsername()
-                            + " in the organization " + organization.getName()));
+                    return this.updateMemberRole(organization, user, userRole, currentUser, originHeader);
                 });
     }
 
@@ -371,7 +405,7 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
         Map<String, Policy> actionPolicyMap = policyUtils.generateInheritedPoliciesFromSourcePolicies(pagePolicyMap, Page.class, Action.class);
 
         //Now update the organization policies
-        Organization updatedOrganization = (Organization) policyUtils.addPoliciesToExistingObject(orgPolicyMap, organization);
+        Organization updatedOrganization = policyUtils.addPoliciesToExistingObject(orgPolicyMap, organization);
         updatedOrganization.setUserRoles(userRoles);
 
         // Update the underlying application/page/action
@@ -380,7 +414,6 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
                 .cache();
         Flux<NewPage> updatedPagesFlux = updatedApplicationsFlux
                 .flatMap(application -> policyUtils.updateWithApplicationPermissionsToAllItsPages(application.getId(), pagePolicyMap, true));
-
         Flux<NewAction> updatedActionsFlux = updatedApplicationsFlux
                 .flatMap(application -> policyUtils.updateWithPagePermissionsToAllItsActions(application.getId(), actionPolicyMap, true));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserOrganizationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserOrganizationServiceTest.java
@@ -1,0 +1,184 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.acl.AppsmithRole;
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.domains.Organization;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.domains.UserRole;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.repositories.OrganizationRepository;
+import com.appsmith.server.repositories.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@DirtiesContext
+class UserOrganizationServiceTest {
+
+    @Autowired
+    private UserOrganizationService userOrganizationService;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Organization organization;
+    private User user;
+
+    @BeforeEach
+    public void setup() {
+        Organization org = new Organization();
+        org.setName("Test org");
+
+        UserRole userRole = new UserRole();
+        userRole.setUsername("dummy_username");
+        userRole.setUserId("dummy_user_id");
+        userRole.setName("dummy_username");
+        userRole.setRoleName(AppsmithRole.ORGANIZATION_DEVELOPER.getName());
+        userRole.setRole(AppsmithRole.ORGANIZATION_DEVELOPER);
+
+        List<UserRole> userRoles = new ArrayList<>();
+        userRoles.add(userRole);
+        org.setUserRoles(userRoles);
+
+        this.organization = organizationRepository.save(org).block();
+    }
+
+    @AfterEach
+    public void clear() {
+        User currentUser = userRepository.findByEmail("api_user").block();
+        currentUser.getOrganizationIds().remove(organization.getId());
+        userRepository.save(currentUser);
+
+        organizationRepository.deleteById(organization.getId()).block();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    void leaveOrganization_WhenUserExistsInOrg_RemovesUser() {
+        User currentUser = userRepository.findByEmail("api_user").block();
+        Set<String> organizationIdsBefore = Set.copyOf(currentUser.getOrganizationIds());
+
+        List<UserRole> userRolesBeforeAddUser = List.copyOf(organization.getUserRoles());
+
+        currentUser.getOrganizationIds().add(organization.getId());
+        userRepository.save(currentUser).block();
+
+        UserRole userRole = new UserRole();
+        userRole.setUsername(currentUser.getUsername());
+        userRole.setUserId(currentUser.getId());
+        userRole.setName(currentUser.getName());
+        userRole.setRoleName(AppsmithRole.ORGANIZATION_DEVELOPER.getName());
+
+        Organization updatedOrganization = userOrganizationService.addUserToOrganizationGivenUserObject(
+                this.organization, currentUser, userRole
+        ).block();
+
+        Mono<User> userMono = userOrganizationService.leaveOrganization(this.organization.getId());
+        StepVerifier.create(userMono).assertNext(user -> {
+            assertEquals("api_user", user.getEmail());
+            assertEquals(organizationIdsBefore, user.getOrganizationIds());
+        }).verifyComplete();
+
+        StepVerifier.create(organizationRepository.findById(this.organization.getId())).assertNext(organization1 -> {
+            assertEquals(userRolesBeforeAddUser.size(), organization1.getUserRoles().size());
+        }).verifyComplete();
+
+        StepVerifier.create(userRepository.findByEmail("api_user")).assertNext(user1 -> {
+            assertFalse(
+                    "user's orgId list should not have left org id",
+                    user1.getOrganizationIds().contains(this.organization.getId())
+            );
+        }).verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    void leaveOrganization_WhenUserDoesNotExistInOrg_ThrowsException() {
+        Mono<User> userMono = userOrganizationService.leaveOrganization(this.organization.getId());
+        StepVerifier.create(userMono).expectErrorMessage(
+                AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.USER + " api_user in the organization", organization.getName())
+        ).verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void updateRoleForMember_WhenAdminRoleRemovedWithNoOtherAdmin_ThrowsExceptions() {
+        // add the current user as an admin to the organization first
+        User currentUser = userRepository.findByEmail("api_user").block();
+        UserRole userRole = new UserRole();
+        userRole.setUsername(currentUser.getUsername());
+        userRole.setRole(AppsmithRole.ORGANIZATION_DEVELOPER);
+        userRole.setRoleName(AppsmithRole.ORGANIZATION_ADMIN.getName());
+
+        userOrganizationService.addUserToOrganizationGivenUserObject(organization, currentUser, userRole).block();
+
+        // try to remove the user from org
+        UserRole updatedRole = new UserRole();
+        updatedRole.setUsername(currentUser.getUsername());
+
+        Mono<UserRole> userRoleMono = userOrganizationService.updateRoleForMember(organization.getId(), updatedRole, null);
+        StepVerifier.create(userRoleMono).expectErrorMessage(
+                AppsmithError.REMOVE_LAST_ORG_ADMIN_ERROR.getMessage()
+        ).verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void updateRoleForMember_WhenAdminRoleRemovedButOtherAdminExists_MemberRemoved() {
+        // add another admin role to the organization
+        UserRole adminRole = new UserRole();
+        adminRole.setUsername("dummy_username2");
+        adminRole.setUserId("dummy_user_id2");
+        adminRole.setName("dummy_username2");
+        adminRole.setRoleName(AppsmithRole.ORGANIZATION_ADMIN.getName());
+        adminRole.setRole(AppsmithRole.ORGANIZATION_ADMIN);
+        this.organization.getUserRoles().add(adminRole);
+
+        this.organization = organizationRepository.save(this.organization).block();
+
+        // add the current user as an admin to the organization
+        User currentUser = userRepository.findByEmail("api_user").block();
+        UserRole userRole = new UserRole();
+        userRole.setUsername(currentUser.getUsername());
+        userRole.setRole(AppsmithRole.ORGANIZATION_ADMIN);
+        userRole.setRoleName(AppsmithRole.ORGANIZATION_ADMIN.getName());
+
+        userOrganizationService.addUserToOrganizationGivenUserObject(organization, currentUser, userRole).block();
+
+        // try to remove the user from org
+        UserRole updatedRole = new UserRole();
+        updatedRole.setUsername(currentUser.getUsername());
+
+        Mono<UserRole> userRoleMono = userOrganizationService.updateRoleForMember(organization.getId(), updatedRole, null);
+        StepVerifier.create(userRoleMono).assertNext(
+                userRole1 -> {
+                    assertEquals(currentUser.getUsername(), userRole1.getUsername());
+                }
+        ).verifyComplete();
+    }
+}


### PR DESCRIPTION
## Description
Currently, an admin user can not remove himself from an organization. He can only remove other members. After this change, admin users will be able to remove themselves also if there is minimum one admin.

Also added an API so that any user can leave an organization no matter what role he has. Currently only admin users can access the members page and hence can leave an organization.

Fixes # (issue)
Issue #4572 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>