### PR TITLE
Added optional audience and resource fields for oauth2 datasources

### DIFF
--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -33,6 +33,8 @@ export interface Oauth2Common {
   headerPrefix: string;
   scopeString: string;
   isTokenHeader: boolean;
+  audience: string;
+  resource: string;
 }
 
 export interface ClientCredentials extends Oauth2Common {

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -687,7 +687,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             ]}
           />
         </FormInputContainer>
-        {!_.get(formData.authentication, "isAuthorizationHeader") &&
+        {!_.get(formData.authentication, "isAuthorizationHeader", true) &&
           this.renderOauth2CommonAdvanced()}
         <FormInputContainer>
           <AuthorizeButton

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -604,12 +604,35 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
     );
   };
 
+  renderOauth2CommonAdvanced = () => {
+    return (
+      <>
+        <FormInputContainer>
+          <InputTextControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.audience"
+            label="Audience"
+            placeholderText="https://example.com/oauth/audience"
+          />
+        </FormInputContainer>
+        <FormInputContainer>
+          <InputTextControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.resource"
+            label="Resource"
+            placeholderText="https://example.com/oauth/resource"
+          />
+        </FormInputContainer>
+      </>
+    );
+  };
+
   renderOauth2ClientCredentials = () => {
     return this.renderOauth2Common();
   };
 
   renderOauth2AuthorizationCode = () => {
-    const { datasource, datasourceId, isSaving, pageId } = this.props;
+    const { datasource, datasourceId, formData, isSaving, pageId } = this.props;
     const isAuthorized = _.get(
       datasource,
       "datasourceConfiguration.authentication.isAuthorized",
@@ -664,6 +687,8 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             ]}
           />
         </FormInputContainer>
