### PR TITLE
Removing non-required fields from Heroku deployment.

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     ],
 
     "website": "https://appsmith.com/",
-    "logo": "https://raw.githubusercontent.com/appsmithorg/appsmith/release/static/logo.png",
+    "logo": "https://raw.githubusercontent.com/appsmithorg/appsmith/master/static/logo.png",
     "success_url": "/",
     "stack": "container",
     "scripts": {
@@ -32,86 +32,6 @@
       "APPSMITH_ENCRYPTION_SALT": {
         "description" : "Encryption salt used to encrypt all sensitive credentials in the database. You can use any random string (Eg. abcd). The more random, the better.",
         "value": ""
-      },
-      "APPSMITH_MAIL_ENABLED": {
-        "description" : "Set this value to true to enable email sending",
-        "value": "false",
-        "required": false
-      },
-      "APPSMITH_MAIL_FROM": {
-        "description" : "Email ID using which emails will be sent from your installation ",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_REPLY_TO": {
-        "description" : "Email ID to which all email replies will be sent to",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_MAIL_HOST": {
-        "description" : "The host endpoint for the SMTP server",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_MAIL_SMTP_TLS_ENABLED" : {
-        "description": "Set this value to enable TLS for your SMTP server",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_MAIL_USERNAME": {
-        "description" : "SMTP username",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_MAIL_PASSWORD": {
-        "description" : "SMTP password",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_MAIL_SMTP_AUTH" : {
-        "description" : "Set this value to true if your SMTP server requires authentication",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_OAUTH2_GOOGLE_CLIENT_ID": {
-        "description": "Client ID provided by Google for OAuth2 login",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET": {
-        "description" : "Client secret provided by Google for OAuth2 login",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_OAUTH2_GITHUB_CLIENT_ID": {
-        "description" : "Client ID provided by Github for OAuth2 login",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET": {
-        "description" : "Client secret provided by Github for OAuth2 login",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_GOOGLE_MAPS_API_KEY": {
-        "description" : "Google Maps API key which is required if you wish to leverage Google Maps widget. Read more at: https://docs.appsmith.com/v/v1.2.1/setup/docker/google-maps",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_RECAPTCHA_SITE_KEY": {
-        "description" : "Google reCAPTCHA v3 site key, it is required if you wish to enable protection against spam/abusive users. Read more at: https://developers.google.com/recaptcha/docs/v3",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_RECAPTCHA_SECRET_KEY": {
-        "description" : "Google reCAPTCHA v3 verification secret key, it is required if you wish to enable spam protection in your backend server.",
-        "value": "",
-        "required": false
-      },
-      "APPSMITH_RECAPTCHA_ENABLED": {
-        "description" : "Boolean config to enable or disable Google reCAPTCHA v3 verification feature. If set to true, both site key and secret key should be provided.",
-        "value": "",
-        "required": false
       },
       "APPSMITH_DISABLE_TELEMETRY": {
         "description" : "We want to be transparent and request that you share anonymous usage data with us. This data is purely statistical in nature and helps us understand your needs & provide better support to your self-hosted instance. You can read more about what information is collected in our documentation https://docs.appsmith.com/v/v1.2.1/setup/telemetry",


### PR DESCRIPTION
Simplifying the Heroku deployment process by removing all non-required configuration parameters from the setup flow. They can be set by a user later via the Heroku CLI or Web login. 

Now the user only needs to set 4 variables:
1. Telemetry enable/disable
2. Encryption password
3. Encryption secret
4. Mongo DB URL