### PR TITLE
Removed check for encryption since this is not handled manually anymore

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -43,9 +43,6 @@ public class AuthenticationDTO implements AppsmithDomain {
 
     Set<Property> customAuthenticationParameters;
 
-    @JsonIgnore
-    private Boolean isEncrypted;
-
     private Boolean isAuthorized;
 
     @JsonIgnore

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
@@ -83,7 +83,7 @@ public class GoogleSheetsPlugin extends BasePlugin {
 
             // Authentication will already be valid at this point
             final OAuth2 oauth2 = (OAuth2) datasourceConfiguration.getAuthentication();
-            assert (!oauth2.getIsEncrypted() && oauth2.getAuthenticationResponse() != null);
+            assert (oauth2.getAuthenticationResponse() != null);
 
             // Triggering the actual REST API call
             return method.executePrerequisites(methodConfig, oauth2)

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ClientCredentialsTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/OAuth2ClientCredentialsTest.java
@@ -36,7 +36,6 @@ public class OAuth2ClientCredentialsTest {
         AuthenticationResponse authenticationResponse = new AuthenticationResponse();
         oAuth2.setIsTokenHeader(true);
         authenticationResponse.setToken("SomeToken");
-        oAuth2.setIsEncrypted(false);
         authenticationResponse.setExpiresAt(Instant.now().plusSeconds(1200));
         oAuth2.setAuthenticationResponse(authenticationResponse);
         OAuth2ClientCredentials connection = OAuth2ClientCredentials.create(oAuth2).block(Duration.ofMillis(100));
@@ -51,7 +50,6 @@ public class OAuth2ClientCredentialsTest {
         AuthenticationResponse authenticationResponse = new AuthenticationResponse();
         oAuth2.setIsTokenHeader(true);
         authenticationResponse.setToken("SomeToken");
-        oAuth2.setIsEncrypted(false);
         authenticationResponse.setExpiresAt(Instant.now().plusSeconds(1200));
         oAuth2.setAuthenticationResponse(authenticationResponse);
         OAuth2ClientCredentials connection = OAuth2ClientCredentials.create(oAuth2).block(Duration.ofMillis(100));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -1509,25 +1509,25 @@ public class DatabaseChangelog {
         });
     }
 
-    @ChangeSet(order = "046", id = "ensure-encrypted-field-for-datasources", author = "")
-    public void ensureIsEncryptedFieldForDatasources(MongoTemplate mongoTemplate) {
-        final String isEncryptedField = "datasourceConfiguration.authentication.isEncrypted";
-        final String passwordField = "datasourceConfiguration.authentication.password";
-
-        final org.springframework.data.mongodb.core.query.Query query = query(new Criteria().andOperator(
-                where(passwordField).exists(true),
-                where(isEncryptedField).exists(false)
-        ));
-        query.fields().include("_id");
-
-        for (final Datasource datasource : mongoTemplate.find(query, Datasource.class)) {
-            mongoTemplate.updateFirst(
-                    query(where(fieldName(QDatasource.datasource.id)).is(datasource.getId())),
-                    update(isEncryptedField, true),
-                    Datasource.class
-            );
-        }
-    }
+//    @ChangeSet(order = "046", id = "ensure-encrypted-field-for-datasources", author = "")
+//    public void ensureIsEncryptedFieldForDatasources(MongoTemplate mongoTemplate) {
+//        final String isEncryptedField = "datasourceConfiguration.authentication.isEncrypted";
+//        final String passwordField = "datasourceConfiguration.authentication.password";
+//
+//        final org.springframework.data.mongodb.core.query.Query query = query(new Criteria().andOperator(
+//                where(passwordField).exists(true),
+//                where(isEncryptedField).exists(false)
+//        ));
+//        query.fields().include("_id");
+//
+//        for (final Datasource datasource : mongoTemplate.find(query, Datasource.class)) {
+//            mongoTemplate.updateFirst(
+//                    query(where(fieldName(QDatasource.datasource.id)).is(datasource.getId())),
+//                    update(isEncryptedField, true),
+//                    Datasource.class
+//            );
+//        }
+//    }
 
     @ChangeSet(order = "047", id = "add-isSendSessionEnabled-key-for-datasources", author = "")
     public void addIsSendSessionEnabledPropertyInDatasources(MongoTemplate mongoTemplate) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -1509,26 +1509,6 @@ public class DatabaseChangelog {
         });
     }
 
