### PR TITLE
bugfix: redirect user to homepage when user was inside an org and lef…

### DIFF
--- a/app/client/src/sagas/OrgSagas.ts
+++ b/app/client/src/sagas/OrgSagas.ts
@@ -139,7 +139,6 @@ export function* deleteOrgUserSaga(action: ReduxAction<DeleteOrgUserRequest>) {
       if (currentUser?.username == action.payload.username) {
         history.replace(APPLICATIONS_URL);
       } else {
-        console.log("User removed someone");
         yield put({
           type: ReduxActionTypes.DELETE_ORG_USER_SUCCESS,
           payload: {

--- a/app/client/src/sagas/OrgSagas.ts
+++ b/app/client/src/sagas/OrgSagas.ts
@@ -28,8 +28,10 @@ import { ApiResponse } from "api/ApiResponses";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
 import { getCurrentOrg } from "selectors/organizationSelectors";
+import { getCurrentUser } from "selectors/usersSelectors";
 import { Org } from "constants/orgConstants";
 import history from "utils/history";
+import { APPLICATIONS_URL } from "constants/routes";
 import { getAllApplications } from "actions/applicationActions";
 import log from "loglevel";
 
@@ -133,12 +135,18 @@ export function* deleteOrgUserSaga(action: ReduxAction<DeleteOrgUserRequest>) {
     const response: ApiResponse = yield call(OrgApi.deleteOrgUser, request);
     const isValidResponse = yield validateResponse(response);
     if (isValidResponse) {
-      yield put({
-        type: ReduxActionTypes.DELETE_ORG_USER_SUCCESS,
-        payload: {
-          username: action.payload.username,
-        },
-      });
+      const currentUser = yield select(getCurrentUser);
+      if (currentUser?.username == action.payload.username) {
+        history.replace(APPLICATIONS_URL);
+      } else {
+        console.log("User removed someone");
+        yield put({
+          type: ReduxActionTypes.DELETE_ORG_USER_SUCCESS,
+          payload: {
+            username: action.payload.username,
+          },
+        });
+      }
       Toaster.show({
         text: `${response.data.username} has been removed successfully`,
         variant: Variant.success,


### PR DESCRIPTION
## Description
Currently an admin user can delete himself from the members page of an organization if there is at least one other admin user. But after deleting himself from the organization, user stays at the members page. Although he'll not be able to do anything from that page as he no more belongs to that organization, the user experience might be confusing.

Changes in this PR simply takes the user to home page i.e. `/applications` when he removes himself from an organization.

Fixes # (issue)
Issue #4884

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
-Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: bugfix/reload-homepage-after-delete-ownself 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.58 **(-0.01)** | 32.66 **(-0.02)** | 29.75 **(0)** | 52.1 **(0)**
 :green_circle: | app/client/src/sagas/OrgSagas.ts | 22.56 **(0.51)** | 3.03 **(-0.82)** | 14.29 **(0)** | 26.42 **(0.68)**</details>