### PR TITLE
Bugfix for generate page from db table and add analytics event after the successful CRUD page creation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/AnalyticsEvents.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/AnalyticsEvents.java
@@ -10,7 +10,8 @@ public enum AnalyticsEvents {
     EXECUTE_ACTION("execute_ACTION_TRIGGERED"),
     UPDATE_LAYOUT,
     PUBLISH_APPLICATION("publish_APPLICATION"),
-    FORK
+    FORK,
+    GENERATE_CRUD_PAGE("generate_CRUD_PAGE")
     ;
 
     private final String eventName;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Entity.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Entity.java
@@ -5,4 +5,5 @@ public interface Entity {
     String APPLICATIONS = "applications";
     String PAGES = "pages";
     String DATASOURCES = "datasources";
+    String S3_PLUGIN_PACKAGE_NAME = "amazons3-plugin";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
@@ -405,7 +405,7 @@ public class CreateDBTablePageSolution {
     /**
      * This will fetch the template application resource which then act as a reference to clone layouts and actions
      * @param filePath template application path
-     * @return
+     * @return template application file
      * @throws IOException
      */
     private ApplicationJson fetchTemplateApplication(String filePath) throws IOException {
@@ -430,9 +430,9 @@ public class CreateDBTablePageSolution {
     /**
      * This function will clone actions from the template application and update action configuration using mapped
      * columns between the template datasource and datasource in context
-     * @param datasource
-     * @param tableName
-     * @param pageId
+     * @param datasource datasource connected by user
+     * @param tableName Table name provided by the user
+     * @param pageId Page to which actions needs to be cloned
      * @param templateActionList Actions from the template application related to specific datasource
      * @param mappedColumns Mapped column names between template and resource table under consideration
      * @param deletedWidgetNames Deleted column ref when template application have more # of columns than the users table

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
@@ -783,23 +783,22 @@ public class CreateDBTablePageSolution {
 
     private Mono<PageDTO> sendGenerateCRUDPageAnalyticsEvent(PageDTO page, Datasource datasource, String pluginName) {
         return sessionUserService.getCurrentUser()
-        .flatMap(currUser -> {
-
-            final Map<String, Object> data = Map.of(
-                "applicationId", page.getApplicationId(),
-                "pageId", page.getId(),
-                "pageName", page.getName(),
-                "pluginName", pluginName,
-                "datasourceId", datasource.getId(),
-                "organizationId", datasource.getOrganizationId()
-            );
-            analyticsService.sendEvent(AnalyticsEvents.GENERATE_CRUD_PAGE.getEventName(), currUser.getUsername(), data);
-            return Mono.just(page);
-        })
-        .onErrorResume(e -> {
-            log.warn("Error sending generate CRUD DB table page data point", e);
-            return Mono.just(page);
-        });
+            .map(currentUser -> {
+                try {
+                    final Map<String, Object> data = Map.of(
+                        "applicationId", page.getApplicationId(),
+                        "pageId", page.getId(),
+                        "pageName", page.getName(),
+                        "pluginName", pluginName,
+                        "datasourceId", datasource.getId(),
+                        "organizationId", datasource.getOrganizationId()
+                    );
+                    analyticsService.sendEvent(AnalyticsEvents.GENERATE_CRUD_PAGE.getEventName(), currentUser.getUsername(), data);
+                } catch (Exception e) {
+                    log.warn("Error sending generate CRUD DB table page data point", e);
+                }
+                return page;
+            });
     }
 
 }


### PR DESCRIPTION
## Description

> Find query was failing for MongoDB datasource because of the _where_ operator, which is linked with Select Widget. Allocation of labels and values were incorrect earlier for MongoDB datasource. Also added a analytics datapoint after successful page creation.   

Fixes #6086

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Tested manually on local instance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
