### PR TITLE
Enable smart substitution for widgets

### DIFF
--- a/app/client/src/constants/PropertyControlConstants.tsx
+++ b/app/client/src/constants/PropertyControlConstants.tsx
@@ -1,5 +1,6 @@
 import { getPropertyControlTypes } from "components/propertyControls";
 import { VALIDATION_TYPES } from "constants/WidgetValidation";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 const ControlTypes = getPropertyControlTypes();
 export type ControlType = typeof ControlTypes[keyof typeof ControlTypes];
 
@@ -48,6 +49,7 @@ export type PropertyPaneControlConfig = {
   additionalAutoComplete?: (
     props: any,
   ) => Record<string, Record<string, unknown>>;
+  evaluationSubstitutionType?: EvaluationSubstitutionType;
 };
 
 export type PropertyPaneConfig =

--- a/app/client/src/entities/Widget/utils.test.ts
+++ b/app/client/src/entities/Widget/utils.test.ts
@@ -115,7 +115,7 @@ describe("getAllPathsFromPropertyConfig", () => {
       bindingPaths: {
         selectedRow: EvaluationSubstitutionType.TEMPLATE,
         selectedRows: EvaluationSubstitutionType.TEMPLATE,
-        tableData: EvaluationSubstitutionType.TEMPLATE,
+        tableData: EvaluationSubstitutionType.SMART_SUBSTITUTE,
         defaultSearchText: EvaluationSubstitutionType.TEMPLATE,
         defaultSelectedRow: EvaluationSubstitutionType.TEMPLATE,
         isVisible: EvaluationSubstitutionType.TEMPLATE,
@@ -217,7 +217,7 @@ describe("getAllPathsFromPropertyConfig", () => {
         chartType: EvaluationSubstitutionType.TEMPLATE,
         chartName: EvaluationSubstitutionType.TEMPLATE,
         "chartData.random-id.seriesName": EvaluationSubstitutionType.TEMPLATE,
-        "chartData.random-id.data": EvaluationSubstitutionType.TEMPLATE,
+        "chartData.random-id.data": EvaluationSubstitutionType.SMART_SUBSTITUTE,
         xAxisName: EvaluationSubstitutionType.TEMPLATE,
         yAxisName: EvaluationSubstitutionType.TEMPLATE,
         isVisible: EvaluationSubstitutionType.TEMPLATE,

--- a/app/client/src/entities/Widget/utils.ts
+++ b/app/client/src/entities/Widget/utils.ts
@@ -36,6 +36,7 @@ export const getAllPathsFromPropertyConfig = (
             !controlConfig.isTriggerProperty
           ) {
             bindingPaths[controlConfig.propertyName] =
+              controlConfig.evaluationSubstitutionType ||
               EvaluationSubstitutionType.TEMPLATE;
             if (controlConfig.validation) {
               validationPaths[controlConfig.propertyName] =
@@ -80,6 +81,7 @@ export const getAllPathsFromPropertyConfig = (
                               !panelColumnControlConfig.isTriggerProperty
                             ) {
                               bindingPaths[panelPropertyPath] =
+                                controlConfig.evaluationSubstitutionType ||
                                 EvaluationSubstitutionType.TEMPLATE;
                               if (panelColumnControlConfig.validation) {
                                 validationPaths[panelPropertyPath] =
@@ -119,6 +121,7 @@ export const getAllPathsFromPropertyConfig = (
                   !childPropertyConfig.isTriggerProperty
                 ) {
                   bindingPaths[childArrayPropertyPath] =
+                    controlConfig.evaluationSubstitutionType ||
                     EvaluationSubstitutionType.TEMPLATE;
                   if (childPropertyConfig.validation) {
                     validationPaths[childArrayPropertyPath] =

--- a/app/client/src/entities/Widget/utils.ts
+++ b/app/client/src/entities/Widget/utils.ts
@@ -121,7 +121,7 @@ export const getAllPathsFromPropertyConfig = (
                   !childPropertyConfig.isTriggerProperty
                 ) {
                   bindingPaths[childArrayPropertyPath] =
-                    controlConfig.evaluationSubstitutionType ||
+                    childPropertyConfig.evaluationSubstitutionType ||
                     EvaluationSubstitutionType.TEMPLATE;
                   if (childPropertyConfig.validation) {
                     validationPaths[childArrayPropertyPath] =

--- a/app/client/src/widgets/ChartWidget/propertyConfig.ts
+++ b/app/client/src/widgets/ChartWidget/propertyConfig.ts
@@ -1,5 +1,6 @@
 import { ChartWidgetProps } from "widgets/ChartWidget";
 import { VALIDATION_TYPES } from "constants/WidgetValidation";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 export default [
   {
@@ -77,6 +78,7 @@ export default [
         validation: VALIDATION_TYPES.CUSTOM_FUSION_CHARTS_DATA,
         hidden: (props: ChartWidgetProps) =>
           props.chartType !== "CUSTOM_FUSION_CHART",
+        evaluationSubstitutionType: EvaluationSubstitutionType.SMART_SUBSTITUTE,
       },
       {
         helpText: "Populates the chart with the data",
@@ -106,6 +108,8 @@ export default [
             isBindProperty: true,
             isTriggerProperty: false,
             validation: VALIDATION_TYPES.CHART_SERIES_DATA,
+            evaluationSubstitutionType:
+              EvaluationSubstitutionType.SMART_SUBSTITUTE,
           },
         ],
       },

--- a/app/client/src/widgets/DropdownWidget.tsx
+++ b/app/client/src/widgets/DropdownWidget.tsx
@@ -9,6 +9,7 @@ import { Intent as BlueprintIntent } from "@blueprintjs/core";
 import * as Sentry from "@sentry/react";
 import withMeta, { WithMeta } from "./MetaHOC";
 import { IconName } from "@blueprintjs/icons";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
   static getPropertyPaneConfig() {
@@ -45,6 +46,8 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
             isBindProperty: true,
             isTriggerProperty: false,
             validation: VALIDATION_TYPES.OPTIONS_DATA,
+            evaluationSubstitutionType:
+              EvaluationSubstitutionType.SMART_SUBSTITUTE,
           },
           {
             helpText: "Selects the option with value by default",

--- a/app/client/src/widgets/FilepickerWidget.tsx
+++ b/app/client/src/widgets/FilepickerWidget.tsx
@@ -19,6 +19,7 @@ import _ from "lodash";
 import * as Sentry from "@sentry/react";
 import withMeta, { WithMeta } from "./MetaHOC";
 import FileDataTypes from "./FileDataTypes";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 class FilePickerWidget extends BaseWidget<
   FilePickerWidgetProps,
@@ -114,6 +115,8 @@ class FilePickerWidget extends BaseWidget<
             isBindProperty: true,
             isTriggerProperty: false,
             validation: VALIDATION_TYPES.ARRAY,
+            evaluationSubstitutionType:
+              EvaluationSubstitutionType.SMART_SUBSTITUTE,
           },
           {
             helpText: "Set the format of the data read from the files",

--- a/app/client/src/widgets/ListWidget/ListPropertyPaneConfig.ts
+++ b/app/client/src/widgets/ListWidget/ListPropertyPaneConfig.ts
@@ -2,6 +2,7 @@ import { get } from "lodash";
 import { WidgetProps } from "widgets/BaseWidget";
 import { ListWidgetProps } from "./ListWidget";
 import { VALIDATION_TYPES } from "constants/WidgetValidation";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 const PropertyPaneConfig = [
   {
@@ -17,6 +18,7 @@ const PropertyPaneConfig = [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.LIST_DATA,
+        evaluationSubstitutionType: EvaluationSubstitutionType.SMART_SUBSTITUTE,
       },
       {
         propertyName: "backgroundColor",

--- a/app/client/src/widgets/MapWidget.tsx
+++ b/app/client/src/widgets/MapWidget.tsx
@@ -10,6 +10,7 @@ import * as Sentry from "@sentry/react";
 import withMeta, { WithMeta } from "./MetaHOC";
 import { DEFAULT_CENTER } from "constants/WidgetConstants";
 import { getBorderCSSShorthand } from "constants/DefaultTheme";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 const { google } = getAppsmithConfigs();
 
@@ -63,6 +64,8 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
             isBindProperty: true,
             isTriggerProperty: false,
             validation: VALIDATION_TYPES.MARKERS,
+            evaluationSubstitutionType:
+              EvaluationSubstitutionType.SMART_SUBSTITUTE,
           },
           {
             propertyName: "enableSearch",

--- a/app/client/src/widgets/RadioGroupWidget.tsx
+++ b/app/client/src/widgets/RadioGroupWidget.tsx
@@ -6,6 +6,7 @@ import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { VALIDATION_TYPES } from "constants/WidgetValidation";
 import * as Sentry from "@sentry/react";
 import withMeta, { WithMeta } from "./MetaHOC";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
   static getPropertyPaneConfig() {
@@ -23,6 +24,8 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
             isBindProperty: true,
             isTriggerProperty: false,
             validation: VALIDATION_TYPES.OPTIONS_DATA,
+            evaluationSubstitutionType:
+              EvaluationSubstitutionType.SMART_SUBSTITUTE,
           },
           {
             helpText: "Selects a value of the options entered by default",

--- a/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
+++ b/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
@@ -219,8 +219,6 @@ export default [
                   },
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "inputFormat",
@@ -322,8 +320,6 @@ export default [
                   },
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "outputFormat",
@@ -425,8 +421,6 @@ export default [
                   },
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
               ],
             },
@@ -468,8 +462,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "textSize",
@@ -512,8 +504,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "fontStyle",
@@ -534,8 +524,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "verticalAlignment",
@@ -561,8 +549,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "textColor",
@@ -573,8 +559,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "cellBackground",
@@ -585,8 +569,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
               ],
             },
@@ -605,8 +587,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "buttonStyle",
@@ -619,8 +599,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "buttonLabelColor",
@@ -632,8 +610,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   helpText: "Triggers an action when the button is clicked",
@@ -652,8 +628,6 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: true,
-                  evaluationSubstitutionType:
-                    EvaluationSubstitutionType.TEMPLATE,
                 },
               ],
             },
@@ -668,7 +642,6 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.TEXT,
-        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText: "Selects the default selected row",
@@ -679,7 +652,6 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.DEFAULT_SELECTED_ROW,
-        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText:
@@ -699,7 +671,6 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.BOOLEAN,
-        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         propertyName: "multiRowSelection",
@@ -721,7 +692,6 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
-        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText: "Triggers an action when a table page is changed",
@@ -731,7 +701,6 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
-        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText: "Triggers an action when a table page size is changed",
@@ -741,7 +710,6 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
-        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         propertyName: "onSearchTextChanged",
@@ -750,7 +718,6 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
-        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
     ],
   },

--- a/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
+++ b/app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts
@@ -3,6 +3,7 @@ import { Colors } from "constants/Colors";
 import { ColumnProperties } from "components/designSystems/appsmith/TableComponent/Constants";
 import { TableWidgetProps } from "./TableWidgetConstants";
 import { VALIDATION_TYPES } from "constants/WidgetValidation";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 // A hook to update all column styles when global table styles are updated
 const updateColumnStyles = (
@@ -144,6 +145,7 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.TABLE_DATA,
+        evaluationSubstitutionType: EvaluationSubstitutionType.SMART_SUBSTITUTE,
       },
       {
         helpText: "Columns",
@@ -217,6 +219,8 @@ export default [
                   },
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "inputFormat",
@@ -318,6 +322,8 @@ export default [
                   },
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "outputFormat",
@@ -419,6 +425,8 @@ export default [
                   },
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
               ],
             },
@@ -460,6 +468,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "textSize",
@@ -502,6 +512,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "fontStyle",
@@ -522,6 +534,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "verticalAlignment",
@@ -547,6 +561,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "textColor",
@@ -557,6 +573,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "cellBackground",
@@ -567,6 +585,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
               ],
             },
@@ -585,6 +605,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "buttonStyle",
@@ -597,6 +619,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   propertyName: "buttonLabelColor",
@@ -608,6 +632,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: false,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
                 {
                   helpText: "Triggers an action when the button is clicked",
@@ -626,6 +652,8 @@ export default [
                   updateHook: updateDerivedColumnsHook,
                   isBindProperty: true,
                   isTriggerProperty: true,
+                  evaluationSubstitutionType:
+                    EvaluationSubstitutionType.TEMPLATE,
                 },
               ],
             },
@@ -640,6 +668,7 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.TEXT,
+        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText: "Selects the default selected row",
@@ -650,6 +679,7 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.DEFAULT_SELECTED_ROW,
+        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText:
@@ -669,6 +699,7 @@ export default [
         isBindProperty: true,
         isTriggerProperty: false,
         validation: VALIDATION_TYPES.BOOLEAN,
+        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         propertyName: "multiRowSelection",
@@ -690,6 +721,7 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
+        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText: "Triggers an action when a table page is changed",
@@ -699,6 +731,7 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
+        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         helpText: "Triggers an action when a table page size is changed",
@@ -708,6 +741,7 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
+        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
       {
         propertyName: "onSearchTextChanged",
@@ -716,6 +750,7 @@ export default [
         isJSConvertible: true,
         isBindProperty: true,
         isTriggerProperty: true,
+        evaluationSubstitutionType: EvaluationSubstitutionType.TEMPLATE,
       },
     ],
   },


### PR DESCRIPTION
Widget properties that require an object like structure were failing when a user had multiple bindings in that property. This was because we would templatise the final output which would make the final output a string with escaped characters.
This change will enable smart substitution evaluation we use in JSON inputs like API post body to correctly evaluate properties configured with multiple bindings or binding + string combinations

## Before
<img width="1106" alt="Screenshot 2021-05-31 at 3 30 42 PM" src="https://user-images.githubusercontent.com/12022471/120176674-32fdbb80-c225-11eb-82e2-14fef310b1a5.png">

## After
<img width="1090" alt="Screenshot 2021-05-31 at 3 29 59 PM" src="https://user-images.githubusercontent.com/12022471/120176690-36914280-c225-11eb-9017-9e6140daf845.png">


Fixes #4688
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/smart-substitution-widgets 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.59 **(0.01)** | 32.62 **(0.03)** | 29.76 **(0)** | 52.11 **(0.02)**
 :green_circle: | app/client/src/entities/Widget/utils.ts | 96.88 **(0)** | 85.29 **(1.42)** | 100 **(0)** | 96.77 **(0)**
 :green_circle: | app/client/src/widgets/DropdownWidget.tsx | 45.45 **(1.01)** | 0 **(0)** | 41.67 **(0)** | 47.06 **(1.06)**
 :green_circle: | app/client/src/widgets/FilepickerWidget.tsx | 36.26 **(0.7)** | 0 **(0)** | 14.81 **(0)** | 35.56 **(0.73)**
 :green_circle: | app/client/src/widgets/MapWidget.tsx | 47.62 **(0.85)** | 9.09 **(0)** | 23.53 **(0)** | 48.33 **(0.87)**
 :green_circle: | app/client/src/widgets/RadioGroupWidget.tsx | 82.14 **(0.66)** | 0 **(0)** | 62.5 **(0)** | 84.62 **(0.62)**
 :green_circle: | app/client/src/widgets/ListWidget/ListPropertyPaneConfig.ts | 45.45 **(5.45)** | 0 **(0)** | 0 **(0)** | 45.45 **(5.45)**
 :green_circle: | app/client/src/widgets/TableWidget/TablePropertyPaneConfig.ts | 36.11 **(0.9)** | 13.73 **(0)** | 50 **(0)** | 38.24 **(0.93)**</details>