### PR TITLE
Reset the user in store on 401s

### DIFF
--- a/app/client/src/api/ApiUtils.ts
+++ b/app/client/src/api/ApiUtils.ts
@@ -10,10 +10,10 @@ import {
   ERROR_CODES,
   SERVER_ERROR_CODES,
 } from "constants/ApiConstants";
-import history from "utils/history";
-import { AUTH_LOGIN_URL } from "constants/routes";
 import log from "loglevel";
 import { ActionExecutionResponse } from "api/ActionAPI";
+import store from "store";
+import { logoutUser } from "actions/userActions";
 
 const executeActionRegex = /actions\/execute/;
 const timeoutErrorRegex = /timeout of (\d+)ms exceeded/;
@@ -100,10 +100,9 @@ export const apiFailureResponseInterceptor = (error: any) => {
       const currentUrl = `${window.location.href}`;
       if (error.response.status === API_STATUS_CODES.REQUEST_NOT_AUTHORISED) {
         // Redirect to login and set a redirect url.
-        history.replace({
-          pathname: AUTH_LOGIN_URL,
-          search: `redirectUrl=${encodeURIComponent(currentUrl)}`,
-        });
+        store.dispatch(
+          logoutUser({ redirectURL: encodeURIComponent(currentUrl) }),
+        );
         return Promise.reject({
           code: ERROR_CODES.REQUEST_NOT_AUTHORISED,
           message: "Unauthorized. Redirecting to login page...",

--- a/app/client/src/comments/CommentCard/CommentCard.tsx
+++ b/app/client/src/comments/CommentCard/CommentCard.tsx
@@ -29,7 +29,7 @@ import copy from "copy-to-clipboard";
 import moment from "moment";
 import history from "utils/history";
 
-import UserApi from "api/UserApi";
+import { USER_PHOTO_URL } from "constants/userConstants";
 
 import { getCommentThreadURL } from "../utils";
 
@@ -394,7 +394,7 @@ function CommentCard({
         <HeaderSection>
           <ProfileImage
             side={25}
-            source={`/api/${UserApi.photoURL}/${authorUsername}`}
+            source={`/api/${USER_PHOTO_URL}/${authorUsername}`}
             userName={authorName || ""}
           />
           <UserName>{authorName}</UserName>

--- a/app/client/src/components/ads/MentionsInput.tsx
+++ b/app/client/src/components/ads/MentionsInput.tsx
@@ -10,11 +10,11 @@ import "@draft-js-plugins/mention/lib/plugin.css";
 import "draft-js/dist/Draft.css";
 import { getTypographyByKey } from "constants/DefaultTheme";
 import { EntryComponentProps } from "@draft-js-plugins/mention/lib/MentionSuggestions/Entry/Entry";
-import UserApi from "api/UserApi";
 
 import Icon from "components/ads/Icon";
 
 import { INVITE_A_NEW_USER, createMessage } from "constants/messages";
+import { USER_PHOTO_URL } from "constants/userConstants";
 
 const StyledMention = styled.span`
   color: ${(props) => props.theme.colors.comments.mention};
@@ -103,7 +103,7 @@ function SuggestionComponent(props: EntryComponentProps) {
     <StyledSuggestionsComponent {...parentProps}>
       <ProfileImage
         side={25}
-        source={`/api/${UserApi.photoURL}/${user?.username}`}
+        source={`/api/${USER_PHOTO_URL}/${user?.username}`}
         userName={user?.username || ""}
       />
       <div>

--- a/app/client/src/constants/userConstants.ts
+++ b/app/client/src/constants/userConstants.ts
@@ -32,3 +32,6 @@ export const DefaultCurrentUserDetails: User = {
   gender: "MALE",
   anonymousId: "anonymousId",
 };
+
+// TODO keeping it here instead of the USER_API since it leads to cyclic deps errors during tests
+export const USER_PHOTO_URL = "v1/users/photo";


### PR DESCRIPTION
## Description
Dispatch a logout action which resets the user in store.
Else since we redirect away from login pages based on the user in store there's an infinite loop of redirections.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
Fixes #5149 

## How Has This Been Tested?
- To reproduce: manually delete session cookie, there's an infinite loop of redirection

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: reset-user-on-401 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.7 **(0.01)** | 32.93 **(0)** | 29.64 **(0)** | 52.17 **(0)**</details>