### PR TITLE
Update/bump node version in the doc

### DIFF
--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -90,7 +90,7 @@ This error occurs because the node version is not compatible with the app enviro
 node versions to be used in different projects. Check below for installation and usage details:
 
 1. Install a node version manager. For eg: check [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm).
-1. In the root of the project, run `nvm use 10.16.3` or `fnm use 10.16.3`.
+1. In the root of the project, run `nvm use 14.15.4` or `fnm use 14.15.4`.
 
 #### If you would like to hit a different Appsmith server:
 


### PR DESCRIPTION
## Description

I noticed that the install script mentions needing node version 14.15.4 while we have the old version mentioned in this file.

<img width="561" alt="nodev" src="https://user-images.githubusercontent.com/800578/123659800-b0324580-d850-11eb-985a-1b9c603ef5e7.png">

## Type of change
- This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
