### PR TITLE
Fix editor container fails to run with vanilla config

### DIFF
--- a/app/client/Dockerfile
+++ b/app/client/Dockerfile
@@ -1,12 +1,17 @@
-FROM nginx:1.17.9-alpine
+FROM nginx:1.19-alpine
 
 COPY ./build /var/www/appsmith
 
 EXPOSE 80
-# This is the default nginx template file inside the container. 
+
+# This is the default nginx template file inside the container.
 # This is replaced by the install.sh script during a deployment
-COPY ./docker/templates/nginx-app.conf.template /nginx.conf.template
+# COPY ./docker/templates/nginx-app.conf.template /nginx.conf.template
 COPY ./docker/templates/nginx-root.conf.template /nginx-root.conf.template
+
+COPY ./docker/templates/nginx-app-http.conf.template /etc/nginx/templates/
+COPY ./docker/templates/nginx-app-https.conf.template /nginx-app-https.conf.template
+
 # This is the script that is used to start Nginx when the Docker container starts
 COPY ./docker/start-nginx.sh /start-nginx.sh
 CMD ["/start-nginx.sh"]

--- a/app/client/docker/start-nginx.sh
+++ b/app/client/docker/start-nginx.sh
@@ -1,7 +1,36 @@
 #!/bin/sh
+
 # This script is baked into the appsmith-editor Dockerfile and is used to boot Nginx when the Docker container starts
 # Refer: /app/client/Dockerfile
-set -ue
-cat /nginx.conf.template | sed -e "s|__APPSMITH_CLIENT_PROXY_PASS__|http://localhost:3000|g" | sed -e "s|__APPSMITH_SERVER_PROXY_PASS__|http://localhost:8080|g" | envsubst "$(printf '$%s,' $(env | grep -Eo '^APPSMITH_[A-Z0-9_]+'))" | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' > /etc/nginx/conf.d/default.conf
-cat /nginx-root.conf.template | envsubst "$(printf '$%s,' $(env | grep -Eo '^APPSMITH_[A-Z0-9_]+'))" | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' > /etc/nginx/nginx.conf
+set -o errexit
+set -o xtrace
+
+if [ -z "$APPSMITH_SERVER_PROXY_PASS" ]; then
+  echo "Missing APPSMITH_SERVER_PROXY_PASS env variable. Please point it to where server is avilable." >&2
+  exit 1
+fi
+
+cp /nginx-root.conf.template /etc/nginx/nginx.conf
+
+if [ -f /nginx.conf.template ]; then
+  # This is to support installations where the docker-compose.yml file would mount a template confi at this location.
+  app_template=/nginx.conf.template
+elif [ -z "$APPSMITH_SSL_CERT_PATH" ]; then
+  if [ -z "$APPSMITH_DOMAIN" ]; then
+    export APPSMITH_DOMAIN=_
+  fi
+  app_template=/nginx-app-http.conf.template
+else
+  if [ -z "$APPSMITH_DOMAIN" ]; then
+    echo "APPSMITH_DOMAIN is required when SSL is enabled." >&2
+    exit 2
+  fi
+  app_template=/nginx-app-https.conf.template
+fi
+
+cat "$app_template" \
+  | envsubst "$(printf '$%s,' $(env | grep -Eo '^APPSMITH_[A-Z0-9_]+'))" \
+  | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' \
+  | tee /etc/nginx/conf.d/default.conf
+
 exec nginx -g 'daemon off;'

