### PR TITLE
Increased maximum image size to be uploaded as profile picture

### DIFF
--- a/app/client/src/components/ads/DisplayImageUpload.tsx
+++ b/app/client/src/components/ads/DisplayImageUpload.tsx
@@ -191,6 +191,7 @@ export default function DisplayImageUpload({
       >
         <Dashboard
           id="uppy-img-upload-dashboard"
+          note="File size must not exceed 3 MB"
           plugins={["ImageEditor"]}
           uppy={uppy}
         />

--- a/app/client/src/components/ads/DisplayImageUpload.tsx
+++ b/app/client/src/components/ads/DisplayImageUpload.tsx
@@ -82,7 +82,7 @@ export default function DisplayImageUpload({
       allowMultipleUploads: false,
       restrictions: {
         maxNumberOfFiles: 1,
-        maxFileSize: 250000,
+        maxFileSize: 3145728, // 3 MB
         allowedFileTypes: [".jpg", ".jpeg", ".png"],
       },
       infoTimeout: 5000,
@@ -102,12 +102,14 @@ export default function DisplayImageUpload({
 
     uppy.use(ImageEditor, {
       id: "ImageEditor",
-      quality: 0.8,
+      quality: 0.3,
       cropperOptions: {
         viewMode: 1,
+        aspectRatio: 1,
         background: false,
-        autoCropArea: 1,
         responsive: true,
+        autoCropArea: 0.8,
+        autoCrop: true,
       },
       actions: {
         revert: false,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
@@ -42,7 +42,7 @@ public class UserDataServiceImpl extends BaseService<UserDataRepository, UserDat
 
     private final ReleaseNotesService releaseNotesService;
 
-    private static final int MAX_PROFILE_PHOTO_SIZE_KB = 250;
+    private static final int MAX_PROFILE_PHOTO_SIZE_KB = 1024;
 
     @Autowired
     public UserDataServiceImpl(Scheduler scheduler,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/UserRepositoryTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/UserRepositoryTest.java
@@ -2,13 +2,11 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.domains.User;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceUnitTest.java
@@ -15,14 +15,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.test.StepVerifier;
@@ -93,13 +88,5 @@ public class OrganizationServiceUnitTest {
                 .create(organizationMembers)
                 .expectErrorMessage(AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.ORGANIZATION, sampleOrgId))
                 .verify();
-    }
-
-    @Test
-    public void hello() {
-        Flux<DataBuffer> dataBufferFlux = DataBufferUtils
-                .read(new ClassPathResource("test_assets/OrganizationServiceTest/my_organization_logo.png"), new DefaultDataBufferFactory(), 4096)
-                .repeat()  // So the file size looks like it's much larger than what it actually is.
-                ;
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceUnitTest.java
@@ -15,9 +15,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.test.StepVerifier;
@@ -88,5 +93,13 @@ public class OrganizationServiceUnitTest {
                 .create(organizationMembers)
                 .expectErrorMessage(AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.ORGANIZATION, sampleOrgId))
                 .verify();
+    }
+
+    @Test
+    public void hello() {
+        Flux<DataBuffer> dataBufferFlux = DataBufferUtils
+                .read(new ClassPathResource("test_assets/OrganizationServiceTest/my_organization_logo.png"), new DefaultDataBufferFactory(), 4096)
+                .repeat()  // So the file size looks like it's much larger than what it actually is.
+                ;
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
@@ -155,8 +155,8 @@ public class UserDataServiceTest {
     public void testUploadProfilePhoto_invalidImageSize() {
         FilePart filepart = Mockito.mock(FilePart.class, Mockito.RETURNS_DEEP_STUBS);
         Flux<DataBuffer> dataBufferFlux = DataBufferUtils
-                .read(new ClassPathResource("test_assets/OrganizationServiceTest/my_organization_logo.png"), new DefaultDataBufferFactory(), 4096)
-                .repeat(70)  // So the file size looks like it's much larger than what it actually is.
+                .read(new ClassPathResource("test_assets/OrganizationServiceTest/my_organization_logo_large.png"), new DefaultDataBufferFactory(), 4096)
+                .repeat(100)  // So the file size looks like it's much larger than what it actually is.
                 .cache();
 
         Mockito.when(filepart.content()).thenReturn(dataBufferFlux);


### PR DESCRIPTION
## Description
We have a limit on the image size that can be uploaded as profile picture. The maximum allowed size is 244KB. This PR increases the allowed image size to 3MB in frontend and 1MB in backend.  

Fixes #5041 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>