### PR TITLE
Feature/editor simplify - API to work with mock data sets

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
@@ -10,6 +10,7 @@ import com.appsmith.server.services.DatasourceService;
 import com.appsmith.server.solutions.AuthenticationService;
 import com.appsmith.server.solutions.DatasourceStructureSolution;
 import com.appsmith.server.services.ConfigService;
+import com.appsmith.server.solutions.ExamplesOrganizationCloner;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,17 +37,19 @@ public class DatasourceController extends BaseController<DatasourceService, Data
     private final DatasourceStructureSolution datasourceStructureSolution;
     private final AuthenticationService authenticationService;
     private final ConfigService configService;
+    private final ExamplesOrganizationCloner examplesOrganizationCloner;
 
     private static final String TEMPLATE_ORGANIZATION_CONFIG_NAME = "template-mockdb";
 
     @Autowired
     public DatasourceController(DatasourceService service,
                                 DatasourceStructureSolution datasourceStructureSolution,
-                                AuthenticationService authenticationService, ConfigService configService) {
+                                AuthenticationService authenticationService, ConfigService configService, ExamplesOrganizationCloner examplesOrganizationCloner) {
         super(service);
         this.datasourceStructureSolution = datasourceStructureSolution;
         this.authenticationService = authenticationService;
         this.configService = configService;
+        this.examplesOrganizationCloner = examplesOrganizationCloner;
     }
 
     @PostMapping("/test")
@@ -92,5 +95,10 @@ public class DatasourceController extends BaseController<DatasourceService, Data
                 .map(config -> new ResponseDTO<>(HttpStatus.OK.value(), config.getConfig(), null));
     }
 
+    @PostMapping("/mocks")
+    public Mono<ResponseDTO<Datasource>> createMockDataSet(@RequestParam String datasourceId, @RequestParam String organizationId) {
+        return examplesOrganizationCloner.cloneDatasource(datasourceId, organizationId)
+                .map(datasource -> new ResponseDTO<>(HttpStatus.OK.value(), datasource, null));
+    }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
@@ -3,12 +3,14 @@ package com.appsmith.server.controllers;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.server.constants.Url;
+import com.appsmith.server.domains.Config;
 import com.appsmith.server.domains.Datasource;
 import com.appsmith.server.dtos.AuthorizationCodeCallbackDTO;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.services.DatasourceService;
 import com.appsmith.server.solutions.AuthenticationService;
 import com.appsmith.server.solutions.DatasourceStructureSolution;
+import com.appsmith.server.services.ConfigService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,14 +34,18 @@ public class DatasourceController extends BaseController<DatasourceService, Data
 
     private final DatasourceStructureSolution datasourceStructureSolution;
     private final AuthenticationService authenticationService;
+    private final ConfigService configService;
+
+    private static final String TEMPLATE_ORGANIZATION_CONFIG_NAME = "template-mockdb";
 
     @Autowired
     public DatasourceController(DatasourceService service,
                                 DatasourceStructureSolution datasourceStructureSolution,
-                                AuthenticationService authenticationService) {
+                                AuthenticationService authenticationService, ConfigService configService) {
         super(service);
         this.datasourceStructureSolution = datasourceStructureSolution;
         this.authenticationService = authenticationService;
+        this.configService = configService;
     }
 
     @PostMapping("/test")
@@ -77,6 +83,12 @@ public class DatasourceController extends BaseController<DatasourceService, Data
                     serverWebExchange.getResponse().getHeaders().setLocation(URI.create(url));
                     return serverWebExchange.getResponse().setComplete();
                 });
+    }
+
+    @GetMapping("/mocks")
+    public Mono<ResponseDTO<Config>> getMockDataSets(){
+        return configService.getByName(TEMPLATE_ORGANIZATION_CONFIG_NAME)
+                .map(config -> new ResponseDTO<>(HttpStatus.OK.value(), config, null));
     }
 
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
@@ -3,7 +3,6 @@ package com.appsmith.server.controllers;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.server.constants.Url;
-import com.appsmith.server.domains.Config;
 import com.appsmith.server.domains.Datasource;
 import com.appsmith.server.dtos.AuthorizationCodeCallbackDTO;
 import com.appsmith.server.dtos.ResponseDTO;
