### PR TITLE
Triggers post page load actions in the editor

### DIFF
--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -30,11 +30,15 @@ export const fetchPageList = (
   };
 };
 
-export const fetchPage = (pageId: string): ReduxAction<FetchPageRequest> => {
+export const fetchPage = (
+  pageId: string,
+  isFirstLoad = false,
+): ReduxAction<FetchPageRequest> => {
   return {
     type: ReduxActionTypes.FETCH_PAGE_INIT,
     payload: {
       id: pageId,
+      isFirstLoad,
     },
   };
 };

--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -47,9 +47,13 @@ export const fetchPublishedPage = (pageId: string, bustCache = false) => ({
   },
 });
 
-export const fetchPageSuccess = (): ReduxActionWithoutPayload => {
+export const fetchPageSuccess = (
+  postEvalActions: Array<ReduxAction<unknown> | ReduxActionWithoutPayload>,
+): EvaluationReduxAction<undefined> => {
   return {
     type: ReduxActionTypes.FETCH_PAGE_SUCCESS,
+    postEvalActions,
+    payload: undefined,
   };
 };
 

--- a/app/client/src/api/PageApi.tsx
+++ b/app/client/src/api/PageApi.tsx
@@ -7,6 +7,7 @@ import { PageAction } from "constants/AppsmithActionConstants/ActionConstants";
 
 export interface FetchPageRequest {
   id: string;
+  isFirstLoad?: boolean;
 }
 
 export interface FetchPublishedPageRequest {

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -97,7 +97,7 @@ function* initializeEditorSaga(
     const applicationAndLayoutCalls = yield failFastApiCalls(
       [
         fetchPageList(applicationId, APP_MODE.EDIT),
-        fetchPage(pageId),
+        fetchPage(pageId, true),
         fetchApplication(applicationId, APP_MODE.EDIT),
       ],
       [

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -200,7 +200,12 @@ export function* fetchPageSaga(
       // set current page
       yield put(updateCurrentPage(id));
       // dispatch fetch page success
-      yield put(fetchPageSuccess());
+      yield put(
+        fetchPageSuccess(
+          // Execute page load actions post page load
+          [executePageLoadActions()],
+        ),
+      );
       const extractedDSL = extractCurrentDSL(fetchPageResponse);
       yield put({
         type: ReduxActionTypes.UPDATE_CANVAS_STRUCTURE,

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -177,7 +177,7 @@ export function* fetchPageSaga(
   pageRequestAction: ReduxAction<FetchPageRequest>,
 ) {
   try {
-    const { id } = pageRequestAction.payload;
+    const { id, isFirstLoad } = pageRequestAction.payload;
     PerformanceTracker.startAsyncTracking(
       PerformanceTransactionName.FETCH_PAGE_API,
       { pageId: id },
@@ -203,7 +203,7 @@ export function* fetchPageSaga(
       yield put(
         fetchPageSuccess(
           // Execute page load actions post page load
-          [executePageLoadActions()],
+          isFirstLoad ? [] : [executePageLoadActions()],
         ),
       );
       const extractedDSL = extractCurrentDSL(fetchPageResponse);


### PR DESCRIPTION
## Description

After fetching the page, the necessary actions such as loading the data were done only for published pages. In this PR, I've added the support for the unpublished pages to do the same.

Fixes #5247 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually verified by switching the pages in the editor view and confirmed that the API calls to get data were being made or not.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
