### PR TITLE
changed style of multiselectbox with radius 0

### DIFF
--- a/app/client/src/components/designSystems/appsmith/MultiSelectComponent/index.styled.tsx
+++ b/app/client/src/components/designSystems/appsmith/MultiSelectComponent/index.styled.tsx
@@ -165,6 +165,7 @@ export const DropdownStyles = createGlobalStyle`
       border-width: 2px;
       border-style: solid;
       border-color: ${Colors.GEYSER};
+      border-radius: 0px;
       &::before {
         width: auto;
         height: 1em;


### PR DESCRIPTION
## Description

> Multi-selectbox's checkbox widget has same border-radius as normal checkbox widget.

Fixes #6162 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please refer to attached issue.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>