### PR TITLE
Release frozen related changes

### DIFF
--- a/.github/workflows/build-rts.yml
+++ b/.github/workflows/build-rts.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [release, master]
+    branches: [release, release-frozen, master]
     # Only trigger if files have changed in this specific path
     paths:
       - "app/rts/**"
@@ -63,6 +63,14 @@ jobs:
       # Build release Docker image and push to Docker Hub
       - name: Push release image to Docker Hub
         if: success() && github.ref == 'refs/heads/release'
+        run: |
+          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{steps.vars.outputs.tag}} .
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{steps.vars.outputs.tag}}
+
+      # Build release-frozen Docker image and push to Docker Hub
+      - name: Push release-frozen image to Docker Hub
+        if: success() && github.ref == 'refs/heads/release-frozen'
         run: |
           docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{steps.vars.outputs.tag}} .
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -13,7 +13,7 @@ on:
 
   # trigger for pushes to release and master
   push:
-    branches: [release, master]
+    branches: [release, release-frozen, master]
     paths:
       - "app/client/**"
       - "!app/client/cypress/manual_TestSuite/**"
@@ -212,6 +212,21 @@ jobs:
             --env APPSMITH_CLOUD_SERVICES_PASSWORD= \
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release
 
+      - name: Pull release-frozen server docker container and start it locally
+        if: github.ref == 'refs/heads/release-frozen' || github.event.pull_request.base.ref == 'release-frozen'
+        shell: bash
+        run: |
+          docker run -d --net=host --name appsmith-internal-server -p 8080:8080 \
+            --env APPSMITH_MONGODB_URI=mongodb://localhost:27017/appsmith \
+            --env APPSMITH_REDIS_URL=redis://localhost:6379 \
+            --env APPSMITH_ENCRYPTION_PASSWORD=password \
+            --env APPSMITH_ENCRYPTION_SALT=salt \
+            --env APPSMITH_IS_SELF_HOSTED=false \
+            --env APPSMITH_CLOUD_SERVICES_BASE_URL= \
+            --env APPSMITH_CLOUD_SERVICES_USERNAME= \
+            --env APPSMITH_CLOUD_SERVICES_PASSWORD= \
+            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release-frozen
+
       - name: Pull master server docker container and start it locally
         if: github.ref == 'refs/heads/master' || github.event.pull_request.base.ref == 'master'
         shell: bash
@@ -345,6 +360,14 @@ jobs:
       # Build release Docker image and push to Docker Hub
       - name: Push release image to Docker Hub
         if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        run: |
+          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{steps.branch_name.outputs.tag}} .
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{steps.branch_name.outputs.tag}}
+
+      # Build release-frozen Docker image and push to Docker Hub
+      - name: Push release image to Docker Hub
+        if: success() && github.ref == 'refs/heads/release-frozen' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{steps.branch_name.outputs.tag}} .
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -198,7 +198,7 @@ jobs:
           path: app/client/build
 
       - name: Pull release server docker container and start it locally
-        if: github.ref == 'refs/heads/release' || github.event.pull_request.base.ref == 'release'
+        if: github.ref == 'refs/heads/release' || github.event.pull_request.head.ref == 'release'
         shell: bash
         run: |
           docker run -d --net=host --name appsmith-internal-server -p 8080:8080 \
@@ -213,7 +213,7 @@ jobs:
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release
 
       - name: Pull release-frozen server docker container and start it locally
-        if: github.ref == 'refs/heads/release-frozen' || github.event.pull_request.base.ref == 'release-frozen'
+        if: github.ref == 'refs/heads/release-frozen' || github.event.pull_request.head.ref == 'release-frozen'
         shell: bash
         run: |
           docker run -d --net=host --name appsmith-internal-server -p 8080:8080 \
@@ -228,7 +228,7 @@ jobs:
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release-frozen
 
       - name: Pull master server docker container and start it locally
-        if: github.ref == 'refs/heads/master' || github.event.pull_request.base.ref == 'master'
+        if: github.ref == 'refs/heads/master'
         shell: bash
         run: |
           docker run -d --net=host --name appsmith-internal-server -p 8080:8080 \

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -198,7 +198,7 @@ jobs:
           path: app/client/build
 
       - name: Pull release server docker container and start it locally
-        if: github.ref == 'refs/heads/release' || github.event.pull_request.head.ref == 'release'
+        if: github.ref == 'refs/heads/release' || github.event.pull_request.base.ref == 'release' || github.event.pull_request.head.ref == 'release'
         shell: bash
         run: |
           docker run -d --net=host --name appsmith-internal-server -p 8080:8080 \

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -294,7 +294,7 @@ jobs:
           path: app/client/build
 
       - name: Pull release server docker container and start it locally
