### PR TITLE
Fix: Mysql plugin: change validation check to avoid connection block.

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -76,7 +76,7 @@ public class MySqlPlugin extends BasePlugin {
     private static final String DATE_COLUMN_TYPE_NAME = "date";
     private static final String DATETIME_COLUMN_TYPE_NAME = "datetime";
     private static final String TIMESTAMP_COLUMN_TYPE_NAME = "timestamp";
-    private static final int VALIDATION_CHECK_TIMEOUT = 4; // seconds4
+    private static final int VALIDATION_CHECK_TIMEOUT = 4; // seconds
 
     /**
      * Example output for COLUMNS_QUERY:

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -235,7 +235,7 @@ public class MySqlPlugin extends BasePlugin {
             List<RequestParamDTO> requestParams = List.of(new RequestParamDTO(ACTION_CONFIGURATION_BODY,
                     transformedQuery, null, null, psParams));
 
-            Flux<Result> resultFlux = Mono.from(connection.validate(ValidationDepth.REMOTE))
+            Flux<Result> resultFlux = Mono.from(connection.validate(ValidationDepth.LOCAL))
                     .flatMapMany(isValid -> {
                         if (isValid) {
                             return createAndExecuteQueryFromConnection(finalQuery,
@@ -783,7 +783,7 @@ public class MySqlPlugin extends BasePlugin {
             final Map<String, DatasourceStructure.Table> tablesByName = new LinkedHashMap<>();
             final Map<String, DatasourceStructure.Key> keyRegistry = new HashMap<>();
 
-            return Mono.from(connection.validate(ValidationDepth.REMOTE))
+            return Mono.from(connection.validate(ValidationDepth.LOCAL))
                     .flatMapMany(isValid -> {
                         if (isValid) {
                             return connection.createStatement(COLUMNS_QUERY).execute();

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -44,6 +44,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -58,6 +59,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -74,6 +76,7 @@ public class MySqlPlugin extends BasePlugin {
     private static final String DATE_COLUMN_TYPE_NAME = "date";
     private static final String DATETIME_COLUMN_TYPE_NAME = "datetime";
     private static final String TIMESTAMP_COLUMN_TYPE_NAME = "timestamp";
+    private static final int VALIDATION_CHECK_TIMEOUT = 4; // seconds4
 
     /**
      * Example output for COLUMNS_QUERY:
@@ -235,7 +238,10 @@ public class MySqlPlugin extends BasePlugin {
             List<RequestParamDTO> requestParams = List.of(new RequestParamDTO(ACTION_CONFIGURATION_BODY,
                     transformedQuery, null, null, psParams));
 
-            Flux<Result> resultFlux = Mono.from(connection.validate(ValidationDepth.LOCAL))
+            // TODO: need to write a JUnit TC for VALIDATION_CHECK_TIMEOUT
+            Flux<Result> resultFlux = Mono.from(connection.validate(ValidationDepth.REMOTE))
+                    .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
+                    .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
                     .flatMapMany(isValid -> {
                         if (isValid) {
                             return createAndExecuteQueryFromConnection(finalQuery,
@@ -783,7 +789,9 @@ public class MySqlPlugin extends BasePlugin {
             final Map<String, DatasourceStructure.Table> tablesByName = new LinkedHashMap<>();
             final Map<String, DatasourceStructure.Key> keyRegistry = new HashMap<>();
 
-            return Mono.from(connection.validate(ValidationDepth.LOCAL))
+            return Mono.from(connection.validate(ValidationDepth.REMOTE))
+                    .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
+                    .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
                     .flatMapMany(isValid -> {
                         if (isValid) {
                             return connection.createStatement(COLUMNS_QUERY).execute();


### PR DESCRIPTION
## Description
- The connection seems to get stuck while doing validation check with `depth=REMOTE` i.e it pings the MySQL server waiting for a response - which somehow doesn't seem to come. This check is meant to determine whether the connection is still valid. In case it is invalid a stale connection exception is returned. This PR adds to this check by adding a timeout, assuming the connection to be stale in case the validity check gets stuck for more than timeout seconds. 
- Another solution that could work was to change the validation depth to `depth=LOCAL` in which case the validity check would check for its own side of the connection and not try to probe the server, however it seemed like it would cause a problem when the connection is dropped from the server side as it would not be able to detect it. 
- I also explored adding a connection pool, since we currently have one connection instead of pool, multiple async connections might fail at some point, however, r2dbc based connection pool failed with error. I have reported the error here: https://github.com/r2dbc/r2dbc-pool/issues/135 . In case we want to go with a connection pool, my suggestion would be to do away with the r2dbc based driver that we currently use now. Since we haven't yet made this decision on whether we want to do away with r2dbc based driver, I could not proceed further on this. 
- TBD: JUnit Tc. I spent a good amt of time trying to write a JUnit TC to replicate and test this scenario but haven not been able to replicate the scenario so far. Since the PR is addressing a critical issue, I think we should let the solution go in and work on the TC separately. I have added a TODO comment in the code as well. 

Fixes #2555 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
