### PR TITLE
added cell background of empty rows

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
@@ -285,14 +285,8 @@ export const renderEmptyRows = (
           {multiRowSelection && renderCheckBoxCell(false)}
           {row.cells.map((cell: any, cellIndex: number) => {
             const cellProps = cell.getCellProps();
-            const background =
+            cellProps.style.background =
               columns[0]?.columnProperties?.cellBackground || null;
-            if (background) {
-              cellProps.style = {
-                ...cellProps.style,
-                background,
-              };
-            }
             return <div {...cellProps} className="td" key={cellIndex} />;
           })}
         </div>

--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
@@ -284,9 +284,16 @@ export const renderEmptyRows = (
         <div {...rowProps} className="tr" key={index}>
           {multiRowSelection && renderCheckBoxCell(false)}
           {row.cells.map((cell: any, cellIndex: number) => {
-            return (
-              <div {...cell.getCellProps()} className="td" key={cellIndex} />
-            );
+            const cellProps = cell.getCellProps();
+            const background =
+              columns[0]?.columnProperties?.cellBackground || null;
+            if (background) {
+              cellProps.style = {
+                ...cellProps.style,
+                background,
+              };
+            }
+            return <div {...cellProps} className="td" key={cellIndex} />;
           })}
         </div>
       );

--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
@@ -285,8 +285,10 @@ export const renderEmptyRows = (
           {multiRowSelection && renderCheckBoxCell(false)}
           {row.cells.map((cell: any, cellIndex: number) => {
             const cellProps = cell.getCellProps();
-            cellProps.style.background =
-              columns[0]?.columnProperties?.cellBackground || null;
+            if (columns[0]?.columnProperties?.cellBackground) {
+              cellProps.style.background =
+                columns[0].columnProperties.cellBackground;
+            }
             return <div {...cellProps} className="td" key={cellIndex} />;
           })}
         </div>


### PR DESCRIPTION
## Description

> When apply cell background of table property, it should be applied to empty row's cells.

Fixes #2868 

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please refer attached issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: FIX/2868-issue-of-adding-background-table 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.7 **(0)** | 33.62 **(-0.02)** | 29.55 **(0)** | 52.35 **(-0.01)**
 :red_circle: | app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx | 38.02 **(-0.96)** | 16.85 **(-2.14)** | 9.38 **(0)** | 36.04 **(-1)**</details>