### PR TITLE
[Fix] Query editor fields get appended when switching between Mongo and other SQL Datasource queries.

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -508,7 +508,6 @@ export function EditorJSONtoForm(props: Props) {
         } else {
           try {
             const { configProperty } = formControlOrSection;
-            console.log(`${configProperty}_${idx}`);
             return (
               <FieldWrapper key={`${configProperty}_${idx}`}>
                 <FormControl

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -500,24 +500,30 @@ export function EditorJSONtoForm(props: Props) {
   };
 
   const renderEachConfig = (formName: string) => (section: any): any => {
-    return section.children.map((formControlOrSection: ControlProps) => {
-      if (isHidden(props.formData, section.hidden)) return null;
-      if (formControlOrSection.hasOwnProperty("children")) {
-        return renderEachConfig(formName)(formControlOrSection);
-      } else {
-        try {
-          const { configProperty } = formControlOrSection;
-          return (
-            <FieldWrapper key={configProperty}>
-              <FormControl config={formControlOrSection} formName={formName} />
-            </FieldWrapper>
-          );
-        } catch (e) {
-          log.error(e);
+    return section.children.map(
+      (formControlOrSection: ControlProps, idx: number) => {
+        if (isHidden(props.formData, section.hidden)) return null;
+        if (formControlOrSection.hasOwnProperty("children")) {
+          return renderEachConfig(formName)(formControlOrSection);
+        } else {
+          try {
+            const { configProperty } = formControlOrSection;
+            console.log(`${configProperty}_${idx}`);
+            return (
+              <FieldWrapper key={`${configProperty}_${idx}`}>
+                <FormControl
+                  config={formControlOrSection}
+                  formName={formName}
+                />
+              </FieldWrapper>
+            );
+          } catch (e) {
+            log.error(e);
+          }
         }
-      }
-      return null;
-    });
+        return null;
+      },
+    );
   };
 
   const responseTabs = [


### PR DESCRIPTION
## Description
Identical key `actionConfiguration.body` was being assigned to query editor component which was causing problem during update. Adding a unique key resolved the issue.

Fixes #5676 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/bug-5676-sql-body-problem 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.76 **(0.02)** | 35.79 **(0.02)** | 32.32 **(0)** | 54.33 **(0.02)**
 :green_circle: | app/client/src/sagas/ErrorSagas.tsx | 68.14 **(3.54)** | 52.38 **(4.76)** | 50 **(0)** | 68.63 **(3.92)**
 :green_circle: | app/client/src/sagas/CommentSagas/index.ts | 45.45 **(3.03)** | 17.86 **(0)** | 50 **(0)** | 44.12 **(1.96)**</details>