### PR TITLE
Fix: fix data type appearing with data value for citext type for Postgres plugin

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/pom.xml
+++ b/app/server/appsmith-plugins/postgresPlugin/pom.xml
@@ -49,7 +49,6 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.2.12</version>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.ObjectUtils;
 import org.pf4j.Extension;
 import org.pf4j.PluginWrapper;
+import org.postgresql.util.PGobject;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
@@ -360,6 +361,18 @@ public class PostgresPlugin extends BasePlugin {
                                     value = objectMapper.readTree(resultSet.getString(i));
                                 } else {
                                     value = resultSet.getObject(i);
+
+                                    /**
+                                     * Any type that JDBC does not understand gets mapped to PGobject. PGobject has
+                                     * two attributes: type and value. Hence, when PGobject gets serialized, it gets
+                                     * converted into a JSON like {"type":"citext", "value":"someText"}. Since we are
+                                     * only interested in the value and not the type, it makes sense to extract out
+                                     * the value as a string.
+                                     * Reference: https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/util/PGobject.html
+                                     */
+                                    if (value instanceof PGobject) {
+                                        value = ((PGobject) value).getValue();
+                                    }
                                 }
 
                                 row.put(metaData.getColumnName(i), value);


### PR DESCRIPTION
## Description
- fix data type appearing with data value for types that JDBC does not internally map. 
- ref: https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/util/PGobject.html 

```
Normally, a data type not known by the driver is returned by ResultSet.getObject() as a PGobject instance
```
ref: https://www.postgresql.org/docs/7.3/jdbc-ext.html 

Fixes #4225 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
