### PR TITLE
Fix JS error message showing call stack in firefox

### DIFF
--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -182,8 +182,9 @@ export default function evaluate(
         triggers = [...self.triggers];
       }
     } catch (e) {
+      const errorMessage = `${e.name}: ${e.message}`;
       errors.push({
-        errorMessage: `${e.stack.split(`\n`)[0]}`,
+        errorMessage: errorMessage,
         severity: Severity.ERROR,
         raw: script,
         errorType: PropertyEvaluationErrorType.PARSE,


### PR DESCRIPTION
## Description
Firefox JS errors were returning the call stack in the Evaluated value pane
<img width="1679" alt="Screenshot 2021-07-28 at 7 01 53 PM" src="https://user-images.githubusercontent.com/12022471/127439054-9004eabc-5bbc-4f1a-b132-d456ac62d440.png">

This PR fixes this issue

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/js-error-handleing-firefox 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.84 **(0)** | 33.67 **(0.01)** | 29.75 **(0)** | 52.47 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.83 **(0.24)** | 40.25 **(0.84)** | 36.21 **(0)** | 55.04 **(0.27)**</details>