### PR TITLE
Fix multiline js issues

### DIFF
--- a/app/client/src/workers/evaluate.test.ts
+++ b/app/client/src/workers/evaluate.test.ts
@@ -34,11 +34,6 @@ describe("evaluate", () => {
     const response = evaluate(js, {});
     expect(response.result).toBe("Hello!");
   });
-  it("unescapes string and removes linebreaks before evaluation", () => {
-    const js = "'Hello,\\nworld!'";
-    const response = evaluate(js, {});
-    expect(response.result).toBe("Hello,world!");
-  });
   it("throws error for undefined js", () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -17,7 +17,7 @@ export default function evaluate(
   data: DataTree,
   callbackData?: Array<any>,
 ): EvalResult {
-  const unescapedJS = unescapeJS(js).replace(/(\r\n|\n|\r)/gm, "");
+  const unescapedJS = unescapeJS(js);
   const scriptToEvaluate = `
         const result = ${unescapedJS};
         return { result, triggers: self.triggers }


### PR DESCRIPTION
## Description
Evaluating multi-line JS without semicolons was failing because we would remove line break characters from the script before evaluating. This was also causing the line comments to fail in multi-line code. By avoiding the removal of line breaks, these errors go away

Fixes #948 
Fixes #1998 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>