### PR TITLE
changed default image to old

### DIFF
--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -64,7 +64,8 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       version: 1,
     },
     IMAGE_WIDGET: {
-      defaultImage: "https://source.unsplash.com/random/1500x600",
+      defaultImage:
+        "https://res.cloudinary.com/drako999/image/upload/v1589196259/default.png",
       imageShape: "RECTANGLE",
       maxZoomLevel: 1,
       enableRotation: false,
@@ -958,7 +959,7 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
                                     position: { top: 0, left: 0 },
                                     props: {
                                       defaultImage:
-                                        "https://source.unsplash.com/random/1500x600",
+                                        "https://res.cloudinary.com/drako999/image/upload/v1589196259/default.png",
                                       imageShape: "RECTANGLE",
                                       maxZoomLevel: 1,
                                       image: "{{currentItem.img}}",


### PR DESCRIPTION
## Description

> Image widget - default is large, now replaced with the old default

Fixes #6427

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>