### PR TITLE
resolving header ordering issue with latest release

### DIFF
--- a/app/client/src/components/ads/DraggableList.tsx
+++ b/app/client/src/components/ads/DraggableList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { clamp } from "lodash-es";
 import swap from "lodash-move";
-import { useDrag } from "react-use-gesture";
+import { useGesture } from "react-use-gesture";
 import { useSprings, animated, interpolate } from "react-spring";
 import styled from "styled-components";
 import { debounce, get } from "lodash";
@@ -64,13 +64,16 @@ function DraggableList(props: any) {
   const shouldReRender = get(props, "shouldReRender", true);
   // order of items in the list
   const order = useRef<any>(items.map((_: any, index: any) => index));
+  const listWrapper = useRef<HTMLDivElement | null>(null);
+  const selectedItem = useRef<number>(-1);
+  const scrollTop = useRef<number>(0);
 
-  const onDrop = (originalIndex: number, newIndex: number) => {
-    onUpdate(order.current, originalIndex, newIndex);
-
+  const onDrop = () => {
+    onUpdate(order.current);
     if (shouldReRender) {
       order.current = items.map((_: any, index: any) => index);
       setSprings(updateSpringStyles(order.current, itemHeight));
+      selectedItem.current = -1;
     }
   };
 
@@ -82,38 +85,125 @@ function DraggableList(props: any) {
     }
   }, [items]);
 
+  let isScrolling: any = null;
+  const handleScroll = () => {
+    window.clearTimeout(isScrolling);
+
+    isScrolling = setTimeout(() => {
+      const scrollWrapper = listWrapper.current?.closest(
+        ".t--property-pane-content-section",
+      );
+      const offset = (scrollWrapper?.scrollTop || 0) - scrollTop.current;
+      // console.log(offset);
+      if (selectedItem.current > -1) {
+        const curRow = clamp(
+          Math.round((selectedItem.current * itemHeight + offset) / itemHeight),
+          0,
+          items.length - 1,
+        );
+        const newOrder = [...order.current];
+        // The dragged column
+        const movedColumnName = newOrder.splice(selectedItem.current, 1);
+        // If the dragged column exists
+        if (movedColumnName && movedColumnName.length === 1) {
+          newOrder.splice(curRow, 0, movedColumnName[0]);
+        }
+        order.current = newOrder;
+        selectedItem.current = newOrder.indexOf(selectedItem.current);
+        setSprings(updateSpringStyles(order.current, itemHeight));
+      }
+      scrollTop.current = scrollWrapper?.scrollTop || 0;
+    }, 166);
+  };
+
+  useEffect(() => {
+    const scrollWrapper = listWrapper.current?.closest(
+      ".t--property-pane-content-section",
+    );
+    if (scrollWrapper) {
+      scrollWrapper.addEventListener("scroll", handleScroll);
+      return () => {
+        scrollWrapper.removeEventListener("scroll", handleScroll);
+      };
+    }
+  }, [listWrapper]);
+
   const [springs, setSprings] = useSprings<any>(
     items.length,
     updateSpringStyles(order.current, itemHeight),
   );
 
