### PR TITLE
Fix cyclical dependency issue when Api returns an error

### DIFF
--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -96,6 +96,7 @@ ctx.addEventListener(
       }
       case EVAL_WORKER_ACTIONS.EVAL_ACTION_BINDINGS: {
         const { bindings, executionParams } = requestData;
+        debugger;
         if (!dataTreeEvaluator) {
           return { values: undefined, errors: [] };
         }

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -96,7 +96,6 @@ ctx.addEventListener(
       }
       case EVAL_WORKER_ACTIONS.EVAL_ACTION_BINDINGS: {
         const { bindings, executionParams } = requestData;
-        debugger;
         if (!dataTreeEvaluator) {
           return { values: undefined, errors: [] };
         }

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -141,7 +141,6 @@ export const translateDiffEventToDataTreeDiffEvent = (
         isTrueObject(difference.lhs) &&
         !isTrueObject(difference.rhs)
       ) {
-        debugger;
         // This will happen for static value changes where a property went
         // from being an object to any other type like string or number
         // in such a case we want to delete all nested paths of the
@@ -160,7 +159,6 @@ export const translateDiffEventToDataTreeDiffEvent = (
         !isTrueObject(difference.lhs) &&
         isTrueObject(difference.rhs)
       ) {
-        debugger;
         // This will happen for static value changes where a property went
         // from being any other type like string or number to an object
         // in such a case we want to add all nested paths of the

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -129,24 +129,19 @@ export const translateDiffEventToDataTreeDiffEvent = (
       } else if (difference.lhs === undefined || difference.rhs === undefined) {
         // Handle static value changes that change structure that can lead to
         // old bindings being eligible
-        if (
-          difference.lhs === undefined &&
-          typeof difference.rhs === "object"
-        ) {
+        if (difference.lhs === undefined && isTrueObject(difference.rhs)) {
           result.event = DataTreeDiffEvent.NEW;
           result.payload = { propertyPath };
         }
-        if (
-          difference.rhs === undefined &&
-          typeof difference.lhs === "object"
-        ) {
+        if (difference.rhs === undefined && isTrueObject(difference.lhs)) {
           result.event = DataTreeDiffEvent.DELETE;
           result.payload = { propertyPath };
         }
       } else if (
-        typeof difference.lhs === "object" &&
-        typeof difference.rhs !== "object"
+        isTrueObject(difference.lhs) &&
+        !isTrueObject(difference.rhs)
       ) {
+        debugger;
         // This will happen for static value changes where a property went
         // from being an object to any other type like string or number
         // in such a case we want to delete all nested paths of the
@@ -162,9 +157,10 @@ export const translateDiffEventToDataTreeDiffEvent = (
           };
         });
       } else if (
-        typeof difference.lhs !== "object" &&
-        typeof difference.rhs === "object"
+        !isTrueObject(difference.lhs) &&
+        isTrueObject(difference.rhs)
       ) {
+        debugger;
         // This will happen for static value changes where a property went
         // from being any other type like string or number to an object
         // in such a case we want to add all nested paths of the
@@ -579,4 +575,10 @@ export const addErrorToEntityProperty = (
     );
   }
   return dataTree;
+};
+
+// For the times when you need to know if something truly an object like { a: 1, b: 2}
+// typeof, lodash.isObject and others will return false positives for things like array, null, etc
+export const isTrueObject = (item: unknown): boolean => {
+  return Object.prototype.toString.call(item) === "[object Object]";
 };

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -89,7 +89,6 @@ export function getEntityNameAndPropertyPath(
 export const translateDiffEventToDataTreeDiffEvent = (
   difference: Diff<any, any>,
 ): DataTreeDiff | DataTreeDiff[] => {
-  debugger;
   let result: DataTreeDiff | DataTreeDiff[] = {
     payload: {
       propertyPath: "",


### PR DESCRIPTION
## Description
Translating edit differences had an issue where static changes were processed as NOOP when the data type changed from an object to some other type and vice versa. This caused a cyclic dependency for nodes when a nested dependency path was deleted and newly added paths were not processed. Fixed this by translating those events correctly

Fixes #4775 

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Follow the steps in the issue. When the API is returning a string error, it should not result in a cyclical dependency. When you fix the API again to make it return an object, it should populate the table again

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/cyclical-api-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/workers/DataTreeEvaluator.ts | 88.68 **(0.07)** | 79.27 **(0)** | 87.32 **(0)** | 88.86 **(0.07)**
 :red_circle: | app/client/src/workers/evaluationUtils.ts | 86.96 **(-2.67)** | 71.77 **(-4.12)** | 87.23 **(-3.68)** | 86.24 **(-3.13)**</details>