### PR TITLE
[Issue #3785][Bug] User names in organization management page are stale

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceUnitTest.java
@@ -1,0 +1,98 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.acl.RoleGraph;
+import com.appsmith.server.domains.Organization;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.domains.UserRole;
+import com.appsmith.server.repositories.AssetRepository;
+import com.appsmith.server.repositories.OrganizationRepository;
+import com.appsmith.server.repositories.PluginRepository;
+import com.appsmith.server.repositories.UserRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.test.StepVerifier;
+
+import javax.validation.Validator;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.appsmith.server.acl.AclPermission.ORGANIZATION_INVITE_USERS;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class OrganizationServiceUnitTest {
+
+    @MockBean PluginRepository pluginRepository;
+    @MockBean SessionUserService sessionUserService;
+    @MockBean UserOrganizationService userOrganizationService;
+    @MockBean UserRepository userRepository;
+    @MockBean RoleGraph roleGraph;
+    @MockBean AssetRepository assetRepository;
+    @MockBean AssetService assetService;
+    @MockBean Scheduler scheduler;
+    @MockBean MongoConverter mongoConverter;
+    @MockBean ReactiveMongoTemplate reactiveMongoTemplate;
+    @MockBean OrganizationRepository organizationRepository;
+    @MockBean Validator validator;
+    @MockBean AnalyticsService analyticsService;
+
+    OrganizationService organizationService;
+
+    @Before
+    public void setUp() {
+        organizationService = new OrganizationServiceImpl(scheduler, validator, mongoConverter, reactiveMongoTemplate,
+                organizationRepository, analyticsService, pluginRepository, sessionUserService, userOrganizationService,
+                userRepository, roleGraph, assetRepository, assetService
+        );
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void getOrganizationMembers_WhenNameNotInRoleButInUser_NameFetchedFromUser() {
+        // create a organization object
+        Organization testOrg = new Organization();
+        testOrg.setName("Get All Members For Organization Test");
+        testOrg.setDomain("test.com");
+        testOrg.setWebsite("https://test.com");
+        testOrg.setId("test-org-id");
+
+        // add a role to the test org object
+        List<UserRole> userRoleList = new ArrayList<>();
+        UserRole userRole = new UserRole();
+        userRole.setUserId("test-user-id");
+        userRole.setName("Initial Name");
+        userRoleList.add(userRole);
+        testOrg.setUserRoles(userRoleList);
+
+        // create the user which acts as updated user object
+        User user = new User();
+        user.setId("test-user-id");
+        user.setName("Updated name");
+
+        // mock repository methods so that they return the objects we've created
+        Mockito.when(organizationRepository.findById("test-org-id", ORGANIZATION_INVITE_USERS))
+                .thenReturn(Mono.just(testOrg));
+        Mockito.when(userRepository.findAllById(List.of("test-user-id")))
+                .thenReturn(Flux.just(user));
+
+        Mono<List<UserRole>> organizationMembers = organizationService.getOrganizationMembers(testOrg.getId());
+        StepVerifier
+                .create(organizationMembers)
+                .assertNext(userRoles -> {
+                    Assert.assertNotNull(userRoles);
+                    UserRole userRole1 = userRoles.get(0);
+                    Assert.assertEquals("Updated name", userRole1.getName());
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Description
When a user changes their name in the profile settings page, the user's display name in organizations they are invited to, shows the old name, before the change.

Fixes # (issue)
Issue #3785 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit test
- Tested in local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
