### PR TITLE
Redirecting to view mode of datasource after authorization

### DIFF
--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -19,7 +19,6 @@ import {
   redirectAuthorizationCode,
   updateDatasource,
 } from "actions/datasourceActions";
-import { createNewQueryName } from "utils/AppsmithUtils";
 import { createActionRequest } from "actions/actionActions";
 import { ActionDataState } from "reducers/entityReducers/actionsReducer";
 import {
@@ -92,18 +91,6 @@ const EditDatasourceButton = styled(AdsButton)`
   }
 `;
 
-const NewQueryBtn = styled(AdsButton)`
-  padding: 10px 20px;
-  &&&& {
-    height: 36px;
-    //max-width: 120px;
-    width: auto;
-  }
-  span > svg > path {
-    stroke: white;
-  }
-`;
-
 class DatasourceSaaSEditor extends JSONtoForm<Props> {
   componentDidMount() {
     super.componentDidMount();
@@ -142,33 +129,6 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
     return this.renderForm(content);
   }
 
-  createQueryAction = () => {
-    const {
-      actions,
-      datasource,
-      match: {
-        params: { pageId },
-      },
-    } = this.props;
-    const newQueryName = createNewQueryName(actions, pageId || "");
-
-    const payload = {
-      name: newQueryName,
-      pageId: pageId,
-      pluginId: datasource?.pluginId,
-      datasource: {
-        id: datasource?.id,
-      },
-      actionConfiguration: {},
-      eventData: {
-        actionType: "Query",
-        from: "datasource-pane",
-      },
-    } as Partial<Action>;
-
-    this.props.createAction(payload);
-  };
-
   renderDataSourceConfigForm = (sections: any) => {
     const {
       deleteDatasource,
@@ -192,7 +152,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
             <PluginImage alt="Datasource" src={this.props.pluginImage} />
             <FormTitle focusOnMount={this.props.isNewDatasource} />
           </FormTitleContainer>
-          {viewMode ? (
+          {viewMode && (
             <EditDatasourceButton
               category={Category.tertiary}
               className="t--edit-datasource"
@@ -210,13 +170,6 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
                 );
               }}
               text="EDIT"
-            />
-          ) : (
-            <NewQueryBtn
-              className="t--create-query"
-              icon="plus"
-              onClick={this.createQueryAction}
-              text={"New Query"}
             />
           )}
         </Header>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationService.java
@@ -276,11 +276,13 @@ public class AuthenticationService {
                         "edit" + Entity.SLASH +
                         Entity.DATASOURCES + Entity.SLASH +
                         datasourceId +
-                        "?response_status=" + responseStatus)
+                        "?response_status=" + responseStatus +
+                        "&view_mode=true")
                 .onErrorResume(e -> Mono.just(
                         redirectOrigin + Entity.SLASH +
                                 Entity.APPLICATIONS +
-                                "?response_status=" + responseStatus));
+                                "?response_status=" + responseStatus +
+                                "&view_mode=true"));
     }
 
     public Mono<String> getAppsmithToken(String datasourceId, String pageId, ServerHttpRequest request) {


### PR DESCRIPTION
## Description
1. Changing the redirection URL to redirect user to view mode, on google sheet datasource successful connection.
2. Remove the `New Query` btn from G Sheet datasource edit mode

Fixes #5759 

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/view-mode-true 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.84 **(0.01)** | 35.81 **(0.01)** | 32.44 **(0.01)** | 54.42 **(0.01)**
 :green_circle: | app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx | 36.26 **(1.61)** | 17.39 **(0.25)** | 6.25 **(0.37)** | 38.55 **(1.99)**</details>