### PR TITLE
Feature: datasource changes for api key auth, bearer token auth, combine config.

### DIFF
--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -67,7 +67,7 @@ export interface Basic {
 
 export interface ApiKey {
   authenticationType: AuthType.apiKey;
-  key: string;
+  label: string;
   value: string;
   addTo: string;
 }

--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -8,6 +8,11 @@ export enum AuthType {
   bearerToken = "bearerToken",
 }
 
+export enum ApiKeyAuthType {
+  QueryParams = "queryParams",
+  Header = "header",
+}
+
 export enum GrantType {
   ClientCredentials = "client_credentials",
   AuthorizationCode = "authorization_code",
@@ -63,6 +68,8 @@ export interface Basic {
 export interface ApiKey {
   authenticationType: AuthType.apiKey;
   key: string;
+  value: string;
+  addTo: string;
 }
 
 export interface BearerToken {

--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -4,6 +4,8 @@ export enum AuthType {
   NONE = "NONE",
   OAuth2 = "oAuth2",
   basic = "basic",
+  apiKey = "apiKey",
+  bearerToken = "bearerToken",
 }
 
 export enum GrantType {
@@ -11,7 +13,12 @@ export enum GrantType {
   AuthorizationCode = "authorization_code",
 }
 
-export type Authentication = ClientCredentials | AuthorizationCode | Basic;
+export type Authentication =
+  | ClientCredentials
+  | AuthorizationCode
+  | Basic
+  | ApiKey
+  | BearerToken;
 export interface ApiDatasourceForm {
   datasourceId: string;
   pluginId: string;
@@ -51,4 +58,14 @@ export interface Basic {
   authenticationType: AuthType.basic;
   username: string;
   password: string;
+}
+
+export interface ApiKey {
+  authenticationType: AuthType.apiKey;
+  key: string;
+}
+
+export interface BearerToken {
+  authenticationType: AuthType.bearerToken;
+  bearerToken: string;
 }

--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -5,7 +5,7 @@ export interface DatasourceAuthentication {
   authType?: string;
   username?: string;
   password?: string;
-  key?: string;
+  label?: string;
   value?: string;
   addTo?: string;
   bearerToken?: string;

--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -5,6 +5,8 @@ export interface DatasourceAuthentication {
   authType?: string;
   username?: string;
   password?: string;
+  key?: string;
+  bearerToken?: string;
 }
 
 export interface DatasourceColumns {

--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -6,6 +6,8 @@ export interface DatasourceAuthentication {
   username?: string;
   password?: string;
   key?: string;
+  value?: string;
+  addTo?: string;
   bearerToken?: string;
 }
 

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -490,7 +490,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
         <FormInputContainer>
           <InputTextControl
             {...COMMON_INPUT_PROPS}
-            configProperty="authentication.key"
+            configProperty="authentication.label"
             label="Key Label"
             placeholderText="api_key"
           />

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -443,6 +443,14 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
                 label: "OAuth 2.0",
                 value: AuthType.OAuth2,
               },
+              {
+                label: "API Key",
+                value: AuthType.apiKey,
+              },
+              {
+                label: "Bearer Token",
+                value: AuthType.bearerToken,
+              },
             ]}
             placeholderText=""
             propertyValue=""
@@ -461,6 +469,10 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
       content = this.renderOauth2();
     } else if (authType === AuthType.basic) {
       content = this.renderBasic();
+    } else if (authType === AuthType.apiKey) {
+      content = this.renderApiKey();
+    } else if (authType === AuthType.bearerToken) {
+      content = this.renderBearerToken();
     }
     if (content) {
       return (
@@ -469,6 +481,32 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
         </Collapsible>
       );
     }
+  };
+
+  renderBearerToken = () => {
+    return (
+      <FormInputContainer>
+        <InputTextControl
+          {...COMMON_INPUT_PROPS}
+          configProperty="authentication.bearerToken"
+          label="Bearer Token"
+          placeholderText="Bearer Token"
+        />
+      </FormInputContainer>
+    );
+  };
+
+  renderApiKey = () => {
+    return (
+      <FormInputContainer>
+        <InputTextControl
+          {...COMMON_INPUT_PROPS}
+          configProperty="authentication.key"
+          label="API Key"
+          placeholderText="Key"
+        />
+      </FormInputContainer>
+    );
   };
 
   renderBasic = () => {

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -491,7 +491,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
           <InputTextControl
             {...COMMON_INPUT_PROPS}
             configProperty="authentication.label"
-            label="Key Label"
+            label="Key"
             placeholderText="api_key"
           />
         </FormInputContainer>
@@ -499,8 +499,8 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
           <InputTextControl
             {...COMMON_INPUT_PROPS}
             configProperty="authentication.value"
-            label="Key Value"
-            placeholderText="my_key"
+            label="Value"
+            placeholderText="value"
           />
         </FormInputContainer>
         <FormInputContainer>

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -42,6 +42,7 @@ import {
 } from "transformers/RestAPIDatasourceFormTransformer";
 import {
   ApiDatasourceForm,
+  ApiKeyAuthType,
   AuthType,
   GrantType,
 } from "entities/Datasource/RestAPIForm";
@@ -483,6 +484,48 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
     }
   };
 
+  renderApiKey = () => {
+    return (
+      <>
+        <FormInputContainer>
+          <InputTextControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.key"
+            label="Key Label"
+            placeholderText="api_key"
+          />
+        </FormInputContainer>
+        <FormInputContainer>
+          <InputTextControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.value"
+            label="Key Value"
+            placeholderText="my_key"
+          />
+        </FormInputContainer>
+        <FormInputContainer>
+          <DropDownControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.addTo"
+            label="Add To"
+            options={[
+              {
+                label: "Query Params",
+                value: ApiKeyAuthType.QueryParams,
+              },
+              {
+                label: "Header",
+                value: ApiKeyAuthType.Header,
+              },
+            ]}
+            placeholderText=""
+            propertyValue=""
+          />
+        </FormInputContainer>
+      </>
+    );
+  };
+
   renderBearerToken = () => {
     return (
       <FormInputContainer>
@@ -491,19 +534,6 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
           configProperty="authentication.bearerToken"
           label="Bearer Token"
           placeholderText="Bearer Token"
-        />
-      </FormInputContainer>
-    );
-  };
-
-  renderApiKey = () => {
-    return (
-      <FormInputContainer>
-        <InputTextControl
-          {...COMMON_INPUT_PROPS}
-          configProperty="authentication.key"
-          label="API Key"
-          placeholderText="Key"
         />
       </FormInputContainer>
     );

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -120,7 +120,9 @@ const formToDatasourceAuthentication = (
     if ("key" in authentication) {
       const apiKey: ApiKey = {
         authenticationType: AuthType.apiKey,
-        key: authentication.key,
+        key: authentication.key || "",
+        value: authentication.value || "",
+        addTo: authentication.addTo || "",
       };
       return apiKey;
     }
@@ -197,6 +199,8 @@ const datasourceToFormAuthentication = (
     const apiKey: ApiKey = {
       authenticationType: AuthType.apiKey,
       key: authentication.key || "",
+      value: authentication.value || "",
+      addTo: authentication.addTo || "",
     };
     return apiKey;
   }

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -117,12 +117,12 @@ const formToDatasourceAuthentication = (
     }
   }
   if (authType === AuthType.apiKey) {
-    if ("key" in authentication) {
+    if ("label" in authentication) {
       const apiKey: ApiKey = {
         authenticationType: AuthType.apiKey,
-        key: authentication.key || "",
-        value: authentication.value || "",
-        addTo: authentication.addTo || "",
+        label: authentication.label,
+        value: authentication.value,
+        addTo: authentication.addTo,
       };
       return apiKey;
     }
@@ -198,7 +198,7 @@ const datasourceToFormAuthentication = (
   if (authType === AuthType.apiKey) {
     const apiKey: ApiKey = {
       authenticationType: AuthType.apiKey,
-      key: authentication.key || "",
+      label: authentication.label || "",
       value: authentication.value || "",
       addTo: authentication.addTo || "",
     };

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -9,6 +9,8 @@ import {
   GrantType,
   Oauth2Common,
   Basic,
+  ApiKey,
+  BearerToken,
 } from "entities/Datasource/RestAPIForm";
 import _ from "lodash";
 
@@ -105,12 +107,32 @@ const formToDatasourceAuthentication = (
     }
   }
   if (authType === AuthType.basic) {
-    const basic: Basic = {
-      authenticationType: AuthType.basic,
-      username: authentication.username,
-      password: authentication.password,
-    };
-    return basic;
+    if ("username" in authentication) {
+      const basic: Basic = {
+        authenticationType: AuthType.basic,
+        username: authentication.username,
+        password: authentication.password,
+      };
+      return basic;
+    }
+  }
+  if (authType === AuthType.apiKey) {
+    if ("key" in authentication) {
+      const apiKey: ApiKey = {
+        authenticationType: AuthType.apiKey,
+        key: authentication.key,
+      };
+      return apiKey;
+    }
+  }
+  if (authType === AuthType.bearerToken) {
+    if ("bearerToken" in authentication) {
+      const bearerToken: BearerToken = {
+        authenticationType: AuthType.bearerToken,
+        bearerToken: authentication.bearerToken,
+      };
+      return bearerToken;
+    }
   }
   return null;
 };
@@ -170,6 +192,20 @@ const datasourceToFormAuthentication = (
       password: authentication.password || "",
     };
     return basic;
+  }
+  if (authType === AuthType.apiKey) {
+    const apiKey: ApiKey = {
+      authenticationType: AuthType.apiKey,
+      key: authentication.key || "",
+    };
+    return apiKey;
+  }
+  if (authType === AuthType.bearerToken) {
+    const bearerToken: BearerToken = {
+      authenticationType: AuthType.bearerToken,
+      bearerToken: authentication.bearerToken || "",
+    };
+    return bearerToken;
   }
 };
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -38,5 +38,6 @@ public class Authentication {
     public static final String AUTHORIZATION_HEADER = "Authorization";
 
     // Other constants
-    public static final String BEARER = "Bearer";
+    public static final String BEARER_HEADER_PREFIX = "Bearer";
+    public static final String BASIC_HEADER_PREFIX = "Basic ";
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -25,6 +25,7 @@ public class Authentication {
     public static final String AUTHORIZATION_URL = "authorization_url";
     public static final String ACCESS_TOKEN_URL = "access_token_url";
     public static final String RESPONSE_TYPE = "response_type";
+    public static final String API_KEY_PARAM = "api_key";
 
     // Request parameter values
     public static final String AUTHORIZATION_CODE = "authorization_code";
@@ -35,4 +36,7 @@ public class Authentication {
 
     // Header names
     public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    // Other constants
+    public static final String BEARER = "Bearer";
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -7,6 +7,8 @@ public class Authentication {
     public static final String OAUTH2 = "oAuth2";
     public static final String BASIC = "basic";
     public static final String API_KEY = "apiKey";
+    public static final String API_KEY_AUTH_TYPE_QUERY_PARAMS = "queryParams";
+    public static final String API_KEY_AUTH_TYPE_HEADER = "header";
     public static final String BEARER_TOKEN = "bearerToken";
 
     // Request parameter names
@@ -25,7 +27,6 @@ public class Authentication {
     public static final String AUTHORIZATION_URL = "authorization_url";
     public static final String ACCESS_TOKEN_URL = "access_token_url";
     public static final String RESPONSE_TYPE = "response_type";
-    public static final String API_KEY_PARAM = "api_key";
 
     // Request parameter values
     public static final String AUTHORIZATION_CODE = "authorization_code";

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -6,6 +6,8 @@ public class Authentication {
     public static final String DB_AUTH = "dbAuth";
     public static final String OAUTH2 = "oAuth2";
     public static final String BASIC = "basic";
+    public static final String API_KEY = "apiKey";
+    public static final String BEARER_TOKEN = "bearerToken";
 
     // Request parameter names
     public static final String CLIENT_ID = "client_id";

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -32,4 +32,7 @@ public class Authentication {
 
     // Response codes
     public static final String SUCCESS = "success";
+
+    // Header names
+    public static final String AUTHORIZATION_HEADER = "Authorization";
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
@@ -1,0 +1,24 @@
+package com.appsmith.external.models;
+
+import com.appsmith.external.annotations.documenttype.DocumentType;
+import com.appsmith.external.annotations.encryption.Encrypted;
+import com.appsmith.external.constants.Authentication;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@DocumentType(Authentication.API_KEY)
+public class ApiKeyAuth extends AuthenticationDTO {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Encrypted
+    String key;
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
@@ -5,11 +5,13 @@ import com.appsmith.external.annotations.encryption.Encrypted;
 import com.appsmith.external.constants.Authentication;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+@Builder
 @Getter
 @Setter
 @ToString

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
@@ -20,7 +20,17 @@ import lombok.ToString;
 @DocumentType(Authentication.API_KEY)
 public class ApiKeyAuth extends AuthenticationDTO {
 
+    public enum Type {
+        @JsonProperty(Authentication.API_KEY_AUTH_TYPE_QUERY_PARAMS)
+        QUERY_PARAMS,
+        @JsonProperty(Authentication.API_KEY_AUTH_TYPE_HEADER)
+        HEADER,
+    }
+
+    Type addTo;
+    String label;
+
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Encrypted
-    String key;
+    String value;
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -24,8 +24,8 @@ import java.util.Set;
         @JsonSubTypes.Type(value = DBAuth.class, name = Authentication.DB_AUTH),
         @JsonSubTypes.Type(value = OAuth2.class, name = Authentication.OAUTH2),
         @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BASIC),
-        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.API_KEY),
-        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BEARER_TOKEN)
+        @JsonSubTypes.Type(value = ApiKeyAuth.class, name = Authentication.API_KEY),
+        @JsonSubTypes.Type(value = BearerTokenAuth.class, name = Authentication.BEARER_TOKEN)
 })
 public class AuthenticationDTO implements AppsmithDomain {
     // In principle, this class should've been abstract. However, when this class is abstract, Spring's deserialization

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -23,7 +23,9 @@ import java.util.Set;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = DBAuth.class, name = Authentication.DB_AUTH),
         @JsonSubTypes.Type(value = OAuth2.class, name = Authentication.OAUTH2),
-        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BASIC)
+        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BASIC),
+        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.API_KEY),
+        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BEARER_TOKEN)
 })
 public class AuthenticationDTO implements AppsmithDomain {
     // In principle, this class should've been abstract. However, when this class is abstract, Spring's deserialization

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BearerTokenAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BearerTokenAuth.java
@@ -1,0 +1,24 @@
+package com.appsmith.external.models;
+
+import com.appsmith.external.annotations.documenttype.DocumentType;
+import com.appsmith.external.annotations.encryption.Encrypted;
+import com.appsmith.external.constants.Authentication;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@DocumentType(Authentication.BEARER_TOKEN)
+public class BearerTokenAuth extends AuthenticationDTO {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Encrypted
+    String bearerToken;
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
@@ -1,5 +1,7 @@
 package com.appsmith.external.models;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +11,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
 
+@Builder(toBuilder = true)
 @Getter
 @Setter
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor
+@AllArgsConstructor
 @Document
 public class DatasourceConfiguration implements AppsmithDomain {
 

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
@@ -2,8 +2,10 @@ package com.external.connections;
 
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.models.ApiKeyAuth;
 import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.BasicAuth;
+import com.appsmith.external.models.BearerTokenAuth;
 import com.appsmith.external.models.OAuth2;
 import reactor.core.publisher.Mono;
 
@@ -25,6 +27,10 @@ public class APIConnectionFactory {
             }
         } else if (authenticationType instanceof BasicAuth) {
             return Mono.from(BasicAuthentication.create((BasicAuth) authenticationType));
+        } else if (authenticationType instanceof ApiKeyAuth) {
+            return Mono.from(ApiKeyAuthentication.create((ApiKeyAuth) authenticationType));
+        } else if (authenticationType instanceof BearerTokenAuth) {
+            return Mono.from(BearerTokenAuthentication.create((BearerTokenAuth) authenticationType));
         } else {
             return Mono.empty();
         }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
@@ -1,0 +1,42 @@
+package com.external.connections;
+
+import com.appsmith.external.models.ApiKeyAuth;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiKeyAuthentication extends APIConnection{
+    private final String PARAM_NAME = "api_key";
+    private String key;
+
+    public static Mono<ApiKeyAuthentication> create(ApiKeyAuth apiKeyAuth) {
+        return Mono.just(
+                ApiKeyAuthentication.builder()
+                        .key(apiKeyAuth.getKey())
+                        .build()
+        );
+    }
+
+    @Override
+    public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
+        return Mono.justOrEmpty(ClientRequest.from(request)
+                .attribute(PARAM_NAME, this.key)
+                .build())
+                // Carry on to next exchange function
+                .flatMap(next::exchange)
+                // Default to next exchange function if something went wrong
+                .switchIfEmpty(next.exchange(request));
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
@@ -16,13 +16,14 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 
+import static com.appsmith.external.constants.Authentication.API_KEY_PARAM;
+
 @Setter
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiKeyAuthentication extends APIConnection{
-    private final String PARAM_NAME = "api_key";
     private String key;
 
     public static Mono<ApiKeyAuthentication> create(ApiKeyAuth apiKeyAuth) {
@@ -61,7 +62,7 @@ public class ApiKeyAuthentication extends APIConnection{
 
     private String appendApiKeyParamToQuery(String oldQuery) {
         return StringUtils.isEmpty(oldQuery) ?
-                PARAM_NAME + "=" + this.key :
-                oldQuery + "&" + PARAM_NAME + "=" + this.key;
+                API_KEY_PARAM + "=" + this.key :
+                oldQuery + "&" + API_KEY_PARAM + "=" + this.key;
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
@@ -7,10 +7,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
+
+import java.net.URI;
 
 @Setter
 @Getter
@@ -32,11 +36,32 @@ public class ApiKeyAuthentication extends APIConnection{
     @Override
     public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
         return Mono.justOrEmpty(ClientRequest.from(request)
-                .attribute(PARAM_NAME, this.key)
+                .url(appendApiKeyParamToUrl(request.url()))
                 .build())
                 // Carry on to next exchange function
                 .flatMap(next::exchange)
                 // Default to next exchange function if something went wrong
                 .switchIfEmpty(next.exchange(request));
+    }
+
+    private URI appendApiKeyParamToUrl(URI oldUrl) {
+        String query = appendApiKeyParamToQuery(oldUrl.getQuery());
+
+        return UriComponentsBuilder
+                .newInstance()
+                .scheme(oldUrl.getScheme())
+                .host(oldUrl.getHost())
+                .port(oldUrl.getPort())
+                .path(oldUrl.getPath())
+                .query(query)
+                .fragment(oldUrl.getFragment())
+                .build()
+                .toUri();
+    }
+
+    private String appendApiKeyParamToQuery(String oldQuery) {
+        return StringUtils.isEmpty(oldQuery) ?
+                PARAM_NAME + "=" + this.key :
+                oldQuery + "&" + PARAM_NAME + "=" + this.key;
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
@@ -46,7 +45,6 @@ public class ApiKeyAuthentication extends APIConnection{
     }
 
     private URI appendApiKeyParamToUrl(URI oldUrl) {
-        String query = appendApiKeyParamToQuery(oldUrl.getQuery());
 
         return UriComponentsBuilder
                 .newInstance()
@@ -54,15 +52,10 @@ public class ApiKeyAuthentication extends APIConnection{
                 .host(oldUrl.getHost())
                 .port(oldUrl.getPort())
                 .path(oldUrl.getPath())
-                .query(query)
+                .query(oldUrl.getQuery())
+                .queryParam(API_KEY_PARAM, this.key)
                 .fragment(oldUrl.getFragment())
                 .build()
                 .toUri();
-    }
-
-    private String appendApiKeyParamToQuery(String oldQuery) {
-        return StringUtils.isEmpty(oldQuery) ?
-                API_KEY_PARAM + "=" + this.key :
-                oldQuery + "&" + API_KEY_PARAM + "=" + this.key;
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
@@ -1,6 +1,9 @@
 package com.external.connections;
 
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.external.models.ApiKeyAuth.Type;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,29 +18,47 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 
-import static com.appsmith.external.constants.Authentication.API_KEY_PARAM;
-
 @Setter
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiKeyAuthentication extends APIConnection{
-    private String key;
+    private String label;
+    private String value;
+    Type addTo;
 
     public static Mono<ApiKeyAuthentication> create(ApiKeyAuth apiKeyAuth) {
         return Mono.just(
                 ApiKeyAuthentication.builder()
-                        .key(apiKeyAuth.getKey())
+                        .label(apiKeyAuth.getLabel())
+                        .value(apiKeyAuth.getValue())
+                        .addTo(apiKeyAuth.getAddTo())
                         .build()
         );
     }
 
     @Override
     public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
-        return Mono.justOrEmpty(ClientRequest.from(request)
-                .url(appendApiKeyParamToUrl(request.url()))
-                .build())
+        ClientRequest.Builder requestBuilder = ClientRequest.from(request);
+        switch (addTo) {
+            case QUERY_PARAMS:
+                requestBuilder.url(appendApiKeyParamToUrl(request.url()));
+                break;
+            case HEADER:
+                requestBuilder.headers(header -> header.set(label, value));
+                break;
+            default:
+                return Mono.error(
+                        new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Appsmith server has found an unsupported api key authentication type. Please reach " +
+                                        "out to Appsmith customer support to resolve this."
+                        )
+                );
+        }
+
+        return Mono.justOrEmpty(requestBuilder.build())
                 // Carry on to next exchange function
                 .flatMap(next::exchange)
                 // Default to next exchange function if something went wrong
@@ -53,7 +74,7 @@ public class ApiKeyAuthentication extends APIConnection{
                 .port(oldUrl.getPort())
                 .path(oldUrl.getPath())
                 .query(oldUrl.getQuery())
-                .queryParam(API_KEY_PARAM, this.key)
+                .queryParam(label, value)
                 .fragment(oldUrl.getFragment())
                 .build()
                 .toUri();

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BasicAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BasicAuthentication.java
@@ -14,13 +14,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static com.appsmith.external.constants.Authentication.AUTHORIZATION_HEADER;
+import static com.appsmith.external.constants.Authentication.BASIC_HEADER_PREFIX;
 
 @Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BasicAuthentication extends APIConnection {
     private String encodedAuthorizationHeader;
-    final private static String HEADER_PREFIX = "Basic ";
 
     public static Mono<BasicAuthentication> create(BasicAuth basicAuth) {
         final BasicAuthentication basicAuthentication = new BasicAuthentication();
@@ -45,6 +45,6 @@ public class BasicAuthentication extends APIConnection {
     }
 
     private String getHeaderValue() {
-        return HEADER_PREFIX + this.encodedAuthorizationHeader;
+        return BASIC_HEADER_PREFIX + this.encodedAuthorizationHeader;
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BearerTokenAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BearerTokenAuthentication.java
@@ -13,6 +13,7 @@ import org.springframework.web.reactive.function.client.ExchangeFunction;
 import reactor.core.publisher.Mono;
 
 import static com.appsmith.external.constants.Authentication.AUTHORIZATION_HEADER;
+import static com.appsmith.external.constants.Authentication.BEARER;
 
 @Setter
 @Getter
@@ -20,7 +21,6 @@ import static com.appsmith.external.constants.Authentication.AUTHORIZATION_HEADE
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class BearerTokenAuthentication extends APIConnection {
-    private final String HEADER_PREFIX = "Bearer";
     private String bearerToken;
 
     public static Mono<BearerTokenAuthentication> create(BearerTokenAuth bearerTokenAuth) {
@@ -43,7 +43,6 @@ public class BearerTokenAuthentication extends APIConnection {
     }
 
     private String getHeaderValue() {
-        return HEADER_PREFIX + " " + this.bearerToken;
+        return BEARER + " " + this.bearerToken;
     }
-
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BearerTokenAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BearerTokenAuthentication.java
@@ -13,7 +13,7 @@ import org.springframework.web.reactive.function.client.ExchangeFunction;
 import reactor.core.publisher.Mono;
 
 import static com.appsmith.external.constants.Authentication.AUTHORIZATION_HEADER;
-import static com.appsmith.external.constants.Authentication.BEARER;
+import static com.appsmith.external.constants.Authentication.BEARER_HEADER_PREFIX;
 
 @Setter
 @Getter
@@ -43,6 +43,6 @@ public class BearerTokenAuthentication extends APIConnection {
     }
 
     private String getHeaderValue() {
-        return BEARER + " " + this.bearerToken;
+        return BEARER_HEADER_PREFIX + " " + this.bearerToken;
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -45,6 +45,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
@@ -72,6 +72,14 @@
             {
               "label": "OAuth2 (Client credentials)",
               "value": "oAuth2"
+            },
+            {
+              "label": "API Key",
+              "value": "apiKey"
+            },
+            {
+              "label": "Bearer Token",
+              "value": "bearerToken"
             }
           ]
         },

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
@@ -2,8 +2,8 @@ package com.external.connections;
 
 import com.appsmith.external.models.ApiKeyAuth;
 import org.junit.Test;
-
-import java.time.Duration;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -11,11 +11,17 @@ import static org.junit.Assert.assertEquals;
 public class ApiKeyAuthenticationTest {
 
     @Test
-    public void testCreateMethod() {
-        String dummyKey = "key";
-        ApiKeyAuth apiKeyAuthDTO = new ApiKeyAuth(dummyKey);
-        ApiKeyAuthentication connection = ApiKeyAuthentication.create(apiKeyAuthDTO).block(Duration.ofMillis(100));
-        assertThat(connection).isNotNull();
-        assertEquals(dummyKey, connection.getKey());
+    public void testCreateMethodWithQueryParamsLabel() {
+        String label = "label";
+        String value = "value";
+        ApiKeyAuth.Type type = ApiKeyAuth.Type.QUERY_PARAMS;
+        ApiKeyAuth apiKeyAuthDTO = new ApiKeyAuth(type, label, value);
+        Mono<ApiKeyAuthentication> connectionMono = ApiKeyAuthentication.create(apiKeyAuthDTO);
+        StepVerifier.create(connectionMono)
+                .assertNext(connection -> {
+                    assertThat(connection).isNotNull();
+                    assertEquals(value, connection.getValue());
+                })
+                .verifyComplete();
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
@@ -1,0 +1,21 @@
+package com.external.connections;
+
+import com.appsmith.external.models.ApiKeyAuth;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class ApiKeyAuthenticationTest {
+
+    @Test
+    public void testCreateMethod() {
+        String dummyKey = "key";
+        ApiKeyAuth apiKeyAuthDTO = new ApiKeyAuth(dummyKey);
+        ApiKeyAuthentication connection = ApiKeyAuthentication.create(apiKeyAuthDTO).block(Duration.ofMillis(100));
+        assertThat(connection).isNotNull();
+        assertEquals(dummyKey, connection.getKey());
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/BearerTokenAuthenticationTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/BearerTokenAuthenticationTest.java
@@ -1,0 +1,22 @@
+package com.external.connections;
+
+import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.external.models.BearerTokenAuth;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class BearerTokenAuthenticationTest {
+
+    @Test
+    public void testCreateMethod() {
+        String bearerToken = "key";
+        BearerTokenAuth bearerTokenAuthDTO = new BearerTokenAuth(bearerToken);
+        BearerTokenAuthentication connection = BearerTokenAuthentication.create(bearerTokenAuthDTO).block(Duration.ofMillis(100));
+        assertThat(connection).isNotNull();
+        assertEquals(bearerToken, connection.getBearerToken());
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/BearerTokenAuthenticationTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/BearerTokenAuthenticationTest.java
@@ -1,10 +1,9 @@
 package com.external.connections;
 
-import com.appsmith.external.models.ApiKeyAuth;
 import com.appsmith.external.models.BearerTokenAuth;
 import org.junit.Test;
-
-import java.time.Duration;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -15,8 +14,12 @@ public class BearerTokenAuthenticationTest {
     public void testCreateMethod() {
         String bearerToken = "key";
         BearerTokenAuth bearerTokenAuthDTO = new BearerTokenAuth(bearerToken);
-        BearerTokenAuthentication connection = BearerTokenAuthentication.create(bearerTokenAuthDTO).block(Duration.ofMillis(100));
-        assertThat(connection).isNotNull();
-        assertEquals(bearerToken, connection.getBearerToken());
+        Mono<BearerTokenAuthentication> connectionMono = BearerTokenAuthentication.create(bearerTokenAuthDTO);
+        StepVerifier.create(connectionMono)
+                .assertNext(connection -> {
+                    assertThat(connection).isNotNull();
+                    assertEquals(bearerToken, connection.getBearerToken());
+                })
+                .verifyComplete();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Datasource.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Datasource.java
@@ -34,6 +34,9 @@ public class Datasource extends BaseDomain {
 
     DatasourceConfiguration datasourceConfiguration;
 
+    @JsonIgnore
+    DatasourceConfiguration combinedDatasourceConfiguration;
+
     private String templateId;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/DatasourceTemplateRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/DatasourceTemplateRepository.java
@@ -1,0 +1,6 @@
+package com.appsmith.server.repositories;
+
+import com.appsmith.server.domains.DatasourceTemplate;
+
+public interface DatasourceTemplateRepository  extends BaseRepository<DatasourceTemplate, String> {
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -148,19 +148,15 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
                     if (combinedConfig.getHeaders() == null) {
                         combinedConfig.setHeaders(userConfig.getHeaders());
                     }
-                    else {
-                        if (!CollectionUtils.isEmpty(userConfig.getHeaders())) {
+                    else if (!CollectionUtils.isEmpty(userConfig.getHeaders())) {
                             combinedConfig.getHeaders().addAll(userConfig.getHeaders());
-                        }
                     }
 
                     if (combinedConfig.getProperties() == null) {
                         combinedConfig.setProperties(userConfig.getProperties());
                     }
-                    else {
-                        if (!CollectionUtils.isEmpty(userConfig.getProperties())) {
+                    else if (!CollectionUtils.isEmpty(userConfig.getProperties())) {
                             combinedConfig.getProperties().addAll(userConfig.getProperties());
-                        }
                     }
 
                     datasource.setCombinedDatasourceConfiguration(combinedConfig);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -149,14 +149,14 @@ public class DatasourceServiceImpl extends BaseService<DatasourceRepository, Dat
                         combinedConfig.setHeaders(userConfig.getHeaders());
                     }
                     else if (!CollectionUtils.isEmpty(userConfig.getHeaders())) {
-                            combinedConfig.getHeaders().addAll(userConfig.getHeaders());
+                        combinedConfig.getHeaders().addAll(userConfig.getHeaders());
                     }
 
                     if (combinedConfig.getProperties() == null) {
                         combinedConfig.setProperties(userConfig.getProperties());
                     }
                     else if (!CollectionUtils.isEmpty(userConfig.getProperties())) {
-                            combinedConfig.getProperties().addAll(userConfig.getProperties());
+                        combinedConfig.getProperties().addAll(userConfig.getProperties());
                     }
 
                     datasource.setCombinedDatasourceConfiguration(combinedConfig);


### PR DESCRIPTION
## Description
- add support for api key auth, bearer token auth
- combine default config with user config.

Fixes #4511 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
