### PR TITLE
fix: inclusion of authorization error for Google sheets

### DIFF
--- a/app/client/cypress/fixtures/saveAction.json
+++ b/app/client/cypress/fixtures/saveAction.json
@@ -26,7 +26,6 @@
       ],
       "authentication": {
         "authenticationType": "dbAuth",
-        "authenticationType": "dbAuth",
         "authType": "SCRAM_SHA_1",
         "username": "cypress-test",
         "databaseName": "admin"

--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -9,6 +9,7 @@ export interface DatasourceAuthentication {
   value?: string;
   addTo?: string;
   bearerToken?: string;
+  authenticationStatus?: string;
 }
 
 export interface DatasourceColumns {

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -245,7 +245,12 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
             </SaveButtonContainer>
           </>
         ) : (
-          <Connected />
+          <>
+            <Connected />
+            {!isAuthorized && (
+              <StyledAuthMessage>Datasource not authorized</StyledAuthMessage>
+            )}
+          </>
         )}
       </form>
     );

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -62,6 +62,10 @@ interface DispatchFunctions {
   redirectToNewIntegrations: (applicationId: string, pageId: string) => void;
 }
 
+interface DatasourceSaasEditorState {
+  isAuthorized: boolean;
+}
+
 type DatasourceSaaSEditorProps = StateProps &
   DispatchFunctions &
   RouteComponentProps<{
@@ -91,7 +95,17 @@ const EditDatasourceButton = styled(AdsButton)`
   }
 `;
 
-class DatasourceSaaSEditor extends JSONtoForm<Props> {
+class DatasourceSaaSEditor extends JSONtoForm<
+  Props,
+  DatasourceSaasEditorState
+> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      isAuthorized: false,
+    };
+  }
+
   componentDidMount() {
     super.componentDidMount();
     const search = new URLSearchParams(this.props.location.search);
@@ -108,6 +122,11 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
         }
         Toaster.show({ text: display_message || message, variant });
       } else {
+        // set authorization status
+        this.setState({
+          isAuthorized: true,
+        });
+
         this.props.getOAuthAccessToken(this.props.match.params.datasourceId);
       }
       AnalyticsUtil.logEvent("GSHEET_AUTH_COMPLETE", {
@@ -152,6 +171,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
             <PluginImage alt="Datasource" src={this.props.pluginImage} />
             <FormTitle focusOnMount={this.props.isNewDatasource} />
           </FormTitleContainer>
+
           {viewMode && (
             <EditDatasourceButton
               category={Category.tertiary}
@@ -215,7 +235,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props> {
                   );
                 }}
                 size="small"
-                text="Continue"
+                text={this.state.isAuthorized ? "Re-authorize" : "Authorize"}
               />
             </SaveButtonContainer>
           </>

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -95,6 +95,15 @@ const EditDatasourceButton = styled(AdsButton)`
   }
 `;
 
+const StyledAuthMessage = styled.div`
+  color: ${(props) => props.theme.colors.error};
+  margin-top: 15px;
+  &:after {
+    content: " *";
+    color: inherit;
+  }
+`;
+
 class DatasourceSaaSEditor extends JSONtoForm<
   Props,
   DatasourceSaasEditorState
@@ -198,6 +207,11 @@ class DatasourceSaaSEditor extends JSONtoForm<
             {!_.isNil(sections)
               ? _.map(sections, this.renderMainSection)
               : null}
+
+            {!this.state.isAuthorized && (
+              <StyledAuthMessage>Datasource not authorized</StyledAuthMessage>
+            )}
+
             <SaveButtonContainer>
               <ActionButton
                 accent="error"
@@ -214,6 +228,7 @@ class DatasourceSaaSEditor extends JSONtoForm<
                 }
                 text="Delete"
               />
+
               <StyledButton
                 className="t--save-datasource"
                 disabled={this.validate()}


### PR DESCRIPTION
## Description

Show status of authorization on Gsheets datasource form

Fixes #6101

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: hotfix/include-timestamp-for-gsheet-authorisation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.62 **(0)** | 36.68 **(-0.01)** | 33.05 **(0.01)** | 55.23 **(0)**
 :green_circle: | app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx | 38.38 **(2.12)** | 19.51 **(2.12)** | 11.11 **(4.86)** | 40.66 **(2.11)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>