-  const bind: any = useDrag<any>((props: any) => {
-    const originalIndex = props.args[0];
-    const curIndex = order.current.indexOf(originalIndex);
-    const curRow = clamp(
-      Math.round((curIndex * itemHeight + props.movement[1]) / itemHeight),
-      0,
-      items.length - 1,
-    );
-    const newOrder = swap(order.current, curIndex, curRow);
-    setSprings(
-      dragIdleSpringStyles(newOrder, {
-        down: props.down,
-        originalIndex,
-        curIndex,
-        y: props.movement[1],
-        itemHeight,
-      }),
-    );
-    if (curRow !== curIndex) {
-      // Feed springs new style data, they'll animate the view without causing a single render
-      if (!props.down) {
-        order.current = newOrder;
-        setSprings(updateSpringStyles(order.current, itemHeight));
-        debounce(onDrop, 400)(curIndex, curRow);
-      }
-    }
-  });
+  const bind: any = useGesture(
+    {
+      onDrag: (props: any) => {
+        const originalIndex = props.args[0];
+        const curIndex = order.current.indexOf(originalIndex);
+        selectedItem.current = curIndex;
+        const curRow = clamp(
+          Math.round((curIndex * itemHeight + props.movement[1]) / itemHeight),
+          0,
+          items.length - 1,
+        );
+        const newOrder = swap(order.current, curIndex, curRow);
+        const scrollWrapper = listWrapper.current?.closest(
+          ".t--property-pane-content-section",
+        );
+        const sRect = scrollWrapper?.getBoundingClientRect();
+        const dRect = listWrapper.current?.getBoundingClientRect();
+        const sPos: any = {
+          top: sRect?.top || 0,
+          bottom: sRect?.bottom || 0,
+        };
+        const dPos = {
+          top: dRect?.top || 0,
+          bottom: dRect?.bottom || 0,
+        };
+        // scrolled down
+        if (
+          props.movement[1] > 0 &&
+          props.xy[1] > sPos.bottom - itemHeight * 1.5
+        ) {
+          if (dPos.bottom > sPos.bottom && curRow < items.length - 1) {
+            scrollWrapper?.scrollTo({
+              top: scrollTop.current + itemHeight * 2,
+              behavior: "smooth",
+            });
+          }
+        }
+        // scrolled up
+        else if (
+          props.xy[1] < sPos.top + itemHeight * 1.5 &&
+          dPos.top < sPos.top &&
+          curRow > 0
+        ) {
+          scrollWrapper?.scrollTo({
+            top: scrollTop.current - itemHeight * 2,
+            behavior: "smooth",
+          });
+        }
+
+        setSprings(
+          dragIdleSpringStyles(newOrder, {
+            down: props.down,
+            originalIndex,
+            curIndex,
+            y: props.movement[1],
+            itemHeight,
+          }),
+        );
+        if (curRow !== curIndex) {
+          // Feed springs new style data, they'll animate the view without causing a single render
+          if (!props.down) {
+            order.current = newOrder;
+            setSprings(updateSpringStyles(order.current, itemHeight));
+            debounce(onDrop, 400)();
+          }
+        }
+      },
+    },
+    {},
+  );
+
   return (
     <DraggableListWrapper
       className="content"
@@ -122,6 +212,7 @@ function DraggableList(props: any) {
         document.onmouseup = null;
         document.onmousemove = null;
       }}
