### PR TITLE
Fix add widget test by mocking the response

### DIFF
--- a/app/client/cypress/fixtures/addWidgetTable-mock.json
+++ b/app/client/cypress/fixtures/addWidgetTable-mock.json
@@ -1,0 +1,53 @@
+{
+    "responseMeta": {
+      "status": 200,
+      "success": true
+    },
+    "data": {
+      "body": [
+        {
+            "id": 3,
+            "configName": "New Config",
+            "configJson": "{'key': 'val1'}",
+            "configVersion": 1,
+            "updatedAt": "2020-08-26 11:14:28.458209+00",
+            "updatedBy": ""
+        },
+        {
+            "id": 5,
+            "configName": "New Config",
+            "configJson": "{'key': 'val2'}",
+            "configVersion": 1,
+            "updatedAt": "2020-08-26 11:14:28.458209+00",
+            "updatedBy": ""
+        }
+      ],
+      "isExecutionSuccess": true,
+      "messages": [],
+      "request": {
+        "requestParams": {
+          "Query": {
+            "value": "SELECT * FROM public.\"users\" LIMIT 10;",
+            "substitutedParams": {}
+          }
+        }
+      },
+      "dataTypes": [
+        {
+          "dataType": "TABLE"
+        },
+        {
+          "dataType": "JSON"
+        },
+        {
+          "dataType": "RAW"
+        }
+      ],
+      "suggestedWidgets": [
+        {
+          "type": "TABLE_WIDGET",
+          "bindingQuery": "data"
+        }
+      ]
+    }
+  }

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/AddWidgetTableAndBind_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/AddWidgetTableAndBind_spec.js
@@ -36,6 +36,10 @@ describe("Addwidget from Query and bind with other widgets", function() {
       .type("SELECT * FROM configs LIMIT 10;");
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500);
+    // Mock the response for this test
+    cy.intercept("/api/v1/actions/execute", {
+      fixture: "addWidgetTable-mock",
+    });
     cy.get(queryEditor.runQuery).click();
     cy.wait("@postExecute").should(
       "have.nested.property",


### PR DESCRIPTION
## Description

Mock the execute action api for the add widget test. 

Fixes https://dashboard.cypress.io/projects/eyxvp8/analytics/top-failures/4c795857-06f9-c825-ec3a-f080836ef66e-a63d6407-9c5c-5344-7eb0-78f0bd6a39e7

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>