### PR TITLE
Updating the URL object in appsmith global object when the pageid is same as the previous one

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -116,6 +116,7 @@ import AppsmithConsole from "utils/AppsmithConsole";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import LOG_TYPE from "entities/AppsmithConsole/logtype";
 import { matchPath } from "react-router";
+import { setDataUrl } from "./PageSagas";
 
 export enum NavigationTargetType {
   SAME_WINDOW = "SAME_WINDOW",
@@ -155,6 +156,7 @@ function* navigateActionSaga(
     (page: Page) => page.pageName === pageNameOrUrl,
   );
   if (page) {
+    const currentPageId = yield select(getCurrentPageId);
     AnalyticsUtil.logEvent("NAVIGATE", {
       pageName: pageNameOrUrl,
       pageParams: params,
@@ -166,6 +168,9 @@ function* navigateActionSaga(
         : getApplicationViewerPageURL(applicationId, page.pageId, params);
     if (target === NavigationTargetType.SAME_WINDOW) {
       history.push(path);
+      if (currentPageId === page.pageId) {
+        yield call(setDataUrl);
+      }
     } else if (target === NavigationTargetType.NEW_WINDOW) {
       window.open(path, "_blank");
     }


### PR DESCRIPTION
## Description

`navigateTo('page',{})` doesn't clear the appsmith.URL.queryParam variable when being used on the same page. Reported by a user on Intercom.

When a button click triggers the navigateTo option for the same page in the same window with different query params, the `appsmith.URL` store is not getting updated because the `history.push` method didn't trigger any changes. Have added an explicit call to the function to update the URL parameters

Fixes #5544 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/5544-clearing-url-query-params 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.84 **(-0.01)** | 35.8 **(-0.01)** | 32.49 **(0)** | 54.42 **(0)**
 :green_circle: | app/client/src/sagas/ActionExecutionSagas.ts | 12.25 **(0.09)** | 1.28 **(-0.01)** | 7.14 **(0)** | 14.08 **(0.13)**</details>