### PR TITLE
Fix: Fix redis plugin socket error 

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -110,8 +110,8 @@ public class RedisPlugin extends BasePlugin {
                         /*
                          * - For some reason, Jedis throws a socket error when kept idle for like 10 min when
                          * appsmith is setup via docker image.
-                         * - APMU, jedis.close() should disconnect the connection, causing jedis to re-connect during
-                         *  next execution.
+                         * - APMU, jedis.close() should disconnect the connection, causing jedis to refresh connection
+                         * during next execution.
                          * - This is a placeholder solution till better fix is available (would connection pool fix
                          * it ?)
                          */

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
 
 public class RedisPlugin extends BasePlugin {
-    private static final Integer DEFAULT_PORT = 6379;
+    private static final Long DEFAULT_PORT = 6379L;
 
     public RedisPlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -105,6 +105,17 @@ public class RedisPlugin extends BasePlugin {
                         ActionExecutionResult result = actionExecutionResult;
                         result.setRequest(request);
                         return result;
+                    })
+                    .doFinally(signalType -> {
+                        /*
+                         * - For some reason, Jedis throws a socket error when kept idle for like 10 min when
+                         * appsmith is setup via docker image.
+                         * - APMU, jedis.close() should disconnect the connection, causing jedis to re-connect during
+                         *  next execution.
+                         * - This is a placeholder solution till better fix is available (would connection pool fix
+                         * it ?)
+                         */
+                        jedis.close();
                     })
                     .subscribeOn(scheduler);
         }
@@ -177,9 +188,6 @@ public class RedisPlugin extends BasePlugin {
                 Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
                 if (StringUtils.isNullOrEmpty(endpoint.getHost())) {
                     invalids.add("Missing host for endpoint");
-                }
-                if (endpoint.getPort() == null) {
-                    invalids.add("Missing port for endpoint");
                 }
             }
 

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -83,7 +83,7 @@ public class RedisPluginTest {
         Endpoint endpoint = new Endpoint();
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
-        Assert.assertEquals(Set.of("Missing port for endpoint", "Missing host for endpoint"),
+        Assert.assertEquals(Set.of("Missing host for endpoint"),
                 pluginExecutor.validateDatasource(invalidDatasourceConfiguration));
     }
 
@@ -95,7 +95,8 @@ public class RedisPluginTest {
         endpoint.setHost("test-host");
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
-        Assert.assertEquals(pluginExecutor.validateDatasource(invalidDatasourceConfiguration), Set.of("Missing port for endpoint"));
+        // Since default port is picked, set of invalids should be empty.
+        Assert.assertEquals(pluginExecutor.validateDatasource(invalidDatasourceConfiguration), Set.of());
     }
 
     @Test
@@ -112,7 +113,7 @@ public class RedisPluginTest {
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
         Assert.assertEquals(
-                Set.of("Missing port for endpoint", "Missing username for authentication.", "Missing password for authentication."),
+                Set.of("Missing username for authentication.", "Missing password for authentication."),
                 pluginExecutor.validateDatasource(invalidDatasourceConfiguration)
         );
     }


### PR DESCRIPTION
## Description
- fix socket error
- fix default port
- remove invalid check for missing port, since default port would be supplied if user leaves the port field empty. 

Fixes #4560 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
