### PR TITLE
Fix: Wrap overflowing option in multiselect dropdown

### DIFF
--- a/app/client/src/components/designSystems/appsmith/MultiSelectComponent/index.styled.tsx
+++ b/app/client/src/components/designSystems/appsmith/MultiSelectComponent/index.styled.tsx
@@ -56,6 +56,8 @@ export const DropdownStyles = createGlobalStyle`
 }
 .rc-select-item-option-content {
 	flex: 1 1 0;
+  overflow-wrap: break-word;
+  overflow: hidden;
 }
 .rc-select-item-option-active {
 	background: rgb(233, 250, 243);
@@ -144,7 +146,7 @@ export const DropdownStyles = createGlobalStyle`
 
 	position: absolute;
 	background: #fff;
-	width: 100%;
+	width: auto;
 	border: 1px solid rgba(0, 0, 0, 0.2);
 	border-radius: 0px;
 	margin-top: 8px;
@@ -184,6 +186,7 @@ export const DropdownStyles = createGlobalStyle`
 	padding: 5px 16px;
 	align-items: center;
 	cursor: pointer;
+  width: 100%;
 }
 .rc-select-item-option-state {
 	.bp3-control.bp3-checkbox {


### PR DESCRIPTION
## Description

Wrap overflowing option in multiselect dropdown
Fixes #6389  (issue)

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/Multiselect-options-gets-truncated 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 51.69 **(0.01)** | 33.62 **(0.01)** | 29.51 **(0.01)** | 52.35 **(0.01)**
 :green_circle: | app/client/src/utils/helpers.tsx | 54.88 **(1.83)** | 30.14 **(4.11)** | 25 **(3.57)** | 48.06 **(1.55)**</details>