### PR TITLE
Fix: Dynamodb Plugin: remove data type info keys from raw values. 

### DIFF
--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
@@ -58,17 +58,6 @@ import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATI
 
 public class DynamoPlugin extends BasePlugin {
 
-    private static final String SCAN_ACTION_VALUE = "Scan";
-    private static final String GET_ITEM_ACTION_VALUE = "GetItem";
-    private static final String BATCH_GET_ITEM_ACTION_VALUE = "BatchGetItem";
-    private static final String TRANSACT_GET_ITEMS_ACTION_VALUE = "TransactGetItems";
-    private static final String PUT_ITEM_ACTION_VALUE = "PutItem";
-    private static final String UPDATE_ITEM_ACTION_VALUE = "UpdateItem";
-    private static final String DELETE_ITEM_ACTION_VALUE = "DeleteItem";
-    private static final String ITEMS_KEY = "Items";
-    private static final String ITEM_KEY = "Item";
-    private static final String ATTRIBUTES_KEY = "Attributes";
-    private static final String RESPONSES_KEY = "Responses";
     private static final String DYNAMO_TYPE_STRING_LABEL = "S";
     private static final String DYNAMO_TYPE_NUMBER_LABEL = "N";
     private static final String DYNAMO_TYPE_BINARY_LABEL = "B";
@@ -172,6 +161,7 @@ public class DynamoPlugin extends BasePlugin {
                 return extractedValueMap;
             }
         }
