### PR TITLE
Add version check for import-export flow

### DIFF
--- a/app/client/cypress/fixtures/application-file.json
+++ b/app/client/cypress/fixtures/application-file.json
@@ -1,5 +1,5 @@
 {
-    "appsmithVersion":"UNKNOWN",
+    "appsmithVersion":"v1.5.13",
     "exportedApplication": {
         "userPermissions": [
             "canComment:applications",

--- a/app/client/cypress/fixtures/application-file.json
+++ b/app/client/cypress/fixtures/application-file.json
@@ -1,4 +1,5 @@
 {
+    "appsmithVersion":"UNKNOWN",
     "exportedApplication": {
         "userPermissions": [
             "canComment:applications",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
@@ -15,6 +15,8 @@ import java.util.Set;
 @Getter
 @Setter
 public class ApplicationJson {
+
+    String version;
     
     Application exportedApplication;
     

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
@@ -16,7 +16,7 @@ import java.util.Set;
 @Setter
 public class ApplicationJson {
 
-    String version;
+    String appsmithVersion;
     
     Application exportedApplication;
     

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -15,7 +15,7 @@ public enum AppsmithError {
     DUPLICATE_KEY_USER_ERROR(400, 4005, "{0} already exists. Please use a different {1}", AppsmithErrorAction.DEFAULT, null),
     PAGE_DOESNT_BELONG_TO_USER_ORGANIZATION(400, 4006, "Page {0} does not belong to the current user {1} " +
             "organization", AppsmithErrorAction.LOG_EXTERNALLY, null),
-    UNSUPPORTED_OPERATION(400, 4007, "Unsupported operation", AppsmithErrorAction.DEFAULT, null),
+    UNSUPPORTED_OPERATION(400, 4007, "Unsupported operation, {0}", AppsmithErrorAction.DEFAULT, null),
     USER_DOESNT_BELONG_ANY_ORGANIZATION(400, 4009, "User {0} does not belong to any organization",
             AppsmithErrorAction.LOG_EXTERNALLY, null),
     USER_DOESNT_BELONG_TO_ORGANIZATION(400, 4010, "User {0} does not belong to an organization with id {1}",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -15,7 +15,7 @@ public enum AppsmithError {
     DUPLICATE_KEY_USER_ERROR(400, 4005, "{0} already exists. Please use a different {1}", AppsmithErrorAction.DEFAULT, null),
     PAGE_DOESNT_BELONG_TO_USER_ORGANIZATION(400, 4006, "Page {0} does not belong to the current user {1} " +
             "organization", AppsmithErrorAction.LOG_EXTERNALLY, null),
-    UNSUPPORTED_OPERATION(400, 4007, "Unsupported operation, {0}", AppsmithErrorAction.DEFAULT, null),
+    UNSUPPORTED_OPERATION(400, 4007, "Unsupported operation", AppsmithErrorAction.DEFAULT, null),
     USER_DOESNT_BELONG_ANY_ORGANIZATION(400, 4009, "User {0} does not belong to any organization",
             AppsmithErrorAction.LOG_EXTERNALLY, null),
     USER_DOESNT_BELONG_TO_ORGANIZATION(400, 4010, "User {0} does not belong to an organization with id {1}",
@@ -66,6 +66,7 @@ public enum AppsmithError {
     INVALID_LOGIN_METHOD(401, 4030, "Please use {0} authentication to login to Appsmith", AppsmithErrorAction.DEFAULT, null),
     REMOVE_LAST_ORG_ADMIN_ERROR(400, 4037, "The last admin can not be removed from an organization", AppsmithErrorAction.DEFAULT, null),
     INVALID_CRUD_PAGE_REQUEST(400, 4038, "Unable to process page generation request, {0}", AppsmithErrorAction.DEFAULT, null),
+    INVALID_IMPORTED_FILE_ERROR(400, 4039, "Provided file is from different version, please wait till Appsmith gets auto-updated to latest version. This may take a day or two. We are really sorry for the inconvenience caused", AppsmithErrorAction.DEFAULT, null),
     INTERNAL_SERVER_ERROR(500, 5000, "Internal server error while processing request", AppsmithErrorAction.LOG_EXTERNALLY, null),
     REPOSITORY_SAVE_FAILED(500, 5001, "Failed to save the repository. Try again.", AppsmithErrorAction.DEFAULT, null),
     PLUGIN_INSTALLATION_FAILED_DOWNLOAD_ERROR(500, 5002, "Plugin installation failed due to an error while " +

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -75,6 +75,7 @@ public class ImportExportApplicationService {
     private final NewActionService newActionService;
     private final SequenceService sequenceService;
     private final ExamplesOrganizationCloner examplesOrganizationCloner;
+    private final ReleaseNotesService releaseNotesService;
 
     private static final Set<MediaType> ALLOWED_CONTENT_TYPES = Set.of(MediaType.APPLICATION_JSON);
     private static final String INVALID_JSON_FILE = "invalid json file";
@@ -118,6 +119,9 @@ public class ImportExportApplicationService {
             })
             .then(applicationMono)
             .flatMap(application -> {
+
+                // Insert the release version for exported file
+                applicationJson.setVersion(releaseNotesService.getReleasedVersion());
 
                 // Assign the default page names for published and unpublished field in applicationJson object
                 ApplicationPage unpublishedDefaultPage = application.getPages()
@@ -353,6 +357,9 @@ public class ImportExportApplicationService {
         
         if(!errorField.isEmpty()) {
             return Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, errorField, INVALID_JSON_FILE));
+        } else if(importedDoc.getVersion() != null && !releaseNotesService.getReleasedVersion().equals(importedDoc.getVersion())) {
+            return Mono.error(new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION, ", provided file is of " +
+                "different version. Please try updating Appsmith to the latest version"));
         }
         
         return pluginRepository.findAll()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -121,7 +121,7 @@ public class ImportExportApplicationService {
             .flatMap(application -> {
 
                 // Insert the release version for exported file
-                applicationJson.setVersion(releaseNotesService.getReleasedVersion());
+                applicationJson.setAppsmithVersion(releaseNotesService.getReleasedVersion());
 
                 // Assign the default page names for published and unpublished field in applicationJson object
                 ApplicationPage unpublishedDefaultPage = application.getPages()
@@ -357,14 +357,14 @@ public class ImportExportApplicationService {
         
         if(!errorField.isEmpty()) {
             return Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, errorField, INVALID_JSON_FILE));
-        } else if(importedDoc.getVersion() == null) {
+        } else if(importedDoc.getAppsmithVersion() == null) {
             return Mono.error(
                 new AppsmithException(
                     AppsmithError.JSON_PROCESSING_ERROR,
                     ": Unable to find version field in the uploaded file. Can you please try exporting the " +
                         "application from source Appsmith server and then importing it once again"
                 ));
-        } else if(!releaseNotesService.getReleasedVersion().equals(importedDoc.getVersion())) {
+        } else if(!releaseNotesService.getReleasedVersion().equals(importedDoc.getAppsmithVersion())) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_IMPORTED_FILE_ERROR));
         }
         

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -357,9 +357,15 @@ public class ImportExportApplicationService {
         
         if(!errorField.isEmpty()) {
             return Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, errorField, INVALID_JSON_FILE));
-        } else if(importedDoc.getVersion() != null && !releaseNotesService.getReleasedVersion().equals(importedDoc.getVersion())) {
-            return Mono.error(new AppsmithException(AppsmithError.UNSUPPORTED_OPERATION, ", provided file is of " +
-                "different version. Please try updating Appsmith to the latest version"));
+        } else if(importedDoc.getVersion() == null) {
+            return Mono.error(
+                new AppsmithException(
+                    AppsmithError.JSON_PROCESSING_ERROR,
+                    ": Unable to find version field in the uploaded file. Can you please try exporting the " +
+                        "application from source Appsmith server and then importing it once again"
+                ));
+        } else if(!releaseNotesService.getReleasedVersion().equals(importedDoc.getVersion())) {
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_IMPORTED_FILE_ERROR));
         }
         
         return pluginRepository.findAll()

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/invalid-file-without-version.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/invalid-file-without-version.json
@@ -1,0 +1,10 @@
+{
+  "exportedApplication": {},
+  "datasourceList": [],
+  "pageList": [
+    {
+      "applicationId": "invalid_application"
+    }
+  ],
+  "actionList": []
+}

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
@@ -1,4 +1,5 @@
 {
+    "appsmithVersion":"UNKNOWN",
     "exportedApplication": {
       "userPermissions": [
         "canComment:applications",


### PR DESCRIPTION
## Description

> If we try import-export application flow for different versions of appsmith, application breaks because of data migration issues, upgraded version may support different widgets than the other one etc. To avoid this we are introducing the version check as the first step so that the imported application won't break after it has been rehydrated in the destination instance.  

Fixes #6519 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested manually on local instance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: bug-import-export 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.75 **(0)** | 36.75 **(-0.01)** | 33.07 **(0)** | 55.32 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>