### PR TITLE
Feature: add support in Redis plugin to select database when creating db connection.

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
@@ -1,0 +1,67 @@
+package com.external.utils;
+
+import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.Endpoint;
+import org.apache.commons.lang.ObjectUtils;
+import org.pf4j.util.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class RedisURIUtils {
+    private static final Long DEFAULT_PORT = 6379L;
+    private static final String REDIS_SCHEME = "redis://";
+
+    public static URI getURI(DatasourceConfiguration datasourceConfiguration) throws URISyntaxException {
+        StringBuilder builder = new StringBuilder();
+        builder.append(REDIS_SCHEME);
+
+        String uriAuth = getUriAuth(datasourceConfiguration);
+        builder.append(uriAuth);
+
+        String uriHostAndPort = getUriHostAndPort(datasourceConfiguration);
+        builder.append(uriHostAndPort);
+
+        String uriDatabase = getUriDatabase(datasourceConfiguration);
+        builder.append(uriDatabase);
+
+        return new URI(builder.toString());
+    }
+
+    private static String getUriDatabase(DatasourceConfiguration datasourceConfiguration) {
+        StringBuilder builder = new StringBuilder();
+        DBAuth auth = (DBAuth) datasourceConfiguration.getAuthentication();
+        if (auth != null && StringUtils.isNotNullOrEmpty(auth.getDatabaseName())) {
+            builder.append("/" + auth.getDatabaseName());
+        }
+
+        return builder.toString();
+    }
+
+    private static String getUriHostAndPort(DatasourceConfiguration datasourceConfiguration) {
+        // Jedis does not have support for backup hosts.
+        Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
+        String host = endpoint.getHost();
+        Integer port = (int) (long) ObjectUtils.defaultIfNull(endpoint.getPort(), DEFAULT_PORT);
+        StringBuilder builder = new StringBuilder();
+        builder.append(host + ":" + port);
+
+        return builder.toString();
+    }
+
+    private static String getUriAuth(DatasourceConfiguration datasourceConfiguration) {
+        StringBuilder builder = new StringBuilder();
+        DBAuth auth = (DBAuth) datasourceConfiguration.getAuthentication();
+        if (auth != null && StringUtils.isNotNullOrEmpty(auth.getPassword())) {
+            if (StringUtils.isNotNullOrEmpty(auth.getUsername())) {
+                // If username is available, then provide username.
+                builder.append(auth.getUsername());
+            }
+
+            builder.append(":" + auth.getPassword() + "@");
+        }
+
+        return builder.toString();
+    }
+}

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/utils/RedisURIUtils.java
@@ -39,6 +39,7 @@ public class RedisURIUtils {
         return builder.toString();
     }
 
+    // Skipping validation checks, since they are taken care of via 'validateDatasource(...)' method.
     private static String getUriHostAndPort(DatasourceConfiguration datasourceConfiguration) {
         // Jedis does not have support for backup hosts.
         Endpoint endpoint = datasourceConfiguration.getEndpoints().get(0);
@@ -50,6 +51,7 @@ public class RedisURIUtils {
         return builder.toString();
     }
 
+    // Skipping validation checks, since they are taken care of via 'validateDatasource(...)' method.
     private static String getUriAuth(DatasourceConfiguration datasourceConfiguration) {
         StringBuilder builder = new StringBuilder();
         DBAuth auth = (DBAuth) datasourceConfiguration.getAuthentication();

--- a/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/resources/form.json
@@ -21,6 +21,13 @@
               "controlType": "KEYVALUE_ARRAY"
             }
           ]
+        },
+        {
+          "label": "Database Number",
+          "configProperty": "datasourceConfiguration.authentication.databaseName",
+          "controlType": "INPUT_TEXT",
+          "dataType": "NUMBER",
+          "placeholderText": "0"
         }
       ]
     },


### PR DESCRIPTION
## Description
- add support in Redis plugin to select database when creating db connection.
- refactor code to use URI string instead of constructor call, because of lack of appropriate constructor.
- add TCs.
- fix validate datasource.

Fixes #5394 

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?
- JUnit TCs.
- Manual.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
