### PR TITLE
Fix: Remove property from dependency map when binding is removed

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -923,6 +923,13 @@ export default class DataTreeEvaluator {
                   }
                 }
               }
+              // If the whole binding was removed then the value
+              // at this path would be "".
+              // In this case if the path exists in the dependency map
+              // remove it.
+              else if (fullPropertyPath in this.dependencyMap) {
+                delete this.dependencyMap[fullPropertyPath];
+              }
             }
             break;
           }


### PR DESCRIPTION
## Description

Remove property from dependency map when binding is removed

Fixes #5537 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/depedency-not-getting-removed 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.07 **(0)** | 36.09 **(0)** | 32.57 **(0)** | 54.61 **(-0.01)**
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 88.3 **(-0.36)** | 78.46 **(-0.81)** | 87.32 **(0)** | 88.44 **(-0.4)**</details>