### PR TITLE
Added filter for new header and doing atob on the response

### DIFF
--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -110,6 +110,7 @@ export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/[\s\S]*?)(\?(?![^{]*})[\
 export const EXECUTION_PARAM_KEY = "executionParams";
 export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params/g;
 
+export const RESP_HEADER_DATATYPE = "X-APPSMITH-DATATYPE";
 export const API_REQUEST_HEADERS: APIHeaders = {
   "Content-Type": "application/json",
 };

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -228,6 +228,7 @@ const actionsReducer = createReducer(initialState, {
   ): ActionDataState => {
     const actionId = Object.keys(action.payload)[0];
     if (
+      action.payload[actionId].statusCode === "200" &&
       action.payload[actionId].headers.hasOwnProperty("X-APPSMITH-DATATYPE") &&
       action.payload[actionId].headers["X-APPSMITH-DATATYPE"].length > 0 &&
       action.payload[actionId].headers["X-APPSMITH-DATATYPE"][0] ===

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -10,7 +10,6 @@ import _ from "lodash";
 import { Action } from "entities/Action";
 import { UpdateActionPropertyActionPayload } from "actions/actionActions";
 import produce from "immer";
-import { getType, Types } from "utils/TypeHelpers";
 
 export interface ActionData {
   isLoading: boolean;
@@ -31,10 +30,6 @@ export interface PartialActionData {
   isLoading: boolean;
   config: { id: string };
   data?: ActionResponse;
-}
-
-enum ActionResponseDataTypes {
-  BINARY = "BINARY",
 }
 
 const initialState: ActionDataState = [];
@@ -227,18 +222,6 @@ const actionsReducer = createReducer(initialState, {
     action: ReduxAction<{ [id: string]: ActionResponse }>,
   ): ActionDataState => {
     const actionId = Object.keys(action.payload)[0];
-    if (
-      action.payload[actionId].statusCode === "200" &&
-      action.payload[actionId].headers.hasOwnProperty("X-APPSMITH-DATATYPE") &&
-      action.payload[actionId].headers["X-APPSMITH-DATATYPE"].length > 0 &&
-      action.payload[actionId].headers["X-APPSMITH-DATATYPE"][0] ===
-        ActionResponseDataTypes.BINARY &&
-      getType(action.payload[actionId].body) === Types.STRING
-    ) {
-      action.payload[actionId].body = atob(
-        action.payload[actionId].body as string,
-      );
-    }
     return state.map((a) => {
       if (a.config.id === actionId) {
         return { ...a, isLoading: false, data: action.payload[actionId] };

--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -870,7 +870,8 @@ function* runActionSaga(
 
       if (
         actionObject.pluginType === PluginType.API &&
-        payload.statusCode === "200 OK"
+        payload.statusCode === "200 OK" &&
+        payload.hasOwnProperty("headers")
       ) {
         const respHeaders = payload.headers;
         if (
@@ -880,6 +881,9 @@ function* runActionSaga(
             ActionResponseDataTypes.BINARY &&
           getType(payload.body) === Types.STRING
         ) {
+          // Decoding from base64 to handle the binary files because direct
+          // conversion of binary files to string causes corruption in the final output
+          // this is to only handle the download of binary files
           payload.body = atob(payload.body as string);
         }
       }


### PR DESCRIPTION
## Description

Added filter for the new header from server `X-APPSMITH-DATATYPE` and performing `atob` on the response.

Fixes #5878 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/5878-adding-server-side-support-for-binaries 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.6 **(0)** | 35.34 **(-0.01)** | 32.15 **(0.01)** | 54.16 **(0)**
 :green_circle: | app/client/src/sagas/ActionExecutionSagas.ts | 12.53 **(0.3)** | 1.97 **(0.73)** | 9.68 **(3.01)** | 14.36 **(0.32)**</details>