### PR TITLE
Fix: Mark comment threads as viewed when they are resolved

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -67,9 +67,14 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
 
     @Override
     public Mono<Long> countUnreadThreads(String applicationId, String userEmail) {
+        String resolvedActiveFieldKey = String.format("%s.%s",
+                fieldName(QCommentThread.commentThread.resolvedState),
+                fieldName(QCommentThread.commentThread.resolvedState.active)
+        );
         List<Criteria> criteriaList = List.of(
-            where(fieldName(QCommentThread.commentThread.viewedByUsers)).ne(userEmail),
-            where(fieldName(QCommentThread.commentThread.applicationId)).is(applicationId)
+                where(fieldName(QCommentThread.commentThread.viewedByUsers)).ne(userEmail),
+                where(fieldName(QCommentThread.commentThread.applicationId)).is(applicationId),
+                where(resolvedActiveFieldKey).is(false)
         );
         return count(criteriaList, AclPermission.READ_THREAD);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -281,7 +281,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                         return saveCommentThread(commentThread, application, user);
                     })
                     .flatMap(thread ->
-                        analyticsService.sendCreateEvent(thread, Map.of("git a", thread.getWidgetType()))
+                        analyticsService.sendCreateEvent(thread, Map.of("widgetType", thread.getWidgetType()))
                     )
                     .flatMapMany(thread -> {
                         List<Mono<Comment>> commentSaverMonos = new ArrayList<>();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -280,9 +280,15 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                         }
                         return saveCommentThread(commentThread, application, user);
                     })
-                    .flatMap(thread ->
-                        analyticsService.sendCreateEvent(thread, Map.of("widgetType", thread.getWidgetType()))
-                    )
+                    .flatMap(thread -> {
+                        if(thread.getWidgetType() != null) {
+                            return analyticsService.sendCreateEvent(
+                                    thread, Map.of("widgetType", thread.getWidgetType())
+                            );
+                        } else {
+                            return analyticsService.sendCreateEvent(thread);
+                        }
+                    })
                     .flatMapMany(thread -> {
                         List<Mono<Comment>> commentSaverMonos = new ArrayList<>();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CommentServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CommentServiceTest.java
@@ -288,23 +288,29 @@ public class CommentServiceTest {
         );
         Set<Policy> policies = Set.copyOf(stringPolicyMap.values());
 
+        CommentThread.CommentThreadState resolvedState = new CommentThread.CommentThreadState();
+        resolvedState.setActive(false);
+
         // first thread which is read by api_user
         CommentThread c1 = new CommentThread();
         c1.setApplicationId("test-application-1");
         c1.setViewedByUsers(Set.of("api_user", "user2"));
         c1.setPolicies(policies);
+        c1.setResolvedState(resolvedState);
 
         // second thread which is not read by api_user
         CommentThread c2 = new CommentThread();
         c2.setApplicationId("test-application-1");
         c2.setViewedByUsers(Set.of("user2"));
         c2.setPolicies(policies);
+        c2.setResolvedState(resolvedState);
 
         // third thread which is read by api_user but in another application
         CommentThread c3 = new CommentThread();
         c3.setApplicationId("test-application-2");
         c3.setViewedByUsers(Set.of("user2", "api_user"));
         c3.setPolicies(policies);
+        c3.setResolvedState(resolvedState);
 
         Mono<Long> unreadCountMono = commentThreadRepository
                 .saveAll(List.of(c1, c2, c3)) // save all the threads


### PR DESCRIPTION
## Description
If a thread is marked as resolved when it's still not viewed by some user, that user can see a red circle on the comment icon which means there are unread comments. But they can see none as resolved comments are hidden by default. This PR fixes this issue. It also logs `widgetType` to analytics when new threads are created.

Fixes #6150 #6222 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Tested locally on dev machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
