### PR TITLE
Bug - Set Suggested widgets before processing data types

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -684,6 +684,11 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
     }
 
     private ActionExecutionResult addDataTypesAndSetSuggestedWidget(ActionExecutionResult result, Boolean viewMode) {
+
+        if(FALSE.equals(viewMode)) {
+            result.setSuggestedWidgets(getSuggestedWidget(result.getBody()));
+        }
+
         /*
          * - Do not process if data types are already present.
          * - It means that data types have been added by specific plugin.
@@ -694,10 +699,6 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
         }
 
         result.setDataTypes(getDisplayDataTypes(result.getBody()));
-
-        if(FALSE.equals(viewMode)) {
-            result.setSuggestedWidgets(getSuggestedWidget(result.getBody()));
-        }
 
         return result;
     }


### PR DESCRIPTION
## Description

Before processing the data type we need to set the suggested widgets. If the data types are already defined along with the response then widget suggestion method will not be executed. 

Fixes # 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
