### PR TITLE
Fix: Value of API's data is different in widgets and entity explorer. Showing curly brackets when empty data is received

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
@@ -10,6 +10,7 @@ import PerformanceTracker, {
 } from "utils/PerformanceTracker";
 import * as Sentry from "@sentry/react";
 import { AppState } from "reducers";
+import _ from "lodash";
 
 export const EntityProperties = memo(
   (props: {
@@ -62,8 +63,14 @@ export const EntityProperties = memo(
                 actionProperty = actionProperty + "()";
               }
               if (actionProperty === "data") {
-                value =
-                  entity.data?.body === undefined ? "{}" : entity.data?.body;
+                if (
+                  _.isEmpty(entity.data) ||
+                  !entity.data.hasOwnProperty("body")
+                ) {
+                  value = "{}";
+                } else {
+                  value = entity.data.body;
+                }
               }
               return {
                 propertyName: actionProperty,

--- a/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
@@ -62,7 +62,8 @@ export const EntityProperties = memo(
                 actionProperty = actionProperty + "()";
               }
               if (actionProperty === "data") {
-                value = entity.data?.body;
+                value =
+                  entity.data?.body === undefined ? "{}" : entity.data?.body;
               }
               return {
                 propertyName: actionProperty,


### PR DESCRIPTION
## Description

Value of API's data was different in widgets and entity explorer. 

1. Create an API Api1
2. Drop a text widget and bind text to the API data.
3. Now disable the on-page loading of Api1
4. Reload the page.
5. See entity explorer value of Api1 and the value widget is getting. Both are different

When the API is run, the data is properly loaded and the same in both locations. The issue was only when the data was empty or the API was not yet run. For this case, I added a test to check if the data is undefined and set the value as `"{}"`. This way, the data shown at both the places is the same.

Fixes #4665  

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/4991-data-difference-bw-widget-and-entity-explorer 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx | 23.64 **(0.56)** | 0 **(0)** | 0 **(0)** | 24.07 **(0.54)**</details>