### PR TITLE
Fix/api editor enhancement

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -432,7 +432,9 @@ function ImportedHeaders(props: { headers: any }) {
 
 function ApiEditorForm(props: Props) {
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [showDatasources, toggleDatasources] = useState(false);
+  const [showDatasources, toggleDatasources] = useState(
+    !!props.datasources.length,
+  );
   const [
     apiBindHelpSectionVisible,
     setApiBindHelpSectionVisible,

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -575,7 +575,7 @@ function* storeAsDatasourceSaga() {
   datasource = _.omit(datasource, ["name"]);
   const originalHeaders = _.get(values, "actionConfiguration.headers", []);
   const datasourceHeaders = originalHeaders.filter(
-    ({ key, value }: { key: string; value: string }) => {
+    ({ value }: { key: string; value: string }) => {
       const bindOpen = value.indexOf("{{");
       const bindClose = value.indexOf("}}");
       return !(bindOpen > -1 && bindClose > -1 && bindOpen < bindClose);

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -76,7 +76,7 @@ import { APPSMITH_TOKEN_STORAGE_KEY } from "pages/Editor/SaaSEditor/constants";
 import { checkAndGetPluginFormConfigsSaga } from "sagas/PluginSagas";
 import { PluginType } from "entities/Action";
 import LOG_TYPE from "entities/AppsmithConsole/logtype";
-import { DATA_BIND_REGEX_GLOBAL } from "constants/BindingsConstants";
+import { isDynamicValue } from "utils/DynamicBindingUtils";
 
 function* fetchDatasourcesSaga() {
   try {
@@ -577,9 +577,7 @@ function* storeAsDatasourceSaga() {
   const originalHeaders = _.get(values, "actionConfiguration.headers", []);
   const datasourceHeaders = originalHeaders.filter(
     ({ key, value }: { key: string; value: string }) => {
-      return !(
-        DATA_BIND_REGEX_GLOBAL.test(key) || DATA_BIND_REGEX_GLOBAL.test(value)
-      );
+      return !(isDynamicValue(key) || isDynamicValue(value));
     },
   );
   const actionHeaders = _.difference(originalHeaders, datasourceHeaders);

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -575,12 +575,12 @@ function* storeAsDatasourceSaga() {
   let datasource = _.get(values, "datasource");
   datasource = _.omit(datasource, ["name"]);
   const originalHeaders = _.get(values, "actionConfiguration.headers", []);
-  const datasourceHeaders = originalHeaders.filter(
+  const [datasourceHeaders, actionHeaders] = _.partition(
+    originalHeaders,
     ({ key, value }: { key: string; value: string }) => {
       return !(isDynamicValue(key) || isDynamicValue(value));
     },
   );
-  const actionHeaders = _.difference(originalHeaders, datasourceHeaders);
   yield put(
     setActionProperty({
       actionId: values.id,

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -76,6 +76,7 @@ import { APPSMITH_TOKEN_STORAGE_KEY } from "pages/Editor/SaaSEditor/constants";
 import { checkAndGetPluginFormConfigsSaga } from "sagas/PluginSagas";
 import { PluginType } from "entities/Action";
 import LOG_TYPE from "entities/AppsmithConsole/logtype";
+import { DATA_BIND_REGEX_GLOBAL } from "constants/BindingsConstants";
 
 function* fetchDatasourcesSaga() {
   try {
@@ -575,10 +576,10 @@ function* storeAsDatasourceSaga() {
   datasource = _.omit(datasource, ["name"]);
   const originalHeaders = _.get(values, "actionConfiguration.headers", []);
   const datasourceHeaders = originalHeaders.filter(
-    ({ value }: { key: string; value: string }) => {
-      const bindOpen = value.indexOf("{{");
-      const bindClose = value.indexOf("}}");
-      return !(bindOpen > -1 && bindClose > -1 && bindOpen < bindClose);
+    ({ key, value }: { key: string; value: string }) => {
+      return !(
+        DATA_BIND_REGEX_GLOBAL.test(key) || DATA_BIND_REGEX_GLOBAL.test(value)
+      );
     },
   );
   const actionHeaders = _.difference(originalHeaders, datasourceHeaders);

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -573,7 +573,23 @@ function* storeAsDatasourceSaga() {
   const pageId = yield select(getCurrentPageId);
   let datasource = _.get(values, "datasource");
   datasource = _.omit(datasource, ["name"]);
-
+  const originalHeaders = _.get(values, "actionConfiguration.headers", []);
+  const datasourceHeaders = originalHeaders.filter(
+    ({ key, value }: { key: string; value: string }) => {
+      const bindOpen = value.indexOf("{{");
+      const bindClose = value.indexOf("}}");
+      return !(bindOpen > -1 && bindClose > -1 && bindOpen < bindClose);
+    },
+  );
+  const actionHeaders = _.difference(originalHeaders, datasourceHeaders);
+  yield put(
+    setActionProperty({
+      actionId: values.id,
+      propertyName: "actionConfiguration.headers",
+      value: actionHeaders,
+    }),
+  );
+  _.set(datasource, "datasourceConfiguration.headers", datasourceHeaders);
   history.push(DATA_SOURCES_EDITOR_URL(applicationId, pageId));
 
   yield put(createDatasourceFromForm(datasource));


### PR DESCRIPTION
## Description
Minor enhancement to copy action headers to datasources on save. 
Keeping the datasource tab on the right open by default.

Fixes #5094 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/api_editor_enhancement 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.66 **(-0.01)** | 32.89 **(-0.01)** | 29.59 **(0)** | 52.14 **(-0.01)**
 :red_circle: | app/client/src/sagas/DatasourcesSagas.ts | 13.91 **(-0.04)** | 2.11 **(-0.04)** | 9.52 **(-0.48)** | 16.36 **(-0.07)**</details>