### PR TITLE
[Improvement]- Improve the password reset feature

### DIFF
--- a/app/client/src/pages/UserAuth/ResetPassword.tsx
+++ b/app/client/src/pages/UserAuth/ResetPassword.tsx
@@ -57,12 +57,12 @@ const validate = (values: ResetPasswordFormValues) => {
 type ResetPasswordProps = InjectedFormProps<
   ResetPasswordFormValues,
   {
-    verifyToken: (token: string, email: string) => void;
+    verifyToken: (token: string) => void;
     isTokenValid: boolean;
     validatingToken: boolean;
   }
 > & {
-  verifyToken: (token: string, email: string) => void;
+  verifyToken: (token: string) => void;
   isTokenValid: boolean;
   validatingToken: boolean;
   theme: Theme;
@@ -83,11 +83,10 @@ export function ResetPassword(props: ResetPasswordProps) {
   } = props;
 
   useLayoutEffect(() => {
-    if (initialValues.token && initialValues.email)
-      verifyToken(initialValues.token, initialValues.email);
-  }, [initialValues.token, initialValues.email, verifyToken]);
+    if (initialValues.token) verifyToken(initialValues.token);
+  }, [initialValues.token, verifyToken]);
 
-  const showInvalidMessage = !initialValues.token || !initialValues.email;
+  const showInvalidMessage = !initialValues.token;
   const showExpiredMessage = !isTokenValid && !validatingToken;
   const showSuccessMessage = submitSucceeded && !pristine;
   const showFailureMessage = submitFailed && !!error;
