### PR TITLE
[skip_changelog] Form login disabled after user uses OAuth login method

### DIFF
--- a/app/client/src/pages/UserAuth/Login.tsx
+++ b/app/client/src/pages/UserAuth/Login.tsx
@@ -95,6 +95,7 @@ export function Login(props: LoginFormProps) {
   if (queryParams.get("error")) {
     showError = true;
   }
+  const errorMsg = showError && queryParams.get("message");
 
   let loginURL = "/api/v1/" + LOGIN_SUBMIT_PATH;
   let signupURL = SIGN_UP_URL;
@@ -126,17 +127,25 @@ export function Login(props: LoginFormProps) {
       </SignUpLinkSection>
       {showError && (
         <FormMessage
-          actions={[
-            {
-              url: FORGOT_PASSWORD_URL,
-              text: createMessage(
-                LOGIN_PAGE_INVALID_CREDS_FORGOT_PASSWORD_LINK,
-              ),
-              intent: "success",
-            },
-          ]}
+          actions={
+            !!errorMsg
+              ? []
+              : [
+                  {
+                    url: FORGOT_PASSWORD_URL,
+                    text: createMessage(
+                      LOGIN_PAGE_INVALID_CREDS_FORGOT_PASSWORD_LINK,
+                    ),
+                    intent: "success",
+                  },
+                ]
+          }
           intent="warning"
-          message={createMessage(LOGIN_PAGE_INVALID_CREDS_ERROR)}
+          message={
+            !!errorMsg
+              ? errorMsg
+              : createMessage(LOGIN_PAGE_INVALID_CREDS_ERROR)
+          }
         />
       )}
       {SocialLoginList.length > 0 && (

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.authentication.handlers;
 
 import com.appsmith.server.domains.LoginSource;
+import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +48,7 @@ public class CustomFormLoginServiceImpl implements ReactiveUserDetailsService {
                         // We can have a implementation to give which login method user should use but this will
                         // expose the sign-in source for external world and in turn to spammers
                         throw new InternalAuthenticationServiceException(
-                            "Please use " + user.getSource().toString() + " authentication as login service"
+                            AppsmithError.INVALID_LOGIN_METHOD.getMessage(user.getSource().toString())
                         );
                     }
                     return user;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
@@ -1,8 +1,10 @@
 package com.appsmith.server.authentication.handlers;
 
+import com.appsmith.server.domains.LoginSource;
 import com.appsmith.server.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -36,6 +38,19 @@ public class CustomFormLoginServiceImpl implements ReactiveUserDetailsService {
                     return error;
                 })
                 // This seemingly useless call to `.map` is required to Java's type checker to compile.
-                .map(user -> user);
+                .map(user -> {
+                    // As this will be used for form login only, if the password field is null we can assume this login
+                    // request will fail because of invalid credentials but actual reason might be user has signed up
+                    // using form and then used OAuth for login which removes the password field from user object for
+                    // more details refer AuthenticationSuccessHandler
+                    if (user.getPassword() == null && !LoginSource.FORM.equals(user.getSource())) {
+                        // We can have a implementation to give which login method user should use but this will
+                        // expose the sign-in source for external world and in turn to spammers
+                        throw new InternalAuthenticationServiceException(
+                            "Please use " + user.getSource().toString() + " authentication as login service"
+                        );
+                    }
+                    return user;
+                });
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -62,7 +62,7 @@ public enum AppsmithError {
     GENERIC_BAD_REQUEST(400, 4028, "Bad Request: {0}", AppsmithErrorAction.DEFAULT, null),
     VALIDATION_FAILURE(400, 4028, "Validation Failure(s): {0}", AppsmithErrorAction.DEFAULT, null),
     INVALID_CURL_COMMAND(400, 4029, "Invalid cURL command, couldn't import.", AppsmithErrorAction.DEFAULT, null),
-    INVALID_LOGIN_METHOD(401, 4030, "Please use {0} authentication as login service.", AppsmithErrorAction.DEFAULT, null),
+    INVALID_LOGIN_METHOD(401, 4030, "Please use {0} authentication to login to Appsmith", AppsmithErrorAction.DEFAULT, null),
     REMOVE_LAST_ORG_ADMIN_ERROR(400, 4037, "The last admin can not be removed from an organization", AppsmithErrorAction.DEFAULT, null),
     INVALID_CRUD_PAGE_REQUEST(400, 4038, "Unable to process page generation request, {0}", AppsmithErrorAction.DEFAULT, null),
     INTERNAL_SERVER_ERROR(500, 5000, "Internal server error while processing request", AppsmithErrorAction.LOG_EXTERNALLY, null),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -62,6 +62,7 @@ public enum AppsmithError {
     GENERIC_BAD_REQUEST(400, 4028, "Bad Request: {0}", AppsmithErrorAction.DEFAULT, null),
     VALIDATION_FAILURE(400, 4028, "Validation Failure(s): {0}", AppsmithErrorAction.DEFAULT, null),
     INVALID_CURL_COMMAND(400, 4029, "Invalid cURL command, couldn't import.", AppsmithErrorAction.DEFAULT, null),
+    INVALID_LOGIN_METHOD(401, 4030, "Please use {0} authentication as login service.", AppsmithErrorAction.DEFAULT, null),
     REMOVE_LAST_ORG_ADMIN_ERROR(400, 4037, "The last admin can not be removed from an organization", AppsmithErrorAction.DEFAULT, null),
     INVALID_CRUD_PAGE_REQUEST(400, 4038, "Unable to process page generation request, {0}", AppsmithErrorAction.DEFAULT, null),
     INTERNAL_SERVER_ERROR(500, 5000, "Internal server error while processing request", AppsmithErrorAction.LOG_EXTERNALLY, null),


### PR DESCRIPTION
## Description

With this change, we are implementing a hierarchical login flow where OAuth takes precedence over Form login. So in a nutshell users will have a single login method at any point in time. 

Scenario 1: User signs up with FORM method, user can use form login until she uses OAuth login after that only OAuth method will be enabled
Scenario 2: User signs up with OAuth then only the OAuth method is available. User can't sign in with the form method  

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: oauth-signin-config 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.3 **(0)** | 34.81 **(-0.01)** | 31.39 **(0)** | 53.85 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>