### PR TITLE
Fix: Fix onboarding flow after new nav changes

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
@@ -2,12 +2,9 @@
 // const explorer = require("../../../../locators/explorerlocators.json");
 const homePage = require("../../../../locators/HomePage.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
-const pages = require("../../../../locators/Pages.json");
-const datasourceEditor = require("../../../../locators/DatasourcesEditor.json");
-const datasource = require("../../../../locators/DatasourcesEditor.json");
 
 describe("Onboarding", function() {
-  it("Onboarding flow", function() {
+  it("Onboarding flow - manual without using do it for me option", function() {
     cy.get(commonlocators.homeIcon).click({ force: true });
 
     cy.get(".t--welcome-tour").click();
@@ -70,7 +67,11 @@ describe("Onboarding", function() {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000);
         cy.contains(".t--onboarding-helper-title", "Capture Hero Updates");
-        cy.get(".t--onboarding-cheat-action").click();
+        cy.dragAndDropToCanvas("inputwidget", { x: 360, y: 40 });
+        cy.get(".t--property-control-onsubmit .t--open-dropdown-Select-Action")
+          .click({ force: true })
+          .selectOnClickOption("Execute a Query")
+          .selectOnClickOption("Create New Query");
 
         cy.contains(
           ".t--onboarding-helper-title",

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -32,6 +32,9 @@ import history from "utils/history";
 import { keyBy } from "lodash";
 import { getPluginIcon, apiIcon } from "pages/Editor/Explorer/ExplorerIcons";
 import { getActionConfig } from "pages/Editor/Explorer/Actions/helpers";
+import { getCurrentStep, getCurrentSubStep } from "sagas/OnboardingSagas";
+import { OnboardingStep } from "constants/OnboardingConstants";
+import { ReduxActionTypes } from "constants/ReduxActionConstants";
 
 /* eslint-disable @typescript-eslint/ban-types */
 /* TODO: Function and object types need to be updated to enable the lint rule */
@@ -365,6 +368,9 @@ function useIntegrationsOptionTree() {
   });
   const pluginGroups: any = useMemo(() => keyBy(plugins, "id"), [plugins]);
   const actions = useSelector(getActionsForCurrentPage);
+  // For onboarding
+  const currentStep = useSelector(getCurrentStep);
+  const currentSubStep = useSelector(getCurrentSubStep);
 
   const integrationOptionTree = getIntegrationOptionsWithChildren(
     pageId,
@@ -379,9 +385,18 @@ function useIntegrationsOptionTree() {
       icon: "plus",
       className: "t--create-datasources-query-btn",
       onSelect: () => {
-        history.push(
-          INTEGRATION_EDITOR_URL(applicationId, pageId, INTEGRATION_TABS.NEW),
-        );
+        // For onboarding
+        if (currentStep === OnboardingStep.ADD_INPUT_WIDGET) {
+          if (currentSubStep === 2) {
+            dispatch({
+              type: ReduxActionTypes.ONBOARDING_ADD_ONSUBMIT_BINDING,
+            });
+          }
+        } else {
+          history.push(
+            INTEGRATION_EDITOR_URL(applicationId, pageId, INTEGRATION_TABS.NEW),
+          );
+        }
       },
     },
     dispatch,


### PR DESCRIPTION
## Description

Previously creating a query from onSubmit action selector used to create a query with the first datasource which was the datasource used for onboarding, but with the new nav flow it won't anymore. This is fixed by conditionally creating a specific query when clicking on the Create new query option.

Fixes #5438

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/onboarding-nav 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.6 **(0)** | 35.33 **(-0.01)** | 32.15 **(0.01)** | 54.16 **(0)**
 :green_circle: | app/client/src/components/editorComponents/ActionCreator/index.tsx | 49.62 **(0.84)** | 10.81 **(-0.62)** | 56.52 **(0)** | 48.84 **(0.91)**
 :green_circle: | app/client/src/sagas/OnboardingSagas.ts | 16.98 **(0.27)** | 1.46 **(0)** | 12.24 **(2.04)** | 17.14 **(0.31)**</details>