@@ -209,7 +208,6 @@ export default connect(
     const queryParams = new URLSearchParams(props.location.search);
     return {
       initialValues: {
-        email: queryParams.get("email") || undefined,
         token: queryParams.get("token") || undefined,
       },
       isTokenValid: getIsTokenValid(state),
@@ -217,17 +215,17 @@ export default connect(
     };
   },
   (dispatch: any) => ({
-    verifyToken: (token: string, email: string) =>
+    verifyToken: (token: string) =>
       dispatch({
         type: ReduxActionTypes.RESET_PASSWORD_VERIFY_TOKEN_INIT,
-        payload: { token, email },
+        payload: { token },
       }),
   }),
 )(
   reduxForm<
     ResetPasswordFormValues,
     {
-      verifyToken: (token: string, email: string) => void;
+      verifyToken: (token: string) => void;
       validatingToken: boolean;
       isTokenValid: boolean;
     }

--- a/app/client/src/sagas/userSagas.tsx
+++ b/app/client/src/sagas/userSagas.tsx
@@ -318,9 +318,13 @@ export function* verifyResetPasswordTokenSaga(
       request,
     );
     const isValidResponse = yield validateResponse(response);
-    if (isValidResponse) {
+    if (isValidResponse && response.data) {
       yield put({
         type: ReduxActionTypes.RESET_PASSWORD_VERIFY_TOKEN_SUCCESS,
+      });
+    } else {
+      yield put({
+        type: ReduxActionErrorTypes.RESET_PASSWORD_VERIFY_TOKEN_ERROR,
       });
     }
   } catch (error) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
@@ -121,8 +121,8 @@ public class UserController extends BaseController<UserService, User, String> {
     }
 
     @GetMapping("/verifyPasswordResetToken")
-    public Mono<ResponseDTO<Boolean>> verifyPasswordResetToken(@RequestParam String email, @RequestParam String token) {
-        return service.verifyPasswordResetToken(email, token)
+    public Mono<ResponseDTO<Boolean>> verifyPasswordResetToken(@RequestParam String token) {
+        return service.verifyPasswordResetToken(token)
                 .map(result -> new ResponseDTO<>(HttpStatus.OK.value(), result, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/PasswordResetToken.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/PasswordResetToken.java
@@ -15,12 +15,8 @@ import java.time.Instant;
 @NoArgsConstructor
 @Document
 public class PasswordResetToken extends BaseDomain {
-
     String tokenHash;
-
-    //Password Reset Token should be valid only for a specified amount of time.
     String email;
-
     int requestCount; // number of requests in last 24 hours
-    Instant firstRequestTime; // first time request was generated in last 24 hours
+    Instant firstRequestTime; // when a request was first generated in last 24 hours
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/PasswordResetToken.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/PasswordResetToken.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.Instant;
+
 @Getter
 @Setter
 @ToString
@@ -18,4 +20,7 @@ public class PasswordResetToken extends BaseDomain {
 
     //Password Reset Token should be valid only for a specified amount of time.
     String email;
+
+    int requestCount; // number of requests in last 24 hours
+    Instant firstRequestTime; // first time request was generated in last 24 hours
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/EmailTokenDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/EmailTokenDTO.java
@@ -1,0 +1,11 @@
+package com.appsmith.server.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class EmailTokenDTO {
+    private String email;
+    private String token;
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -93,6 +93,7 @@ public enum AppsmithError {
     INVALID_CURL_HEADER(400, 4036, "Invalid header in cURL command: {0}.", AppsmithErrorAction.DEFAULT, null),
     AUTHENTICATION_FAILURE(500, 5010, "Authentication failed with error: {0}", AppsmithErrorAction.DEFAULT, null),
     INSTANCE_REGISTRATION_FAILURE(500, 5011, "Registration for instance failed with error: {0}", AppsmithErrorAction.LOG_EXTERNALLY, null),
+    TOO_MANY_REQUESTS(429, 4039, "Too many requests received. Please try later.", AppsmithErrorAction.DEFAULT, "Too many requests"),
     ;
 
     private final Integer httpErrorCode;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserService.java
@@ -20,7 +20,7 @@ public interface UserService extends CrudService<User, String> {
 
     Mono<Boolean> forgotPasswordTokenGenerate(ResetUserPasswordDTO resetUserPasswordDTO);
 
-    Mono<Boolean> verifyPasswordResetToken(String email, String token);
+    Mono<Boolean> verifyPasswordResetToken(String token);
 
     Mono<Boolean> resetPasswordAfterForgotPassword(String token, User user);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -290,7 +290,13 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
      */
     @Override
     public Mono<Boolean> verifyPasswordResetToken(String encryptedToken) {
-        EmailTokenDTO emailTokenDTO = parseValueFromEncryptedToken(encryptedToken);
+        EmailTokenDTO emailTokenDTO;
+        try {
+            emailTokenDTO = parseValueFromEncryptedToken(encryptedToken);
+        } catch (Exception e) {
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.TOKEN));
+        }
+
         return passwordResetTokenRepository
                 .findByEmail(emailTokenDTO.getEmail())
                 .switchIfEmpty(Mono.error(new AppsmithException(
@@ -309,7 +315,13 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
      */
     @Override
     public Mono<Boolean> resetPasswordAfterForgotPassword(String encryptedToken, User user) {
-        EmailTokenDTO emailTokenDTO = parseValueFromEncryptedToken(encryptedToken);
+        EmailTokenDTO emailTokenDTO;
+        try {
+            emailTokenDTO = parseValueFromEncryptedToken(encryptedToken);
+        } catch (Exception e) {
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.TOKEN));
+        }
+
         return passwordResetTokenRepository
                 .findByEmail(emailTokenDTO.getEmail())
                 .switchIfEmpty(Mono.error(new AppsmithException(
@@ -327,7 +339,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                 })
                 .flatMap(emailAddress -> repository
                         .findByEmail(emailAddress)
-                        .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.USER, user.getEmail())))
+                        .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.USER, emailAddress)))
                         .flatMap(userFromDb -> {
                             if(!ValidationUtils.validateLoginPassword(user.getPassword())){
                                 return Mono.error(new AppsmithException(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -119,7 +119,8 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                            ConfigService configService,
                            CommonConfig commonConfig,
                            EmailConfig emailConfig,
-                           UserChangedHandler userChangedHandler, EncryptionService encryptionService) {
+                           UserChangedHandler userChangedHandler,
+                           EncryptionService encryptionService) {
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
         this.organizationService = organizationService;
         this.sessionUserService = sessionUserService;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -300,9 +300,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
 
         return passwordResetTokenRepository
                 .findByEmail(emailTokenDTO.getEmail())
-                .switchIfEmpty(Mono.error(new AppsmithException(
-                        AppsmithError.NO_RESOURCE_FOUND, FieldName.EMAIL, emailTokenDTO.getEmail()
-                )))
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.INVALID_PASSWORD_RESET)))
                 .map(obj -> this.passwordEncoder.matches(emailTokenDTO.getToken(), obj.getTokenHash()));
     }
 
@@ -325,15 +323,11 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
 
         return passwordResetTokenRepository
                 .findByEmail(emailTokenDTO.getEmail())
-                .switchIfEmpty(Mono.error(new AppsmithException(
-                        AppsmithError.NO_RESOURCE_FOUND, FieldName.EMAIL, emailTokenDTO.getEmail()
-                )))
+                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.INVALID_PASSWORD_RESET)))
                 .map(passwordResetToken -> {
                     boolean matches = this.passwordEncoder.matches(emailTokenDTO.getToken(), passwordResetToken.getTokenHash());
                     if (!matches) {
-                        throw new AppsmithException(
-                                AppsmithError.GENERIC_BAD_REQUEST, FieldName.TOKEN
-                        );
+                        throw new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, FieldName.TOKEN);
                     } else {
                         return emailTokenDTO.getEmail();
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -294,7 +294,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
         EmailTokenDTO emailTokenDTO;
         try {
             emailTokenDTO = parseValueFromEncryptedToken(encryptedToken);
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.TOKEN));
         }
 
@@ -317,7 +317,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
         EmailTokenDTO emailTokenDTO;
         try {
             emailTokenDTO = parseValueFromEncryptedToken(encryptedToken);
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.TOKEN));
         }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -526,7 +526,7 @@ public class UserServiceTest {
         Mockito.when(passwordResetTokenRepository.findByEmail(testEmail)).thenReturn(Mono.empty());
 
         StepVerifier.create(userService.verifyPasswordResetToken(getEncodedToken(testEmail, "123456789")))
-                .expectErrorMessage(AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.EMAIL, testEmail))
+                .expectErrorMessage(AppsmithError.INVALID_PASSWORD_RESET.getMessage())
                 .verify();
     }
 
@@ -570,7 +570,7 @@ public class UserServiceTest {
         Mockito.when(passwordResetTokenRepository.findByEmail(testEmail)).thenReturn(Mono.empty());
 
         StepVerifier.create(userService.resetPasswordAfterForgotPassword(token, null))
-                .expectErrorMessage(AppsmithError.NO_RESOURCE_FOUND.getMessage(FieldName.EMAIL, testEmail))
+                .expectErrorMessage(AppsmithError.INVALID_PASSWORD_RESET.getMessage())
                 .verify();
 
         // ** check if token present but hash does not match ** //


### PR DESCRIPTION
## Description
This PR enhances the password reset experience. It brings the following changes:

- Instead of sending email and token in email, it'll send a encrypted token which will contain the email and token
- Adds a rate limiter which allows to send 3 password reset requests in each 24 hours 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: improvement/password-reset 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.81 **(-0.01)** | 36.76 **(-0.01)** | 33.15 **(0)** | 55.39 **(-0.01)**
 :red_circle: | app/client/src/sagas/userSagas.tsx | 16.67 **(-0.08)** | 1.75 **(-0.1)** | 5.88 **(0)** | 19.88 **(-0.12)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>