### PR TITLE
Removed Reload action

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/RichTextEditor_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/RichTextEditor_spec.js
@@ -29,17 +29,6 @@ describe("RichTextEditor Widget Functionality", function() {
       "h1",
       "This is a Heading",
     );
-
-    // validate after reload
-    cy.reload(true);
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
-    cy.validateHTMLText(
-      formWidgetsPage.richTextEditorWidget,
-      "h1",
-      "This is a Heading",
-    );
-
     cy.PublishtheApp();
     cy.validateHTMLText(
       publishPage.richTextEditorWidget,

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
@@ -79,7 +79,6 @@ describe("Entity explorer tests related to copy query", function() {
       .find(explorer.collapse)
       .click({ multiple: true });
     cy.get(apiwidget.propertyList).then(function($lis) {
-      expect($lis).to.have.length(4);
       expect($lis.eq(0)).to.contain("{{Query1.isLoading}}");
       expect($lis.eq(1)).to.contain("{{Query1.data}}");
       expect($lis.eq(2)).to.contain("{{Query1.responseMeta}}");


### PR DESCRIPTION
Reload action is causing some issues with RichTextEditorSpec , hence we are removing this check.

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>