### PR TITLE
Bugfix: Create notification when comment added, deleted and thread resolved, deleted

### DIFF
--- a/app/client/src/notifications/NotificationListItem.tsx
+++ b/app/client/src/notifications/NotificationListItem.tsx
@@ -106,6 +106,7 @@ function CommentNotification(props: { notification: AppsmithNotification }) {
     comment,
     createdAt,
     creationTime,
+    event,
     id,
     isRead,
   } = props.notification;
@@ -123,6 +124,12 @@ function CommentNotification(props: { notification: AppsmithNotification }) {
 
   const _createdAt = createdAt || creationTime;
   const displayName = authorName || authorUsername;
+  let eventName = event;
+  if (!event || event == "CREATED") {
+    eventName = "left";
+  } else if (event == "TAGGED") {
+    eventName = "mentioned you in";
+  }
 
   const handleClick = async () => {
     const modeFromRole = await getModeFromUserRole(orgId);
@@ -154,7 +161,8 @@ function CommentNotification(props: { notification: AppsmithNotification }) {
       </ProfileImageContainer>
       <NotificationBodyContainer>
         <div>
-          <b>{displayName}</b> left a comment on <b>{applicationName}</b>
+          <b>{displayName}</b> {eventName.toLowerCase()} a comment on
+          <b> {applicationName}</b>
         </div>
         <Time>{moment(_createdAt).fromNow()}</Time>
       </NotificationBodyContainer>
@@ -171,6 +179,7 @@ function CommentThreadNotification(props: {
     commentThread,
     createdAt,
     creationTime,
+    event,
     id: notificationId,
     isRead,
   } = props.notification;
@@ -215,6 +224,7 @@ function CommentThreadNotification(props: {
 
   const _createdAt = createdAt || creationTime;
   const displayName = authorName || authorUsername;
+  const eventName = event || "updated";
 
   return (
     <FlexContainer onClick={handleClick}>
@@ -228,7 +238,8 @@ function CommentThreadNotification(props: {
       </ProfileImageContainer>
       <NotificationBodyContainer>
         <div>
-          <b>{displayName}</b> left a comment on <b>{applicationName}</b>
+          <b>{displayName}</b> {eventName.toLowerCase()} a thread on
+          <b> {applicationName}</b>
         </div>
         <Time>{moment(_createdAt).fromNow()}</Time>
       </NotificationBodyContainer>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentNotification.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentNotification.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.domains;
 
+import com.appsmith.server.events.CommentNotificationEvent;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -8,7 +9,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @EqualsAndHashCode(callSuper = true)
 @Document
 public class CommentNotification extends Notification {
-
+    CommentNotificationEvent event;
     Comment comment;
-
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThreadNotification.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThreadNotification.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.domains;
 
+import com.appsmith.server.events.CommentNotificationEvent;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -8,7 +9,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @EqualsAndHashCode(callSuper = true)
 @Document
 public class CommentThreadNotification extends Notification {
-
+    CommentNotificationEvent event;
     CommentThread commentThread;
-
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentNotificationEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentNotificationEvent.java
@@ -1,0 +1,5 @@
+package com.appsmith.server.events;
+
+public enum CommentNotificationEvent {
+    CREATED, UPDATED, RESOLVED, TAGGED
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentNotificationEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentNotificationEvent.java
@@ -1,5 +1,5 @@
 package com.appsmith.server.events;
 
 public enum CommentNotificationEvent {
-    CREATED, UPDATED, RESOLVED, TAGGED
+    CREATED, UPDATED, RESOLVED, TAGGED, DELETED
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/NotificationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/NotificationRepository.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 
 @Repository
 public interface NotificationRepository extends BaseRepository<Notification, String>, CustomNotificationRepository {
-    Flux<Notification> findByForUsername(String userId, Pageable pageable);
     Flux<Notification> findByForUsernameAndCreatedAtBefore(String userId, Instant instant, Pageable pageable);
     Mono<Long> countByForUsername(String userId);
     Mono<Long> countByForUsernameAndIsReadIsFalse(String userId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -483,6 +483,11 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
     public Mono<CommentThread> deleteThread(String threadId) {
         return threadRepository.findById(threadId, AclPermission.MANAGE_THREAD)
                 .flatMap(threadRepository::archive)
+                .flatMap(commentThread ->
+                    notificationService.createNotification(
+                            commentThread, CommentNotificationEvent.DELETED, commentThread.getAuthorUsername()
+                    ).collectList().thenReturn(commentThread)
+                )
                 .flatMap(analyticsService::sendDeleteEvent);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationService.java
@@ -5,12 +5,13 @@ import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.domains.Notification;
 import com.appsmith.server.dtos.UpdateIsReadNotificationByIdDTO;
 import com.appsmith.server.dtos.UpdateIsReadNotificationDTO;
+import com.appsmith.server.events.CommentNotificationEvent;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface NotificationService extends CrudService<Notification, String> {
-    Mono<Notification> createNotification(Comment comment, String forUsername);
-    Flux<Notification> createNotification(CommentThread commentThread, String authorUserName);
+    Mono<Notification> createNotification(Comment comment, CommentNotificationEvent event, String forUsername);
+    Flux<Notification> createNotification(CommentThread commentThread, CommentNotificationEvent event, String authorUserName);
     Mono<UpdateIsReadNotificationByIdDTO> updateIsRead(UpdateIsReadNotificationByIdDTO dto);
     Mono<UpdateIsReadNotificationDTO> updateIsRead(UpdateIsReadNotificationDTO dto);
     Mono<Long> getUnreadCount();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationServiceImpl.java
@@ -122,11 +122,11 @@ public class NotificationServiceImpl
     }
 
     @Override
-    public Flux<Notification> createNotification(CommentThread commentThread, CommentNotificationEvent event, String forUsername) {
+    public Flux<Notification> createNotification(CommentThread commentThread, CommentNotificationEvent event, String authorUsername) {
         if(!CollectionUtils.isEmpty(commentThread.getSubscribers())) {
             List<Notification> notificationMonoList = new ArrayList<>(commentThread.getSubscribers().size());
             for(String subscriberUserName: commentThread.getSubscribers()) {
-                if(!subscriberUserName.equals(forUsername)) {
+                if(!subscriberUserName.equals(authorUsername)) {
                     CommentThreadNotification commentThreadNotification = new CommentThreadNotification();
                     commentThreadNotification.setCommentThread(commentThread);
                     commentThreadNotification.setForUsername(subscriberUserName);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NotificationServiceImpl.java
@@ -8,6 +8,7 @@ import com.appsmith.server.domains.Notification;
 import com.appsmith.server.domains.QNotification;
 import com.appsmith.server.dtos.UpdateIsReadNotificationByIdDTO;
 import com.appsmith.server.dtos.UpdateIsReadNotificationDTO;
+import com.appsmith.server.events.CommentNotificationEvent;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.NumberUtils;
@@ -107,27 +108,30 @@ public class NotificationServiceImpl
      * Creates a notification for the provided comment which is under provided comment thread
      * @param comment
      * @param forUsername
+     * @param event
      * @return
      */
     @Override
-    public Mono<Notification> createNotification(Comment comment, String forUsername) {
+    public Mono<Notification> createNotification(Comment comment, CommentNotificationEvent event, String forUsername) {
         final CommentNotification notification = new CommentNotification();
         notification.setComment(comment);
         notification.setForUsername(forUsername);
         notification.setIsRead(false);
+        notification.setEvent(event);
         return repository.save(notification);
     }
 
     @Override
-    public Flux<Notification> createNotification(CommentThread commentThread, String authorUserName) {
+    public Flux<Notification> createNotification(CommentThread commentThread, CommentNotificationEvent event, String forUsername) {
         if(!CollectionUtils.isEmpty(commentThread.getSubscribers())) {
             List<Notification> notificationMonoList = new ArrayList<>(commentThread.getSubscribers().size());
             for(String subscriberUserName: commentThread.getSubscribers()) {
-                if(!subscriberUserName.equals(authorUserName)) {
+                if(!subscriberUserName.equals(forUsername)) {
                     CommentThreadNotification commentThreadNotification = new CommentThreadNotification();
                     commentThreadNotification.setCommentThread(commentThread);
                     commentThreadNotification.setForUsername(subscriberUserName);
                     commentThreadNotification.setIsRead(false);
+                    commentThreadNotification.setEvent(event);
                     notificationMonoList.add(commentThreadNotification);
                 }
             }


### PR DESCRIPTION
## Description
When an user mentions another user in the first comment of a thread, the mentioned user does not get a notification but gets the email notification. This PR fixes this issue. It also sends notifications for the following cases:
- A comment is deleted
- Someone is tagged in a comment
- A thread is deleted
- A thread is resolved


Fixes #6483 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>