### PR TITLE
Fix datetime parsing error in notifications

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/MongoConfig.java
@@ -3,9 +3,10 @@ package com.appsmith.server.configurations;
 import com.appsmith.external.annotations.documenttype.DocumentTypeMapper;
 import com.appsmith.external.annotations.encryption.EncryptionMongoEventListener;
 import com.appsmith.external.models.AuthenticationDTO;
-import com.appsmith.server.configurations.mongo.SoftDeleteMongoRepositoryFactoryBean;
-import com.appsmith.server.repositories.BaseRepositoryImpl;
 import com.appsmith.external.services.EncryptionService;
+import com.appsmith.server.configurations.mongo.SoftDeleteMongoRepositoryFactoryBean;
+import com.appsmith.server.converters.StringToInstantConverter;
+import com.appsmith.server.repositories.BaseRepositoryImpl;
 import com.github.cloudyrock.mongock.SpringBootMongock;
 import com.github.cloudyrock.mongock.SpringBootMongockBuilder;
 import lombok.extern.slf4j.Slf4j;
@@ -21,12 +22,14 @@ import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.convert.MongoTypeMapper;
 import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * This configures the JPA Mongo repositories. The default base implementation is defined in {@link BaseRepositoryImpl}.
@@ -57,7 +60,12 @@ public class MongoConfig {
 
     @Bean
     public MongoTemplate mongoTemplate(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
-        return new MongoTemplate(mongoDbFactory, mappingMongoConverter);
+        MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory, mappingMongoConverter);
+        MappingMongoConverter conv = (MappingMongoConverter) mongoTemplate.getConverter();
+        // tell mongodb to use the custom converters
+        conv.setCustomConversions(mongoCustomConversions());
+        conv.afterPropertiesSet();
+        return mongoTemplate;
     }
 
     // Custom type mapper here includes our annotation based mapper that is meant to ensure correct mapping for sub-classes
@@ -73,9 +81,15 @@ public class MongoConfig {
     }
 
     @Bean
+    public MongoCustomConversions mongoCustomConversions() {
+        return new MongoCustomConversions(Collections.singletonList(new StringToInstantConverter()));
+    }
+
+    @Bean
     public MappingMongoConverter mappingMongoConverter(DefaultTypeMapper<Bson> typeMapper, MongoMappingContext context) {
         MappingMongoConverter converter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, context);
         converter.setTypeMapper((MongoTypeMapper) typeMapper);
+        converter.setCustomConversions(mongoCustomConversions());
         return converter;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/converters/StringToInstantConverter.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/converters/StringToInstantConverter.java
