### PR TITLE
Adding a max size of approximately 1 MB of data fetched using appsmith

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -14,6 +14,9 @@ public enum AppsmithPluginError {
     PLUGIN_QUERY_TIMEOUT_ERROR(504, 5002, "{0} timed out in {1} milliseconds. " +
             "Please increase timeout. This can be found in Settings tab of {0}.", AppsmithErrorAction.DEFAULT, "Timed" +
             " out on query execution"),
+    PLUGIN_MAX_RESULT_SIZE_EXCEEDED(504, 5009, "{0} result size exceeded the supported"
+            + " size in Appsmith. Please limit the number of data points returned.",
+            AppsmithErrorAction.DEFAULT, "Large Result Set Not Supported"),
     PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR(504, 5003, "{0}", AppsmithErrorAction.LOG_EXTERNALLY, "Timed out when fetching" +
             " datasource structure"),
     PLUGIN_DATASOURCE_ARGUMENT_ERROR(500, 5004, "{0}", AppsmithErrorAction.DEFAULT, "Datasource configuration is " +

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -14,7 +14,7 @@ public enum AppsmithPluginError {
     PLUGIN_QUERY_TIMEOUT_ERROR(504, 5002, "{0} timed out in {1} milliseconds. " +
             "Please increase timeout. This can be found in Settings tab of {0}.", AppsmithErrorAction.DEFAULT, "Timed" +
             " out on query execution"),
-    PLUGIN_MAX_RESULT_SIZE_EXCEEDED(504, 5009, "{0} result size exceeded the supported"
+    PLUGIN_MAX_RESULT_SIZE_EXCEEDED(504, 5009, "Result size exceeded the supported"
             + " size in Appsmith. Please limit the number of data points returned.",
             AppsmithErrorAction.DEFAULT, "Large Result Set Not Supported"),
     PLUGIN_GET_STRUCTURE_TIMEOUT_ERROR(504, 5003, "{0}", AppsmithErrorAction.LOG_EXTERNALLY, "Timed out when fetching" +

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Sizeof.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Sizeof.java
@@ -1,0 +1,20 @@
+package com.appsmith.external.helpers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+public class Sizeof {
+
+    public static int sizeof(Object obj) throws IOException {
+
+        ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteOutputStream);
+
+        objectOutputStream.writeObject(obj);
+        objectOutputStream.flush();
+        objectOutputStream.close();
+
+        return byteOutputStream.toByteArray().length;
+    }
+}

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -226,6 +226,8 @@ public class MssqlPlugin extends BasePlugin {
 
                         rowsList.add(Map.of("affectedRows", updateCount));
                     } else {
+                        int fetchSize = resultSet.getFetchSize();
+                        System.out.println("Fetch size : " + fetchSize);
                         ResultSetMetaData metaData = resultSet.getMetaData();
                         int colCount = metaData.getColumnCount();
                         columnsList.addAll(getColumnsListForJdbcPlugin(metaData));

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -226,8 +226,6 @@ public class MssqlPlugin extends BasePlugin {
 
                         rowsList.add(Map.of("affectedRows", updateCount));
                     } else {
-                        int fetchSize = resultSet.getFetchSize();
-                        System.out.println("Fetch size : " + fetchSize);
                         ResultSetMetaData metaData = resultSet.getMetaData();
                         int colCount = metaData.getColumnCount();
                         columnsList.addAll(getColumnsListForJdbcPlugin(metaData));

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -330,10 +330,10 @@ public class PostgresPlugin extends BasePlugin {
                             // Only check the data size at low frequency to ensure the performance is not impacted heavily
                             if (iterator% HEAVY_OP_FREQUENCY == 0) {
                                 int objectSize = sizeof(rowsList);
-                                System.out.println("current size of results : " + objectSize);
 
                                 if (objectSize > MAX_SIZE_SUPPORTED) {
-                                    System.out.println("Erroring out because current size of results : " + objectSize);
+                                    System.out.println(Thread.currentThread().getName() +
+                                            "[PostgresPlugin] Result size exceeded. Current size : " + objectSize);
                                     return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_MAX_RESULT_SIZE_EXCEEDED));
                                 }
                             }

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -319,8 +319,6 @@ public class PostgresPlugin extends BasePlugin {
 
                     } else {
 
-                        int fetchSize = resultSet.getFetchSize();
-                        System.out.println("Fetch size : " + fetchSize);
                         ResultSetMetaData metaData = resultSet.getMetaData();
                         int colCount = metaData.getColumnCount();
                         columnsList.addAll(getColumnsListForJdbcPlugin(metaData));
@@ -329,6 +327,7 @@ public class PostgresPlugin extends BasePlugin {
                         while (resultSet.next()) {
                             iterator++;
 
+                            // Only check the data size at low frequency to ensure the performance is not impacted heavily
                             if (iterator% HEAVY_OP_FREQUENCY == 0) {
                                 int objectSize = sizeof(rowsList);
                                 System.out.println("current size of results : " + objectSize);

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -112,6 +112,8 @@ public class PostgresPlugin extends BasePlugin {
 
     private static final int HEAVY_OP_FREQUENCY = 100;
 
+    private static final int MAX_SIZE_SUPPORTED = 1000000;
+
     public PostgresPlugin(PluginWrapper wrapper) {
         super(wrapper);
     }
@@ -164,8 +166,6 @@ public class PostgresPlugin extends BasePlugin {
                         "order by self_schema, self_table;";
 
         private static final int PREPARED_STATEMENT_INDEX = 0;
-
-//        private static volatile Instrumentation globalInstrumentation;
 
         /**
          * Instead of using the default executeParametrized provided by pluginExecutor, this implementation affords an opportunity
@@ -333,8 +333,9 @@ public class PostgresPlugin extends BasePlugin {
                                 int objectSize = sizeof(rowsList);
                                 System.out.println("current size of results : " + objectSize);
 
-                                if (objectSize > 300000) {
-                                    return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR))
+                                if (objectSize > MAX_SIZE_SUPPORTED) {
+                                    System.out.println("Erroring out because current size of results : " + objectSize);
+                                    return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_MAX_RESULT_SIZE_EXCEEDED));
                                 }
                             }
 


### PR DESCRIPTION
Fixes #5923

An error is now returned if you try to fetch more than 1 MB of data in one go using Postgres plugin

<img width="1669" alt="Screenshot 2021-08-09 at 9 18 49 PM" src="https://user-images.githubusercontent.com/8403079/128735374-3db80037-03a9-47ec-a626-ba73dfa18d8f.png">
