### PR TITLE
[Enhancement] Double click to open Property pane.

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Property_JsonUpdate_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Property_JsonUpdate_spec.js
@@ -53,6 +53,7 @@ describe("Test Create Api and Bind to Table widget", function() {
   });
 
   it("Check Selected Row(s) Resets When Table Data Changes", function() {
+    cy.openPropertyPane("tablewidget");
     cy.isSelectRow(1);
     cy.testJsontext("tabledata", "[]");
     cy.wait("@updateLayout");

--- a/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
+++ b/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
@@ -1,9 +1,9 @@
-import React, { CSSProperties, ReactNode, useCallback, useMemo } from "react";
+import React, { CSSProperties, ReactNode, useMemo } from "react";
 import { BaseStyle } from "widgets/BaseWidget";
 import { WIDGET_PADDING } from "constants/WidgetConstants";
 import { generateClassName } from "utils/generators";
 import styled from "styled-components";
-import { useClickOpenPropPane } from "utils/hooks/useClickOpenPropPane";
+import { useDoubleClickOpenPropPane } from "utils/hooks/useDoubleClickOpenPropPane";
 import { stopEventPropagation } from "utils/AppsmithUtils";
 import { Layers } from "constants/Layers";
 
@@ -26,7 +26,7 @@ export function PositionedContainer(props: PositionedContainerProps) {
   const x = props.style.xPosition + (props.style.xPositionUnit || "px");
   const y = props.style.yPosition + (props.style.yPositionUnit || "px");
   const padding = WIDGET_PADDING;
-  const openPropertyPane = useClickOpenPropPane();
+  const doubleClickRef = useDoubleClickOpenPropPane(props.widgetId);
   // memoized classname
   const containerClassName = useMemo(() => {
     return (
@@ -54,19 +54,13 @@ export function PositionedContainer(props: PositionedContainerProps) {
     };
   }, [props.style]);
 
-  const openPropPane = useCallback((e) => openPropertyPane(e, props.widgetId), [
-    props.widgetId,
-    openPropertyPane,
-  ]);
-
   return (
     <PositionedWidget
       className={containerClassName}
       data-testid="test-widget"
       id={props.widgetId}
       onClick={stopEventPropagation}
-      // Positioned Widget is the top enclosure for all widgets and clicks on/inside the widget should not be propogated/bubbled out of this Container.
-      onClickCapture={openPropPane}
+      ref={doubleClickRef}
       //Before you remove: This is used by property pane to reference the element
       style={containerStyle}
     >

--- a/app/client/src/components/editorComponents/DraggableComponent.tsx
+++ b/app/client/src/components/editorComponents/DraggableComponent.tsx
@@ -6,10 +6,7 @@ import { WIDGET_PADDING } from "constants/WidgetConstants";
 import { useSelector } from "react-redux";
 import { AppState } from "reducers";
 import { getColorWithOpacity } from "constants/DefaultTheme";
-import {
-  useShowPropertyPane,
-  useWidgetDragResize,
-} from "utils/hooks/dragResizeHooks";
+import { useWidgetDragResize } from "utils/hooks/dragResizeHooks";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { commentModeSelector } from "selectors/commentsSelectors";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
@@ -59,9 +56,6 @@ export const canDrag = (
 };
 
 function DraggableComponent(props: DraggableComponentProps) {
-  // Dispatch hook handy to toggle property pane
-  const showPropertyPane = useShowPropertyPane();
-
   // Dispatch hook handy to set a widget as focused/selected
   const { focusWidget, selectWidget } = useWidgetSelection();
 
@@ -130,9 +124,6 @@ function DraggableComponent(props: DraggableComponentProps) {
       // of the property pane is taken into account.
       // See utils/hooks/dragResizeHooks.tsx
       const didDrop = monitor.didDrop();
-      if (didDrop) {
-        showPropertyPane && showPropertyPane(props.widgetId, undefined, true);
-      }
       // Take this to the bottom of the stack. So that it runs last.
       // We do this because, we don't want erroraneous mouse clicks to propagate.
       setTimeout(() => setIsDragging && setIsDragging(false), 0);

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -186,6 +186,7 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
 
         // Select the widget if it is a new widget
         selectWidget && selectWidget(widget.widgetId);
+        showPropertyPane();
         persistDropTargetRows(widget.widgetId, widgetBottomRow);
 
         /* Finally update the widget */

--- a/app/client/src/components/editorComponents/ResizableComponent.tsx
+++ b/app/client/src/components/editorComponents/ResizableComponent.tsx
@@ -14,10 +14,7 @@ import {
   computeFinalRowCols,
   computeRowCols,
 } from "./ResizableUtils";
-import {
-  useShowPropertyPane,
-  useWidgetDragResize,
-} from "utils/hooks/dragResizeHooks";
+import { useWidgetDragResize } from "utils/hooks/dragResizeHooks";
 import { useSelector } from "react-redux";
 import { AppState } from "reducers";
 import Resizable from "resizable";
@@ -59,7 +56,6 @@ export const ResizableComponent = memo(function ResizableComponent(
 
   const isCommentMode = useSelector(commentModeSelector);
 
-  const showPropertyPane = useShowPropertyPane();
   const { selectWidget } = useWidgetSelection();
   const { setIsResizing } = useWidgetDragResize();
   const selectedWidget = useSelector(
@@ -236,10 +232,6 @@ export const ResizableComponent = memo(function ResizableComponent(
     selectWidget &&
       selectedWidget !== props.widgetId &&
       selectWidget(props.widgetId);
-    // Let the propertypane show.
-    // The propertypane decides whether to show itself, based on
-    // whether it was showing when the widget resize started.
-    showPropertyPane && showPropertyPane(props.widgetId, undefined, true);
 
     AnalyticsUtil.logEvent("WIDGET_RESIZE_END", {
       widgetName: props.widgetName,

--- a/app/client/src/pages/Editor/GlobalHotKeys.test.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.test.tsx
@@ -78,6 +78,8 @@ describe("Select all hotkey", () => {
     expect(canvasWidgets.length).toBe(2);
     if (canvasWidgets[1].firstChild) {
       fireEvent.mouseOver(canvasWidgets[1].firstChild);
+      // simulating double click to open property pane.
+      fireEvent.click(canvasWidgets[1].firstChild);
       fireEvent.click(canvasWidgets[1].firstChild);
     }
     propPane = component.queryByTestId("t--propertypane");

--- a/app/client/src/utils/hooks/useClick.tsx
+++ b/app/client/src/utils/hooks/useClick.tsx
@@ -4,6 +4,7 @@ export default (
   currentRef: MutableRefObject<HTMLElement | null>,
   singleClk: (e: MouseEvent<HTMLElement>) => void,
   doubleClk?: (e: MouseEvent<HTMLElement>) => void,
+  capture?: boolean,
 ) => {
   useEffect(() => {
     let clickCount = 0;
@@ -28,9 +29,9 @@ export default (
     };
 
     const el = currentRef.current;
-    el?.addEventListener("click", handleClick);
+    el?.addEventListener("click", handleClick, !!capture);
     return () => {
-      el?.removeEventListener("click", handleClick);
+      el?.removeEventListener("click", handleClick, !!capture);
     };
   }, [currentRef, singleClk, doubleClk]);
 };

--- a/app/client/src/utils/hooks/useDoubleClickOpenPropPane.tsx
+++ b/app/client/src/utils/hooks/useDoubleClickOpenPropPane.tsx
@@ -1,9 +1,6 @@
 import { get } from "lodash";
 import { useShowPropertyPane } from "utils/hooks/dragResizeHooks";
-import {
-  getCurrentWidgetId,
-  getIsPropertyPaneVisible,
-} from "selectors/propertyPaneSelectors";
+import { getIsPropertyPaneVisible } from "selectors/propertyPaneSelectors";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { useSelector } from "store";
 import { AppState } from "reducers";
@@ -11,7 +8,10 @@ import { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsRe
 import { APP_MODE } from "reducers/entityReducers/appReducer";
 import { getAppMode } from "selectors/applicationSelectors";
 import { getWidgets } from "sagas/selectors";
+import { getSelectedWidget } from "selectors/ui";
 import { useWidgetSelection } from "./useWidgetSelection";
+import { useCallback, useRef } from "react";
+import useClick from "utils/hooks/useClick";
 
 /**
  *
@@ -49,12 +49,12 @@ export function getParentToOpenIfAny(
   return;
 }
 
-export const useClickOpenPropPane = () => {
+export const useDoubleClickOpenPropPane = (widgetId: string) => {
   const showPropertyPane = useShowPropertyPane();
   const { focusWidget, selectWidget } = useWidgetSelection();
   const isPropPaneVisible = useSelector(getIsPropertyPaneVisible);
   const widgets: CanvasWidgetsReduxState = useSelector(getWidgets);
-  const selectedWidgetId = useSelector(getCurrentWidgetId);
+  const selectedWidgetId = useSelector(getSelectedWidget);
   const focusedWidgetId = useSelector(
     (state: AppState) => state.ui.widgetDragResize.focusedWidget,
   );
@@ -70,35 +70,57 @@ export const useClickOpenPropPane = () => {
   );
 
   const parentWidgetToOpen = getParentToOpenIfAny(focusedWidgetId, widgets);
-  const openPropertyPane = (e: any, targetWidgetId: string) => {
+  const selectWidgetFn = (isMultiSelect: boolean) => {
+    const widgetToSelect = parentWidgetToOpen
+      ? parentWidgetToOpen.widgetId
+      : focusedWidgetId;
+    if (focusedWidgetId !== widgetToSelect) {
+      focusWidget(widgetToSelect);
+    }
+    if (selectedWidgetId !== widgetToSelect) {
+      selectWidget(widgetToSelect, isMultiSelect);
+    }
+  };
+  const openPropertyPaneOnDoubleClickFn = () => {
+    const widgetId = parentWidgetToOpen
+      ? parentWidgetToOpen.widgetId
+      : focusedWidgetId;
+    showPropertyPane(widgetId, undefined, true);
+  };
+  const initSelectWidgetOnClick = (e: any, isDoubleClick = false) => {
     // ignore click captures if the component was resizing or dragging coz it is handled internally in draggable component
     if (
       isResizing ||
       isDragging ||
       appMode !== APP_MODE.EDIT ||
-      targetWidgetId !== focusedWidgetId
+      widgetId !== focusedWidgetId
     )
       return;
     if (
       (!isPropPaneVisible && selectedWidgetId === focusedWidgetId) ||
       selectedWidgetId !== focusedWidgetId
     ) {
-      const isMultiSelect = e.metaKey || e.ctrlKey || e.shiftKey;
-
-      if (parentWidgetToOpen) {
-        selectWidget(parentWidgetToOpen.widgetId, isMultiSelect);
-        focusWidget(parentWidgetToOpen.widgetId);
-        showPropertyPane(parentWidgetToOpen.widgetId, undefined, true);
-      } else {
-        selectWidget(focusedWidgetId, isMultiSelect);
-        focusWidget(focusedWidgetId);
-        showPropertyPane(focusedWidgetId, undefined, true);
+      const isMultiSelect = e.metaKey || e.ctrlKey;
+      selectWidgetFn(isMultiSelect);
+      if (isDoubleClick) {
+        openPropertyPaneOnDoubleClickFn();
       }
-
       if (isMultiSelect) {
         e.stopPropagation();
       }
     }
   };
-  return openPropertyPane;
+  const initSelectWidgetOnDoubleClick = useCallback(
+    (e) => initSelectWidgetOnClick(e, true),
+    [widgetId, initSelectWidgetOnClick],
+  );
+  // Positioned Widget is the top enclosure for all widgets and clicks on/inside the widget should not be propogated/bubbled out of this Container.
+  const doubleClickRef = useRef<HTMLDivElement | null>(null);
+  useClick(
+    doubleClickRef,
+    initSelectWidgetOnClick,
+    initSelectWidgetOnDoubleClick,
+    true,
+  );
+  return doubleClickRef;
 };


### PR DESCRIPTION
> Pull Request Template
>
> Use this template to quickly create a well written pull request. Delete all quotes before creating the pull request.

## Description

Open property pane only via the widget toggle(widget name) and double-clicking on the widget instead of opening it up on clicking on the widget/ resizing/ dragging.

Fixes #5424 

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/prop-pane-double-click 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.92 **(0.02)** | 36.03 **(0.03)** | 32.6 **(0)** | 54.5 **(0.03)**
 :green_circle: | app/client/src/components/editorComponents/DraggableComponent.tsx | 85.71 **(2.66)** | 68.57 **(7.03)** | 73.33 **(0)** | 86 **(2.98)**
 :red_circle: | app/client/src/components/editorComponents/DropTargetComponent.tsx | 63.64 **(-0.65)** | 39.73 **(0)** | 50 **(0)** | 59.09 **(-0.68)**
 :green_circle: | app/client/src/components/editorComponents/ResizableComponent.tsx | 59.55 **(0.21)** | 23.73 **(0.78)** | 63.64 **(0)** | 58.62 **(0.19)**
 :red_circle: | app/client/src/selectors/propertyPaneSelectors.tsx | 92.31 **(-3.84)** | 94.12 **(0)** | 83.33 **(-16.67)** | 92 **(-4)**
 :green_circle: | app/client/src/utils/hooks/useClick.tsx | 95 **(15)** | 78.57 **(14.28)** | 100 **(0)** | 95 **(15)**
 :sparkles: :new: | **app/client/src/utils/hooks/useDoubleClickOpenPropPane.tsx** | **86.36** | **48.94** | **100** | **85.48**
 :x: | ~~app/client/src/utils/hooks/useClickOpenPropPane.tsx~~ | ~~81.13~~ | ~~52.63~~ | ~~100~~ | ~~80~~</details>