### PR TITLE
Change cta to apply datasource on datasource card click

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -59,7 +59,7 @@ export const HintStyles = createGlobalStyle<{
   }
 
   .datasource-hint {
-    padding: 10px;
+    padding: 10px !important;
     display: block;
     width: 500px;
     height: 32px;

--- a/app/client/src/components/editorComponents/StoreAsDatasource.tsx
+++ b/app/client/src/components/editorComponents/StoreAsDatasource.tsx
@@ -10,7 +10,7 @@ export const DatasourceIcon = styled.div<{ enable?: boolean }>`
   display: flex;
   align-items: center;
   cursor: pointer;
-  margin-left: 5px;
+  margin-left: 10px;
   height: 100%;
   min-height: 37px;
   .${Classes.TEXT} {

--- a/app/client/src/components/editorComponents/StoreAsDatasource.tsx
+++ b/app/client/src/components/editorComponents/StoreAsDatasource.tsx
@@ -7,12 +7,12 @@ import Icon, { IconSize } from "components/ads/Icon";
 import { Classes } from "components/ads/common";
 
 export const DatasourceIcon = styled.div<{ enable?: boolean }>`
-  position: absolute;
-  right: -155px;
-  top: 7px;
   display: flex;
   align-items: center;
   cursor: pointer;
+  margin-left: 5px;
+  height: 100%;
+  min-height: 37px;
   .${Classes.TEXT} {
     color: ${(props) => props.theme.colors.text.heading};
   }

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -298,7 +298,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
     return (
       <DatasourceContainer>
         <CodeEditor {...props} />
-        {datasource && !("id" in datasource) ? (
+        {displayValue && datasource && !("id" in datasource) ? (
           <StoreAsDatasource enable={!!displayValue} />
         ) : datasource && "id" in datasource ? (
           <DatasourceIcon

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -63,7 +63,6 @@ type Props = EditorProps &
 const DatasourceContainer = styled.div`
   display: flex;
   position: relative;
-  width: calc(100% - 155px);
 `;
 
 const hintContainerStyles: React.CSSProperties = {

--- a/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
+++ b/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { IconSize } from "components/ads/Icon";
+import Icon, { IconSize } from "components/ads/Icon";
 import { StyledSeparator } from "pages/Applications/ProductUpdatesModal/ReleaseComponent";
+import { DATA_SOURCES_EDITOR_ID_URL } from "constants/routes";
+import history from "utils/history";
 import { TabComponent } from "components/ads/Tabs";
 import Text, { FontWeight, TextType } from "components/ads/Text";
 import { TabbedViewContainer } from "./Form";
@@ -59,20 +61,25 @@ const DatasourceCard = styled.div`
 
 const DatasourceURL = styled.span`
   margin: 8px 0;
-  padding: 5px;
   font-size: 12px;
-  border: 1px solid #69b5ff;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  background: #e7f3ff;
+  color: #457ae6;
   width: fit-content;
   max-width: 100%;
+  font-weight: 500;
 `;
 
 const PadTop = styled.div`
   padding-top: 5px;
   border: none;
+`;
+
+const DataSourceNameContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
 `;
 
 export const getDatasourceInfo = (datasource: any): string => {
@@ -108,25 +115,51 @@ export default function DataSourceList(props: any) {
                   <DataSourceListWrapper
                     className={selectedIndex === 0 ? "show" : ""}
                   >
-                    {(props.datasources || []).map((d: any, idx: number) => (
-                      <DatasourceCard
-                        key={idx}
-                        onClick={() => props.onClick(d)}
-                      >
-                        <Text type={TextType.H5} weight={FontWeight.BOLD}>
-                          {d.name}
-                        </Text>
-                        <DatasourceURL>
-                          {d.datasourceConfiguration.url}
-                        </DatasourceURL>
-                        <StyledSeparator />
-                        <PadTop>
-                          <Text type={TextType.P3} weight={FontWeight.NORMAL}>
-                            {getDatasourceInfo(d)}
-                          </Text>
-                        </PadTop>
-                      </DatasourceCard>
-                    ))}
+                    {(props.datasources || []).map((d: any, idx: number) => {
+                      const dataSourceInfo: string = getDatasourceInfo(d);
+                      return (
+                        <DatasourceCard
+                          key={idx}
+                          onClick={() => props.onClick(d)}
+                        >
+                          <DataSourceNameContainer>
+                            <Text type={TextType.H5} weight={FontWeight.BOLD}>
+                              {d.name}
+                            </Text>
+                            <Icon
+                              name="edit"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                history.push(
+                                  DATA_SOURCES_EDITOR_ID_URL(
+                                    props.applicationId,
+                                    props.currentPageId,
+                                    d.id,
+                                  ),
+                                );
+                              }}
+                              size={IconSize.LARGE}
+                            />
+                          </DataSourceNameContainer>
+                          <DatasourceURL>
+                            {d.datasourceConfiguration.url}
+                          </DatasourceURL>
+                          {dataSourceInfo && (
+                            <>
+                              <StyledSeparator />
+                              <PadTop>
+                                <Text
+                                  type={TextType.P3}
+                                  weight={FontWeight.NORMAL}
+                                >
+                                  {dataSourceInfo}
+                                </Text>
+                              </PadTop>
+                            </>
+                          )}
+                        </DatasourceCard>
+                      );
+                    })}
                   </DataSourceListWrapper>
                 ) : (
                   <EmptyDatasourceContainer>

--- a/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
+++ b/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
@@ -80,6 +80,27 @@ const DataSourceNameContainer = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
+  .cs-text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .cs-icon {
+    flex-shrink: 0;
+    svg {
+      path {
+        fill: #a9a7a7;
+      }
+    }
+    &: hover {
+      background-color: ${(props) => props.theme.colors.apiPane.iconHoverBg};
+      svg {
+        path {
+          fill: #4b4848;
+        }
+      }
+    }
+  }
 `;
 
 export const getDatasourceInfo = (datasource: any): string => {

--- a/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
+++ b/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
@@ -54,8 +54,15 @@ const DatasourceCard = styled.div`
   border: 1px solid ${(props) => props.theme.colors.apiPane.dividerBg};
   cursor: pointer;
   transition: 0.3s all ease;
+  .cs-icon {
+    opacity: 0;
+    transition: 0.3s all ease;
+  }
   &:hover {
     box-shadow: 0 0 5px #c7c7c7;
+    .cs-icon {
+      opacity: 1;
+    }
   }
 `;
 
@@ -89,16 +96,11 @@ const DataSourceNameContainer = styled.div`
     flex-shrink: 0;
     svg {
       path {
-        fill: #a9a7a7;
+        fill: #4b4848;
       }
     }
     &: hover {
       background-color: ${(props) => props.theme.colors.apiPane.iconHoverBg};
-      svg {
-        path {
-          fill: #4b4848;
-        }
-      }
     }
   }
 `;

--- a/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
+++ b/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
@@ -113,15 +113,7 @@ export default function DataSourceList(props: any) {
                     {(props.datasources || []).map((d: any, idx: number) => (
                       <DatasourceCard
                         key={idx}
-                        onClick={() =>
-                          history.push(
-                            DATA_SOURCES_EDITOR_ID_URL(
-                              props.applicationId,
-                              props.currentPageId,
-                              d.id,
-                            ),
-                          )
-                        }
+                        onClick={() => props.onClick(d)}
                       >
                         <Text type={TextType.H5} weight={FontWeight.BOLD}>
                           {d.name}

--- a/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
+++ b/app/client/src/pages/Editor/APIEditor/DatasourceList.tsx
@@ -2,8 +2,6 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { IconSize } from "components/ads/Icon";
 import { StyledSeparator } from "pages/Applications/ProductUpdatesModal/ReleaseComponent";
-import { DATA_SOURCES_EDITOR_ID_URL } from "constants/routes";
-import history from "utils/history";
 import { TabComponent } from "components/ads/Tabs";
 import Text, { FontWeight, TextType } from "components/ads/Text";
 import { TabbedViewContainer } from "./Form";

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -363,6 +363,11 @@ const CloseIconContainer = styled.div`
   position: absolute;
   top: 12px;
   right: 10px;
+  svg {
+    path {
+      fill: #a9a7a7;
+    }
+  }
 `;
 
 function renderHelpSection(

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import { connect, useSelector, useDispatch } from "react-redux";
-import { formValueSelector, InjectedFormProps, reduxForm } from "redux-form";
+import {
+  formValueSelector,
+  InjectedFormProps,
+  reduxForm,
+  change,
+} from "redux-form";
 import {
   HTTP_METHOD_OPTIONS,
   HTTP_METHODS,
@@ -41,6 +46,7 @@ import { Icon as ButtonIcon } from "@blueprintjs/core";
 import { IconSize } from "components/ads/Icon";
 import get from "lodash/get";
 import DataSourceList from "./DatasourceList";
+import { Datasource } from "entities/Datasource";
 const Form = styled.form`
   display: flex;
   flex-direction: column;
@@ -197,6 +203,7 @@ interface APIFormProps {
   datasources?: any;
   currentPageId?: string;
   applicationId?: string;
+  updateDatasource: (datasource: Datasource) => void;
 }
 
 type Props = APIFormProps & InjectedFormProps<Action, APIFormProps>;
@@ -433,6 +440,7 @@ function ApiEditorForm(props: Props) {
     paramsCount,
     pluginId,
     settingsConfig,
+    updateDatasource,
   } = props;
   const dispatch = useDispatch();
   const allowPostBody =
@@ -617,6 +625,7 @@ function ApiEditorForm(props: Props) {
               applicationId={props.applicationId}
               currentPageId={props.currentPageId}
               datasources={props.datasources}
+              onClick={updateDatasource}
             />
             <CloseIconContainer>
               <Icon
@@ -634,6 +643,16 @@ function ApiEditorForm(props: Props) {
 }
 
 const selector = formValueSelector(API_EDITOR_FORM_NAME);
+
+type ReduxDispatchProps = {
+  updateDatasource: (datasource: Datasource) => void;
+};
+
+const mapDispatchToProps = (dispatch: any): ReduxDispatchProps => ({
+  updateDatasource: (datasource) => {
+    dispatch(change(API_EDITOR_FORM_NAME, "datasource", datasource));
+  },
+});
 
 export default connect((state: AppState, props: { pluginId: string }) => {
   const httpMethodFromForm = selector(state, "actionConfiguration.httpMethod");
@@ -690,7 +709,7 @@ export default connect((state: AppState, props: { pluginId: string }) => {
     currentPageId: state.entities.pageList.currentPageId,
     applicationId: state.entities.pageList.applicationId,
   };
-})(
+}, mapDispatchToProps)(
   reduxForm<Action, APIFormProps>({
     form: API_EDITOR_FORM_NAME,
   })(ApiEditorForm),

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -326,6 +326,11 @@ const DatasourceListTrigger = styled.div`
   }
 `;
 
+const BoundaryContainer = styled.div`
+  border: 1px solid transparent;
+  border-right: none;
+`;
+
 function renderImportedHeadersButton(
   headersCount: number,
   onClick: any,
@@ -492,15 +497,17 @@ function ApiEditorForm(props: Props) {
           </ActionButtons>
         </FormRow>
         <FormRow className="api-info-row">
-          <RequestDropdownField
-            className="t--apiFormHttpMethod"
-            height={"35px"}
-            name="actionConfiguration.httpMethod"
-            optionWidth={"100px"}
-            options={HTTP_METHOD_OPTIONS}
-            placeholder="Method"
-            width={"100px"}
-          />
+          <BoundaryContainer>
+            <RequestDropdownField
+              className="t--apiFormHttpMethod"
+              height={"35px"}
+              name="actionConfiguration.httpMethod"
+              optionWidth={"100px"}
+              options={HTTP_METHOD_OPTIONS}
+              placeholder="Method"
+              width={"100px"}
+            />
+          </BoundaryContainer>
           <DatasourceWrapper className="t--dataSourceField">
             <EmbeddedDatasourcePathField
               name="actionConfiguration.path"


### PR DESCRIPTION
## Description
Change CTA to apply datasource on click instead of navigation to datasource form. Fixed alignment of request method button. New UI changes for datasource list

Fixes #4858 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes








## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/change_datasource_card_cta 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.59 **(-0.01)** | 32.66 **(0.01)** | 29.74 **(-0.02)** | 52.11 **(0)**
 :red_circle: | app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx | 29.37 **(0)** | 2.67 **(-0.03)** | 4 **(0)** | 31.3 **(0)**
 :red_circle: | app/client/src/pages/Editor/APIEditor/DatasourceList.tsx | 48.78 **(-4)** | 46.67 **(0.52)** | 0 **(0)** | 51.35 **(-4.9)**
 :green_circle: | app/client/src/pages/Editor/APIEditor/Form.tsx | 37.8 **(0.3)** | 47.92 **(1.11)** | 0 **(0)** | 40 **(0.53)**</details>