### PR TITLE
Test/cypress external work flow

### DIFF
--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -312,7 +312,15 @@ jobs:
       - name: Wait for 30 seconds for server to start
         run: |
             sleep 30s 
-            ps -ef | grep server-1.0-SNAPSHOT
+            
+      - name: Exit if Server hasnt started
+        run: |
+         if [[ `ps -ef | grep "server-1.0-SNAPSHOTwrong" | grep java |wc -l` == 0 ]]; then
+            echo "Server Not Started";
+            exit 1;
+          else
+            echo "Server Found";
+          fi
 
       - name: Use Node.js 14.15.4
         uses: actions/setup-node@v1

--- a/.github/workflows/client-test.yml
+++ b/.github/workflows/client-test.yml
@@ -315,7 +315,7 @@ jobs:
             
       - name: Exit if Server hasnt started
         run: |
-         if [[ `ps -ef | grep "server-1.0-SNAPSHOTwrong" | grep java |wc -l` == 0 ]]; then
+         if [[ `ps -ef | grep "server-1.0-SNAPSHOT" | grep java |wc -l` == 0 ]]; then
             echo "Server Not Started";
             exit 1;
           else

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -77,11 +77,7 @@ jobs:
           APPSMITH_ENCRYPTION_SALT: "salt"
           APPSMITH_IS_SELF_HOSTED: false
         run: |
-          mvn --batch-mode versions:set \
-            -DnewVersion=${{ steps.vars.outputs.version }} \
-            -DgenerateBackupPoms=false \
-            -DprocessAllModules=true
-          mvn --batch-mode package
+          ./build.sh
 
        # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -77,7 +77,10 @@ jobs:
           APPSMITH_ENCRYPTION_SALT: "salt"
           APPSMITH_IS_SELF_HOSTED: false
         run: |
-            ./build.sh
+            ./build.sh versions:set \
+            -DnewVersion=${{ steps.vars.outputs.version }} \
+            -DgenerateBackupPoms=false \
+            -DprocessAllModules=true
 
        # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -330,7 +330,7 @@ jobs:
             
       - name: Exit if Server hasnt started
         run: |
-         if [[ `ps -ef | grep "server-1.0-SNAPSHOTwrong" | grep java |wc -l` == 0 ]]; then
+         if [[ `ps -ef | grep "server-1.0-SNAPSHOT" | grep java |wc -l` == 0 ]]; then
             echo "Server Not Started";
             exit 1;
           else

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -77,7 +77,7 @@ jobs:
           APPSMITH_ENCRYPTION_SALT: "salt"
           APPSMITH_IS_SELF_HOSTED: false
         run: |
-          ./build.sh
+            ./build.sh
 
        # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle

--- a/.github/workflows/external-client-test.yml
+++ b/.github/workflows/external-client-test.yml
@@ -324,8 +324,15 @@ jobs:
       - name: Wait for 30 seconds for server to start
         run: |
             sleep 30s
-            ps -ef | grep server-1.0-SNAPSHOT
-
+            
+      - name: Exit if Server hasnt started
+        run: |
+         if [[ `ps -ef | grep "server-1.0-SNAPSHOTwrong" | grep java |wc -l` == 0 ]]; then
+            echo "Server Not Started";
+            exit 1;
+          else
+            echo "Server Found";
+          fi
 
       - name: Installing Yarn serve
         run: |


### PR DESCRIPTION
## Description

Added a fix to check if server has started, if not exit.
In external test workflow replaced mvn batch with build.sh

Fixes #5845 


## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

Tested in my fork. Detials below

Grep Success continue
https://github.com/yatinappsmith/appsmith/actions/runs/1058300525
Run if [[ `ps -ef | grep "server-1.0-SNAPSHOT" | grep java |wc -l` == 0 ]]; then
Server Found

Grep wrong exit
https://github.com/yatinappsmith/appsmith/actions/runs/1058338982
Run if [[ `ps -ef | grep "server-1.0-SNAPSHOTwrong" | grep java |wc -l` == 0 ]]; then
Server Not Started
Error: Process completed with exit code 1

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
