### PR TITLE
changed texts on datasources page

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/NewApi.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/NewApi.tsx
@@ -189,7 +189,7 @@ function NewApiScreen(props: Props) {
                 src={PlusLogo}
               />
             </div>
-            <p className="textBtn">Create new</p>
+            <p className="textBtn">Create new API</p>
           </CardContentWrapper>
           {isCreating && <Spinner className="cta" size={25} />}
         </ApiCard>
@@ -210,7 +210,7 @@ function NewApiScreen(props: Props) {
                 src={CurlLogo}
               />
             </div>
-            <p className="textBtn">CURL</p>
+            <p className="textBtn">CURL import</p>
           </CardContentWrapper>
         </ApiCard>
         {authApiPlugin && (


### PR DESCRIPTION

## Description

> I changed the texts on the datasources page ( from "Create new" to "Create new API" and from "CURL to CURL import").
> Here is how the updated version looks.

<img width="567" alt="Screenshot 2021-07-22 at 16 04 59" src="https://user-images.githubusercontent.com/46670083/126662356-88a2ef61-e5cf-48fb-8f7f-36e9ae6ff2f1.png">


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Since, only texts were changed, I did not perform any new test. I however ensured that all tests passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
