### PR TITLE
[Bug] Slash command in query pane

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/commandsHelper.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/commandsHelper.ts
@@ -19,10 +19,12 @@ export const commandsHelper: HintHelper = (editor, data: any) => {
       {
         datasources,
         executeCommand,
+        mutedHinting,
         pluginIdToImageLocation,
         recentEntities,
         updatePropertyValue,
       }: {
+        mutedHinting?: boolean;
         datasources: Datasource[];
         executeCommand: (payload: { actionType: string; args?: any }) => void;
         pluginIdToImageLocation: Record<string, string>;
@@ -43,7 +45,7 @@ export const commandsHelper: HintHelper = (editor, data: any) => {
       const cursorBetweenBinding = checkIfCursorInsideBinding(editor);
       const value = editor.getValue();
       const slashIndex = value.lastIndexOf("/");
-      const shouldShowBinding = !value || slashIndex > -1;
+      const shouldShowBinding = (!value && !mutedHinting) || slashIndex > -1;
       if (!cursorBetweenBinding && shouldShowBinding) {
         const searchText = value.substring(slashIndex + 1);
         const list = generateQuickCommands(

--- a/app/client/src/components/editorComponents/CodeEditor/generateQuickCommands.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/generateQuickCommands.tsx
@@ -103,7 +103,6 @@ export const generateQuickCommands = (
     [],
     3,
   );
-  console.log({ currentEntityType });
   if (currentEntityType === "WIDGET") {
     createNewCommandsMatchingSearchText.push(
       ...matchingCommands([newDatasource], searchText, []),

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -359,7 +359,7 @@ class CodeEditor extends Component<Props, State> {
     this.updateMarkings();
   };
 
-  handleAutocompleteVisibility = (cm: CodeMirror.Editor) => {
+  handleAutocompleteVisibility = (cm: CodeMirror.Editor, force?: boolean) => {
     const expected = this.props.expected ? this.props.expected : "";
     const { entityName } = getEntityNameAndPropertyPath(
       this.props.dataTreePath || "",
@@ -367,7 +367,7 @@ class CodeEditor extends Component<Props, State> {
     let hinterOpen = false;
     for (let i = 0; i < this.hinters.length; i++) {
       hinterOpen = this.hinters[i].showHint(cm, expected, entityName, {
-        mutedHinting: this.props.mutedHinting,
+        mutedHinting: force ? !force : this.props.mutedHinting,
         datasources: this.props.datasources.list,
         pluginIdToImageLocation: this.props.pluginIdToImageLocation,
         updatePropertyValue: this.updatePropertyValue.bind(this),
@@ -418,7 +418,7 @@ class CodeEditor extends Component<Props, State> {
     });
     this.setState({ isFocused: true }, () => {
       if (preventAutoComplete) return;
-      this.handleAutocompleteVisibility(this.editor);
+      this.handleAutocompleteVisibility(this.editor, true);
     });
   }
 

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -92,6 +92,7 @@ export type EditorStyleProps = {
   disabled?: boolean;
   link?: string;
   showLightningMenu?: boolean;
+  mutedHinting?: boolean;
   dataTreePath?: string;
   evaluatedValue?: any;
   expected?: string;
@@ -366,6 +367,7 @@ class CodeEditor extends Component<Props, State> {
     let hinterOpen = false;
     for (let i = 0; i < this.hinters.length; i++) {
       hinterOpen = this.hinters[i].showHint(cm, expected, entityName, {
+        mutedHinting: this.props.mutedHinting,
         datasources: this.props.datasources.list,
         pluginIdToImageLocation: this.props.pluginIdToImageLocation,
         updatePropertyValue: this.updatePropertyValue.bind(this),

--- a/app/client/src/components/editorComponents/form/fields/KeyValueFieldArray.tsx
+++ b/app/client/src/components/editorComponents/form/fields/KeyValueFieldArray.tsx
@@ -169,6 +169,7 @@ function KeyValueRow(props: Props & WrappedFieldArrayProps) {
                         )
                       }
                       expected={FIELD_VALUES.API_ACTION.params}
+                      mutedHinting
                       name={`${field}.value`}
                       placeholder={
                         props.placeholder

--- a/app/client/src/components/editorComponents/form/fields/KeyValueFieldArray.tsx
+++ b/app/client/src/components/editorComponents/form/fields/KeyValueFieldArray.tsx
@@ -149,6 +149,7 @@ function KeyValueRow(props: Props & WrappedFieldArrayProps) {
                       dataTreePath={`${props.dataTreePath}[${index}].value`}
                       expected={FIELD_VALUES.API_ACTION.params}
                       hoverInteraction
+                      mutedHinting
                       name={`${field}.value`}
                       placeholder={`Value ${index + 1}`}
                       theme={props.theme}

--- a/app/client/src/components/formControls/DynamicTextFieldControl.tsx
+++ b/app/client/src/components/formControls/DynamicTextFieldControl.tsx
@@ -65,9 +65,9 @@ class DynamicTextControl extends BaseControl<
       configProperty,
       evaluationSubstitutionType,
       label,
+      mutedHinting,
       placeholderText,
       responseType,
-      showLightningMenu,
     } = this.props;
     const dataTreePath = actionPathFromName(actionName, configProperty);
     const isNewQuery =
@@ -105,9 +105,9 @@ class DynamicTextControl extends BaseControl<
             dataTreePath={dataTreePath}
             evaluationSubstitutionType={evaluationSubstitutionType}
             mode={mode}
+            mutedHinting={mutedHinting}
             name={this.props.configProperty}
             placeholder={placeholderText}
-            showLightningMenu={showLightningMenu}
             size={EditorSize.EXTENDED}
             tabBehaviour={TabBehaviour.INDENT}
           />
@@ -124,7 +124,7 @@ export interface DynamicTextFieldProps extends ControlProps {
   responseType: string;
   placeholderText?: string;
   evaluationSubstitutionType: EvaluationSubstitutionType;
-  showLightningMenu?: boolean;
+  mutedHinting?: boolean;
 }
 
 const mapStateToProps = (state: AppState, props: DynamicTextFieldProps) => {

--- a/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
+++ b/app/client/src/pages/Editor/APIEditor/PostBodyData.tsx
@@ -72,11 +72,11 @@ function PostBodyData(props: Props) {
                 dataTreePath={`${dataTreePath}.body`}
                 expected={FIELD_VALUES.API_ACTION.body}
                 mode={EditorModes.JSON_WITH_BINDING}
+                mutedHinting
                 name="actionConfiguration.body"
                 placeholder={
                   '{\n  "name":"{{ inputName.property }}",\n  "preference":"{{ dropdownName.property }}"\n}\n\n\\\\Take widget inputs using {{ }}'
                 }
-                showLightningMenu={false}
                 showLineNumbers
                 size={EditorSize.EXTENDED}
                 tabBehaviour={TabBehaviour.INDENT}

--- a/app/client/src/pages/Editor/APIEditor/RapidApiEditorForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/RapidApiEditorForm.tsx
@@ -183,16 +183,16 @@ function RapidApiEditorForm(props: Props) {
           <DynamicTextField
             disabled
             leftImage={providerImage}
+            mutedHinting
             name="provider.name"
             placeholder="Provider name"
-            showLightningMenu={false}
           />
           <DynamicTextField
             disabled
             leftIcon={FormIcons.SLASH_ICON}
+            mutedHinting
             name="actionConfiguration.path"
             placeholder="v1/method"
-            showLightningMenu={false}
           />
         </FormRow>
         {/* Display How to get Credentials info if it is present */}

--- a/app/client/src/utils/FormControlRegistry.tsx
+++ b/app/client/src/utils/FormControlRegistry.tsx
@@ -76,9 +76,7 @@ class FormControlRegistry {
     });
     FormControlFactory.registerControlBuilder("QUERY_DYNAMIC_TEXT", {
       buildPropertyControl(controlProps: DynamicTextFieldProps): JSX.Element {
-        return (
-          <DynamicTextControl {...controlProps} showLightningMenu={false} />
-        );
+        return <DynamicTextControl {...controlProps} mutedHinting />;
       },
     });
     FormControlFactory.registerControlBuilder("QUERY_DYNAMIC_INPUT_TEXT", {


### PR DESCRIPTION
## Description
Reactivated the slash command in query/api pane. The suggestion box would only show up if user manually enters `/` or clicks on `/` button.

Fixes #5664

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: bug/slash-command-in-query-pane 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/commandsHelper.ts | 42.11 **(1.04)** | 40 **(-1.67)** | 22.22 **(0)** | 44.23 **(1.09)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/generateQuickCommands.tsx | 17.24 **(0.29)** | 0 **(0)** | 0 **(0)** | 15.79 **(0.27)**
 :red_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 72.96 **(0)** | 54.96 **(-0.08)** | 52.78 **(0)** | 73.64 **(0)**</details>