### PR TITLE
[Fix] on google sheet deletion success, redirecting user to active datasources

### DIFF
--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -42,6 +42,7 @@ import { Action, PluginType } from "entities/Action";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import Connected from "../DataSourceEditor/Connected";
 import { Colors } from "constants/Colors";
+import { redirectToNewIntegrations } from "../../../actions/apiPaneActions";
 
 interface StateProps extends JSONtoFormProps {
   isSaving: boolean;
@@ -59,6 +60,7 @@ interface DispatchFunctions {
   deleteDatasource: (id: string, onSuccess?: ReduxAction<unknown>) => void;
   getOAuthAccessToken: (id: string) => void;
   createAction: (data: Partial<Action>) => void;
+  redirectToNewIntegrations: (applicationId: string, pageId: string) => void;
 }
 
 type DatasourceSaaSEditorProps = StateProps &
@@ -228,7 +230,15 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
                 accent="error"
                 className="t--delete-datasource"
                 loading={isDeleting}
-                onClick={() => deleteDatasource(datasourceId)}
+                onClick={() =>
+                  deleteDatasource(
+                    datasourceId,
+                    this.props.redirectToNewIntegrations(
+                      applicationId,
+                      pageId,
+                    ) as any,
+                  )
+                }
                 text="Delete"
               />
               <StyledButton
@@ -303,6 +313,9 @@ const mapDispatchToProps = (dispatch: any): DispatchFunctions => {
       dispatch(getOAuthAccessToken(datasourceId)),
     createAction: (data: Partial<Action>) => {
       dispatch(createActionRequest(data));
+    },
+    redirectToNewIntegrations: (applicationId: string, pageId: string) => {
+      dispatch(redirectToNewIntegrations(applicationId, pageId));
     },
   };
 };


### PR DESCRIPTION
## Description
On successful deletion of google sheet data source, user will be redirected to active datasources.

Fixes #5747

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: bug/google-sheet-deletion 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.83 **(0)** | 35.8 **(0)** | 32.43 **(-0.01)** | 54.41 **(0)**
 :green_circle: | app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx | 34.65 **(0.31)** | 17.14 **(0)** | 5.88 **(-0.37)** | 36.56 **(0.3)**</details>