@@ -1,0 +1,22 @@
+package com.appsmith.server.converters;
+
+import org.springframework.core.convert.converter.Converter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+
+public class StringToInstantConverter implements Converter<String, Instant> {
+    @Override
+    public Instant convert(String s) {
+        try {
+            LocalDateTime ldt = LocalDateTime.parse(s, ISO_DATE_TIME);
+            return ldt.toInstant(ZoneOffset.UTC);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
@@ -222,13 +222,20 @@ public class PolicyUtils {
     }
 
     public Flux<CommentThread> updateWithApplicationPermissionsToAllItsCommentThreads(
-            String applicationId, Map<String, Policy> commentThreadPolicyMap, boolean addPolicyToObject) {
+            String applicationId, Map<String, Policy> commentThreadPolicyMap, String username, boolean addPolicyToObject) {
 
         return
                 // fetch comment threads with read permissions
                 commentThreadRepository.findByApplicationId(applicationId, AclPermission.READ_THREAD)
                 .switchIfEmpty(Mono.empty())
                 .map(thread -> {
+                    if (addPolicyToObject) {
+                        return addPoliciesToExistingObject(commentThreadPolicyMap, thread);
+                    } else {
+                        if(CollectionUtils.isNotEmpty(thread.getSubscribers())) {
+                            thread.getSubscribers().remove(username);
+                        }
+                        return removePoliciesFromExistingObject(commentThreadPolicyMap, thread);
                     if(!Boolean.TRUE.equals(thread.getIsPrivate())) {
                         if (addPolicyToObject) {
                             return addPoliciesToExistingObject(commentThreadPolicyMap, thread);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
@@ -229,17 +229,13 @@ public class PolicyUtils {
                 commentThreadRepository.findByApplicationId(applicationId, AclPermission.READ_THREAD)
                 .switchIfEmpty(Mono.empty())
                 .map(thread -> {
-                    if (addPolicyToObject) {
-                        return addPoliciesToExistingObject(commentThreadPolicyMap, thread);
-                    } else {
-                        if(CollectionUtils.isNotEmpty(thread.getSubscribers())) {
-                            thread.getSubscribers().remove(username);
-                        }
-                        return removePoliciesFromExistingObject(commentThreadPolicyMap, thread);
                     if(!Boolean.TRUE.equals(thread.getIsPrivate())) {
                         if (addPolicyToObject) {
                             return addPoliciesToExistingObject(commentThreadPolicyMap, thread);
                         } else {
+                            if(CollectionUtils.isNotEmpty(thread.getSubscribers())) {
+                                thread.getSubscribers().remove(username);
+                            }
                             return removePoliciesFromExistingObject(commentThreadPolicyMap, thread);
                         }
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -397,6 +397,19 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                         return saveUserDataMono.then(saveThreadMono).thenReturn(TRUE);
                     }
                     return Mono.just(FALSE);
+                                if(resolvedState != null && resolvedState.getActive()) {
+                                    Mono<Boolean> publishEmailMono = emailEventHandler.publish(
+                                            user.getUsername(),
+                                            updatedThread.getApplicationId(),
+                                            updatedThread,
+                                            originHeader
+                                    );
+                                    return notificationService.createNotification(updatedThread, user.getUsername())
+                                            .then(publishEmailMono).thenReturn(updatedThread);
+                                } else {
+                                    return Mono.just(updatedThread);
+                                }
+                            });
                 });
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationService.java
@@ -3,14 +3,14 @@ package com.appsmith.server.services;
 import com.appsmith.server.domains.Comment;
 import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.domains.Notification;
-import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.UpdateIsReadNotificationByIdDTO;
 import com.appsmith.server.dtos.UpdateIsReadNotificationDTO;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface NotificationService extends CrudService<Notification, String> {
     Mono<Notification> createNotification(Comment comment, String forUsername);
-    Mono<Notification> createNotification(CommentThread commentThread, String forUsername, User authorUser);
+    Flux<Notification> createNotification(CommentThread commentThread, String authorUserName);
     Mono<UpdateIsReadNotificationByIdDTO> updateIsRead(UpdateIsReadNotificationByIdDTO dto);
     Mono<UpdateIsReadNotificationDTO> updateIsRead(UpdateIsReadNotificationDTO dto);
     Mono<Long> getUnreadCount();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserOrganizationServiceImpl.java
@@ -258,7 +258,9 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
         Flux<NewAction> updatedActionsFlux = updatedApplicationsFlux
                 .flatMap(application -> policyUtils.updateWithPagePermissionsToAllItsActions(application.getId(), actionPolicyMap, false));
         Flux<CommentThread> updatedThreadsFlux = updatedApplicationsFlux
-                .flatMap(application -> policyUtils.updateWithApplicationPermissionsToAllItsCommentThreads(application.getId(), commentThreadPolicyMap, false));
+                .flatMap(application -> policyUtils.updateWithApplicationPermissionsToAllItsCommentThreads(
+                        application.getId(), commentThreadPolicyMap, user.getUsername(), false
+                        ));
 
         return Mono.zip(
                 updatedDatasourcesFlux.collectList(),
@@ -432,7 +434,9 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
         Flux<NewAction> updatedActionsFlux = updatedApplicationsFlux
                 .flatMap(application -> policyUtils.updateWithPagePermissionsToAllItsActions(application.getId(), actionPolicyMap, true));
         Flux<CommentThread> updatedThreadsFlux = updatedApplicationsFlux
-                .flatMap(application -> policyUtils.updateWithApplicationPermissionsToAllItsCommentThreads(application.getId(), commentThreadPolicyMap, true));
+                .flatMap(application -> policyUtils.updateWithApplicationPermissionsToAllItsCommentThreads(
+                        application.getId(), commentThreadPolicyMap, null, true
+                ));
 
         return Mono.when(
                 updatedDatasourcesFlux.collectList(),


### PR DESCRIPTION
## Description
For an unknown reason, the `updatedAt` field in `resolvedState` and `pinnedState` is updated to a string instead of ISODate object. Due to this issue, the notification API raises an internal server error. This PR added a converter from string to instant. When there is a malformed string, it catches the exception and set the date to null so that the API does not fail.

Fixes #5194 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
