### PR TITLE
Stop creating bot comment thread when user is app viewer

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.constants.CommentConstants.APPSMITH_BOT_NAME;
 import static com.appsmith.server.constants.CommentConstants.APPSMITH_BOT_USERNAME;
 import static java.lang.Boolean.FALSE;
@@ -255,8 +256,11 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                     .flatMap(tuple -> {
                         final UserData userData = tuple.getT1();
                         final Application application = tuple.getT2();
+                        boolean shouldCreateBotThread = policyUtils.isPermissionPresentForUser(
+                                application.getPolicies(), MANAGE_APPLICATIONS.getValue(), user.getUsername()
+                        );
                         // check whether this thread should be converted to bot thread
-                        if (userData.getLatestCommentEvent() == null) {
+                        if (userData.getLatestCommentEvent() == null && shouldCreateBotThread) {
                             commentThread.setIsPrivate(true);
                             userData.setLatestCommentEvent(CommentBotEvent.COMMENTED);
                             return userDataRepository.save(userData).then(

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CommentServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CommentServiceTest.java
@@ -7,9 +7,11 @@ import com.appsmith.server.domains.Comment;
 import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.domains.UserData;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.repositories.CommentRepository;
 import com.appsmith.server.repositories.CommentThreadRepository;
+import com.appsmith.server.repositories.UserDataRepository;
 import com.appsmith.server.solutions.EmailEventHandler;
 import com.segment.analytics.Analytics;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -62,6 +65,12 @@ public class CommentServiceTest {
 
     @Autowired
     PolicyUtils policyUtils;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    private UserDataRepository userDataRepository;
 
     @MockBean
     private Analytics analytics;
@@ -332,4 +341,59 @@ public class CommentServiceTest {
 
     }
 
+    private Mono<CommentThread> createAndFetchTestCommentThreadForBotTest(Set<AclPermission> applicationPermissions) {
+        return userService.findByEmail("api_user")
+                .flatMap(user ->
+                        userDataRepository.findByUserId(user.getId()) // setup userdata first
+                                .defaultIfEmpty(new UserData(user.getId()))
+                                .map(userData -> {
+                                    userData.setLatestCommentEvent(null);
+                                    return userData;
+                                })
+                                .flatMap(userDataRepository::save).thenReturn(user)
+
+                )
+                .flatMap(user -> {
+                    // create an application
+                    Application application = new Application();
+                    Map<String, Policy> stringPolicyMap = policyUtils.generatePolicyFromPermission(
+                            applicationPermissions, user
+                    );
+                    application.setPolicies(Set.copyOf(stringPolicyMap.values()));
+                    application.setName(UUID.randomUUID().toString());
+                    return applicationService.save(application);
+                }).flatMap(application -> {
+                    // create a thread
+                    CommentThread commentThread = new CommentThread();
+                    commentThread.setApplicationId(application.getId());
+                    Comment comment = makePlainTextComment("test comment here");
+                    commentThread.setComments(List.of(comment));
+                    return commentService.createThread(commentThread, null);
+                }).flatMap(thread -> commentThreadRepository.findById(thread.getId())); // fetch the thread to check
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createThread_WhenFirstCommentFromUser_CreatesBotThreadAndComment() {
+        Mono<CommentThread> commentThreadMono = createAndFetchTestCommentThreadForBotTest(
+                Set.of(AclPermission.MANAGE_APPLICATIONS, AclPermission.COMMENT_ON_APPLICATIONS)
+        );
+
+        StepVerifier.create(commentThreadMono).assertNext(thread -> {
+            assertThat(thread.getIsPrivate()).isTrue();
+            assertThat(thread.getSequenceId()).isEqualTo("#0");
+        }).verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void createThread_WhenFirstCommentFromViewer_BotThreadNotCreated() {
+        Mono<CommentThread> commentThreadMono = createAndFetchTestCommentThreadForBotTest(
+                Set.of(AclPermission.READ_APPLICATIONS)
+        );
+
+        StepVerifier.create(commentThreadMono).assertNext(thread -> {
+            assertThat(thread.getIsPrivate()).isNotEqualTo(Boolean.TRUE);
+        }).verifyComplete();
+    }
 }


### PR DESCRIPTION
## Description
Currently, the first comment thread created by an user is a private thread. In that thread, we create a bot comment telling the user about how to use the comment features. Private thread is created for all roles. This PR disables the private thread for app viewers.

Fixes #6110 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
