### PR TITLE
fix: Font size

### DIFF
--- a/app/client/src/components/designSystems/appsmith/MultiSelectComponent/index.styled.tsx
+++ b/app/client/src/components/designSystems/appsmith/MultiSelectComponent/index.styled.tsx
@@ -179,7 +179,7 @@ export const DropdownStyles = createGlobalStyle`
 						outline: none !important;
     }
     .rc-select-item {
-	font-size: 16px;
+	font-size: 14px;
 	line-height: 1.5;
 	padding: 5px 16px;
 	align-items: center;


### PR DESCRIPTION
## Description

Same Font-size for Select and Multiselect Dropdown
Fixes #6388 


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/font-size-for-multiselect-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.68 **(0)** | 33.6 **(-0.01)** | 29.5 **(0)** | 52.34 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>