### PR TITLE
Fix slash command not executed on click

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -290,12 +290,6 @@ class CodeEditor extends Component<Props, State> {
   };
 
   handleEditorFocus = () => {
-    if (this.state.isFocused) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore: No types available
-      this.editor.closeHint();
-      return;
-    }
     this.setState({ isFocused: true });
     this.editor.refresh();
     if (this.props.size === EditorSize.COMPACT) {
@@ -310,11 +304,6 @@ class CodeEditor extends Component<Props, State> {
 
   handleEditorBlur = (cm: CodeMirror.Editor) => {
     this.handleChange();
-    if (this.state.isFocused) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore: No types available
-      this.editor.closeHint();
-    }
     if (!cm.state.completionActive) this.setState({ isFocused: false });
     if (this.props.size === EditorSize.COMPACT) {
       this.editor.setOption("lineWrapping", false);


### PR DESCRIPTION
## Description
On selecting a slash command menu item the editor gets blurred and the item doesn't register a click event. So it doesn't execute the click handler

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
