### PR TITLE
Fix: Use connection pool for Redis

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -117,11 +117,6 @@ public class RedisPlugin extends BasePlugin {
                          * - Return resource back to the pool.
                          * - https://stackoverflow.com/questions/54902337/is-it-necessary-to-use-jedis-close
                          * - https://www.baeldung.com/jedis-java-redis-client-library:
-                         * '''
-                         * We used the Java try-with-resources statement to avoid having to manually close the
-                         * Jedis resource, but if you cannot use this statement you can also close the resource
-                         * manually in the finally clause.
-                         * '''
                          */
                         if (jedis != null) {
                             jedis.close();

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -153,6 +153,12 @@ public class RedisPlugin extends BasePlugin {
             }
         }
 
+
+        /**
+         * - Config taken from https://www.baeldung.com/jedis-java-redis-client-library
+         * - To understand what these config mean:
+         * https://www.infoworld.com/article/2071834/pool-resources-using-apache-s-commons-pool-framework.html
+         */
         private JedisPoolConfig buildPoolConfig() {
             final JedisPoolConfig poolConfig = new JedisPoolConfig();
             poolConfig.setMaxTotal(128);

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -162,9 +162,9 @@ public class RedisPlugin extends BasePlugin {
          */
         private JedisPoolConfig buildPoolConfig() {
             final JedisPoolConfig poolConfig = new JedisPoolConfig();
-            poolConfig.setMaxTotal(128);
-            poolConfig.setMaxIdle(128);
-            poolConfig.setMinIdle(16);
+            poolConfig.setMaxTotal(5);
+            poolConfig.setMaxIdle(5);
+            poolConfig.setMinIdle(0);
             poolConfig.setTestOnBorrow(true);
             poolConfig.setTestOnReturn(true);
             poolConfig.setTestWhileIdle(true);

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -129,6 +129,7 @@ public class RedisPlugin extends BasePlugin {
             DBAuth auth = (DBAuth) datasourceConfiguration.getAuthentication();
             if (auth != null && StringUtils.isNotNullOrEmpty(auth.getPassword())) {
                 if (StringUtils.isNullOrEmpty(auth.getUsername())) {
+                    // If username is empty, then authenticate with password only.
                     jedis.auth(auth.getPassword());
                 }
                 else {

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -19,8 +19,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-import reactor.util.function.Tuple4;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import java.util.ArrayList;
@@ -265,42 +263,6 @@ public class RedisPluginTest {
                     Assert.assertNotNull(actionExecutionResult.getBody());
                     final JsonNode node = ((ArrayNode) actionExecutionResult.getBody()).get(0);
                     Assert.assertEquals("value", node.get("result").asText());
-                }).verifyComplete();
-    }
-
-    @Test
-    public void executeMultipleCommandsSimultaneously() {
-        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
-        Mono<JedisPool> jedisPoolMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
-
-        ActionConfiguration actionConfiguration = new ActionConfiguration();
-        actionConfiguration.setBody("PING");
-
-        Mono<ActionExecutionResult> actionExecutionResultMono1 = jedisPoolMono
-                .flatMap(jedisPool -> pluginExecutor.execute(jedisPool, datasourceConfiguration, actionConfiguration));
-
-        Mono<ActionExecutionResult> actionExecutionResultMono2 = jedisPoolMono
-                .flatMap(jedisPool -> pluginExecutor.execute(jedisPool, datasourceConfiguration, actionConfiguration));
-
-        Mono<ActionExecutionResult> actionExecutionResultMono3 = jedisPoolMono
-                .flatMap(jedisPool -> pluginExecutor.execute(jedisPool, datasourceConfiguration, actionConfiguration));
-
-        Mono<ActionExecutionResult> actionExecutionResultMono4 = jedisPoolMono
-                .flatMap(jedisPool -> pluginExecutor.execute(jedisPool, datasourceConfiguration, actionConfiguration));
-
-        Mono<Tuple4<ActionExecutionResult, ActionExecutionResult, ActionExecutionResult, ActionExecutionResult>> resultsMono = Mono.zip(actionExecutionResultMono1, actionExecutionResultMono2, actionExecutionResultMono3, actionExecutionResultMono4);
-
-        StepVerifier.create(resultsMono)
-                .assertNext(tuple -> {
-                    ActionExecutionResult r1 = tuple.getT1();
-                    ActionExecutionResult r2 = tuple.getT1();
-                    ActionExecutionResult r3 = tuple.getT1();
-                    ActionExecutionResult r4 = tuple.getT1();
-
-                    /*Assert.assertNotNull(actionExecutionResult);
-                    Assert.assertNotNull(actionExecutionResult.getBody());
-                    final JsonNode node = ((ArrayNode) actionExecutionResult.getBody()).get(0);
-                    assertEquals("PONG", node.get("result").asText());*/
                 }).verifyComplete();
     }
 }


### PR DESCRIPTION
## Description
- Replace single connection instance with a connection pool. This will ensure that simultaneous actions don't fail / break the connection. 

Fixes #4924 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual. Created six actions and set them to on page load. Earlier I could see actions failing, but with this change no such failure is seen. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