-//    @ChangeSet(order = "046", id = "ensure-encrypted-field-for-datasources", author = "")
-//    public void ensureIsEncryptedFieldForDatasources(MongoTemplate mongoTemplate) {
-//        final String isEncryptedField = "datasourceConfiguration.authentication.isEncrypted";
-//        final String passwordField = "datasourceConfiguration.authentication.password";
-//
-//        final org.springframework.data.mongodb.core.query.Query query = query(new Criteria().andOperator(
-//                where(passwordField).exists(true),
-//                where(isEncryptedField).exists(false)
-//        ));
-//        query.fields().include("_id");
-//
-//        for (final Datasource datasource : mongoTemplate.find(query, Datasource.class)) {
-//            mongoTemplate.updateFirst(
-//                    query(where(fieldName(QDatasource.datasource.id)).is(datasource.getId())),
-//                    update(isEncryptedField, true),
-//                    Datasource.class
-//            );
-//        }
-//    }
-
     @ChangeSet(order = "047", id = "add-isSendSessionEnabled-key-for-datasources", author = "")
     public void addIsSendSessionEnabledPropertyInDatasources(MongoTemplate mongoTemplate) {
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
@@ -215,8 +215,6 @@ public class AuthenticationService {
                                     oAuth2.setScopeString("");
                                 }
                                 oAuth2.setAuthenticationResponse(authenticationResponse);
-                                // Resetting encryption
-                                oAuth2.setIsEncrypted(null);
                                 datasource.getDatasourceConfiguration().setAuthentication(oAuth2);
                                 return datasourceService.update(datasource.getId(), datasource);
                             });
@@ -369,7 +367,6 @@ public class AuthenticationService {
                                         .setAuthenticationStatus(AuthenticationDTO.AuthenticationStatus.SUCCESS);
                                 OAuth2 oAuth2 = (OAuth2) datasource.getDatasourceConfiguration().getAuthentication();
                                 oAuth2.setAuthenticationResponse(authenticationResponse);
-                                oAuth2.setIsEncrypted(null);
                                 datasource.getDatasourceConfiguration().setAuthentication(oAuth2);
                                 return Mono.just(datasource);
                             });
@@ -420,7 +417,6 @@ public class AuthenticationService {
                             })
                             .flatMap(authenticationResponse -> {
                                 oAuth2.setAuthenticationResponse(authenticationResponse);
-                                oAuth2.setIsEncrypted(null);
                                 datasource.getDatasourceConfiguration().setAuthentication(oAuth2);
                                 // We return the same object instead of the update value because the updates value
                                 // will be in the encrypted form

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -469,7 +469,6 @@ public class DatasourceServiceTest {
 
         Mono<DatasourceTestResult> testResultMono = datasourceMono.flatMap(datasource1 -> {
             ((DBAuth) datasource1.getDatasourceConfiguration().getAuthentication()).setPassword(null);
-            datasource1.getDatasourceConfiguration().getAuthentication().setIsEncrypted(false);
             return datasourceService.testDatasource(datasource1);
         });
 
@@ -618,8 +617,6 @@ public class DatasourceServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void checkEncryptionOfAuthenticationDTONullPassword() {
-        // For this test, all fields that are meant to be encrypted are going to be empty
-        // In such a scenario, we want the isEncrypted field to be in an inactive state, that is, null
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
 
         Mono<Plugin> pluginMono = pluginService.findByName("Installed Plugin Name");


### PR DESCRIPTION
This check removes the references to the redundant field `isEncrypted`. The value for this would always be false within the server now because all encryption logic has been moved to the database interface.