### PR TITLE
[Fix] Support Videos in omnibar

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
@@ -20,16 +20,16 @@ export const htmlToElement = (html: string) => {
  */
 const strip = (text: string) => text.replace(/{% .*?%}/gm, "");
 
+export const YT_EMBEDDING_SELECTION_REGEX = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=(.*?)\&.*? %}/m;
+
 const updateYoutubeEmbedingsWithIframe = (text: string) => {
   let docString = text;
-  const ytIdSelectionRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=(.*?)\&.*? %}/m;
-  const ytEmbeddingRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=.*? %}/m;
   let match;
-  while ((match = ytIdSelectionRegex.exec(docString)) !== null) {
+  while ((match = YT_EMBEDDING_SELECTION_REGEX.exec(docString)) !== null) {
     // gitbook adds \\ in front of a _ char in an id. TO remove that we have to do this.
     const videoId = match[1].replaceAll("%5C", "");
     docString = docString.replace(
-      ytEmbeddingRegex,
+      YT_EMBEDDING_SELECTION_REGEX,
       `<iframe width="100%" height="280" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
     );
   }

--- a/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
@@ -20,16 +20,16 @@ export const htmlToElement = (html: string) => {
  */
 const strip = (text: string) => text.replace(/{% .*?%}/gm, "");
 
-const updateVideoEmbedingsWithIframe = (text: string) => {
+const updateYoutubeEmbedingsWithIframe = (text: string) => {
   let docString = text;
-  const videoIdSelectionRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=(.*?)\&.*? %}/m;
-  const videoEmbeddingRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=.*? %}/m;
+  const ytIdSelectionRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=(.*?)\&.*? %}/m;
+  const ytEmbeddingRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=.*? %}/m;
   let match;
-  while ((match = videoIdSelectionRegex.exec(docString)) !== null) {
+  while ((match = ytIdSelectionRegex.exec(docString)) !== null) {
     // gitbook adds \\ in front of a _ char in an id. TO remove that we have to do this.
     const videoId = match[1].replaceAll("%5C", "");
     docString = docString.replace(
-      videoEmbeddingRegex,
+      ytEmbeddingRegex,
       `<iframe width="100%" height="280" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
     );
   }
@@ -224,7 +224,7 @@ const parseDocumentationContent = (item: any): string | undefined => {
     removeBadHighlights(documentObj, query);
     // update description title
     updateDocumentDescriptionTitle(documentObj, item);
-    let content = updateVideoEmbedingsWithIframe(documentObj.body.innerHTML);
+    let content = updateYoutubeEmbedingsWithIframe(documentObj.body.innerHTML);
     content = strip(content).trim();
     return content;
   } catch (e) {

--- a/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
@@ -20,6 +20,22 @@ export const htmlToElement = (html: string) => {
  */
 const strip = (text: string) => text.replace(/{% .*?%}/gm, "");
 
+const updateVideoEmbedingsWithIframe = (text: string) => {
+  let docString = text;
+  const videoIdSelectionRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=(.*?)\&.*? %}/m;
+  const videoEmbeddingRegex = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=.*? %}/m;
+  let match;
+  while ((match = videoIdSelectionRegex.exec(docString)) !== null) {
+    // gitbook adds \\ in front of a _ char in an id. TO remove that we have to do this.
+    const videoId = match[1].replaceAll("%5C", "");
+    docString = docString.replace(
+      videoEmbeddingRegex,
+      `<iframe width="100%" height="280" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
+    );
+  }
+  return docString;
+};
+
 /**
  * strip: description tag from the top
  */
@@ -208,8 +224,8 @@ const parseDocumentationContent = (item: any): string | undefined => {
     removeBadHighlights(documentObj, query);
     // update description title
     updateDocumentDescriptionTitle(documentObj, item);
-
-    const content = strip(documentObj.body.innerHTML).trim();
+    let content = updateVideoEmbedingsWithIframe(documentObj.body.innerHTML);
+    content = strip(content).trim();
     return content;
   } catch (e) {
     log.error(e);


### PR DESCRIPTION
## Description
Added a parsing logic to replace the gitbook embeddings with iframe to support youtube videos

Fixes #4887 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/video-in-ominibar 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.71 **(-0.02)** | 35.68 **(-0.02)** | 32.32 **(0.01)** | 54.29 **(-0.02)**
 :red_circle: | app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts | 78.79 **(-0.33)** | 43.02 **(0)** | 92.86 **(0.55)** | 79.17 **(-0.38)**
 :red_circle: | app/client/src/sagas/ErrorSagas.tsx | 64.6 **(-3.54)** | 47.62 **(-4.76)** | 50 **(0)** | 64.71 **(-3.92)**
 :red_circle: | app/client/src/sagas/CommentSagas/index.ts | 42.42 **(-3.03)** | 17.86 **(0)** | 50 **(0)** | 42.16 **(-1.96)**</details>