### PR TITLE
Add list buckets API to S3

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Action.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Action.java
@@ -4,5 +4,6 @@ enum AmazonS3Action {
     LIST,
     UPLOAD_FILE_FROM_BODY,
     READ_FILE,
-    DELETE_FILE
+    DELETE_FILE,
+    LIST_BUCKETS
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -904,6 +904,9 @@ public class AmazonS3Plugin extends BasePlugin {
             return Mono.empty();
         }
 
+        // This function executes the DB query to fetch details about the datasource from plugin specified templates
+        // when we don't want to create new action just to get the information about the datasource in this case we can
+        // get list of S3 buckets etc.
         @Override
         public Mono<ActionExecutionResult> getDatasourceMetadata(List<Property> pluginSpecifiedTemplates,
                                                                  DatasourceConfiguration datasourceConfiguration) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
@@ -379,7 +379,7 @@ public class CreateDBTablePageSolution {
             .collectList()
             .flatMap(pages -> {
                 // Avoid duplicating page names
-                String pageName = "Admin Page:" + WordUtils.capitalize(tableName);
+                String pageName = WordUtils.capitalize(tableName);
                 long maxCount = 0L;
                 for (PageDTO pageDTO : pages) {
                     if (pageDTO.getName().matches("^" + Pattern.quote(pageName) + "\\d*$")) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolution.java
@@ -8,7 +8,6 @@ import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.plugins.PluginExecutor;
-import com.appsmith.external.services.EncryptionService;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Datasource;
@@ -16,6 +15,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.CustomDatasourceRepository;
+import com.appsmith.server.services.AuthenticationValidator;
 import com.appsmith.server.services.DatasourceContextService;
 import com.appsmith.server.services.DatasourceService;
 import com.appsmith.server.services.PluginService;
@@ -29,21 +29,19 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import static com.appsmith.external.models.AuthenticationDTO.AuthenticationStatus.SUCCESS;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class DatasourceStructureSolution {
 
-    public static final int GET_STRUCTURE_TIMEOUT_SECONDS = 10;
+    public static final int GET_STRUCTURE_TIMEOUT_SECONDS = 15;
 
     private final DatasourceService datasourceService;
     private final PluginExecutorHelper pluginExecutorHelper;
     private final PluginService pluginService;
     private final DatasourceContextService datasourceContextService;
-    private final EncryptionService encryptionService;
     private final CustomDatasourceRepository datasourceRepository;
+    private final AuthenticationValidator authenticationValidator;
 
     public Mono<DatasourceStructure> getStructure(String datasourceId, boolean ignoreCache) {
         return datasourceService.getById(datasourceId)
@@ -150,14 +148,15 @@ public class DatasourceStructureSolution {
         Mono<Datasource> datasourceMono = datasourceService.findById(datasourceId, AclPermission.MANAGE_DATASOURCES)
             .switchIfEmpty(Mono.error(new AppsmithException(
                 AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasourceId
-            )));
+            )))
+            .flatMap(authenticationValidator::validateAuthentication);
 
         return datasourceMono.flatMap(datasource -> {
 
             AuthenticationDTO auth = datasource.getDatasourceConfiguration() == null
                 || datasource.getDatasourceConfiguration().getAuthentication() == null ?
                 null : datasource.getDatasourceConfiguration().getAuthentication();
-            if (auth == null || !SUCCESS.equals(auth.getAuthenticationStatus())) {
+            if (auth == null) {
                 // Don't attempt to run query for invalid datasources.
                 return Mono.error(new AppsmithException(
                     AppsmithError.INVALID_DATASOURCE,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -208,7 +208,7 @@ public class CreateDBTablePageSolutionTests {
             .create(resultMono)
             .assertNext(page -> {
                 Layout layout = page.getLayouts().get(0);
-                assertThat(page.getName()).containsIgnoringCase("Admin Page:");
+                assertThat(page.getName()).isEqualTo("SampleTable");
                 assertThat(page.getLayouts()).isNotEmpty();
                 assertThat(layout.getDsl()).isNotEmpty();
                 assertThat(layout.getLayoutOnLoadActions()).hasSize(1);
@@ -406,7 +406,7 @@ public class CreateDBTablePageSolutionTests {
                 PageDTO page = tuple.getT1();
                 List<NewAction> actions = tuple.getT2();
                 Layout layout = page.getLayouts().get(0);
-                assertThat(page.getName()).containsIgnoringCase("Admin Page:");
+                assertThat(page.getName()).isEqualTo("SampleTable");
                 assertThat(page.getLayouts()).isNotEmpty();
                 assertThat(layout.getDsl()).isNotEmpty();
                 assertThat(layout.getLayoutOnLoadActions()).hasSize(1);
@@ -458,7 +458,7 @@ public class CreateDBTablePageSolutionTests {
                 PageDTO page = tuple.getT1();
                 List<NewAction> actions = tuple.getT2();
                 Layout layout = page.getLayouts().get(0);
-                assertThat(page.getName()).containsIgnoringCase("Admin Page:");
+                assertThat(page.getName()).isEqualTo("SampleTable");
                 assertThat(page.getLayouts()).isNotEmpty();
                 assertThat(layout.getDsl()).isNotEmpty();
                 assertThat(layout.getLayoutOnLoadActions()).hasSize(1);
@@ -509,7 +509,7 @@ public class CreateDBTablePageSolutionTests {
                 PageDTO page = tuple.getT1();
                 List<NewAction> actions = tuple.getT2();
                 Layout layout = page.getLayouts().get(0);
-                assertThat(page.getName()).containsIgnoringCase("Admin Page:");
+                assertThat(page.getName()).isEqualTo("SampleTable");
                 assertThat(page.getLayouts()).isNotEmpty();
                 assertThat(layout.getDsl()).isNotEmpty();
                 assertThat(layout.getActionsUsedInDynamicBindings()).isNotEmpty();


### PR DESCRIPTION
To generate a page from the DB table, to select the bucket on which the CRUD page needs to be created create an API to fetch all the buckets from the connected S3 datasource.

Fixes #6333

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Tested manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