+
         /*
          * - Transform response for easy consumption. For details please visit
          *   https://github.com/appsmithorg/appsmith/issues/3010
@@ -180,98 +170,17 @@ public class DynamoPlugin extends BasePlugin {
                                              String action) throws AppsmithPluginException {
 
             Map<String, Object> transformedResponse = new HashMap<>();
-
-            /*
-             * - Any action other than the following do not return transformed response:
-             *  - Scan
-             *  - GetItem
-             *  - PutItem
-             *  - UpdateItem
-             *  - DeleteItem
-             *  - BatchGetItem
-             *  - TransactGetItem
-             */
-            if (!SCAN_ACTION_VALUE.equals(action)
-                    && !GET_ITEM_ACTION_VALUE.equals(action)
-                    && !PUT_ITEM_ACTION_VALUE.equals(action)
-                    && !UPDATE_ITEM_ACTION_VALUE.equals(action)
-                    && !DELETE_ITEM_ACTION_VALUE.equals(action)
-                    && !BATCH_GET_ITEM_ACTION_VALUE.equals(action)
-                    && !TRANSACT_GET_ITEMS_ACTION_VALUE.equals(action)) {
-                return rawResponse;
-            }
-
-            /*
-             * - Transform response based on action.
-             */
-            String topLevelKey;
-            switch (action) {
-                case SCAN_ACTION_VALUE:
-                    topLevelKey = ITEMS_KEY;
-                    break;
-                case GET_ITEM_ACTION_VALUE:
-                    topLevelKey = ITEM_KEY;
-                    break;
-                case PUT_ITEM_ACTION_VALUE:
-                case UPDATE_ITEM_ACTION_VALUE:
-                case DELETE_ITEM_ACTION_VALUE:
-                    topLevelKey = ATTRIBUTES_KEY;
-                    break;
-                case BATCH_GET_ITEM_ACTION_VALUE:
-                case TRANSACT_GET_ITEMS_ACTION_VALUE:
-                    topLevelKey = RESPONSES_KEY;
-                    break;
-                default:
-                    throw new AppsmithPluginException(
-                            AppsmithPluginError.PLUGIN_ERROR,
-                            "Appsmith has encountered an unexpected error when transforming raw DynamoDb response" +
-                                    ". Please reach out to Appsmith customer support to resolve this."
-                    );
-            }
-
             for (Map.Entry<String, Object> responseEntry: rawResponse.entrySet()) {
-                if (!responseEntry.getKey().equals(topLevelKey)) {
-                    transformedResponse.put(responseEntry.getKey(), responseEntry.getValue());
-                }
-                else {
-                    if (rawResponse.get(topLevelKey) instanceof Collection) {
+                    Object rawItems = responseEntry.getValue();
+                    if (rawItems != null) {
                         /*
-                         * - Need to have an empty list if rawItems is null.
+                         * - Insert transformed values into extractedResponse list.
                          */
-                        List<Object> extractedResponse = new ArrayList<>();
-                        Collection<Object> rawItems = (Collection<Object>) (rawResponse.get(topLevelKey));
-                        if (rawItems != null) {
-                            /*
-                             * - Insert transformed values into extractedResponse list.
-                             */
-                            extractedResponse = rawItems
-                                    .stream()
-                                    .map(item -> extractValue(item))
-                                    .collect(Collectors.toList());
-                        }
-
-                        transformedResponse.put(topLevelKey, extractedResponse);
+                        transformedResponse.put(responseEntry.getKey(), extractValue(rawItems));
                     }
-                    else if (rawResponse.get(topLevelKey) instanceof Map) {
-                        /*
-                         * - Need to have an empty map if rawItems is null.
-                         */
-                        Map<Object, Object> extractedResponse = new HashMap<>();
-                        HashMap<String, Object> rawItems = (HashMap<String, Object>) rawResponse.get(topLevelKey);
-                        if (rawItems != null) {
-                            /*
-                             * - Insert transformed values into extractedResponse map.
-                             */
-                            extractedResponse = rawItems
-                                    .entrySet()
-                                    .stream()
-                                    .map(item -> Map.entry(item.getKey(), extractValue(item.getValue())))
-                                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                        }
-
-                        transformedResponse.put(topLevelKey, extractedResponse);
+                    else {
+                        transformedResponse.put(responseEntry.getKey(), null);
                     }
-                }
             }
 
             return transformedResponse;
@@ -331,6 +240,8 @@ public class DynamoPlugin extends BasePlugin {
                     final Object sdkValue = plainToSdk(parameters, requestClass);
                     final DynamoDbResponse response = (DynamoDbResponse) actionExecuteMethod.invoke(ddb, sdkValue);
                     Object rawResponse = sdkToPlain(response);
+                    // TODO: remove it.
+                    System.out.println("devtest: raw response: " + rawResponse);
                     Object transformedResponse = getTransformedResponse((Map<String, Object>)rawResponse, action);
                     result.setBody(transformedResponse);
                 } catch (AppsmithPluginException | InvocationTargetException | IllegalAccessException | NoSuchMethodException | ClassNotFoundException e) {

--- a/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/main/java/com/external/plugins/DynamoPlugin.java
@@ -240,8 +240,6 @@ public class DynamoPlugin extends BasePlugin {
                     final Object sdkValue = plainToSdk(parameters, requestClass);
                     final DynamoDbResponse response = (DynamoDbResponse) actionExecuteMethod.invoke(ddb, sdkValue);
                     Object rawResponse = sdkToPlain(response);
-                    // TODO: remove it.
-                    System.out.println("devtest: raw response: " + rawResponse);
                     Object transformedResponse = getTransformedResponse((Map<String, Object>)rawResponse, action);
                     result.setBody(transformedResponse);
                 } catch (AppsmithPluginException | InvocationTargetException | IllegalAccessException | NoSuchMethodException | ClassNotFoundException e) {

--- a/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
+++ b/app/server/appsmith-plugins/dynamoPlugin/src/test/java/com/external/plugins/DynamoPluginTest.java
@@ -230,6 +230,29 @@ public class DynamoPluginTest {
     }
 
     @Test
+    public void testQuery() {
+        final String body = "{\n" +
+                "  \"TableName\": \"cities\", \n" +
+                "\t\"KeyConditionExpression\": \"Id=:v1\",\n" +
+                "\t\"ExpressionAttributeValues\": {\n" +
+                "        \":v1\": {\"S\": \"1\"}\n" +
+                "    },\n" +
+                "    \"ReturnConsumedCapacity\": \"TOTAL\"\n" +
+                "}";
+
+        StepVerifier.create(execute("Query", body))
+                .assertNext(result -> {
+                    assertNotNull(result);
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+                    Map<String, Object> resultBody = (Map<String, Object>) result.getBody();
+                    Map<String, String> transformedItem = ((List<Map<String, String>>) resultBody.get("Items")).get(0);
+                    assertEquals("New Delhi", transformedItem.get("City"));
+                })
+                .verifyComplete();
+    }
+
+    @Test
     public void testPutItem() {
         final String body = "{\n" +
                 "  \"TableName\": \"cities\",\n" +


### PR DESCRIPTION
## Description
- A fix had been introduced earlier (I had introduced it a few months back) to remove data type info keys from the raw response. However, the transformation was not getting applied to the `Query` action as the transformation was explicitly limited to few actions. This PR removes that check and allows the transformation for all actions as there does not seem to be any reason to withhold this transformation for other actions.
- The earlier fix also restricted this transformation to results that had specific keys. This PR removes this check as well as it does not seem to be required and further may lead to similar issues if any particular key gets missed. 
- Some other redundant checks have been removed from the flow as the transformation function itself takes care of it as edge/base case. 

Fixes #6581 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- JUnit TC

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
