### PR TITLE
Allow only organization admins to export application

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ExportApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ExportApplication_spec.js
@@ -3,13 +3,19 @@ const homePage = require("../../../../locators/HomePage.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
 
 describe("Export application as a JSON file", function() {
+  let orgid;
+  let appid;
+  let currentUrl;
+  let newOrganizationName;
+  let appname;
+
   before(() => {
     cy.addDsl(dsl);
   });
 
   it("Check if exporting app flow works as expected", function() {
     cy.get(commonlocators.homeIcon).click({ force: true });
-    const appname = localStorage.getItem("AppName");
+    appname = localStorage.getItem("AppName");
     cy.get(homePage.searchInput).type(appname);
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(2000);
@@ -22,5 +28,132 @@ describe("Export application as a JSON file", function() {
       .click({ force: true });
     cy.get(homePage.exportAppFromMenu).click({ force: true });
     cy.get(homePage.toastMessage).should("contain", "Successfully exported");
+    cy.LogOut();
+  });
+
+  it("User with admin access,should be able to export the app", function() {
+    cy.LogintoApp(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+    cy.NavigateToHome();
+    cy.generateUUID().then((uid) => {
+      orgid = uid;
+      appid = uid;
+      localStorage.setItem("OrgName", orgid);
+      cy.createOrg();
+      cy.wait("@createOrg").then((interception) => {
+        newOrganizationName = interception.response.body.data.name;
+        cy.renameOrg(newOrganizationName, orgid);
+      });
+      cy.CreateAppForOrg(orgid, appid);
+      cy.wait("@getPagesForCreateApp").should(
+        "have.nested.property",
+        "response.body.responseMeta.status",
+        200,
+      );
+      cy.get("h2").contains("Drag and drop a widget here");
+      cy.get(homePage.shareApp).click({ force: true });
+      cy.shareApp(Cypress.env("TESTUSERNAME1"), homePage.adminRole);
+
+      cy.LogOut();
+
+      cy.LogintoApp(Cypress.env("TESTUSERNAME1"), Cypress.env("TESTPASSWORD1"));
+      cy.NavigateToHome();
+      cy.wait(2000);
+      cy.log({ appid });
+      cy.get(homePage.searchInput).type(appid);
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(2000);
+
+      cy.get(homePage.applicationCard)
+        .first()
+        .trigger("mouseover");
+      cy.get(homePage.appMoreIcon)
+        .first()
+        .click({ force: true });
+      cy.get(homePage.exportAppFromMenu).should("be.visible");
+    });
+    cy.LogOut();
+  });
+
+  it("User with developer access,should not be able to export the app", function() {
+    cy.LogintoApp(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+    cy.NavigateToHome();
+    cy.generateUUID().then((uid) => {
+      orgid = uid;
+      appid = uid;
+      localStorage.setItem("OrgName", orgid);
+      cy.createOrg();
+      cy.wait("@createOrg").then((interception) => {
+        newOrganizationName = interception.response.body.data.name;
+        cy.renameOrg(newOrganizationName, orgid);
+      });
+      cy.CreateAppForOrg(orgid, appid);
+      cy.wait("@getPagesForCreateApp").should(
+        "have.nested.property",
+        "response.body.responseMeta.status",
+        200,
+      );
+      cy.get("h2").contains("Drag and drop a widget here");
+      cy.get(homePage.shareApp).click({ force: true });
+      cy.shareApp(Cypress.env("TESTUSERNAME1"), homePage.developerRole);
+
+      cy.LogOut();
+
+      cy.LogintoApp(Cypress.env("TESTUSERNAME1"), Cypress.env("TESTPASSWORD1"));
+      cy.NavigateToHome();
+      cy.wait(2000);
+      cy.log({ appid });
+      cy.get(homePage.searchInput).type(appid);
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(2000);
+
+      cy.get(homePage.applicationCard)
+        .first()
+        .trigger("mouseover");
+      cy.get(homePage.appMoreIcon)
+        .first()
+        .click({ force: true });
+      cy.get(homePage.exportAppFromMenu).should("not.exist");
+    });
+    cy.LogOut();
+  });
+
+  it("User with viewer access,should not be able to export the app", function() {
+    cy.LogintoApp(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+    cy.NavigateToHome();
+    cy.generateUUID().then((uid) => {
+      orgid = uid;
+      appid = uid;
+      localStorage.setItem("OrgName", orgid);
+      cy.createOrg();
+      cy.wait("@createOrg").then((interception) => {
+        newOrganizationName = interception.response.body.data.name;
+        cy.renameOrg(newOrganizationName, orgid);
+      });
+      cy.CreateAppForOrg(orgid, appid);
+      cy.wait("@getPagesForCreateApp").should(
+        "have.nested.property",
+        "response.body.responseMeta.status",
+        200,
+      );
+      cy.get("h2").contains("Drag and drop a widget here");
+      cy.get(homePage.shareApp).click({ force: true });
+      cy.shareApp(Cypress.env("TESTUSERNAME1"), homePage.viewerRole);
+
+      cy.LogOut();
+
+      cy.LogintoApp(Cypress.env("TESTUSERNAME1"), Cypress.env("TESTPASSWORD1"));
+      cy.NavigateToHome();
+      cy.wait(2000);
+      cy.log({ appid });
+      cy.get(homePage.searchInput).type(appid);
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(2000);
+
+      cy.get(homePage.applicationCard)
+        .first()
+        .trigger("mouseover");
+      cy.get(homePage.appEditIcon).should("not.exist");
+    });
+    cy.LogOut();
   });
 });

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -300,7 +300,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
         cypressSelector: "t--fork-app",
       });
     }
-    if (!!props.enableImportExport && hasEditPermission) {
+    if (!!props.enableImportExport && hasExportPermission) {
       moreActionItems.push({
         onSelect: exportApplicationAsJSONFile,
         text: "Export",
@@ -322,6 +322,10 @@ export function ApplicationCard(props: ApplicationCardProps) {
   const hasReadPermission = isPermitted(
     props.application?.userPermissions ?? [],
     PERMISSION_TYPE.READ_APPLICATION,
+  );
+  const hasExportPermission = isPermitted(
+    props.application?.userPermissions ?? [],
+    PERMISSION_TYPE.EXPORT_APPLICATION,
   );
   const updateColor = (color: string) => {
     setSelectedColor(color);

--- a/app/client/src/pages/Applications/permissionHelpers.tsx
+++ b/app/client/src/pages/Applications/permissionHelpers.tsx
@@ -2,6 +2,7 @@ export enum PERMISSION_TYPE {
   MANAGE_ORGANIZATION = "manage:organizations",
   CREATE_APPLICATION = "manage:orgApplications",
   MANAGE_APPLICATION = "manage:applications",
+  EXPORT_APPLICATION = "export:applications",
   READ_APPLICATION = "read:applications",
   READ_ORGANIZATION = "read:organizations",
   INVITE_USER_TO_ORGANIZATION = "inviteUsers:organization",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
@@ -44,6 +44,7 @@ public enum AclPermission {
     ORGANIZATION_MANAGE_APPLICATIONS("manage:orgApplications", Organization.class),
     ORGANIZATION_READ_APPLICATIONS("read:orgApplications", Organization.class),
     ORGANIZATION_PUBLISH_APPLICATIONS("publish:orgApplications", Organization.class),
+    ORGANIZATION_EXPORT_APPLICATIONS("export:orgApplications", Organization.class),
 
     // Invitation related permissions
     ORGANIZATION_INVITE_USERS("inviteUsers:organization", Organization.class),
@@ -51,6 +52,7 @@ public enum AclPermission {
     MANAGE_APPLICATIONS("manage:applications", Application.class),
     READ_APPLICATIONS("read:applications", Application.class),
     PUBLISH_APPLICATIONS("publish:applications", Application.class),
+    EXPORT_APPLICATIONS("export:applications", Application.class),
 
     // Making an application public permission at Organization level
     MAKE_PUBLIC_APPLICATIONS("makePublic:applications", Application.class),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AppsmithRole.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AppsmithRole.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_ORGANIZATIONS;
+import static com.appsmith.server.acl.AclPermission.ORGANIZATION_EXPORT_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_INVITE_USERS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_PUBLISH_APPLICATIONS;
@@ -20,7 +21,7 @@ public enum AppsmithRole {
     APPLICATION_ADMIN("Application Administrator", "", Set.of(MANAGE_APPLICATIONS)),
     APPLICATION_VIEWER("Application Viewer", "",  Set.of(READ_APPLICATIONS)),
     ORGANIZATION_ADMIN("Administrator", "Can modify all organization settings including editing applications and inviting other users to the organization",
-            Set.of(MANAGE_ORGANIZATIONS, ORGANIZATION_INVITE_USERS)),
+            Set.of(MANAGE_ORGANIZATIONS, ORGANIZATION_INVITE_USERS, ORGANIZATION_EXPORT_APPLICATIONS)),
     ORGANIZATION_DEVELOPER("Developer", "Can edit and view applications along with inviting other users to the organization",  Set.of(READ_ORGANIZATIONS,
             ORGANIZATION_MANAGE_APPLICATIONS, ORGANIZATION_READ_APPLICATIONS, ORGANIZATION_PUBLISH_APPLICATIONS, ORGANIZATION_INVITE_USERS)),
     ORGANIZATION_VIEWER(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AppsmithRole.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AppsmithRole.java
@@ -20,10 +20,12 @@ import static com.appsmith.server.acl.AclPermission.READ_ORGANIZATIONS;
 public enum AppsmithRole {
     APPLICATION_ADMIN("Application Administrator", "", Set.of(MANAGE_APPLICATIONS)),
     APPLICATION_VIEWER("Application Viewer", "",  Set.of(READ_APPLICATIONS)),
-    ORGANIZATION_ADMIN("Administrator", "Can modify all organization settings including editing applications and inviting other users to the organization",
-            Set.of(MANAGE_ORGANIZATIONS, ORGANIZATION_INVITE_USERS, ORGANIZATION_EXPORT_APPLICATIONS)),
-    ORGANIZATION_DEVELOPER("Developer", "Can edit and view applications along with inviting other users to the organization",  Set.of(READ_ORGANIZATIONS,
-            ORGANIZATION_MANAGE_APPLICATIONS, ORGANIZATION_READ_APPLICATIONS, ORGANIZATION_PUBLISH_APPLICATIONS, ORGANIZATION_INVITE_USERS)),
+    ORGANIZATION_ADMIN("Administrator", "Can modify all organization settings including editing applications, " +
+        "inviting other users to the organization and exporting applications from the organization",
+        Set.of(MANAGE_ORGANIZATIONS, ORGANIZATION_INVITE_USERS, ORGANIZATION_EXPORT_APPLICATIONS)),
+    ORGANIZATION_DEVELOPER("Developer", "Can edit and view applications along with inviting other users to the organization",
+        Set.of(READ_ORGANIZATIONS, ORGANIZATION_MANAGE_APPLICATIONS, ORGANIZATION_READ_APPLICATIONS,
+            ORGANIZATION_PUBLISH_APPLICATIONS, ORGANIZATION_INVITE_USERS)),
     ORGANIZATION_VIEWER(
             "App Viewer",
             "Can view applications and invite other users to view applications",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/PolicyGenerator.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/PolicyGenerator.java
@@ -23,6 +23,7 @@ import static com.appsmith.server.acl.AclPermission.COMMENT_ON_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.COMMENT_ON_THREAD;
 import static com.appsmith.server.acl.AclPermission.EXECUTE_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.EXECUTE_DATASOURCES;
+import static com.appsmith.server.acl.AclPermission.EXPORT_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MAKE_PUBLIC_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
@@ -30,6 +31,7 @@ import static com.appsmith.server.acl.AclPermission.MANAGE_DATASOURCES;
 import static com.appsmith.server.acl.AclPermission.MANAGE_ORGANIZATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
 import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
+import static com.appsmith.server.acl.AclPermission.ORGANIZATION_EXPORT_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_PUBLISH_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_READ_APPLICATIONS;
@@ -115,6 +117,7 @@ public class PolicyGenerator {
         hierarchyGraph.addEdge(ORGANIZATION_READ_APPLICATIONS, READ_APPLICATIONS);
         hierarchyGraph.addEdge(ORGANIZATION_PUBLISH_APPLICATIONS, PUBLISH_APPLICATIONS);
         hierarchyGraph.addEdge(MANAGE_ORGANIZATIONS, MAKE_PUBLIC_APPLICATIONS);
+        hierarchyGraph.addEdge(ORGANIZATION_EXPORT_APPLICATIONS, EXPORT_APPLICATIONS);
 
         // If the user is being given MANAGE_APPLICATION permission, they must also be given READ_APPLICATION perm
         lateralGraph.addEdge(MANAGE_APPLICATIONS, READ_APPLICATIONS);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -99,7 +99,9 @@ import java.util.stream.Collectors;
 
 import static com.appsmith.external.helpers.BeanCopyUtils.copyNewFieldValuesIntoOldObject;
 import static com.appsmith.server.acl.AclPermission.EXECUTE_ACTIONS;
+import static com.appsmith.server.acl.AclPermission.EXPORT_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MAKE_PUBLIC_APPLICATIONS;
+import static com.appsmith.server.acl.AclPermission.ORGANIZATION_EXPORT_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_INVITE_USERS;
 import static com.appsmith.server.acl.AclPermission.READ_ACTIONS;
 import static com.appsmith.server.helpers.CollectionUtils.isNullOrEmpty;
@@ -2385,5 +2387,76 @@ public class DatabaseChangelog {
          */
         firestoreActionQueries.stream()
                 .forEach(action -> mongoTemplate.save(action));
+    }
+
+    @ChangeSet(order = "071", id = "add-application-export-permissions", author = "")
+    public void addApplicationExportPermissions(MongoTemplate mongoTemplate) {
+        final List<Organization> organizations = mongoTemplate.find(
+            query(where("userRoles").exists(true)),
+            Organization.class
+        );
+
+        for (final Organization organization : organizations) {
+            Set<String> adminUsernames = organization.getUserRoles()
+                .stream()
+                .filter(role -> (role.getRole().equals(AppsmithRole.ORGANIZATION_ADMIN)))
+                .map(role -> role.getUsername())
+                .collect(Collectors.toSet());
+
+            if (adminUsernames.isEmpty()) {
+                continue;
+            }
+            // All the administrators of the organization should be allowed to export applications permission
+            Set<String> exportApplicationPermissionUsernames = new HashSet<>();
+            exportApplicationPermissionUsernames.addAll(adminUsernames);
+
+            Set<Policy> policies = organization.getPolicies();
+            if (policies == null) {
+                policies = new HashSet<>();
+            }
+
+            Optional<Policy> exportAppOrgLevelOptional = policies.stream()
+                .filter(policy -> policy.getPermission().equals(ORGANIZATION_EXPORT_APPLICATIONS.getValue())).findFirst();
+
+            if (exportAppOrgLevelOptional.isPresent()) {
+                Policy exportApplicationPolicy = exportAppOrgLevelOptional.get();
+                exportApplicationPolicy.getUsers().addAll(exportApplicationPermissionUsernames);
+            } else {
+                // this policy doesnt exist. create and add this to the policy set
+                Policy inviteUserPolicy = Policy.builder().permission(ORGANIZATION_EXPORT_APPLICATIONS.getValue())
+                    .users(exportApplicationPermissionUsernames).build();
+                organization.getPolicies().add(inviteUserPolicy);
+            }
+
+            mongoTemplate.save(organization);
+
+            // Update the applications with export applications policy for all administrators of the organization
+            List<Application> orgApplications = mongoTemplate.find(
+                query(where(fieldName(QApplication.application.organizationId)).is(organization.getId())),
+                Application.class
+            );
+
+            for (final Application application : orgApplications) {
+                Set<Policy> applicationPolicies = application.getPolicies();
+                if (applicationPolicies == null) {
+                    applicationPolicies = new HashSet<>();
+                }
+
+                Optional<Policy> exportAppOptional = applicationPolicies.stream()
+                    .filter(policy -> policy.getPermission().equals(EXPORT_APPLICATIONS.getValue())).findFirst();
+
+                if (exportAppOptional.isPresent()) {
+                    Policy exportAppPolicy = exportAppOptional.get();
+                    exportAppPolicy.getUsers().addAll(adminUsernames);
+                } else {
+                    // this policy doesn't exist, create and add this to the policy set
+                    Policy newExportAppPolicy = Policy.builder().permission(EXPORT_APPLICATIONS.getValue())
+                        .users(adminUsernames).build();
+                    application.getPolicies().add(newExportAppPolicy);
+                }
+
+                mongoTemplate.save(application);
+            }
+        }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -10,7 +10,6 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DecryptedSensitiveFields;
 import com.appsmith.external.models.OAuth2;
 import com.appsmith.server.acl.AclPermission;
-import com.appsmith.server.acl.AppsmithRole;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.ApplicationJson;
@@ -18,7 +17,6 @@ import com.appsmith.server.domains.ApplicationPage;
 import com.appsmith.server.domains.Datasource;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
-import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.PluginType;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.ActionDTO;
@@ -94,10 +92,10 @@ public class ImportExportApplicationService {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.APPLICATION_ID));
         }
 
-        Mono<Application> applicationMono = applicationService
-            .findById(applicationId, AclPermission.EXPORT_APPLICATIONS)
-            .switchIfEmpty(Mono.error(new AppsmithException(
-                AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION, applicationId)));
+        Mono<Application> applicationMono = applicationService.findById(applicationId, AclPermission.EXPORT_APPLICATIONS)
+            .switchIfEmpty(Mono.error(
+                new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION_ID, applicationId))
+            );
 
         return pluginRepository
             .findAll()
@@ -106,15 +104,8 @@ public class ImportExportApplicationService {
                 return plugin;
             })
             .then(applicationMono)
-            .zipWhen(application -> applicationExportPermitted(application))
-            .flatMap(tuple -> {
-                Application application = tuple.getT1();
-                Boolean hasValidPermission = tuple.getT2();
-                if (!hasValidPermission) {
-                    return Mono.error(new AppsmithException(
-                        AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.ORGANIZATION + " with id", application.getOrganizationId())
-                    );
-                }
+            .flatMap(application -> {
+
                 ApplicationPage unpublishedDefaultPage = application.getPages()
                     .stream()
                     .filter(ApplicationPage::getIsDefault)
@@ -257,26 +248,6 @@ public class ImportExportApplicationService {
                 })
                 .then()
                 .thenReturn(applicationJson);
-    }
-
-    Mono<Boolean> applicationExportPermitted(Application application) {
-        String organizationId = application.getOrganizationId();
-        return organizationService.findById(organizationId, AclPermission.ORGANIZATION_EXPORT_APPLICATIONS)
-            .switchIfEmpty(Mono.error(
-                new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.ORGANIZATION + " with id", organizationId))
-            )
-            .zipWith(sessionUserService.getCurrentUser())
-            .map(tuple -> {
-                Organization organization = tuple.getT1();
-                User user = tuple.getT2();
-                return organization.getUserRoles()
-                    .stream()
-                    .filter(userRole -> StringUtils.equals(userRole.getUsername(), user.getUsername()))
-                    .findAny()
-                    .map(userRole -> userRole.getRole().equals(AppsmithRole.ORGANIZATION_ADMIN)
-                        || userRole.getRole().equals(AppsmithRole.APPLICATION_ADMIN))
-                    .orElse(false);
-            });
     }
 
     public Mono<Application> extractFileAndSaveApplication(String orgId, Part filePart) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -97,8 +97,7 @@ public class ImportExportApplicationService {
         Mono<Application> applicationMono = applicationService
             .findById(applicationId, AclPermission.MANAGE_APPLICATIONS)
             .switchIfEmpty(Mono.error(new AppsmithException(
-                AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION, applicationId)))
-            .cache();
+                AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION, applicationId)));
 
         return pluginRepository
             .findAll()


### PR DESCRIPTION
## Description

> This PR fixes the issue where only admins can have the export application functionality.

Fixes #5061

## Type of change

- Enhancement (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually with the following steps:

1. Create 2 dummy users: User1, User2
2. Login to User1 account
3. Create a dummy application
4. Try exporting application (_Success_)
5. Share the application with User2 as a developer
6. Login with User2 account, export option will not be available.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feature/allow-only-admins-to-export-application 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/pages/Applications/permissionHelpers.tsx | 91.67 **(0.76)** | 100 **(0)** | 50 **(0)** | 90.91 **(0.91)**</details>