### PR TITLE
Memoize the evaluate popup placement value

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useRef, useState } from "react";
+import React, { memo, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import _ from "lodash";
 import Popper from "pages/Editor/Popper";
@@ -310,13 +310,15 @@ function EvaluatedValuePopup(props: Props) {
   const [contentHovered, setContentHovered] = useState(false);
 
   const wrapperRef = useRef<HTMLDivElement>(null);
-  let placement: Placement = "left-start";
-  if (wrapperRef.current) {
-    const boundingRect = wrapperRef.current.getBoundingClientRect();
-    if (boundingRect.left < theme.evaluatedValuePopup.width) {
-      placement = "right-start";
+  const placement: Placement = useMemo(() => {
+    if (wrapperRef.current) {
+      const boundingRect = wrapperRef.current.getBoundingClientRect();
+      if (boundingRect.left < theme.evaluatedValuePopup.width) {
+        return "right-start";
+      }
     }
-  }
+    return "left-start";
+  }, [wrapperRef.current]);
 
   return (
     <Wrapper ref={wrapperRef}>


### PR DESCRIPTION
## Description
Evaluated value pop is re rendered on every keypress and few other things.
On every render it triggers expensive style calculation of about 10-15ms. This value doesn't change after the initial mount, so calculate it only once.

Fixes #4679
 
## Type of change
 
- UI Performance improvement 

## How Has This Been Tested?

Profiling before and after

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: ui/perf/optimize-expensive-style-calc-evalauatedValuePopup/4679 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.62 **(0.01)** | 32.45 **(0)** | 29.83 **(0.01)** | 52.09 **(0)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx | 64.2 **(0.45)** | 60.66 **(0)** | 42.86 **(2.12)** | 66.67 **(0.45)**</details>