### PR TITLE
Fix #6084: Fix alignment issue with multiselection checkbox when ther…

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
@@ -291,40 +291,42 @@ export const renderEmptyRows = (
         </div>
       );
     });
+  } else {
+    const tableColumns = columns.length
+      ? columns
+      : new Array(3).fill({ width: tableWidth / 3, isHidden: false });
+    return (
+      <>
+        {rows.map((row: string, index: number) => {
+          return (
+            <div
+              className="tr"
+              key={index}
+              style={{
+                display: "flex",
+                flex: "1 0 auto",
+              }}
+            >
+              {multiRowSelection && renderCheckBoxCell(false)}
+              {tableColumns.map((column: any, colIndex: number) => {
+                return (
+                  <div
+                    className="td"
+                    key={colIndex}
+                    style={{
+                      width: column.width + "px",
+                      boxSizing: "border-box",
+                      flex: `${column.width} 0 auto`,
+                    }}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+      </>
+    );
   }
-  const tableColumns = columns.length
-    ? columns
-    : new Array(3).fill({ width: tableWidth / 3, isHidden: false });
-  return (
-    <>
-      {rows.map((row: string, index: number) => {
-        return (
-          <div
-            className="tr"
-            key={index}
-            style={{
-              display: "flex",
-              flex: "1 0 auto",
-            }}
-          >
-            {tableColumns.map((column: any, colIndex: number) => {
-              return (
-                <div
-                  className="td"
-                  key={colIndex}
-                  style={{
-                    width: column.width + "px",
-                    boxSizing: "border-box",
-                    flex: `${column.width} 0 auto`,
-                  }}
-                />
-              );
-            })}
-          </div>
-        );
-      })}
-    </>
-  );
 };
 
 const AscendingIcon = styled(ControlIcons.SORT_CONTROL as AnyStyledComponent)`


### PR DESCRIPTION
…e are

no rows present in the table

## Description
Commit fixes an alignment issue with multiselection checkbox when there are no  rows present in the table by displaying dummy checkboxes.

Fixes #6084 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/table-multiselection-misalignment 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.9 **(0)** | 33.45 **(-0.02)** | 30.03 **(0)** | 52.57 **(-0.01)**
 :red_circle: | app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx | 38.98 **(0)** | 18.99 **(-0.49)** | 9.38 **(0)** | 37.04 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.59 **(-0.24)** | 39.41 **(-0.84)** | 36.21 **(0)** | 54.77 **(-0.27)**</details>