### PR TITLE
Set mode (EDIT/PUBLISHED) for comments for notification links

### DIFF
--- a/app/client/src/entities/Comments/CommentsInterfaces.ts
+++ b/app/client/src/entities/Comments/CommentsInterfaces.ts
@@ -16,6 +16,7 @@ import { APP_MODE } from "reducers/entityReducers/appReducer";
 
 export type CreateCommentRequest = {
   body: RawDraftContentState;
+  mode?: APP_MODE;
 };
 
 export type CreateCommentThreadRequest = {

--- a/app/client/src/notifications/NotificationListItem.tsx
+++ b/app/client/src/notifications/NotificationListItem.tsx
@@ -72,7 +72,7 @@ function CommentNotification(props: { notification: AppsmithNotification }) {
     applicationName,
     authorName,
     authorUsername,
-    // mode, TODO get from comment thread
+    mode,
     pageId,
     // resolvedState, TODO get from comment thread
     threadId,
@@ -82,7 +82,7 @@ function CommentNotification(props: { notification: AppsmithNotification }) {
     applicationId,
     commentThreadId: threadId,
     // isResolved: resolvedState?.active,
-    // mode,
+    mode,
     pageId,
   });
 

--- a/app/client/src/sagas/CommentSagas/index.ts
+++ b/app/client/src/sagas/CommentSagas/index.ts
@@ -91,8 +91,9 @@ function* addCommentToThread(
     const { payload } = action;
     const { callback, commentBody, commentThread } = payload;
 
+    const mode = yield select((state: AppState) => state.entities.app.mode);
     const response = yield CommentsApi.createNewThreadComment(
-      { body: commentBody },
+      { body: commentBody, mode },
       commentThread.id,
     );
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
@@ -44,6 +44,9 @@ public class Comment extends BaseDomain {
 
     Body body;
 
+    /** Edit/Published Mode */
+    String mode;
+
     List<Reaction> reactions;
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThread.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThread.java
@@ -47,6 +47,7 @@ public class CommentThread extends BaseDomain {
     @JsonIgnore
     Set<String> subscribers;
 
+    /** Edit/Published Mode */
     String mode;
 
     /**


### PR DESCRIPTION
## Description
Set mode (EDIT/PUBLISHED) for comment, that can be used to link comments with the viewer or editor page

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: add-mode-to-comments 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.28 **(0.01)** | 35.27 **(0)** | 31.88 **(0.01)** | 53.81 **(0)**
 :green_circle: | app/client/src/sagas/CommentSagas/index.ts | 49.18 **(1.28)** | 20.83 **(0)** | 56.25 **(2.92)** | 48.39 **(0.56)**</details>