### PR TITLE
Feature: return hint message to user if the expected content type is json but the api response is not a valid json.

### DIFF
--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -83,6 +83,7 @@ export interface ActionResponse {
   duration: string;
   size: string;
   isExecutionSuccess?: boolean;
+  messages?: Array<string>;
 }
 
 export interface MoveActionRequest {

--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -151,6 +151,11 @@ const InlineButton = styled(Button)`
   margin: 0 4px;
 `;
 
+const HelpSection = styled.div`
+  margin-bottom: 5px;
+  margin-top: 10px;
+`;
+
 interface ReduxStateProps {
   responses: Record<string, ActionResponse | undefined>;
   isRunning: Record<string, boolean>;
@@ -207,12 +212,20 @@ function ApiResponseView(props: Props) {
   }, []);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const messages = response?.messages;
   const tabs = [
     {
       key: "body",
       title: "Response Body",
       panelComponent: (
         <ResponseTabWrapper>
+          {messages && (
+            <HelpSection>
+              {messages.map((msg, i) => (
+                <Callout fill key={i} text={msg} variant={Variant.warning} />
+              ))}
+            </HelpSection>
+          )}
           {hasFailed && !isRunning && (
             <StyledCallout
               fill

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -199,6 +199,9 @@ public class RestApiPlugin extends BasePlugin {
             errorResult.setIsExecutionSuccess(false);
             errorResult.setTitle(AppsmithPluginError.PLUGIN_ERROR.getTitle());
 
+            // Set of hint messages that can be returned to the user.
+            Set<String> hintMessages = new HashSet();
+
             // Initializing request URL
             String path = (actionConfiguration.getPath() == null) ? "" : actionConfiguration.getPath();
             String url = datasourceConfiguration.getUrl() + path;
@@ -361,6 +364,13 @@ public class RestApiPlugin extends BasePlugin {
                                     System.out.println("Unable to parse response JSON. Setting response body as string.");
                                     String bodyString = new String(body);
                                     result.setBody(bodyString.trim());
+
+                                    // Warn user that the API response is not a valid JSON.
+                                    hintMessages.add("The response returned by this API is not a valid JSON. Please " +
+                                            "be careful when using the API response anywhere a valid JSON is required" +
+                                            ". You may resolve this issue either by modifying the MIME type to " +
+                                            "indicate a non-JSON response or by modifying the API response to return " +
+                                            "a valid JSON.");
                                 }
                             } else if (MediaType.IMAGE_GIF.equals(contentType) ||
                                     MediaType.IMAGE_JPEG.equals(contentType) ||
@@ -374,6 +384,7 @@ public class RestApiPlugin extends BasePlugin {
                             }
                         }
 
+                        result.setMessages(hintMessages);
                         return result;
                     })
                     .onErrorResume(error -> {

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -368,9 +368,9 @@ public class RestApiPlugin extends BasePlugin {
                                     // Warn user that the API response is not a valid JSON.
                                     hintMessages.add("The response returned by this API is not a valid JSON. Please " +
                                             "be careful when using the API response anywhere a valid JSON is required" +
-                                            ". You may resolve this issue either by modifying the MIME type to " +
-                                            "indicate a non-JSON response or by modifying the API response to return " +
-                                            "a valid JSON.");
+                                            ". You may resolve this issue either by modifying the 'Content-Type' " +
+                                            "Header to indicate a non-JSON response or by modifying the API response " +
+                                            "to return a valid JSON.");
                                 }
                             } else if (MediaType.IMAGE_GIF.equals(contentType) ||
                                     MediaType.IMAGE_JPEG.equals(contentType) ||

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -424,6 +424,14 @@ public class RestApiPluginTest {
                     assertEquals("invalid json text", result.getBody());
                     ArrayNode data = (ArrayNode) result.getHeaders().get("Content-Type");
                     assertEquals("application/json; charset=utf-8", data.get(0).asText());
+
+                    assertEquals(1, result.getMessages().size());
+                    String expectedMessage = "The response returned by this API is not a valid JSON. Please " +
+                            "be careful when using the API response anywhere a valid JSON is required" +
+                            ". You may resolve this issue either by modifying the MIME type to " +
+                            "indicate a non-JSON response or by modifying the API response to return " +
+                            "a valid JSON.";
+                    assertEquals(expectedMessage, result.getMessages().toArray()[0]);
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -428,9 +428,9 @@ public class RestApiPluginTest {
                     assertEquals(1, result.getMessages().size());
                     String expectedMessage = "The response returned by this API is not a valid JSON. Please " +
                             "be careful when using the API response anywhere a valid JSON is required" +
-                            ". You may resolve this issue either by modifying the MIME type to " +
-                            "indicate a non-JSON response or by modifying the API response to return " +
-                            "a valid JSON.";
+                            ". You may resolve this issue either by modifying the 'Content-Type' " +
+                            "Header to indicate a non-JSON response or by modifying the API response " +
+                            "to return a valid JSON.";
                     assertEquals(expectedMessage, result.getMessages().toArray()[0]);
                 })
                 .verifyComplete();


### PR DESCRIPTION
## Description
- return hint message to user if the expected content type is json but the api response is not a valid json.

![Screenshot 2021-07-09 at 7 42 47 PM](https://user-images.githubusercontent.com/1757421/125092231-c19c0d00-e0ee-11eb-8947-cd891555ad1d.png)


Fixes #5667 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- JUnit TC
- Via curl cmd: 
```
curl --request POST 'https://mock-api.appsmith.com/echo/raw' \
--header 'Content-Type: application/json' \
--data-raw '{
    "headers": {
        "Content-Type": "application/json"
    },
    "body": "raw text"
}'
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feature/add_json_warning_msg 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/editorComponents/ApiResponseView.tsx | 53.33 **(-0.84)** | 36.11 **(-1.39)** | 0 **(0)** | 54.79 **(-0.92)**</details>