### PR TITLE
Fix redirect URL on 401s

### DIFF
--- a/app/client/src/api/ApiUtils.ts
+++ b/app/client/src/api/ApiUtils.ts
@@ -14,6 +14,7 @@ import log from "loglevel";
 import { ActionExecutionResponse } from "api/ActionAPI";
 import store from "store";
 import { logoutUser } from "actions/userActions";
+import { AUTH_LOGIN_URL } from "constants/routes";
 
 const executeActionRegex = /actions\/execute/;
 const timeoutErrorRegex = /timeout of (\d+)ms exceeded/;
@@ -101,7 +102,11 @@ export const apiFailureResponseInterceptor = (error: any) => {
       if (error.response.status === API_STATUS_CODES.REQUEST_NOT_AUTHORISED) {
         // Redirect to login and set a redirect url.
         store.dispatch(
-          logoutUser({ redirectURL: encodeURIComponent(currentUrl) }),
+          logoutUser({
+            redirectURL: `${AUTH_LOGIN_URL}?redirectUrl=${encodeURIComponent(
+              currentUrl,
+            )}`,
+          }),
         );
         return Promise.reject({
           code: ERROR_CODES.REQUEST_NOT_AUTHORISED,


### PR DESCRIPTION
## Description
We're using the complete href instead of relative path, that the saga expected.

There's another logic for redirection that was trigged while testing so this bug wasn't detected:
```
// if user is not logged and the error is "PAGE_NOT_FOUND",
  // redirecting user to login page with redirecTo param
  if (
    get(user, "email") === ANONYMOUS_USERNAME &&
    code === ERROR_CODES.PAGE_NOT_FOUND
  ) {
    window.location.href = `${AUTH_LOGIN_URL}?redirectUrl=${window.location.href}`;

    return false;
  }
```

Fixes #5149

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Navigate to edit app
- Delete session cookie
- Click on appsmith home icon
- Should be redirected to the login page with the applications page as the redirectURL (redirectUrl should be the complete href)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix-redirection-on-401 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/api/ApiUtils.ts | 66.04 **(0.66)** | 45.71 **(0)** | 80 **(0)** | 63.27 **(0.77)**</details>