### PR TITLE
[Fix] Fix mouse click for the autocomplete at the api pane

### DIFF
--- a/app/client/cypress/locators/apiWidgetslocator.json
+++ b/app/client/cypress/locators/apiWidgetslocator.json
@@ -25,7 +25,7 @@
   "marketPlaceapi": ".t--eachProviderCard p",
   "addPageButton": ".t--addToPageBtn",
   "apidocumentaionLink": ".t--apiDocumentationLink",
-  "postbody": "(//div[contains(@class,'CodeMirror-wrap')]//textarea)[1]",
+  "postbody": "(//div[contains(@class,'CodeMirror-wrap')]//textarea)[2]",
   "paginationTab": "li:contains('Pagination')",
   "apiInputTab": "li:contains('API Input')",
   "paginationOption": ".t--apiFormPaginationType div>input",

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -168,7 +168,7 @@ class CodeEditor extends Component<Props, State> {
         tabSize: 2,
         autoCloseBrackets: true,
         indentWithTabs: this.props.tabBehaviour === TabBehaviour.INDENT,
-        lineWrapping: this.props.size !== EditorSize.COMPACT,
+        lineWrapping: true,
         lineNumbers: this.props.showLineNumbers,
         addModeClass: true,
         matchBrackets: false,
@@ -261,9 +261,7 @@ class CodeEditor extends Component<Props, State> {
         // Safe update of value of the editor when value updated outside the editor
         const inputValue = getInputValue(this.props.input.value);
         if (!!inputValue || inputValue === "") {
-          if (this.props.size === EditorSize.COMPACT) {
-            this.editor.setValue(removeNewLineChars(inputValue));
-          } else if (inputValue !== editorValue) {
+          if (inputValue !== editorValue) {
             this.editor.setValue(inputValue);
           }
         }
@@ -327,14 +325,6 @@ class CodeEditor extends Component<Props, State> {
 
   handleEditorFocus = () => {
     this.setState({ isFocused: true });
-    if (this.props.size === EditorSize.COMPACT) {
-      this.editor.operation(() => {
-        const inputValue = this.props.input.value;
-        this.editor.setOption("lineWrapping", true);
-        this.editor.setValue(inputValue);
-        this.editor.setCursor(inputValue.length);
-      });
-    }
     if (this.editor.getValue().length === 0)
       this.handleAutocompleteVisibility(this.editor);
   };
@@ -342,9 +332,6 @@ class CodeEditor extends Component<Props, State> {
   handleEditorBlur = () => {
     this.handleChange();
     this.setState({ isFocused: false });
-    if (this.props.size === EditorSize.COMPACT) {
-      this.editor.setOption("lineWrapping", false);
-    }
     this.editor.setOption("matchBrackets", false);
   };
 

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -243,6 +243,14 @@ export const EditorWrapper = styled.div<{
           position: relative;
         `}
     ${(props) => (props.isFocused ? `z-index: 3;` : `z-index: 0;`)}
+
+    ${(props) => {
+      let height = props.height || "auto";
+      if (props.size === EditorSize.COMPACT && !props.isFocused) {
+        height = props.height || "32px";
+      }
+      return `height: ${height}`;
+    }}
   }
 `;
 

--- a/app/client/src/components/formControls/DynamicInputTextControl.test.tsx
+++ b/app/client/src/components/formControls/DynamicInputTextControl.test.tsx
@@ -5,6 +5,7 @@ import { reduxForm } from "redux-form";
 import { mockCodemirrorRender } from "test/__mocks__/CodeMirrorEditorMock";
 import userEvent from "@testing-library/user-event";
 import { waitFor } from "@testing-library/dom";
+import { EditorSize } from "components/editorComponents/CodeEditor/EditorConfig";
 
 function TestForm(props: any) {
   return <div>{props.children}</div>;
@@ -38,9 +39,9 @@ describe("DynamicInputTextControl", () => {
       {},
     );
 
-    const input = screen.getAllByText("My test value")[0];
-    userEvent.type(input, "New text");
     waitFor(async () => {
+      const input = screen.getAllByText("My test value")[0];
+      userEvent.type(input, "New text");
       await expect(screen.getAllByText("New text")).toHaveLength(2);
       await expect(screen.findByText("My test value")).toBeNull();
     });

--- a/app/client/src/components/formControls/DynamicInputTextControl.test.tsx
+++ b/app/client/src/components/formControls/DynamicInputTextControl.test.tsx
@@ -5,7 +5,6 @@ import { reduxForm } from "redux-form";
 import { mockCodemirrorRender } from "test/__mocks__/CodeMirrorEditorMock";
 import userEvent from "@testing-library/user-event";
 import { waitFor } from "@testing-library/dom";
-import { EditorSize } from "components/editorComponents/CodeEditor/EditorConfig";
 
 function TestForm(props: any) {
   return <div>{props.children}</div>;


### PR DESCRIPTION
During blur and focus events we remove new line characters.
Here instead we set the height of the input when the size is COMPACT, when not in focus to fix the height

Another approach could be delaying the `blur` event and racing it with a `focus` event, such that in case we're picking a value from the autocomplete we don't reset the input value


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: try-fixing-autocomplete-1 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.6 **(0.01)** | 35.35 **(0.02)** | 32.14 **(0.02)** | 54.16 **(0.02)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 70.54 **(1.74)** | 42.97 **(-0.31)** | 51.28 **(1.28)** | 71.77 **(1.91)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/styledComponents.ts | 90.38 **(0.8)** | 60.47 **(4.06)** | 100 **(0)** | 94 **(0.52)**</details>