### PR TITLE
Minor fixes for errors

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -280,9 +280,7 @@ function PopoverContent(props: PopoverContentProps) {
   } = props;
   let error;
   if (hasError) {
-    error = errors.filter(
-      (error) => error.errorType !== PropertyEvaluationErrorType.LINT,
-    )[0];
+    error = errors[0];
   }
 
   return (

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -55,6 +55,7 @@ import {
   EvaluationError,
   getEvalErrorPath,
   getEvalValuePath,
+  PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
 
 const LightningMenu = lazy(() =>
@@ -366,11 +367,14 @@ class CodeEditor extends Component<Props, State> {
       getEvalErrorPath(dataTreePath),
       [],
     ) as EvaluationError[];
+    const filteredLintErrors = errors.filter(
+      (error) => error.errorType !== PropertyEvaluationErrorType.LINT,
+    );
     const pathEvaluatedValue = _.get(dataTree, getEvalValuePath(dataTreePath));
 
     return {
-      isInvalid: errors.length > 0,
-      errors,
+      isInvalid: filteredLintErrors.length > 0,
+      errors: filteredLintErrors,
       pathEvaluatedValue,
     };
   };

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -515,7 +515,7 @@ export default class DataTreeEvaluator {
 
       let entityType = "UNKNOWN";
       const entityName = node.split(".")[0];
-      const entity = _.find(this.oldUnEvalTree, { name: entityName });
+      const entity = _.get(this.oldUnEvalTree, entityName);
       if (entity && isWidget(entity)) {
         entityType = entity.type;
       } else if (entity && isAction(entity)) {
@@ -813,7 +813,6 @@ export default class DataTreeEvaluator {
             break;
           }
           case DataTreeDiffEvent.DELETE: {
-            debugger;
             // Add to removedPaths as they have been deleted from the evalTree
             removedPaths.push(dataTreeDiff.payload.propertyPath);
             // If an existing widget was deleted, remove all the bindings from the global dependency map

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -148,7 +148,7 @@ export default function evaluate(
       triggers = [...self.triggers];
     } catch (e) {
       errors.push({
-        errorMessage: `${e.name}: ${e.message}`,
+        errorMessage: `${e.stack.split(`\n`)[0]}`,
         severity: Severity.ERROR,
         raw: script,
         errorType: PropertyEvaluationErrorType.PARSE,


### PR DESCRIPTION
## Description
- Don't mark error fields when lint errors occur
- Correctly log widget entity type when cyclical dependency occurs
- Slightly improve JS error message


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/lint-validation-for-inputs 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx | 64.71 **(0.76)** | 61.29 **(0)** | 42.86 **(1.48)** | 67.09 **(0.84)**
 :red_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 73.79 **(-0.23)** | 50.43 **(0)** | 56.25 **(-1.81)** | 74.61 **(-0.26)**
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 88.66 **(-0.02)** | 79.27 **(0)** | 87.32 **(0)** | 88.84 **(-0.02)**</details>