### PR TITLE
[Fix] Minor omnibar updates

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/index.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/index.tsx
@@ -92,6 +92,16 @@ const getSectionTitle = (title: string, icon: any) => ({
   icon,
 });
 
+const getQueryIndexForSorting = (item: SearchItem, query: string) => {
+  if (item.kind === SEARCH_ITEM_TYPES.document) {
+    const title = item?._highlightResult?.title?.value;
+    return title.indexOf(algoliaHighlightTag);
+  } else {
+    const title = getItemTitle(item) || "";
+    return title.toLowerCase().indexOf(query.toLowerCase());
+  }
+};
+
 const getSortedResults = (
   query: string,
   filteredActions: Array<any>,
@@ -108,11 +118,8 @@ const getSortedResults = (
     ...filteredDatasources,
     ...documentationSearchResults,
   ].sort((a: any, b: any) => {
-    const titleA = getItemTitle(a) || "";
-    const titleB = getItemTitle(b) || "";
-
-    const queryIndexA = titleA.toLowerCase().indexOf(query.toLowerCase());
-    const queryIndexB = titleB.toLowerCase().indexOf(query.toLowerCase());
+    const queryIndexA = getQueryIndexForSorting(a, query);
+    const queryIndexB = getQueryIndexForSorting(b, query);
 
     if (queryIndexA === queryIndexB) {
       const pageA = getItemPage(a);

--- a/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
@@ -83,8 +83,6 @@ const updateDocumentDescriptionTitle = (documentObj: any, item: any) => {
     // append documentation button after title:
     const ctaElement = getDocumentationCTA(path) as Node;
     firstChild.appendChild(ctaElement);
-
-    removeBadHighlights(firstChild, item.query);
   }
 };
 
@@ -155,6 +153,9 @@ const parseDocumentationContent = (item: any): string | undefined => {
       } catch (e) {}
     });
 
+    // update description title
+    updateDocumentDescriptionTitle(documentObj, item);
+
     // Combine adjacent highlighted nodes into a single one
     let adjacentMatches: string[] = [];
     const letterRegex = /[a-zA-Z]/g;
@@ -222,8 +223,6 @@ const parseDocumentationContent = (item: any): string | undefined => {
 
     // Remove highlight for nodes that don't match well
     removeBadHighlights(documentObj, query);
-    // update description title
-    updateDocumentDescriptionTitle(documentObj, item);
     let content = updateYoutubeEmbedingsWithIframe(documentObj.body.innerHTML);
     content = strip(content).trim();
     return content;


### PR DESCRIPTION
## Description
- Use alogolia's highlight tag to determine query index, that is later used for sorting the search results, so matching results show on top
- Fix highlighting for the document title

Fixes #6096

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: docs-updates 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.91 **(0)** | 33.47 **(-0.01)** | 30.04 **(-0.01)** | 52.58 **(0)**
 :red_circle: | app/client/src/components/editorComponents/GlobalSearch/index.tsx | 57.69 **(-0.64)** | 13.75 **(-1.11)** | 39.53 **(-0.95)** | 58.2 **(-0.72)**
 :green_circle: | app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts | 78.57 **(-0.22)** | 45.35 **(2.33)** | 92.86 **(0)** | 78.95 **(-0.22)**</details>