### PR TITLE
Fix/6163 add confirm of clicking url on text

### DIFF
--- a/app/client/src/components/designSystems/blueprint/TextComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/TextComponent.tsx
@@ -92,6 +92,7 @@ class TextComponent extends React.Component<TextComponentProps> {
           <Interweave
             content={text}
             matchers={[new EmailMatcher("email"), new UrlMatcher("url")]}
+            newWindow
           />
         </StyledText>
       </TextContainer>


### PR DESCRIPTION
## Description

> When a user click link or email over text component, it should be opened on new tab, not on same tab.

Fixes #6163

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: FIX/6163-add-confirm-of-clicking-url-on-text 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.84 **(0.01)** | 33.7 **(0.01)** | 29.74 **(0)** | 52.47 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.83 **(0.24)** | 40.25 **(0.84)** | 36.21 **(0)** | 55.04 **(0.27)**</details>