### PR TITLE
Add UTF-8 encoding in the RestApiPlugin for all invocations

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -355,11 +355,11 @@ public class RestApiPlugin extends BasePlugin {
                             if (MediaType.APPLICATION_JSON.equals(contentType) ||
                                     MediaType.APPLICATION_JSON_UTF8.equals(contentType)) {
                                 try {
-                                    String jsonBody = new String(body);
+                                    String jsonBody = new String(body, StandardCharsets.UTF_8);
                                     result.setBody(objectMapper.readTree(jsonBody));
                                 } catch (IOException e) {
                                     System.out.println("Unable to parse response JSON. Setting response body as string.");
-                                    String bodyString = new String(body);
+                                    String bodyString = new String(body, StandardCharsets.UTF_8);
                                     result.setBody(bodyString.trim());
                                 }
                             } else if (MediaType.IMAGE_GIF.equals(contentType) ||
@@ -369,7 +369,7 @@ public class RestApiPlugin extends BasePlugin {
                                 result.setBody(encode);
                             } else {
                                 // If the body is not of JSON type, just set it as is.
-                                String bodyString = new String(body);
+                                String bodyString = new String(body, StandardCharsets.UTF_8);
                                 result.setBody(bodyString.trim());
                             }
                         }


### PR DESCRIPTION
## Description
RestApiPlugin get httpCall's response body which is a byte array, and then construst jsonBody by new String method,
but the default charset used by String constructor is determined during virtual-machine startup and typically depends upon the locale and charset of the underlying operating system,
if don't specify the charset in String constructor, the jsonBody byte array would not be decoded by UTF-8 when self-host locale charset is not UTF-8.

Fixes #5639

## Type of change

- Bug fix

## How Has This Been Tested?

- Tested in China which windows10's default charset is GBK

