### PR TITLE
Fix #5075 Retain search keyword and search results when user navigates to profile page and comes back to home page.

### DIFF
--- a/app/client/src/pages/Applications/index.tsx
+++ b/app/client/src/pages/Applications/index.tsx
@@ -970,6 +970,7 @@ class Applications extends Component<
               search={{
                 placeholder: "Search for apps...",
                 queryFn: this.props.searchApplications,
+                defaultValue: this.props.searchKeyword,
               }}
             />
             <ApplicationsSection searchKeyword={this.props.searchKeyword} />

--- a/app/client/src/pages/common/SubHeader.tsx
+++ b/app/client/src/pages/common/SubHeader.tsx
@@ -47,6 +47,7 @@ type SubHeaderProps = {
     placeholder: string;
     debounce?: boolean;
     queryFn?: (keyword: string) => void;
+    defaultValue?: string;
   };
 };
 
@@ -67,6 +68,7 @@ export function ApplicationsSubHeader(props: SubHeaderProps) {
           <ControlGroup>
             <SearchInput
               cypressSelector={"t--application-search-input"}
+              defaultValue={props.search.defaultValue}
               disabled={isFetchingApplications}
               onChange={query || noop}
               placeholder={props.search.placeholder}


### PR DESCRIPTION
## Description

Fixed an issue in home page where searched key gets reset but searched results doesn't.

Fixes #5075 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>