### PR TITLE
[skip-changelog] Enable S3 and GSheet plugins for generate CRUD page

### DIFF
--- a/app/client/cypress/fixtures/application-file.json
+++ b/app/client/cypress/fixtures/application-file.json
@@ -1,5 +1,5 @@
 {
-    "appsmithVersion":"v1.5.13",
+    "appsmithVersion":"1.5.14",
     "exportedApplication": {
         "userPermissions": [
             "canComment:applications",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -2946,4 +2946,18 @@ public class DatabaseChangelog {
             }
         });
     }
+
+    @ChangeSet(order = "081", id = "create-plugin-reference-for-S3-GSheet-genarate-CRUD-page", author = "")
+    public void createPluginReferenceForS3AndGSheetGenerateCRUDPage(MongockTemplate mongoTemplate) {
+
+        Set<String> validPackageNames = Set.of("amazons3-plugin", "google-sheets-plugin");
+
+        List<Plugin> plugins = mongoTemplate.findAll(Plugin.class);
+        for (Plugin plugin : plugins) {
+            if (validPackageNames.contains(plugin.getPackageName())) {
+                plugin.setGenerateCRUDPageComponent(plugin.getName());
+            }
+            mongoTemplate.save(plugin);
+        }
+    }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -41,8 +41,10 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -515,7 +517,6 @@ public class CreateDBTablePageSolutionTests {
             .verifyComplete();
     }
 
-    /*
     @Test
     @WithUserDetails(value = "api_user")
     public void createPageWithNullPageIdForS3() {
@@ -528,6 +529,7 @@ public class CreateDBTablePageSolutionTests {
                 datasource.setPluginId(plugin.getId());
                 datasource.setOrganizationId(testOrg.getId());
                 datasource.setName("S3-CRUD-Page-Table-DS");
+                datasource.setDatasourceConfiguration(datasourceConfiguration);
                 return datasourceService.create(datasource);
             });
 
@@ -584,6 +586,7 @@ public class CreateDBTablePageSolutionTests {
                 Datasource datasource = new Datasource();
                 datasource.setPluginId(plugin.getId());
                 datasource.setOrganizationId(testOrg.getId());
+                datasource.setDatasourceConfiguration(datasourceConfiguration);
                 datasource.setName("Google-Sheet-CRUD-Page-Table-DS");
                 return datasourceService.create(datasource);
             });
@@ -626,8 +629,6 @@ public class CreateDBTablePageSolutionTests {
             })
             .verifyComplete();
     }
-
-    */
 
     @Test
     @WithUserDetails(value = "api_user")


### PR DESCRIPTION
## Description

> This PR will enable the S3 and GSheet plugin for generate CRUD page from DB. Earlier we have commented this as FE code was not available to address the customisations required for these plugins. Also, small fix related to versioning in cypruss test for import application is also included 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> TC update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: enable-s3-gsheet-generate-page 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.91 **(-0.01)** | 36.93 **(-0.01)** | 33.26 **(0)** | 55.5 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>