### PR TITLE
Fix-Column definition get truncated when copying a table widget

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Copy_Paste_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Copy_Paste_spec.js
@@ -32,6 +32,11 @@ describe("Test Suite to validate copy/paste table Widget", function() {
       200,
     );
     cy.get(commonlocators.toastAction).should("be.visible");
+
+    //Check after copying new table widget should not have any warnings
+    cy.get('.t--widget-propertypane-toggle [name="warning"]').should(
+      "not.exist",
+    );
     /*
     cy.get(commonlocators.toastAction)
       .contains("UNDO")

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -1571,7 +1571,16 @@ function* pasteWidgetSaga() {
           for (let i = 0; i < newWidgetList.length; i++) {
             const widget = newWidgetList[i];
             const oldWidgetName = widget.widgetName;
-
+            // Generate a new unique widget name
+            const newWidgetName = getNextWidgetName(
+              widgets,
+              widget.type,
+              evalTree,
+              {
+                prefix: oldWidgetName,
+                startWithoutIndex: true,
+              },
+            );
             // Update the children widgetIds if it has children
             if (widget.children && widget.children.length > 0) {
               widget.children.forEach(
@@ -1602,12 +1611,6 @@ function* pasteWidgetSaga() {
             // Update the table widget column properties
             if (widget.type === WidgetTypes.TABLE_WIDGET) {
               try {
-                const oldWidgetName = widget.widgetName;
-                const newWidgetName = getNextWidgetName(
-                  widgets,
-                  widget.type,
-                  evalTree,
-                );
                 // If the primaryColumns of the table exist
                 if (widget.primaryColumns) {
                   // For each column
@@ -1699,16 +1702,7 @@ function* pasteWidgetSaga() {
               )?.widgetId;
               if (newParentId) widget.parentId = newParentId;
             }
-            // Generate a new unique widget name
-            widget.widgetName = getNextWidgetName(
-              widgets,
-              widget.type,
-              evalTree,
-              {
-                prefix: oldWidgetName,
-                startWithoutIndex: true,
-              },
-            );
+            widget.widgetName = newWidgetName;
             widgetNameMap[oldWidgetName] = widget.widgetName;
             // Add the new widget to the canvas widgets
             widgets[widget.widgetId] = widget;


### PR DESCRIPTION
## Description
Fix column definition get truncated when copying a table widget

Fixes #5279 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Updated cypress test to validate no new errors exists on new table

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/copy-table-column-computation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.17 **(0.01)** | 36.12 **(0)** | 32.85 **(0)** | 54.66 **(0)**
 :green_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 44.14 **(0.21)** | 30.28 **(0)** | 50.59 **(0)** | 44.54 **(0.24)**</details>