### PR TITLE
Changed omnibar landing tab to documentation.

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/HelpBar.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/HelpBar.tsx
@@ -3,10 +3,14 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { getTypographyByKey } from "constants/DefaultTheme";
 import Text, { TextType } from "components/ads/Text";
-import { toggleShowGlobalSearchModal } from "actions/globalSearchActions";
+import {
+  setGlobalSearchFilterContext,
+  toggleShowGlobalSearchModal,
+} from "actions/globalSearchActions";
 import { HELPBAR_PLACEHOLDER } from "constants/messages";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { isMac } from "utils/helpers";
+import { SEARCH_CATEGORIES } from "./utils";
 
 const StyledHelpBar = styled.div`
   padding: 0 ${(props) => props.theme.spaces[4]}px;
@@ -53,6 +57,9 @@ function HelpBar({ toggleShowModal }: Props) {
 const mapDispatchToProps = (dispatch: any) => ({
   toggleShowModal: () => {
     AnalyticsUtil.logEvent("OPEN_OMNIBAR", { source: "NAVBAR_CLICK" });
+    dispatch(
+      setGlobalSearchFilterContext({ category: SEARCH_CATEGORIES.INIT }),
+    );
     dispatch(toggleShowGlobalSearchModal());
   },
 });

--- a/app/client/src/components/editorComponents/GlobalSearch/index.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/index.tsx
@@ -24,7 +24,6 @@ import { useNavigateToWidget } from "pages/Editor/Explorer/Widgets/useNavigateTo
 import {
   toggleShowGlobalSearchModal,
   setGlobalSearchQuery,
-  setGlobalSearchFilterContext,
   cancelSnippet,
   insertSnippet,
 } from "actions/globalSearchActions";

--- a/app/client/src/components/editorComponents/GlobalSearch/index.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/index.tsx
@@ -163,7 +163,9 @@ function GlobalSearch() {
   const currentPageId = useSelector(getCurrentPageId);
   const modalOpen = useSelector(isModalOpenSelector);
   const dispatch = useDispatch();
-  const [category, setCategory] = useState({ id: SEARCH_CATEGORIES.INIT });
+  const [category, setCategory] = useState({
+    id: SEARCH_CATEGORIES.DOCUMENTATION,
+  });
   const [snippets, setSnippetsState] = useState([]);
   const initCategoryId = useSelector(
     (state: AppState) => state.ui.globalSearch.filterContext.category,
@@ -171,20 +173,15 @@ function GlobalSearch() {
   useEffect(() => {
     const triggeredCategory = filterCategories.find(
       (c) => c.id === initCategoryId,
-    );
-    if (triggeredCategory) setCategory(triggeredCategory);
-    return () => {
-      dispatch(
-        setGlobalSearchFilterContext({ category: SEARCH_CATEGORIES.INIT }),
-      );
-    };
+    ) || { id: SEARCH_CATEGORIES.INIT };
+    setCategory(triggeredCategory);
   }, [initCategoryId]);
   const defaultDocs = useDefaultDocumentationResults(modalOpen);
   const params = useParams<ExplorerURLParams>();
   const toggleShow = () => {
     if (modalOpen) {
       setQuery("");
-      setCategory({ id: SEARCH_CATEGORIES.INIT });
+      setCategory(filterCategories[1]);
     }
     dispatch(toggleShowGlobalSearchModal());
     dispatch(cancelSnippet());

--- a/app/client/src/reducers/uiReducers/globalSearchReducer.ts
+++ b/app/client/src/reducers/uiReducers/globalSearchReducer.ts
@@ -11,7 +11,7 @@ const initialState: GlobalSearchReduxState = {
   recentEntities: [],
   recentEntitiesRestored: false,
   filterContext: {
-    category: SEARCH_CATEGORIES.INIT,
+    category: SEARCH_CATEGORIES.DOCUMENTATION,
   },
 };
 


### PR DESCRIPTION
## Description
Set the category of the omni bar to Documentation to show the relevant debugging/help docs.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/omnibar_landing 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.37 **(0.02)** | 34.84 **(0.07)** | 31.44 **(-0.02)** | 53.92 **(0.02)**
 :red_circle: | app/client/src/actions/globalSearchActions.ts | 74.19 **(-3.23)** | 100 **(0)** | 20 **(-10)** | 100 **(0)**
 :red_circle: | app/client/src/components/editorComponents/GlobalSearch/HelpBar.tsx | 89.29 **(-3.02)** | 75 **(0)** | 90 **(0)** | 88.46 **(-3.21)**
 :green_circle: | app/client/src/components/editorComponents/GlobalSearch/index.tsx | 56.86 **(2.6)** | 14.36 **(2.57)** | 45.45 **(0.81)** | 58.04 **(2.73)**
 :green_circle: | app/client/src/components/editorComponents/GlobalSearch/utils.tsx | 65.91 **(3.41)** | 24.42 **(6.98)** | 61.54 **(0)** | 64.79 **(4.23)**
 :red_circle: | app/client/src/reducers/uiReducers/globalSearchReducer.ts | 53.85 **(-7.69)** | 0 **(0)** | 14.29 **(-14.28)** | 53.85 **(-7.69)**</details>