### PR TITLE
Onboarding typeform related fixes

### DIFF
--- a/app/client/src/pages/Applications/OnboardingForm.tsx
+++ b/app/client/src/pages/Applications/OnboardingForm.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useScript, ScriptStatus } from "utils/hooks/useScript";
 import { getCurrentUser } from "selectors/usersSelectors";
 import styled from "styled-components";
+import { setOnboardingFormInProgress } from "utils/storage";
 
 export const TypeformContainer = styled.div`
   & iframe {
@@ -18,6 +19,10 @@ export const TypeformContainer = styled.div`
 function OnboardingForm() {
   const status = useScript(`https://embed.typeform.com/embed.js`);
   const currentUser = useSelector(getCurrentUser);
+
+  useEffect(() => {
+    setOnboardingFormInProgress(true);
+  }, []);
 
   if (status !== ScriptStatus.READY || !currentUser) return null;
 

--- a/app/client/src/pages/Applications/index.tsx
+++ b/app/client/src/pages/Applications/index.tsx
@@ -934,14 +934,18 @@ class Applications extends Component<
 
     // Redirect directly in case we're not showing the onboarding form
     if (isFromSignUp && !onboardingFormEnabled) {
-      const urlObject = new URL(window.location.href);
-      const redirectUrl = urlObject?.searchParams.get("redirectUrl");
-      if (redirectUrl) {
-        try {
-          window.location.replace(redirectUrl);
-        } catch (e) {
-          console.error("Error handling the redirect url");
-        }
+      this.redirectUsingQueryParam();
+    }
+  };
+
+  redirectUsingQueryParam = () => {
+    const urlObject = new URL(window.location.href);
+    const redirectUrl = urlObject?.searchParams.get("redirectUrl");
+    if (redirectUrl) {
+      try {
+        window.location.replace(redirectUrl);
+      } catch (e) {
+        console.error("Error handling the redirect url");
       }
     }
   };
@@ -949,6 +953,7 @@ class Applications extends Component<
   handleTypeFormMessage = (event: any) => {
     if (event?.data?.type === "form-submit" && this.state.showOnboardingForm) {
       setOnboardingFormInProgress();
+      this.redirectUsingQueryParam();
     }
   };
 

--- a/app/client/src/utils/storage.ts
+++ b/app/client/src/utils/storage.ts
@@ -11,6 +11,7 @@ const STORAGE_KEYS: { [id: string]: string } = {
   ONBOARDING_WELCOME_STATE: "OnboardingWelcomeState",
   RECENT_ENTITIES: "RecentEntities",
   COMMENTS_INTRO_SEEN: "CommentsIntroSeen",
+  ONBOARDING_FORM_IN_PROGRESS: "ONBOARDING_FORM_IN_PROGRESS",
 };
 
 const store = localforage.createInstance({
@@ -202,5 +203,32 @@ export const getCommentsIntroSeen = async () => {
     return commentsIntroSeen;
   } catch (error) {
     console.log("An error occurred while fetching COMMENTS_INTRO_SEEN", error);
+  }
+};
+
+export const setOnboardingFormInProgress = async (flag?: boolean) => {
+  try {
+    await store.setItem(STORAGE_KEYS.ONBOARDING_FORM_IN_PROGRESS, flag);
+    return true;
+  } catch (error) {
+    console.log(
+      "An error occurred when setting ONBOARDING_FORM_IN_PROGRESS",
+      error,
+    );
+    return false;
+  }
+};
+
+export const getOnboardingFormInProgress = async () => {
+  try {
+    const onboardingFormInProgress = await store.getItem(
+      STORAGE_KEYS.ONBOARDING_FORM_IN_PROGRESS,
+    );
+    return onboardingFormInProgress;
+  } catch (error) {
+    console.log(
+      "An error occurred while fetching ONBOARDING_FORM_IN_PROGRESS",
+      error,
+    );
   }
 };


### PR DESCRIPTION
## Description
Onboarding typeform related changes:
- Always show typeform on `/applications` page, if it was started and not completed
- Redirect away from the form using the redirect url, instead to `/applications`

Fixes #5132
Fixes #5131 
Fixes #5130
Fixes #5129

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: show-onboarding-form-if-not-completed 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.24 **(-0.01)** | 35.22 **(0)** | 31.92 **(-0.02)** | 53.75 **(-0.01)**
 :red_circle: | app/client/src/utils/storage.ts | 34.38 **(-0.4)** | 0 **(0)** | 3.33 **(-0.37)** | 27.47 **(-0.58)**</details>