### PR TITLE
[Imrpovement] - Add page name in comment notification emails

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/AbstractCommentEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/AbstractCommentEvent.java
@@ -10,4 +10,5 @@ public abstract class AbstractCommentEvent {
     private final Organization organization;
     private final Application application;
     private final String originHeader;
+    private final String pageName;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentAddedEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentAddedEvent.java
@@ -12,9 +12,9 @@ public class CommentAddedEvent extends AbstractCommentEvent {
     private final Comment comment;
     private final Set<String> subscribers;
 
-    public CommentAddedEvent(String authorUserName, Organization organization, Application application,
-                             String originHeader, Comment comment, Set<String> subscribers) {
-        super(authorUserName, organization, application, originHeader);
+    public CommentAddedEvent(Organization organization, Application application,
+                             String originHeader, Comment comment, Set<String> subscribers, String pageName) {
+        super(comment.getAuthorUsername(), organization, application, originHeader, pageName);
         this.comment = comment;
         this.subscribers = subscribers;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentThreadClosedEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/CommentThreadClosedEvent.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 public class CommentThreadClosedEvent extends AbstractCommentEvent {
     private final CommentThread commentThread;
 
-    public CommentThreadClosedEvent(String authorUserName, Organization organization, Application application, String originHeader, CommentThread commentThread) {
-        super(authorUserName, organization, application, originHeader);
+    public CommentThreadClosedEvent(String authorUserName, Organization organization, Application application, String originHeader, CommentThread commentThread, String pagename) {
+        super(authorUserName, organization, application, originHeader, pagename);
         this.commentThread = commentThread;
     }
 }

--- a/app/server/appsmith-server/src/main/resources/email/commentAddedTemplate.html
+++ b/app/server/appsmith-server/src/main/resources/email/commentAddedTemplate.html
@@ -197,7 +197,7 @@
 																<td style="padding:0px 0px 18px 0px; line-height:22px; text-align:center; background-color:#ffffff;"
 																	height="100%" valign="top" bgcolor="#ffffff"
 																	role="module-content">
-																	<div style="margin-top:37px;font-size:25px;line-height: 35px;">
+																	<div style="margin-top:37px;font-size:18px;line-height: 35px;">
 																		<b>{{Commenter_Name}}</b>,
 																		{{#NewComment}} added {{/NewComment}}
 																		{{#Resolved}} resolved {{/Resolved}}
@@ -205,10 +205,10 @@
 																		{{#Mentioned}} mentioned you in {{/Mentioned}}
 																		{{#Resolved}} a comment thread {{/Resolved}}
 																		{{^Resolved}} a comment on {{/Resolved}}
-																		<br><b>{{Organization_Name}}, {{Application_Name}}</b>:
+																		<br><b>{{Application_Name}}, {{Page_Name}}</b>:
 																	</div>
 																	{{#Comment_Body}}
-																	<div style="display:inline-block;padding:10px;margin-top: 40px; color: #5c5959;background-color:#F0F0F0">
+																	<div style="display:block;padding:10px;margin-top: 40px; color: #5c5959;background-color:#F0F0F0">
 																		{{ . }}
 																	</div>
 																	{{/Comment_Body}}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EmailEventHandlerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EmailEventHandlerTest.java
@@ -5,13 +5,16 @@ import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.Comment;
 import com.appsmith.server.domains.CommentThread;
+import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.UserRole;
+import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.events.CommentAddedEvent;
 import com.appsmith.server.events.CommentThreadClosedEvent;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.notifications.EmailSender;
 import com.appsmith.server.repositories.ApplicationRepository;
+import com.appsmith.server.repositories.NewPageRepository;
 import com.appsmith.server.repositories.OrganizationRepository;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,6 +49,8 @@ public class EmailEventHandlerTest {
     @MockBean
     private ApplicationRepository applicationRepository;
     @MockBean
+    private NewPageRepository newPageRepository;
+    @MockBean
     private EmailConfig emailConfig;
 
     @MockBean
@@ -64,7 +69,13 @@ public class EmailEventHandlerTest {
     @Before
     public void setUp() {
         emailEventHandler = new EmailEventHandler(
-                applicationEventPublisher, emailSender, organizationRepository, applicationRepository, policyUtils, emailConfig
+                applicationEventPublisher,
+                emailSender,
+                organizationRepository,
+                applicationRepository,
+                newPageRepository,
+                policyUtils,
+                emailConfig
         );
         application = new Application();
         application.setName("Test application for comment");
@@ -79,14 +90,20 @@ public class EmailEventHandlerTest {
 
         Mockito.when(applicationRepository.findById(applicationId)).thenReturn(Mono.just(application));
         Mockito.when(organizationRepository.findById(organizationId)).thenReturn(Mono.just(organization));
+
+        NewPage newPage = new NewPage();
+        newPage.setUnpublishedPage(new PageDTO());
+        newPage.getUnpublishedPage().setName("Page1");
+        Mockito.when(newPageRepository.findById(anyString())).thenReturn(Mono.just(newPage));
     }
 
     @Test
     public void publish_CommentProvidedWithSubscriber_ReturnsTrue() {
         Comment comment = new Comment();
+        comment.setPageId("page-id");
         Set<String> subscribers = Set.of("dummy-username1");
         CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
-                authorUserName, organization, application, originHeader, comment, subscribers
+                organization, application, originHeader, comment, subscribers, "Page1"
         );
 
         Mockito.doNothing().when(applicationEventPublisher).publishEvent(commentAddedEvent);
@@ -123,7 +140,7 @@ public class EmailEventHandlerTest {
     public void publish_WhenCommentThreadHasNoPublishersProvided_ReturnsFalse() {
         CommentThread commentThread = new CommentThread();
         CommentThreadClosedEvent commentThreadClosedEvent = new CommentThreadClosedEvent(
-                authorUserName, organization, application, originHeader, commentThread
+                authorUserName, organization, application, originHeader, commentThread, "Page1"
         );
         Mockito.doNothing().when(applicationEventPublisher).publishEvent(commentThreadClosedEvent);
 
@@ -136,9 +153,10 @@ public class EmailEventHandlerTest {
     @Test
     public void publish_WhenCommentThreadHasPublishersProvided_ReturnsTrue() {
         CommentThread commentThread = new CommentThread();
+        commentThread.setPageId("page-id");
         commentThread.setSubscribers(Set.of("abc"));
         CommentThreadClosedEvent commentThreadClosedEvent = new CommentThreadClosedEvent(
-                authorUserName, organization, application, originHeader, commentThread
+                authorUserName, organization, application, originHeader, commentThread, "Page1"
         );
         Mockito.doNothing().when(applicationEventPublisher).publishEvent(commentThreadClosedEvent);
 
@@ -158,7 +176,7 @@ public class EmailEventHandlerTest {
 
         // send the event
         CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
-                authorUserName, organization, application, originHeader, sampleComment, subscribers
+                organization, application, originHeader, sampleComment, subscribers, "Page1"
         );
         emailEventHandler.handle(commentAddedEvent);
 
@@ -180,7 +198,7 @@ public class EmailEventHandlerTest {
 
         // send the event
         CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
-                authorUserName, organization, application, originHeader, sampleComment, subscribers
+                organization, application, originHeader, sampleComment, subscribers, "Page1"
         );
         emailEventHandler.handle(commentAddedEvent);
 
@@ -230,7 +248,7 @@ public class EmailEventHandlerTest {
 
         // send the event
         CommentAddedEvent commentAddedEvent = new CommentAddedEvent(
-                authorUserName, organization, application, originHeader, sampleComment, subscribers
+                organization, application, originHeader, sampleComment, subscribers, "Page1"
         );
         emailEventHandler.handle(commentAddedEvent);
 
@@ -259,7 +277,7 @@ public class EmailEventHandlerTest {
 
         // send the event
         CommentThreadClosedEvent commentAddedEvent = new CommentThreadClosedEvent(
-                authorUserName, organization, application, originHeader, commentThread
+                authorUserName, organization, application, originHeader, commentThread, "Page1"
         );
         emailEventHandler.handle(commentAddedEvent);
 


### PR DESCRIPTION
## Description
Currently, the notification emails contain the organization name and application name. As per the UI design, it should contain application name and page names. This PR fixes that issue.

Fixes #6622 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit tests
- Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
