### PR TITLE
Fix: Adding missing widget properties when a new tab is created.

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/DuplicateApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/DuplicateApplication_spec.js
@@ -6,7 +6,7 @@ let duplicateApplicationDsl;
 
 describe("Duplicate application", function() {
   before(() => {
-    dsl.dsl.version = 20; // latest migrated version
+    dsl.dsl.version = 21; // latest migrated version
     cy.addDsl(dsl);
   });
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ForkApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ForkApplication_spec.js
@@ -5,7 +5,7 @@ let forkedApplicationDsl;
 
 describe("Fork application across orgs", function() {
   before(() => {
-    dsl.dsl.version = 20; // latest migrated version
+    dsl.dsl.version = 21; // latest migrated version
     cy.addDsl(dsl);
   });
 

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -96,7 +96,7 @@ export const layoutConfigurations: LayoutConfigurations = {
   FLUID: { minWidth: -1, maxWidth: -1 },
 };
 
-export const LATEST_PAGE_VERSION = 20;
+export const LATEST_PAGE_VERSION = 21;
 
 export const GridDefaults = {
   DEFAULT_CELL_SIZE: 1,

--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -368,7 +368,7 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
           },
         ],
       },
-      version: 2,
+      version: 3,
     },
     MODAL_WIDGET: {
       rows: 6 * GRID_DENSITY_MIGRATION_V1,

--- a/app/client/src/utils/WidgetPropsUtils.test.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.test.tsx
@@ -4,9 +4,11 @@ import {
   migrateChartDataFromArrayToObject,
   migrateToNewLayout,
   migrateInitialValues,
+  extractCurrentDSL,
 } from "./WidgetPropsUtils";
 import {
   buildChildren,
+  widgetCanvasFactory,
   buildDslWithChildren,
 } from "test/factories/WidgetFactoryUtils";
 import { cloneDeep } from "lodash";
@@ -693,5 +695,49 @@ describe("Initial value migration test", () => {
     };
 
     expect(migrateInitialValues(input)).toEqual(output);
+  });
+  it("", () => {
+    const tabsWidgetDSL: any = (version = 1) => {
+      const children: any = buildChildren([
+        {
+          version,
+          type: "TABS_WIDGET",
+          children: [
+            {
+              type: "CANVAS_WIDGET",
+              tabId: "tab1212332",
+              tabName: "Newly Added Tab",
+              widgetId: "o9ody00ep7",
+              parentId: "jd83uvbkmp",
+              detachFromLayout: true,
+              children: [],
+              parentRowSpace: 1,
+              parentColumnSpace: 1,
+              // leftColumn: 0,
+              // rightColumn: 592, // Commenting these coz they are not provided for a newly added tab in the Tabs widget version 2
+              // bottomRow: 280,
+              topRow: 0,
+              isLoading: false,
+              widgetName: "Canvas1",
+              renderMode: "CANVAS",
+            },
+          ],
+        },
+      ]);
+      const dsl: any = widgetCanvasFactory.build({
+        children,
+      });
+      return {
+        data: {
+          layouts: [{ dsl }],
+        },
+      };
+    };
+    const migratedDslV2: any = extractCurrentDSL(tabsWidgetDSL());
+    expect(migratedDslV2.children[0].children[0].leftColumn).toBeNaN();
+    const migratedDslV3: any = extractCurrentDSL(tabsWidgetDSL(2));
+    expect(migratedDslV3.children[0].version).toBe(3);
+    expect(migratedDslV3.children[0].children[0].leftColumn).not.toBeNaN();
+    expect(migratedDslV3.children[0].children[0].leftColumn).toBe(0);
   });
 });

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -752,6 +752,10 @@ const migrateNewlyAddedTabsWidgetsMissingData = (
   if (currentDSL.type === WidgetTypes.TABS_WIDGET && currentDSL.version === 2) {
     try {
       if (currentDSL.children && currentDSL.children.length) {
+        // because Tabs widget can contain Tabs widgets
+        currentDSL.children = currentDSL.children.map(
+          migrateNewlyAddedTabsWidgetsMissingData,
+        );
         currentDSL.children = currentDSL.children.map((each) => {
           each.version = 3;
           if (has(currentDSL, ["leftColumn", "rightColumn", "bottomRow"])) {

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -752,10 +752,6 @@ const migrateNewlyAddedTabsWidgetsMissingData = (
   if (currentDSL.type === WidgetTypes.TABS_WIDGET && currentDSL.version === 2) {
     try {
       if (currentDSL.children && currentDSL.children.length) {
-        // because Tabs widget can contain Tabs widgets
-        currentDSL.children = currentDSL.children.map(
-          migrateNewlyAddedTabsWidgetsMissingData,
-        );
         currentDSL.children = currentDSL.children.map((each) => {
           each.version = 3;
           if (has(currentDSL, ["leftColumn", "rightColumn", "bottomRow"])) {

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -757,7 +757,6 @@ const migrateNewlyAddedTabsWidgetsMissingData = (
           migrateNewlyAddedTabsWidgetsMissingData,
         );
         currentDSL.children = currentDSL.children.map((each) => {
-          each.version = 3;
           if (has(currentDSL, ["leftColumn", "rightColumn", "bottomRow"])) {
             return each;
           }
@@ -773,6 +772,7 @@ const migrateNewlyAddedTabsWidgetsMissingData = (
           };
         });
       }
+      currentDSL.version = 3;
     } catch (error) {
       Sentry.captureException({
         message: "Tabs Migration to add missing fields Failed",

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -22,7 +22,7 @@ import defaultTemplate from "templates/default";
 import { generateReactKey } from "./generators";
 import { ChartDataPoint } from "widgets/ChartWidget";
 import { FlattenedWidgetProps } from "reducers/entityReducers/canvasWidgetsReducer";
-import { isString, set } from "lodash";
+import { has, isString, set } from "lodash";
 import log from "loglevel";
 import {
   migrateTablePrimaryColumnsBindings,
@@ -735,9 +735,56 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
       currentDSL.detachFromLayout || false,
     );
     currentDSL = migrateToNewLayout(currentDSL);
+    currentDSL.version = 20;
+  }
+
+  if (currentDSL.version === 20) {
+    currentDSL = migrateNewlyAddedTabsWidgetsMissingData(currentDSL);
     currentDSL.version = LATEST_PAGE_VERSION;
   }
 
+  return currentDSL;
+};
+
+const migrateNewlyAddedTabsWidgetsMissingData = (
+  currentDSL: ContainerWidgetProps<WidgetProps>,
+) => {
+  if (currentDSL.type === WidgetTypes.TABS_WIDGET && currentDSL.version === 2) {
+    try {
+      if (currentDSL.children && currentDSL.children.length) {
+        // because Tabs widget can contain Tabs widgets
+        currentDSL.children = currentDSL.children.map(
+          migrateNewlyAddedTabsWidgetsMissingData,
+        );
+        currentDSL.children = currentDSL.children.map((each) => {
+          each.version = 3;
+          if (has(currentDSL, ["leftColumn", "rightColumn", "bottomRow"])) {
+            return each;
+          }
+          return {
+            ...each,
+            leftColumn: 0,
+            rightColumn:
+              (currentDSL.rightColumn - currentDSL.leftColumn) *
+              currentDSL.parentColumnSpace,
+            bottomRow:
+              (currentDSL.bottomRow - currentDSL.topRow) *
+              currentDSL.parentRowSpace,
+          };
+        });
+      }
+    } catch (error) {
+      Sentry.captureException({
+        message: "Tabs Migration to add missing fields Failed",
+        oldData: currentDSL.tabs,
+      });
+    }
+  }
+  if (currentDSL.children && currentDSL.children.length) {
+    currentDSL.children = currentDSL.children.map(
+      migrateNewlyAddedTabsWidgetsMissingData,
+    );
+  }
   return currentDSL;
 };
 

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -752,10 +752,6 @@ const migrateNewlyAddedTabsWidgetsMissingData = (
   if (currentDSL.type === WidgetTypes.TABS_WIDGET && currentDSL.version === 2) {
     try {
       if (currentDSL.children && currentDSL.children.length) {
-        // because Tabs widget can contain Tabs widgets
-        currentDSL.children = currentDSL.children.map(
-          migrateNewlyAddedTabsWidgetsMissingData,
-        );
         currentDSL.children = currentDSL.children.map((each) => {
           if (has(currentDSL, ["leftColumn", "rightColumn", "bottomRow"])) {
             return each;

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -776,7 +776,7 @@ const migrateNewlyAddedTabsWidgetsMissingData = (
     } catch (error) {
       Sentry.captureException({
         message: "Tabs Migration to add missing fields Failed",
-        oldData: currentDSL.tabs,
+        oldData: currentDSL.children,
       });
     }
   }

--- a/app/client/src/widgets/Tabs/TabsWidget.tsx
+++ b/app/client/src/widgets/Tabs/TabsWidget.tsx
@@ -210,6 +210,13 @@ class TabsWidget extends BaseWidget<
           topRow: 1,
           newWidgetId,
           widgetId: this.props.widgetId,
+          leftColumn: 0,
+          rightColumn:
+            (this.props.rightColumn - this.props.leftColumn) *
+            this.props.parentColumnSpace,
+          bottomRow:
+            (this.props.bottomRow - this.props.topRow) *
+            this.props.parentRowSpace,
           props: {
             tabId: tab.id,
             tabName: tab.label,


### PR DESCRIPTION
## Description

Tabs widget implementation had not included some position widget properties coz it already had rows required to render but new grid migration needs them, so I have added migration for tabs widgets.

Fixes # (issue)
> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce. 
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/tabs-bad-data 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.58 **(0.03)** | 32.52 **(0.06)** | 29.69 **(0.02)** | 52.09 **(0.03)**
 :green_circle: | app/client/src/utils/WidgetFactory.tsx | 65.15 **(3.03)** | 63.16 **(5.27)** | 50 **(0)** | 65.15 **(3.03)**
 :green_circle: | app/client/src/utils/WidgetPropsUtils.tsx | 65.81 **(0.85)** | 51.51 **(1.37)** | 54.84 **(1.51)** | 65.19 **(0.92)**</details>