### PR TITLE
Feature: add api key based and bearer token based authentication options to REST API datasource

### DIFF
--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -4,6 +4,13 @@ export enum AuthType {
   NONE = "NONE",
   OAuth2 = "oAuth2",
   basic = "basic",
+  apiKey = "apiKey",
+  bearerToken = "bearerToken",
+}
+
+export enum ApiKeyAuthType {
+  QueryParams = "queryParams",
+  Header = "header",
 }
 
 export enum GrantType {
@@ -11,7 +18,13 @@ export enum GrantType {
   AuthorizationCode = "authorization_code",
 }
 
-export type Authentication = ClientCredentials | AuthorizationCode | Basic;
+export type Authentication =
+  | ClientCredentials
+  | AuthorizationCode
+  | Basic
+  | ApiKey
+  | BearerToken;
+
 export interface ApiDatasourceForm {
   datasourceId: string;
   pluginId: string;
@@ -53,4 +66,16 @@ export interface Basic {
   authenticationType: AuthType.basic;
   username: string;
   password: string;
+}
+
+export interface ApiKey {
+  authenticationType: AuthType.apiKey;
+  label: string;
+  value: string;
+  addTo: string;
+}
+
+export interface BearerToken {
+  authenticationType: AuthType.bearerToken;
+  bearerToken: string;
 }

--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -5,6 +5,10 @@ export interface DatasourceAuthentication {
   authType?: string;
   username?: string;
   password?: string;
+  label?: string;
+  value?: string;
+  addTo?: string;
+  bearerToken?: string;
 }
 
 export interface DatasourceColumns {

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -41,6 +41,7 @@ import {
 } from "transformers/RestAPIDatasourceFormTransformer";
 import {
   ApiDatasourceForm,
+  ApiKeyAuthType,
   AuthType,
   GrantType,
 } from "entities/Datasource/RestAPIForm";
@@ -433,6 +434,14 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
                 label: "OAuth 2.0",
                 value: AuthType.OAuth2,
               },
+              {
+                label: "API Key",
+                value: AuthType.apiKey,
+              },
+              {
+                label: "Bearer Token",
+                value: AuthType.bearerToken,
+              },
             ]}
             placeholderText=""
             propertyValue=""
@@ -451,6 +460,10 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
       content = this.renderOauth2();
     } else if (authType === AuthType.basic) {
       content = this.renderBasic();
+    } else if (authType === AuthType.apiKey) {
+      content = this.renderApiKey();
+    } else if (authType === AuthType.bearerToken) {
+      content = this.renderBearerToken();
     }
     if (content) {
       return (
@@ -459,6 +472,61 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
         </Collapsible>
       );
     }
+  };
+
+  renderApiKey = () => {
+    return (
+      <>
+        <FormInputContainer>
+          <InputTextControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.label"
+            label="Key"
+            placeholderText="api_key"
+          />
+        </FormInputContainer>
+        <FormInputContainer>
+          <InputTextControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.value"
+            label="Value"
+            placeholderText="value"
+          />
+        </FormInputContainer>
+        <FormInputContainer>
+          <DropDownControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.addTo"
+            label="Add To"
+            options={[
+              {
+                label: "Query Params",
+                value: ApiKeyAuthType.QueryParams,
+              },
+              {
+                label: "Header",
+                value: ApiKeyAuthType.Header,
+              },
+            ]}
+            placeholderText=""
+            propertyValue=""
+          />
+        </FormInputContainer>
+      </>
+    );
+  };
+
+  renderBearerToken = () => {
+    return (
+      <FormInputContainer>
+        <InputTextControl
+          {...COMMON_INPUT_PROPS}
+          configProperty="authentication.bearerToken"
+          label="Bearer Token"
+          placeholderText="Bearer Token"
+        />
+      </FormInputContainer>
+    );
   };
 
   renderBasic = () => {

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -11,7 +11,6 @@ import {
   Basic,
   ApiKey,
   BearerToken,
-  ApiKeyAuthType,
 } from "entities/Datasource/RestAPIForm";
 import _ from "lodash";
 

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -23,11 +23,6 @@ export const datasourceToFormValues = (
     "datasourceConfiguration.authentication.authenticationType",
     AuthType.NONE,
   );
-  const apiKeyType = _.get(
-    datasource,
-    "datasourceConfiguration.authentication.addTo",
-    ApiKeyAuthType.Header,
-  );
   const authentication = datasourceToFormAuthentication(authType, datasource);
   const isSendSessionEnabled =
     _.get(datasource, "datasourceConfiguration.properties[0].value", "N") ===
@@ -45,7 +40,7 @@ export const datasourceToFormValues = (
     isSendSessionEnabled: isSendSessionEnabled,
     sessionSignatureKey: sessionSignatureKey,
     authType: authType,
-    authentication: { ...(authentication as ApiKey), addTo: apiKeyType },
+    authentication: authentication,
   };
 };
 
