### PR TITLE
Removed the reload

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/aTobAndbToaBasictest_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/aTobAndbToaBasictest_spec.js
@@ -31,7 +31,6 @@ describe("aTob and bToa library tests ", function() {
       "response.body.responseMeta.status",
       200,
     );
-    cy.reload();
   });
 
   it("publish widget and validate the data displayed in input widgets value for aToB and bToa", function() {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/loadashBasictest_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/loadashBasictest_spec.js
@@ -31,7 +31,6 @@ describe("Loadash basic test with input Widget", function() {
       "response.body.responseMeta.status",
       200,
     );
-    cy.reload();
   });
 
   it("publish widget and validate the data displayed in input widgets from loadash function", function() {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/momentBasictest_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/momentBasictest_spec.js
@@ -31,7 +31,6 @@ describe("Moment basic test with input Widget", function() {
       "response.body.responseMeta.status",
       200,
     );
-    cy.reload();
   });
 
   it("publish widget and validate the data displayed in input widgets", function() {


### PR DESCRIPTION
cy.reload was causing some issue in saving the default value for input2.

## Description
In the test cases, cy.reload was causing some issue in saving the default value for input2.

Fixes # (issue)
Removed the cy.reload() to prevent the issue in saving the default value of input2.

## Type of change
Deleted below line from each test case. 
cy.reload()

## Checklist:

- [ ✓] My code follows the style guidelines of this project
- [ ✓] I have performed a self-review of my own code
- [ ✓] I have commented my code, particularly in hard-to-understand areas
- [ ✓] I have made corresponding changes to the documentation
- [ ✓] My changes generate no new warnings
- [ ✓] I have added tests that prove my fix is effective or that my feature works
- [ ✓] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>