@@ -24,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
+import net.minidev.json.JSONObject;
 
 import java.net.URI;
 
@@ -86,9 +87,9 @@ public class DatasourceController extends BaseController<DatasourceService, Data
     }
 
     @GetMapping("/mocks")
-    public Mono<ResponseDTO<Config>> getMockDataSets() {
+    public Mono<ResponseDTO<JSONObject>> getMockDataSets() {
         return configService.getByName(TEMPLATE_ORGANIZATION_CONFIG_NAME)
-                .map(config -> new ResponseDTO<>(HttpStatus.OK.value(), config, null));
+                .map(config -> new ResponseDTO<>(HttpStatus.OK.value(), config.getConfig(), null));
     }
 
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/DatasourceController.java
@@ -86,7 +86,7 @@ public class DatasourceController extends BaseController<DatasourceService, Data
     }
 
     @GetMapping("/mocks")
-    public Mono<ResponseDTO<Config>> getMockDataSets(){
+    public Mono<ResponseDTO<Config>> getMockDataSets() {
         return configService.getByName(TEMPLATE_ORGANIZATION_CONFIG_NAME)
                 .map(config -> new ResponseDTO<>(HttpStatus.OK.value(), config, null));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -370,7 +370,7 @@ public class ExamplesOrganizationCloner {
                 );
     }
 
-    private Mono<Datasource> cloneDatasource(String datasourceId, String toOrganizationId) {
+    public Mono<Datasource> cloneDatasource(String datasourceId, String toOrganizationId) {
         final Mono<List<Datasource>> existingDatasourcesMono = datasourceRepository.findAllByOrganizationId(toOrganizationId)
                 .collectList();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -78,7 +78,7 @@ public class ExamplesOrganizationCloner {
      * @return Empty Mono.
      */
     private Mono<Organization> cloneExamplesOrganization(User user) {
-        if (!CollectionUtils.isEmpty(user.getOrganizationIds())) {
+        if (CollectionUtils.isEmpty(user.getOrganizationIds())) {
             // Don't create an examples organization if the user already has some organizations, perhaps because they
             // were invited to some.
             return Mono.empty();
@@ -90,7 +90,7 @@ public class ExamplesOrganizationCloner {
                         templateOrganizationId,
                         user,
                         configService.getTemplateApplications(),
-                        configService.getTemplateDatasources()
+                        Flux.empty()
                 ));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -78,7 +78,7 @@ public class ExamplesOrganizationCloner {
      * @return Empty Mono.
      */
     private Mono<Organization> cloneExamplesOrganization(User user) {
-        if (CollectionUtils.isEmpty(user.getOrganizationIds())) {
+        if (!CollectionUtils.isEmpty(user.getOrganizationIds())) {
             // Don't create an examples organization if the user already has some organizations, perhaps because they
             // were invited to some.
             return Mono.empty();
@@ -90,7 +90,7 @@ public class ExamplesOrganizationCloner {
                         templateOrganizationId,
                         user,
                         configService.getTemplateApplications(),
-                        Flux.empty()
+                        configService.getTemplateDatasources()
                 ));
     }
 


### PR DESCRIPTION
## Description

As a part of editor/nav simplification project, i have added two APIs 
1. To get the list of available mock datasets to user 
2. Create a mock data set from the available datasets. 

I have also removed the the flow - pre populating of fakeAPI dataset when the user is logged in for the first time. The reason to do this is because we have decided to give the control to user where he can choose mock-data set of his own choice. 

Fixes #4542 
Fixes #4962 


## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?


- Tested locally via postman

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Existing unit tests pass locally with my changes
