### PR TITLE
Fix: parse json/jsonb data type values as json for postgres plugin

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -89,6 +89,8 @@ public class PostgresPlugin extends BasePlugin {
 
     private static final String INTERVAL_TYPE_NAME = "interval";
 
+    private static final String JSON_TYPE_NAME = "json";
+
     private static final String JSONB_TYPE_NAME = "jsonb";
 
     private static final int MINIMUM_POOL_SIZE = 1;
@@ -339,9 +341,9 @@ public class PostgresPlugin extends BasePlugin {
                                 } else if (typeName.startsWith("_")) {
                                     value = resultSet.getArray(i).getArray();
 
-                                } else if (JSONB_TYPE_NAME.equalsIgnoreCase(typeName)) {
-                                    value = resultSet.getString(i);
-
+                                } else if (JSON_TYPE_NAME.equalsIgnoreCase(typeName)
+                                        || JSONB_TYPE_NAME.equalsIgnoreCase(typeName)) {
+                                    value = objectMapper.readTree(resultSet.getString(i));
                                 } else {
                                     value = resultSet.getObject(i);
                                 }
@@ -356,6 +358,11 @@ public class PostgresPlugin extends BasePlugin {
                 } catch (SQLException e) {
                     System.out.println(Thread.currentThread().getName() + ": In the PostgresPlugin, got action execution error");
                     return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, e.getMessage()));
+                } catch (IOException e) {
+                    // Since postgres json type field can only hold valid json data, this exception is not expected
+                    // to occur.
+                    System.out.println(Thread.currentThread().getName() + ": In the PostgresPlugin, got action execution error");
+                    return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, e.getMessage()));
                 } finally {
                     idleConnections = poolProxy.getIdleConnections();
                     activeConnections = poolProxy.getActiveConnections();


### PR DESCRIPTION
## Description
- parse json/jsonb data type values as json
- add support for json (non binary, earlier support for jsonb was added)

Fixes #4226 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Via Junit TC
- Manual: by creating tables with json and jsonb types

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
