### PR TITLE
[Fix] Reset comment mode hotkey

### DIFF
--- a/app/client/src/pages/AppViewer/GlobalHotKeys.tsx
+++ b/app/client/src/pages/AppViewer/GlobalHotKeys.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { connect } from "react-redux";
 import { Hotkey, Hotkeys } from "@blueprintjs/core";
 import { HotkeysTarget } from "@blueprintjs/core/lib/esnext/components/hotkeys/hotkeysTarget.js";
 

--- a/app/client/src/pages/AppViewer/GlobalHotKeys.tsx
+++ b/app/client/src/pages/AppViewer/GlobalHotKeys.tsx
@@ -2,12 +2,10 @@ import React from "react";
 import { connect } from "react-redux";
 import { Hotkey, Hotkeys } from "@blueprintjs/core";
 import { HotkeysTarget } from "@blueprintjs/core/lib/esnext/components/hotkeys/hotkeysTarget.js";
-import { setCommentMode as setCommentModeAction } from "actions/commentActions";
 
 import { setCommentModeInUrl } from "pages/Editor/ToggleModeButton";
 
 type Props = {
-  resetCommentMode: () => void;
   children: React.ReactNode;
 };
 
@@ -22,7 +20,7 @@ class GlobalHotKeys extends React.Component<Props> {
           group="Canvas"
           label="Reset"
           onKeyDown={(e: any) => {
-            this.props.resetCommentMode();
+            setCommentModeInUrl(false);
             e.preventDefault();
           }}
         />
@@ -30,7 +28,7 @@ class GlobalHotKeys extends React.Component<Props> {
           combo="v"
           global
           label="View Mode"
-          onKeyDown={this.props.resetCommentMode}
+          onKeyDown={() => setCommentModeInUrl(false)}
         />
         <Hotkey
           combo="c"
@@ -47,10 +45,4 @@ class GlobalHotKeys extends React.Component<Props> {
   }
 }
 
-const mapDispatchToProps = (dispatch: any) => {
-  return {
-    resetCommentMode: () => dispatch(setCommentModeAction(false)),
-  };
-};
-
-export default connect(null, mapDispatchToProps)(GlobalHotKeys);
+export default GlobalHotKeys;

--- a/app/client/src/pages/Editor/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.tsx
@@ -22,7 +22,6 @@ import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { getSelectedText } from "utils/helpers";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { WIDGETS_SEARCH_ID } from "constants/Explorer";
-import { setCommentMode as setCommentModeAction } from "actions/commentActions";
 import { resetSnipingMode as resetSnipingModeAction } from "actions/propertyPaneActions";
 import { showDebugger } from "actions/debuggerActions";
 
@@ -35,7 +34,6 @@ type Props = {
   deleteSelectedWidget: () => void;
   cutSelectedWidget: () => void;
   toggleShowGlobalSearchModal: () => void;
-  resetCommentMode: () => void;
   resetSnipingMode: () => void;
   openDebugger: () => void;
   closeProppane: () => void;
@@ -190,7 +188,7 @@ class GlobalHotKeys extends React.Component<Props> {
           group="Canvas"
           label="Deselect all Widget"
           onKeyDown={(e: any) => {
-            this.props.resetCommentMode();
+            setCommentModeInUrl(false);
             this.props.resetSnipingMode();
             this.props.deselectAllWidgets();
             this.props.closeProppane();
@@ -203,7 +201,7 @@ class GlobalHotKeys extends React.Component<Props> {
           global
           label="Edit Mode"
           onKeyDown={(e: any) => {
-            this.props.resetCommentMode();
+            setCommentModeInUrl(false);
             this.props.resetSnipingMode();
             e.preventDefault();
           }}
@@ -245,7 +243,6 @@ const mapDispatchToProps = (dispatch: any) => {
     deleteSelectedWidget: () => dispatch(deleteSelectedWidget(true)),
     cutSelectedWidget: () => dispatch(cutWidget()),
     toggleShowGlobalSearchModal: () => dispatch(toggleShowGlobalSearchModal()),
-    resetCommentMode: () => dispatch(setCommentModeAction(false)),
     resetSnipingMode: () => dispatch(resetSnipingModeAction()),
     openDebugger: () => dispatch(showDebugger()),
     closeProppane: () => dispatch(closePropertyPane()),


### PR DESCRIPTION
## Description
Fix reset comment mode hotkey: set comment mode by updating the query param.
The `handleLocationUpdate` listener within the `ToggleModeButton` listens to this param and updates the store.

Fixes: #6402

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix-reset-comment-mode-hotkey 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.72 **(-0.01)** | 33.43 **(-0.02)** | 29.41 **(-0.03)** | 52.39 **(0)**
 :red_circle: | app/client/src/actions/commentActions.ts | 72.8 **(-0.8)** | 100 **(0)** | 22.5 **(-2.5)** | 73.02 **(0)**
 :red_circle: | app/client/src/pages/Editor/GlobalHotKeys.tsx | 69.77 **(-0.68)** | 39.13 **(0)** | 59.38 **(-1.23)** | 68.29 **(-0.76)**
 :green_circle: | app/client/src/pages/Editor/ToggleModeButton.tsx | 68.79 **(4.25)** | 26.15 **(0)** | 43.33 **(3.33)** | 67.44 **(4.65)**
 :red_circle: | app/client/src/reducers/uiReducers/commentsReducer/commentsReducer.ts | 37.84 **(-1.35)** | 10 **(0)** | 33.33 **(-3.71)** | 43.08 **(-1.54)**
 :red_circle: | app/client/src/sagas/CommentSagas/index.ts | 9.77 **(-3.76)** | 3.23 **(-9.67)** | 5.26 **(-5.27)** | 12.62 **(-3.88)**</details>