### PR TITLE
fix cypress mockdatasource flaky test

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/MockDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/MockDatasource_spec.js
@@ -10,7 +10,7 @@ describe("Create, test, save then delete a user mock datasource", function() {
     cy.get(datasource.mockUserDatabase).click();
     cy.get(datasource.mockUserDatasources)
       .last()
-      .click();
+      .click({ force: true });
     cy.fillUsersMockDatasourceForm();
     cy.testSaveDeleteDatasource();
   });
@@ -20,7 +20,7 @@ describe("Create, test, save then delete a user mock datasource", function() {
     cy.get(datasource.mockUserDatabase).click();
     cy.get(datasource.mockUserDatasources)
       .last()
-      .click();
+      .click({ force: true });
     cy.fillUsersMockDatasourceForm(true);
     cy.testSaveDeleteDatasource();
   });


### PR DESCRIPTION
## Description

[Mockdatasource test](https://github.com/appsmithorg/appsmith/blob/release/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/MockDatasource_spec.js) is flaky.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>