### PR TITLE
Refresh sidebar comments list when thread is unresolved

### DIFF
--- a/app/client/src/reducers/uiReducers/commentsReducer/handleUpdateCommentThreadEvent.ts
+++ b/app/client/src/reducers/uiReducers/commentsReducer/handleUpdateCommentThreadEvent.ts
@@ -17,11 +17,11 @@ const handleUpdateCommentThreadEvent = (
     commentThreadInStore?.pinnedState?.active !==
     action.payload?.pinnedState?.active;
 
-  const isNowResolved =
-    !commentThreadInStore?.resolvedState?.active &&
+  const resolvedStateUpdated =
+    !commentThreadInStore?.resolvedState?.active !==
     action.payload?.resolvedState?.active;
 
-  const shouldRefreshList = isNowResolved || pinnedStateChanged;
+  const shouldRefreshList = resolvedStateUpdated || pinnedStateChanged;
 
   state.commentThreadsMap[id] = {
     ...(commentThreadInStore || {}),


### PR DESCRIPTION
## Description
Refresh sidebar comments list when thread is unresolved:
When a resolved comment is unresolved it should be updated in the UI at realtime and should now be visible in the comments list.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-refresh-list-when-thread-is-unresolved 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.51 **(0.01)** | 33.54 **(0.03)** | 29.3 **(0)** | 52.13 **(0)**
 :green_circle: | app/client/src/reducers/uiReducers/commentsReducer/handleUpdateCommentThreadEvent.ts | 100 **(6.67)** | 71.05 **(13.55)** | 100 **(0)** | 100 **(6.67)**</details>