### PR TITLE
Fix: Fix redis plugin socket error  (#4791)

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
 
 public class RedisPlugin extends BasePlugin {
-    private static final Integer DEFAULT_PORT = 6379;
+    private static final Long DEFAULT_PORT = 6379L;
 
     public RedisPlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -105,6 +105,17 @@ public class RedisPlugin extends BasePlugin {
                         ActionExecutionResult result = actionExecutionResult;
                         result.setRequest(request);
                         return result;
+                    })
+                    .doFinally(signalType -> {
+                        /*
+                         * - For some reason, Jedis throws a socket error when kept idle for like 10 min when
+                         * appsmith is setup via docker image.
+                         * - APMU, jedis.close() should disconnect the connection, causing jedis to refresh connection
+                         * during next execution.
+                         * - This is a placeholder solution till better fix is available (would connection pool fix
+                         * it ?)
+                         */
+                        jedis.close();
                     })
                     .subscribeOn(scheduler);
         }
@@ -177,9 +188,6 @@ public class RedisPlugin extends BasePlugin {
                 Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
                 if (StringUtils.isNullOrEmpty(endpoint.getHost())) {
                     invalids.add("Missing host for endpoint");
-                }
-                if (endpoint.getPort() == null) {
-                    invalids.add("Missing port for endpoint");
                 }
             }
 

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -83,7 +83,7 @@ public class RedisPluginTest {
         Endpoint endpoint = new Endpoint();
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
-        Assert.assertEquals(Set.of("Missing port for endpoint", "Missing host for endpoint"),
+        Assert.assertEquals(Set.of("Missing host for endpoint"),
                 pluginExecutor.validateDatasource(invalidDatasourceConfiguration));
     }
 
@@ -95,7 +95,8 @@ public class RedisPluginTest {
         endpoint.setHost("test-host");
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
-        Assert.assertEquals(pluginExecutor.validateDatasource(invalidDatasourceConfiguration), Set.of("Missing port for endpoint"));
+        // Since default port is picked, set of invalids should be empty.
+        Assert.assertEquals(pluginExecutor.validateDatasource(invalidDatasourceConfiguration), Set.of());
     }
 
     @Test
@@ -112,7 +113,7 @@ public class RedisPluginTest {
         invalidDatasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
         Assert.assertEquals(
-                Set.of("Missing port for endpoint", "Missing username for authentication.", "Missing password for authentication."),
+                Set.of("Missing username for authentication.", "Missing password for authentication."),
                 pluginExecutor.validateDatasource(invalidDatasourceConfiguration)
         );
     }


### PR DESCRIPTION
## Description
Hotfix for redis plugin issue https://github.com/appsmithorg/appsmith/issues/4560 
* fix socket error
* fix default port
* remove invalid check for missing port, since default port would be supplied if user leaves the port field empty.

(cherry picked from commit e2f4fd5e94a1ca34fc703b2a94e5c773ca454d63)