@@ -210,7 +205,7 @@ const datasourceToFormAuthentication = (
       authenticationType: AuthType.apiKey,
       label: authentication.label || "",
       value: authentication.value || "",
-      addTo: authentication.addTo || ApiKeyAuthType.Header,
+      addTo: authentication.addTo || "",
     };
     return apiKey;
   }

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -9,6 +9,9 @@ import {
   GrantType,
   Oauth2Common,
   Basic,
+  ApiKey,
+  BearerToken,
+  ApiKeyAuthType,
 } from "entities/Datasource/RestAPIForm";
 import _ from "lodash";
 
@@ -19,6 +22,11 @@ export const datasourceToFormValues = (
     datasource,
     "datasourceConfiguration.authentication.authenticationType",
     AuthType.NONE,
+  );
+  const apiKeyType = _.get(
+    datasource,
+    "datasourceConfiguration.authentication.addTo",
+    ApiKeyAuthType.Header,
   );
   const authentication = datasourceToFormAuthentication(authType, datasource);
   const isSendSessionEnabled =
@@ -37,7 +45,7 @@ export const datasourceToFormValues = (
     isSendSessionEnabled: isSendSessionEnabled,
     sessionSignatureKey: sessionSignatureKey,
     authType: authType,
-    authentication: authentication,
+    authentication: { ...(authentication as ApiKey), addTo: apiKeyType },
   };
 };
 
@@ -107,12 +115,34 @@ const formToDatasourceAuthentication = (
     }
   }
   if (authType === AuthType.basic) {
-    const basic: Basic = {
-      authenticationType: AuthType.basic,
-      username: authentication.username,
-      password: authentication.password,
-    };
-    return basic;
+    if ("username" in authentication) {
+      const basic: Basic = {
+        authenticationType: AuthType.basic,
+        username: authentication.username,
+        password: authentication.password,
+      };
+      return basic;
+    }
+  }
+  if (authType === AuthType.apiKey) {
+    if ("label" in authentication) {
+      const apiKey: ApiKey = {
+        authenticationType: AuthType.apiKey,
+        label: authentication.label,
+        value: authentication.value,
+        addTo: authentication.addTo,
+      };
+      return apiKey;
+    }
+  }
+  if (authType === AuthType.bearerToken) {
+    if ("bearerToken" in authentication) {
+      const bearerToken: BearerToken = {
+        authenticationType: AuthType.bearerToken,
+        bearerToken: authentication.bearerToken,
+      };
+      return bearerToken;
+    }
   }
   return null;
 };
@@ -174,6 +204,22 @@ const datasourceToFormAuthentication = (
       password: authentication.password || "",
     };
     return basic;
