### PR TITLE
fix stop Rich text Editor from crashing on Modal

### DIFF
--- a/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/RichTextEditorComponent.tsx
@@ -59,7 +59,10 @@ export function RichtextEditorComponent(props: RichtextEditorComponentProps) {
       editorContent.current = content;
       props.onValueChange(content);
     }, 200);
-    const selector = `textarea#rte-${props.widgetId}`;
+
+    const editorId = `rte-${props.widgetId}`;
+    const selector = `textarea#${editorId}`;
+
     (window as any).tinyMCE.init({
       forced_root_block: false,
       height: "100%",
@@ -99,7 +102,7 @@ export function RichtextEditorComponent(props: RichtextEditorComponentProps) {
     });
 
     return () => {
-      (window as any).tinyMCE.EditorManager.remove(selector);
+      (window as any).tinyMCE.get(editorId).remove();
       editorInstance !== null && editorInstance.remove();
     };
   }, [status]);


### PR DESCRIPTION
## Description

Changed Rich text Mechanism of onDestroy to fix Rich text Editor on Modal.

Fixes #6035 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
UI verification

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
