### PR TITLE
Add an option to set tags on sentry performance transactions #5147

### DIFF
--- a/app/client/src/utils/PerformanceTracker.ts
+++ b/app/client/src/utils/PerformanceTracker.ts
@@ -56,7 +56,7 @@ class PerformanceTracker {
     eventName: PerformanceTransactionName,
     data?: any,
     skipLog = false,
-    tags: null | Array<PerfTag> = null,
+    tags: Array<PerfTag> = [],
   ) => {
     if (appsmithConfigs.sentry.enabled) {
       const currentTransaction = Sentry.getCurrentHub()
@@ -84,7 +84,7 @@ class PerformanceTracker {
           );
         }
         const newTransaction = Sentry.startTransaction({ name: eventName });
-        if (tags && Array.isArray(tags)) {
+        if (Array.isArray(tags)) {
           tags.forEach(({ name: tagName, value }) => {
             newTransaction.setTag(tagName, value);
           });

--- a/app/client/src/utils/PerformanceTracker.ts
+++ b/app/client/src/utils/PerformanceTracker.ts
@@ -33,8 +33,13 @@ export enum PerformanceTransactionName {
   LOGIN_CLICK = "LOGIN_CLICK",
   INIT_EDIT_APP = "INIT_EDIT_APP",
   INIT_VIEW_APP = "INIT_VIEW_APP",
+  SHOW_RESIZE_HANDLES = "SHOW_RESIZE_HANDLES",
 }
 
+export type PerfTag = {
+  name: "string";
+  value: "string";
+};
 export interface PerfLog {
   sentrySpan: Span;
   skipLog?: boolean;
@@ -51,6 +56,7 @@ class PerformanceTracker {
     eventName: PerformanceTransactionName,
     data?: any,
     skipLog = false,
+    tags: null | Array<PerfTag> = null,
   ) => {
     if (appsmithConfigs.sentry.enabled) {
       const currentTransaction = Sentry.getCurrentHub()
@@ -78,6 +84,11 @@ class PerformanceTracker {
           );
         }
         const newTransaction = Sentry.startTransaction({ name: eventName });
+        if (tags && Array.isArray(tags)) {
+          tags.forEach(({ name: tagName, value }) => {
+            newTransaction.setTag(tagName, value);
+          });
+        }
         newTransaction.setData("startData", data);
         Sentry.getCurrentHub().configureScope((scope) =>
           scope.setSpan(newTransaction),

--- a/app/client/src/utils/PerformanceTracker.ts
+++ b/app/client/src/utils/PerformanceTracker.ts
@@ -37,8 +37,8 @@ export enum PerformanceTransactionName {
 }
 
 export type PerfTag = {
-  name: "string";
-  value: "string";
+  name: string;
+  value: string;
 };
 export interface PerfLog {
   sentrySpan: Span;

--- a/app/client/src/utils/PerformanceTracker.ts
+++ b/app/client/src/utils/PerformanceTracker.ts
@@ -84,11 +84,11 @@ class PerformanceTracker {
           );
         }
         const newTransaction = Sentry.startTransaction({ name: eventName });
-        if (Array.isArray(tags)) {
-          tags.forEach(({ name: tagName, value }) => {
-            newTransaction.setTag(tagName, value);
-          });
-        }
+
+        tags.forEach(({ name: tagName, value }) => {
+          newTransaction.setTag(tagName, value);
+        });
+
         newTransaction.setData("startData", data);
         Sentry.getCurrentHub().configureScope((scope) =>
           scope.setSpan(newTransaction),


### PR DESCRIPTION

## Description
Add an option to set tags on transactions to easily filter them, for example by widget type.
Unlike context tags are indexed.

Fixes #5147

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change
 
- New feature (non-breaking change which adds functionality)
 

## How Has This Been Tested?
Verified in a separate react app as I couldn't get sentry to work locally in appsmith app 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: ui/perf/add-tags-option-to-performance-tracker 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.71 **(-0.01)** | 32.96 **(0.01)** | 29.66 **(-0.01)** | 52.2 **(0)**
 :red_circle: | app/client/src/utils/PerformanceTracker.ts | 52.99 **(-1.06)** | 12.66 **(0.97)** | 54.55 **(-5.45)** | 53.51 **(-0.13)**</details>