### PR TITLE
Add react-hooks/exhaustive-deps rule

### DIFF
--- a/app/client/.eslintrc.json
+++ b/app/client/.eslintrc.json
@@ -21,6 +21,7 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": 0,
     "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn", 
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-var-requires": 0,
     "import/no-webpack-loader-syntax": 0,


### PR DESCRIPTION
## Description

Add eslint rule to show a warning for `react-hooks/exhaustive-deps` 

Fixes # (issue)

## Type of change

- Development setup

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>