### PR TITLE
Feature: select all rows across table pages

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/Table.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/Table.tsx
@@ -182,22 +182,22 @@ export function Table(props: TableProps) {
     // return : 0; no row selected | 1; all row selected | 2: some rows selected
     if (!props.multiRowSelection) return null;
     const selectedRowCount = reduce(
-      subPage,
+      page,
       (count, row) => {
         return selectedRowIndices.includes(row.index) ? count + 1 : count;
       },
       0,
     );
     const result =
-      selectedRowCount === 0 ? 0 : selectedRowCount === subPage.length ? 1 : 2;
+      selectedRowCount === 0 ? 0 : selectedRowCount === page.length ? 1 : 2;
     return result;
-  }, [selectedRowIndices, subPage]);
+  }, [selectedRowIndices, page]);
   const handleAllRowSelectClick = (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
     // if all / some rows are selected we remove selection on click
     // else select all rows
-    props.toggleAllRowSelect(!Boolean(rowSelectionState), subPage);
+    props.toggleAllRowSelect(!Boolean(rowSelectionState), page);
     // loop over subPage rows and toggleRowSelected if required
     e.stopPropagation();
   };


### PR DESCRIPTION
## Description

Extended "select all" to all rows on all pages instead of only those rows on the current page.

Fixes #6430

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have populated the table and verified the correct selection of the rows through the selectedRows property.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
