### PR TITLE
Fix to enable scroll in sql query results.

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/Resizer/index.tsx
+++ b/app/client/src/components/editorComponents/Debugger/Resizer/index.tsx
@@ -20,6 +20,7 @@ const Top = styled.div`
 
 type ResizerProps = {
   panelRef: RefObject<HTMLDivElement>;
+  setResizeWindowHeight?: (height: number) => void;
 };
 
 function Resizer(props: ResizerProps) {
@@ -41,8 +42,14 @@ function Resizer(props: ResizerProps) {
       updatedHeight > minHeight
     ) {
       panel.style.height = `${height - movementY}px`;
+      props.setResizeWindowHeight &&
+        props.setResizeWindowHeight(height - movementY);
     }
   };
+
+  useEffect(() => {
+    handleResize(0);
+  }, []);
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {

--- a/app/client/src/components/editorComponents/Debugger/Resizer/index.tsx
+++ b/app/client/src/components/editorComponents/Debugger/Resizer/index.tsx
@@ -20,7 +20,7 @@ const Top = styled.div`
 
 type ResizerProps = {
   panelRef: RefObject<HTMLDivElement>;
-  setResizeWindowHeight?: (height: number) => void;
+  setContainerDimensions?: (height: number) => void;
 };
 
 function Resizer(props: ResizerProps) {
@@ -42,8 +42,8 @@ function Resizer(props: ResizerProps) {
       updatedHeight > minHeight
     ) {
       panel.style.height = `${height - movementY}px`;
-      props.setResizeWindowHeight &&
-        props.setResizeWindowHeight(height - movementY);
+      props.setContainerDimensions &&
+        props.setContainerDimensions(height - movementY);
     }
   };
 

--- a/app/client/src/constants/DefaultTheme.tsx
+++ b/app/client/src/constants/DefaultTheme.tsx
@@ -316,7 +316,6 @@ export type Theme = {
   propertyPane: PropertyPaneTheme;
   headerHeight: string;
   smallHeaderHeight: string;
-  tableHeaderHeight: string;
   homePage: any;
   sidebarWidth: string;
   canvasPadding: string;
@@ -362,6 +361,7 @@ export type Theme = {
     };
   };
   pageContentWidth: number;