+      ref={listWrapper}
       style={{ height: items.length * itemHeight }}
     >
       {springs.map(({ scale, y, zIndex }, i) => (

--- a/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx
@@ -405,8 +405,13 @@ export function TableHeaderCell(props: {
   sortTableColumn: (columnIndex: number, asc: boolean) => void;
   isResizingColumn: boolean;
   column: any;
+  orgLeft: number;
+  orgTop: number;
+  provided: any;
+  snapshot: any;
+  setOrgPosition: (left: number, top: number) => void;
 }) {
-  const { column } = props;
+  const { column, provided, snapshot } = props;
   const handleSortColumn = () => {
     if (props.isResizingColumn) return;
     let columnIndex = props.columnIndex;
@@ -418,11 +423,47 @@ export function TableHeaderCell(props: {
     props.sortTableColumn(columnIndex, sortOrder);
   };
 
+  const handleMouseDown = (e: any) => {
+    const colElem = e.target.closest(".th.header-reorder");
+    const tblWrap = e.target.closest(".tableWrap");
+    if (colElem && tblWrap) {
+      const rectArea = colElem.getBoundingClientRect();
+      const rectTbl = tblWrap.getBoundingClientRect();
+      const offsetX = rectArea.left - rectTbl.left;
+      const offsetY = rectArea.top - rectTbl.top + 40;
+      props.setOrgPosition(offsetX, offsetY);
+    }
+  };
+
+  const getItemStyle = () => {
+    const { isDragging, isDropAnimating } = snapshot;
+    return {
+      ...provided.draggableProps.style,
+      ...(isDropAnimating && { transitionDuration: "0.001s" }),
+      left: props.orgLeft,
+      top: props.orgTop,
+      width: "100%",
+      ...(isDragging && {
+        background: "#efefef",
+        borderRadius: "4px",
+        zIndex: 100,
+        width: column.width,
+        textOverflow: "none",
+        overflow: "none",
+        opacity: 0.6,
+      }),
+      ...(!isDragging && {
+        transform: "none",
+      }),
+    };
+  };
+
   return (
     <div
       {...column.getHeaderProps()}
       className="th header-reorder"
       onClick={handleSortColumn}
+      onMouseDown={handleMouseDown}
     >
       {props.isAscOrder !== undefined ? (
         <SortIconWrapper>
@@ -434,6 +475,8 @@ export function TableHeaderCell(props: {
         </SortIconWrapper>
       ) : null}
       <DraggableHeaderWrapper
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
         className={
           !props.isHidden
             ? `draggable-header ${
@@ -442,9 +485,29 @@ export function TableHeaderCell(props: {
             : "hidden-header"
         }
         horizontalAlignment={column.columnProperties.horizontalAlignment}
+        ref={provided.innerRef}
+        style={{
+          ...getItemStyle(),
+          // position: "absolute",
+          // width: "100%",
+        }}
       >
         {props.columnName}
       </DraggableHeaderWrapper>
+      {props.snapshot.isDragging ? (
+        <DraggableHeaderWrapper
+          className={
+            !props.isHidden
+              ? `draggable-header ${
+                  props.isAscOrder !== undefined ? "sorted" : ""
+                }`
+              : "hidden-header"
+          }
+          horizontalAlignment={column.columnProperties.horizontalAlignment}
+        >
+          {props.columnName}
+        </DraggableHeaderWrapper>
+      ) : null}
       <div
         {...column.getResizerProps()}
         className={`resizer ${column.isResizing ? "isResizing" : ""}`}

--- a/app/client/src/components/designSystems/appsmith/TableComponent/index.tsx
+++ b/app/client/src/components/designSystems/appsmith/TableComponent/index.tsx
@@ -8,7 +8,7 @@ import { Row } from "react-table";
 import Table from "components/designSystems/appsmith/TableComponent/Table";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { isEqual } from "lodash";
-import React, { useEffect, useMemo } from "react";
+import React from "react";
 
 export interface ColumnMenuOptionProps {
   content: string | JSX.Element;
@@ -117,95 +117,6 @@ function ReactTableComponent(props: ReactTableComponentProps) {
     width,
   } = props;
 
-  const { columnOrder, hiddenColumns } = useMemo(() => {
-    const order: string[] = [];
-    const hidden: string[] = [];
-    columns.forEach((item) => {
-      if (item.isHidden) {
-        hidden.push(item.accessor);
-      } else {
-        order.push(item.accessor);
-      }
-    });
-    return { columnOrder: order, hiddenColumns: hidden };
-  }, [columns]);
-
-  useEffect(() => {
-    let dragged = -1;
-    const headers = Array.prototype.slice.call(
-      document.querySelectorAll(`#table${widgetId} .draggable-header`),
-    );
-    headers.forEach((header, i) => {
-      header.setAttribute("draggable", true);
-
-      header.ondragstart = (e: React.DragEvent<HTMLDivElement>) => {
-        header.style =
-          "background: #efefef; border-radius: 4px; z-index: 100; width: 100%; text-overflow: none; overflow: none;";
-        e.stopPropagation();
-        dragged = i;
-      };
-
-      header.ondrag = (e: React.DragEvent<HTMLDivElement>) => {
-        e.stopPropagation();
-      };
-
-      header.ondragend = (e: React.DragEvent<HTMLDivElement>) => {
-        header.style = "";
-        e.stopPropagation();
-        setTimeout(() => (dragged = -1), 1000);
-      };
-
-      // the dropped header
-      header.ondragover = (e: React.DragEvent<HTMLDivElement>) => {
-        if (i !== dragged && dragged !== -1) {
-          if (dragged > i) {
-            header.parentElement.className = "th header-reorder highlight-left";
-          } else if (dragged < i) {
-            header.parentElement.className =
-              "th header-reorder highlight-right";
-          }
-        }
-        e.preventDefault();
-      };
-
-      header.ondragenter = (e: React.DragEvent<HTMLDivElement>) => {
-        if (i !== dragged && dragged !== -1) {
-          if (dragged > i) {
-            header.parentElement.className = "th header-reorder highlight-left";
-          } else if (dragged < i) {
-            header.parentElement.className =
-              "th header-reorder highlight-right";
-          }
-        }
-        e.preventDefault();
-      };
-
-      header.ondragleave = (e: React.DragEvent<HTMLDivElement>) => {
-        header.parentElement.className = "th header-reorder";
-        e.preventDefault();
-      };
-
-      header.ondrop = (e: React.DragEvent<HTMLDivElement>) => {
-        header.style = "";
-        header.parentElement.className = "th header-reorder";
-        if (i !== dragged && dragged !== -1) {
-          e.preventDefault();
-          const newColumnOrder = [...columnOrder];
-          // The dragged column
-          const movedColumnName = newColumnOrder.splice(dragged, 1);
-
-          // If the dragged column exists
-          if (movedColumnName && movedColumnName.length === 1) {
-            newColumnOrder.splice(i, 0, movedColumnName[0]);
-          }
-          handleReorderColumn([...newColumnOrder, ...hiddenColumns]);
-        } else {
-          dragged = -1;
-        }
-      };
-    });
-  });
-
   const sortTableColumn = (columnIndex: number, asc: boolean) => {
     if (columnIndex === -1) {
       _sortTableColumn("", asc);
@@ -254,6 +165,7 @@ function ReactTableComponent(props: ReactTableComponentProps) {
         disableDrag(false);
       }}
       filters={filters}
+      handleReorderColumn={handleReorderColumn}
       handleResizeColumn={handleResizeColumn}
       height={height}
       isLoading={isLoading}

--- a/app/client/src/pages/Editor/PropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/index.tsx
@@ -183,7 +183,7 @@ function PropertyPaneView(
         widgetId={widgetProperties.widgetId}
         widgetType={widgetProperties?.type}
       />
-      <PropertyPaneBodyWrapper>
+      <PropertyPaneBodyWrapper className="t--property-pane-content-section">
         {!doActionsExist && !hideConnectDataCTA && (
           <ConnectDataCTA
             widgetId={widgetProperties.widgetId}


### PR DESCRIPTION
## Description

> Table header ordering by DnD
> Table header ordering by DnD Propertypan's dragable list of header defination. 

Fixes #4266

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please follow linked issue.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: FIX/4266-table-header-ordering 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.82 **(-0.04)** | 36.73 **(-0.24)** | 33.2 **(-0.02)** | 55.39 **(-0.05)**
 :red_circle: | app/client/src/components/ads/DraggableList.tsx | 12.24 **(-7.43)** | 1.94 **(-9.17)** | 0 **(0)** | 13.95 **(-10.54)**
 :red_circle: | app/client/src/components/designSystems/appsmith/TableComponent/Table.tsx | 54.07 **(-7.56)** | 18.69 **(-18.56)** | 32.14 **(-6.75)** | 51.97 **(-9.01)**
 :red_circle: | app/client/src/components/designSystems/appsmith/TableComponent/TableUtilities.tsx | 40.15 **(-4.02)** | 19.19 **(-3.7)** | 17.65 **(-1.1)** | 38.52 **(-4.21)**
 :green_circle: | app/client/src/components/designSystems/appsmith/TableComponent/index.tsx | 43.48 **(16.21)** | 4 **(1.37)** | 14.29 **(-1.5)** | 43.48 **(17.8)**</details>