+        {!_.get(formData.authentication, "isAuthorizationHeader") &&
+          this.renderOauth2CommonAdvanced()}
         <FormInputContainer>
           <AuthorizeButton
             disabled={this.disableSave()}

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -84,6 +84,8 @@ const formToDatasourceAuthentication = (
       scopeString: authentication.scopeString,
       clientSecret: authentication.clientSecret,
       isTokenHeader: authentication.isTokenHeader,
+      audience: authentication.audience,
+      resource: authentication.resource,
     };
     if (isClientCredentials(authType, authentication)) {
       return {
@@ -140,6 +142,8 @@ const datasourceToFormAuthentication = (
       scopeString: authentication.scopeString || "",
       clientSecret: authentication.clientSecret,
       isTokenHeader: !!authentication.isTokenHeader,
+      audience: authentication.audience || "",
+      resource: authentication.resource || "",
     };
     if (isClientCredentials(authType, authentication)) {
       return {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -23,6 +23,8 @@ public class Authentication {
     public static final String AUTHORIZATION_URL = "authorization_url";
     public static final String ACCESS_TOKEN_URL = "access_token_url";
     public static final String RESPONSE_TYPE = "response_type";
+    public static final String AUDIENCE = "audience";
+    public static final String RESOURCE = "resource";
 
     // Request parameter values
     public static final String AUTHORIZATION_CODE = "authorization_code";

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -60,6 +60,10 @@ public class OAuth2 extends AuthenticationDTO {
 
     Set<Property> customTokenParameters;
 
+    String audience;
+
+    String resource;
+
     public String getScopeString() {
         if (scopeString != null && !scopeString.isBlank()) {
             return scopeString;

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
@@ -171,7 +171,14 @@ public class OAuth2AuthorizationCode extends APIConnection implements UpdatableC
                 .with(Authentication.CLIENT_ID, oAuth2.getClientId())
                 .with(Authentication.CLIENT_SECRET, oAuth2.getClientSecret())
                 .with(Authentication.REFRESH_TOKEN, oAuth2.getAuthenticationResponse().getRefreshToken());
-
+        // Adding optional audience parameter
+        if (oAuth2.getAudience() != null && !oAuth2.getAudience().isBlank()) {
+            body.with(Authentication.AUDIENCE, oAuth2.getAudience());
+        }
+        // Adding optional resource parameter
+        if (oAuth2.getResource() != null && !oAuth2.getResource().isBlank()) {
+            body.with(Authentication.RESOURCE, oAuth2.getResource());
+        }
         // Optionally add scope, if applicable
         if (!CollectionUtils.isEmpty(oAuth2.getScope())) {
             body.with(Authentication.SCOPE, StringUtils.collectionToDelimitedString(oAuth2.getScope(), " "));

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
@@ -172,11 +172,11 @@ public class OAuth2AuthorizationCode extends APIConnection implements UpdatableC
                 .with(Authentication.CLIENT_SECRET, oAuth2.getClientSecret())
                 .with(Authentication.REFRESH_TOKEN, oAuth2.getAuthenticationResponse().getRefreshToken());
         // Adding optional audience parameter
-        if (oAuth2.getAudience() != null && !oAuth2.getAudience().isBlank()) {
+        if (!StringUtils.isEmpty(oAuth2.getAudience())) {
             body.with(Authentication.AUDIENCE, oAuth2.getAudience());
         }
         // Adding optional resource parameter
-        if (oAuth2.getResource() != null && !oAuth2.getResource().isBlank()) {
+        if (!StringUtils.isEmpty(oAuth2.getResource())) {
             body.with(Authentication.RESOURCE, oAuth2.getResource());
         }
         // Optionally add scope, if applicable

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -166,11 +166,11 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
                 .with(Authentication.CLIENT_ID, oAuth2.getClientId())
                 .with(Authentication.CLIENT_SECRET, oAuth2.getClientSecret());
         // Adding optional audience parameter
-        if (oAuth2.getAudience() != null && !oAuth2.getAudience().isBlank()) {
+        if (!StringUtils.isEmpty(oAuth2.getAudience())) {
             body.with(Authentication.AUDIENCE, oAuth2.getAudience());
         }
         // Adding optional resource parameter
-        if (oAuth2.getResource() != null && !oAuth2.getResource().isBlank()) {
+        if (!StringUtils.isEmpty(oAuth2.getResource())) {
             body.with(Authentication.RESOURCE, oAuth2.getResource());
         }
         // Optionally add scope, if applicable

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -165,6 +165,14 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
                 .fromFormData(Authentication.GRANT_TYPE, Authentication.CLIENT_CREDENTIALS)
                 .with(Authentication.CLIENT_ID, oAuth2.getClientId())
                 .with(Authentication.CLIENT_SECRET, oAuth2.getClientSecret());
+        // Adding optional audience parameter
+        if (oAuth2.getAudience() != null && !oAuth2.getAudience().isBlank()) {
+            body.with(Authentication.AUDIENCE, oAuth2.getAudience());
+        }
+        // Adding optional resource parameter
+        if (oAuth2.getResource() != null && !oAuth2.getResource().isBlank()) {
+            body.with(Authentication.RESOURCE, oAuth2.getResource());
+        }
         // Optionally add scope, if applicable
         if (!CollectionUtils.isEmpty(oAuth2.getScope())) {
             body.with(Authentication.SCOPE, StringUtils.collectionToDelimitedString(oAuth2.getScope(), " "));

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
@@ -159,6 +159,28 @@
               "value": false
             }
           ]
+        },
+        {
+          "label": "Audience(s)",
+          "configProperty": "datasourceConfiguration.authentication.audience",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Resource(s)",
+          "configProperty": "datasourceConfiguration.authentication.resource",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
         }
       ]
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
@@ -182,11 +182,11 @@ public class AuthenticationService {
                         map.add(CLIENT_ID, oAuth2.getClientId());
                         map.add(CLIENT_SECRET, oAuth2.getClientSecret());
                         // Adding optional audience parameter
-                        if (oAuth2.getAudience() != null && !oAuth2.getAudience().isBlank()) {
+                        if (!StringUtils.isEmpty(oAuth2.getAudience())) {
                             map.add(AUDIENCE, oAuth2.getAudience());
                         }
                         // Adding optional resource parameter
-                        if (oAuth2.getResource() != null && !oAuth2.getResource().isBlank()) {
+                        if (!StringUtils.isEmpty(oAuth2.getResource())) {
                             map.add(RESOURCE, oAuth2.getResource());
                         }
                     } else if (Boolean.TRUE.equals(oAuth2.getIsAuthorizationHeader())) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.solutions;
 
+import com.appsmith.external.constants.Authentication;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.AuthenticationDTO;
@@ -44,14 +45,15 @@ import java.util.List;
 import java.util.Map;
 
 import static com.appsmith.external.constants.Authentication.ACCESS_TOKEN;
+import static com.appsmith.external.constants.Authentication.AUDIENCE;
 import static com.appsmith.external.constants.Authentication.AUTHORIZATION_CODE;
 import static com.appsmith.external.constants.Authentication.CLIENT_ID;
 import static com.appsmith.external.constants.Authentication.CLIENT_SECRET;
 import static com.appsmith.external.constants.Authentication.CODE;
-import static com.appsmith.external.constants.Authentication.EXPIRES_IN;
 import static com.appsmith.external.constants.Authentication.GRANT_TYPE;
 import static com.appsmith.external.constants.Authentication.REDIRECT_URI;
 import static com.appsmith.external.constants.Authentication.REFRESH_TOKEN;
+import static com.appsmith.external.constants.Authentication.RESOURCE;
 import static com.appsmith.external.constants.Authentication.RESPONSE_TYPE;
 import static com.appsmith.external.constants.Authentication.SCOPE;
 import static com.appsmith.external.constants.Authentication.STATE;
@@ -179,6 +181,14 @@ public class AuthenticationService {
                     if (Boolean.FALSE.equals(oAuth2.getIsAuthorizationHeader())) {
                         map.add(CLIENT_ID, oAuth2.getClientId());
                         map.add(CLIENT_SECRET, oAuth2.getClientSecret());
+                        // Adding optional audience parameter
+                        if (oAuth2.getAudience() != null && !oAuth2.getAudience().isBlank()) {
+                            map.add(AUDIENCE, oAuth2.getAudience());
+                        }
+                        // Adding optional resource parameter
+                        if (oAuth2.getResource() != null && !oAuth2.getResource().isBlank()) {
+                            map.add(RESOURCE, oAuth2.getResource());
+                        }
                     } else if (Boolean.TRUE.equals(oAuth2.getIsAuthorizationHeader())) {
                         byte[] clientCredentials = (oAuth2.getClientId() + ":" + oAuth2.getClientSecret()).getBytes();
                         final String authorizationHeader = "Basic " + Base64.encode(clientCredentials);
@@ -207,7 +217,23 @@ public class AuthenticationService {
                                 authenticationResponse.setTokenResponse(response);
                                 authenticationResponse.setToken((String) response.get(ACCESS_TOKEN));
                                 authenticationResponse.setRefreshToken((String) response.get(REFRESH_TOKEN));
-                                authenticationResponse.setExpiresAt(Instant.now().plusSeconds(Long.valueOf((Integer) response.get(EXPIRES_IN))));
+                                // Parse useful fields for quick access
+                                Object issuedAtResponse = response.get(Authentication.ISSUED_AT);
+                                // Default issuedAt to current time
+                                Instant issuedAt = Instant.now();
+                                if (issuedAtResponse != null) {
+                                    issuedAt = Instant.ofEpochMilli(Long.parseLong((String) issuedAtResponse));
+                                }
+                                // We expect at least one of the following to be present
+                                Object expiresAtResponse = response.get(Authentication.EXPIRES_AT);
+                                Object expiresInResponse = response.get(Authentication.EXPIRES_IN);
+                                Instant expiresAt = null;
+                                if (expiresAtResponse != null) {
+                                    expiresAt = Instant.ofEpochSecond(Long.valueOf((Integer) expiresAtResponse));
+                                } else if (expiresInResponse != null) {
+                                    expiresAt = issuedAt.plusSeconds(Long.valueOf((Integer) expiresInResponse));
+                                }
+                                authenticationResponse.setExpiresAt(expiresAt);
                                 // Replacing with returned scope instead
                                 if (scope != null && !scope.isBlank()) {
                                     oAuth2.setScopeString(String.join(",", scope.split(" ")));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -851,7 +851,9 @@ public class ExamplesOrganizationClonerTests {
                             Set.of(
                                     new Property("custom token param 1", "custom token param value 1"),
                                     new Property("custom token param 2", "custom token param value 2")
-                            )
+                            ),
+                            null,
+                            null
                     ));
 
                     final Datasource ds3 = new Datasource();


### PR DESCRIPTION
Adds the `audience` and `resource` fields to the token request when client credentials are being shared via body. When shared as a basic token in the authorization header, these fields are not available.

This field is stored as a string, and hence always added to the request as is. This means that the if the provider expects any form of encoding for the field, this should be handled on the Appsmith client itself. Similarly, in case multiple audiences or resources are required, the string expects to have the proper stringified array representation.

<img width="497" alt="Screenshot 2021-05-25 at 8 56 55 PM" src="https://user-images.githubusercontent.com/5298848/119524987-c05f8c80-bd9b-11eb-8ccb-d93a8be1f37a.png">

Fixes #4666 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
-Tested against mocklab endpoint

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/oauth2-audience-resource 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.55 **(0)** | 32.44 **(-0.02)** | 29.67 **(0)** | 52.06 **(0)**
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx | 28.09 **(-0.48)** | 22.92 **(-0.48)** | 3.23 **(-0.1)** | 31.61 **(-0.42)**</details>