### PR TITLE
Add instance id in analytics datapoint

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ConfigController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ConfigController.java
@@ -15,10 +15,11 @@ import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping(Url.CONFIG_URL)
-public class ConfigController extends BaseController<ConfigService, Config, String> {
+public class ConfigController {
 
+    private final ConfigService service;
     public ConfigController(ConfigService service) {
-        super(service);
+        this.service = service;
     }
 
     @GetMapping("/name/{name}")

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,14 +25,17 @@ public class AnalyticsService {
     private final Analytics analytics;
     private final SessionUserService sessionUserService;
     private final CommonConfig commonConfig;
+    private final ConfigService configService;
 
     @Autowired
     public AnalyticsService(@Autowired(required = false) Analytics analytics,
                             SessionUserService sessionUserService,
-                            CommonConfig commonConfig) {
+                            CommonConfig commonConfig,
+                            ConfigService configService) {
         this.analytics = analytics;
         this.sessionUserService = sessionUserService;
         this.commonConfig = commonConfig;
+        this.configService = configService;
     }
     public boolean isActive() {
         return analytics != null;
@@ -92,8 +96,6 @@ public class AnalyticsService {
             userId = hashedUserId;
         }
 
-        TrackMessage.Builder messageBuilder = TrackMessage.builder(event).userId(userId);
-
         if (!CollectionUtils.isEmpty(analyticsProperties) && commonConfig.isCloudHosting()) {
             // Segment throws an NPE if any value in `properties` is null.
             for (final Map.Entry<String, Object> entry : analyticsProperties.entrySet()) {
@@ -102,9 +104,16 @@ public class AnalyticsService {
                 }
             }
         }
-        messageBuilder = messageBuilder.properties(analyticsProperties);
 
-        analytics.enqueue(messageBuilder);
+        final String finalUserId = userId;
+        configService.getInstanceId().map(instanceId -> {
+            TrackMessage.Builder messageBuilder = TrackMessage.builder(event).userId(finalUserId);
+            analyticsProperties.put("originService", "appsmith-server");
+            analyticsProperties.put("instanceId", instanceId);
+            messageBuilder = messageBuilder.properties(analyticsProperties);
+            analytics.enqueue(messageBuilder);
+            return instanceId;
+        }).subscribeOn(Schedulers.boundedElastic()).subscribe();
     }
 
     public <T extends BaseDomain> Mono<T> sendObjectEvent(AnalyticsEvents event, T object, Map<String, Object> extraProperties) {
@@ -131,7 +140,6 @@ public class AnalyticsService {
                     HashMap<String, Object> analyticsProperties = new HashMap<>();
                     analyticsProperties.put("id", username);
                     analyticsProperties.put("oid", object.getId());
-                    analyticsProperties.put("originService", "appsmith-server");
                     if (extraProperties != null) {
                         analyticsProperties.putAll(extraProperties);
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigService.java
@@ -6,7 +6,7 @@ import com.appsmith.server.domains.Datasource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public interface ConfigService extends CrudService<Config, String> {
+public interface ConfigService {
     Mono<Config> getByName(String name);
 
     Mono<Config> updateByName(String name, Config config);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ConfigServiceImpl.java
@@ -10,14 +10,10 @@ import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.ConfigRepository;
 import com.appsmith.server.repositories.DatasourceRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
 
-import javax.validation.Validator;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,27 +21,23 @@ import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 @Slf4j
 @Service
-public class ConfigServiceImpl extends BaseService<ConfigRepository, Config, String> implements ConfigService {
+public class ConfigServiceImpl implements ConfigService {
 
     private static final String TEMPLATE_ORGANIZATION_CONFIG_NAME = "template-organization";
 
     private final ApplicationRepository applicationRepository;
     private final DatasourceRepository datasourceRepository;
+    private final ConfigRepository repository;
 
     // This is permanently cached through the life of the JVM process as this is not intended to change at runtime ever.
     private String instanceId = null;
 
-    public ConfigServiceImpl(Scheduler scheduler,
-                             Validator validator,
-                             MongoConverter mongoConverter,
-                             ReactiveMongoTemplate reactiveMongoTemplate,
-                             ConfigRepository repository,
-                             AnalyticsService analyticsService,
+    public ConfigServiceImpl(ConfigRepository repository,
                              ApplicationRepository applicationRepository,
                              DatasourceRepository datasourceRepository) {
-        super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
         this.applicationRepository = applicationRepository;
         this.datasourceRepository = datasourceRepository;
+        this.repository = repository;
     }
 
     @Override


### PR DESCRIPTION
## Description

> For each backend analytics datapoint insert instanceId to differentiate between self-hosted instances. 

Fixes #6250 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Tested on local instance with segment platform