### PR TITLE
Fix - tests don't run on an M1 Silicon Mac

### DIFF
--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
@@ -38,9 +38,8 @@ public class ElasticSearchPluginTest {
     ElasticSearchPlugin.ElasticSearchPluginExecutor pluginExecutor = new ElasticSearchPlugin.ElasticSearchPluginExecutor();
 
     @ClassRule
-    public static final ElasticsearchContainer container =
-            new ElasticsearchContainer(DockerImageName.parse("arm64v8/elasticsearch:7.12.1").asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch:6.4.1"))
-                    .withEnv("discovery.type", "single-node");
+    public static final ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.12.1")
+            .withEnv("discovery.type", "single-node");
 
     private static final DatasourceConfiguration dsConfig = new DatasourceConfiguration();
     private static String host;

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
@@ -15,6 +15,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -38,7 +39,7 @@ public class ElasticSearchPluginTest {
 
     @ClassRule
     public static final ElasticsearchContainer container =
-            new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:6.4.1")
+            new ElasticsearchContainer(DockerImageName.parse("arm64v8/elasticsearch:7.12.1").asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch:6.4.1"))
                     .withEnv("discovery.type", "single-node");
 
     private static final DatasourceConfiguration dsConfig = new DatasourceConfiguration();

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -22,6 +22,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -57,7 +58,8 @@ public class MssqlPluginTest {
     @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is pseudo-optional.
     @ClassRule
     public static final MSSQLServerContainer container =
-            new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2017-latest")
+            new MSSQLServerContainer<>(
+                    DockerImageName.parse("mcr.microsoft.com/azure-sql-edge:latest").asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server:2017-latest"))
                     .acceptLicense()
                     .withExposedPorts(1433)
                     .withPassword("Mssql123");

--- a/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/test/java/com/external/plugins/MssqlPluginTest.java
@@ -59,7 +59,7 @@ public class MssqlPluginTest {
     @ClassRule
     public static final MSSQLServerContainer container =
             new MSSQLServerContainer<>(
-                    DockerImageName.parse("mcr.microsoft.com/azure-sql-edge:latest").asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server:2017-latest"))
+                    DockerImageName.parse("mcr.microsoft.com/azure-sql-edge:1.0.3").asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server:2017-latest"))
                     .acceptLicense()
                     .withExposedPorts(1433)
                     .withPassword("Mssql123");

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -56,7 +56,7 @@ public class MySqlPluginTest {
     @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is pseudo-optional.
     @ClassRule
     public static MySQLContainer mySQLContainer = new MySQLContainer(
-            DockerImageName.parse("mysql/mysql-server:latest-aarch64").asCompatibleSubstituteFor("mysql"))
+            DockerImageName.parse("mysql/mysql-server:8.0.25").asCompatibleSubstituteFor("mysql"))
             .withUsername("mysql")
             .withPassword("password")
             .withDatabaseName("test_db");
@@ -64,7 +64,7 @@ public class MySqlPluginTest {
     @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is pseudo-optional.
     @ClassRule
     public static MySQLContainer mySQLContainerWithInvalidTimezone = (MySQLContainer) new MySQLContainer(
-            DockerImageName.parse("mysql/mysql-server:latest-aarch64").asCompatibleSubstituteFor("mysql"))
+            DockerImageName.parse("mysql/mysql-server:8.0.25").asCompatibleSubstituteFor("mysql"))
             .withUsername("mysql")
             .withPassword("password")
             .withDatabaseName("test_db")

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -27,6 +27,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.MySQLR2DBCDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -54,14 +55,16 @@ public class MySqlPluginTest {
 
     @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is pseudo-optional.
     @ClassRule
-    public static MySQLContainer mySQLContainer = new MySQLContainer("mysql:5.7")
+    public static MySQLContainer mySQLContainer = new MySQLContainer(
+            DockerImageName.parse("mysql/mysql-server:latest-aarch64").asCompatibleSubstituteFor("mysql"))
             .withUsername("mysql")
             .withPassword("password")
             .withDatabaseName("test_db");
 
     @SuppressWarnings("rawtypes") // The type parameter for the container type is just itself and is pseudo-optional.
     @ClassRule
-    public static MySQLContainer mySQLContainerWithInvalidTimezone = (MySQLContainer) new MySQLContainer()
+    public static MySQLContainer mySQLContainerWithInvalidTimezone = (MySQLContainer) new MySQLContainer(
+            DockerImageName.parse("mysql/mysql-server:latest-aarch64").asCompatibleSubstituteFor("mysql"))
             .withUsername("mysql")
             .withPassword("password")
             .withDatabaseName("test_db")
@@ -764,7 +767,7 @@ public class MySqlPluginTest {
                     assertTrue(result.getIsExecutionSuccess());
                     Object body = result.getBody();
                     assertNotNull(body);
-                    assertEquals("[{\"Variable_name\":\"Ssl_cipher\",\"Value\":\"ECDHE-RSA-AES128-SHA\"}]",
+                    assertEquals("[{\"Variable_name\":\"Ssl_cipher\",\"Value\":\"ECDHE-RSA-AES128-GCM-SHA256\"}]",
                             body.toString());
                 })
                 .verifyComplete();
@@ -788,7 +791,7 @@ public class MySqlPluginTest {
                     assertTrue(result.getIsExecutionSuccess());
                     Object body = result.getBody();
                     assertNotNull(body);
-                    assertEquals("[{\"Variable_name\":\"Ssl_cipher\",\"Value\":\"ECDHE-RSA-AES128-SHA\"}]",
+                    assertEquals("[{\"Variable_name\":\"Ssl_cipher\",\"Value\":\"ECDHE-RSA-AES128-GCM-SHA256\"}]",
                             body.toString());
                 })
                 .verifyComplete();
@@ -812,7 +815,7 @@ public class MySqlPluginTest {
                     assertTrue(result.getIsExecutionSuccess());
                     Object body = result.getBody();
                     assertNotNull(body);
-                    assertEquals("[{\"Variable_name\":\"Ssl_cipher\",\"Value\":\"ECDHE-RSA-AES128-SHA\"}]",
+                    assertEquals("[{\"Variable_name\":\"Ssl_cipher\",\"Value\":\"ECDHE-RSA-AES128-GCM-SHA256\"}]",
                             body.toString());
                 })
                 .verifyComplete();


### PR DESCRIPTION
## Description
The MySQL, MSSQL and Elasticsearch tests in the server codebase use the image which is only available for linux/amd64 architecture and not for arm64. Running this on M1 Silicon Mac needs the image to be available for the arm64 architecture as well.

Fixes #4860 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] This change requires a documentation update

## How Has This Been Tested?


- Ran the tests on M1 mac and verified
- Need to run this on a intel chip machine and make sure that things are not breaking

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
