### PR TITLE
Enable auto-start of containers after VM restart in self-hosted installations

### DIFF
--- a/deploy/template/docker-compose.yml.sh
+++ b/deploy/template/docker-compose.yml.sh
@@ -27,6 +27,7 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
     networks:
       - appsmith
+    restart: always
 
   certbot:
     image: certbot/certbot
@@ -36,6 +37,7 @@ services:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait \$\${!}; done;'"
     networks:
       - appsmith
+    restart: always
 
   appsmith-internal-server:
     image: index.docker.io/appsmith/appsmith-server
@@ -53,6 +55,7 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
     networks:
       - appsmith
+    restart: always
 
   mongo:
     image: mongo:4.4.6
@@ -67,6 +70,7 @@ services:
       - ./data/mongo/init.js:/docker-entrypoint-initdb.d/init.js:ro
     networks:
       - appsmith
+    restart: always
 
   redis:
     image: redis
@@ -74,6 +78,7 @@ services:
       - "6379"
     networks:
       - appsmith
+    restart: always
 
   watchtower:
     image: containrrr/watchtower
@@ -83,6 +88,7 @@ services:
     command: --interval 300 --label-enable --cleanup
     networks:
       - appsmith
+    restart: always
 
 networks:
   appsmith:


### PR DESCRIPTION
This PR adds a `restart: always` configuration to all containers in the default `docker-compose.yml` file generated by `install.sh`. This will allow the containers to start automatically when the VM restarts (or the Docker daemon restarts). Otherwise, currently, after a VM restart, we need to SSH into the server and issue a `docker-compose up -d` command in the installation folder to bring Appsmith up.

Docs: <https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy>.

Thanks to @abulka from <https://github.com/appsmithorg/appsmith/issues/4705#issuecomment-893956711>.

Fixes #4705.