-        if: github.ref == 'refs/heads/release' || github.event.pull_request.head.ref == 'release'
+        if: github.ref == 'refs/heads/release' || github.event.pull_request.base.ref == 'release'|| github.event.pull_request.head.ref == 'release'
         shell: bash
         run: |
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -294,7 +294,7 @@ jobs:
           path: app/client/build
 
       - name: Pull release server docker container and start it locally
-        if: github.ref == 'refs/heads/release' || github.event.pull_request.base.ref == 'release'
+        if: github.ref == 'refs/heads/release' || github.event.pull_request.head.ref == 'release'
         shell: bash
         run: |
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
@@ -311,7 +311,7 @@ jobs:
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release
 
       - name: Pull release-frozen server docker container and start it locally
-        if: github.ref == 'refs/heads/release-frozen' || github.event.pull_request.base.ref == 'release-frozen'
+        if: github.ref == 'refs/heads/release-frozen' || github.event.pull_request.head.ref == 'release-frozen'
         shell: bash
         run: |
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
@@ -328,7 +328,7 @@ jobs:
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release-frozen
 
       - name: Pull master server docker container and start it locally
-        if: github.ref == 'refs/heads/master' || github.event.pull_request.base.ref == 'master'
+        if: github.ref == 'refs/heads/master'
         shell: bash
         run: |
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -310,6 +310,23 @@ jobs:
             --env APPSMITH_CLOUD_SERVICES_PASSWORD= \
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release
 
+      - name: Pull release-frozen server docker container and start it locally
+        if: github.ref == 'refs/heads/release-frozen' || github.event.pull_request.base.ref == 'release-frozen'
+        shell: bash
+        run: |
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+
+          docker run -d --net=host --name appsmith-internal-server -p 8080:8080 \
+            --env APPSMITH_MONGODB_URI=mongodb://localhost:27017/appsmith \
+            --env APPSMITH_REDIS_URL=redis://localhost:6379 \
+            --env APPSMITH_ENCRYPTION_PASSWORD=password \
+            --env APPSMITH_ENCRYPTION_SALT=salt \
+            --env APPSMITH_IS_SELF_HOSTED=false \
+            --env APPSMITH_CLOUD_SERVICES_BASE_URL= \
+            --env APPSMITH_CLOUD_SERVICES_USERNAME= \
+            --env APPSMITH_CLOUD_SERVICES_PASSWORD= \
+            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:release-frozen
+
       - name: Pull master server docker container and start it locally
         if: github.ref == 'refs/heads/master' || github.event.pull_request.base.ref == 'master'
         shell: bash
@@ -461,45 +478,9 @@ jobs:
       run:
         working-directory: app/client
     # Run this job only if all the previous steps are a success and the reference if the release or master branch
-    if: success() && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/master')
+    if: success() && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/release-frozen' || github.ref == 'refs/heads/master')
 
     steps:
-      # Check out merge commit
-      - name: Fork based /ok-to-test checkout
-        uses: actions/checkout@v2
-        with:
-          ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
-
-      - name: Download the react build artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: app/client/build
-
-      # Here, the GITHUB_REF is of type /refs/head/<branch_name>. We extract branch_name from this by removing the
-      # first 11 characters. This can be used to build images for several branches
-      - name: Get the version to tag the Docker image
-        id: branch_name
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
-
-      # Build release Docker image and push to Docker Hub
-      - name: Push release image to Docker Hub
-        if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        run: |
-          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{steps.branch_name.outputs.tag}} .
-          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{steps.branch_name.outputs.tag}}
-
-      # Build master Docker image and push to Docker Hub
-      - name: Push production image to Docker Hub with commit tag
-        if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        run: |
-          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${GITHUB_SHA} .
-          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:nightly .
-          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${GITHUB_SHA}
-          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:nightly
-
       # Update check run called "package"
       - name: Mark package job as complete
         uses: actions/github-script@v1

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [release, master]
+    branches: [release, release-frozen, master]
     # Only trigger if files have changed in this specific path
     paths:
       - "app/server/**"
@@ -97,6 +97,14 @@ jobs:
       # Build release Docker image and push to Docker Hub
       - name: Push release image to Docker Hub
         if: success() && github.ref == 'refs/heads/release'
+        run: |
+          docker build --build-arg APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }} -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{steps.vars.outputs.tag}} .
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{steps.vars.outputs.tag}}
+
+      # Build release-frozen Docker image and push to Docker Hub
+      - name: Push release-frozen image to Docker Hub
+        if: success() && github.ref == 'refs/heads/release-frozen'
         run: |
           docker build --build-arg APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }} -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{steps.vars.outputs.tag}} .
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin


### PR DESCRIPTION
Made changes to workflows to include triggers for the `release-frozen` branch as well. The triggers are only for pushes into the branch, and not PRs, since the process of creating the branch is manual today. When a new branch is created, the push trigger should create the relevant docker images.

The PR related images how also been updated to use the PR head instead of the target branch server images while running client tests.