### PR TITLE
Added logic to show form data requests in debugger

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/BodyReceiver.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/BodyReceiver.java
@@ -1,0 +1,215 @@
+package com.external.helpers;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserter;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class BodyReceiver {
+    private static final Object DUMMY = new Object();
+
+    private final AtomicReference<Object> reference = new AtomicReference<>(DUMMY);
+
+    public Object receiveValue(BodyInserter<?, ? extends ReactiveHttpOutputMessage> bodyInserter) {
+        demandValueFrom(bodyInserter);
+
+        return receivedValue();
+    }
+
+    private void demandValueFrom(BodyInserter<?, ? extends ReactiveHttpOutputMessage> bodyInserter) {
+        var inserter = (BodyInserter<Object, MinimalHttpOutputMessage>) bodyInserter;
+
+        inserter.insert(
+                MinimalHttpOutputMessage.INSTANCE,
+                new SingleWriterContext(new WriteToConsumer<>(reference::set))
+        );
+    }
+
+    private Object receivedValue() {
+        Object value = reference.get();
+        reference.set(DUMMY);
+
+        Object validatedValue;
+
+        if (value == DUMMY) {
+            throw new RuntimeException("Value was not received, Check your inserter worked properly");
+        } else {
+            validatedValue = value;
+        }
+
+        return validatedValue;
+    }
+
+    static class WriteToConsumer<T> implements HttpMessageWriter<T> {
+
+        private final Consumer<T> consumer;
+        private final List<MediaType> mediaTypes;
+
+        WriteToConsumer(Consumer<T> consumer) {
+            this.consumer = consumer;
+            this.mediaTypes = Collections.singletonList(MediaType.ALL);
+        }
+
+        @Override
+        public List<MediaType> getWritableMediaTypes() {
+            return mediaTypes;
+        }
+
+        @Override
+        public boolean canWrite(ResolvableType elementType, MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public Mono<Void> write(
+                Publisher<? extends T> inputStream,
+                ResolvableType elementType,
+                MediaType mediaType,
+                ReactiveHttpOutputMessage message,
+                Map<String, Object> hints
+        ) {
+            inputStream.subscribe(new OneValueConsumption<>(consumer));
+            return Mono.empty();
+        }
+    }
+
+    static class MinimalHttpOutputMessage implements ClientHttpRequest {
+
+        public static MinimalHttpOutputMessage INSTANCE = new MinimalHttpOutputMessage();
+
+        private MinimalHttpOutputMessage() {
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return HttpHeaders.EMPTY;
+        }
+
+        @Override
+        public DataBufferFactory bufferFactory() {
+            return null;
+        }
+
+        @Override
+        public void beforeCommit(Supplier<? extends Mono<Void>> action) {
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return false;
+        }
+
+        @Override
+        public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+            return null;
+        }
+
+        @Override
+        public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<? extends DataBuffer>> body) {
+            return null;
+        }
+
+        @Override
+        public Mono<Void> setComplete() {
+            return null;
+        }
+
+        @Override
+        public HttpMethod getMethod() {
+            return null;
+        }
+
+        @Override
+        public URI getURI() {
+            return null;
+        }
+
+        @Override
+        public MultiValueMap<String, HttpCookie> getCookies() {
+            return null;
+        }
+    }
+
+    static class OneValueConsumption<T> implements Subscriber<T> {
+
+        private final Consumer<T> consumer;
+        private int remainedAccepts;
+
+        public OneValueConsumption(Consumer<T> consumer) {
+            this.consumer = Objects.requireNonNull(consumer);
+            this.remainedAccepts = 1;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(1);
+        }
+
+        @Override
+        public void onNext(T o) {
+            if (remainedAccepts > 0) {
+                consumer.accept(o);
+                remainedAccepts -= 1;
+            } else {
+                throw new RuntimeException("No more values can be consumed");
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            throw new RuntimeException("Single value was not consumed", t);
+        }
+
+        @Override
+        public void onComplete() {
+            // nothing
+        }
+    }
+
+    static class SingleWriterContext implements BodyInserter.Context {
+
+        private final List<HttpMessageWriter<?>> singleWriterList;
+
+        SingleWriterContext(HttpMessageWriter<?> writer) {
+            this.singleWriterList = List.of(writer);
+        }
+
+        @Override
+        public List<HttpMessageWriter<?>> messageWriters() {
+            return singleWriterList;
+        }
+
+        @Override
+        public Optional<ServerHttpRequest> serverRequest() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Map<String, Object> hints() {
+            return null;
+        }
+    }
+}

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/BufferingFilter.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/BufferingFilter.java
@@ -17,6 +17,7 @@ import reactor.core.publisher.Mono;
  * It then adds this content length as a header to the original request
  */
 public class BufferingFilter implements ExchangeFilterFunction {
+
     @Override
     @NonNull
     public Mono<ClientResponse> filter(@NonNull ClientRequest request, ExchangeFunction next) {
@@ -43,7 +44,7 @@ public class BufferingFilter implements ExchangeFilterFunction {
                     .flatMap(dataBuffer -> {
                         int length = dataBuffer.readableByteCount();
                         this.getDelegate().getHeaders().setContentLength(length);
-                        return super.writeWith(Mono.just(dataBuffer));
+                        return super.writeWith(body);
                     });
         }
     }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
@@ -2,9 +2,11 @@ package com.external.helpers;
 
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionRequest;
+import com.appsmith.external.models.Property;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.lang.NonNull;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedCaseInsensitiveMap;
@@ -21,6 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 /**
  * This filter captures the request that was sent out via WebClient so that the execution response can
@@ -31,6 +37,7 @@ public class RequestCaptureFilter implements ExchangeFilterFunction {
 
     private ClientRequest request;
     private final ObjectMapper objectMapper;
+    private final BodyReceiver bodyReceiver = new BodyReceiver();
 
     public RequestCaptureFilter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
@@ -49,18 +56,29 @@ public class RequestCaptureFilter implements ExchangeFilterFunction {
         actionExecutionRequest.setUrl(request.url().toString());
         actionExecutionRequest.setHttpMethod(request.method());
         MultiValueMap<String, String> headers = CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+        AtomicBoolean isMultipart = new AtomicBoolean(false);
         request.headers().forEach((header, value) -> {
             if (HttpHeaders.AUTHORIZATION.equalsIgnoreCase(header) || "api_key".equalsIgnoreCase(header)) {
                 headers.add(header, "****");
             } else {
                 headers.addAll(header, value);
             }
+            if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(header) && MULTIPART_FORM_DATA_VALUE.equalsIgnoreCase(value.get(0))) {
+                isMultipart.set(true);
+            }
         });
         actionExecutionRequest.setHeaders(objectMapper.valueToTree(headers));
-        actionExecutionRequest.setBody(existing.getBody());
+
         actionExecutionRequest.setRequestParams(existing.getRequestParams());
         actionExecutionRequest.setExecutionParameters(existing.getExecutionParameters());
         actionExecutionRequest.setProperties(existing.getProperties());
+
+        // Apart from multipart, refer to the request that was actually sent
+        if (!isMultipart.get()) {
+            actionExecutionRequest.setBody(bodyReceiver.receiveValue(this.request.body()));
+        } else {
+            actionExecutionRequest.setBody(existing.getBody());
+        }
 
         return actionExecutionRequest;
     }
@@ -78,17 +96,42 @@ public class RequestCaptureFilter implements ExchangeFilterFunction {
             actionExecutionRequest.setProperties(requestData);
         }
 
+        AtomicReference<String> reqContentType = new AtomicReference<>();
+
         if (actionConfiguration.getHeaders() != null) {
             MultiValueMap<String, String> reqMultiMap = CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
 
-            actionConfiguration.getHeaders().stream()
-                    .forEach(header -> reqMultiMap.put(header.getKey(), Arrays.asList((String) header.getValue())));
+            actionConfiguration.getHeaders()
+                    .forEach(header -> {
+                        if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(header.getKey())) {
+                            reqContentType.set((String) header.getValue());
+                        }
+                        reqMultiMap.put(header.getKey(), Arrays.asList((String) header.getValue()));
+                    });
             actionExecutionRequest.setHeaders(objectMapper.valueToTree(reqMultiMap));
         }
 
         // If the body is set, then use that field as the request body by default
         if (actionConfiguration.getBody() != null) {
             actionExecutionRequest.setBody(actionConfiguration.getBody());
+        }
+
+        if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType.get())) {
+            final List<Property> bodyFormData = actionConfiguration.getBodyFormData();
+            Map<String, Object> bodyDataMap = new HashMap<>();
+            bodyFormData.forEach(property -> bodyDataMap.put(property.getKey(), property.getValue()));
+            actionExecutionRequest.setBody(bodyDataMap);
+        } else if (MediaType.MULTIPART_FORM_DATA_VALUE.equals(reqContentType.get())) {
+            final List<Property> bodyFormData = actionConfiguration.getBodyFormData();
+            Map<String, Object> bodyDataMap = new HashMap<>();
+            bodyFormData.forEach(property -> {
+                if ("FILE".equalsIgnoreCase(property.getType())) {
+                    bodyDataMap.put(property.getKey(), "<file>");
+                } else {
+                    bodyDataMap.put(property.getKey(), property.getValue());
+                }
+            });
+            actionExecutionRequest.setBody(bodyDataMap);
         }
 
         if (actionConfiguration.getHttpMethod() != null) {


### PR DESCRIPTION
Fixes #5462 

The changes will now show requests in the debugger pane as:
_Content type: Anything other than multipart or url encoded form data_
<img width="307" alt="Screenshot 2021-08-03 at 12 08 57 PM" src="https://user-images.githubusercontent.com/5298848/127981507-571dfe29-2b2c-454f-90a3-95a17b9e3303.png">
_Content type: URL encoded form data_
<img width="469" alt="Screenshot 2021-08-03 at 12 09 51 PM" src="https://user-images.githubusercontent.com/5298848/127981509-0e82db83-9d39-4536-a07e-8fd2af84f357.png">
_Content type: Multipart with normal text value_
<img width="311" alt="Screenshot 2021-08-03 at 12 10 21 PM" src="https://user-images.githubusercontent.com/5298848/127981512-f6f1c751-e694-49f1-b693-134e9492a1f8.png">
_Content type: Multipart for files_
This will literally always say `<file>` since we do not want to delay execution with such heavy payloads
<img width="289" alt="Screenshot 2021-08-03 at 1 37 09 PM" src="https://user-images.githubusercontent.com/5298848/127981431-8609d7fb-ccf6-414c-b205-fa9655376d0d.png">
