### PR TITLE
[Draft] Feature: JS editor action related changes for json path keys and on page load actions. 

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
@@ -60,6 +60,8 @@ public class ActionConfiguration implements AppsmithDomain {
     List<JSValue> jsConstants;
     List<JSFunction> jsFunctions;
 
+    boolean executeOnClient = false;
+
     /*
      * Future plugins could require more fields that are not covered above.
      * They will have to represented in a key-value format where the plugin

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/DslActionDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/DslActionDTO.java
@@ -18,4 +18,5 @@ public class DslActionDTO {
     PluginType pluginType;
     Set<String> jsonPathKeys;
     Integer timeoutInMillisecond = DEFAULT_ACTION_EXECUTION_TIMEOUT_MS;
+    boolean executeOnClient;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -2277,4 +2277,28 @@ public class DatabaseChangelog {
 
         installPluginToAllOrganizations(mongoTemplate, plugin.getId());
     }
+
+    @ChangeSet(order = "070", id = "update-execute-on-client", author = "")
+    public void updateExecuteOnClient(MongoTemplate mongoTemplate) {
+        List<NewAction> allNewActions = mongoTemplate.findAll(NewAction.class);
+
+        allNewActions.stream()
+                .forEach(newAction -> {
+                    // For unpublished action
+                    if (newAction.getUnpublishedAction() != null
+                            && newAction.getUnpublishedAction().getActionConfiguration() != null) {
+                        newAction.getUnpublishedAction().getActionConfiguration().setExecuteOnClient(false);
+                    }
+
+                    // For published action
+                    if (newAction.getPublishedAction() != null
+                            && newAction.getPublishedAction().getActionConfiguration() != null) {
+                        newAction.getPublishedAction().getActionConfiguration().setExecuteOnClient(false);
+                    }
+                });
+
+        // Save action objects if all the above updates went through without error.
+        allNewActions.stream()
+                .forEach(newAction ->  mongoTemplate.save(newAction));
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -318,7 +318,18 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
             return new HashSet<>();
         }
 
-        return MustacheHelper.extractMustacheKeysFromFields(actionConfiguration);
+        // Extract keys from any expression inside mustache braces {{ }}
+        Set<String> mustacheKeys = MustacheHelper.extractMustacheKeysFromFields(actionConfiguration);
+
+        /**
+         * - JS function is not enclosed inside mustache braces {{ }} and hence would not be captured by the method used
+         * above.
+         * - Since all of the JS Function body is a valid JS, hence add the whole body to keys set.
+         */
+        actionConfiguration.getJsFunctions().stream()
+                .forEach(jsFunction -> mustacheKeys.add(jsFunction.getBody()));
+
+        return mustacheKeys;
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/PageLoadActionsUtil.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/PageLoadActionsUtil.java
@@ -119,10 +119,9 @@ public class PageLoadActionsUtil {
 
         onPageLoadActions.stream()
                 .forEachOrdered(actionSet -> {
-                    HashSet updatedActionSet = new HashSet<>();
-                    actionSet.stream()
+                    HashSet updatedActionSet = actionSet.stream()
                             .filter(dslActionDTO -> !dslActionDTO.isExecuteOnClient())
-                            .forEach(dslActionDTO -> updatedActionSet.add(dslActionDTO));
+                            .collect(Collectors.toCollection(HashSet::new));
 
                     if (!updatedActionSet.isEmpty()) {
                         serverExecutedOnPageLoadActions.add(updatedActionSet);


### PR DESCRIPTION
## [Draft] Description
- add JS function to jsonPathKeys
- remove any action that executes on client from on page load action execution order list. For e.g. say `a->b` indicates `a` depends on `b` then, if `action1 -> jsAction1 -> action2` then, execution order returned would be `[[action2], [action1]]`. It is assumed that any JS action eval would happen automatically by the client if all required dependencies have been evaluated, which in this case is `action2`.
- introduce attribute executeOnClient to indicate actions that execute on client instead of api server.
- add migration code to update executeOnClient attribute
- migration change takes ~ 14 sec on my local. Over a network it might take ~ 60 sec.

Fixes # 4728

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- WIP

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
