### PR TITLE
Fixed overlapping dropdown

### DIFF
--- a/app/client/src/components/designSystems/appsmith/Dropdown.tsx
+++ b/app/client/src/components/designSystems/appsmith/Dropdown.tsx
@@ -50,12 +50,15 @@ const selectStyles = {
     padding: "5px",
   }),
   indicatorSeparator: () => ({}),
+  menu: (provided: any) => ({ ...provided, zIndex: 99 }),
+  menuPortal: (base: any) => ({ ...base, zIndex: 99 }),
 };
 
 export function BaseDropdown(props: DropdownProps) {
   const { customSelectStyles, input } = props;
   return (
     <Select
+      menuPortalTarget={document.body}
       styles={{ ...selectStyles, ...customSelectStyles }}
       {...input}
       isDisabled={props.isDisabled}

--- a/app/client/src/components/designSystems/appsmith/Dropdown.tsx
+++ b/app/client/src/components/designSystems/appsmith/Dropdown.tsx
@@ -50,8 +50,8 @@ const selectStyles = {
     padding: "5px",
   }),
   indicatorSeparator: () => ({}),
-  menu: (provided: any) => ({ ...provided, zIndex: 99 }),
-  menuPortal: (base: any) => ({ ...base, zIndex: 99 }),
+  menu: (provided: any) => ({ ...provided, zIndex: 2 }),
+  menuPortal: (base: any) => ({ ...base, zIndex: 2 }),
 };
 
 export function BaseDropdown(props: DropdownProps) {

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -81,14 +81,21 @@ const datasourceNameStyles: React.CSSProperties = {
   fontSize: "14px",
   fontWeight: 500,
   color: "#090707",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
 };
 const datasourceInfoStyles: React.CSSProperties = {
   color: "#4B4848",
   fontWeight: 400,
   fontSize: "12px",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
 };
 const italicInfoStyles = {
   ...datasourceInfoStyles,
+  flexShrink: 0,
   fontStyle: "italic",
 };
 


### PR DESCRIPTION
## Description
Fixed overlapping dropdown in mysql datasource form

Fixes #4890 
## Type of change

> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: bug/overlapping_dropdown_mysql_form 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.58 **(0)** | 32.65 **(0)** | 29.74 **(-0.01)** | 52.1 **(0)**
 :red_circle: | app/client/src/components/designSystems/appsmith/Dropdown.tsx | 33.33 **(-4.17)** | 0 **(0)** | 0 **(0)** | 33.33 **(-4.17)**</details>