### PR TITLE
updated ExecutionSpec

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/ExecutionParams_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/ExecutionParams_spec.js
@@ -93,8 +93,15 @@ describe("API Panel Test Functionality", function() {
     cy.get(publishPage.buttonWidget)
       .first()
       .click();
+
+    //Wait for postExecute to finish
+    cy.wait("@postExecute").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
+    cy.wait(5000);
     // Assert statically bound "users" data
     cy.readTabledataPublish("1", "1").then((cellData) => {
       expect(cellData).to.be.equal("OUT_FOR_DELIVERY");
@@ -104,8 +111,15 @@ describe("API Panel Test Functionality", function() {
     cy.get(publishPage.buttonWidget)
       .eq(1)
       .click();
+
+    //Wait for postExecute to finish
+    cy.wait("@postExecute").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
+    cy.wait(5000);
     // Assert dynamically bound "todos" data
     cy.readTabledataPublish("0", "1").then((cellData) => {
       expect(cellData).to.be.equal("DISCOUNT");


### PR DESCRIPTION
updated Wait for PostExecute call to finish after button click
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>