### PR TITLE
Fix: Close widget pane when user moves away from canvas

### DIFF
--- a/app/client/src/pages/Editor/WidgetSidebar.tsx
+++ b/app/client/src/pages/Editor/WidgetSidebar.tsx
@@ -17,9 +17,14 @@ import produce from "immer";
 import { createMessage, WIDGET_SIDEBAR_CAPTION } from "constants/messages";
 import Boxed from "components/editorComponents/Onboarding/Boxed";
 import { OnboardingStep } from "constants/OnboardingConstants";
-import { getCurrentStep, getCurrentSubStep } from "sagas/OnboardingSagas";
+import {
+  getCurrentStep,
+  getCurrentSubStep,
+  inOnboarding,
+} from "sagas/OnboardingSagas";
 import { BUILDER_PAGE_URL } from "constants/routes";
 import OnboardingIndicator from "components/editorComponents/Onboarding/Indicator";
+import { useLocation } from "react-router";
 
 const MainWrapper = styled.div`
   text-transform: capitalize;
@@ -86,6 +91,7 @@ const Info = styled.div`
 `;
 
 function WidgetSidebar(props: IPanelProps) {
+  const location = useLocation();
   const cards = useSelector(getWidgetCards);
   const [filteredCards, setFilteredCards] = useState(cards);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
@@ -110,6 +116,7 @@ function WidgetSidebar(props: IPanelProps) {
   };
 
   // For onboarding
+  const isInOnboarding = useSelector(inOnboarding);
   const currentStep = useSelector(getCurrentStep);
   const currentSubStep = useSelector(getCurrentSubStep);
   const applicationId = useSelector(getCurrentApplicationId);
@@ -117,10 +124,13 @@ function WidgetSidebar(props: IPanelProps) {
   const onCanvas =
     BUILDER_PAGE_URL(applicationId, pageId) === window.location.pathname;
   useEffect(() => {
-    if (currentStep === OnboardingStep.DEPLOY && !onCanvas) {
+    if (
+      (currentStep === OnboardingStep.DEPLOY || !isInOnboarding) &&
+      !onCanvas
+    ) {
       props.closePanel();
     }
-  }, [currentStep, onCanvas]);
+  }, [currentStep, onCanvas, isInOnboarding, location]);
 
   const search = debounce((e: any) => {
     filterCards(e.target.value.toLowerCase());


### PR DESCRIPTION
## Description
On location change, closing the widget panel

Fixes #6515 


## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/close-widget-pane-on-canvas-close 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 53.34 **(-0.01)** | 34.75 **(-0.02)** | 31.46 **(-0.01)** | 53.89 **(0)**
 :red_circle: | app/client/src/pages/Editor/WidgetSidebar.tsx | 34.72 **(-0.06)** | 20.83 **(-0.45)** | 0 **(0)** | 35.71 **(-0.11)**
 :red_circle: | app/client/src/utils/helpers.tsx | 54.88 **(-1.83)** | 28.77 **(-4.11)** | 25 **(-3.57)** | 48.84 **(-1.55)**</details>