### PR TITLE
Fix to show datasource auth info clearly

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -59,7 +59,7 @@ export const HintStyles = createGlobalStyle<{
   }
 
   .datasource-hint {
-    padding: 10px !important;
+    padding: 10px 20px 10px 10px !important;
     display: block;
     width: 500px;
     height: 32px;


### PR DESCRIPTION
## Description
 Fixes partially hidden information in the right side of the suggestion box

Fixes #4897 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>