### PR TITLE
[Fix] Mark resolved threads as read in real time, refresh list when thread resolved status is updated

### DIFF
--- a/app/client/src/reducers/uiReducers/commentsReducer/handleUpdateCommentThreadEvent.ts
+++ b/app/client/src/reducers/uiReducers/commentsReducer/handleUpdateCommentThreadEvent.ts
@@ -18,7 +18,7 @@ const handleUpdateCommentThreadEvent = (
     action.payload?.pinnedState?.active;
 
   const resolvedStateUpdated =
-    !commentThreadInStore?.resolvedState?.active !==
+    commentThreadInStore?.resolvedState?.active !==
     action.payload?.resolvedState?.active;
 
   const shouldRefreshList = resolvedStateUpdated || pinnedStateChanged;

--- a/app/client/src/sagas/WebsocketSagas/handleSocketEvent.ts
+++ b/app/client/src/sagas/WebsocketSagas/handleSocketEvent.ts
@@ -47,6 +47,10 @@ export default function* handleSocketEvent(event: any) {
       );
 
       const isThreadInStoreViewed = threadInStore?.isViewed;
+
+      const isNowResolved =
+        !threadInStore?.resolvedState?.active && thread?.resolvedState?.active;
+
       const isThreadFromEventViewed = thread?.viewedByUsers?.includes(
         currentUser?.username,
       );
@@ -54,13 +58,16 @@ export default function* handleSocketEvent(event: any) {
       yield put(
         updateCommentThreadEvent({
           ...thread,
-          isViewed: isThreadFromEventViewed,
+          isViewed: isThreadFromEventViewed || thread?.resolvedState?.active, // resolved threads can't be unread
         }),
       );
 
       if (isThreadInStoreViewed && !isThreadFromEventViewed) {
         yield put(incrementThreadUnreadCount());
-      } else if (!isThreadInStoreViewed && isThreadFromEventViewed) {
+      } else if (
+        !isThreadInStoreViewed &&
+        (isThreadFromEventViewed || isNowResolved)
+      ) {
         yield put(decrementThreadUnreadCount());
       }
 


### PR DESCRIPTION
## Description
- Mark resolved threads as read in realtime: thread should be marked as read, unread indicator should be updated
- Refresh list when thread resolved status is updated

Fixes #6406

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: mark-resolved-threads-as-read 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 51.69 **(-0.03)** | 33.56 **(-0.08)** | 29.51 **(0)** | 52.34 **(-0.03)**
 :red_circle: | app/client/src/constants/messages.ts | 69.12 **(0.01)** | 100 **(0)** | 6.72 **(0.03)** | 75.99 **(-0.07)**
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/Connected.tsx | 49.02 **(-14.98)** | 11.11 **(-8.89)** | 0 **(0)** | 50 **(-14)**
 :red_circle: | app/client/src/pages/Editor/IntegrationEditor/ActiveDataSources.tsx | 44 **(-6)** | 17.14 **(-57.86)** | 9.09 **(9.09)** | 51.22 **(-0.78)**
 :red_circle: | app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx | 48.28 **(-7.88)** | 51.72 **(-0.13)** | 0 **(0)** | 50 **(-6.16)**
 :red_circle: | app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx | 26.8 **(-0.17)** | 11.9 **(0)** | 4.55 **(0)** | 29.85 **(-0.23)**
 :red_circle: | app/client/src/sagas/WebsocketSagas/handleSocketEvent.ts | 17.78 **(-0.4)** | 0 **(0)** | 0 **(0)** | 19.05 **(-0.46)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**
 :x: | ~~app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx~~ | ~~37.5~~ | ~~3.45~~ | ~~0~~ | ~~40.54~~</details>