### PR TITLE
[Fix] Focus the comment thread when opened after dismissing

### DIFF
--- a/app/client/src/comments/CommentCard/CommentCard.tsx
+++ b/app/client/src/comments/CommentCard/CommentCard.tsx
@@ -44,7 +44,6 @@ import {
   deleteCommentThreadRequest,
   addCommentReaction,
   removeCommentReaction,
-  setVisibleThread,
 } from "actions/commentActions";
 import { useDispatch, useSelector } from "react-redux";
 import { commentThreadsSelector } from "selectors/commentsSelectors";
@@ -383,8 +382,6 @@ function CommentCard({
     history.push(
       `${commentThreadURL.pathname}${commentThreadURL.search}${commentThreadURL.hash}`,
     );
-
-    dispatch(setVisibleThread(commentThreadId));
 
     if (!commentThread.isViewed) {
       dispatch(markThreadAsReadRequest(commentThreadId));

--- a/app/client/src/comments/inlineComments/InlineCommentPin.tsx
+++ b/app/client/src/comments/inlineComments/InlineCommentPin.tsx
@@ -21,6 +21,7 @@ import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 import { Popover2 } from "@blueprintjs/popover2";
 
 import { getPosition, getShouldPositionAbsolutely } from "comments/utils";
+import history from "utils/history";
 
 /**
  * The relavent pixel position is bottom right for the comment cursor
@@ -120,6 +121,21 @@ const focusThread = (commentThreadId: string) => {
   }
 };
 
+const resetCommentThreadIdInURL = (commentThreadId: string) => {
+  if (!window.location.href) return;
+  const currentURL = new URL(window.location.href);
+  const searchParams = currentURL.searchParams;
+  if (searchParams.get("commentThreadId") === commentThreadId) {
+    searchParams.delete("commentId");
+    searchParams.delete("commentThreadId");
+
+    history.replace({
+      ...window.location,
+      search: searchParams.toString(),
+    });
+  }
+};
+
 /**
  * Comment pins that toggle comment thread popover visibility on click
  * They position themselves using position absolute based on top and left values (in percent)
@@ -214,6 +230,7 @@ function InlineCommentPin({
             dispatch(setVisibleThread(commentThreadId));
           } else {
             dispatch(resetVisibleThread(commentThreadId));
+            resetCommentThreadIdInURL(commentThreadId);
           }
         }}
         placement={"right-start"}

--- a/app/client/src/comments/inlineComments/InlineCommentPin.tsx
+++ b/app/client/src/comments/inlineComments/InlineCommentPin.tsx
@@ -126,7 +126,6 @@ const resetCommentThreadIdInURL = (commentThreadId: string) => {
   const currentURL = new URL(window.location.href);
   const searchParams = currentURL.searchParams;
   if (searchParams.get("commentThreadId") === commentThreadId) {
-    searchParams.delete("commentId");
     searchParams.delete("commentThreadId");
 
     history.replace({


### PR DESCRIPTION
## Description
Focus the comment thread when opened after dismissing
Reset the comment thread in the URL to re-trigger effects to set the visible thread and scroll it into view

Fixes #5993

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: reset-comment-thread-in-url-on-closing 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.41 **(0.01)** | 34.99 **(0.01)** | 31.54 **(0.01)** | 53.96 **(0.01)**
 :green_circle: | app/client/src/comments/CommentCard/CommentCard.tsx | 71.67 **(0.4)** | 59.2 **(0)** | 42.86 **(0)** | 72.02 **(0.42)**
 :red_circle: | app/client/src/comments/inlineComments/InlineCommentPin.tsx | 94.52 **(-3.89)** | 69.57 **(-1.86)** | 100 **(0)** | 96.97 **(-3.03)**</details>