### PR TITLE
Filepicker Improvement - Don't store large files in the dataStore

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -1,3 +1,4 @@
+import { parseBlobUrl } from "./../utils/AppsmithUtils";
 import {
   ApplicationPayload,
   Page,
@@ -1144,10 +1145,7 @@ export function* watchActionExecutionSagas() {
  * @returns promise that resolves to file content
  */
 function* readBlob(blobUrl: string): any {
-  const urlObj = new URL(blobUrl);
-  const { pathname } = urlObj;
-  const url = `blob:${pathname}`;
-  const fileType = urlObj.searchParams.get("type");
+  const [url, fileType] = parseBlobUrl(blobUrl);
   const file = yield fetch(url).then((r) => r.blob());
 
   const data = yield new Promise((resolve) => {

--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -71,7 +71,7 @@ import {
   isActionSaving,
 } from "selectors/entitiesSelector";
 import { AppState } from "reducers";
-import { mapToPropList } from "utils/AppsmithUtils";
+import { isBlobUrl, mapToPropList } from "utils/AppsmithUtils";
 import { validateResponse } from "sagas/ErrorSagas";
 import { TypeOptions } from "react-toastify";
 import { DEFAULT_EXECUTE_ACTION_TIMEOUT_MS } from "constants/ApiConstants";
@@ -118,6 +118,7 @@ import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import LOG_TYPE from "entities/AppsmithConsole/logtype";
 import { matchPath } from "react-router";
 import { setDataUrl } from "./PageSagas";
+import FileDataTypes from "widgets/FileDataTypes";
 
 enum ActionResponseDataTypes {
   BINARY = "BINARY",
@@ -492,11 +493,15 @@ export function* evaluateActionParams(
 
   // Convert to object and transform non string values
   const actionParams: Record<string, string> = {};
-  bindings.forEach((key, i) => {
+  for (let i = 0; i < bindings.length; i++) {
+    const key = bindings[i];
     let value = values[i];
     if (typeof value === "object") value = JSON.stringify(value);
+    if (isBlobUrl(value)) {
+      value = yield call(readBlob, value);
+    }
     actionParams[key] = value;
-  });
+  }
   return mapToPropList(actionParams);
 }
 
@@ -1131,4 +1136,32 @@ export function* watchActionExecutionSagas() {
       executePageLoadActionsSaga,
     ),
   ]);
+}
+
+/**
+ *
+ * @param blobUrl string A blob url with type added a query param
+ * @returns promise that resolves to file content
+ */
+function* readBlob(blobUrl: string): any {
+  const urlObj = new URL(blobUrl);
+  const { pathname } = urlObj;
+  const url = `blob:${pathname}`;
+  const fileType = urlObj.searchParams.get("type");
+  const file = yield fetch(url).then((r) => r.blob());
+
+  const data = yield new Promise((resolve) => {
+    const reader = new FileReader();
+    if (fileType === FileDataTypes.Base64) {
+      reader.readAsDataURL(file);
+    } else if (fileType === FileDataTypes.Binary) {
+      reader.readAsBinaryString(file);
+    } else {
+      reader.readAsText(file);
+    }
+    reader.onloadend = () => {
+      resolve(reader.result);
+    };
+  });
+  return data;
 }

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -304,3 +304,7 @@ export const retryPromise = (
 export const getRandomPaletteColor = (colorPalette: string[]) => {
   return colorPalette[Math.floor(Math.random() * colorPalette.length)];
 };
+
+export const isBlobUrl = (url: string) => {
+  return url.startsWith("blob:");
+};

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -306,7 +306,7 @@ export const getRandomPaletteColor = (colorPalette: string[]) => {
 };
 
 export const isBlobUrl = (url: string) => {
-  return url.startsWith("blob:");
+  return typeof url === "string" && url.startsWith("blob:");
 };
 
 /**

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -308,3 +308,31 @@ export const getRandomPaletteColor = (colorPalette: string[]) => {
 export const isBlobUrl = (url: string) => {
   return url.startsWith("blob:");
 };
+
+/**
+ *
+ * @param data string file data
+ * @param type string file type
+ * @returns string containing blob id and type
+ */
+export const createBlobUrl = (data: string, type: string) => {
+  let url = URL.createObjectURL(data);
+  url = url.replace(
+    `${window.location.protocol}//${window.location.hostname}/`,
+    "",
+  );
+
+  return `${url}?type=${type}`;
+};
+
+/**
+ *
+ * @param blobId string blob id along with type.
+ * @returns [string,string] [blobUrl, type]
+ */
+export const parseBlobUrl = (blobId: string) => {
+  const url = `blob:${window.location.protocol}//${
+    window.location.hostname
+  }/${blobId.substring(5)}`;
+  return url.split("?type=");
+};

--- a/app/client/src/utils/TypeHelpers.ts
+++ b/app/client/src/utils/TypeHelpers.ts
@@ -27,7 +27,7 @@ export const getType = (value: unknown) => {
 
 export function isURL(str: string) {
   const pattern = new RegExp(
-    "^(https?:\\/\\/)?" + // protocol
+    "^((blob:)?https?:\\/\\/)?" + // protocol
     "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // domain name
     "((\\d{1,3}\\.){3}\\d{1,3}))" + // OR ip (v4) address
     "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // port and path
@@ -35,5 +35,6 @@ export function isURL(str: string) {
       "(\\#[-a-z\\d_]*)?$",
     "i",
   ); // fragment locator
+
   return !!pattern.test(str);
 }


### PR DESCRIPTION
## Description
Solves the issue of file picker crashing on large file uploads by not storing files larger than 5MB in dataTree.

Fixes #6297 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: bug-fix/dont-stire-large-files-in-dataTree 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.25 **(-0.04)** | 34.72 **(-0.04)** | 31.32 **(-0.02)** | 53.82 **(-0.03)**
 :red_circle: | app/client/src/sagas/ActionExecutionSagas.ts | 12.53 **(-0.24)** | 1.93 **(-0.07)** | 8.82 **(-0.86)** | 14.47 **(-0.13)**
 :red_circle: | app/client/src/utils/AppsmithUtils.tsx | 53.44 **(-0.23)** | 26.14 **(-0.6)** | 32.5 **(-2.64)** | 48.15 **(-0.87)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**
 :red_circle: | app/client/src/widgets/FilepickerWidget.tsx | 35.24 **(-3.22)** | 0 **(0)** | 17.24 **(-0.62)** | 35.64 **(-2.14)**</details>