### PR TITLE
Added new API to get unread comment thread count

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
@@ -106,4 +106,10 @@ public class CommentController extends BaseController<CommentService, Comment, S
                 .map(isSaved -> new ResponseDTO<>(HttpStatus.OK.value(), isSaved, null));
     }
 
+    @GetMapping("count/unread/{applicationId}")
+    public Mono<ResponseDTO<Long>> getUnreadThreadCount(@PathVariable String applicationId) {
+        return service.getUnreadCount(applicationId)
+                .map(response -> new ResponseDTO<>(HttpStatus.OK.value(), response, null));
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
@@ -105,11 +105,4 @@ public class CommentController extends BaseController<CommentService, Comment, S
         return service.deleteReaction(commentId, reaction)
                 .map(isSaved -> new ResponseDTO<>(HttpStatus.OK.value(), isSaved, null));
     }
-
-    @GetMapping("count/unread/{applicationId}")
-    public Mono<ResponseDTO<Long>> getUnreadThreadCount(@PathVariable String applicationId) {
-        return service.getUnreadCount(applicationId)
-                .map(response -> new ResponseDTO<>(HttpStatus.OK.value(), response, null));
-    }
-
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -46,6 +46,9 @@ public class Application extends BaseDomain {
     @Transient
     boolean appIsExample = false;
 
+    @Transient
+    long unreadComments;
+
     @JsonIgnore
     String clonedFromApplicationId;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -47,7 +47,7 @@ public class Application extends BaseDomain {
     boolean appIsExample = false;
 
     @Transient
-    long unreadComments;
+    long unreadCommentThreads;
 
     @JsonIgnore
     String clonedFromApplicationId;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CommentThreadRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CommentThreadRepository.java
@@ -2,8 +2,9 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.domains.CommentThread;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
 
 @Repository
 public interface CommentThreadRepository extends BaseRepository<CommentThread, String>, CustomCommentThreadRepository {
-
+    Mono<Long> countByApplicationIdAndViewedByUsersNot(String applicationId, String username);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CommentThreadRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CommentThreadRepository.java
@@ -2,9 +2,8 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.domains.CommentThread;
 import org.springframework.stereotype.Repository;
-import reactor.core.publisher.Mono;
 
 @Repository
 public interface CommentThreadRepository extends BaseRepository<CommentThread, String>, CustomCommentThreadRepository {
-    Mono<Long> countByApplicationIdAndViewedByUsersNot(String applicationId, String username);
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
@@ -11,4 +11,5 @@ import java.util.Set;
 public interface CustomCommentThreadRepository extends AppsmithRepository<CommentThread> {
     Flux<CommentThread> findByApplicationId(String applicationId, AclPermission permission);
     Mono<UpdateResult> addToSubscribers(String threadId, Set<String> usernames);
+    Mono<Long> countUnreadThreads(String applicationId, String userEmail);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -46,4 +46,13 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
                 CommentThread.class
         );
     }
+
+    @Override
+    public Mono<Long> countUnreadThreads(String applicationId, String userEmail) {
+        List<Criteria> criteriaList = List.of(
+            where(fieldName(QCommentThread.commentThread.viewedByUsers)).ne(userEmail),
+            where(fieldName(QCommentThread.commentThread.applicationId)).is(applicationId)
+        );
+        return count(criteriaList, AclPermission.READ_THREAD);
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentService.java
@@ -23,4 +23,6 @@ public interface CommentService extends CrudService<Comment, String> {
     Mono<Boolean> createReaction(String commentId, Comment.Reaction reaction);
 
     Mono<Boolean> deleteReaction(String commentId, Comment.Reaction reaction);
+
+    Mono<Long> getUnreadCount(String applicationId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -414,4 +414,11 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                 });
     }
 
+    @Override
+    public Mono<Long> getUnreadCount(String applicationId) {
+        return sessionUserService.getCurrentUser()
+                .flatMap(user ->
+                        threadRepository.countByApplicationIdAndViewedByUsersNot(applicationId, user.getUsername())
+                );
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -418,7 +418,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
     public Mono<Long> getUnreadCount(String applicationId) {
         return sessionUserService.getCurrentUser()
                 .flatMap(user ->
-                        threadRepository.countByApplicationIdAndViewedByUsersNot(applicationId, user.getUsername())
+                        threadRepository.countUnreadThreads(applicationId, user.getUsername())
                 );
     }
 }


### PR DESCRIPTION
## Description
In order to show a marker on the comment icon to denote there are unread comments, a new field has been added in the get applications API. The field will contain the number of unread threads for the currently logged in user under that application.

Fixes #5224 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
