### PR TITLE
Fix date picker derived values issue

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2.tsx
+++ b/app/client/src/widgets/DatePickerWidget2.tsx
@@ -194,8 +194,8 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
   static getDerivedPropertiesMap(): DerivedPropertiesMap {
     return {
       isValid: `{{ this.isRequired ? !!this.selectedDate : true }}`,
-      selectedDate: `{{ this.value ? moment(this.value).toISOString() : (this.defaultDate ? moment(this.defaultDate).toISOString() : "")}}`,
-      formattedDate: `{{ this.value ? moment(this.value).format(this.dateFormat) : (this.defaultDate ? moment(this.defaultDate).format(this.dateFormat) : "")}}`,
+      selectedDate: `{{ this.value ? moment(this.value).toISOString() : "" }}`,
+      formattedDate: `{{ this.value ? moment(this.value).format(this.dateFormat) : "" }}`,
     };
   }
 


### PR DESCRIPTION
## Description
Update the date picker derived values to only refer to the meta value and not the default value

Fixes #5052

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Follow the steps in the issue

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>