### PR TITLE
Hotfix Table Widget crashes when there is a cyclical dependency

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.ts
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.ts
@@ -10,16 +10,18 @@ export const removeSpecialChars = (value: string, limit?: number) => {
 };
 
 export const getAllTableColumnKeys = (
-  tableData: Array<Record<string, unknown>>,
+  tableData?: Array<Record<string, unknown>>,
 ) => {
   const columnKeys: string[] = [];
-  for (let i = 0, tableRowCount = tableData.length; i < tableRowCount; i++) {
-    const row = tableData[i];
-    for (const key in row) {
-      // Replace all special characters to _, limit key length to 200 characters.
-      const sanitizedKey = removeSpecialChars(key, 200);
-      if (!columnKeys.includes(sanitizedKey)) {
-        columnKeys.push(sanitizedKey);
+  if (tableData) {
+    for (let i = 0, tableRowCount = tableData.length; i < tableRowCount; i++) {
+      const row = tableData[i];
+      for (const key in row) {
+        // Replace all special characters to _, limit key length to 200 characters.
+        const sanitizedKey = removeSpecialChars(key, 200);
+        if (!columnKeys.includes(sanitizedKey)) {
+          columnKeys.push(sanitizedKey);
+        }
       }
     }
   }

--- a/app/client/src/widgets/TableWidget/index.tsx
+++ b/app/client/src/widgets/TableWidget/index.tsx
@@ -538,9 +538,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
     // The binding has returned a new value
     if (tableDataModified && this.props.renderMode === RenderModes.CANVAS) {
       // Get columns keys from this.props.tableData
-      const columnIds: string[] = getAllTableColumnKeys(
-        this.props.sanitizedTableData,
-      );
+      const columnIds: string[] = getAllTableColumnKeys(this.props.tableData);
       // Get column keys from columns except for derivedColumns
       const primaryColumnIds = Object.keys(primaryColumns).filter(
         (id: string) => {


### PR DESCRIPTION
## Description

Fixed generating table column keys as it was crashing during a cyclical dependency

Fixes #6459

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/data-tree-update-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.36 **(0.01)** | 34.78 **(0.01)** | 31.48 **(0.02)** | 53.9 **(0)**
 :red_circle: | app/client/src/components/designSystems/appsmith/TableComponent/TableHelpers.ts | 100 **(0)** | 75 **(-5)** | 100 **(0)** | 100 **(0)**
 :green_circle: | app/client/src/utils/helpers.tsx | 56.71 **(1.83)** | 32.88 **(4.11)** | 28.57 **(3.57)** | 50.39 **(1.55)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>