### PR TITLE
Wait for server to start before Cypress tests

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -333,7 +333,11 @@ jobs:
           APPSMITH_ENCRYPTION_SALT: "salt"
           APPSMITH_IS_SELF_HOSTED: false
         run: |
-            ./scripts/start-dev-server.sh > /dev/null 2>&1 &             
+            ./scripts/start-dev-server.sh > /dev/null 2>&1 &
+
+      - name: Wait for 30 seconds for server to start
+        run: sleep 30s
+        shell: bash
 
       - name: Use Node.js 14.15.4
         uses: actions/setup-node@v1

--- a/app/client/cypress/setup-test.sh
+++ b/app/client/cypress/setup-test.sh
@@ -40,7 +40,6 @@ sleep 30
 
 echo "Checking if the containers have started"
 sudo docker ps -a 
-sudo docker logs wildcard-ngnix
 
 echo "Checking if the server has started"
 status_code=$(curl -o /dev/null -s -w "%{http_code}\n" https://dev.appsmith.com/api/v1/users)

--- a/app/client/cypress/setup-test.sh
+++ b/app/client/cypress/setup-test.sh
@@ -54,7 +54,8 @@ while [  "$retry_count" -le "3"  -a  "$status_code" -eq "502"  ]; do
 done
 
 if [ "$status_code" -eq "502" ]; then
-  echo "Hit 502"
+  echo "Unable to connect to server"
+  exit 1
 fi
 
 # Create the test user 

--- a/app/client/cypress/setup-test.sh
+++ b/app/client/cypress/setup-test.sh
@@ -40,6 +40,23 @@ sleep 30
 
 echo "Checking if the containers have started"
 sudo docker ps -a 
+sudo docker logs wildcard-ngnix
+
+echo "Checking if the server has started"
+status_code=$(curl -o /dev/null -s -w "%{http_code}\n" https://dev.appsmith.com/api/v1/users)
+
+retry_count=1
+
+while [  "$retry_count" -le "3"  -a  "$status_code" -eq "502"  ]; do
+	echo "Hit 502.Server not started retrying..."
+	retry_count=$((1 + $retry_count))
+	sleep 30
+	status_code=$(curl -o /dev/null -s -w "%{http_code}\n" https://dev.appsmith.com/api/v1/users)
+done
+
+if [ "$status_code" -eq "502" ]; then
+  echo "Hit 502"
+fi
 
 # Create the test user 
 curl -k --request POST -v 'https://dev.appsmith.com/api/v1/users' \


### PR DESCRIPTION
## Description
This PR checks if the server has started before proceeding to cypress tests

Fixes #5845

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

I have tested the new workflow in my local fork.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>