### PR TITLE
Fix: App crash on list widget after copy/paste

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -1483,6 +1483,7 @@ function* pasteWidgetSaga() {
     parentId: string;
     list: WidgetProps[];
   }[] = yield getCopiedWidgets();
+
   if (!Array.isArray(copiedWidgetGroups)) {
     return;
     // to avoid invoking old copied widgets
@@ -1492,12 +1493,16 @@ function* pasteWidgetSaga() {
     getSelectedWidget,
   );
 
+  selectedWidget = yield checkIfPastingIntoListWidget(
+    selectedWidget,
+    copiedWidgetGroups,
+  );
+
   const pastingIntoWidgetId: string = yield getParentWidgetIdForPasting(
     { ...stateWidgets },
     selectedWidget,
   );
 
-  selectedWidget = yield checkIfPastingIntoListWidget(selectedWidget);
   let widgets = { ...stateWidgets };
   const newlyCreatedWidgetIds: string[] = [];
   const sortedWidgetList = copiedWidgetGroups.sort(

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -1301,7 +1301,11 @@ const unsetPropertyPath = (obj: Record<string, unknown>, path: string) => {
 
 function* resetChildrenMetaSaga(action: ReduxAction<{ widgetId: string }>) {
   const parentWidgetId = action.payload.widgetId;
-  const childrenIds: string[] = yield call(getWidgetChildren, parentWidgetId);
+  const canvasWidgets: CanvasWidgetsReduxState = yield select(getWidgets);
+  const childrenIds: string[] = getWidgetChildren(
+    canvasWidgets,
+    parentWidgetId,
+  );
   for (const childIndex in childrenIds) {
     const childId = childrenIds[childIndex];
     yield put(resetWidgetMetaProperty(childId));
@@ -1494,6 +1498,7 @@ function* pasteWidgetSaga() {
   );
 
   selectedWidget = yield checkIfPastingIntoListWidget(
+    stateWidgets,
     selectedWidget,
     copiedWidgetGroups,
   );

--- a/app/client/src/sagas/WidgetOperationUtils.test.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.test.ts
@@ -3,6 +3,7 @@ import {
   handleIfParentIsListWidgetWhilePasting,
   handleSpecificCasesWhilePasting,
   doesTriggerPathsContainPropertyPath,
+  checkIfPastingIntoListWidget,
 } from "./WidgetOperationUtils";
 
 describe("WidgetOperationSaga", () => {
@@ -383,5 +384,76 @@ describe("WidgetOperationSaga", () => {
     expect(result["twnxjwy3r1"].onClick).toStrictEqual(
       "{{closeModal('Modal1Copy')}}",
     );
+  });
+
+  it("should returns widgets after executing checkIfPastingIntoListWidget", async () => {
+    const result = checkIfPastingIntoListWidget(
+      {
+        list2: {
+          widgetId: "list2",
+          type: "LIST_WIDGET",
+          widgetName: "List2",
+          parentId: "0",
+          renderMode: "CANVAS",
+          parentColumnSpace: 2,
+          parentRowSpace: 3,
+          leftColumn: 2,
+          rightColumn: 3,
+          topRow: 1,
+          bottomRow: 3,
+          isLoading: false,
+          listData: [],
+          version: 16,
+          disablePropertyPane: false,
+          template: {},
+        },
+      },
+      {
+        widgetId: "list2",
+        type: "LIST_WIDGET",
+        widgetName: "List2",
+        parentId: "0",
+        renderMode: "CANVAS",
+        parentColumnSpace: 2,
+        parentRowSpace: 3,
+        leftColumn: 2,
+        rightColumn: 3,
+        topRow: 1,
+        bottomRow: 3,
+        isLoading: false,
+        listData: [],
+        version: 16,
+        disablePropertyPane: false,
+        template: {},
+      },
+      [
+        {
+          widgetId: "list2",
+          parentId: "0",
+          list: [
+            {
+              widgetId: "list2",
+              type: "LIST_WIDGET",
+              widgetName: "List2",
+              parentId: "0",
+              renderMode: "CANVAS",
+              parentColumnSpace: 2,
+              parentRowSpace: 3,
+              leftColumn: 2,
+              rightColumn: 3,
+              topRow: 1,
+              bottomRow: 3,
+              isLoading: false,
+              listData: [],
+              version: 16,
+              disablePropertyPane: false,
+              template: {},
+            },
+          ],
+        },
+      ],
+    );
+
+    expect(result?.type).toStrictEqual("LIST_WIDGET");
   });
 });

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -303,8 +303,6 @@ export const checkIfPastingIntoListWidget = function*(
 ) {
   const stateWidgets: CanvasWidgetsReduxState = yield select(getWidgets);
 
-  console.log({ selectedWidget });
-
   // when list widget is selected, if the user is pasting, we want it to be pasted in the template
   // which is first children of list widget
   if (


### PR DESCRIPTION
Fixes the crashing of the list widget when the list widget is pasted into list widget.

Fixes #5591

## Type of change
- Bug fix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/list-widget-in-list-widget-when-pasting 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.15 **(-0.01)** | 36.12 **(0)** | 32.85 **(0)** | 54.64 **(-0.02)**
 :red_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 43.87 **(-0.06)** | 30.28 **(0)** | 50.59 **(0)** | 44.22 **(-0.08)**
 :red_circle: | app/client/src/sagas/WidgetOperationUtils.ts | 52.99 **(-1.88)** | 32.58 **(-0.75)** | 69.23 **(0)** | 52.34 **(-3.11)**</details>