### PR TITLE
changed texts on datasources page

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/NewApi.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/NewApi.tsx
@@ -189,7 +189,7 @@ function NewApiScreen(props: Props) {
                 src={PlusLogo}
               />
             </div>
-            <p className="textBtn">Create new</p>
+            <p className="textBtn">Create new API</p>
           </CardContentWrapper>
           {isCreating && <Spinner className="cta" size={25} />}
         </ApiCard>
@@ -210,7 +210,7 @@ function NewApiScreen(props: Props) {
                 src={CurlLogo}
               />
             </div>
-            <p className="textBtn">CURL</p>
+            <p className="textBtn">CURL import</p>
           </CardContentWrapper>
         </ApiCard>
         {authApiPlugin && (


### PR DESCRIPTION
## Description

Changed the texts on the datasources page from "Create new" to "Create new API" and from "CURL" to "CURL import".

This is a fix for issue #6019 

Here is an image showing the effected change.

<img width="501" alt="Screenshot 2021-07-26 at 09 50 06" src="https://user-images.githubusercontent.com/46670083/126963157-15988b22-f313-4403-a64b-4c9f077f1218.png">


Fixes #6019 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Text change did not require tests, however I ensured that all existing tests passed.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>