### PR TITLE
Updated image spec

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Image_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Image_spec.js
@@ -34,28 +34,14 @@ describe("Image Widget Functionality", function() {
     cy.closePropertyPane();
   });
 
-  it("Zoom-in functionality check", function() {
+  it("No Zoom functionality check", function() {
     cy.openPropertyPane("imagewidget");
     //Zoom validation
-    cy.changeZoomLevel("2x");
+    cy.changeZoomLevel("1x (No Zoom)");
     cy.get(commonlocators.editPropCrossButton).click({ force: true });
     cy.get(commonlocators.imgWidget)
       .invoke("attr", "style")
-      .should("contain", "zoom-in");
-    cy.get(commonlocators.imgWidget).click({ force: true });
-    cy.get(commonlocators.imgWidget).click({ force: true });
-    cy.get(commonlocators.imgWidget).click({ force: true });
-    cy.get(commonlocators.imgWidget).click({ force: true });
-    cy.get(commonlocators.imgWidget)
-      .invoke("attr", "style")
       .should("not.contain", "zoom-in");
-    cy.get(commonlocators.imgWidget)
-      .invoke("attr", "style")
-      .should("contain", "zoom-out");
-    cy.get(commonlocators.imgWidget).click({ force: true });
-    cy.get(commonlocators.imgWidget)
-      .invoke("attr", "style")
-      .should("contain", "zoom-in");
     cy.PublishtheApp();
   });
 


### PR DESCRIPTION
Changed the zoom test, from zoom in to no zoom and validated things accordingly

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>