### PR TITLE
Locking mongo Docker container to 4.4.6

### DIFF
--- a/app/server/docker-compose.yml
+++ b/app/server/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - appsmith
 
   mongo:
-    image: mongo
+    image: mongo:4.4.6
     environment:
       - MONGO_INITDB_DATABASE=appsmith
     volumes:

--- a/deploy/ansible/appsmith_playbook/roles/generate_template/templates/docker-compose.j2
+++ b/deploy/ansible/appsmith_playbook/roles/generate_template/templates/docker-compose.j2
@@ -46,7 +46,7 @@ services:
       - appsmith
 
   mongo:
-    image: mongo
+    image: mongo:4.4.6
     expose:
       - "27017"
     environment:

--- a/deploy/k8s/templates/mongo-template.yaml
+++ b/deploy/k8s/templates/mongo-template.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: mongo
-        image: mongo
+        image: mongo:4.4.6
         ports:
           - containerPort: 27017
         volumeMounts:

--- a/deploy/template/docker-compose.yml.sh
+++ b/deploy/template/docker-compose.yml.sh
@@ -55,7 +55,7 @@ services:
       - appsmith
 
   mongo:
-    image: mongo
+    image: mongo:4.4.6
     expose:
       - "27017"
     environment:


### PR DESCRIPTION
Mongo v5 has some issues with seeding data. Refer:  https://stackoverflow.com/questions/68392064/error-when-running-mongo-image-docker-entrypoint-sh-line-381

Hence, locking the mongo version to a known working tag till we have more information on the problem.