### PR TITLE
FIX #4573 : added custom fusion chart config to override default message

### DIFF
--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -541,6 +541,12 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       },
       xAxisName: "Last Week",
       yAxisName: "Total Order Revenue $",
+      customFusionChartConfig: {
+        config: {
+          type: "",
+          dataSource: {},
+        },
+      },
     },
     FORM_BUTTON_WIDGET: {
       rows: 1 * GRID_DENSITY_MIGRATION_V1,

--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -542,9 +542,49 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       xAxisName: "Last Week",
       yAxisName: "Total Order Revenue $",
       customFusionChartConfig: {
-        config: {
-          type: "",
-          dataSource: {},
+        type: "column2d",
+        dataSource: {
+          chart: {
+            caption: "Monthly revenue for last year",
+            subCaption: "Harry's SuperMart",
+            xAxisName: "Month",
+            yAxisName: "Revenues (In USD)",
+            numberPrefix: "$",
+            theme: "fusion",
+          },
+          data: [
+            {
+              label: "Jan",
+              value: "420000",
+            },
+            {
+              label: "Feb",
+              value: "810000",
+            },
+            {
+              label: "Mar",
+              value: "720000",
+            },
+            {
+              label: "Apr",
+              value: "550000",
+            },
+            {
+              label: "May",
+              value: "910000",
+            },
+          ],
+          trendlines: [
+            {
+              line: [
+                {
+                  startvalue: "700000",
+                  valueOnRight: "1",
+                  displayvalue: "Monthly Target",
+                },
+              ],
+            },
+          ],
         },
       },
     },

--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -545,42 +545,48 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
         type: "column2d",
         dataSource: {
           chart: {
-            caption: "Monthly revenue for last year",
-            subCaption: "Harry's SuperMart",
-            xAxisName: "Month",
-            yAxisName: "Revenues (In USD)",
-            numberPrefix: "$",
+            caption: "Last week's revenue",
+            xAxisName: "Last Week",
+            yAxisName: "Total Order Revenue $",
             theme: "fusion",
           },
           data: [
             {
-              label: "Jan",
-              value: "420000",
+              label: "Mon",
+              value: 10000,
             },
             {
-              label: "Feb",
-              value: "810000",
+              label: "Tue",
+              value: 12000,
             },
             {
-              label: "Mar",
-              value: "720000",
+              label: "Wed",
+              value: 32000,
             },
             {
-              label: "Apr",
-              value: "550000",
+              label: "Thu",
+              value: 28000,
             },
             {
-              label: "May",
-              value: "910000",
+              label: "Fri",
+              value: 14000,
+            },
+            {
+              label: "Sat",
+              value: 19000,
+            },
+            {
+              label: "Sun",
+              value: 36000,
             },
           ],
           trendlines: [
             {
               line: [
                 {
-                  startvalue: "700000",
+                  startvalue: "38000",
                   valueOnRight: "1",
-                  displayvalue: "Monthly Target",
+                  displayvalue: "Weekly Target",
                 },
               ],
             },

--- a/app/client/src/widgets/ChartWidget/index.tsx
+++ b/app/client/src/widgets/ChartWidget/index.tsx
@@ -92,7 +92,7 @@ export interface ChartData {
 export interface ChartWidgetProps extends WidgetProps, WithMeta {
   chartType: ChartType;
   chartData: AllChartData;
-  customFusionChartConfig: { config: CustomFusionChartConfig };
+  customFusionChartConfig: CustomFusionChartConfig;
   xAxisName: string;
   yAxisName: string;
   chartName: string;


### PR DESCRIPTION
## Description
When the User drag and drop the Chart widget->and select the custom chart from chart type->the "chart type not supported text" is displayed. Added a default config to resolve it.

Fixes #4573 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> tested locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>