### PR TITLE
[Fix] Support short youtube video link embedding format, for videos in omnibar

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts
@@ -20,19 +20,25 @@ export const htmlToElement = (html: string) => {
  */
 const strip = (text: string) => text.replace(/{% .*?%}/gm, "");
 
-export const YT_EMBEDDING_SELECTION_REGEX = /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=(.*?)\&.*? %}/m;
+export const YT_EMBEDDING_SELECTION_REGEX = [
+  /{% embed url="<a href="https:\/\/www.youtube.com\/watch\?v=(.*?)\&.*? %}/m,
+  /{% embed url="<a href="https:\/\/youtu.be.*?>https:\/\/youtu.be\/(.*?)".*? %}/m,
+];
 
-const updateYoutubeEmbedingsWithIframe = (text: string) => {
+const getYtIframe = (videoId: string) => {
+  return `<iframe width="100%" height="280" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
+};
+const updateYoutubeEmbeddingsWithIframe = (text: string) => {
   let docString = text;
   let match;
-  while ((match = YT_EMBEDDING_SELECTION_REGEX.exec(docString)) !== null) {
-    // gitbook adds \\ in front of a _ char in an id. TO remove that we have to do this.
-    const videoId = match[1].replaceAll("%5C", "");
-    docString = docString.replace(
-      YT_EMBEDDING_SELECTION_REGEX,
-      `<iframe width="100%" height="280" src="https://www.youtube.com/embed/${videoId}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
-    );
-  }
+  YT_EMBEDDING_SELECTION_REGEX.forEach((ytRegex) => {
+    while ((match = ytRegex.exec(docString)) !== null) {
+      // gitbook adds \\ in front of a _ char in an id. TO remove that we have to do this.
+      let videoId = match[1].replaceAll("%5C", "");
+      videoId = videoId.replaceAll("\\", "");
+      docString = docString.replace(ytRegex, getYtIframe(videoId));
+    }
+  });
   return docString;
 };
 
@@ -223,7 +229,7 @@ const parseDocumentationContent = (item: any): string | undefined => {
 
     // Remove highlight for nodes that don't match well
     removeBadHighlights(documentObj, query);
-    let content = updateYoutubeEmbedingsWithIframe(documentObj.body.innerHTML);
+    let content = updateYoutubeEmbeddingsWithIframe(documentObj.body.innerHTML);
     content = strip(content).trim();
     return content;
   } catch (e) {


### PR DESCRIPTION
## Description
This fix will add support for links of the format - `https://youtu.be/{videoId}`

Fixes #6161 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/bug-6161-video-in-omnibar-v2 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.83 **(-0.01)** | 33.69 **(-0.01)** | 29.75 **(0.01)** | 52.47 **(0)**
 :red_circle: | app/client/src/components/editorComponents/GlobalSearch/parseDocumentationContent.ts | 77.45 **(-1.12)** | 45.35 **(0)** | 87.5 **(-5.36)** | 77.78 **(-1.17)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.59 **(-0.24)** | 39.41 **(-0.84)** | 36.21 **(0)** | 54.77 **(-0.27)**</details>