### PR TITLE
Datasource url overflow bug

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
+++ b/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
@@ -68,6 +68,8 @@ const DatasourceURL = styled.span`
   text-overflow: ellipsis;
   white-space: nowrap;
   background: #e7f3ff;
+  width: fit-content;
+  max-width: 100%;
 `;
 
 const PadTop = styled.div`

--- a/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
+++ b/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
@@ -67,7 +67,6 @@ const DatasourceURL = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: max-content;
   background: #e7f3ff;
 `;
 


### PR DESCRIPTION
## Description
Prevent text overflow in datasource source tab in API editor

<img width="269" alt="Screenshot 2021-05-28 at 3 55 33 PM" src="https://user-images.githubusercontent.com/32433245/119982322-4ff37e00-bfdc-11eb-9068-c609e939e8a0.png">


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>