### PR TITLE
Added fix for cmd + enter not running google sheets actions

### DIFF
--- a/app/client/src/sagas/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecutionSagas.ts
@@ -48,6 +48,7 @@ import {
   QUERIES_EDITOR_URL,
   INTEGRATION_EDITOR_URL,
 } from "constants/routes";
+import { SAAS_EDITOR_API_ID_URL } from "pages/Editor/SaaSEditor/constants";
 import {
   executeApiActionRequest,
   executeApiActionSuccess,
@@ -759,6 +760,7 @@ function* runActionShortcutSaga() {
       QUERIES_EDITOR_ID_URL(),
       API_EDITOR_URL_WITH_SELECTED_PAGE_ID(),
       INTEGRATION_EDITOR_URL(),
+      SAAS_EDITOR_API_ID_URL(),
     ],
     exact: true,
     strict: false,


### PR DESCRIPTION
## Description
This PR fixes the issue where command + enter was not executing the action when google sheets were used as a data source.
Issue Link: - https://github.com/appsmithorg/appsmith/issues/6414

Fixes #6414

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested this issue by creating a test API with google sheets as a data source and executed the run button using shortcut key command + enter in MacOS. I was able to run the API which was not happening before.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
