### PR TITLE
Fix/5879 video widget name fix

### DIFF
--- a/app/client/src/widgets/VideoWidget.tsx
+++ b/app/client/src/widgets/VideoWidget.tsx
@@ -107,7 +107,10 @@ class VideoWidget extends BaseWidget<VideoWidgetProps, WidgetState> {
   }
 
   shouldComponentUpdate(nextProps: VideoWidgetProps) {
-    return nextProps.url !== this.props.url;
+    return (
+      nextProps.url !== this.props.url ||
+      nextProps.widgetName !== this.props.widgetName
+    );
   }
 
   getPageView() {

--- a/app/client/src/widgets/VideoWidget.tsx
+++ b/app/client/src/widgets/VideoWidget.tsx
@@ -106,13 +106,6 @@ class VideoWidget extends BaseWidget<VideoWidgetProps, WidgetState> {
     return {};
   }
 
-  shouldComponentUpdate(nextProps: VideoWidgetProps) {
-    return (
-      nextProps.url !== this.props.url ||
-      nextProps.widgetName !== this.props.widgetName
-    );
-  }
-
   getPageView() {
     const { autoPlay, onEnd, onPause, onPlay, url } = this.props;
     return (


### PR DESCRIPTION
## Description

removing `shouldComponentUpdate` from VideoWidget as it causes a lot more issues while handling VideoWidget. There is already a `shouldComponentUpdate` in BaseWidget, so it should re-render only when necessary.

Fixes #5789 
Fixes #5079 
Fixes #5739 
Fixes #5077 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

verifying in UI

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/5879_video_widget_name_fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.75 **(0)** | 35.77 **(0)** | 32.32 **(0.01)** | 54.32 **(0)**
 :green_circle: | app/client/src/widgets/VideoWidget.tsx | 62.79 **(0.57)** | 40 **(0)** | 38.46 **(2.75)** | 74.29 **(1.32)**</details>