### PR TITLE
[Bugfix] Mark a comment thread as unread when there is a new comment in the thread

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -113,22 +113,25 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
             }
         });
 
-        Mono<CommentThread> commentThreadMono = threadRepository.findById(threadId, AclPermission.COMMENT_ON_THREAD)
-                .flatMap(commentThread -> {
-                    if (CommentUtils.isAnyoneMentioned(comment) && Boolean.TRUE.equals(commentThread.getIsPrivate())) {
-                        return convertToPublic(commentThread);
-                    }
-                    return Mono.just(commentThread);
-                });
+        return userMono.flatMap(user ->
+            threadRepository
+                    .findById(threadId, AclPermission.COMMENT_ON_THREAD)
+                    .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, "comment thread", threadId)))
+                    .flatMap(commentThread -> updateThreadIfRequired(commentThread, comment, user))
+                    .flatMap(commentThread -> create(commentThread, user, comment, originHeader, true))
+        );
+    }
 
+    private Mono<CommentThread> updateThreadIfRequired(CommentThread commentThread, Comment comment, User user) {
+        commentThread.setViewedByUsers(Set.of(user.getUsername()));
+        if(commentThread.getResolvedState().getActive() == TRUE) {
+            commentThread.getResolvedState().setActive(FALSE);
+        }
 
-        return userMono.zipWith(commentThreadMono)
-                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, "comment thread", threadId)))
-                .flatMap(tuple -> {
-                    final User user = tuple.getT1();
-                    final CommentThread thread = tuple.getT2();
-                    return create(thread, user, comment, originHeader, true);
-                });
+        if (CommentUtils.isAnyoneMentioned(comment) && Boolean.TRUE.equals(commentThread.getIsPrivate())) {
+            return convertToPublic(commentThread).flatMap(threadRepository::save);
+        }
+        return threadRepository.save(commentThread);
     }
 
     /**
@@ -140,7 +143,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
     private Mono<CommentThread> convertToPublic(CommentThread commentThread) {
         return applicationService.findById(commentThread.getApplicationId())
                 .zipWith(sequenceService.getNext(CommentThread.class, commentThread.getApplicationId()))
-                .flatMap(objects -> {
+                .map(objects -> {
                     Application application = objects.getT1();
                     commentThread.setSequenceId("#" + objects.getT2());
                     commentThread.setIsPrivate(FALSE);
@@ -155,7 +158,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                             commentThread.getAuthorUsername()
                     ).get(AclPermission.MANAGE_THREAD.getValue()));
                     commentThread.setPolicies(policies);
-                    return threadRepository.save(commentThread);
+                    return commentThread;
         });
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CommentServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CommentServiceTest.java
@@ -10,6 +10,7 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.repositories.CommentRepository;
 import com.appsmith.server.repositories.CommentThreadRepository;
+import com.appsmith.server.solutions.EmailEventHandler;
 import com.segment.analytics.Analytics;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
@@ -26,6 +27,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -64,10 +66,16 @@ public class CommentServiceTest {
     @MockBean
     private Analytics analytics;
 
+    @MockBean
+    private EmailEventHandler emailEventHandler;
+
     @Before
     public void setUp() {
         Mockito.doNothing().when(analytics).enqueue(any());
         Mockito.doNothing().when(analytics).flush();
+
+        Mockito.when(emailEventHandler.publish(any(), any(), any(), any(), any())).thenReturn(Mono.just(Boolean.TRUE));
+        Mockito.when(emailEventHandler.publish(any(), any(), any(), any())).thenReturn(Mono.just(Boolean.TRUE));
     }
 
     @Test
@@ -288,6 +296,40 @@ public class CommentServiceTest {
         StepVerifier.create(unreadCountMono).assertNext(aLong -> {
             assertThat(aLong).isEqualTo(1);
         }).verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void create_WhenThreadIsResolvedAndAlreadyViewed_ThreadIsUnresolvedAndUnread() {
+        // create a thread first with resolved=true
+        Collection<Policy> threadPolicies = policyUtils.generatePolicyFromPermission(
+                Set.of(AclPermission.COMMENT_ON_THREAD),
+                "api_user"
+        ).values();
+
+        CommentThread commentThread = new CommentThread();
+        CommentThread.CommentThreadState commentThreadState = new CommentThread.CommentThreadState();
+        commentThreadState.setActive(true);
+        commentThread.setResolvedState(commentThreadState);
+        commentThread.setPolicies(Set.copyOf(threadPolicies));
+        commentThread.setViewedByUsers(Set.of("api_user", "test_user"));
+
+        Mono<CommentThread> commentThreadMono = commentThreadRepository.save(commentThread)
+                .flatMap(savedThread -> {
+                    Comment comment = makePlainTextComment("Test comment");
+                    comment.setThreadId(savedThread.getId());
+                    return commentService.create(savedThread.getId(), comment, null);
+                })
+                .flatMap(savedComment ->
+                        commentThreadRepository.findById(savedComment.getThreadId())
+                );
+
+        StepVerifier.create(commentThreadMono).assertNext(thread -> {
+            assertThat(thread.getResolvedState().getActive()).isFalse();
+            assertThat(thread.getViewedByUsers().size()).isEqualTo(1);
+            assertThat(thread.getViewedByUsers()).contains("api_user");
+        }).verifyComplete();
+
     }
 
 }


### PR DESCRIPTION
## Description
When a new comment added to a thread, the thread should be marked as unread. This is shown as a red circle on the comment icon in the UI. This PR also includes another fix. When a new comment is added to a resolved thread, the thread should be marked as unresolved.

Fixes #5814 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
