### PR TITLE
Fix: Fix redis plugin db authentication

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -150,7 +150,7 @@ public class RedisPlugin extends BasePlugin {
                 Jedis jedis = new Jedis(endpoint.getHost(), port);
 
                 DBAuth auth = (DBAuth) datasourceConfiguration.getAuthentication();
-                if (auth != null && DBAuth.Type.USERNAME_PASSWORD.equals(auth.getAuthType())) {
+                if (auth != null) {
                     jedis.auth(auth.getUsername(), auth.getPassword());
                 }
 


### PR DESCRIPTION
## Description
- remove DB Auth type check, since the type is not getting set and the check does not seem to be required in any way. 

Fixes #4862 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
