### PR TITLE
Fix invalid quotes breaking evaluation

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -294,14 +294,16 @@ class CodeEditor extends Component<Props, State> {
     cm: CodeMirror.Editor,
     change: CodeMirror.EditorChangeCancellable,
   ) {
-    // Remove all non ASCII quotes since they are invalid in Javascript
-    const formattedText = change.text.map((line) => {
-      let formattedLine = line.replace(/[‘’]/g, "'");
-      formattedLine = formattedLine.replace(/[“”]/g, '"');
-      return formattedLine;
-    });
-    if (change.update) {
-      change.update(undefined, undefined, formattedText);
+    if (change.origin === "paste") {
+      // Remove all non ASCII quotes since they are invalid in Javascript
+      const formattedText = change.text.map((line) => {
+        let formattedLine = line.replace(/[‘’]/g, "'");
+        formattedLine = formattedLine.replace(/[“”]/g, '"');
+        return formattedLine;
+      });
+      if (change.update) {
+        change.update(undefined, undefined, formattedText);
+      }
     }
   }
 

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -294,14 +294,14 @@ class CodeEditor extends Component<Props, State> {
     cm: CodeMirror.Editor,
     change: CodeMirror.EditorChangeCancellable,
   ) {
-    if (change.origin === "paste") {
-      // Remove all non ASCII quotes since they are invalid in Javascript
-      const formattedText = change.text.map((line) =>
-        line.replace(/[“‘’”]/g, "'"),
-      );
-      if (change.update) {
-        change.update(undefined, undefined, formattedText);
-      }
+    // Remove all non ASCII quotes since they are invalid in Javascript
+    const formattedText = change.text.map((line) => {
+      let formattedLine = line.replace(/[‘’]/g, "'");
+      formattedLine = formattedLine.replace(/[“”]/g, '"');
+      return formattedLine;
+    });
+    if (change.update) {
+      change.update(undefined, undefined, formattedText);
     }
   }
 

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -172,6 +172,7 @@ class CodeEditor extends Component<Props, State> {
         };
       }
       this.editor = CodeMirror.fromTextArea(this.textArea.current, options);
+      this.editor.on("beforeChange", this.handleBeforeChange);
       this.editor.on("change", _.debounce(this.handleChange, 300));
       this.editor.on("change", this.handleAutocompleteVisibility);
       this.editor.on("change", this.onChangeTrigger);
@@ -288,6 +289,21 @@ class CodeEditor extends Component<Props, State> {
 
     this.editor.setOption("matchBrackets", false);
   };
+
+  handleBeforeChange(
+    cm: CodeMirror.Editor,
+    change: CodeMirror.EditorChangeCancellable,
+  ) {
+    if (change.origin === "paste") {
+      // Remove all non ASCII quotes since they are invalid in Javascript
+      const formattedText = change.text.map((line) =>
+        line.replace(/[“‘’”]/g, "'"),
+      );
+      if (change.update) {
+        change.update(undefined, undefined, formattedText);
+      }
+    }
+  }
 
   handleChange = (instance?: any, changeObj?: any) => {
     const value = this.editor.getValue();


### PR DESCRIPTION
## Description
When a non-ASCII quote gets added, it breaks evaluations as they are not valid javascript. To fix this, we are replacing the quotes with ASCII quotes when typing

Fixes #3873

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Follow steps in the issue by pasting or typing those characters

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/invalid-quote-chars 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.23 **(0)** | 35.23 **(-0.01)** | 31.92 **(0.01)** | 53.74 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 72.09 **(-1.7)** | 49.58 **(-0.85)** | 55.88 **(-0.37)** | 72.77 **(-1.84)**</details>