### PR TITLE
Fix: intercom triggers are not working properly

### DIFF
--- a/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
+++ b/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
@@ -290,7 +290,7 @@ const HelpBody = styled.div<{ hideSearch?: boolean }>`
   ${(props) =>
     props.hideSearch
       ? `
-    padding: ${props.theme.spaces[2]}px; 
+    padding: ${props.theme.spaces[2]}px;
   `
       : `
     padding-top: 68px;
@@ -341,6 +341,18 @@ if (intercomAppID) {
   });
 }
 
+export function bootIntercom(intercomAppID: string, user?: User) {
+  console.log("Mounting Intercom");
+  if (intercomAppID && window.Intercom) {
+    window.Intercom("boot", {
+      app_id: intercomAppID,
+      user_id: user?.username,
+      name: user?.name,
+      email: user?.email,
+    });
+  }
+}
+
 class DocumentationSearch extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -348,17 +360,7 @@ class DocumentationSearch extends React.Component<Props, State> {
       showResults: props.defaultRefinement.length > 0,
     };
   }
-  componentDidMount() {
-    const { user } = this.props;
-    if (intercomAppID && window.Intercom) {
-      window.Intercom("boot", {
-        app_id: intercomAppID,
-        user_id: user?.username,
-        name: user?.name,
-        email: user?.email,
-      });
-    }
-  }
+
   onSearchValueChange = (event: SyntheticEvent<HTMLInputElement, Event>) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: No types available

--- a/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
+++ b/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
@@ -342,7 +342,6 @@ if (intercomAppID) {
 }
 
 export function bootIntercom(intercomAppID: string, user?: User) {
-  console.log("Mounting Intercom");
   if (intercomAppID && window.Intercom) {
     window.Intercom("boot", {
       app_id: intercomAppID,

--- a/app/client/src/components/designSystems/appsmith/help/HelpModal.tsx
+++ b/app/client/src/components/designSystems/appsmith/help/HelpModal.tsx
@@ -1,5 +1,7 @@
 import React, { SyntheticEvent } from "react";
-import DocumentationSearch from "components/designSystems/appsmith/help/DocumentationSearch";
+import DocumentationSearch, {
+  bootIntercom,
+} from "components/designSystems/appsmith/help/DocumentationSearch";
 import { getHelpModalOpen } from "selectors/helpSelectors";
 import {
   setHelpDefaultRefinement,
@@ -15,6 +17,9 @@ import { connect } from "react-redux";
 import { AppState } from "reducers";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { HELP_MODAL_HEIGHT, HELP_MODAL_WIDTH } from "constants/HelpConstants";
+import { getCurrentUser } from "selectors/usersSelectors";
+import { User } from "constants/userConstants";
+const { intercomAppID } = getAppsmithConfigs();
 
 const { algolia } = getAppsmithConfigs();
 const HelpButton = styled.button<{
@@ -58,11 +63,21 @@ type Props = {
   isHelpModalOpen: boolean;
   dispatch: any;
   page: string;
+  user?: User;
 };
 
 class HelpModal extends React.Component<Props> {
   static contextType = LayersContext;
-
+  componentDidMount() {
+    const { user } = this.props;
+    bootIntercom(intercomAppID, user);
+  }
+  componentDidUpdate(prevProps: Props) {
+    const { user } = this.props;
+    if (user?.email && prevProps.user?.email !== user?.email) {
+      bootIntercom(intercomAppID, user);
+    }
+  }
   /**
    * closes help modal
    *
@@ -137,6 +152,7 @@ class HelpModal extends React.Component<Props> {
 
 const mapStateToProps = (state: AppState) => ({
   isHelpModalOpen: getHelpModalOpen(state),
+  user: getCurrentUser(state),
 });
 
 export default connect(mapStateToProps)(HelpModal);

--- a/app/client/src/pages/Editor/HelpButton.tsx
+++ b/app/client/src/pages/Editor/HelpButton.tsx
@@ -1,13 +1,18 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled, { createGlobalStyle, withTheme } from "styled-components";
 import { Popover, Position } from "@blueprintjs/core";
 
-import DocumentationSearch from "components/designSystems/appsmith/help/DocumentationSearch";
+import DocumentationSearch, {
+  bootIntercom,
+} from "components/designSystems/appsmith/help/DocumentationSearch";
 import Icon, { IconSize } from "components/ads/Icon";
 
 import { HELP_MODAL_WIDTH } from "constants/HelpConstants";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { Theme } from "constants/DefaultTheme";
+import { getAppsmithConfigs } from "../../configs";
+import { getCurrentUser } from "../../selectors/usersSelectors";
+import { useSelector } from "react-redux";
 
 const HelpPopoverStyle = createGlobalStyle`
   .bp3-popover.bp3-minimal.navbar-help-popover {
@@ -41,7 +46,15 @@ const Trigger = withTheme(({ theme }: { theme: Theme }) => (
 const onOpened = () => {
   AnalyticsUtil.logEvent("OPEN_HELP", { page: "Editor" });
 };
+
+const { intercomAppID } = getAppsmithConfigs();
 function HelpButton() {
+  const user = useSelector(getCurrentUser);
+
+  useEffect(() => {
+    bootIntercom(intercomAppID, user);
+  }, [user?.email]);
+
   return (
     <Popover
       minimal


### PR DESCRIPTION
## Description
User would only receive automated trigger msgs, if they open the intercom at least once on their own. Intercom was being initialised in inner component that doesn't get mounted on page load. 

Fixes #6514 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/intercom-triggers-not-working-properly 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 53.36 **(0.02)** | 34.79 **(0.03)** | 31.48 **(0.02)** | 53.91 **(0.02)**
 :green_circle: | app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx | 61.33 **(2.12)** | 37.14 **(4.28)** | 14.29 **(7.15)** | 62.69 **(2.4)**
 :red_circle: | app/client/src/pages/Editor/HelpButton.tsx | 96 **(1.56)** | 87.5 **(-12.5)** | 83.33 **(3.33)** | 95.65 **(1.9)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>