### PR TITLE
Feature/implement comment thread subscriber

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThread.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThread.java
@@ -41,6 +41,12 @@ public class CommentThread extends BaseDomain {
     @JsonIgnore
     Set<String> viewedByUsers;
 
+    /**
+     * username i.e. email of users who are subscribed for notifications in this thread
+     */
+    @JsonIgnore
+    Set<String> subscribers;
+
     String mode;
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentAddedEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentAddedEvent.java
@@ -5,12 +5,17 @@ import com.appsmith.server.domains.Comment;
 import com.appsmith.server.domains.Organization;
 import lombok.Getter;
 
+import java.util.Set;
+
 @Getter
 public class CommentAddedEvent extends AbstractCommentEvent {
     private final Comment comment;
+    private final Set<String> subscribers;
 
-    public CommentAddedEvent(String authorUserName, Organization organization, Application application, String originHeader, Comment comment) {
+    public CommentAddedEvent(String authorUserName, Organization organization, Application application,
+                             String originHeader, Comment comment, Set<String> subscribers) {
         super(authorUserName, organization, application, originHeader);
         this.comment = comment;
+        this.subscribers = subscribers;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CommentUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CommentUtils.java
@@ -31,6 +31,35 @@ public class CommentUtils {
         return false;
     }
 
+    /**
+     * Returns the list of usernames who should subscribe to a thread
+     * It'll include the author username. It'll also include anyone who is mentioned in this comment by the author.
+     * For example, if this comment is from user1 and user2 and user3 are mentioned in this comment,
+     * it'll return a list of user1, user2, user3
+     * @param comment The comment object
+     * @return list of usernames. Size of the list will be at least 1
+     */
+    public static List<String> getSubscriberUsernames(Comment comment) {
+        List<String> usernameList = new ArrayList<>();
+        // add the author itself
+        usernameList.add(comment.getAuthorUsername());
+
+        if(comment.getBody() != null && comment.getBody().getEntityMap() != null) {
+            for(String key : comment.getBody().getEntityMap().keySet()) {
+                Comment.Entity commentEntity = comment.getBody().getEntityMap().get(key);
+                if(commentEntity != null && commentEntity.getType() != null
+                        && commentEntity.getType().equals("mention")) {
+                    // this comment has a mention, check the provided user is mentioned or not
+                    if(commentEntity.getData() != null) {
+                        Comment.EntityData.Mention mention = commentEntity.getData().getMention();
+                        usernameList.add(mention.getUser().getUsername());
+                    }
+                }
+            }
+        }
+        return usernameList;
+    }
+
     public static List<String> getCommentBody(Comment comment) {
         List<String> commentLines = new ArrayList<>();
         if(comment.getBody() != null && comment.getBody().getBlocks() != null) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CommentUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CommentUtils.java
@@ -3,7 +3,9 @@ package com.appsmith.server.helpers;
 import com.appsmith.server.domains.Comment;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class CommentUtils {
     /**
@@ -34,15 +36,15 @@ public class CommentUtils {
     /**
      * Returns the list of usernames who should subscribe to a thread
      * It'll include the author username. It'll also include anyone who is mentioned in this comment by the author.
-     * For example, if this comment is from user1 and user2 and user3 are mentioned in this comment,
+     * For example, if this comment is from user1 where user2 and user3 are mentioned in this comment,
      * it'll return a list of user1, user2, user3
      * @param comment The comment object
      * @return list of usernames. Size of the list will be at least 1
      */
-    public static List<String> getSubscriberUsernames(Comment comment) {
-        List<String> usernameList = new ArrayList<>();
+    public static Set<String> getSubscriberUsernames(Comment comment) {
+        Set<String> usernamesSet = new HashSet<>();
         // add the author itself
-        usernameList.add(comment.getAuthorUsername());
+        usernamesSet.add(comment.getAuthorUsername());
 
         if(comment.getBody() != null && comment.getBody().getEntityMap() != null) {
             for(String key : comment.getBody().getEntityMap().keySet()) {
@@ -52,12 +54,12 @@ public class CommentUtils {
                     // this comment has a mention, check the provided user is mentioned or not
                     if(commentEntity.getData() != null) {
                         Comment.EntityData.Mention mention = commentEntity.getData().getMention();
-                        usernameList.add(mention.getUser().getUsername());
+                        usernamesSet.add(mention.getUser().getUsername());
                     }
                 }
             }
         }
-        return usernameList;
+        return usernamesSet;
     }
 
     public static List<String> getCommentBody(Comment comment) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
@@ -6,9 +6,9 @@ import com.mongodb.client.result.UpdateResult;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.List;
+import java.util.Set;
 
 public interface CustomCommentThreadRepository extends AppsmithRepository<CommentThread> {
     Flux<CommentThread> findByApplicationId(String applicationId, AclPermission permission);
-    Mono<UpdateResult> addToSubscribers(String threadId, List<String> usernames);
+    Mono<UpdateResult> addToSubscribers(String threadId, Set<String> usernames);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
@@ -2,10 +2,13 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.CommentThread;
+import com.mongodb.client.result.UpdateResult;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 public interface CustomCommentThreadRepository extends AppsmithRepository<CommentThread> {
-
     Flux<CommentThread> findByApplicationId(String applicationId, AclPermission permission);
-
+    Mono<UpdateResult> addToSubscribers(String threadId, List<String> usernames);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -3,12 +3,16 @@ package com.appsmith.server.repositories;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.domains.QCommentThread;
+import com.mongodb.client.result.UpdateResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -16,7 +20,8 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 @Component
 @Slf4j
-public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImpl<CommentThread> implements CustomCommentThreadRepository {
+public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImpl<CommentThread>
+        implements CustomCommentThreadRepository {
 
     public CustomCommentThreadRepositoryImpl(ReactiveMongoOperations mongoOperations, MongoConverter mongoConverter) {
         super(mongoOperations, mongoConverter);
@@ -26,6 +31,19 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
     public Flux<CommentThread> findByApplicationId(String applicationId, AclPermission permission) {
         Criteria criteria = where(fieldName(QCommentThread.commentThread.applicationId)).is(applicationId);
         return queryAll(List.of(criteria), permission);
+    }
+
+    /**
+     * Adds the provided username i.e. email address to the subscriber list of this thread
+     * @return updated result object
+     */
+    @Override
+    public Mono<UpdateResult> addToSubscribers(String threadId, List<String> usernames) {
+        return mongoOperations.updateFirst(
+                Query.query(where("id").is(threadId)),
+                new Update().addToSet(fieldName(QCommentThread.commentThread.subscribers)).each(usernames),
+                CommentThread.class
+        );
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -15,6 +15,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
@@ -38,7 +39,7 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
      * @return updated result object
      */
     @Override
-    public Mono<UpdateResult> addToSubscribers(String threadId, List<String> usernames) {
+    public Mono<UpdateResult> addToSubscribers(String threadId, Set<String> usernames) {
         return mongoOperations.updateFirst(
                 Query.query(where("id").is(threadId)),
                 new Update().addToSet(fieldName(QCommentThread.commentThread.subscribers)).each(usernames),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -131,7 +131,11 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                     List<String> subscribersFromThisComment = CommentUtils.getSubscriberUsernames(comment);
 
                     // add them to current thread so that we don't need to query again
-                    thread.getSubscribers().addAll(subscribersFromThisComment);
+                    if(thread.getSubscribers() != null) {
+                        thread.getSubscribers().addAll(subscribersFromThisComment);
+                    } else {
+                        thread.setSubscribers(new HashSet<>(subscribersFromThisComment));
+                    }
 
                     return Mono.zip(
                             Mono.just(user),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EmailEventHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EmailEventHandler.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.solutions;
 
-import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.Comment;
 import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.domains.Organization;
@@ -24,9 +23,9 @@ import reactor.core.scheduler.Schedulers;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -41,11 +40,16 @@ public class EmailEventHandler {
     private final OrganizationRepository organizationRepository;
     private final ApplicationRepository applicationRepository;
 
-    public Mono<Boolean> publish(String authorUserName, String applicationId, Comment comment, String originHeader) {
+    public Mono<Boolean> publish(String authorUserName, String applicationId, Comment comment, String originHeader,
+                                 Set<String> subscribers) {
+        if(subscribers == null || subscribers.size() == 0) {  // no subscriber found, return without doing anything
+            return Mono.just(Boolean.FALSE);
+        }
+
         return applicationRepository.findById(applicationId).flatMap(application -> {
             return organizationRepository.findById(application.getOrganizationId()).flatMap(organization -> {
                 applicationEventPublisher.publishEvent(
-                        new CommentAddedEvent(authorUserName, organization, application, originHeader, comment)
+                        new CommentAddedEvent(authorUserName, organization, application, originHeader, comment, subscribers)
                 );
                 return Mono.just(organization);
             });
@@ -53,6 +57,11 @@ public class EmailEventHandler {
     }
 
     public Mono<Boolean> publish(String authorUserName, String applicationId, CommentThread thread, String originHeader) {
+        if(thread.getSubscribers() == null || thread.getSubscribers().size() == 0) {
+            // no subscriber found, return without doing anything
+            return Mono.just(Boolean.FALSE);
+        }
+
         return applicationRepository.findById(applicationId).flatMap(application -> {
             return organizationRepository.findById(application.getOrganizationId()).flatMap(organization -> {
                 applicationEventPublisher.publishEvent(
@@ -67,8 +76,8 @@ public class EmailEventHandler {
     @EventListener
     public void handle(CommentAddedEvent event) {
         this.sendEmailForComment(
-                event.getAuthorUserName(), event.getApplication(), event.getOrganization(),
-                event.getComment(), event.getOriginHeader()
+                event.getAuthorUserName(), event.getOrganization(),
+                event.getComment(), event.getOriginHeader(), event.getSubscribers()
         ).subscribeOn(Schedulers.elastic())
         .subscribe();
     }
@@ -77,47 +86,47 @@ public class EmailEventHandler {
     @EventListener
     public void handle(CommentThreadClosedEvent event) {
         this.sendEmailForComment(
-                event.getAuthorUserName(), event.getApplication(), event.getOrganization(),
-                event.getCommentThread(), event.getOriginHeader()
+                event.getAuthorUserName(), event.getOrganization(),
+                event.getCommentThread(), event.getOriginHeader(), event.getCommentThread().getSubscribers()
         )
         .subscribeOn(Schedulers.elastic())
         .subscribe();
     }
 
     private Mono<Boolean> getEmailSenderMono(UserRole receiverUserRole, CommentThread commentThread,
-                                             String originHeader, Application application, Organization organization) {
+                                             String originHeader, Organization organization) {
         String receiverName = StringUtils.isEmpty(receiverUserRole.getName()) ? "User" : receiverUserRole.getName();
         String receiverEmail = receiverUserRole.getUsername();
         CommentThread.CommentThreadState resolvedState = commentThread.getResolvedState();
         Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("App_User_Name", receiverName);
         templateParams.put("Commenter_Name", resolvedState.getAuthorName());
-        templateParams.put("Application_Name", application.getName());
+        templateParams.put("Application_Name", commentThread.getApplicationName());
         templateParams.put("Organization_Name", organization.getName());
         templateParams.put("inviteUrl", originHeader);
 
         String emailSubject = String.format(
-                "%s has resolved comment in %s", resolvedState.getAuthorName(), application.getName()
+                "%s has resolved comment in %s", resolvedState.getAuthorName(), commentThread.getApplicationName()
         );
         return emailSender.sendMail(receiverEmail, emailSubject, THREAD_RESOLVED_EMAIL_TEMPLATE, templateParams);
     }
 
     private Mono<Boolean> getEmailSenderMono(UserRole receiverUserRole, Comment comment, String originHeader,
-                                             Application application, Organization organization) {
+                                             Organization organization) {
         String receiverName = StringUtils.isEmpty(receiverUserRole.getName()) ? "User" : receiverUserRole.getName();
         String receiverEmail = receiverUserRole.getUsername();
 
         Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("App_User_Name", receiverName);
         templateParams.put("Commenter_Name", comment.getAuthorName());
-        templateParams.put("Application_Name", application.getName());
+        templateParams.put("Application_Name", comment.getApplicationName());
         templateParams.put("Organization_Name", organization.getName());
         templateParams.put("Comment_Body", CommentUtils.getCommentBody(comment));
         templateParams.put("inviteUrl", originHeader);
 
         String emailTemplate = COMMENT_ADDED_EMAIL_TEMPLATE;
         String emailSubject = String.format(
-                "New comment from %s in %s", comment.getAuthorName(), application.getName()
+                "New comment from %s in %s", comment.getAuthorName(), comment.getApplicationName()
         );
 
         // check if user has been mentioned in the comment
@@ -128,22 +137,17 @@ public class EmailEventHandler {
         return emailSender.sendMail(receiverEmail, emailSubject, emailTemplate, templateParams);
     }
 
-    private <E> Mono<Boolean> sendEmailForComment(String authorUserName, Application application, Organization organization,
-                                                  E commentDomain, String originHeader) {
-
+    private <E> Mono<Boolean> sendEmailForComment(String authorUserName, Organization organization,
+                                                  E commentDomain, String originHeader, Set<String> subscribers) {
         List<Mono<Boolean>> emailMonos = new ArrayList<>();
         for (UserRole userRole : organization.getUserRoles()) {
-            if(!authorUserName.equals(userRole.getUsername())) {
+            if(!authorUserName.equals(userRole.getUsername()) && subscribers.contains(userRole.getUsername())) {
                 if(commentDomain instanceof Comment) {
                     Comment comment = (Comment)commentDomain;
-                    emailMonos.add(
-                            getEmailSenderMono(userRole, comment, originHeader, application, organization)
-                    );
+                    emailMonos.add(getEmailSenderMono(userRole, comment, originHeader, organization));
                 } else if(commentDomain instanceof CommentThread) {
                     CommentThread commentThread = (CommentThread) commentDomain;
-                    emailMonos.add(
-                            getEmailSenderMono(userRole, commentThread, originHeader, application, organization)
-                    );
+                    emailMonos.add(getEmailSenderMono(userRole, commentThread, originHeader, organization));
                 }
             }
         }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CommentUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CommentUtilsTest.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class CommentUtilsTest {
     @Test
     void getCommentBody_WhenBodyIsNull_ReturnsEmptyList() {
@@ -87,5 +89,34 @@ class CommentUtilsTest {
         Assert.assertTrue(CommentUtils.isUserMentioned(comment, "2"));
         Assert.assertTrue(CommentUtils.isUserMentioned(comment, "3"));
         Assert.assertFalse(CommentUtils.isUserMentioned(comment, "4"));
+    }
+
+    @Test
+    public void getSubscriberUsernames_WhenNoMention_ContainsAuthorOnly() {
+        Comment comment = new Comment();
+        comment.setAuthorUsername("abc");
+
+        List<String> subscriberUsernames = CommentUtils.getSubscriberUsernames(comment);
+        assertThat(subscriberUsernames.size()).isEqualTo(1);
+        assertThat(subscriberUsernames).contains("abc");
+    }
+
+    @Test
+    public void getSubscriberUsernames_WhenMentionExists_ContainsAuthorAndMentions() {
+        Map<String, Comment.Entity> entityMap = createEntityMapForUsers(
+                List.of("1", "2", "3")
+        );
+        Comment.Body body = new Comment.Body();
+        body.setEntityMap(entityMap);
+        Comment comment = new Comment();
+        comment.setBody(body);
+        comment.setAuthorUsername("abc");
+
+        List<String> subscriberUsernames = CommentUtils.getSubscriberUsernames(comment);
+        assertThat(subscriberUsernames.size()).isEqualTo(4);
+        assertThat(subscriberUsernames).contains("abc");
+        assertThat(subscriberUsernames).contains("1");
+        assertThat(subscriberUsernames).contains("2");
+        assertThat(subscriberUsernames).contains("3");
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CommentUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CommentUtilsTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,9 +31,9 @@ class CommentUtilsTest {
         Comment comment = new Comment();
         comment.setBody(commentBody);
 
-        Assert.assertEquals(2, CommentUtils.getCommentBody(comment).size());
-        Assert.assertEquals(commentBlock1.getText(), CommentUtils.getCommentBody(comment).get(0));
-        Assert.assertEquals(commentBlock2.getText(), CommentUtils.getCommentBody(comment).get(1));
+        assertThat(CommentUtils.getCommentBody(comment).size()).isEqualTo(2);
+        assertThat(CommentUtils.getCommentBody(comment).get(0)).isEqualTo(commentBlock1.getText());
+        assertThat(CommentUtils.getCommentBody(comment).get(1)).isEqualTo(commentBlock2.getText());
     }
 
     @Test
@@ -96,7 +97,7 @@ class CommentUtilsTest {
         Comment comment = new Comment();
         comment.setAuthorUsername("abc");
 
-        List<String> subscriberUsernames = CommentUtils.getSubscriberUsernames(comment);
+        Set<String> subscriberUsernames = CommentUtils.getSubscriberUsernames(comment);
         assertThat(subscriberUsernames.size()).isEqualTo(1);
         assertThat(subscriberUsernames).contains("abc");
     }
@@ -112,7 +113,7 @@ class CommentUtilsTest {
         comment.setBody(body);
         comment.setAuthorUsername("abc");
 
-        List<String> subscriberUsernames = CommentUtils.getSubscriberUsernames(comment);
+        Set<String> subscriberUsernames = CommentUtils.getSubscriberUsernames(comment);
         assertThat(subscriberUsernames.size()).isEqualTo(4);
         assertThat(subscriberUsernames).contains("abc");
         assertThat(subscriberUsernames).contains("1");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EmailEventHandlerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EmailEventHandlerTest.java
@@ -24,7 +24,9 @@ import reactor.test.StepVerifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -73,23 +75,61 @@ public class EmailEventHandlerTest {
     }
 
     @Test
-    public void publish_WhenValidCommentProvided_ReturnsTrue() {
+    public void publish_CommentProvidedWithSubscriber_ReturnsTrue() {
         Comment comment = new Comment();
+        Set<String> subscribers = Set.of("dummy-username1");
         CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
-                authorUserName, organization, application, originHeader, comment
+                authorUserName, organization, application, originHeader, comment, subscribers
         );
 
         Mockito.doNothing().when(applicationEventPublisher).publishEvent(commentAddedEvent);
 
-        Mono<Boolean> booleanMono = emailEventHandler.publish(authorUserName, applicationId, comment, originHeader);
+        Mono<Boolean> booleanMono = emailEventHandler.publish(
+                authorUserName, applicationId, comment, originHeader, subscribers
+        );
         StepVerifier.create(booleanMono).assertNext(aBoolean -> {
             Assert.assertEquals(Boolean.TRUE, aBoolean);
         }).verifyComplete();
     }
 
     @Test
-    public void publish_WhenValidCommentThreadProvided_ReturnsTrue() {
+    public void publish_CommentProvidedSubscriberIsNull_ReturnsFalse() {
+        Mono<Boolean> booleanMono = emailEventHandler.publish(
+                authorUserName, applicationId, new Comment(), originHeader, null
+        );
+        StepVerifier.create(booleanMono).assertNext(aBoolean -> {
+            Assert.assertEquals(Boolean.FALSE, aBoolean);
+        }).verifyComplete();
+    }
+
+    @Test
+    public void publish_CommentProvidedSubscriberIsEmpty_ReturnsFalse() {
+        Mono<Boolean> booleanMono = emailEventHandler.publish(
+                authorUserName, applicationId, new Comment(), originHeader, Set.of()
+        );
+        StepVerifier.create(booleanMono).assertNext(aBoolean -> {
+            Assert.assertEquals(Boolean.FALSE, aBoolean);
+        }).verifyComplete();
+    }
+
+    @Test
+    public void publish_WhenCommentThreadHasNoPublishersProvided_ReturnsFalse() {
         CommentThread commentThread = new CommentThread();
+        CommentThreadClosedEvent commentThreadClosedEvent = new CommentThreadClosedEvent(
+                authorUserName, organization, application, originHeader, commentThread
+        );
+        Mockito.doNothing().when(applicationEventPublisher).publishEvent(commentThreadClosedEvent);
+
+        Mono<Boolean> booleanMono = emailEventHandler.publish(authorUserName, applicationId, commentThread, originHeader);
+        StepVerifier.create(booleanMono).assertNext(aBoolean -> {
+            Assert.assertEquals(Boolean.FALSE, aBoolean);
+        }).verifyComplete();
+    }
+
+    @Test
+    public void publish_WhenCommentThreadHasPublishersProvided_ReturnsTrue() {
+        CommentThread commentThread = new CommentThread();
+        commentThread.setSubscribers(Set.of("abc"));
         CommentThreadClosedEvent commentThreadClosedEvent = new CommentThreadClosedEvent(
                 authorUserName, organization, application, originHeader, commentThread
         );
@@ -102,14 +142,16 @@ public class EmailEventHandlerTest {
     }
 
     @Test
-    public void handle_WhenValidCommentAddedEvent_ReturnsTrue() {
+    public void handle_WhenValidCommentAddedEvent_SendEmailCalled() {
         Comment sampleComment = new Comment();
         sampleComment.setAuthorUsername(authorUserName);
         sampleComment.setAuthorName("Test Author");
+        sampleComment.setApplicationName(application.getName());
+        Set<String> subscribers = Set.of(emailReceiverUsername);
 
         // send the event
         CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
-                authorUserName, organization, application, originHeader, sampleComment
+                authorUserName, organization, application, originHeader, sampleComment, subscribers
         );
         emailEventHandler.handle(commentAddedEvent);
 
@@ -119,6 +161,28 @@ public class EmailEventHandlerTest {
         // check email sender was called with expected template and subject
         Mockito.verify(emailSender, Mockito.times(1)).sendMail(
                 eq(emailReceiverUsername), eq(expectedEmailSubject), eq(COMMENT_ADDED_EMAIL_TEMPLATE), Mockito.anyMap()
+        );
+    }
+
+    @Test
+    public void handle_WhenSubscriberDoesNotMatch_SendEmailNotCalled() {
+        Comment sampleComment = new Comment();
+        sampleComment.setAuthorUsername(authorUserName);
+        sampleComment.setAuthorName("Test Author");
+        Set<String> subscribers = Set.of("test-subscriber-1");
+
+        // send the event
+        CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
+                authorUserName, organization, application, originHeader, sampleComment, subscribers
+        );
+        emailEventHandler.handle(commentAddedEvent);
+
+        String expectedEmailSubject = String.format(
+                "New comment from %s in %s", sampleComment.getAuthorName(), application.getName()
+        );
+        // check email sender was called with expected template and subject
+        Mockito.verify(emailSender, Mockito.times(0)).sendMail(
+                anyString(), anyString(), anyString(), Mockito.anyMap()
         );
     }
 
@@ -146,6 +210,7 @@ public class EmailEventHandlerTest {
         Comment sampleComment = new Comment();
         sampleComment.setAuthorUsername(authorUserName);
         sampleComment.setAuthorName("Test Author");
+        Set<String> subscribers = Set.of(emailReceiverUsername);
 
         // mention the emailReceiverUsername in the sample comment
         Map<String, Comment.Entity> entityMap = createEntityMapForUsers(List.of(emailReceiverUsername));
@@ -155,7 +220,7 @@ public class EmailEventHandlerTest {
 
         // send the event
         CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
-                authorUserName, organization, application, originHeader, sampleComment
+                authorUserName, organization, application, originHeader, sampleComment, subscribers
         );
         emailEventHandler.handle(commentAddedEvent);
 
@@ -179,6 +244,8 @@ public class EmailEventHandlerTest {
 
         CommentThread commentThread = new CommentThread();
         commentThread.setResolvedState(resolveState);
+        commentThread.setSubscribers(Set.of(emailReceiverUsername));
+        commentThread.setApplicationName(application.getName());
 
         // send the event
         CommentThreadClosedEvent commentAddedEvent = new CommentThreadClosedEvent(


### PR DESCRIPTION
## Description
Currently, if there is a new comment - an email and a notification is sent to everyone in the organization. For an organization with many users and applications - this will be very annoying. Instead we should send email to interested people only.

This PR will send notification and email to the users who have participated in the thread only or tagged by others in this thread. In future, we'll be able to add feature to unsubscribe from the thread notifications also.

Fixes #5195 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Manual test on developer machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
