### PR TITLE
Improved label, updating navigateTo default prams when action type is changed to navigateTo in JS actions

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -350,14 +350,18 @@ const fieldConfigs: FieldConfigs = {
     setter: (option: TreeDropdownOption) => {
       const type: ActionType = option.type || option.value;
       let value = option.value;
+      let defaultParams = "";
       switch (type) {
         case ActionType.integration:
           value = `${value}.run`;
           break;
+        case ActionType.navigateTo:
+          defaultParams = `,'{}'`;
+          break;
         default:
           break;
       }
-      return value === "none" ? "" : `{{${value}()}}`;
+      return value === "none" ? "" : `{{${value}(${defaultParams})}}`;
     },
     view: ViewTypes.SELECTOR_VIEW,
   },
@@ -456,6 +460,9 @@ const fieldConfigs: FieldConfigs = {
       return textGetter(value, 1);
     },
     setter: (value: any, currentValue: string) => {
+      if (value === "") {
+        value = undefined;
+      }
       return textSetter(value, currentValue, 1);
     },
     view: ViewTypes.TEXT_VIEW,
@@ -621,7 +628,7 @@ function renderField(props: {
       if (fieldType === FieldType.NAVIGATION_TARGET_FIELD) {
         label = "Target";
         options = NAVIGATION_TARGET_FIELD_OPTIONS;
-        defaultText = "Navigation target";
+        defaultText = NAVIGATION_TARGET_FIELD_OPTIONS[0].label;
       }
       viewElement = (view as (props: SelectorViewProps) => JSX.Element)({
         options: options,
@@ -667,7 +674,7 @@ function renderField(props: {
       if (fieldType === FieldType.ALERT_TEXT_FIELD) {
         fieldLabel = "Message";
       } else if (fieldType === FieldType.URL_FIELD) {
-        fieldLabel = "Page Name";
+        fieldLabel = "Page Name or URL";
       } else if (fieldType === FieldType.KEY_TEXT_FIELD) {
         fieldLabel = "Key";
       } else if (fieldType === FieldType.VALUE_TEXT_FIELD) {

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -356,7 +356,7 @@ const fieldConfigs: FieldConfigs = {
           value = `${value}.run`;
           break;
         case ActionType.navigateTo:
-          defaultParams = `,'{}'`;
+          defaultParams = `'#', {}`;
           break;
         default:
           break;


### PR DESCRIPTION
## Description

Resolution for Issues with NavigateTo functionality
- Changed label to improve clarity that the input can be either page name or external URL
- Added default string `'{}'` to Query Params field since without it if navigation target is selected

Fixes #3125 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/3125-adding-default-values-for-navigateTo-action 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.83 **(-0.01)** | 35.81 **(0)** | 32.44 **(0)** | 54.41 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/ActionCreator/Fields.tsx | 28.47 **(-0.53)** | 25.53 **(-0.56)** | 7.69 **(0)** | 27.61 **(-0.53)**</details>