### PR TITLE
[hotfix] Check if comments are enabled for comment intro modal

### DIFF
--- a/app/client/src/selectors/commentsSelectors.ts
+++ b/app/client/src/selectors/commentsSelectors.ts
@@ -159,4 +159,5 @@ export const visibleCommentThreadSelector = (state: AppState) =>
   state.ui.comments.visibleCommentThreadId;
 
 export const isIntroCarouselVisibleSelector = (state: AppState) =>
-  state.ui.comments.isIntroCarouselVisible;
+  state.ui.comments.isIntroCarouselVisible &&
+  areCommentsEnabledForUserAndApp(state);


### PR DESCRIPTION
## Description
Check if comments are enabled for comment intro modal

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: hotfix-disable-comment-intro-shortcut-key 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.68 **(0)** | 33.6 **(-0.01)** | 29.52 **(0)** | 52.33 **(0)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 38.1 **(0)** | 14.29 **(-0.42)** | 11.54 **(0)** | 32.43 **(0)**</details>