### PR TITLE
Env Manager API and super user signup API

### DIFF
--- a/app/client/src/constants/userConstants.ts
+++ b/app/client/src/constants/userConstants.ts
@@ -4,13 +4,10 @@ type Gender = "MALE" | "FEMALE";
 
 export type User = {
   email: string;
-  currentOrganizationId: string;
   organizationIds: string[];
-  applications: UserApplication[];
   username: string;
   name: string;
   gender: Gender;
-  anonymousId: string;
 };
 
 export interface UserApplication {
@@ -25,12 +22,9 @@ export const CurrentUserDetailsRequestPayload = {
 export const DefaultCurrentUserDetails: User = {
   name: ANONYMOUS_USERNAME,
   email: ANONYMOUS_USERNAME,
-  currentOrganizationId: "",
   organizationIds: [],
   username: ANONYMOUS_USERNAME,
-  applications: [],
   gender: "MALE",
-  anonymousId: "anonymousId",
 };
 
 // TODO keeping it here instead of the USER_API since it leads to cyclic deps errors during tests

--- a/app/client/src/selectors/organizationSelectors.tsx
+++ b/app/client/src/selectors/organizationSelectors.tsx
@@ -31,10 +31,6 @@ export const getCurrentAppOrg = (state: AppState) => {
 export const getAllUsers = (state: AppState) => state.ui.orgs.orgUsers;
 export const getAllRoles = (state: AppState) => state.ui.orgs.orgRoles;
 
-export const getUserCurrentOrgId = (state: AppState) => {
-  return state.ui.users.currentUser?.currentOrganizationId;
-};
-
 export const getRoles = createSelector(getRolesFromState, (roles?: OrgRole[]):
   | OrgRole[]
   | undefined => {

--- a/app/client/src/utils/AnalyticsUtil.tsx
+++ b/app/client/src/utils/AnalyticsUtil.tsx
@@ -236,17 +236,12 @@ class AnalyticsUtil {
     const appId = getApplicationId(windowDoc.location);
     if (userData) {
       const { segment } = getAppsmithConfigs();
-      const app = (userData.applications || []).find(
-        (app: any) => app.id === appId,
-      );
       let user: any = {};
       if (segment.enabled && segment.apiKey) {
         user = {
           userId: userData.username,
           email: userData.email,
-          currentOrgId: userData.currentOrganizationId,
           appId: appId,
-          appName: app ? app.name : undefined,
           source: "cloud",
         };
       } else {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
@@ -1,12 +1,7 @@
 package com.appsmith.server;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.PropertySource;
-import org.springframework.core.env.StandardEnvironment;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
@@ -14,38 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class ServerApplication {
 
     public static void main(String[] args) {
-        new SpringApplicationBuilder(ServerApplication.class)
-                // .initializers(new CustomInit())
-                .run(args);
-        // SpringApplication.run(ServerApplication.class, args);
-    }
-
-    static class CustomInit implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-        @Override
-        public void initialize(ConfigurableApplicationContext context) {
-            final ConfigurableEnvironment environment = context.getEnvironment();
-            environment.getPropertySources().addAfter(
-                    StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
-                    new CustomPropertySource("custom-env")
-            );
-        }
-    }
-
-    static class CustomPropertySource extends PropertySource<CustomLoader> {
-        public CustomPropertySource(String name) {
-            super(name);
-        }
-
-        @Override
-        public Object getProperty(String s) {
-            return s + " value";
-        }
-    }
-
-    static class CustomLoader {
-        public Object getValue(String key) {
-            return key;
-        }
+        SpringApplication.run(ServerApplication.class, args);
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
@@ -1,7 +1,12 @@
 package com.appsmith.server;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
@@ -9,7 +14,38 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class ServerApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(ServerApplication.class, args);
+        new SpringApplicationBuilder(ServerApplication.class)
+                // .initializers(new CustomInit())
+                .run(args);
+        // SpringApplication.run(ServerApplication.class, args);
+    }
+
+    static class CustomInit implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        @Override
+        public void initialize(ConfigurableApplicationContext context) {
+            final ConfigurableEnvironment environment = context.getEnvironment();
+            environment.getPropertySources().addAfter(
+                    StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                    new CustomPropertySource("custom-env")
+            );
+        }
+    }
+
+    static class CustomPropertySource extends PropertySource<CustomLoader> {
+        public CustomPropertySource(String name) {
+            super(name);
+        }
+
+        @Override
+        public Object getProperty(String s) {
+            return s + " value";
+        }
+    }
+
+    static class CustomLoader {
+        public Object getValue(String key) {
+            return key;
+        }
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
@@ -31,6 +31,9 @@ public enum AclPermission {
     //Does the user have read organization permissions
     USER_READ_ORGANIZATIONS("read:userOrganization", User.class),
 
+    // Does this user have permission to access Instance Config UI?
+    MANAGE_INSTANCE_CONFIG("manage:instanceConfig", User.class),
+
     // TODO: Add these permissions to PolicyGenerator to assign them to the user when they sign up
     // The following should be applied to Organization and not User
     READ_USERS("read:users", User.class),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
@@ -32,7 +32,7 @@ public enum AclPermission {
     USER_READ_ORGANIZATIONS("read:userOrganization", User.class),
 
     // Does this user have permission to access Instance Config UI?
-    MANAGE_INSTANCE_CONFIG("manage:instanceConfig", User.class),
+    MANAGE_INSTANCE_ENV("manage:instanceEnv", User.class),
 
     // TODO: Add these permissions to PolicyGenerator to assign them to the user when they sign up
     // The following should be applied to Organization and not User

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Url.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Url.java
@@ -30,4 +30,5 @@ public interface Url {
     String ASSET_URL = BASE_URL + VERSION + "/assets";
     String COMMENT_URL = BASE_URL + VERSION + "/comments";
     String NOTIFICATION_URL = BASE_URL + VERSION + "/notifications";
+    String INSTANCE_ADMIN_URL = BASE_URL + VERSION + "/admin";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/InstanceAdminController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/InstanceAdminController.java
@@ -1,0 +1,35 @@
+package com.appsmith.server.controllers;
+
+import com.appsmith.server.constants.Url;
+import com.appsmith.server.dtos.ResponseDTO;
+import com.appsmith.server.solutions.EnvManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import javax.validation.Valid;
+import java.util.Map;
+
+@RestController
+@RequestMapping(Url.INSTANCE_ADMIN_URL)
+@RequiredArgsConstructor
+@Slf4j
+public class InstanceAdminController {
+
+    private final EnvManager envManager;
+
+    @PutMapping("/env")
+    public Mono<ResponseDTO<Boolean>> saveEnvChanges(
+            @Valid @RequestBody Map<String, String> changes
+    ) {
+        log.debug("Applying env updates {}", changes);
+        return envManager.applyChanges(changes)
+                .map(isSaved -> new ResponseDTO<>(HttpStatus.OK.value(), isSaved, null));
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/InstanceAdminController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/InstanceAdminController.java
@@ -29,7 +29,7 @@ public class InstanceAdminController {
     ) {
         log.debug("Applying env updates {}", changes);
         return envManager.applyChanges(changes)
-                .map(isSaved -> new ResponseDTO<>(HttpStatus.OK.value(), isSaved, null));
+                .thenReturn(new ResponseDTO<>(HttpStatus.OK.value(), true, null));
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
@@ -6,6 +6,7 @@ import com.appsmith.server.domains.UserData;
 import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.dtos.ResetUserPasswordDTO;
 import com.appsmith.server.dtos.ResponseDTO;
+import com.appsmith.server.dtos.UserProfileDTO;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.services.UserOrganizationService;
@@ -73,6 +74,12 @@ public class UserController extends BaseController<UserService, User, String> {
         return userSignup.signupAndLoginFromFormData(exchange);
     }
 
+    @PostMapping("/super")
+    public Mono<ResponseDTO<User>> createSuperUser(@Valid @RequestBody User resource, ServerWebExchange exchange) {
+        return userSignup.signupAndLoginSuper(resource, exchange)
+                .map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
+    }
+
     @PutMapping()
     public Mono<ResponseDTO<User>> update(@RequestBody User resource, ServerWebExchange exchange) {
         return service.updateCurrentUser(resource, exchange)
@@ -125,11 +132,11 @@ public class UserController extends BaseController<UserService, User, String> {
                 .map(result -> new ResponseDTO<>(HttpStatus.OK.value(), result, null));
     }
 
-    @Deprecated
     @GetMapping("/me")
-    public Mono<ResponseDTO<User>> getUserProfile() {
+    public Mono<ResponseDTO<UserProfileDTO>> getUserProfile() {
         return sessionUserService.getCurrentUser()
-                .map(user -> new ResponseDTO<>(HttpStatus.OK.value(), user, null));
+                .flatMap(service::buildUserProfileDTO)
+                .map(profile -> new ResponseDTO<>(HttpStatus.OK.value(), profile, null));
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
@@ -1,19 +1,22 @@
 package com.appsmith.server.dtos;
 
-import com.appsmith.server.domains.Organization;
-import com.appsmith.server.domains.User;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
-import java.util.List;
+import java.util.Set;
 
-@Getter
-@Setter
+@Data
 public class UserProfileDTO {
 
-    User user;
+    String email;
 
-    Organization currentOrganization;
+    Set<String> organizationIds;
 
-    List<ApplicationNameIdDTO> applications;
+    String username;
+
+    String name;
+
+    String gender;
+
+    boolean isEmptyInstance = false;
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepository.java
@@ -5,6 +5,11 @@ import com.appsmith.server.domains.User;
 import reactor.core.publisher.Mono;
 
 public interface CustomUserRepository extends AppsmithRepository<User> {
+
     Mono<User> findByEmail(String email, AclPermission aclPermission);
+
     Mono<User> findByCaseInsensitiveEmail(String email);
+
+    Mono<Boolean> isUsersEmpty();
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUserRepositoryImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
 
 @Component
 @Slf4j
@@ -38,4 +39,18 @@ public class CustomUserRepositoryImpl extends BaseAppsmithRepositoryImpl<User> i
         query.addCriteria(emailCriteria);
         return mongoOperations.findOne(query, User.class);
     }
+
+    /**
+     * Fetch minmal information from *a* user document in the database, and if found, return `true`, if empty, return `false`.
+     * @return Boolean, indicated where there exists at least one user in the system or not.
+     */
+    @Override
+    public Mono<Boolean> isUsersEmpty() {
+        final Query q = query(new Criteria());
+        q.fields().include(fieldName(QUser.user.email));
+        return mongoOperations.findOne(q, User.class)
+                .map(ignored -> false)
+                .defaultIfEmpty(true);
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserService.java
@@ -5,6 +5,7 @@ import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.dtos.ResetUserPasswordDTO;
+import com.appsmith.server.dtos.UserProfileDTO;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -34,4 +35,8 @@ public interface UserService extends CrudService<User, String> {
     Mono<User> updateCurrentUser(User updates, ServerWebExchange exchange);
 
     Map<String, String> getEmailParams(Organization organization, User inviterUser, String inviteUrl, boolean isNewUser);
+
+    Mono<Boolean> isUsersEmpty();
+
+    Mono<UserProfileDTO> buildUserProfileDTO(User user);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -91,8 +91,6 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
     private static final String INVITE_USER_EMAIL_TEMPLATE = "email/inviteUserCreatorTemplate.html";
     private static final String USER_ADDED_TO_ORGANIZATION_EMAIL_TEMPLATE = "email/inviteExistingUserToOrganizationTemplate.html";
 
-    private Boolean isUsersEmptyValue = null;
-
     @Autowired
     public UserServiceImpl(Scheduler scheduler,
                            Validator validator,
@@ -795,12 +793,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
 
     @Override
     public Mono<Boolean> isUsersEmpty() {
-        if (isUsersEmptyValue != null) {
-            return Mono.just(isUsersEmptyValue);
-        }
-
-        return repository.isUsersEmpty()
-                .doOnSuccess(value -> isUsersEmptyValue = value);
+        return repository.isUsersEmpty();
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -19,6 +19,7 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserRole;
 import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.dtos.ResetUserPasswordDTO;
+import com.appsmith.server.dtos.UserProfileDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.PolicyUtils;
@@ -89,6 +90,8 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
     private static final String INVITE_USER_CLIENT_URL_FORMAT = "%s/user/signup?email=%s";
     private static final String INVITE_USER_EMAIL_TEMPLATE = "email/inviteUserCreatorTemplate.html";
     private static final String USER_ADDED_TO_ORGANIZATION_EMAIL_TEMPLATE = "email/inviteExistingUserToOrganizationTemplate.html";
+
+    private Boolean isUsersEmptyValue = null;
 
     @Autowired
     public UserServiceImpl(Scheduler scheduler,
@@ -788,6 +791,33 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
             params.put("inviteUrl", inviteUrl + "/applications#" + organization.getSlug());
         }
         return params;
+    }
+
+    @Override
+    public Mono<Boolean> isUsersEmpty() {
+        if (isUsersEmptyValue != null) {
+            return Mono.just(isUsersEmptyValue);
+        }
+
+        return repository.isUsersEmpty()
+                .doOnSuccess(value -> isUsersEmptyValue = value);
+    }
+
+    @Override
+    public Mono<UserProfileDTO> buildUserProfileDTO(User user) {
+        return isUsersEmpty()
+                .map(isUsersEmpty -> {
+                    final UserProfileDTO profile = new UserProfileDTO();
+
+                    profile.setEmail(user.getEmail());
+                    profile.setOrganizationIds(user.getOrganizationIds());
+                    profile.setUsername(user.getUsername());
+                    profile.setName(user.getName());
+                    profile.setGender(user.getGender());
+                    profile.setEmptyInstance(isUsersEmpty);
+
+                    return profile;
+                });
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,7 +36,18 @@ public class EnvManager {
             "^(?<name>[A-Z0-9_]+)\\s*=\\s*\"?(?<value>.*?)\"?$"
     );
 
+    private static final Set<String> DISALLOWED_VARIABLES = Set.of(
+            "APPSMITH_ENCRYPTION_PASSWORD",
+            "APPSMITH_ENCRYPTION_SALT"
+    );
+
     public static List<String> transformEnvContent(String envContent, Map<String, String> changes) {
+        for (final String variable : DISALLOWED_VARIABLES) {
+            if (changes.containsKey(variable)) {
+                throw new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS);
+            }
+        }
+
         return envContent.lines()
                 .map(line -> {
                     final Matcher matcher = ENV_VARIABLE_PATTERN.matcher(line);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
@@ -1,0 +1,87 @@
+package com.appsmith.server.solutions;
+
+import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.PolicyUtils;
+import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.services.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EnvManager {
+
+    private final SessionUserService sessionUserService;
+    private final UserService userService;
+    private final PolicyUtils policyUtils;
+
+    private static final Path ENV_FILE_PATH = Path.of("server-controlled.env");
+
+    private static final Pattern ENV_VARIABLE_PATTERN = Pattern.compile(
+            "^(?<name>[A-Z0-9_]+)\\s*=\\s*\"?(?<value>.*?)\"?$"
+    );
+
+    public static List<String> transformEnvContent(String envContent, Map<String, String> changes) {
+        return envContent.lines()
+                .map(line -> {
+                    final Matcher matcher = ENV_VARIABLE_PATTERN.matcher(line);
+                    if (!matcher.matches()) {
+                        return line;
+                    }
+                    final String name = matcher.group("name");
+                    if (!changes.containsKey(name)) {
+                        return line;
+                    }
+                    return line.substring(0, matcher.start("value"))
+                                    + changes.get(name)
+                                    + line.substring(matcher.end("value"));
+                })
+                .collect(Collectors.toList());
+    }
+
+    public Mono<Boolean> applyChanges(Map<String, String> changes) {
+        return sessionUserService.getCurrentUser()
+                .flatMap(user -> userService.findByEmail(user.getEmail()))
+                .filter(user -> policyUtils.isPermissionPresentForUser(
+                        user.getPolicies(),
+                        AclPermission.MANAGE_INSTANCE_CONFIG.getValue(),
+                        user.getUsername()
+                ))
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS)))
+                .flatMap(user -> {
+                    final String originalContent;
+                    try {
+                        originalContent = Files.readString(ENV_FILE_PATH);
+                    } catch (IOException e) {
+                        log.error("Unable to read env file " + ENV_FILE_PATH, e);
+                        return Mono.error(e);
+                    }
+
+                    final List<String> changedContent = transformEnvContent(originalContent, changes);
+
+                    try {
+                        Files.write(ENV_FILE_PATH, changedContent);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        return Mono.just(false);
+                    }
+
+                    return Mono.just(true);
+                });
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
@@ -36,13 +36,21 @@ public class EnvManager {
             "^(?<name>[A-Z0-9_]+)\\s*=\\s*\"?(?<value>.*?)\"?$"
     );
 
-    private static final Set<String> DISALLOWED_VARIABLES = Set.of(
+    private static final Set<String> VARIABLE_BLACKLIST = Set.of(
             "APPSMITH_ENCRYPTION_PASSWORD",
             "APPSMITH_ENCRYPTION_SALT"
     );
 
+    /**
+     * Updates values of variables in the envContent string, based on the changes map given. This function **only**
+     * updates values of variables that already defined in envContent. It NEVER adds new env variables to it. This is so
+     * a malicious request won't insert new dubious env variables.
+     * @param envContent String content of an env file.
+     * @param changes A map with variable name to new value.
+     * @return List of string lines for updated env file content.
+     */
     public static List<String> transformEnvContent(String envContent, Map<String, String> changes) {
-        for (final String variable : DISALLOWED_VARIABLES) {
+        for (final String variable : VARIABLE_BLACKLIST) {
             if (changes.containsKey(variable)) {
                 throw new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS);
             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
@@ -75,7 +75,7 @@ public class EnvManager {
                 .collect(Collectors.toList());
     }
 
-    public Mono<Boolean> applyChanges(Map<String, String> changes) {
+    public Mono<Void> applyChanges(Map<String, String> changes) {
         return sessionUserService.getCurrentUser()
                 .flatMap(user -> userService.findByEmail(user.getEmail()))
                 .filter(user -> policyUtils.isPermissionPresentForUser(
@@ -99,10 +99,10 @@ public class EnvManager {
                         Files.write(Path.of(envFilePath), changedContent);
                     } catch (IOException e) {
                         log.error("Unable to write to env file " + envFilePath, e);
-                        return Mono.just(false);
+                        return Mono.error(e);
                     }
 
-                    return Mono.just(true);
+                    return Mono.empty();
                 });
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
@@ -98,7 +98,7 @@ public class EnvManager {
                     try {
                         Files.write(Path.of(envFilePath), changedContent);
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        log.error("Unable to write to env file " + envFilePath, e);
                         return Mono.just(false);
                     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -1,5 +1,7 @@
 package com.appsmith.server.solutions;
 
+import com.appsmith.external.models.Policy;
+import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.authentication.handlers.AuthenticationSuccessHandler;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.LoginSource;
@@ -7,6 +9,8 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserState;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.PolicyUtils;
+import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.CaptchaService;
 import com.appsmith.server.services.UserService;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +31,8 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
 
 import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MAX_LENGTH;
 import static com.appsmith.server.helpers.ValidationUtils.LOGIN_PASSWORD_MIN_LENGTH;
@@ -42,6 +48,8 @@ public class UserSignup {
     private final UserService userService;
     private final CaptchaService captchaService;
     private final AuthenticationSuccessHandler authenticationSuccessHandler;
+    private final PolicyUtils policyUtils;
+    private final UserRepository userRepository;
 
     private static final ServerRedirectStrategy redirectStrategy = new DefaultServerRedirectStrategy();
 
@@ -136,6 +144,22 @@ public class UserSignup {
                         redirectUri = URI.create(referer);
                     }
                     return redirectStrategy.sendRedirect(exchange, redirectUri);
+                });
+    }
+
+    public Mono<User> signupAndLoginSuper(User user, ServerWebExchange exchange) {
+        return userService.isUsersEmpty()
+                .flatMap(isEmpty -> {
+                    if (!isEmpty) {
+                        return Mono.error(new AppsmithException(AppsmithError.UNAUTHORIZED_ACCESS));
+                    }
+
+                    policyUtils.addPoliciesToExistingObject(Map.of(
+                            AclPermission.MANAGE_INSTANCE_CONFIG.getValue(),
+                            Policy.builder().permission(AclPermission.MANAGE_INSTANCE_CONFIG.getValue()).users(Set.of(user.getUsername())).build()
+                    ), user);
+
+                    return signupAndLogin(user, exchange);
                 });
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -155,8 +155,8 @@ public class UserSignup {
                     }
 
                     policyUtils.addPoliciesToExistingObject(Map.of(
-                            AclPermission.MANAGE_INSTANCE_CONFIG.getValue(),
-                            Policy.builder().permission(AclPermission.MANAGE_INSTANCE_CONFIG.getValue()).users(Set.of(user.getUsername())).build()
+                            AclPermission.MANAGE_INSTANCE_ENV.getValue(),
+                            Policy.builder().permission(AclPermission.MANAGE_INSTANCE_ENV.getValue()).users(Set.of(user.getUsername())).build()
                     ), user);
 
                     return signupAndLogin(user, exchange);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -1,0 +1,120 @@
+package com.appsmith.server.solutions;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@Slf4j
+public class EnvManagerTest {
+
+    @Test
+    public void simpleSample() {
+        final String content = "VAR_1=first value\nVAR_2=second value\n\nVAR_3=third value";
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of("VAR_1", "new first value")
+        )).containsExactly(
+                "VAR_1=new first value",
+                "VAR_2=second value",
+                "",
+                "VAR_3=third value"
+        );
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of("VAR_2", "new second value")
+        )).containsExactly(
+                "VAR_1=first value",
+                "VAR_2=new second value",
+                "",
+                "VAR_3=third value"
+        );
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of("VAR_3", "new third value")
+        )).containsExactly(
+                "VAR_1=first value",
+                "VAR_2=second value",
+                "",
+                "VAR_3=new third value"
+        );
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of(
+                        "VAR_1", "new first value",
+                        "VAR_3", "new third value"
+                )
+        )).containsExactly(
+                "VAR_1=new first value",
+                "VAR_2=second value",
+                "",
+                "VAR_3=new third value"
+        );
+
+    }
+
+    @Test
+    public void emptyValues() {
+        final String content = "VAR_1=first value\nVAR_2=\n\nVAR_3=third value";
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of("VAR_2", "new second value")
+        )).containsExactly(
+                "VAR_1=first value",
+                "VAR_2=new second value",
+                "",
+                "VAR_3=third value"
+        );
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of("VAR_2", "")
+        )).containsExactly(
+                "VAR_1=first value",
+                "VAR_2=",
+                "",
+                "VAR_3=third value"
+        );
+
+    }
+
+    @Test
+    public void quotedValues() {
+        final String content = "VAR_1=first value\nVAR_2=\"quoted value\"\n\nVAR_3=third value";
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of(
+                        "VAR_1", "new first value",
+                        "VAR_2", "new second value"
+                )
+        )).containsExactly(
+                "VAR_1=new first value",
+                "VAR_2=\"new second value\"",
+                "",
+                "VAR_3=third value"
+        );
+
+        assertThat(EnvManager.transformEnvContent(
+                content,
+                Map.of("VAR_2", "")
+        )).containsExactly(
+                "VAR_1=first value",
+                "VAR_2=\"\"",
+                "",
+                "VAR_3=third value"
+        );
+
+    }
+
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
@@ -3,7 +3,9 @@ package com.appsmith.server.solutions;
 import com.appsmith.server.authentication.handlers.AuthenticationSuccessHandler;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.helpers.ValidationUtils;
+import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.CaptchaService;
 import com.appsmith.server.services.UserService;
 import org.junit.Before;
@@ -25,11 +27,17 @@ public class UserSignupTest {
     @MockBean
     private AuthenticationSuccessHandler authenticationSuccessHandler;
 
+    @MockBean
+    private PolicyUtils policyUtils;
+
+    @MockBean
+    private UserRepository userRepository;
+
     private UserSignup userSignup;
 
     @Before
     public void setUp() {
-        userSignup = new UserSignup(userService, captchaService, authenticationSuccessHandler);
+        userSignup = new UserSignup(userService, captchaService, authenticationSuccessHandler, policyUtils, userRepository);
     }
 
     private String createRandomString(int length) {


### PR DESCRIPTION
Introduces two new APIs, one for creating a super user, and another for updating Env variables.

`PUT /api/v1/admin/env` &mdash; Update env variable values.

Only super user can use this API. This API can only ever _change_ values of variables already defined in the env file. It can never _add_ new ones or _remove_ existing ones. It can, however, set values to empty, if the request payload defines so.

`POST /api/v1/users/super` &mdash; Create a super user with given details.

Creating a super user is currently allowed, when there's no other users on the system.

For existing installations, creating a super user will need to be done by executing a documented query on their MongoDB database. Being able to execute such a query will prove instance level access for the user, so they should be able to do this.

Still pending (coming up in a future PR):

- An API to restart the server.
- Accept richer information for signing up the super user.


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/super-admin-api 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.37 **(0)** | 34.83 **(0.03)** | 31.48 **(0.01)** | 53.92 **(0.01)**
 :green_circle: | app/client/src/selectors/organizationSelectors.tsx | 70 **(0.23)** | 0 **(0)** | 33.33 **(1.75)** | 68 **(1.33)**
 :green_circle: | app/client/src/utils/AnalyticsUtil.tsx | 29.17 **(0.6)** | 7.69 **(0.71)** | 30.77 **(2.2)** | 29.35 **(0.63)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>