### PR TITLE
[Feature #4903] Show warning text for choosing choosing to leave organisation.

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OrganisationTests/LeaveOrganizationTest_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OrganisationTests/LeaveOrganizationTest_spec.js
@@ -27,7 +27,7 @@ describe("Leave organization test spec", function() {
       cy.visit("/applications");
       cy.openOrgOptionsPopup(newOrganizationName);
       cy.contains("Leave Organization").click();
-
+      cy.contains("Are you sure").click();
       cy.wait("@leaveOrgApiCall").then((httpResponse) => {
         expect(httpResponse.status).to.equal(400);
       });

--- a/app/client/src/components/ads/Menu.tsx
+++ b/app/client/src/components/ads/Menu.tsx
@@ -12,6 +12,8 @@ type MenuProps = CommonComponentProps & {
   onOpening?: (node: HTMLElement) => void;
   onClosing?: (node: HTMLElement) => void;
   modifiers?: PopperModifiers;
+  isOpen?: boolean;
+  onClose?: () => void;
 };
 
 const MenuWrapper = styled.div`
@@ -30,8 +32,10 @@ function Menu(props: MenuProps) {
       className={props.className}
       data-cy={props.cypressSelector}
       disabled={props.disabled}
+      isOpen={props.isOpen}
       minimal
       modifiers={props.modifiers}
+      onClose={props.onClose}
       onClosing={props.onClosing}
       onOpening={props.onOpening}
       portalClassName={props.className}

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -332,3 +332,7 @@ export const TROUBLESHOOT_ISSUE = () => "Troubleshoot issue";
 
 // Import/Export Application features
 export const IMPORT_APPLICATION_MODAL_TITLE = () => "Import Application";
+
+export const DELETE_CONFIRMATION_MODAL_TITLE = () => `Are you sure?`;
+export const DELETE_CONFIRMATION_MODAL_SUBTITLE = (name?: string | null) =>
+  `You want to remove ${name} from this organization`;

--- a/app/client/src/pages/Applications/index.tsx
+++ b/app/client/src/pages/Applications/index.tsx
@@ -524,6 +524,8 @@ function ApplicationsSection(props: any) {
       });
     }
   };
+  const [warnLeavingOrganization, setWarnLeavingOrganization] = useState(false);
+  const [orgToOpenMenu, setOrgToOpenMenu] = useState<string | null>(null);
   const updateApplicationDispatch = (
     id: string,
     data: UpdateApplicationPayload,
@@ -543,6 +545,8 @@ function ApplicationsSection(props: any) {
   const Form: any = OrgInviteUsersForm;
 
   const leaveOrg = (orgId: string) => {
+    setWarnLeavingOrganization(false);
+    setOrgToOpenMenu(null);
     dispatch(leaveOrganization(orgId));
   };
 
@@ -563,7 +567,11 @@ function ApplicationsSection(props: any) {
     const { disabled, orgName, orgSlug } = props;
 
     return (
-      <OrgNameWrapper className="t--org-name" disabled={disabled}>
+      <OrgNameWrapper
+        className="t--org-name"
+        disabled={disabled}
+        onClick={() => setOrgToOpenMenu(orgSlug)}
+      >
         <StyledAnchor id={orgSlug} />
         <OrgNameHolder
           className={isFetchingApplications ? BlueprintClasses.SKELETON : ""}
@@ -635,6 +643,13 @@ function ApplicationsSection(props: any) {
                   className="t--org-name"
                   cypressSelector="t--org-name"
                   disabled={isFetchingApplications}
+                  isOpen={organization.slug === orgToOpenMenu}
+                  onClose={() => {
+                    setOrgToOpenMenu(null);
+                  }}
+                  onClosing={() => {
+                    setWarnLeavingOrganization(false);
+                  }}
                   position={Position.BOTTOM_RIGHT}
                   target={OrgMenuTarget({
                     orgName: organization.name,
@@ -704,8 +719,17 @@ function ApplicationsSection(props: any) {
                   )}
                   <MenuItem
                     icon="logout"
-                    onSelect={() => leaveOrg(organization.id)}
-                    text="Leave Organization"
+                    onSelect={() =>
+                      !warnLeavingOrganization
+                        ? setWarnLeavingOrganization(true)
+                        : leaveOrg(organization.id)
+                    }
+                    text={
+                      !warnLeavingOrganization
+                        ? "Leave Organization"
+                        : "Are you sure?"
+                    }
+                    type={!warnLeavingOrganization ? undefined : "warning"}
                   />
                 </Menu>
               )}

--- a/app/client/src/pages/organization/DeleteConfirmationModal.tsx
+++ b/app/client/src/pages/organization/DeleteConfirmationModal.tsx
@@ -67,7 +67,7 @@ function DeleteConfirmationModal(props: DeleteConfirmationProps) {
             className=".button-item"
             onClick={onClose}
             size={Size.large}
-            text={"CANCLE"}
+            text={"CANCEL"}
             variant={Variant.danger}
           />
           <ImportButton

--- a/app/client/src/pages/organization/DeleteConfirmationModal.tsx
+++ b/app/client/src/pages/organization/DeleteConfirmationModal.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import styled from "styled-components";
+import Button, { Size, Category } from "components/ads/Button";
+// import { useSelector } from "store";
+import Text, { TextType } from "components/ads/Text";
+import { Variant } from "components/ads/common";
+import {
+  DELETE_CONFIRMATION_MODAL_TITLE,
+  DELETE_CONFIRMATION_MODAL_SUBTITLE,
+} from "constants/messages";
+import Dialog from "components/ads/DialogComponent";
+import { Classes } from "@blueprintjs/core";
+
+const StyledDialog = styled(Dialog)`
+  && .${Classes.DIALOG_BODY} {
+    padding-top: 0px;
+  }
+`;
+
+const CenteredContainer = styled.div`
+  text-align: center;
+`;
+
+const ImportButton = styled(Button)<{ disabled?: boolean }>`
+  height: 30px;
+  width: 81px;
+  pointer-events: ${(props) => (!!props.disabled ? "none" : "auto")};
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+
+  & > a {
+    margin: 0 4px;
+  }
+`;
+
+type DeleteConfirmationProps = {
+  username?: string | null;
+  name?: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+function DeleteConfirmationModal(props: DeleteConfirmationProps) {
+  const { isOpen, name, onClose, onConfirm, username } = props;
+
+  return (
+    <StyledDialog
+      canOutsideClickClose
+      className={"t--member-delete-confirmation-modal"}
+      isOpen={isOpen}
+      maxHeight={"540px"}
+      setModalClose={onClose}
+      title={DELETE_CONFIRMATION_MODAL_TITLE()}
+    >
+      <CenteredContainer>
+        <Text textAlign="center" type={TextType.P1}>
+          {DELETE_CONFIRMATION_MODAL_SUBTITLE(name || username)}
+        </Text>
+        <ButtonWrapper>
+          <ImportButton
+            category={Category.tertiary}
+            className=".button-item"
+            onClick={onClose}
+            size={Size.large}
+            text={"CANCLE"}
+            variant={Variant.danger}
+          />
+          <ImportButton
+            className=".button-item"
+            cypressSelector={"t--org-import-app-button"}
+            onClick={onConfirm}
+            size={Size.large}
+            text={"REMOVE"}
+            variant={Variant.danger}
+          />
+        </ButtonWrapper>
+      </CenteredContainer>
+    </StyledDialog>
+  );
+}
+
+export default DeleteConfirmationModal;

--- a/app/client/src/pages/organization/DeleteConfirmationModal.tsx
+++ b/app/client/src/pages/organization/DeleteConfirmationModal.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import Button, { Size, Category } from "components/ads/Button";
-// import { useSelector } from "store";
 import Text, { TextType } from "components/ads/Text";
 import { Variant } from "components/ads/common";
 import {
@@ -43,10 +42,11 @@ type DeleteConfirmationProps = {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
+  isDeletingUser: boolean;
 };
 
 function DeleteConfirmationModal(props: DeleteConfirmationProps) {
-  const { isOpen, name, onClose, onConfirm, username } = props;
+  const { isDeletingUser, isOpen, name, onClose, onConfirm, username } = props;
 
   return (
     <StyledDialog
@@ -73,6 +73,7 @@ function DeleteConfirmationModal(props: DeleteConfirmationProps) {
           <ImportButton
             className=".button-item"
             cypressSelector={"t--org-import-app-button"}
+            isLoading={isDeletingUser}
             onClick={onConfirm}
             size={Size.large}
             text={"REMOVE"}

--- a/app/client/src/pages/organization/Members.tsx
+++ b/app/client/src/pages/organization/Members.tsx
@@ -184,7 +184,6 @@ export default function MemberSettings(props: PageProps) {
             }
             name="delete"
             onClick={() => {
-              console.log({ values: cellProps.cell.row.values });
               onConfirmMemberDeletion(
                 cellProps.cell.row.values.username,
                 cellProps.cell.row.values.username,

--- a/app/client/src/pages/organization/Members.tsx
+++ b/app/client/src/pages/organization/Members.tsx
@@ -59,6 +59,7 @@ export default function MemberSettings(props: PageProps) {
     showMemberDeletionConfirmation,
     setShowMemberDeletionConfirmation,
   ] = useState(false);
+  const [isDeletingUser, setIsDeletingUser] = useState(false);
   const onOpenConfirmationModal = () => setShowMemberDeletionConfirmation(true);
   const onCloseConfirmationModal = () =>
     setShowMemberDeletionConfirmation(false);
@@ -94,6 +95,21 @@ export default function MemberSettings(props: PageProps) {
   const currentOrg = useSelector(getCurrentOrg).filter(
     (el) => el.id === orgId,
   )[0];
+
+  useEffect(() => {
+    if (!!userToBeDeleted && showMemberDeletionConfirmation) {
+      const userBeingDeleted = allUsers.find(
+        (user) => user.username === userToBeDeleted.username,
+      );
+      if (!userBeingDeleted) {
+        setUserToBeDeleted(null);
+        onCloseConfirmationModal();
+        setIsDeletingUser(false);
+      } else {
+        setIsDeletingUser(userBeingDeleted.isDeleting);
+      }
+    }
+  }, [allUsers]);
 
   const userTableData = allUsers.map((user) => ({
     ...user,
@@ -209,6 +225,7 @@ export default function MemberSettings(props: PageProps) {
         <>
           <Table columns={columns} data={userTableData} />
           <DeleteConfirmationModal
+            isDeletingUser={isDeletingUser}
             isOpen={showMemberDeletionConfirmation}
             name={userToBeDeleted && userToBeDeleted.name}
             onClose={onCloseConfirmationModal}

--- a/app/client/src/reducers/uiReducers/orgReducer.ts
+++ b/app/client/src/reducers/uiReducers/orgReducer.ts
@@ -78,6 +78,14 @@ const orgReducer = createImmerReducer(initialState, {
       }
     });
   },
+  [ReduxActionErrorTypes.CHANGE_ORG_USER_ROLE_ERROR]: (
+    draftState: OrgReduxState,
+  ) => {
+    draftState.orgUsers.forEach((user: OrgUser) => {
+      //TODO: This will change the status to false even if one role change api fails.
+      user.isChangingRole = false;
+    });
+  },
   [ReduxActionTypes.DELETE_ORG_USER_INIT]: (
     draftState: OrgReduxState,
     action: ReduxAction<{ username: string }>,
@@ -95,14 +103,6 @@ const orgReducer = createImmerReducer(initialState, {
     draftState.orgUsers = draftState.orgUsers.filter(
       (user: OrgUser) => user.username !== action.payload.username,
     );
-  },
-  [ReduxActionErrorTypes.CHANGE_ORG_USER_ROLE_ERROR]: (
-    draftState: OrgReduxState,
-  ) => {
-    draftState.orgUsers.forEach((user: OrgUser) => {
-      //TODO: This will change the status to false even if one role change api fails.
-      user.isChangingRole = false;
-    });
   },
   [ReduxActionErrorTypes.DELETE_ORG_USER_ERROR]: (
     draftState: OrgReduxState,


### PR DESCRIPTION
## Description
1. Added in place warning for `leave org` option in organization context menu.
2. Added a deletion confirmation modal to members page

Fixes # (issue)
#4903 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
> Updated the existing cypress tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feature/confirm-leaving-org 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.61 **(0.01)** | 32.71 **(0)** | 29.71 **(-0.01)** | 52.11 **(0)**
 :red_circle: | app/client/src/constants/messages.ts | 71.4 **(-0.05)** | 100 **(0)** | 13.5 **(-0.14)** | 75.18 **(-0.09)**</details>