### PR TITLE
Add required option to Rich Text Editor for validations when used with Form widget

### DIFF
--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -47,6 +47,7 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       columns: 8 * GRID_DENSITY_MIGRATION_V1,
       isDisabled: false,
       isVisible: true,
+      isRequired: false,
       widgetName: "RichTextEditor",
       isDefaultClickDisabled: true,
       inputType: "html",

--- a/app/client/src/widgets/RichTextEditorWidget.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget.tsx
@@ -126,7 +126,7 @@ class RichTextEditorWidget extends BaseWidget<
     return {
       value: `{{this.text}}`,
       isValid: `{{
-        function(){
+        (()=>{
           if (this.isRequired) {
             if(this.text && this.text.length) {
               return true;              
@@ -134,7 +134,8 @@ class RichTextEditorWidget extends BaseWidget<
               return false;
             }
           } 
-        }()
+          return true;
+        })()
       }}`,
     };
   }

--- a/app/client/src/widgets/RichTextEditorWidget.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget.tsx
@@ -125,18 +125,7 @@ class RichTextEditorWidget extends BaseWidget<
   static getDerivedPropertiesMap(): DerivedPropertiesMap {
     return {
       value: `{{this.text}}`,
-      isValid: `{{
-        (()=>{
-          if (this.isRequired) {
-            if(this.text && this.text.length) {
-              return true;              
-            } else {
-              return false;
-            }
-          } 
-          return true;
-        })()
-      }}`,
+      isValid: `{{ this.isRequired ? this.text && this.text.length : true }}`,
     };
   }
 

--- a/app/client/src/widgets/RichTextEditorWidget.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget.tsx
@@ -62,6 +62,16 @@ class RichTextEditorWidget extends BaseWidget<
             validation: VALIDATION_TYPES.TEXT,
           },
           {
+            propertyName: "isRequired",
+            label: "Required",
+            helpText: "Makes input to the widget mandatory",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: VALIDATION_TYPES.BOOLEAN,
+          },
+          {
             propertyName: "isVisible",
             label: "Visible",
             helpText: "Controls the visibility of the widget",
@@ -115,6 +125,17 @@ class RichTextEditorWidget extends BaseWidget<
   static getDerivedPropertiesMap(): DerivedPropertiesMap {
     return {
       value: `{{this.text}}`,
+      isValid: `{{
+        function(){
+          if (this.isRequired) {
+            if(this.text && this.text.length) {
+              return true;              
+            } else {
+              return false;
+            }
+          } 
+        }()
+      }}`,
     };
   }
 
@@ -162,6 +183,7 @@ export interface RichTextEditorWidgetProps extends WidgetProps, WithMeta {
   onTextChange?: string;
   isDisabled?: boolean;
   isVisible?: boolean;
+  isRequired?: boolean;
 }
 
 export default RichTextEditorWidget;


### PR DESCRIPTION
## Description
Add required option to Rich Text Editor for validations when used with Form widget

Fixes #5161 
Fixes #5376 
Fixes #5380 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>