### PR TITLE
Feature/page order - Include order in get pages API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageNameIdDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageNameIdDTO.java
@@ -13,4 +13,6 @@ public class PageNameIdDTO {
     Boolean isDefault;
 
     Boolean isHidden;
+
+    Integer order;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -218,6 +218,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
                     List<NewPage> pagesFromDb = tuple.getT1();
                     String defaultPageId = tuple.getT2();
                     List<ApplicationPage> pages = tuple.getT3().getPages();
+                    List<ApplicationPage> publishedPages = tuple.getT3().getPublishedPages();
 
                     List<PageNameIdDTO> pageNameIdDTOList = new ArrayList<>();
 
@@ -235,7 +236,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
                             }
                             pageNameIdDTO.setName(pageFromDb.getPublishedPage().getName());
                             pageNameIdDTO.setIsHidden(pageFromDb.getPublishedPage().getIsHidden());
-                            List<ApplicationPage> currentPage = pages.stream().filter(page -> page.getId().equals(pageNameIdDTO.getId())).collect(Collectors.toList());
+                            List<ApplicationPage> currentPage = publishedPages.stream().filter(page -> page.getId().equals(pageNameIdDTO.getId())).collect(Collectors.toList());
                             pageNameIdDTO.setOrder(currentPage.get(currentPage.size()-1).getOrder());
                         } else {
                             pageNameIdDTO.setName(pageFromDb.getUnpublishedPage().getName());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -18,6 +18,7 @@ import com.appsmith.server.dtos.ApplicationAccessDTO;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.OrganizationApplicationsDTO;
 import com.appsmith.server.dtos.PageDTO;
+import com.appsmith.server.dtos.PageNameIdDTO;
 import com.appsmith.server.dtos.UserHomepageDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
@@ -1095,6 +1096,11 @@ public class ApplicationServiceTest {
                     assertThat(applicationPagesDTO.getPages().size()).isEqualTo(4);
                     List<String> pageNames = applicationPagesDTO.getPages().stream().map(pageNameIdDTO -> pageNameIdDTO.getName()).collect(Collectors.toList());
                     assertThat(pageNames).containsExactly("Page1", "Page2", "Page3", "Page4");
+                    Integer order = 0;
+                    for(PageNameIdDTO page : applicationPagesDTO.getPages()){
+                        assertThat(page.getOrder()).isEqualTo(order);
+                        order++;
+                    }
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

This adds the `order` filed to the getPages API to support page reorder persistence. 

Fixes #2786

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually via postman
- Unit Tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
