### PR TITLE
Hotfix/download png jpeg option

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -248,62 +248,59 @@ async function downloadSaga(
   action: { data: any; name: string; type: string },
   event: ExecuteActionPayloadEvent,
 ) {
+  const displayWidgetDownloadError = (message: any) => {
+    return Toaster.show({
+      text: createMessage(ERROR_WIDGET_DOWNLOAD, message),
+      variant: Variant.danger,
+    });
+  };
+
   try {
     const { data, name, type } = action;
-    if (!name) {
-      Toaster.show({
-        text: createMessage(
-          ERROR_WIDGET_DOWNLOAD,
-          "File name was not provided",
-        ),
-        variant: Variant.danger,
-      });
 
+    if (!name) {
+      displayWidgetDownloadError("File name was not provided");
       if (event.callback) event.callback({ success: false });
       return;
     }
     const dataType = getType(data);
+
     if (dataType === Types.ARRAY || dataType === Types.OBJECT) {
       const jsonString = JSON.stringify(data, null, 2);
       downloadjs(jsonString, name, type);
       AppsmithConsole.info({
         text: `download('${jsonString}', '${name}', '${type}') was triggered`,
       });
-    } else if (
-      dataType === Types.STRING &&
-      isURL(data) &&
-      type === "application/x-binary"
-    ) {
-      // Requires a special handling for the use case when the user is trying to download a binary file from a URL
-      // due to incompatibility in the downloadjs library. In this case we are going to fetch the file from the URL
-      // using axios with the arraybuffer header and then pass it to the downloadjs library.
-      Axios.get(data, { responseType: "arraybuffer" })
+    } else {
+      //  Requires a special handling for the use case when the user is trying to download a binary file from a URL
+      //   due to incompatibility in the downloadjs library. In this case we are going to fetch the file from the URL
+      //   using axios with the arraybuffer header and then pass it to the downloadjs library.
+
+      const isBinaryFile =
+        dataType === Types.STRING &&
+        isURL(data) &&
+        type === "application/x-binary";
+
+      const promise = isBinaryFile
+        ? Axios.get(data)
+        : Axios.get(data, { responseType: "arraybuffer" });
+
+      promise
         .then((res) => {
           downloadjs(res.data, name, type);
           AppsmithConsole.info({
             text: `download('${data}', '${name}', '${type}') was triggered`,
           });
+          if (event.callback) event.callback({ success: true });
         })
         .catch((error) => {
           log.error(error);
-          Toaster.show({
-            text: createMessage(ERROR_WIDGET_DOWNLOAD, error),
-            variant: Variant.danger,
-          });
+          displayWidgetDownloadError(error);
           if (event.callback) event.callback({ success: false });
         });
-    } else {
-      downloadjs(data, name, type);
-      AppsmithConsole.info({
-        text: `download('${data}', '${name}', '${type}') was triggered`,
-      });
     }
-    if (event.callback) event.callback({ success: true });
   } catch (err) {
-    Toaster.show({
-      text: createMessage(ERROR_WIDGET_DOWNLOAD, err),
-      variant: Variant.danger,
-    });
+    displayWidgetDownloadError(err);
     if (event.callback) event.callback({ success: false });
   }
 }


### PR DESCRIPTION
## Description

The problem was that Axios wasn't called for cases where the file to be downloaded isn't Binary.  The condition used to detect if the file to be downloaded is binary (type === "application/x-binary") comes from an optional field(as shown in the image below), which is also a potential bug. 

<img width="819" alt="Screenshot 2021-07-27 at 08 09 03" src="https://user-images.githubusercontent.com/46670083/127111267-7ce95ed9-c6c0-4410-9967-662412929f8c.png">

## Changes made

- Axios was called as long as a URL string was provided
- As long as files come from a URL string, { responseType: "arraybuffer" } needs to be added as a config to Axios for the "downloadjs" library to parse the resulting data.

This PR is a fix for issue #5999 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: hotfix/download-png-jpeg-option 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.84 **(0)** | 33.71 **(0.01)** | 29.75 **(0)** | 52.48 **(0)**
 :green_circle: | app/client/src/sagas/ActionExecutionSagas.ts | 12.56 **(0.03)** | 2 **(0.02)** | 9.68 **(0)** | 14.36 **(0)**</details>