### PR TITLE
[Fixed #4933] - App viewer will not be able to export app

### DIFF
--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -300,7 +300,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
         cypressSelector: "t--fork-app",
       });
     }
-    if (!!props.enableImportExport) {
+    if (!!props.enableImportExport && hasEditPermission) {
       moreActionItems.push({
         onSelect: exportApplicationAsJSONFile,
         text: "Export",


### PR DESCRIPTION
## Description
Added a condition to hide export option for members with appViewer permission.

Fixes # (issue)
#4933 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>