### PR TITLE
Fix: Redis plugin: extract cmd and args based on regex

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -78,8 +78,8 @@ public class RedisPlugin extends BasePlugin {
                     return Mono.error(
                             new AppsmithPluginException(
                                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                                    "Appsmith server has failed to parse Redis query. Please check if the Redis query" +
-                                            " has correct format."
+                                    "Appsmith server has failed to parse your Redis query. Are you sure it's" +
+                                            " been formatted correctly."
                             )
                     );
                 }

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -139,11 +139,7 @@ public class RedisPlugin extends BasePlugin {
         }
 
         private boolean isQueryFormatValid(Map cmdAndArgs) {
-            if (cmdAndArgs.containsKey(CMD_KEY)) {
-                return true;
-            }
-
-            return false;
+            return cmdAndArgs.containsKey(CMD_KEY);
         }
 
         private Map getCommandAndArgs(String query) {

--- a/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/main/java/com/external/plugins/RedisPlugin.java
@@ -90,7 +90,7 @@ public class RedisPlugin extends BasePlugin {
                     command = Protocol.Command.valueOf((String) cmdAndArgs.get(CMD_KEY));
                 } catch (IllegalArgumentException exc) {
                     return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
-                            String.format("Not a valid Redis command:%s", cmdAndArgs.get(CMD_KEY))));
+                            String.format("Not a valid Redis command: %s", cmdAndArgs.get(CMD_KEY))));
                 }
 
                 Object commandOutput;

--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -243,7 +243,7 @@ public class RedisPluginTest {
 
         // Setting a key
         ActionConfiguration setActionConfiguration = new ActionConfiguration();
-        setActionConfiguration.setBody("SET key value");
+        setActionConfiguration.setBody("SET key \"my value\"");
         actionExecutionResultMono = jedisPoolMono
                 .flatMap(jedisPool -> pluginExecutor.execute(jedisPool, datasourceConfiguration,
                         setActionConfiguration));
@@ -264,7 +264,7 @@ public class RedisPluginTest {
                     Assert.assertNotNull(actionExecutionResult);
                     Assert.assertNotNull(actionExecutionResult.getBody());
                     final JsonNode node = ((ArrayNode) actionExecutionResult.getBody()).get(0);
-                    Assert.assertEquals("value", node.get("result").asText());
+                    Assert.assertEquals("\"my value\"", node.get("result").asText());
                 }).verifyComplete();
     }
 


### PR DESCRIPTION
## Description
- Earlier `split` method was used to segregate cmd and args which failed when multiple words inside a quoted string formed one argument. e.g. `set key "my value"` would produce `set`, `key`, `"my`, `value"` as the tokens when `split` method is used, which is not correct. This change introduces a regex that would create the following tokens: `set`, `key`, `"my value"`.

Fixes #6363 


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
