### PR TITLE
added string check on options props

### DIFF
--- a/app/client/src/widgets/DropdownWidget.tsx
+++ b/app/client/src/widgets/DropdownWidget.tsx
@@ -149,7 +149,11 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
   }
 
   getPageView() {
-    const options = this.props.options || [];
+    const options = this.props.options
+      ? typeof this.props.options === "string"
+        ? []
+        : this.props.options
+      : [];
     const selectedIndex = _.findIndex(this.props.options, {
       value: this.props.selectedOptionValue,
     });

--- a/app/client/src/widgets/DropdownWidget.tsx
+++ b/app/client/src/widgets/DropdownWidget.tsx
@@ -149,11 +149,7 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
   }
 
   getPageView() {
-    const options = this.props.options
-      ? typeof this.props.options === "string"
-        ? []
-        : this.props.options
-      : [];
+    const options = _.isArray(this.props.options) ? this.props.options : [];
     const selectedIndex = _.findIndex(this.props.options, {
       value: this.props.selectedOptionValue,
     });


### PR DESCRIPTION
## Description
> This issue arises due to DropDown getting string prop  "options" even when validator detected this string input ( i.e. "{{ \n _.chain() \n}}" ) as invalid and returned parsed value as empty Array. I have handled the current scenario, but if I get more insights into how prop value can be different from the value returned by a validated function, there can be a better solution.

Fixes # (#4146)

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ]  I have commented on my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>