### PR TITLE
Revert "Supporting all ASCII characters in table widget"

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.test.ts
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.test.ts
@@ -1,5 +1,5 @@
 import { ColumnProperties } from "./Constants";
-import { removeSpecialChars, reorderColumns } from "./TableHelpers";
+import { reorderColumns } from "./TableHelpers";
 import { getCurrentRowBinding } from "widgets/TableWidget/TableWidgetConstants";
 const MOCK_COLUMNS: Record<string, ColumnProperties> = {
   id: {
@@ -588,30 +588,5 @@ describe("Validate Helpers", () => {
 
     const result = reorderColumns(MOCK_COLUMNS, columnOrder);
     expect(expected).toEqual(result);
-  });
-
-  it("Remove space from table data values", () => {
-    const input1 = "Table Header";
-    const expected1 = "Table_Header";
-    const result1 = removeSpecialChars(input1);
-    expect(expected1).toEqual(result1);
-
-    const input2 = "Col 1";
-    const expected2 = "Col_1";
-    const result2 = removeSpecialChars(input2);
-    expect(expected2).toEqual(result2);
-  });
-
-  it("Remove space from table data that has non ASCII chars", () => {
-    // preserve non ASCII chars even without space
-    const input1 = "Leverantör";
-    const expected1 = "Leverantör";
-    const result1 = removeSpecialChars(input1);
-    expect(expected1).toEqual(result1);
-
-    const input2 = "Leverantör Frö";
-    const expected2 = "Leverantör_Frö";
-    const result2 = removeSpecialChars(input2);
-    expect(expected2).toEqual(result2);
   });
 });

--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.ts
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.ts
@@ -1,8 +1,8 @@
 import { uniq, without } from "lodash";
 import { ColumnProperties } from "./Constants";
 
-export const removeSpecialChars = (value: string, limit?: number) => {
-  const separatorRegex = /\s/;
+const removeSpecialChars = (value: string, limit?: number) => {
+  const separatorRegex = /\W+/;
   return value
     .split(separatorRegex)
     .join("_")

--- a/app/client/src/utils/migrations/TableWidget.ts
+++ b/app/client/src/utils/migrations/TableWidget.ts
@@ -168,7 +168,7 @@ export const tableWidgetPropertyPaneMigrations = (
 };
 
 const removeSpecialChars = (value: string, limit?: number) => {
-  const separatorRegex = /\s/;
+  const separatorRegex = /\W+/;
   return value
     .split(separatorRegex)
     .join("_")

--- a/app/client/src/widgets/TableWidget/derived.js
+++ b/app/client/src/widgets/TableWidget/derived.js
@@ -76,7 +76,7 @@ export default {
   },
   //
   getSanitizedTableData: (props, moment, _) => {
-    const separatorRegex = /\s/;
+    const separatorRegex = /\W+/;
 
     if (props.tableData && Array.isArray(props.tableData)) {
       return props.tableData.map((entry) => {


### PR DESCRIPTION
Reverts appsmithorg/appsmith#6041,

This is causing issue, https://github.com/appsmithorg/appsmith/issues/6375. The special characters in primary columns gets into the `propertyPath`s. Which causes error in updating path dependencies and causes errors in evaluation.

Fixes: #6375 

Reverting the change to fix the blocker issue until we come up with a solution for the special characters

cc: @riodeuno @somangshu @techbhavin 
## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: revert-6041-bug/table-ascii-char 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.39 **(0)** | 34.97 **(-0.01)** | 31.51 **(0)** | 53.94 **(0)**
 :red_circle: | app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.ts | 100 **(0)** | 80 **(-10)** | 100 **(0)** | 100 **(0)**</details>