### PR TITLE
Bugfix for applications with MongoDB datasources authenticated with SRV string

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -703,14 +703,7 @@ public class MongoPlugin extends BasePlugin {
                         if (extractedInfo == null) {
                             invalids.add("Mongo Connection String URI does not seem to be in the correct format. " +
                                     "Please check the URI once.");
-                        } else if (authentication != null && authentication.getUsername() != null
-                            && authentication.getPassword() != null && mongoUri.contains("****")) {
-                            
-                            // remove any default db set via form auto-fill via browser
-                            if (datasourceConfiguration.getConnection() != null) {
-                                datasourceConfiguration.getConnection().setDefaultDatabaseName(null);
-                            }
-                        } else {
+                        } else if (!isAuthenticated(authentication, mongoUri)) {
                             String mongoUriWithHiddenPassword = buildURIfromExtractedInfo(extractedInfo, "****");
                             properties.get(DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX).setValue(mongoUriWithHiddenPassword);
                             authentication = (authentication == null) ? new DBAuth(): authentication;
@@ -1018,6 +1011,15 @@ public class MongoPlugin extends BasePlugin {
         }
 
         return object;
+    }
+    
+    private static boolean isAuthenticated(DBAuth authentication, String mongoUri) {
+        if (authentication != null && authentication.getUsername() != null
+            && authentication.getPassword() != null && mongoUri.contains("****")) {
+            
+            return true;
+        }
+        return false;
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -73,6 +73,11 @@ public class ExamplesOrganizationCloner {
     private final LayoutActionService layoutActionService;
     private final PluginService pluginService;
     
+    /**
+     * The regex matches the following pattern:
+     *  - mongodb+srv://user:password@some-url/some-db....
+     *  Matches "password" excluding ":" and "@"
+     */
     private static final String MONGO_URI_REGEX = "(?<=:)([^:]*?)(?=@)";
     private static final String YES = "Yes";
     private static final int DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX = 0;
@@ -477,6 +482,10 @@ public class ExamplesOrganizationCloner {
                 });
     }
     
+    /**
+     * @param plugin to check if the plugin-type is mongo-plugin
+     * @param datasourceConfig to update Property object
+     */
     public void updateSrvForMongoDatasource(Plugin plugin, DatasourceConfiguration datasourceConfig) {
         
         if (plugin == null || datasourceConfig == null) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -79,7 +79,7 @@ public class ImportExportApplicationService {
     private static final Set<MediaType> ALLOWED_CONTENT_TYPES = Set.of(MediaType.APPLICATION_JSON);
     public final String INVALID_JSON_FILE = "invalid json file";
     private enum PublishType {
-        UNPUBLISH, PUBLISH
+        UNPUBLISHED, PUBLISHED
     }
 
     public Mono<ApplicationJson> exportApplicationById(String applicationId) {
@@ -141,7 +141,7 @@ public class ImportExportApplicationService {
     
                             if (newPage.getUnpublishedPage() != null) {
                                 pageIdToNameMap.put(
-                                    newPage.getId() + PublishType.UNPUBLISH, newPage.getUnpublishedPage().getName()
+                                    newPage.getId() + PublishType.UNPUBLISHED, newPage.getUnpublishedPage().getName()
                                 );
                                 PageDTO unpublishedPageDTO = newPage.getUnpublishedPage();
                                 if (StringUtils.equals(
@@ -160,7 +160,7 @@ public class ImportExportApplicationService {
 
                             if (newPage.getPublishedPage() != null) {
                                 pageIdToNameMap.put(
-                                    newPage.getId() + PublishType.PUBLISH, newPage.getPublishedPage().getName()
+                                    newPage.getId() + PublishType.PUBLISHED, newPage.getPublishedPage().getName()
                                 );
                                 PageDTO publishedPageDTO = newPage.getPublishedPage();
                                 if (applicationJson.getPublishedDefaultPageName() != null &&
@@ -215,11 +215,11 @@ public class ImportExportApplicationService {
                             }
                             if (newAction.getUnpublishedAction() != null) {
                                 ActionDTO actionDTO = newAction.getUnpublishedAction();
-                                actionDTO.setPageId(pageIdToNameMap.get(actionDTO.getPageId() + PublishType.UNPUBLISH));
+                                actionDTO.setPageId(pageIdToNameMap.get(actionDTO.getPageId() + PublishType.UNPUBLISHED));
                             }
                             if (newAction.getPublishedAction() != null) {
                                 ActionDTO actionDTO = newAction.getPublishedAction();
-                                actionDTO.setPageId(pageIdToNameMap.get(actionDTO.getPageId() + PublishType.PUBLISH));
+                                actionDTO.setPageId(pageIdToNameMap.get(actionDTO.getPageId() + PublishType.PUBLISHED));
                             }
                         });
                         applicationJson
@@ -363,8 +363,8 @@ public class ImportExportApplicationService {
             .flatMap(savedApp -> {
                 importedApplication.setId(savedApp.getId());
                 Map<PublishType, List<ApplicationPage>> applicationPages = Map.of(
-                    PublishType.UNPUBLISH, new ArrayList<>(),
-                    PublishType.PUBLISH, new ArrayList<>()
+                    PublishType.UNPUBLISHED, new ArrayList<>(),
+                    PublishType.PUBLISHED, new ArrayList<>()
                 );
                 
                 return importAndSavePages(
@@ -396,16 +396,16 @@ public class ImportExportApplicationService {
                         publishedAppPage.setId(newPage.getId());
                         pageNameMap.put(newPage.getPublishedPage().getName(), newPage);
                     }
-                    applicationPages.get(PublishType.UNPUBLISH).add(unpublishedAppPage);
-                    applicationPages.get(PublishType.PUBLISH).add(publishedAppPage);
+                    applicationPages.get(PublishType.UNPUBLISHED).add(unpublishedAppPage);
+                    applicationPages.get(PublishType.PUBLISHED).add(publishedAppPage);
                     return applicationPages;
                 })
                 .then()
                 .thenReturn(applicationPages);
             })
             .flatMap(applicationPageMap -> {
-                importedApplication.setPages(applicationPageMap.get(PublishType.UNPUBLISH));
-                importedApplication.setPublishedPages(applicationPageMap.get(PublishType.PUBLISH));
+                importedApplication.setPages(applicationPageMap.get(PublishType.UNPUBLISHED));
+                importedApplication.setPublishedPages(applicationPageMap.get(PublishType.PUBLISHED));
                 
                 importedNewActionList.forEach(newAction -> {
                     NewPage parentPage = new NewPage();
@@ -570,16 +570,21 @@ public class ImportExportApplicationService {
                         datasourceConfig.getAuthentication().setAuthenticationResponse(authResponse);
                     }
                     // No matching existing datasource found, so create a new one.
-                    return datasourceService
-                        .findByNameAndOrganizationId(datasource.getName(), toOrgId, AclPermission.MANAGE_DATASOURCES)
-                        .flatMap(duplicateNameDatasource ->
-                            getUniqueSuffixForDuplicateNameEntity(duplicateNameDatasource, toOrgId)
-                        )
-                        .map(suffix -> {
-                            datasource.setName(datasource.getName() + suffix);
-                            return datasource;
-                        })
-                        .then(datasourceService.create(datasource));
+                    return pluginRepository.findById(datasource.getPluginId())
+                    .flatMap(plugin -> {
+                        
+                        examplesOrganizationCloner.updateSrvForMongoDatasource(plugin, datasourceConfig);
+                        return datasourceService
+                            .findByNameAndOrganizationId(datasource.getName(), toOrgId, AclPermission.MANAGE_DATASOURCES)
+                            .flatMap(duplicateNameDatasource ->
+                                getUniqueSuffixForDuplicateNameEntity(duplicateNameDatasource, toOrgId)
+                            )
+                            .map(suffix -> {
+                                datasource.setName(datasource.getName() + suffix);
+                                return datasource;
+                            })
+                            .then(datasourceService.create(datasource));
+                    });
                 }));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -570,21 +570,16 @@ public class ImportExportApplicationService {
                         datasourceConfig.getAuthentication().setAuthenticationResponse(authResponse);
                     }
                     // No matching existing datasource found, so create a new one.
-                    return pluginRepository.findById(datasource.getPluginId())
-                    .flatMap(plugin -> {
-                        
-                        examplesOrganizationCloner.updateSrvForMongoDatasource(plugin, datasourceConfig);
-                        return datasourceService
-                            .findByNameAndOrganizationId(datasource.getName(), toOrgId, AclPermission.MANAGE_DATASOURCES)
-                            .flatMap(duplicateNameDatasource ->
-                                getUniqueSuffixForDuplicateNameEntity(duplicateNameDatasource, toOrgId)
-                            )
-                            .map(suffix -> {
-                                datasource.setName(datasource.getName() + suffix);
-                                return datasource;
-                            })
-                            .then(datasourceService.create(datasource));
-                    });
+                    return datasourceService
+                        .findByNameAndOrganizationId(datasource.getName(), toOrgId, AclPermission.MANAGE_DATASOURCES)
+                        .flatMap(duplicateNameDatasource ->
+                            getUniqueSuffixForDuplicateNameEntity(duplicateNameDatasource, toOrgId)
+                        )
+                        .map(suffix -> {
+                            datasource.setName(datasource.getName() + suffix);
+                            return datasource;
+                        })
+                        .then(datasourceService.create(datasource));
                 }));
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -473,6 +473,7 @@ public class ExamplesOrganizationClonerTests {
                     final Datasource ds1 = new Datasource();
                     ds1.setName("datasource 1");
                     ds1.setOrganizationId(organization.getId());
+                    ds1.setPluginId(installedPlugin.getId());
                     final DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
                     ds1.setDatasourceConfiguration(datasourceConfiguration);
                     datasourceConfiguration.setUrl("http://httpbin.org/get");
@@ -483,6 +484,7 @@ public class ExamplesOrganizationClonerTests {
                     final Datasource ds2 = new Datasource();
                     ds2.setName("datasource 2");
                     ds2.setOrganizationId(organization.getId());
+                    ds2.setPluginId(installedPlugin.getId());
                     ds2.setDatasourceConfiguration(new DatasourceConfiguration());
                     DBAuth auth = new DBAuth();
                     auth.setPassword("answer-to-life");


### PR DESCRIPTION
## Description

When we try to fork or import an application containing the MongoDB datasource authenticated with SRV string, the destination application breaks with an authentication failure error. 

Fixes :
#4936
#4929

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested on local and release instances.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing tests pass locally with my changes
