### PR TITLE
Reliable change application access from public to private & vice versa

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -1098,4 +1098,166 @@ public class ApplicationServiceTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void validChangeViewAccessCancelledMidWay() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Application testApplication = new Application();
+        String appName = "ApplicationServiceTest Public View Application Midway Cancellation";
+        testApplication.setName(appName);
+
+        Application originalApplication = applicationPageService.createApplication(testApplication, orgId)
+                .block();
+
+        String pageId = originalApplication.getPages().get(0).getId();
+
+        Plugin plugin = pluginService.findByName("Installed Plugin Name").block();
+        Datasource datasource = new Datasource();
+        datasource.setName("Public View App Test");
+        datasource.setPluginId(plugin.getId());
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        datasource.setDatasourceConfiguration(datasourceConfiguration);
+        datasource.setOrganizationId(orgId);
+
+        Datasource savedDatasource = datasourceService.create(datasource).block();
+
+        ActionDTO action1 = new ActionDTO();
+        action1.setName("Public View Test action1");
+        action1.setPageId(pageId);
+        action1.setDatasource(savedDatasource);
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action1.setActionConfiguration(actionConfiguration);
+
+        ActionDTO savedAction1 = layoutActionService.createAction(action1).block();
+
+        ActionDTO action2 = new ActionDTO();
+        action2.setName("Public View Test action2");
+        action2.setPageId(pageId);
+        action2.setDatasource(savedDatasource);
+        action2.setActionConfiguration(actionConfiguration);
+
+        ActionDTO savedAction2 = layoutActionService.createAction(action2).block();
+
+        ActionDTO action3 = new ActionDTO();
+        action3.setName("Public View Test action3");
+        action3.setPageId(pageId);
+        action3.setDatasource(savedDatasource);
+        action3.setActionConfiguration(actionConfiguration);
+
+        ActionDTO savedAction3 = layoutActionService.createAction(action3).block();
+
+        ApplicationAccessDTO applicationAccessDTO = new ApplicationAccessDTO();
+        applicationAccessDTO.setPublicAccess(true);
+
+        // Trigger the change view access of application now.
+        applicationService.changeViewAccess(originalApplication.getId(), applicationAccessDTO)
+                .timeout(Duration.ofMillis(10))
+                .subscribe();
+
+        Mono<Application> applicationFromDbPostViewChange = Mono.just(originalApplication)
+                .flatMap(originalApp -> {
+                    try {
+                        // Before fetching the cloned application, sleep for 5 seconds to ensure that the cloning finishes
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    return applicationRepository.findById(originalApplication.getId(), READ_APPLICATIONS);
+                })
+                .cache();
+
+        Mono<List<NewAction>> actionsMono = applicationFromDbPostViewChange
+                .flatMap(clonedAppFromDb -> newActionService
+                        .findAllByApplicationIdAndViewMode(clonedAppFromDb.getId(), false, READ_ACTIONS, null)
+                        .collectList()
+                );
+
+        Mono<List<PageDTO>> pagesMono = applicationFromDbPostViewChange
+                .flatMapMany(application -> Flux.fromIterable(application.getPages()))
+                .flatMap(applicationPage -> newPageService.findPageById(applicationPage.getId(), READ_PAGES, false))
+                .collectList();
+
+        Mono<List<Datasource>> datasourcesMono = applicationFromDbPostViewChange
+                .flatMapMany(application -> datasourceService.findAllByOrganizationId(application.getOrganizationId(), READ_DATASOURCES))
+                .collectList();
+
+        StepVerifier
+                .create(Mono.zip(applicationFromDbPostViewChange, actionsMono, pagesMono, datasourcesMono))
+                .assertNext(tuple -> {
+                    Application updatedApplication = tuple.getT1();
+                    List<NewAction> actions = tuple.getT2();
+                    List<PageDTO> pages = tuple.getT3();
+                    List<Datasource> datasources = tuple.getT4();
+
+                    assertThat(updatedApplication).isNotNull();
+                    assertThat(updatedApplication.getIsPublic()).isTrue();
+                    assertThat(updatedApplication
+                            .getPolicies()
+                            .stream()
+                            .filter(policy -> {
+                                if (policy.getPermission().equals(READ_APPLICATIONS.getValue())) {
+                                    return true;
+                                }
+                                return false;
+                            })
+                            .findFirst()
+                            .get()
+                            .getUsers()
+                    ).contains("anonymousUser");
+
+                    for (PageDTO page : pages) {
+                        assertThat(page
+                                .getPolicies()
+                                .stream()
+                                .filter(policy -> {
+                                    if (policy.getPermission().equals(READ_PAGES.getValue())) {
+                                        return true;
+                                    }
+                                    return false;
+                                })
+                                .findFirst()
+                                .get()
+                                .getUsers()
+                        ).contains("anonymousUser");
+                    }
+
+                    for (NewAction action : actions) {
+                        assertThat(action
+                                .getPolicies()
+                                .stream()
+                                .filter(policy -> {
+                                    if (policy.getPermission().equals(EXECUTE_ACTIONS.getValue())) {
+                                        return true;
+                                    }
+                                    return false;
+                                })
+                                .findFirst()
+                                .get()
+                                .getUsers()
+                        ).contains("anonymousUser");
+                    }
+
+                    for (Datasource updatedDatasource : datasources) {
+                        assertThat(updatedDatasource
+                                .getPolicies()
+                                .stream()
+                                .filter(policy -> {
+                                    if (policy.getPermission().equals(EXECUTE_DATASOURCES.getValue())) {
+                                        return true;
+                                    }
+                                    return false;
+                                })
+                                .findFirst()
+                                .get()
+                                .getUsers()
+                        ).contains("anonymousUser");
+                    }
+                })
+                .verifyComplete();
+
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -1197,12 +1197,7 @@ public class ApplicationServiceTest {
                     assertThat(updatedApplication
                             .getPolicies()
                             .stream()
-                            .filter(policy -> {
-                                if (policy.getPermission().equals(READ_APPLICATIONS.getValue())) {
-                                    return true;
-                                }
-                                return false;
-                            })
+                            .filter(policy -> policy.getPermission().equals(READ_APPLICATIONS.getValue()))
                             .findFirst()
                             .get()
                             .getUsers()
@@ -1212,12 +1207,7 @@ public class ApplicationServiceTest {
                         assertThat(page
                                 .getPolicies()
                                 .stream()
-                                .filter(policy -> {
-                                    if (policy.getPermission().equals(READ_PAGES.getValue())) {
-                                        return true;
-                                    }
-                                    return false;
-                                })
+                                .filter(policy -> policy.getPermission().equals(READ_PAGES.getValue()))
                                 .findFirst()
                                 .get()
                                 .getUsers()
@@ -1228,12 +1218,7 @@ public class ApplicationServiceTest {
                         assertThat(action
                                 .getPolicies()
                                 .stream()
-                                .filter(policy -> {
-                                    if (policy.getPermission().equals(EXECUTE_ACTIONS.getValue())) {
-                                        return true;
-                                    }
-                                    return false;
-                                })
+                                .filter(policy -> policy.getPermission().equals(EXECUTE_ACTIONS.getValue()))
                                 .findFirst()
                                 .get()
                                 .getUsers()
@@ -1244,12 +1229,7 @@ public class ApplicationServiceTest {
                     assertThat(datasource1
                             .getPolicies()
                             .stream()
-                            .filter(policy -> {
-                                if (policy.getPermission().equals(EXECUTE_DATASOURCES.getValue())) {
-                                    return true;
-                                }
-                                return false;
-                            })
+                            .filter(policy -> policy.getPermission().equals(EXECUTE_DATASOURCES.getValue()))
                             .findFirst()
                             .get()
                             .getUsers()

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -1161,7 +1161,8 @@ public class ApplicationServiceTest {
         Mono<Application> applicationFromDbPostViewChange = Mono.just(originalApplication)
                 .flatMap(originalApp -> {
                     try {
-                        // Before fetching the cloned application, sleep for 5 seconds to ensure that the cloning finishes
+                        // Before fetching the public application, sleep for 5 seconds to ensure that the updating
+                        // all appsmith objects with public permission finishes.
                         Thread.sleep(5000);
                     } catch (InterruptedException e) {
                         e.printStackTrace();


### PR DESCRIPTION

## Description

Sometimes, when the server is taking time in finishing the request of changing view access of an application, the client could timeout and trigger cancellation of the process. This leads to partial updation of the application and its underlying actions, pages and datasources. This PR adds the feature where once triggered, the change access process would run to completion without getting cancelled.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a test case which cancels the flow after service function call after 10 ms ensuring that the cancellation is mid way. Asserting that all the appsmith objects got updated correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
