### PR TITLE
updated test to fix flaky Switch DS test

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/QueryPaneTests/SwitchDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/QueryPaneTests/SwitchDatasource_spec.js
@@ -76,7 +76,10 @@ describe("Switch datasource", function() {
     );
 
     cy.get(".t--switch-datasource").click();
-    cy.contains(".t--datasource-option", mongoDatasourceName).click();
+    cy.wait(1000);
+    cy.get(".t--datasource-option")
+      .contains(mongoDatasourceName)
+      .click({ force: true });
 
     cy.get(".CodeMirror")
       .first()


### PR DESCRIPTION
I have updated test, where click was missing in the list 
## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/flakySwitchTest 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.65 **(-0.01)** | 35.45 **(-0.02)** | 32.11 **(-0.02)** | 54.2 **(-0.01)**
 :red_circle: | app/client/src/utils/helpers.tsx | 53.59 **(-1.97)** | 26.76 **(-4.23)** | 23.08 **(-3.84)** | 47.5 **(-1.67)**</details>