### PR TITLE
Fix unnecessary renders of ActionCreator, EntityName, CodeEditor and ActionEntityContextMenu

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -14,7 +14,7 @@ import React, { useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "reducers";
 import { getCurrentStep, getCurrentSubStep } from "sagas/OnboardingSagas";
-import { getWidgets } from "sagas/selectors";
+import { getWidgetOptionsTree } from "sagas/selectors";
 import {
   getCurrentApplicationId,
   getCurrentPageId,
@@ -257,21 +257,6 @@ function useModalDropdownList() {
   return finalList;
 }
 
-function useWidgetOptionTree() {
-  const widgets = useSelector(getWidgets) || {};
-  return useMemo(() => {
-    return Object.values(widgets)
-      .filter((w) => w.type !== "CANVAS_WIDGET" && w.type !== "BUTTON_WIDGET")
-      .map((w) => {
-        return {
-          label: w.widgetName,
-          id: w.widgetName,
-          value: `"${w.widgetName}"`,
-        };
-      });
-  }, [widgets]);
-}
-
 function getIntegrationOptionsWithChildren(
   pageId: string,
   plugins: any,
@@ -407,7 +392,7 @@ type ActionCreatorProps = {
 
 export function ActionCreator(props: ActionCreatorProps) {
   const integrationOptionTree = useIntegrationsOptionTree();
-  const widgetOptionTree = useWidgetOptionTree();
+  const widgetOptionTree = useSelector(getWidgetOptionsTree);
   const modalDropdownList = useModalDropdownList();
   const pageDropdownOptions = useSelector(getPageListAsOptions);
   const fields = getFieldFromValue(props.value);

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -1,40 +1,41 @@
-import React, { useMemo } from "react";
-import { AppState } from "reducers";
-import {
-  getActionsForCurrentPage,
-  getDBDatasources,
-} from "selectors/entitiesSelector";
 import { createActionRequest } from "actions/actionActions";
-import {
-  getModalDropdownList,
-  getNextModalName,
-} from "selectors/widgetSelectors";
+import { createModalAction } from "actions/widgetActions";
+import { TreeDropdownOption } from "components/ads/TreeDropdown";
+import TreeStructure from "components/utils/TreeStructure";
+import { OnboardingStep } from "constants/OnboardingConstants";
+import { ReduxActionTypes } from "constants/ReduxActionConstants";
+import { INTEGRATION_EDITOR_URL, INTEGRATION_TABS } from "constants/routes";
+import { PluginType } from "entities/Action";
+import { Datasource } from "entities/Datasource";
+import { keyBy } from "lodash";
+import { getActionConfig } from "pages/Editor/Explorer/Actions/helpers";
+import { apiIcon, getPluginIcon } from "pages/Editor/Explorer/ExplorerIcons";
+import React, { useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { AppState } from "reducers";
+import { getCurrentStep, getCurrentSubStep } from "sagas/OnboardingSagas";
+import { getWidgets } from "sagas/selectors";
 import {
   getCurrentApplicationId,
   getCurrentPageId,
 } from "selectors/editorSelectors";
-import { Datasource } from "entities/Datasource";
+import {
+  getActionsForCurrentPage,
+  getDBDatasources,
+  getPageListAsOptions,
+} from "selectors/entitiesSelector";
+import {
+  getModalDropdownList,
+  getNextModalName,
+} from "selectors/widgetSelectors";
+import { createNewQueryName } from "utils/AppsmithUtils";
+import history from "utils/history";
 import Fields, {
-  ACTION_TRIGGER_REGEX,
-  ACTION_ANONYMOUS_FUNC_REGEX,
   ActionType,
+  ACTION_ANONYMOUS_FUNC_REGEX,
+  ACTION_TRIGGER_REGEX,
   FieldType,
 } from "./Fields";
-import { TreeDropdownOption } from "components/ads/TreeDropdown";
-import { useDispatch, useSelector } from "react-redux";
-import { createModalAction } from "actions/widgetActions";
-import { createNewQueryName } from "utils/AppsmithUtils";
-import TreeStructure from "components/utils/TreeStructure";
-import { getWidgets } from "sagas/selectors";
-import { PluginType } from "entities/Action";
-import { INTEGRATION_EDITOR_URL, INTEGRATION_TABS } from "constants/routes";
-import history from "utils/history";
-import { keyBy } from "lodash";
-import { getPluginIcon, apiIcon } from "pages/Editor/Explorer/ExplorerIcons";
-import { getActionConfig } from "pages/Editor/Explorer/Actions/helpers";
-import { getCurrentStep, getCurrentSubStep } from "sagas/OnboardingSagas";
-import { OnboardingStep } from "constants/OnboardingConstants";
-import { ReduxActionTypes } from "constants/ReduxActionConstants";
 
 /* eslint-disable @typescript-eslint/ban-types */
 /* TODO: Function and object types need to be updated to enable the lint rule */
@@ -226,14 +227,6 @@ function getFieldFromValue(
   return fields;
 }
 
-function getPageDropdownOptions(state: AppState) {
-  return state.entities.pageList.pages.map((page) => ({
-    label: page.pageName,
-    id: page.pageId,
-    value: `'${page.pageName}'`,
-  }));
-}
-
 function useModalDropdownList() {
   const dispatch = useDispatch();
   const nextModalName = useSelector(getNextModalName);
@@ -266,15 +259,17 @@ function useModalDropdownList() {
 
 function useWidgetOptionTree() {
   const widgets = useSelector(getWidgets) || {};
-  return Object.values(widgets)
-    .filter((w) => w.type !== "CANVAS_WIDGET" && w.type !== "BUTTON_WIDGET")
-    .map((w) => {
-      return {
-        label: w.widgetName,
-        id: w.widgetName,
-        value: `"${w.widgetName}"`,
-      };
-    });
+  return useMemo(() => {
+    return Object.values(widgets)
+      .filter((w) => w.type !== "CANVAS_WIDGET" && w.type !== "BUTTON_WIDGET")
+      .map((w) => {
+        return {
+          label: w.widgetName,
+          id: w.widgetName,
+          value: `"${w.widgetName}"`,
+        };
+      });
+  }, [widgets]);
 }
 
 function getIntegrationOptionsWithChildren(
@@ -414,7 +409,7 @@ export function ActionCreator(props: ActionCreatorProps) {
   const integrationOptionTree = useIntegrationsOptionTree();
   const widgetOptionTree = useWidgetOptionTree();
   const modalDropdownList = useModalDropdownList();
-  const pageDropdownOptions = useSelector(getPageDropdownOptions);
+  const pageDropdownOptions = useSelector(getPageListAsOptions);
   const fields = getFieldFromValue(props.value);
   return (
     <TreeStructure>

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -63,6 +63,7 @@ import { getEntityNameAndPropertyPath } from "workers/evaluationUtils";
 import Button from "components/ads/Button";
 import { getPluginIdToImageLocation } from "sagas/selectors";
 import { ExpectedValueExample } from "utils/validation/common";
+import { getRecentEntityIds } from "selectors/globalSearchSelectors";
 
 const AUTOCOMPLETE_CLOSE_KEY_CODES = [
   "Enter",
@@ -600,7 +601,7 @@ const mapStateToProps = (state: AppState): ReduxStateProps => ({
   dynamicData: getDataTreeForAutocomplete(state),
   datasources: state.entities.datasources,
   pluginIdToImageLocation: getPluginIdToImageLocation(state),
-  recentEntities: state.ui.globalSearch.recentEntities.map((r) => r.id),
+  recentEntities: getRecentEntityIds(state),
 });
 
 const mapDispatchToProps = (dispatch: any): ReduxDispatchProps => ({

--- a/app/client/src/pages/Editor/Explorer/Actions/ActionEntityContextMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/ActionEntityContextMenu.tsx
@@ -1,23 +1,20 @@
-import React, { useCallback } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import TreeDropdown from "pages/Editor/Explorer/TreeDropdown";
-
-import { AppState } from "reducers";
-import ContextMenuTrigger from "../ContextMenuTrigger";
-
 import {
-  moveActionRequest,
   copyActionRequest,
   deleteAction,
+  moveActionRequest,
 } from "actions/actionActions";
-
 import { initExplorerEntityNameEdit } from "actions/explorerActions";
-import { ContextMenuPopoverModifiers, ExplorerURLParams } from "../helpers";
-import { noop } from "lodash";
-import { useNewActionName } from "./helpers";
-import { useParams } from "react-router";
 import { BUILDER_PAGE_URL } from "constants/routes";
+import { noop } from "lodash";
+import TreeDropdown from "pages/Editor/Explorer/TreeDropdown";
+import React, { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import { getPageListAsOptions } from "selectors/entitiesSelector";
 import history from "utils/history";
+import ContextMenuTrigger from "../ContextMenuTrigger";
+import { ContextMenuPopoverModifiers, ExplorerURLParams } from "../helpers";
+import { useNewActionName } from "./helpers";
 
 type EntityContextMenuProps = {
   id: string;
@@ -58,13 +55,7 @@ export function ActionEntityContextMenu(props: EntityContextMenuProps) {
     [dispatch],
   );
 
-  const menuPages = useSelector((state: AppState) => {
-    return state.entities.pageList.pages.map((page) => ({
-      label: page.pageName,
-      id: page.pageId,
-      value: page.pageName,
-    }));
-  });
+  const menuPages = useSelector(getPageListAsOptions);
 
   const editActionName = useCallback(
     () => dispatch(initExplorerEntityNameEdit(props.id)),

--- a/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
@@ -219,8 +219,6 @@ export const EntityName = forwardRef(
   },
 );
 
-EntityName.whyDidYouRender = true;
-
 EntityName.displayName = "EntityName";
 
 export default EntityName;

--- a/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
@@ -15,6 +15,13 @@ import { AppState } from "reducers";
 import { Page, ReduxActionTypes } from "constants/ReduxActionConstants";
 import { Colors } from "constants/Colors";
 import { WidgetTypes } from "constants/WidgetConstants";
+import { isEqual } from "lodash";
+import { createSelector } from "reselect";
+import {
+  getExistingActionNames,
+  getExistingPageNames,
+  getExistingWidgetNames,
+} from "selectors/entitiesSelector";
 
 const searchHighlightSpanClassName = "token";
 const searchTokenizationDelimiter = "!!";
@@ -69,6 +76,12 @@ export interface EntityNameProps {
   nameTransformFn?: (input: string, limit?: number) => string;
 }
 
+function myEqual(prev: any, next: any) {
+  console.log(prev, next);
+  console.log(prev === next, isEqual(prev, next));
+  return isEqual(prev, next);
+}
+
 export const EntityName = forwardRef(
   (props: EntityNameProps, ref: React.Ref<HTMLDivElement>) => {
     const { name, searchKeyword, updateEntityName } = props;
@@ -100,22 +113,12 @@ export const EntityName = forwardRef(
       setUpdatedName(name);
     }, [name, nameUpdateError]);
 
-    const existingPageNames: string[] = useSelector((state: AppState) =>
-      state.entities.pageList.pages.map((page: Page) => page.pageName),
-    );
+    const existingPageNames: string[] = useSelector(getExistingPageNames);
+    const existingWidgetNames: string[] = useSelector(getExistingWidgetNames);
 
-    const existingWidgetNames: string[] = useSelector((state: AppState) =>
-      Object.values(state.entities.canvasWidgets).map(
-        (widget) => widget.widgetName,
-      ),
-    );
     const dispatch = useDispatch();
 
-    const existingActionNames: string[] = useSelector((state: AppState) =>
-      state.entities.actions.map(
-        (action: { config: { name: string } }) => action.config.name,
-      ),
-    );
+    const existingActionNames: string[] = useSelector(getExistingActionNames);
 
     const hasNameConflict = useCallback(
       (
@@ -223,6 +226,8 @@ export const EntityName = forwardRef(
     );
   },
 );
+
+EntityName.whyDidYouRender = true;
 
 EntityName.displayName = "EntityName";
 

--- a/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
@@ -1,27 +1,25 @@
-import React, {
-  useCallback,
-  useMemo,
-  useState,
-  useEffect,
-  forwardRef,
-} from "react";
-import { useSelector, useDispatch } from "react-redux";
-import styled from "styled-components";
 import EditableText, {
   EditInteractionKind,
 } from "components/editorComponents/EditableText";
-import { removeSpecialChars } from "utils/helpers";
-import { AppState } from "reducers";
-import { Page, ReduxActionTypes } from "constants/ReduxActionConstants";
 import { Colors } from "constants/Colors";
+import { ReduxActionTypes } from "constants/ReduxActionConstants";
 import { WidgetTypes } from "constants/WidgetConstants";
-import { isEqual } from "lodash";
-import { createSelector } from "reselect";
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { AppState } from "reducers";
 import {
   getExistingActionNames,
   getExistingPageNames,
   getExistingWidgetNames,
 } from "selectors/entitiesSelector";
+import styled from "styled-components";
+import { removeSpecialChars } from "utils/helpers";
 
 const searchHighlightSpanClassName = "token";
 const searchTokenizationDelimiter = "!!";
@@ -74,12 +72,6 @@ export interface EntityNameProps {
   searchKeyword?: string;
   className?: string;
   nameTransformFn?: (input: string, limit?: number) => string;
-}
-
-function myEqual(prev: any, next: any) {
-  console.log(prev, next);
-  console.log(prev === next, isEqual(prev, next));
-  return isEqual(prev, next);
 }
 
 export const EntityName = forwardRef(

--- a/app/client/src/sagas/selectors.tsx
+++ b/app/client/src/sagas/selectors.tsx
@@ -29,6 +29,18 @@ export const getWidgetIdsByType = (state: AppState, type: WidgetType) => {
     .map((widget: FlattenedWidgetProps) => widget.widgetId);
 };
 
+export const getWidgetOptionsTree = createSelector(getWidgets, (widgets) =>
+  Object.values(widgets)
+    .filter((w) => w.type !== "CANVAS_WIDGET" && w.type !== "BUTTON_WIDGET")
+    .map((w) => {
+      return {
+        label: w.widgetName,
+        id: w.widgetName,
+        value: `"${w.widgetName}"`,
+      };
+    }),
+);
+
 export const getEditorConfigs = (
   state: AppState,
 ): { pageId: string; layoutId: string } | undefined => {

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -369,4 +369,20 @@ export const getPageListAsOptions = createSelector(
     })),
 );
 
+export const getExistingPageNames = createSelector(
+  (state: AppState) => state.entities.pageList.pages,
+  (pages) => pages.map((page) => page.pageName),
+);
+
+export const getExistingWidgetNames = createSelector(
+  (state: AppState) => state.entities.canvasWidgets,
+  (widgets) => Object.values(widgets).map((widget) => widget.pageName),
+);
+
+export const getExistingActionNames = createSelector(
+  (state: AppState) => state.entities.actions,
+  (actions) =>
+    actions.map((action: { config: { name: string } }) => action.config.name),
+);
+
 export const getAppMode = (state: AppState) => state.entities.app.mode;

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -359,4 +359,14 @@ export const getAllPageWidgets = createSelector(
   },
 );
 
+export const getPageListAsOptions = createSelector(
+  (state: AppState) => state.entities.pageList.pages,
+  (pages) =>
+    pages.map((page) => ({
+      label: page.pageName,
+      id: page.pageId,
+      value: `'${page.pageName}'`,
+    })),
+);
+
 export const getAppMode = (state: AppState) => state.entities.app.mode;

--- a/app/client/src/selectors/globalSearchSelectors.tsx
+++ b/app/client/src/selectors/globalSearchSelectors.tsx
@@ -1,0 +1,14 @@
+import { createSelector } from "reselect";
+
+import { AppState } from "reducers";
+import { RecentEntity } from "components/editorComponents/GlobalSearch/utils";
+
+export const getRecentEntities = (state: AppState) =>
+  state.ui.globalSearch.recentEntities;
+
+export const getRecentEntityIds = createSelector(
+  getRecentEntities,
+  (entities: RecentEntity[]) => {
+    return entities.map((r) => r.id);
+  },
+);


### PR DESCRIPTION
## Description

The following components re-render every-time something changes in the redux store. That is about 150 times for a single keypress in a medium sized app.

- ActionCreator,
- EntityName,
- CodeEditor and
- ActionEntityContextMenu

This PR optimizes the selectors to fix these issues. 4-5x improvement in performance.

Fixes #6240 


## Type of change

- UI Performance improvement

## How Has This Been Tested?
- Profiled before and after
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


![Screenshot_2021-07-29_at_7_52_17_AM__2_](https://user-images.githubusercontent.com/441914/127474603-b0f325a8-ef1d-4275-8f5c-b6d3331190ee.jpg)



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: ui/perf/fix-code-editor-actioncreatore-re-renders 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.52 **(0.02)** | 33.46 **(0)** | 29.36 **(0.06)** | 52.15 **(0.03)**
 :red_circle: | app/client/src/components/editorComponents/ActionCreator/index.tsx | 47.2 **(-2.42)** | 7.14 **(-3.67)** | 44.44 **(-12.08)** | 46.77 **(-2.07)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 67.24 **(0.43)** | 38.06 **(-0.75)** | 51.35 **(1.35)** | 69.16 **(0.47)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Actions/ActionEntityContextMenu.tsx | 42.86 **(3.97)** | 0 **(0)** | 0 **(0)** | 42.86 **(2.86)**
 :red_circle: | app/client/src/pages/Editor/Explorer/Entity/Name.tsx | 58.44 **(-1.32)** | 26.19 **(0)** | 38.46 **(-14.17)** | 58.11 **(-0.86)**
 :green_circle: | app/client/src/sagas/selectors.tsx | 73.79 **(1.06)** | 57.69 **(3.52)** | 54.84 **(4.84)** | 68.35 **(1.68)**
 :green_circle: | app/client/src/selectors/entitiesSelector.ts | 51.15 **(2.78)** | 5.19 **(0)** | 26.47 **(8.69)** | 48.7 **(3.4)**
 :sparkles: :new: | **app/client/src/selectors/globalSearchSelectors.tsx** | **85.71** | **100** | **66.67** | **100**</details>