### PR TITLE
Fix: Arango plugin: hide certificate string using dots on UI

### DIFF
--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/form.json
@@ -120,6 +120,7 @@
           "label": "Base64 Encoded CA Certificate String",
           "configProperty": "datasourceConfiguration.connection.ssl.caCertificateFile.base64Content",
           "controlType": "INPUT_TEXT",
+          "dataType": "PASSWORD",
           "encrypted": true,
           "hidden": {
             "path": "datasourceConfiguration.connection.ssl.caCertificateType",


### PR DESCRIPTION
## Description
- replace actual certificate string with '*' like it is done for hiding password on the UI.

Fixes #5762 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
