### PR TITLE
Setting ActionExecutionRequest in response from executed API call

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
@@ -1,0 +1,104 @@
+package com.external.helpers;
+
+import com.appsmith.external.models.ActionConfiguration;
+import com.appsmith.external.models.ActionExecutionRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * This filter captures the request that was sent out via WebClient so that the execution response can
+ * accurately represent the actual request used
+ */
+@Getter
+public class RequestCaptureFilter implements ExchangeFilterFunction {
+
+    private ClientRequest request;
+    private final ObjectMapper objectMapper;
+
+    public RequestCaptureFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @NonNull
+    public Mono<ClientResponse> filter(@NonNull ClientRequest request, ExchangeFunction next) {
+        this.request = request;
+        return next.exchange(request);
+    }
+
+    public ActionExecutionRequest populateRequestFields(ActionExecutionRequest existing) {
+
+        final ActionExecutionRequest actionExecutionRequest = new ActionExecutionRequest();
+        actionExecutionRequest.setUrl(request.url().toString());
+        actionExecutionRequest.setHttpMethod(request.method());
+        MultiValueMap<String, String> headers = CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+        request.headers().forEach((header, value) -> {
+            if (HttpHeaders.AUTHORIZATION.equalsIgnoreCase(header) || "api_key".equalsIgnoreCase(header)) {
+                headers.add(header, "****");
+            } else {
+                headers.addAll(header, value);
+            }
+        });
+        actionExecutionRequest.setHeaders(objectMapper.valueToTree(headers));
+        actionExecutionRequest.setBody(existing.getBody());
+        actionExecutionRequest.setRequestParams(existing.getRequestParams());
+        actionExecutionRequest.setExecutionParameters(existing.getExecutionParameters());
+        actionExecutionRequest.setProperties(existing.getProperties());
+
+        return actionExecutionRequest;
+    }
+
+    public static ActionExecutionRequest populateRequestFields(ActionConfiguration actionConfiguration,
+                                                               URI uri,
+                                                               List<Map.Entry<String, String>> insertedParams,
+                                                               ObjectMapper objectMapper) {
+
+        ActionExecutionRequest actionExecutionRequest = new ActionExecutionRequest();
+
+        if (!insertedParams.isEmpty()) {
+            final Map<String, Object> requestData = new HashMap<>();
+            requestData.put("smart-substitution-parameters", insertedParams);
+            actionExecutionRequest.setProperties(requestData);
+        }
+
+        if (actionConfiguration.getHeaders() != null) {
+            MultiValueMap<String, String> reqMultiMap = CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+
+            actionConfiguration.getHeaders().stream()
+                    .forEach(header -> reqMultiMap.put(header.getKey(), Arrays.asList((String) header.getValue())));
+            actionExecutionRequest.setHeaders(objectMapper.valueToTree(reqMultiMap));
+        }
+
+        // If the body is set, then use that field as the request body by default
+        if (actionConfiguration.getBody() != null) {
+            actionExecutionRequest.setBody(actionConfiguration.getBody());
+        }
+
+        if (actionConfiguration.getHttpMethod() != null) {
+            actionExecutionRequest.setHttpMethod(actionConfiguration.getHttpMethod());
+        }
+
+        if (uri != null) {
+            actionExecutionRequest.setUrl(uri.toString());
+        }
+
+        return actionExecutionRequest;
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -416,6 +416,7 @@ public class RestApiPlugin extends BasePlugin {
                         return result;
                     })
                     .onErrorResume(error -> {
+                        errorResult.setRequest(requestCaptureFilter.populateRequestFields(actionExecutionRequest));
                         errorResult.setIsExecutionSuccess(false);
                         errorResult.setErrorInfo(error);
                         return Mono.just(errorResult);

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -23,6 +23,7 @@ import com.external.constants.ResponseDataType;
 import com.external.helpers.BufferingFilter;
 import com.external.helpers.DataUtils;
 import com.external.helpers.DatasourceValidator;
+import com.external.helpers.RequestCaptureFilter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -40,8 +41,6 @@ import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ClientHttpRequest;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -59,12 +58,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -234,14 +230,16 @@ public class RestApiPlugin extends BasePlugin {
                         actionConfiguration.getQueryParameters(),
                         encodeParamsToggle);
             } catch (URISyntaxException e) {
-                ActionExecutionRequest actionExecutionRequest = populateRequestFields(actionConfiguration, null, insertedParams);
+                ActionExecutionRequest actionExecutionRequest =
+                        RequestCaptureFilter.populateRequestFields(actionConfiguration, null, insertedParams, objectMapper);
                 actionExecutionRequest.setUrl(url);
                 errorResult.setBody(AppsmithPluginError.PLUGIN_ERROR.getMessage(e));
                 errorResult.setRequest(actionExecutionRequest);
                 return Mono.just(errorResult);
             }
 
-            ActionExecutionRequest actionExecutionRequest = populateRequestFields(actionConfiguration, uri, insertedParams);
+            ActionExecutionRequest actionExecutionRequest =
+                    RequestCaptureFilter.populateRequestFields(actionConfiguration, uri, insertedParams, objectMapper);
 
             if (httpMethod == null) {
                 errorResult.setBody(AppsmithPluginError.PLUGIN_ERROR.getMessage("HTTPMethod must be set."));
@@ -318,6 +316,9 @@ public class RestApiPlugin extends BasePlugin {
                 webClientBuilder.filter(new BufferingFilter());
             }
 
+            final RequestCaptureFilter requestCaptureFilter = new RequestCaptureFilter(objectMapper);
+            webClientBuilder.filter(requestCaptureFilter);
+
             WebClient client = webClientBuilder.exchangeStrategies(EXCHANGE_STRATEGIES).build();
 
             // Triggering the actual REST API call
@@ -333,7 +334,7 @@ public class RestApiPlugin extends BasePlugin {
                         ActionExecutionResult result = new ActionExecutionResult();
 
                         // Set the request fields
-                        result.setRequest(actionExecutionRequest);
+                        result.setRequest(requestCaptureFilter.populateRequestFields(actionExecutionRequest));
 
                         result.setStatusCode(statusCode.toString());
                         result.setIsExecutionSuccess(statusCode.is2xxSuccessful());
@@ -632,43 +633,6 @@ public class RestApiPlugin extends BasePlugin {
                 }
             }
             return uriBuilder.build(true).toUri();
-        }
-
-        private ActionExecutionRequest populateRequestFields(ActionConfiguration actionConfiguration,
-                                                             URI uri,
-                                                             List<Map.Entry<String, String>> insertedParams) {
-
-            ActionExecutionRequest actionExecutionRequest = new ActionExecutionRequest();
-
-            if (!insertedParams.isEmpty()) {
-                final Map<String, Object> requestData = new HashMap<>();
-                requestData.put("smart-substitution-parameters", insertedParams);
-                actionExecutionRequest.setProperties(requestData);
-            }
-
-            if (actionConfiguration.getHeaders() != null) {
-                MultiValueMap<String, String> reqMultiMap = CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
-
-                actionConfiguration.getHeaders().stream()
-                        .forEach(header -> reqMultiMap.put(header.getKey(), Arrays.asList((String) header.getValue())));
-                actionExecutionRequest.setHeaders(objectMapper.valueToTree(reqMultiMap));
-            }
-
-            // If the body is set, then use that field as the request body by default
-            if (actionConfiguration.getBody() != null) {
-                actionExecutionRequest.setBody(actionConfiguration.getBody());
-            }
-
-            if (actionConfiguration.getHttpMethod() != null) {
-                actionExecutionRequest.setHttpMethod(actionConfiguration.getHttpMethod());
-            }
-
-            if (uri != null) {
-                actionExecutionRequest.setUrl(uri.toString());
-            }
-
-            log.debug("Got request in actionExecutionResult as: {}", actionExecutionRequest);
-            return actionExecutionRequest;
         }
 
         private ActionConfiguration updateActionConfigurationForPagination(ActionConfiguration actionConfiguration,

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -4,10 +4,13 @@ import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionRequest;
 import com.appsmith.external.models.ActionExecutionResult;
+import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.OAuth2;
 import com.appsmith.external.models.Param;
 import com.appsmith.external.models.Property;
+import com.external.connections.APIConnection;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +25,7 @@ import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -29,6 +33,7 @@ import reactor.test.StepVerifier;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,7 +56,8 @@ public class RestApiPluginTest {
         dsConfig.setUrl("https://postman-echo.com/post");
 
         ActionConfiguration actionConfig = new ActionConfiguration();
-        actionConfig.setHeaders(List.of(new Property("content-type", "application/json")));
+        final List<Property> headers = List.of(new Property("content-type", "application/json"));
+        actionConfig.setHeaders(headers);
         actionConfig.setHttpMethod(HttpMethod.POST);
         String requestBody = "{\"key\":\"value\"}";
         actionConfig.setBody(requestBody);
@@ -63,6 +69,16 @@ public class RestApiPluginTest {
                     assertNotNull(result.getBody());
                     JsonNode data = ((ObjectNode) result.getBody()).get("data");
                     assertEquals(requestBody, data.toString());
+                    final ActionExecutionRequest request = result.getRequest();
+                    assertEquals("https://postman-echo.com/post", request.getUrl());
+                    assertEquals(HttpMethod.POST, request.getHttpMethod());
+                    assertEquals(requestBody, request.getBody());
+                    final Iterator<Map.Entry<String, JsonNode>> fields = ((ObjectNode) result.getRequest().getHeaders()).fields();
+                    fields.forEachRemaining(field -> {
+                        if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(field.getKey())) {
+                            assertEquals("application/json", field.getValue().get(0).asText());
+                        }
+                    });
                 })
                 .verifyComplete();
     }
@@ -111,6 +127,7 @@ public class RestApiPluginTest {
                 .verifyComplete();
     }
 
+    @Test
     public void testValidSignature() {
         DatasourceConfiguration dsConfig = new DatasourceConfiguration();
         dsConfig.setUrl("http://httpbin.org/headers");
@@ -132,12 +149,20 @@ public class RestApiPluginTest {
                     String token = ((ObjectNode) result.getBody()).get("headers").get("X-Appsmith-Signature").asText();
 
                     final SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-                    assertEquals("Appsmith", Jwts.parserBuilder()
+                    final String issuer = Jwts.parserBuilder()
                             .setSigningKey(key)
                             .build()
                             .parseClaimsJws(token)
                             .getBody()
-                            .getIssuer());
+                            .getIssuer();
+                    assertEquals("Appsmith", issuer);
+                    final Iterator<Map.Entry<String, JsonNode>> fields = ((ObjectNode) result.getRequest().getHeaders()).fields();
+                    fields.forEachRemaining(field -> {
+                        if ("X-Appsmith-Signature".equalsIgnoreCase(field.getKey())) {
+                            assertEquals(token, field.getValue().get(0).asText());
+                        }
+                    });
+
                 })
                 .verifyComplete();
     }
