### PR TITLE
FIX #6615 : added check for open filter pane and close if before property pane open

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TableComponent/CascadeFields.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/CascadeFields.tsx
@@ -215,7 +215,7 @@ function RenderOptions(props: {
     trigger: {
       content: (
         <DropdownTrigger className={props.className}>
-          <AutoToolTipComponentWrapper title={selectedValue}>
+          <AutoToolTipComponentWrapper isCellVisible title={selectedValue}>
             {selectedValue}
           </AutoToolTipComponentWrapper>
           <Icon color={Colors.SLATE_GRAY} icon="caret-down" iconSize={16} />

--- a/app/client/src/utils/hooks/useBlocksToBeDraggedOnCanvas.ts
+++ b/app/client/src/utils/hooks/useBlocksToBeDraggedOnCanvas.ts
@@ -8,6 +8,7 @@ import { useSelector } from "store";
 import { AppState } from "reducers";
 import { getSelectedWidgets } from "selectors/ui";
 import { getOccupiedSpaces } from "selectors/editorSelectors";
+import { getTableFilterState } from "selectors/tableFilterSelectors";
 import { OccupiedSpace } from "constants/editorConstants";
 import { getDragDetails, getWidgets } from "sagas/selectors";
 import {
@@ -55,6 +56,9 @@ export const useBlocksToBeDraggedOnCanvas = ({
   const { selectWidget } = useWidgetSelection();
   const containerPadding = noPad ? 0 : CONTAINER_GRID_PADDING;
 
+  // check any table filter is open or not
+  // if filter pane open, close before property pane open
+  const tableFilterPaneState = useSelector(getTableFilterState);
   // dragDetails contains of info needed for a container jump:
   // which parent the dragging widget belongs,
   // which canvas is active(being dragged on),
@@ -244,6 +248,12 @@ export const useBlocksToBeDraggedOnCanvas = ({
         updateWidgetParams.widgetId,
         updateWidgetParams.payload,
       );
+    // close filter pane if any open, before property pane open
+    tableFilterPaneState.isVisible &&
+      dispatch({
+        type: ReduxActionTypes.HIDE_TABLE_FILTER_PANE,
+        payload: { widgetId: tableFilterPaneState.widgetId },
+      });
     // Adding setTimeOut to allow property pane to open only after widget is loaded.
     // Not needed for most widgets except for Modal Widget.
     setTimeout(() => {


### PR DESCRIPTION
## Description

> It is observed that when the user keeps the table filter open and drags and drops any other widgets to the canvas the app crashes. So, added check for open filter pane and close if before property pane open.

Fixes #6615 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: FIX/6615-close-filterpane-before-drag-new-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.86 **(0.01)** | 36.97 **(0.01)** | 33.21 **(0)** | 55.44 **(0.01)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**
 :red_circle: | app/client/src/utils/hooks/useBlocksToBeDraggedOnCanvas.ts | 95.73 **(0.12)** | 84.29 **(-1)** | 86.36 **(0)** | 95.5 **(0.13)**</details>