### PR TITLE
FIX #5287 : updated isLoading state when event action completed

### DIFF
--- a/app/client/src/widgets/FilepickerWidget.tsx
+++ b/app/client/src/widgets/FilepickerWidget.tsx
@@ -384,11 +384,16 @@ class FilePickerWidget extends BaseWidget<
         dynamicString: this.props.onFilesSelected,
         event: {
           type: EventType.ON_FILES_SELECTED,
+          callback: this.handleActionComplete,
         },
       });
 
       this.setState({ isLoading: true });
     }
+  };
+
+  handleActionComplete = () => {
+    this.setState({ isLoading: false });
   };
 
   componentDidUpdate(prevProps: FilePickerWidgetProps) {


### PR DESCRIPTION
## Description

> Picking a file in filepicker keeps on loading. The loading state was not stopped by default fixed it. 

Fixes #5287 
Fixes #5312 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: FIX/5287-filepicker-keep-loading-state 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.24 **(-0.01)** | 35.22 **(0)** | 31.93 **(-0.01)** | 53.76 **(0)**
 :red_circle: | app/client/src/widgets/FilepickerWidget.tsx | 38.46 **(-0.87)** | 0 **(0)** | 17.86 **(-0.66)** | 37.78 **(-0.86)**</details>