### PR TITLE
Removed support for S3 and GSheets for generate CRUD page

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -2813,15 +2813,13 @@ public class DatabaseChangelog {
         mongoTemplate.updateMulti(query(where("publishedPages").exists(TRUE)), update, Application.class);
     }
 
-    @ChangeSet(order = "079", id = "create-plugin-reference-for-genarate-CRUD-page", author = "")
+    @ChangeSet(order = "080", id = "create-plugin-reference-for-genarate-CRUD-page", author = "")
     public void createPluginReferenceForGenerateCRUDPage(MongockTemplate mongoTemplate) {
 
         final String templatePageNameForSQLDatasource = "SQL";
         final Set<String> sqlPackageNames = Set.of("mysql-plugin", "mssql-plugin", "redshift-plugin", "snowflake-plugin");
         Set<String> validPackageNames = new HashSet<>(sqlPackageNames);
         validPackageNames.add("mongo-plugin");
-        validPackageNames.add("amazons3-plugin");
-        validPackageNames.add("google-sheets-plugin");
         validPackageNames.add("postgres-plugin");
 
         List<Plugin> plugins = mongoTemplate.findAll(Plugin.class);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -40,10 +40,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -485,6 +483,7 @@ public class CreateDBTablePageSolutionTests {
             .verifyComplete();
     }
 
+    /*
     @Test
     @WithUserDetails(value = "api_user")
     public void createPageWithNullPageIdForS3() {
@@ -595,6 +594,8 @@ public class CreateDBTablePageSolutionTests {
             })
             .verifyComplete();
     }
+
+    */
 
     @Test
     @WithUserDetails(value = "api_user")


### PR DESCRIPTION
## Description

As the generate CRUD page functionality is not available in FE for S3 and GoogleSheets plugins we are updating the plugin object not to enable support for the mentioned plugins. Also as the changelog has already run previously I have deleted the particular entry from mongockChangeLog and deleted the particular field from the plugin object as well as I don't wanted another migration for this. 