### PR TITLE
Added axios call to the special use case of downloading zip files

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -80,6 +80,7 @@ import {
 } from "actions/pageActions";
 import { getAppStoreName } from "constants/AppConstants";
 import downloadjs from "downloadjs";
+import Axios from "axios";
 import { getType, Types } from "utils/TypeHelpers";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
@@ -264,6 +265,16 @@ async function downloadSaga(
       AppsmithConsole.info({
         text: `download('${jsonString}', '${name}', '${type}') was triggered`,
       });
+    } else if (dataType === Types.URL && type === "application/zip") {
+      Axios.get(data, { responseType: "arraybuffer" })
+        .then((res) => {
+          console.log("download", res.data);
+          downloadjs(res.data, name, type);
+          AppsmithConsole.info({
+            text: `download('${data}', '${name}', '${type}') was triggered`,
+          });
+        })
+        .catch((error) => console.error(error));
     } else {
       downloadjs(data, name, type);
       AppsmithConsole.info({

--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -268,9 +268,9 @@ async function downloadSaga(
     } else if (
       dataType === Types.STRING &&
       isURL(data) &&
-      type === "application/zip"
+      type === "application/x-binary"
     ) {
-      // Requires a special handling for the use case when the user is trying to download a zipped file from a URL
+      // Requires a special handling for the use case when the user is trying to download a binary file from a URL
       // due to incompatibility in the downloadjs library. In this case we are going to fetch the file from the URL
       // using axios with the arraybuffer header and then pass it to the downloadjs library.
       Axios.get(data, { responseType: "arraybuffer" })

--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -81,7 +81,7 @@ import {
 import { getAppStoreName } from "constants/AppConstants";
 import downloadjs from "downloadjs";
 import Axios from "axios";
-import { getType, Types } from "utils/TypeHelpers";
+import { getType, isURL, Types } from "utils/TypeHelpers";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
 import PerformanceTracker, {
@@ -265,7 +265,11 @@ async function downloadSaga(
       AppsmithConsole.info({
         text: `download('${jsonString}', '${name}', '${type}') was triggered`,
       });
-    } else if (dataType === Types.URL && type === "application/zip") {
+    } else if (
+      dataType === Types.STRING &&
+      isURL(data) &&
+      type === "application/zip"
+    ) {
       // Requires a special handling for the use case when the user is trying to download a zipped file from a URL
       // due to incompatibility in the downloadjs library. In this case we are going to fetch the file from the URL
       // using axios with the arraybuffer header and then pass it to the downloadjs library.

--- a/app/client/src/utils/TypeHelpers.ts
+++ b/app/client/src/utils/TypeHelpers.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 
 export enum Types {
+  URL = "URL",
   STRING = "STRING",
   NUMBER = "NUMBER",
   BOOLEAN = "BOOLEAN",
@@ -13,7 +14,10 @@ export enum Types {
 }
 
 export const getType = (value: unknown) => {
-  if (_.isString(value)) return Types.STRING;
+  if (_.isString(value)) {
+    if (isURL(value)) return Types.URL;
+    else return Types.STRING;
+  }
   if (_.isNumber(value)) return Types.NUMBER;
   if (_.isBoolean(value)) return Types.BOOLEAN;
   if (Array.isArray(value)) return Types.ARRAY;
@@ -23,3 +27,16 @@ export const getType = (value: unknown) => {
   if (_.isNull(value)) return Types.NULL;
   return Types.UNKNOWN;
 };
+
+function isURL(str: string) {
+  const pattern = new RegExp(
+    "^(https?:\\/\\/)?" + // protocol
+    "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // domain name
+    "((\\d{1,3}\\.){3}\\d{1,3}))" + // OR ip (v4) address
+    "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // port and path
+    "(\\?[;&a-z\\d%_.~+=-]*)?" + // query string
+      "(\\#[-a-z\\d_]*)?$",
+    "i",
+  ); // fragment locator
+  return !!pattern.test(str);
+}

--- a/app/client/src/utils/TypeHelpers.ts
+++ b/app/client/src/utils/TypeHelpers.ts
@@ -14,10 +14,7 @@ export enum Types {
 }
 
 export const getType = (value: unknown) => {
-  if (_.isString(value)) {
-    if (isURL(value)) return Types.URL;
-    else return Types.STRING;
-  }
+  if (_.isString(value)) return Types.STRING;
   if (_.isNumber(value)) return Types.NUMBER;
   if (_.isBoolean(value)) return Types.BOOLEAN;
   if (Array.isArray(value)) return Types.ARRAY;
@@ -28,7 +25,7 @@ export const getType = (value: unknown) => {
   return Types.UNKNOWN;
 };
 
-function isURL(str: string) {
+export function isURL(str: string) {
   const pattern = new RegExp(
     "^(https?:\\/\\/)?" + // protocol
     "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // domain name


### PR DESCRIPTION
## Description

Steps to reproduce the behaviour:

1. Select download action on button click
2. Enter this JS {{download('https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-large-zip-file.zip','abc.zip','application/zip')}}
3. Download the file
4. You will notice that the downloaded file is corrupt.

Downloadjs library is not able to support the download of binary files directly. For this, when we are making a call via axios and setting the headers as `repsonseType: arraybuffer` then the library is able to parse the binary file. If we use the api to download the data and then pass to downlaodjs lib, it doesn't work, even if we use the string to array buffer conversion. Here, I have added a special type check for URLs and added a special condition where the data type is `URL` and the file type is `application/x-binary`. When this condition is satisfied, the URL is passed to axios and then the result data is passed to downloadjs lib.

Fixes #5878 
#5428 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/5878-zip-download-fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.6 **(-0.01)** | 35.34 **(-0.02)** | 32.14 **(-0.01)** | 54.15 **(-0.02)**
 :red_circle: | app/client/src/sagas/ActionExecutionSagas.ts | 12.23 **(-0.02)** | 1.24 **(-0.04)** | 6.67 **(-0.47)** | 14.04 **(-0.04)**
 :red_circle: | app/client/src/utils/TypeHelpers.ts | 85.29 **(-4.71)** | 83.33 **(0)** | 66.67 **(-33.33)** | 88 **(-7.24)**</details>