### PR TITLE
Ignore comments while preparing executable statement in MySQL plugin

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -15,13 +15,14 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
-import com.appsmith.external.models.PsParameterDTO;
 import com.appsmith.external.models.Property;
+import com.appsmith.external.models.PsParameterDTO;
 import com.appsmith.external.models.RequestParamDTO;
 import com.appsmith.external.models.SSLDetails;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.external.plugins.SmartSubstitutionInterface;
+import com.external.utils.QueryUtils;
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
@@ -223,19 +224,21 @@ public class MySqlPlugin extends BasePlugin {
 
             String query = actionConfiguration.getBody();
 
-            boolean isSelectOrShowQuery = getIsSelectOrShowQuery(query);
+            String finalQuery = QueryUtils.removeQueryComments(query);
+
+            boolean isSelectOrShowQuery = getIsSelectOrShowQuery(finalQuery);
 
             final List<Map<String, Object>> rowsList = new ArrayList<>(50);
             final List<String> columnsList = new ArrayList<>();
             Map<String, Object> psParams = preparedStatement ? new LinkedHashMap<>() : null;
-            String transformedQuery = preparedStatement ? replaceQuestionMarkWithDollarIndex(query) : query;
+            String transformedQuery = preparedStatement ? replaceQuestionMarkWithDollarIndex(finalQuery) : finalQuery;
             List<RequestParamDTO> requestParams = List.of(new RequestParamDTO(ACTION_CONFIGURATION_BODY,
                     transformedQuery, null, null, psParams));
 
             Flux<Result> resultFlux = Mono.from(connection.validate(ValidationDepth.REMOTE))
                     .flatMapMany(isValid -> {
                         if (isValid) {
-                            return createAndExecuteQueryFromConnection(query,
+                            return createAndExecuteQueryFromConnection(finalQuery,
                                     connection,
                                     preparedStatement,
                                     mustacheValuesInOrder,
@@ -266,7 +269,7 @@ public class MySqlPlugin extends BasePlugin {
                         .thenReturn(rowsList);
             } else {
                 resultMono = resultFlux
-                        .flatMap(result -> result.getRowsUpdated())
+                        .flatMap(Result::getRowsUpdated)
                         .collectList()
                         .flatMap(list -> Mono.just(list.get(list.size() - 1)))
                         .map(rowsUpdated -> {
@@ -302,7 +305,7 @@ public class MySqlPlugin extends BasePlugin {
                     // Now set the request in the result to be returned back to the server
                     .map(actionExecutionResult -> {
                         ActionExecutionRequest request = new ActionExecutionRequest();
-                        request.setQuery(query);
+                        request.setQuery(finalQuery);
                         request.setProperties(requestData);
                         request.setRequestParams(requestParams);
                         ActionExecutionResult result = actionExecutionResult;

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/QueryUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/QueryUtils.java
@@ -1,0 +1,48 @@
+package com.external.utils;
+
+public class QueryUtils {
+
+    /**
+     * Parse through the input string to discard all comments from the query string.
+     * This method will retain a substring if it is enclosed by quotes
+     *
+     * @param query
+     * @return
+     */
+    public static String removeQueryComments(String query) {
+        StringBuilder sb = new StringBuilder();
+        final int length = query.length();
+        int commentCharacterCount = 0;
+        boolean inComment = false;
+        boolean inSingleQuotes = false;
+        boolean inDoubleQuotes = false;
+        for (int i = 0; i < length; i++) {
+            char current = query.charAt(i);
+            if ('\'' == current) {
+                inSingleQuotes = !inSingleQuotes;
+            }
+            if ('\n' == current) {
+                inComment = false;
+            }
+            if ('"' == current) {
+                inDoubleQuotes = !inDoubleQuotes;
+            }
+            if ('-' == current) {
+                if (!inDoubleQuotes && !inSingleQuotes) {
+                    commentCharacterCount++;
+                }
+            } else if (!inComment) {
+                commentCharacterCount = 0;
+            }
+            if (commentCharacterCount == 2) {
+                inComment = true;
+                sb.deleteCharAt(sb.length() - 1);
+                commentCharacterCount = 0;
+            }
+            if (!inComment) {
+                sb.append(current);
+            }
+        }
+        return sb.toString().trim();
+    }
+}

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/utils/QueryUtilsTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/utils/QueryUtilsTest.java
@@ -1,0 +1,52 @@
+package com.external.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueryUtilsTest {
+
+    @Test
+    public void testRemoveQueryComments_emptyString_returnsEmptyString() {
+        final String s = QueryUtils.removeQueryComments("");
+        Assert.assertEquals("", s);
+    }
+
+    @Test
+    public void testRemoveQueryComments_multilineWithoutComments_returnsSameString() {
+        final String query = "SELECT * \n FROM table;";
+        final String s = QueryUtils.removeQueryComments(query);
+        Assert.assertEquals(query, s);
+    }
+
+    @Test
+    public void testRemoveQueryComments_multilineWithCommentOnSeparateLine_returnsStringWithoutThatLine() {
+        final String query = "SELECT * \n FROM table; \n -- comment";
+        final String expected = "SELECT * \n FROM table;";
+        final String s = QueryUtils.removeQueryComments(query);
+        Assert.assertEquals(expected, s);
+    }
+
+    @Test
+    public void testRemoveQueryComments_multilineWithCommentOnSameLine_returnsStringWithoutComment() {
+        final String query = "SELECT * --comment \n FROM table; -- comment \n";
+        final String expected = "SELECT * \n FROM table;";
+        final String s = QueryUtils.removeQueryComments(query);
+        Assert.assertEquals(expected, s);
+    }
+
+    @Test
+    public void testRemoveQueryComments_multilineWithCommentKeywordInString_returnsSameString() {
+        final String query = "SELECT * \n FROM table WHERE id = '--';";
+        final String expected = "SELECT * \n FROM table WHERE id = '--';";
+        final String s = QueryUtils.removeQueryComments(query);
+        Assert.assertEquals(expected, s);
+    }
+
+    @Test
+    public void testRemoveQueryComments_multilineWithMultiStatements_returnsSameString() {
+        final String query = "SELECT * \n FROM table; SELECT * \n FROM table2;";
+        final String expected = "SELECT * \n FROM table; SELECT * \n FROM table2;";
+        final String s = QueryUtils.removeQueryComments(query);
+        Assert.assertEquals(expected, s);
+    }
+}


### PR DESCRIPTION
## Description

The issue here was that the executable statement was splitting at the end of query keyword `;`. However, with this logic, comments were considered to be a separate executable statement. There were two things that broke because of this:
1. If the comment was the last substring from the keyword split, the query always returned false in the `isSelectOrShowQuery` check. As a result all such queries returned with the `affectedRows` response, even if it was a select query.
2. For non-select queries, the last executed statement would be the comment, which would always return with `0`, as reported in the original issue.

This fix discards all comments from the query string during execution since they hold no value for the executable statements.

Fixes #5310 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually tested all detected cases

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
