### PR TITLE
Bug - Fix page order sorting

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -269,10 +269,10 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
                     }
                     if(Boolean.TRUE.equals(view)) {
                         Collections.sort(pageNameIdDTOList,
-                                Comparator.comparing(item -> publishedPages.indexOf(item)));
+                                Comparator.comparing(item -> publishedPagesOrder.get(item.getId())));
                     } else {
                         Collections.sort(pageNameIdDTOList,
-                                Comparator.comparing(item -> pages.indexOf(item)));
+                                Comparator.comparing(item -> pagesOrder.get(item.getId())));
                     }
                     return Mono.just(pageNameIdDTOList);
                 });

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -431,11 +431,11 @@ public class PageServiceTest {
                 .create(applicationPageReOrdered)
                 .assertNext(application -> {
                     final List<PageNameIdDTO> pages = application.getPages();
-                    assertThat(application.getPages().size()).isEqualTo(4);
-                    assertThat(application.getPages().get(0).getId().equals(pageIds[0]));
-                    assertThat(application.getPages().get(1).getId().equals(pageIds[3]));
-                    assertThat(application.getPages().get(2).getId().equals(pageIds[1]));
-                    assertThat(application.getPages().get(3).getId().equals(pageIds[2]));
+                    assertThat(pages.size()).isEqualTo(4);
+                    assertThat(pages.get(0).getId()).isEqualTo(pageIds[0]);
+                    assertThat(pages.get(1).getId()).isEqualTo(pageIds[3]);
+                    assertThat(pages.get(2).getId()).isEqualTo(pageIds[1]);
+                    assertThat(pages.get(3).getId()).isEqualTo(pageIds[2]);
                 } )
                 .verifyComplete();
     }
@@ -482,11 +482,11 @@ public class PageServiceTest {
                 .create(applicationPageReOrdered)
                 .assertNext(application -> {
                     final List<PageNameIdDTO> pages = application.getPages();
-                    assertThat(application.getPages().size()).isEqualTo(4);
-                    assertThat(application.getPages().get(3).getId().equals(pageIds[0]));
-                    assertThat(application.getPages().get(0).getId().equals(pageIds[1]));
-                    assertThat(application.getPages().get(1).getId().equals(pageIds[2]));
-                    assertThat(application.getPages().get(2).getId().equals(pageIds[3]));
+                    assertThat(pages.size()).isEqualTo(4);
+                    assertThat(pages.get(3).getId()).isEqualTo(pageIds[0]);
+                    assertThat(pages.get(0).getId()).isEqualTo(pageIds[1]);
+                    assertThat(pages.get(1).getId()).isEqualTo(pageIds[2]);
+                    assertThat(pages.get(2).getId()).isEqualTo(pageIds[3]);
                 } )
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

After the page order is fetched from the Application object, we should use the order from this object. I was not using this value to sort the pages. 

Fixes # 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Unit Tests
- Postman

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
