### PR TITLE
Improvement: Add limit on password length in user signup

### DIFF
--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -32,7 +32,7 @@ export const ENTER_VIDEO_URL = () => `Please provide a valid url`;
 
 export const FORM_VALIDATION_EMPTY_PASSWORD = () => `Please enter the password`;
 export const FORM_VALIDATION_PASSWORD_RULE = () =>
-  `Please provide a password with a minimum of 6 characters`;
+  `Please provide a password between 6 and 42 characters`;
 export const FORM_VALIDATION_INVALID_PASSWORD = FORM_VALIDATION_PASSWORD_RULE;
 
 export const LOGIN_PAGE_SUBTITLE = () => `Use your organization email`;

--- a/app/client/src/pages/UserAuth/Login.tsx
+++ b/app/client/src/pages/UserAuth/Login.tsx
@@ -16,7 +16,6 @@ import {
   LOGIN_PAGE_EMAIL_INPUT_PLACEHOLDER,
   FORM_VALIDATION_EMPTY_PASSWORD,
   FORM_VALIDATION_INVALID_EMAIL,
-  FORM_VALIDATION_INVALID_PASSWORD,
   LOGIN_PAGE_LOGIN_BUTTON_TEXT,
   LOGIN_PAGE_FORGOT_PASSWORD_TEXT,
   LOGIN_PAGE_SIGN_UP_LINK_TEXT,
@@ -30,7 +29,7 @@ import FormGroup from "components/ads/formFields/FormGroup";
 import FormTextField from "components/ads/formFields/TextField";
 import Button, { Size } from "components/ads/Button";
 import ThirdPartyAuth, { SocialLoginTypes } from "./ThirdPartyAuth";
-import { isEmail, isStrongPassword, isEmptyString } from "utils/formhelpers";
+import { isEmail, isEmptyString } from "utils/formhelpers";
 import { LoginFormValues } from "./helpers";
 import { withTheme } from "styled-components";
 import { Theme } from "constants/DefaultTheme";
@@ -59,10 +58,6 @@ const validate = (values: LoginFormValues) => {
   if (!password || isEmptyString(password)) {
     errors[LOGIN_FORM_PASSWORD_FIELD_NAME] = createMessage(
       FORM_VALIDATION_EMPTY_PASSWORD,
-    );
-  } else if (!isStrongPassword(password)) {
-    errors[LOGIN_FORM_PASSWORD_FIELD_NAME] = createMessage(
-      FORM_VALIDATION_INVALID_PASSWORD,
     );
   }
   if (!isEmptyString(email) && !isEmail(email)) {

--- a/app/client/src/utils/formhelpers.ts
+++ b/app/client/src/utils/formhelpers.ts
@@ -1,4 +1,5 @@
 const PASSWORD_MIN_LENGTH = 6;
+const PASSWORD_MAX_LENGTH = 42;
 
 export const hashPassword = (password: string) => {
   return password;
@@ -9,7 +10,11 @@ export const isEmptyString = (value: string) => {
 };
 
 export const isStrongPassword = (value: string) => {
-  return value.trim().length >= PASSWORD_MIN_LENGTH;
+  const passwordLength = value.trim().length;
+  return (
+    passwordLength >= PASSWORD_MIN_LENGTH &&
+    passwordLength < PASSWORD_MAX_LENGTH
+  );
 };
 
 export const noSpaces = (value: string) => {

--- a/app/client/src/utils/formhelpers.ts
+++ b/app/client/src/utils/formhelpers.ts
@@ -1,5 +1,5 @@
 const PASSWORD_MIN_LENGTH = 6;
-const PASSWORD_MAX_LENGTH = 42;
+const PASSWORD_MAX_LENGTH = 48;
 
 export const hashPassword = (password: string) => {
   return password;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
@@ -2,6 +2,7 @@ package com.appsmith.server.constants;
 
 public class FieldName {
     public static final String EMAIL = "email";
+    public static final String PASSWORD = "password";
     public static final String ORGANIZATION_ID = "organizationId";
     public static final String DELETED = "deleted";
     public static final String CREATED_AT = "createdAt";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -50,6 +50,7 @@ public enum AppsmithError {
             AppsmithErrorAction.DEFAULT, null),
     INVALID_PASSWORD_RESET(400, 4020, "Cannot find an outstanding reset password request for this email. Please initiate a request via 'forgot password' " +
             "button to reset your password", AppsmithErrorAction.DEFAULT, null),
+    INVALID_PASSWORD_LENGTH(400, 4037, "Password length should be between {0} and {1}" , AppsmithErrorAction.DEFAULT, null),
     JSON_PROCESSING_ERROR(400, 4022, "Json processing error with error {0}", AppsmithErrorAction.LOG_EXTERNALLY, null),
     INVALID_CREDENTIALS(200, 4023, "Invalid credentials provided. Did you input the credentials correctly?", AppsmithErrorAction.DEFAULT, null),
     UNAUTHORIZED_ACCESS(403, 4025, "Unauthorized access", AppsmithErrorAction.DEFAULT, null),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ValidationUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ValidationUtils.java
@@ -4,7 +4,7 @@ import org.apache.commons.validator.routines.EmailValidator;
 
 public final class ValidationUtils {
     public static final int LOGIN_PASSWORD_MIN_LENGTH = 6;
-    public static final int LOGIN_PASSWORD_MAX_LENGTH = 42;
+    public static final int LOGIN_PASSWORD_MAX_LENGTH = 48;
 
     public static boolean validateEmail(String emailStr) {
         return EmailValidator.getInstance().isValid(emailStr);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ValidationUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ValidationUtils.java
@@ -3,8 +3,15 @@ package com.appsmith.server.helpers;
 import org.apache.commons.validator.routines.EmailValidator;
 
 public final class ValidationUtils {
+    public static final int LOGIN_PASSWORD_MIN_LENGTH = 6;
+    public static final int LOGIN_PASSWORD_MAX_LENGTH = 42;
 
     public static boolean validateEmail(String emailStr) {
         return EmailValidator.getInstance().isValid(emailStr);
+    }
+
+    public static boolean validateLoginPassword(String password) {
+        int passwordLength = password.length();
+        return passwordLength >= LOGIN_PASSWORD_MIN_LENGTH && passwordLength <= LOGIN_PASSWORD_MAX_LENGTH;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -22,6 +22,7 @@ import com.appsmith.server.dtos.ResetUserPasswordDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.PolicyUtils;
+import com.appsmith.server.helpers.ValidationUtils;
 import com.appsmith.server.notifications.EmailSender;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.OrganizationRepository;
@@ -59,6 +60,8 @@ import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_INVITE_USERS;
 import static com.appsmith.server.acl.AclPermission.USER_MANAGE_ORGANIZATIONS;
+import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MAX_LENGTH;
+import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MIN_LENGTH;
 import static com.appsmith.server.repositories.BaseAppsmithRepositoryImpl.fieldName;
 
 @Slf4j
@@ -291,6 +294,10 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                 .flatMap(userFromDb -> {
                     if (!userFromDb.getPasswordResetInitiated()) {
                         return Mono.error(new AppsmithException(AppsmithError.INVALID_PASSWORD_RESET));
+                    } else if(!ValidationUtils.validateLoginPassword(user.getPassword())){
+                        return Mono.error(new AppsmithException(
+                                AppsmithError.INVALID_PASSWORD_LENGTH, LOGIN_PASSWORD_MIN_LENGTH, LOGIN_PASSWORD_MAX_LENGTH)
+                        );
                     }
 
                     //User has verified via the forgot password token verfication route. Allow the user to set new password.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -28,7 +28,10 @@ import reactor.core.publisher.Mono;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MAX_LENGTH;
+import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MIN_LENGTH;
 import static com.appsmith.server.helpers.ValidationUtils.validateEmail;
+import static com.appsmith.server.helpers.ValidationUtils.validateLoginPassword;
 import static org.springframework.security.web.server.context.WebSessionServerSecurityContextRepository.DEFAULT_SPRING_SECURITY_CONTEXT_ATTR_NAME;
 
 @Component
@@ -57,6 +60,12 @@ public class UserSignup {
 
         if (!validateEmail(user.getUsername())) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.EMAIL));
+        }
+
+        if (!validateLoginPassword(user.getPassword())) {
+            return Mono.error(new AppsmithException(
+                    AppsmithError.INVALID_PASSWORD_LENGTH, LOGIN_PASSWORD_MIN_LENGTH, LOGIN_PASSWORD_MAX_LENGTH)
+            );
         }
 
         return Mono

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
@@ -1,0 +1,58 @@
+package com.appsmith.server.solutions;
+
+import com.appsmith.server.authentication.handlers.AuthenticationSuccessHandler;
+import com.appsmith.server.domains.User;
+import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.ValidationUtils;
+import com.appsmith.server.services.CaptchaService;
+import com.appsmith.server.services.UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class UserSignupTest {
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private CaptchaService captchaService;
+
+    @MockBean
+    private AuthenticationSuccessHandler authenticationSuccessHandler;
+
+    private UserSignup userSignup;
+
+    @Before
+    public void setUp() {
+        userSignup = new UserSignup(userService, captchaService, authenticationSuccessHandler);
+    }
+
+    private String createRandomString(int length) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Z".repeat(Math.max(0, length)));
+        return builder.toString();
+    }
+
+    @Test
+    public void signupAndLogin_WhenPasswordTooShort_RaisesException() {
+        User user = new User();
+        user.setPassword(createRandomString(ValidationUtils.LOGIN_PASSWORD_MIN_LENGTH - 1));
+
+        Mono<User> userMono = userSignup.signupAndLogin(user, null);
+        StepVerifier.create(userMono).expectError(AppsmithException.class).verify();
+    }
+
+    @Test
+    public void signupAndLogin_WhenPasswordTooLong_RaisesException() {
+        User user = new User();
+        user.setPassword(createRandomString(ValidationUtils.LOGIN_PASSWORD_MAX_LENGTH + 1));
+
+        Mono<User> userMono = userSignup.signupAndLogin(user, null);
+        StepVerifier.create(userMono).expectError(AppsmithException.class).verify();
+    }
+}


### PR DESCRIPTION
## Description
Added a limit on password length when user signs up.

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit test
- Tested on local dev machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: bugfix/add-password-length-limit 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.7 **(0)** | 33.64 **(0.01)** | 29.55 **(0)** | 52.36 **(0.01)**
 :red_circle: | app/client/src/utils/formhelpers.ts | 73.68 **(-2.79)** | 0 **(0)** | 20 **(0)** | 64.29 **(-2.38)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>