### PR TITLE
Handle exception where prepared statements viewer does not get a value

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -15,6 +15,8 @@ import {
   EvaluationError,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
+import * as Sentry from "@sentry/react";
+import { Severity } from "@sentry/react";
 
 const Wrapper = styled.div`
   position: relative;
@@ -155,6 +157,13 @@ export function PreparedStatementViewer(props: {
   evaluatedValue: PreparedStatementValue;
 }) {
   const { parameters, value } = props.evaluatedValue;
+  if (!value) {
+    Sentry.captureException("Prepared Statement got no value", {
+      level: Severity.Debug,
+      extra: { props },
+    });
+    return <div />;
+  }
   const stringSegments = value.split(/\$\d/);
   const $params = [...value.matchAll(/\$\d/g)].map((matches) => matches[0]);
   const paramsWithTooltips = $params.map((param) => (


### PR DESCRIPTION
## Description
Handle exception and log additional info on sentry

Fixes #5342

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
No valid reproduction found

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/critical-evaluated-value-split 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.07 **(0)** | 36.09 **(0)** | 32.57 **(0)** | 54.61 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx | 63.33 **(-1.38)** | 59.38 **(-1.91)** | 42.86 **(0)** | 65.48 **(-1.61)**</details>