+  }
+  if (authType === AuthType.apiKey) {
+    const apiKey: ApiKey = {
+      authenticationType: AuthType.apiKey,
+      label: authentication.label || "",
+      value: authentication.value || "",
+      addTo: authentication.addTo || ApiKeyAuthType.Header,
+    };
+    return apiKey;
+  }
+  if (authType === AuthType.bearerToken) {
+    const bearerToken: BearerToken = {
+      authenticationType: AuthType.bearerToken,
+      bearerToken: authentication.bearerToken || "",
+    };
+    return bearerToken;
   }
 };
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -6,6 +6,10 @@ public class Authentication {
     public static final String DB_AUTH = "dbAuth";
     public static final String OAUTH2 = "oAuth2";
     public static final String BASIC = "basic";
+    public static final String API_KEY = "apiKey";
+    public static final String API_KEY_AUTH_TYPE_QUERY_PARAMS = "queryParams";
+    public static final String API_KEY_AUTH_TYPE_HEADER = "header";
+    public static final String BEARER_TOKEN = "bearerToken";
 
     // Request parameter names
     public static final String CLIENT_ID = "client_id";
@@ -29,6 +33,13 @@ public class Authentication {
     // Request parameter values
     public static final String AUTHORIZATION_CODE = "authorization_code";
     public static final String CLIENT_CREDENTIALS = "client_credentials";
+
+    // Header names
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    // Other constants
+    public static final String BEARER_HEADER_PREFIX = "Bearer";
+    public static final String BASIC_HEADER_PREFIX = "Basic ";
 
     // Response codes
     public static final String SUCCESS = "success";

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
@@ -1,0 +1,36 @@
+package com.appsmith.external.models;
+
+import com.appsmith.external.annotations.documenttype.DocumentType;
+import com.appsmith.external.annotations.encryption.Encrypted;
+import com.appsmith.external.constants.Authentication;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@DocumentType(Authentication.API_KEY)
+public class ApiKeyAuth extends AuthenticationDTO {
+
+    public enum Type {
+        @JsonProperty(Authentication.API_KEY_AUTH_TYPE_QUERY_PARAMS)
+        QUERY_PARAMS,
+        @JsonProperty(Authentication.API_KEY_AUTH_TYPE_HEADER)
+        HEADER,
+    }
+
+    Type addTo;
+    String label;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Encrypted
+    String value;
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -23,7 +23,10 @@ import java.util.Set;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = DBAuth.class, name = Authentication.DB_AUTH),
         @JsonSubTypes.Type(value = OAuth2.class, name = Authentication.OAUTH2),
-        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BASIC)
+        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BASIC),
+        @JsonSubTypes.Type(value = BasicAuth.class, name = Authentication.BASIC),
+        @JsonSubTypes.Type(value = ApiKeyAuth.class, name = Authentication.API_KEY),
+        @JsonSubTypes.Type(value = BearerTokenAuth.class, name = Authentication.BEARER_TOKEN)
 })
 public class AuthenticationDTO implements AppsmithDomain {
     // In principle, this class should've been abstract. However, when this class is abstract, Spring's deserialization

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BearerTokenAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BearerTokenAuth.java
@@ -1,0 +1,24 @@
+package com.appsmith.external.models;
+
+import com.appsmith.external.annotations.documenttype.DocumentType;
+import com.appsmith.external.annotations.encryption.Encrypted;
+import com.appsmith.external.constants.Authentication;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@DocumentType(Authentication.BEARER_TOKEN)
+public class BearerTokenAuth extends AuthenticationDTO {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Encrypted
+    String bearerToken;
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceConfiguration.java
@@ -3,17 +3,21 @@ package com.appsmith.external.models;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
 
+@Builder(toBuilder = true)
 @Getter
 @Setter
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor
+@AllArgsConstructor
 @Document
 public class DatasourceConfiguration implements AppsmithDomain {
 

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/APIConnectionFactory.java
@@ -5,6 +5,8 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException
 import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.BasicAuth;
 import com.appsmith.external.models.OAuth2;
+import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.external.models.BearerTokenAuth;
 import reactor.core.publisher.Mono;
 
 
@@ -25,6 +27,10 @@ public class APIConnectionFactory {
             }
         } else if (authenticationType instanceof BasicAuth) {
             return Mono.from(BasicAuthentication.create((BasicAuth) authenticationType));
+        } else if (authenticationType instanceof ApiKeyAuth) {
+            return Mono.from(ApiKeyAuthentication.create((ApiKeyAuth) authenticationType));
+        } else if (authenticationType instanceof BearerTokenAuth) {
+            return Mono.from(BearerTokenAuthentication.create((BearerTokenAuth) authenticationType));
         } else {
             return Mono.empty();
         }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/ApiKeyAuthentication.java
@@ -1,0 +1,82 @@
+package com.external.connections;
+
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.external.models.ApiKeyAuth.Type;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiKeyAuthentication extends APIConnection {
+    private String label;
+    private String value;
+    Type addTo;
+
+    public static Mono<ApiKeyAuthentication> create(ApiKeyAuth apiKeyAuth) {
+        return Mono.just(
+                ApiKeyAuthentication.builder()
+                        .label(apiKeyAuth.getLabel())
+                        .value(apiKeyAuth.getValue())
+                        .addTo(apiKeyAuth.getAddTo())
+                        .build()
+        );
+    }
+
+    @Override
+    public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
+        ClientRequest.Builder requestBuilder = ClientRequest.from(request);
+        switch (addTo) {
+            case QUERY_PARAMS:
+                requestBuilder.url(appendApiKeyParamToUrl(request.url()));
+                break;
+            case HEADER:
+                requestBuilder.headers(header -> header.set(label, value));
+                break;
+            default:
+                return Mono.error(
+                        new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Appsmith server has found an unsupported api key authentication type. Please reach " +
+                                        "out to Appsmith customer support to resolve this."
+                        )
+                );
+        }
+
+        return Mono.justOrEmpty(requestBuilder.build())
+                // Carry on to next exchange function
+                .flatMap(next::exchange)
+                // Default to next exchange function if something went wrong
+                .switchIfEmpty(next.exchange(request));
+    }
+
+    private URI appendApiKeyParamToUrl(URI oldUrl) {
+
+        return UriComponentsBuilder
+                .newInstance()
+                .scheme(oldUrl.getScheme())
+                .host(oldUrl.getHost())
+                .port(oldUrl.getPort())
+                .path(oldUrl.getPath())
+                .query(oldUrl.getQuery())
+                .queryParam(label, value)
+                .fragment(oldUrl.getFragment())
+                .build()
+                .toUri();
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BearerTokenAuthentication.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/BearerTokenAuthentication.java
@@ -1,7 +1,9 @@
 package com.external.connections;
 
-import com.appsmith.external.models.BasicAuth;
+import com.appsmith.external.models.BearerTokenAuth;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,35 +12,29 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import reactor.core.publisher.Mono;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import static com.appsmith.external.constants.Authentication.AUTHORIZATION_HEADER;
-import static com.appsmith.external.constants.Authentication.BASIC_HEADER_PREFIX;
+import static com.appsmith.external.constants.Authentication.BEARER_HEADER_PREFIX;
 
 @Setter
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class BasicAuthentication extends APIConnection {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BearerTokenAuthentication extends APIConnection {
+    private String bearerToken;
 
-    private String encodedAuthorizationHeader;
-    final private static String HEADER_PREFIX = "Basic ";
-
-    public static Mono<BasicAuthentication> create(BasicAuth basicAuth) {
-        final BasicAuthentication basicAuthentication = new BasicAuthentication();
-        final String decodedAuthorizationHeader = basicAuth.getUsername() + ":" + basicAuth.getPassword();
-
-        basicAuthentication.setEncodedAuthorizationHeader(
-                Base64.getEncoder().encodeToString(decodedAuthorizationHeader.getBytes(StandardCharsets.UTF_8)));
-
-        return Mono.just(basicAuthentication);
+    public static Mono<BearerTokenAuthentication> create(BearerTokenAuth bearerTokenAuth) {
+        return Mono.just(
+                BearerTokenAuthentication.builder()
+                        .bearerToken(bearerTokenAuth.getBearerToken())
+                        .build()
+        );
     }
-
 
     @Override
     public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
         return Mono.justOrEmpty(ClientRequest.from(request)
-                .headers(headers -> headers.set(AUTHORIZATION_HEADER, getHeaderValue()))
+                .headers(header -> header.set(AUTHORIZATION_HEADER, getHeaderValue()))
                 .build())
                 // Carry on to next exchange function
                 .flatMap(next::exchange)
@@ -47,6 +43,6 @@ public class BasicAuthentication extends APIConnection {
     }
 
     private String getHeaderValue() {
-        return BASIC_HEADER_PREFIX + this.encodedAuthorizationHeader;
+        return BEARER_HEADER_PREFIX + " " + this.bearerToken;
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
@@ -72,6 +72,14 @@
             {
               "label": "OAuth2 (Client credentials)",
               "value": "oAuth2"
+            },
+            {
+              "label": "API Key",
+              "value": "apiKey"
+            },
+            {
+              "label": "Bearer Token",
+              "value": "bearerToken"
             }
           ]
         },

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
@@ -1,0 +1,27 @@
+package com.external.connections;
+
+import com.appsmith.external.models.ApiKeyAuth;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class ApiKeyAuthenticationTest {
+
+    @Test
+    public void testCreateMethodWithQueryParamsLabel() {
+        String label = "label";
+        String value = "value";
+        ApiKeyAuth.Type type = ApiKeyAuth.Type.QUERY_PARAMS;
+        ApiKeyAuth apiKeyAuthDTO = new ApiKeyAuth(type, label, value);
+        Mono<ApiKeyAuthentication> connectionMono = ApiKeyAuthentication.create(apiKeyAuthDTO);
+        StepVerifier.create(connectionMono)
+                .assertNext(connection -> {
+                    assertThat(connection).isNotNull();
+                    assertEquals(value, connection.getValue());
+                })
+                .verifyComplete();
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/BearerTokenAuthenticationTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/BearerTokenAuthenticationTest.java
@@ -1,0 +1,25 @@
+package com.external.connections;
+
+import com.appsmith.external.models.BearerTokenAuth;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class BearerTokenAuthenticationTest {
+
+    @Test
+    public void testCreateMethod() {
+        String bearerToken = "key";
+        BearerTokenAuth bearerTokenAuthDTO = new BearerTokenAuth(bearerToken);
+        Mono<BearerTokenAuthentication> connectionMono = BearerTokenAuthentication.create(bearerTokenAuthDTO);
+        StepVerifier.create(connectionMono)
+                .assertNext(connection -> {
+                    assertThat(connection).isNotNull();
+                    assertEquals(bearerToken, connection.getBearerToken());
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Description
- add api key based and bearer token based authentication options to REST API datasource
- this change is ported to release from https://github.com/appsmithorg/appsmith/pull/4683 

Fixes #5366

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- JUnit TC
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/api_key_and_bearer_token_auth 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.29 **(-0.03)** | 35.23 **(-0.05)** | 31.94 **(0)** | 53.8 **(-0.04)**
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx | 26.88 **(-1.21)** | 22 **(-0.92)** | 3.03 **(-0.2)** | 30.06 **(-1.55)**
 :red_circle: | app/client/src/transformers/RestAPIDatasourceFormTransformer.ts | 14.86 **(-3.78)** | 0 **(0)** | 0 **(0)** | 13.64 **(-4.01)**</details>