### PR TITLE
Fix comment card click at the view mode

### DIFF
--- a/app/client/src/comments/CommentCard/CommentCard.tsx
+++ b/app/client/src/comments/CommentCard/CommentCard.tsx
@@ -362,8 +362,9 @@ function CommentCard({
     if (commentThread.widgetType) {
       const widget = widgetMap[commentThread.refId];
 
-      // only needed for modal widgetMap
-      // TODO check if we can do something similar for tabs
+      // 1. This is only needed for the modal widgetMap
+      // 2. TODO check if we can do something similar for tabs
+      // 3. getAllWidgetsMap doesn't exist for the view mode, so these won't work for the view mode
       if (widget?.parentModalId) {
         navigateToWidget(
           commentThread.refId,

--- a/app/client/src/comments/CommentCard/CommentCard.tsx
+++ b/app/client/src/comments/CommentCard/CommentCard.tsx
@@ -361,9 +361,10 @@ function CommentCard({
     if (inline) return;
     if (commentThread.widgetType) {
       const widget = widgetMap[commentThread.refId];
+
       // only needed for modal widgetMap
       // TODO check if we can do something similar for tabs
-      if (widget.parentModalId) {
+      if (widget?.parentModalId) {
         navigateToWidget(
           commentThread.refId,
           commentThread.widgetType,


### PR DESCRIPTION
## Description
Widget by page map doesn't exist for the view mode.
Adding a check as a quick fix.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-comment-card-link-view-mode 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.51 **(0)** | 33.56 **(0.01)** | 29.3 **(0)** | 52.14 **(0.01)**
 :red_circle: | app/client/src/comments/CommentCard/CommentCard.tsx | 32.6 **(0)** | 22.4 **(-0.74)** | 7.14 **(0)** | 34.32 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.83 **(0.24)** | 40.25 **(0.84)** | 36.21 **(0)** | 55.04 **(0.27)**</details>