### PR TITLE
[Bug] Comment is not refocused on closing the comment thread and clicking on it again

### DIFF
--- a/app/client/src/comments/inlineComments/Comments.tsx
+++ b/app/client/src/comments/inlineComments/Comments.tsx
@@ -6,12 +6,14 @@ import {
   commentThreadsSelector,
   refCommentThreadsSelector,
   unpublishedCommentThreadSelector,
+  visibleCommentThreadSelector,
 } from "../../selectors/commentsSelectors";
 import {
   getCurrentApplicationId,
   getCurrentPageId,
 } from "selectors/editorSelectors";
 import { useLocation } from "react-router";
+import { AppState } from "reducers";
 
 // TODO refactor application comment threads by page id to optimise
 // if lists turn out to be expensive
@@ -24,11 +26,18 @@ function InlinePageCommentPin({
 }) {
   const commentThread = useSelector(commentThreadsSelector(commentThreadId));
   const currentPageId = useSelector(getCurrentPageId);
+  const isVisibleCommentThread = useSelector(
+    (state: AppState) =>
+      visibleCommentThreadSelector(state) === commentThreadId,
+  );
 
   if (commentThread && commentThread.pageId !== currentPageId) return null;
 
   return (
-    <InlineCommentPin commentThreadId={commentThreadId} focused={focused} />
+    <InlineCommentPin
+      commentThreadId={commentThreadId}
+      focused={focused || isVisibleCommentThread}
+    />
   );
 }
 

--- a/app/client/src/selectors/commentsSelectors.ts
+++ b/app/client/src/selectors/commentsSelectors.ts
@@ -155,7 +155,7 @@ export const appCommentsFilter = (state: AppState) =>
 export const showUnreadIndicator = (state: AppState) =>
   state.ui.comments.unreadCommentThreadsCount > 0;
 
-export const visibleCommentThread = (state: AppState) =>
+export const visibleCommentThreadSelector = (state: AppState) =>
   state.ui.comments.visibleCommentThreadId;
 
 export const isIntroCarouselVisibleSelector = (state: AppState) =>


### PR DESCRIPTION
## Description
1. Add a comment at a position such that we need to scroll
2. Click on the comment card link from the sidebar 
3. Close the comment thread, scroll away and click on the same card again
4. The comment card is not refocused

Fixes #5993

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix-comment-card-link 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.85 **(-0.01)** | 33.53 **(0)** | 29.94 **(0)** | 52.53 **(0)**
 :red_circle: | app/client/src/comments/inlineComments/Comments.tsx | 28.57 **(-1.73)** | 0 **(0)** | 0 **(0)** | 31.25 **(-2.08)**</details>