### PR TITLE
FIX #5235: added text color js convertible support in text widget

### DIFF
--- a/app/client/src/constants/WidgetValidation.ts
+++ b/app/client/src/constants/WidgetValidation.ts
@@ -31,6 +31,7 @@ export enum VALIDATION_TYPES {
   ROW_INDICES = "ROW_INDICES",
   IMAGE = "IMAGE",
   TABS_DATA = "TABS_DATA",
+  COLOR_PICKER_TEXT = "COLOR_PICKER_TEXT",
 }
 
 export type ValidationResponse = {

--- a/app/client/src/widgets/TextWidget.tsx
+++ b/app/client/src/widgets/TextWidget.tsx
@@ -56,8 +56,10 @@ class TextWidget extends BaseWidget<TextWidgetProps, WidgetState> {
             propertyName: "textColor",
             label: "Text Color",
             controlType: "COLOR_PICKER",
-            isBindProperty: false,
+            isJSConvertible: true,
+            isBindProperty: true,
             isTriggerProperty: false,
+            validation: VALIDATION_TYPES.COLOR_PICKER_TEXT,
           },
           {
             propertyName: "fontSize",

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -508,3 +508,37 @@ describe("List data validator", () => {
     });
   });
 });
+
+describe("Color Picker Text validator", () => {
+  const validator = VALIDATORS.COLOR_PICKER_TEXT;
+  const inputs = [
+    "#e0e0e0",
+    "rgb(200,200,200)",
+    "{{Text2.text}}",
+    "<p>red</p>",
+  ];
+  const expected = [
+    {
+      isValid: true,
+      parsed: "#e0e0e0",
+    },
+    {
+      isValid: true,
+      parsed: "rgb(200,200,200)",
+    },
+    {
+      isValid: false,
+      parsed: "",
+      message: "This value does not evaluate to type: text",
+    },
+    {
+      isValid: false,
+      parsed: "",
+      message: "This value does not evaluate to type: text",
+    },
+  ];
+  inputs.forEach((input, index) => {
+    const response = validator(input, DUMMY_WIDGET);
+    expect(response).toStrictEqual(expected[index]);
+  });
+});

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -15,6 +15,7 @@ import _, {
   isPlainObject,
   isString,
   isUndefined,
+  startsWith,
   toNumber,
   toString,
 } from "lodash";
@@ -1032,5 +1033,21 @@ export const VALIDATORS: Record<VALIDATION_TYPES, Validator> = {
       parsed: [],
       message: `${WIDGET_TYPE_VALIDATION_ERROR}: number[]`,
     };
+  },
+  [VALIDATION_TYPES.COLOR_PICKER_TEXT]: (
+    value: any,
+    props: WidgetProps,
+  ): ValidationResponse => {
+    // check value should be string
+    const { isValid, parsed } = VALIDATORS[VALIDATION_TYPES.TEXT](value, props);
+    // check value should not html tag or unparsed js
+    if (startsWith(parsed, "{{") || startsWith(parsed, "<")) {
+      return {
+        isValid: false,
+        parsed: "",
+        message: `${WIDGET_TYPE_VALIDATION_ERROR}: text`,
+      };
+    }
+    return { isValid, parsed };
   },
 };


### PR DESCRIPTION

## Description

> Added text color js convertible support in text widget.
> Added COLOR_PICKER_TEXT validation.

Fixes #5235 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Test cases
> Testes locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/5235-textwidget-textcolor-js-convertible 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.26 **(0.01)** | 35.24 **(0.02)** | 31.95 **(0.01)** | 53.77 **(0.01)**
 :green_circle: | app/client/src/workers/validations.ts | 38.93 **(0.99)** | 33.45 **(0.92)** | 43.48 **(1.26)** | 39.36 **(0.72)**</details>