### PR TITLE
Fix: Update debugger message for js errors

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/LogItem.tsx
+++ b/app/client/src/components/editorComponents/Debugger/LogItem.tsx
@@ -190,7 +190,10 @@ function LogItem(props: LogItemProps) {
 
   const openHelpModal = useCallback((e, message?: string) => {
     e.stopPropagation();
-    const text = message || props.text;
+    const text =
+      message ||
+      (props.messages?.length ? props.messages[0].message : false) ||
+      props.text;
 
     AnalyticsUtil.logEvent("OPEN_OMNIBAR", {
       source: "DEBUGGER",

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -350,6 +350,8 @@ export const WIDGET_PROPERTIES_UPDATED = () => "Widget properties were updated";
 export const EMPTY_RESPONSE_FIRST_HALF = () => "🙌 Click on";
 export const EMPTY_RESPONSE_LAST_HALF = () => "to get a response";
 export const INVALID_EMAIL = () => "Please enter a valid email";
+export const VALUE_IS_INVALID = (propertyPath: string) =>
+  `The value at ${propertyPath} is invalid`;
 
 export const TROUBLESHOOT_ISSUE = () => "Troubleshoot issue";
 

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -11,7 +11,6 @@ import {
   EvaluationError,
   getEvalErrorPath,
   getEvalValuePath,
-  PropertyEvalErrorTypeDebugMessage,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
 import _ from "lodash";
@@ -32,6 +31,7 @@ import {
   createMessage,
   ERROR_EVAL_ERROR_GENERIC,
   ERROR_EVAL_TRIGGER,
+  VALUE_IS_INVALID,
 } from "constants/messages";
 import log from "loglevel";
 import { AppState } from "reducers";
@@ -115,9 +115,7 @@ function getLatestEvalPropertyErrors(
         // Add or update
         updatedDebuggerErrors[debuggerKey] = {
           logType: LOG_TYPE.EVAL_ERROR,
-          text: PropertyEvalErrorTypeDebugMessage[error.errorType](
-            propertyPath,
-          ),
+          text: createMessage(VALUE_IS_INVALID, propertyPath),
           messages: errorMessages,
           severity: error.severity,
           timestamp: moment().format("hh:mm:ss"),

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -115,6 +115,8 @@ function getLatestEvalPropertyErrors(
         // Add or update
         updatedDebuggerErrors[debuggerKey] = {
           logType: LOG_TYPE.EVAL_ERROR,
+          // Unless the intention is to change the message shown in the debugger please do not
+          // change the text shown here
           text: createMessage(VALUE_IS_INVALID, propertyPath),
           messages: errorMessages,
           severity: error.severity,


### PR DESCRIPTION
## Description

- Update debugger error text for js errors to always show `The value at ${propertyPath} is invalid`.
- If there are error messages use that to search the omnibar after clicking on the wand

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/debugger-error-message 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.31 **(0.01)** | 34.81 **(0)** | 31.39 **(0)** | 53.85 **(0)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/LogItem.tsx | 35.82 **(0)** | 22.22 **(-4.1)** | 0 **(0)** | 35.94 **(0)**
 :red_circle: | app/client/src/constants/messages.ts | 70.26 **(-0.01)** | 100 **(0)** | 10.16 **(-0.04)** | 76.33 **(-0.16)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>