+  tabPanelHeight: number;
   alert: Record<string, { color: Color }>;
   lightningMenu: {
     [Skin.DARK]: {
@@ -2335,7 +2335,6 @@ export const theme: Theme = {
   },
   headerHeight: "48px",
   smallHeaderHeight: "35px",
-  tableHeaderHeight: "38px",
   canvasPadding: "0 0 200px 0",
   sideNav: {
     maxWidth: 220,
@@ -2390,6 +2389,7 @@ export const theme: Theme = {
     },
   },
   pageContentWidth: 1224,
+  tabPanelHeight: 34,
   alert: {
     info: {
       color: Colors.AZURE_RADIANCE,

--- a/app/client/src/constants/DefaultTheme.tsx
+++ b/app/client/src/constants/DefaultTheme.tsx
@@ -316,6 +316,7 @@ export type Theme = {
   propertyPane: PropertyPaneTheme;
   headerHeight: string;
   smallHeaderHeight: string;
+  tableHeaderHeight: string;
   homePage: any;
   sidebarWidth: string;
   canvasPadding: string;
@@ -2334,6 +2335,7 @@ export const theme: Theme = {
   },
   headerHeight: "48px",
   smallHeaderHeight: "35px",
+  tableHeaderHeight: "38px",
   canvasPadding: "0 0 200px 0",
   sideNav: {
     maxWidth: 220,

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -386,6 +386,9 @@ export function EditorJSONtoForm(props: Props) {
   let hintMessages: Array<string> = [];
   const panelRef: RefObject<HTMLDivElement> = useRef(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [resizeWindowHeight, setResizeWindowHeight] = useState(
+    window.innerHeight,
+  );
 
   if (executedQueryData) {
     if (!executedQueryData.isExecutionSuccess) {
@@ -529,7 +532,7 @@ export function EditorJSONtoForm(props: Props) {
           )}
           {output &&
             (isTableResponse ? (
-              <Table data={output} />
+              <Table data={output} resizeWindowHeight={resizeWindowHeight} />
             ) : (
               <JSONViewer src={output} />
             ))}
@@ -688,7 +691,12 @@ export function EditorJSONtoForm(props: Props) {
         </TabContainerView>
 
         <TabbedViewContainer ref={panelRef}>
-          <Resizable panelRef={panelRef} />
+          <Resizable
+            panelRef={panelRef}
+            setResizeWindowHeight={(height: number) =>
+              setResizeWindowHeight(height - 100)
+            }
+          />
           {output && !!output.length && (
             <Boxed step={OnboardingStep.SUCCESSFUL_BINDING}>
               <ResultsCount>

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -386,7 +386,7 @@ export function EditorJSONtoForm(props: Props) {
   let hintMessages: Array<string> = [];
   const panelRef: RefObject<HTMLDivElement> = useRef(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [resizeWindowHeight, setResizeWindowHeight] = useState(
+  const [tableBodyHeight, setTableBodyHeightHeight] = useState(
     window.innerHeight,
   );
 
@@ -532,7 +532,7 @@ export function EditorJSONtoForm(props: Props) {
           )}
           {output &&
             (isTableResponse ? (
-              <Table data={output} resizeWindowHeight={resizeWindowHeight} />
+              <Table data={output} tableBodyHeight={tableBodyHeight} />
             ) : (
               <JSONViewer src={output} />
             ))}
@@ -693,8 +693,8 @@ export function EditorJSONtoForm(props: Props) {
         <TabbedViewContainer ref={panelRef}>
           <Resizable
             panelRef={panelRef}
-            setResizeWindowHeight={(height: number) =>
-              setResizeWindowHeight(height - 100)
+            setContainerDimensions={
+              (height: number) => setTableBodyHeightHeight(height - 115) //accounts for the tab containers height and the table header.
             }
           />
           {output && !!output.length && (

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -693,8 +693,8 @@ export function EditorJSONtoForm(props: Props) {
         <TabbedViewContainer ref={panelRef}>
           <Resizable
             panelRef={panelRef}
-            setContainerDimensions={
-              (height: number) => setTableBodyHeightHeight(height - 115) //accounts for the tab containers height and the table header.
+            setContainerDimensions={(height: number) =>
+              setTableBodyHeightHeight(height)
             }
           />
           {output && !!output.length && (

--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -12,7 +12,7 @@ import AutoToolTipComponent from "components/designSystems/appsmith/TableCompone
 
 interface TableProps {
   data: Record<string, any>[];
-  resizeWindowHeight?: number;
+  tableBodyHeight?: number;
 }
 
 const TABLE_SIZES = {
@@ -293,7 +293,7 @@ function Table(props: TableProps) {
 
             <div {...getTableBodyProps()} className="tbody">
               <FixedSizeList
-                height={props.resizeWindowHeight || window.innerHeight}
+                height={props.tableBodyHeight || window.innerHeight}
                 itemCount={rows.length}
                 itemSize={35}
                 width={totalColumnsWidth + scrollBarSize}

--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -12,6 +12,7 @@ import AutoToolTipComponent from "components/designSystems/appsmith/TableCompone
 
 interface TableProps {
   data: Record<string, any>[];
+  resizeWindowHeight?: number;
 }
 
 const TABLE_SIZES = {
@@ -44,13 +45,13 @@ export const TableWrapper = styled.div`
     background: ${Colors.ATHENS_GRAY_DARKER};
     display: table;
     width: 100%;
+    height: 100%;
     .thead,
     .tbody {
       overflow: hidden;
     }
     .tbody {
-      overflow-y: scroll;
-      height: 100%;
+      height: calc(100% - 38px);
       .tr {
         width: 100%;
       }
@@ -292,7 +293,7 @@ function Table(props: TableProps) {
 
             <div {...getTableBodyProps()} className="tbody">
               <FixedSizeList
-                height={window.innerHeight}
+                height={props.resizeWindowHeight || window.innerHeight}
                 itemCount={rows.length}
                 itemSize={35}
                 width={totalColumnsWidth + scrollBarSize}

--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -54,7 +54,7 @@ export const TableWrapper = styled.div`
       overflow: hidden;
     }
     .tbody {
-      height: calc(100% - ${(props) => props.theme.tableHeaderHeight});
+      height: calc(100% - ${TABLE_SIZES.COLUMN_HEADER_HEIGHT}px);
       .tr {
         width: 100%;
       }

--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { withTheme } from "styled-components";
 import { FixedSizeList } from "react-window";
 import { useTable, useBlockLayout } from "react-table";
 
@@ -9,10 +9,12 @@ import { getType, Types } from "utils/TypeHelpers";
 import ErrorBoundary from "components/editorComponents/ErrorBoundry";
 import { CellWrapper } from "components/designSystems/appsmith/TableComponent/TableStyledWrappers";
 import AutoToolTipComponent from "components/designSystems/appsmith/TableComponent/AutoToolTipComponent";
+import { Theme } from "constants/DefaultTheme";
 
 interface TableProps {
   data: Record<string, any>[];
   tableBodyHeight?: number;
+  theme: Theme;
 }
 
 const TABLE_SIZES = {
@@ -20,6 +22,7 @@ const TABLE_SIZES = {
   TABLE_HEADER_HEIGHT: 42,
   ROW_HEIGHT: 40,
   ROW_FONT_SIZE: 14,
+  SCROLL_SIZE: 20,
 };
 
 export const TableWrapper = styled.div`
@@ -202,6 +205,13 @@ function Table(props: TableProps) {
     return [];
   }, [data]);
 
+  const tableBodyHeightComputed =
+    (props.tableBodyHeight || window.innerHeight) -
+    TABLE_SIZES.COLUMN_HEADER_HEIGHT -
+    props.theme.tabPanelHeight -
+    TABLE_SIZES.SCROLL_SIZE -
+    2 * props.theme.spaces[5]; //top and bottom padding
+
   const defaultColumn = React.useMemo(
     () => ({
       width: 170,
@@ -293,7 +303,7 @@ function Table(props: TableProps) {
 
             <div {...getTableBodyProps()} className="tbody">
               <FixedSizeList
-                height={props.tableBodyHeight || window.innerHeight}
+                height={tableBodyHeightComputed || window.innerHeight}
                 itemCount={rows.length}
                 itemSize={35}
                 width={totalColumnsWidth + scrollBarSize}
@@ -308,4 +318,4 @@ function Table(props: TableProps) {
   );
 }
 
-export default Table;
+export default withTheme(Table);

--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -51,7 +51,7 @@ export const TableWrapper = styled.div`
       overflow: hidden;
     }
     .tbody {
-      height: calc(100% - 38px);
+      height: calc(100% - ${(props) => props.theme.tableHeaderHeight});
       .tr {
         width: 100%;
       }


### PR DESCRIPTION
## Description
Fix to enable scroll in sql query results and disappearing scroll bar.
Dynamically adjust table virtualiser's height according to re-sizer's.

Fixes #5042 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/scroll_sql_query 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.34 **(-0.01)** | 35.31 **(-0.01)** | 31.92 **(-0.01)** | 53.85 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/Resizer/index.tsx | 15 **(-1.22)** | 28.57 **(-4.76)** | 0 **(0)** | 16.67 **(-1.51)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 48.51 **(-1.49)** | 48.48 **(0)** | 0 **(0)** | 50.78 **(-0.81)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/Table.tsx | 24.56 **(-0.44)** | 8.33 **(-1.67)** | 0 **(0)** | 25.93 **(-0.49)**</details>