--- a/app/client/docker/templates/nginx-app-http.conf.template
+++ b/app/client/docker/templates/nginx-app-http.conf.template
@@ -1,0 +1,69 @@
+server {
+    listen 80;
+    server_name $APPSMITH_DOMAIN;
+
+    client_max_body_size 100m;
+
+    gzip on;
+
+    root /var/www/appsmith;
+    index index.html index.htm;
+
+    proxy_ssl_server_name on;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header Accept-Encoding "";
+
+    sub_filter_once off;
+    location / {
+        try_files $uri /index.html =404;
+
+        sub_filter __APPSMITH_SENTRY_DSN__ '${APPSMITH_SENTRY_DSN}';
+        sub_filter __APPSMITH_SMART_LOOK_ID__ '${APPSMITH_SMART_LOOK_ID}';
+        sub_filter __APPSMITH_OAUTH2_GOOGLE_CLIENT_ID__ '${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID}';
+        sub_filter __APPSMITH_OAUTH2_GITHUB_CLIENT_ID__ '${APPSMITH_OAUTH2_GITHUB_CLIENT_ID}';
+        sub_filter __APPSMITH_MARKETPLACE_ENABLED__ '${APPSMITH_MARKETPLACE_ENABLED}';
+        sub_filter __APPSMITH_SEGMENT_KEY__ '${APPSMITH_SEGMENT_KEY}';
+        sub_filter __APPSMITH_OPTIMIZELY_KEY__ '${APPSMITH_OPTIMIZELY_KEY}';
+        sub_filter __APPSMITH_ALGOLIA_API_ID__ '${APPSMITH_ALGOLIA_API_ID}';
+        sub_filter __APPSMITH_ALGOLIA_SEARCH_INDEX_NAME__ '${APPSMITH_ALGOLIA_SEARCH_INDEX_NAME}';
+        sub_filter __APPSMITH_ALGOLIA_API_KEY__ '${APPSMITH_ALGOLIA_API_KEY}';
+        sub_filter __APPSMITH_CLIENT_LOG_LEVEL__ '${APPSMITH_CLIENT_LOG_LEVEL}';
+        sub_filter __APPSMITH_GOOGLE_MAPS_API_KEY__ '${APPSMITH_GOOGLE_MAPS_API_KEY}';
+        sub_filter __APPSMITH_TNC_PP__ '${APPSMITH_TNC_PP}';
+        sub_filter __APPSMITH_SENTRY_RELEASE__ '${APPSMITH_SENTRY_RELEASE}';
+        sub_filter __APPSMITH_SENTRY_ENVIRONMENT__ '${APPSMITH_SENTRY_ENVIRONMENT}';
+        sub_filter __APPSMITH_VERSION_ID__ '${APPSMITH_VERSION_ID}';
+        sub_filter __APPSMITH_VERSION_RELEASE_DATE__ '${APPSMITH_VERSION_RELEASE_DATE}';
+        sub_filter __APPSMITH_INTERCOM_APP_ID__ '${APPSMITH_INTERCOM_APP_ID}';
+        sub_filter __APPSMITH_MAIL_ENABLED__ '${APPSMITH_MAIL_ENABLED}';
+        sub_filter __APPSMITH_DISABLE_TELEMETRY__ '${APPSMITH_DISABLE_TELEMETRY}';
+        sub_filter __APPSMITH_CLOUD_SERVICES_BASE_URL__ '${APPSMITH_CLOUD_SERVICES_BASE_URL}';
+        sub_filter __APPSMITH_RECAPTCHA_SITE_KEY__ '${APPSMITH_RECAPTCHA_SITE_KEY}';
+    }
+
+    location /f {
+       proxy_pass https://cdn.optimizely.com/;
+    }
+
+    location /api {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass ${APPSMITH_SERVER_PROXY_PASS};
+    }
+
+    location /oauth2 {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass ${APPSMITH_SERVER_PROXY_PASS};
+    }
+
+    location /login {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass ${APPSMITH_SERVER_PROXY_PASS};
+    }
+}
+

