### PR TITLE
Dont enable comment mode if deactivated

### DIFF
--- a/app/client/src/comments/tests/Comments.test.tsx
+++ b/app/client/src/comments/tests/Comments.test.tsx
@@ -4,7 +4,10 @@ import { unmountComponentAtNode } from "react-dom";
 import OverlayCommentsWrapper from "../inlineComments/OverlayCommentsWrapper";
 import store from "store";
 import { createEvent, fireEvent, render, waitFor } from "test/testUtils";
-import { fetchApplicationCommentsRequest } from "actions/commentActions";
+import {
+  fetchApplicationCommentsRequest,
+  setAreCommentsEnabled,
+} from "actions/commentActions";
 import { ReduxActionTypes } from "constants/ReduxActionConstants";
 import { setCommentMode } from "actions/commentActions";
 import { resetEditorSuccess } from "actions/initActions";
@@ -25,6 +28,7 @@ describe("Comment threads", () => {
     document.body.appendChild(container);
     // application id is required
     setMockPages();
+    store.dispatch(setAreCommentsEnabled(true));
     store.dispatch(setCommentMode(true));
     // dispatch fetch comments and mock the axios req
     store.dispatch(fetchApplicationCommentsRequest());

--- a/app/client/src/reducers/uiReducers/commentsReducer/commentsReducer.ts
+++ b/app/client/src/reducers/uiReducers/commentsReducer/commentsReducer.ts
@@ -72,7 +72,7 @@ const commentsReducer = createReducer(initialState, {
     action: ReduxAction<boolean>,
   ) => ({
     ...state,
-    isCommentMode: action.payload,
+    isCommentMode: action.payload && state.areCommentsEnabled,
     isIntroCarouselVisible: false,
   }),
   [ReduxActionTypes.CREATE_COMMENT_THREAD_REQUEST]: (


### PR DESCRIPTION

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: check-comments-enabled-for-hotkeys 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.86 **(0.03)** | 35.81 **(0.01)** | 32.49 **(0.05)** | 54.44 **(0.02)**
 :green_circle: | app/client/src/actions/commentActions.ts | 80.33 **(0.82)** | 100 **(0)** | 46.15 **(2.56)** | 77.42 **(0)**
 :green_circle: | app/client/src/reducers/uiReducers/commentsReducer/commentsReducer.ts | 45.95 **(1.36)** | 35.71 **(10.71)** | 55.56 **(3.71)** | 52.31 **(1.54)**
 :green_circle: | app/client/src/sagas/WebsocketSagas/WebsocketSagas.ts | 29.69 **(10.94)** | 15.79 **(5.26)** | 26.67 **(13.34)** | 33.33 **(11.11)**</details>