### PR TITLE
[Feature] Keep the scroll position into a widget when user switches to comment mode

### DIFF
--- a/app/client/src/comments/inlineComments/OverlayCommentsWrapper.tsx
+++ b/app/client/src/comments/inlineComments/OverlayCommentsWrapper.tsx
@@ -20,11 +20,12 @@ type Props = {
   widgetType: WidgetType;
 };
 
-const Container = styled.div`
+const Container = styled.div<{ isCommentMode: boolean }>`
   width: 100%;
   height: 100%;
   position: relative;
-  cursor: url("${commentIcon}") 25 20 , auto;
+  ${(props) =>
+    props.isCommentMode && `cursor: url("${commentIcon}") 25 20 , auto;`}
 `;
 
 /**
@@ -45,6 +46,7 @@ function OverlayCommentsWrapper({ children, refId, widgetType }: Props) {
 
   // create new unpublished thread
   const clickHandler = (e: any) => {
+    if (!isCommentMode) return;
     proceedToNextTourStep();
     e.persist();
     if (containerRef.current) {
@@ -60,17 +62,15 @@ function OverlayCommentsWrapper({ children, refId, widgetType }: Props) {
     }
   };
 
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  if (!isCommentMode) return <>{children}</>;
-
   return (
     <Container
       data-cy="overlay-comments-wrapper"
+      isCommentMode={isCommentMode}
       onClick={clickHandler}
-      ref={containerRef}
+      ref={isCommentMode ? containerRef : null}
     >
       {children}
-      <Comments refId={refId} />
+      {isCommentMode && <Comments refId={refId} />}
     </Container>
   );
 }

--- a/app/client/src/comments/inlineComments/OverlayCommentsWrapper.tsx
+++ b/app/client/src/comments/inlineComments/OverlayCommentsWrapper.tsx
@@ -51,7 +51,6 @@ function OverlayCommentsWrapper({ children, refId, widgetType }: Props) {
     e.persist();
     if (containerRef.current) {
       const position = getOffsetPos(e, containerRef.current);
-      if (!isCommentMode) return;
       dispatch(
         createUnpublishedCommentThreadRequest({
           refId,


### PR DESCRIPTION
## Description
This fix makes sure that we maintain the scroll position inside a widget when user switches to comment mode, if a user has scrolled into a scrollable widget (e.g. - form, table and container etc.).

Fixes #5795 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feature/keep-widget-scroll-in-comment-mode 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.95 **(0)** | 33.76 **(-0.01)** | 30.03 **(0.01)** | 52.6 **(0)**
 :green_circle: | app/client/src/comments/inlineComments/OverlayCommentsWrapper.tsx | 76.67 **(2.48)** | 41.67 **(4.17)** | 66.67 **(16.67)** | 77.78 **(3.71)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.59 **(-0.24)** | 39.41 **(-0.84)** | 36.21 **(0)** | 54.77 **(-0.27)**</details>