### PR TITLE
Fix install script on RHEL

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -75,7 +75,12 @@ install_docker() {
     else
         yum_cmd="sudo yum --assumeyes --quiet"
         $yum_cmd install yum-utils
-        sudo yum-config-manager --add-repo "https://download.docker.com/linux/$os/docker-ce.repo"
+        os_in_repo_link="$os"
+        if [[ $os == rhel ]]; then
+            # For RHEL, there's no separate repo link. We can use the CentOS one though.
+            os_in_repo_link=centos
+        fi
+        sudo yum-config-manager --add-repo "https://download.docker.com/linux/$os_in_repo_link/docker-ce.repo"
         echo "Installing docker"
         $yum_cmd install docker-ce docker-ce-cli containerd.io
 


### PR DESCRIPTION
The RHEL images are missing on Docker's S3 bucket.

See <https://download.docker.com/linux/rhel/8/x86_64/stable/repodata/repomd.xml>, and notice that `x86_64` isn't listed here. But on <https://download.docker.com/linux/centos/8/x86_64/stable/repodata/repomd.xml>, we see that an `x86_64` is indeed listed.

Now, if we look at the repo definition file at <https://download.docker.com/linux/centos/docker-ce.repo>, we can see the base URL for download Docker stable is:

```
baseurl=https://download.docker.com/linux/rhel/$releasever/$basearch/stable
```

This, on RHEL 8, on `x86_64` architecture, would resolve to `https://download.docker.com/linux/rhel/8/x86_64/stable`, which, sadly, suddenly, doesn't exist.

There's a chance this might be a deliberate action, since RHEL appears to be recommending their own repos for installing Docker, and these repos are only accessible to registered users of RHEL. See <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/getting_started_with_containers/index#getting_docker_in_rhel_7> for more details.