@@ -432,6 +457,40 @@ public class RestApiPluginTest {
                             "Header to indicate a non-JSON response or by modifying the API response " +
                             "to return a valid JSON.";
                     assertEquals(expectedMessage, result.getMessages().toArray()[0]);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testRequestWithApiKeyHeader() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        dsConfig.setUrl("https://postman-echo.com/post");
+        AuthenticationDTO authenticationDTO = new ApiKeyAuth(ApiKeyAuth.Type.HEADER, "api_key", "test");
+        dsConfig.setAuthentication(authenticationDTO);
+
+        ActionConfiguration actionConfig = new ActionConfiguration();
+        actionConfig.setHeaders(List.of(
+                new Property("content-type", "application/json"),
+                new Property(HttpHeaders.AUTHORIZATION, "auth-value")
+        ));
+        actionConfig.setHttpMethod(HttpMethod.POST);
+
+        String requestBody = "{\"key\":\"value\"}";
+        actionConfig.setBody(requestBody);
+
+        final APIConnection apiConnection = pluginExecutor.datasourceCreate(dsConfig).block();
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor.executeParameterized(apiConnection, new ExecuteActionDTO(), dsConfig, actionConfig);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getRequest().getBody());
+                    final Iterator<Map.Entry<String, JsonNode>> fields = ((ObjectNode) result.getRequest().getHeaders()).fields();
+                    fields.forEachRemaining(field -> {
+                        if ("api_key".equalsIgnoreCase(field.getKey()) || HttpHeaders.AUTHORIZATION.equalsIgnoreCase(field.getKey())) {
+                            assertEquals("****", field.getValue().get(0).asText());
+                        }
+                    });
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
This change now returns the request object populated from the actual request sent via WebClient. It handles both success and error states. The headers are redacted only for `Authorization` or `api_key` headers.

Fixes #5473 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually tested
- JUnit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
