### PR TITLE
Add missed new nav analytics for connections

### DIFF
--- a/app/client/src/components/editorComponents/ActionRightPane/Connections.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/Connections.tsx
@@ -3,15 +3,10 @@ import { Collapsible } from ".";
 import Icon, { IconSize } from "components/ads/Icon";
 import styled from "styled-components";
 import LongArrowSVG from "assets/images/long-arrow-bottom.svg";
-import Tooltip from "components/ads/Tooltip";
 import { useEntityLink } from "../Debugger/hooks";
 import Text, { TextType } from "components/ads/Text";
 import { Classes } from "components/ads/common";
 import { getTypographyByKey } from "constants/DefaultTheme";
-import { useSelector } from "store";
-import { getDataTree } from "selectors/dataTreeSelectors";
-import { isAction, isWidget } from "workers/evaluationUtils";
-import { useCallback } from "react";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import {
   createMessage,
@@ -21,17 +16,13 @@ import {
   OUTGOING_ENTITIES,
   SEE_CONNECTED_ENTITIES,
 } from "constants/messages";
+import { Connection } from "../Debugger/EntityDependecies";
 
 const ConnectionType = styled.span`
   span:nth-child(2) {
     padding-left: ${(props) => props.theme.spaces[2] - 1}px;
   }
   padding-bottom: ${(props) => props.theme.spaces[2]}px;
-`;
-
-const ConnectionWrapper = styled.div`
-  margin: ${(props) => props.theme.spaces[1]}px
-    ${(props) => props.theme.spaces[0] + 2}px;
 `;
 
 const NoConnections = styled.div`
@@ -83,49 +74,26 @@ const ConnectionsContainer = styled.span`
   }
 `;
 
-const useGetEntityType = () => {
-  const dataTree = useSelector(getDataTree);
-
-  const getEntityType = useCallback((name) => {
-    if (isWidget(dataTree[name])) {
-      return "widget";
-    } else if (isAction(dataTree[name])) {
-      return "integration";
-    }
-  }, []);
-
-  return getEntityType;
-};
-
 function Dependencies(props: any) {
   const { navigateToEntity } = useEntityLink();
-  const getEntityType = useGetEntityType();
 
-  const onClick = (entityName: string) => {
+  const onClick = (entityName: string, entityType: string) => {
     navigateToEntity(entityName);
     AnalyticsUtil.logEvent("ASSOCIATED_ENTITY_CLICK", {
       source: "INTEGRATION",
+      entityType: entityType,
     });
   };
 
   return props.dependencies.length ? (
     <ConnectionsContainer>
       {props.dependencies.map((entityName: string) => {
-        const entityType = getEntityType(entityName);
-
         return (
-          <Tooltip
-            content={`Open ${entityType}`}
-            disabled={!entityType}
-            hoverOpenDelay={1000}
+          <Connection
+            entityName={entityName}
             key={entityName}
-          >
-            <ConnectionWrapper>
-              <span className="connection" onClick={() => onClick(entityName)}>
-                {entityName}
-              </span>
-            </ConnectionWrapper>
-          </Tooltip>
+            onClick={onClick}
+          />
         );
       })}
     </ConnectionsContainer>

--- a/app/client/src/components/editorComponents/ActionRightPane/Connections.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/Connections.tsx
@@ -104,7 +104,7 @@ function Dependencies(props: any) {
   const onClick = (entityName: string) => {
     navigateToEntity(entityName);
     AnalyticsUtil.logEvent("ASSOCIATED_ENTITY_CLICK", {
-      screen: "INTEGRATION",
+      source: "INTEGRATION",
     });
   };
 

--- a/app/client/src/components/editorComponents/Debugger/EntityDependecies.tsx
+++ b/app/client/src/components/editorComponents/Debugger/EntityDependecies.tsx
@@ -163,7 +163,7 @@ function Dependencies(props: any) {
   const onClick = (entityName: string) => {
     navigateToEntity(entityName);
     AnalyticsUtil.logEvent("ASSOCIATED_ENTITY_CLICK", {
-      screen: "INTEGRATION",
+      source: "DEBUGGER",
     });
   };
 

--- a/app/client/src/components/editorComponents/Debugger/helpers.tsx
+++ b/app/client/src/components/editorComponents/Debugger/helpers.tsx
@@ -1,4 +1,4 @@
-import { Severity } from "entities/AppsmithConsole";
+import { Message, Severity } from "entities/AppsmithConsole";
 import React from "react";
 import styled from "styled-components";
 import { getTypographyByKey } from "constants/DefaultTheme";
@@ -119,6 +119,15 @@ export function getDependencyChain(
   });
   return currentChain;
 }
+
+export const doesEntityHaveErrors = (
+  entityId: string,
+  debuggerErrors: Record<string, Message>,
+) => {
+  const ids = Object.keys(debuggerErrors);
+
+  return ids.some((e: string) => e.includes(entityId));
+};
 
 export const onApiEditor = (
   applicationId: string | undefined,

--- a/app/client/src/components/editorComponents/Debugger/hooks.ts
+++ b/app/client/src/components/editorComponents/Debugger/hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { ENTITY_TYPE, Message } from "entities/AppsmithConsole";
@@ -11,14 +11,26 @@ import {
   getCurrentApplicationId,
   getCurrentPageId,
 } from "selectors/editorSelectors";
-import { getAction } from "selectors/entitiesSelector";
+import { getAction, getDatasource } from "selectors/entitiesSelector";
 import {
   getCurrentWidgetId,
   getIsPropertyPaneVisible,
 } from "selectors/propertyPaneSelectors";
 import { isWidget, isAction } from "workers/evaluationUtils";
-import { onApiEditor, onQueryEditor, onCanvas } from "./helpers";
+import {
+  onApiEditor,
+  onQueryEditor,
+  onCanvas,
+  doesEntityHaveErrors,
+} from "./helpers";
 import history from "utils/history";
+import { getDebuggerErrors } from "selectors/debuggerSelectors";
+import { isEqual, keyBy } from "lodash";
+import {
+  getPluginIcon,
+  getWidgetIcon,
+} from "pages/Editor/Explorer/ExplorerIcons";
+import { isStoredDatasource } from "entities/Action";
 
 export const useFilteredLogs = (query: string, filter?: any) => {
   let logs = useSelector((state: AppState) => state.ui.debugger.logs);
@@ -146,4 +158,53 @@ export const useEntityLink = () => {
   return {
     navigateToEntity,
   };
+};
+
+export const useGetEntityInfo = (name: string) => {
+  const entity = useSelector((state: AppState) => state.evaluations.tree[name]);
+  const debuggerErrors: Record<string, Message> = useSelector(
+    getDebuggerErrors,
+  );
+  const action = useSelector((state: AppState) =>
+    isAction(entity) ? getAction(state, entity.actionId) : undefined,
+  );
+
+  const plugins = useSelector((state: AppState) => {
+    return state.entities.plugins.list;
+  }, isEqual);
+  const pluginGroups = useMemo(() => keyBy(plugins, "id"), [plugins]);
+  const icon = action && getPluginIcon(pluginGroups[action.pluginId]);
+  const datasource = useSelector((state: AppState) =>
+    action && isStoredDatasource(action.datasource)
+      ? getDatasource(state, action.datasource.id)
+      : undefined,
+  );
+
+  const getEntityInfo = useCallback(() => {
+    if (isWidget(entity)) {
+      const icon = getWidgetIcon(entity.type);
+      const hasError = doesEntityHaveErrors(entity.widgetId, debuggerErrors);
+
+      return {
+        name,
+        icon,
+        hasError,
+        type: ENTITY_TYPE.WIDGET,
+        entityType: entity.type,
+      };
+    } else if (isAction(entity)) {
+      const hasError = doesEntityHaveErrors(entity.actionId, debuggerErrors);
+
+      return {
+        name,
+        icon,
+        datasourceName: datasource?.name ?? "",
+        hasError,
+        type: ENTITY_TYPE.ACTION,
+        entityType: action?.pluginId ? pluginGroups[action.pluginId].name : "",
+      };
+    }
+  }, [name]);
+
+  return getEntityInfo;
 };

--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
@@ -292,6 +292,9 @@ function OptionNode(props: any) {
       }
     }
     navigateToEntity(props.option.label);
+    AnalyticsUtil.logEvent("ASSOCIATED_ENTITY_CLICK", {
+      source: "PROPERTY_PANE",
+    });
   };
 
   return (

--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from "react";
+import React, { memo, useMemo, useCallback } from "react";
 import styled from "styled-components";
 import Icon, { IconSize } from "components/ads/Icon";
 import Dropdown, {
@@ -10,19 +10,19 @@ import { AppState } from "reducers";
 import { useDispatch, useSelector } from "react-redux";
 import { getDataTree } from "selectors/dataTreeSelectors";
 import { isAction, isWidget } from "workers/evaluationUtils";
-import { getPluginIcon, getWidgetIcon } from "../Explorer/ExplorerIcons";
-import { getAction, getDatasource } from "selectors/entitiesSelector";
-import { keyBy } from "lodash";
-import { isStoredDatasource } from "entities/Action";
 import Text, { TextType } from "components/ads/Text";
 import { Classes } from "components/ads/common";
-import { useEntityLink } from "components/editorComponents/Debugger/hooks";
-import { getDependenciesFromInverseDependencies } from "components/editorComponents/Debugger/helpers";
+import {
+  useEntityLink,
+  useGetEntityInfo,
+} from "components/editorComponents/Debugger/hooks";
+import {
+  doesEntityHaveErrors,
+  getDependenciesFromInverseDependencies,
+} from "components/editorComponents/Debugger/helpers";
 import { getDebuggerErrors } from "selectors/debuggerSelectors";
-import { Message } from "entities/AppsmithConsole";
+import { ENTITY_TYPE, Message } from "entities/AppsmithConsole";
 import { DebugButton } from "components/editorComponents/Debugger/DebugCTA";
-import { useCallback } from "react";
-import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
 import { showDebugger } from "actions/debuggerActions";
 import { setActionTabsInitialIndex } from "actions/actionActions";
 import { getTypographyByKey } from "constants/DefaultTheme";
@@ -177,15 +177,6 @@ type TriggerNodeProps = DefaultDropDownValueNodeProps & {
   hasError: boolean;
 };
 
-const doesEntityHaveErrors = (
-  entityId: string,
-  debuggerErrors: Record<string, Message>,
-) => {
-  const ids = Object.keys(debuggerErrors);
-
-  return ids.some((e: string) => e.includes(entityId));
-};
-
 const doConnectionsHaveErrors = (
   options: DropdownOption[],
   debuggerErrors: Record<string, Message>,
@@ -193,51 +184,6 @@ const doConnectionsHaveErrors = (
   return options.some((option) =>
     doesEntityHaveErrors(option.value as string, debuggerErrors),
   );
-};
-
-const useGetEntityInfo = (name: string) => {
-  const dataTree = useSelector(getDataTree);
-  const debuggerErrors: Record<string, Message> = useSelector(
-    getDebuggerErrors,
-  );
-
-  const entity = dataTree[name];
-  const action = useSelector((state: AppState) =>
-    isAction(entity) ? getAction(state, entity.actionId) : undefined,
-  );
-
-  const plugins = useSelector((state: AppState) => {
-    return state.entities.plugins.list;
-  });
-  const pluginGroups = useMemo(() => keyBy(plugins, "id"), [plugins]);
-  const icon = action && getPluginIcon(pluginGroups[action.pluginId]);
-  const datasource = useSelector((state: AppState) =>
-    action && isStoredDatasource(action.datasource)
-      ? getDatasource(state, action.datasource.id)
-      : undefined,
-  );
-
-  if (isWidget(entity)) {
-    const icon = getWidgetIcon(entity.type);
-    const hasError = doesEntityHaveErrors(entity.widgetId, debuggerErrors);
-
-    return {
-      name,
-      icon,
-      hasError,
-      type: ENTITY_TYPE.WIDGET,
-    };
-  } else if (isAction(entity)) {
-    const hasError = doesEntityHaveErrors(entity.actionId, debuggerErrors);
-
-    return {
-      name,
-      icon,
-      datasourceName: datasource?.name ?? "",
-      hasError,
-      type: ENTITY_TYPE.ACTION,
-    };
-  }
 };
 
 const useDependencyList = (name: string) => {
@@ -279,7 +225,8 @@ const useDependencyList = (name: string) => {
 };
 
 function OptionNode(props: any) {
-  const entityInfo = useGetEntityInfo(props.option.label);
+  const getEntityInfo = useGetEntityInfo(props.option.label);
+  const entityInfo = getEntityInfo();
   const dispatch = useDispatch();
   const { navigateToEntity } = useEntityLink();
 
@@ -294,6 +241,7 @@ function OptionNode(props: any) {
     navigateToEntity(props.option.label);
     AnalyticsUtil.logEvent("ASSOCIATED_ENTITY_CLICK", {
       source: "PROPERTY_PANE",
+      entityType: entityInfo?.entityType,
     });
   };
 


### PR DESCRIPTION
## Description

- Log event when property pane connected entity is clicked
- Also add entity type info to event
- Refactor to make this happen by moving useGetEntityInfo hook to debugger hooks

Related to #6221 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/missing-analytics 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.85 **(0.01)** | 33.63 **(-0.03)** | 29.78 **(0.03)** | 52.48 **(0.01)**
 :green_circle: | app/client/src/components/editorComponents/ActionRightPane/Connections.tsx | 42.5 **(2.84)** | 30.77 **(-0.48)** | 0 **(0)** | 42.5 **(2.84)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/EntityDependecies.tsx | 35.14 **(0)** | 21.62 **(-4.19)** | 0 **(0)** | 36.11 **(0)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/helpers.tsx | 77.97 **(-3.51)** | 80 **(0)** | 33.33 **(-5.13)** | 79.59 **(-3.02)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/hooks.ts | 30.63 **(-2.7)** | 0 **(0)** | 4.76 **(-2.38)** | 29.9 **(-2.98)**
 :green_circle: | app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx | 65.59 **(8.92)** | 30.91 **(3.93)** | 47.06 **(8.04)** | 65.22 **(7.96)**
 :green_circle: | app/client/src/utils/helpers.tsx | 55.35 **(1.89)** | 30.14 **(4.11)** | 25.93 **(3.71)** | 48.8 **(1.6)**</details>