### PR TITLE
Optimize the selectors to prevent uncessary renders

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/hooks.ts
+++ b/app/client/src/components/editorComponents/Debugger/hooks.ts
@@ -1,3 +1,4 @@
+import { createSelector } from "reselect";
 import { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";

--- a/app/client/src/selectors/propertyPaneSelectors.tsx
+++ b/app/client/src/selectors/propertyPaneSelectors.tsx
@@ -10,6 +10,7 @@ import { PropertyPaneReduxState } from "reducers/uiReducers/propertyPaneReducer"
 import { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
 import { getSelectedWidget, getSelectedWidgets } from "./ui";
 import { EVALUATION_PATH } from "utils/DynamicBindingUtils";
+import { getDependenciesFromInverseDependencies } from "components/editorComponents/Debugger/helpers";
 
 const getPropertyPaneState = (state: AppState): PropertyPaneReduxState =>
   state.ui.propertyPane;
@@ -77,3 +78,14 @@ export const getIsPropertyPaneVisible = createSelector(
     );
   },
 );
+
+const getAllDependencies = (state: AppState) => state.evaluations.dependencies;
+
+export function getSelectorEntityDependenciesFromName(name: string) {
+  return createSelector(getAllDependencies, (deps) => {
+    return getDependenciesFromInverseDependencies(
+      deps.inverseDependencyMap,
+      name,
+    );
+  });
+}


### PR DESCRIPTION
## Description
PropertyPaneConnections components re-renders because it subscribes to the entire dataTree, this PR optimizes those selectors and brings down the renders from 4 to 2.

Fixes #6089


## Type of change
- Performance improvement

## How Has This Been Tested?
- Profiled before and after

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