--- a/app/client/docker/templates/nginx-app-https.conf.template
+++ b/app/client/docker/templates/nginx-app-https.conf.template
@@ -1,0 +1,79 @@
+server {
+    listen 80;
+    server_name $APPSMITH_DOMAIN;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name _;
+
+    ssl_certificate ${APPSMITH_SSL_CERT_PATH};
+    ssl_certificate_key ${APPSMITH_SSL_CERT_KEY_PATH};
+
+    client_max_body_size 100m;
+
+    gzip on;
+
+    root /var/www/appsmith;
+    index index.html index.htm;
+
+    proxy_ssl_server_name on;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header Accept-Encoding "";
+
+    sub_filter_once off;
+    location / {
+        try_files $uri /index.html =404;
+
+        sub_filter __APPSMITH_SENTRY_DSN__ '${APPSMITH_SENTRY_DSN}';
+        sub_filter __APPSMITH_SMART_LOOK_ID__ '${APPSMITH_SMART_LOOK_ID}';
+        sub_filter __APPSMITH_OAUTH2_GOOGLE_CLIENT_ID__ '${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID}';
+        sub_filter __APPSMITH_OAUTH2_GITHUB_CLIENT_ID__ '${APPSMITH_OAUTH2_GITHUB_CLIENT_ID}';
+        sub_filter __APPSMITH_MARKETPLACE_ENABLED__ '${APPSMITH_MARKETPLACE_ENABLED}';
+        sub_filter __APPSMITH_SEGMENT_KEY__ '${APPSMITH_SEGMENT_KEY}';
+        sub_filter __APPSMITH_OPTIMIZELY_KEY__ '${APPSMITH_OPTIMIZELY_KEY}';
+        sub_filter __APPSMITH_ALGOLIA_API_ID__ '${APPSMITH_ALGOLIA_API_ID}';
+        sub_filter __APPSMITH_ALGOLIA_SEARCH_INDEX_NAME__ '${APPSMITH_ALGOLIA_SEARCH_INDEX_NAME}';
+        sub_filter __APPSMITH_ALGOLIA_API_KEY__ '${APPSMITH_ALGOLIA_API_KEY}';
+        sub_filter __APPSMITH_CLIENT_LOG_LEVEL__ '${APPSMITH_CLIENT_LOG_LEVEL}';
+        sub_filter __APPSMITH_GOOGLE_MAPS_API_KEY__ '${APPSMITH_GOOGLE_MAPS_API_KEY}';
+        sub_filter __APPSMITH_TNC_PP__ '${APPSMITH_TNC_PP}';
+        sub_filter __APPSMITH_SENTRY_RELEASE__ '${APPSMITH_SENTRY_RELEASE}';
+        sub_filter __APPSMITH_SENTRY_ENVIRONMENT__ '${APPSMITH_SENTRY_ENVIRONMENT}';
+        sub_filter __APPSMITH_VERSION_ID__ '${APPSMITH_VERSION_ID}';
+        sub_filter __APPSMITH_VERSION_RELEASE_DATE__ '${APPSMITH_VERSION_RELEASE_DATE}';
+        sub_filter __APPSMITH_INTERCOM_APP_ID__ '${APPSMITH_INTERCOM_APP_ID}';
+        sub_filter __APPSMITH_MAIL_ENABLED__ '${APPSMITH_MAIL_ENABLED}';
+        sub_filter __APPSMITH_DISABLE_TELEMETRY__ '${APPSMITH_DISABLE_TELEMETRY}';
+        sub_filter __APPSMITH_CLOUD_SERVICES_BASE_URL__ '${APPSMITH_CLOUD_SERVICES_BASE_URL}';
+        sub_filter __APPSMITH_RECAPTCHA_SITE_KEY__ '${APPSMITH_RECAPTCHA_SITE_KEY}';
+    }
+
+    location /f {
+       proxy_pass https://cdn.optimizely.com/;
+    }
+
+    location /api {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass ${APPSMITH_SERVER_PROXY_PASS};
+    }
+
+    location /oauth2 {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass ${APPSMITH_SERVER_PROXY_PASS};
+    }
+
+    location /login {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass ${APPSMITH_SERVER_PROXY_PASS};
+    }
+}
+


### PR DESCRIPTION
Fixes #4635.

After this is fixed, the appsmith-editor container will be able to be run with a command like the following:

```sh
docker run -p 80:80 -p 443443 -e APPSMITH_SERVER_PROXY_PASS='http://host.docker.internal:8080' appsmith/appsmith-editor
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/editor-container-vanilla 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.66 **(-0.01)** | 33.66 **(-0.01)** | 29.53 **(0)** | 52.32 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.59 **(-0.24)** | 39.41 **(-0.84)** | 36.21 **(0)** | 54.77 **(-0.27)**</details>