### PR TITLE
Added null check for widget names in empty layout validation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
@@ -381,7 +381,7 @@ public class CreateDBTablePageSolution {
                 )
                 .map(newPage -> {
                     Layout layout = newPage.getUnpublishedPage().getLayouts().get(0);
-                    if (layout.getWidgetNames().size() > 1) {
+                    if (!CollectionUtils.isEmpty(layout.getWidgetNames()) && layout.getWidgetNames().size() > 1) {
                         throw new AppsmithException(AppsmithError.INVALID_CRUD_PAGE_REQUEST, "please try on empty layout");
                     }
                     return newPage;


### PR DESCRIPTION
## Description

> Check for NPE to find if the layout already has some widgets. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested manually 