### PR TITLE
Enhancement - chart widget x-axis label orientation

### DIFF
--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -20,6 +20,7 @@ import {
   ButtonStyleTypes,
   ButtonVariantTypes,
 } from "components/designSystems/appsmith/IconButtonComponent";
+import { LabelOrientation } from "components/designSystems/appsmith/ChartComponent";
 
 /*
  ********************************{Grid Density Migration}*********************************
@@ -645,6 +646,7 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       },
       xAxisName: "Last Week",
       yAxisName: "Total Order Revenue $",
+      labelOrientation: LabelOrientation.AUTO,
       customFusionChartConfig: {
         type: "column2d",
         dataSource: {

--- a/app/client/src/widgets/ChartWidget/index.tsx
+++ b/app/client/src/widgets/ChartWidget/index.tsx
@@ -1,13 +1,14 @@
-import React, { lazy, Suspense } from "react";
-import BaseWidget, { WidgetProps, WidgetState } from "widgets/BaseWidget";
-import { WidgetType } from "constants/WidgetConstants";
-import Skeleton from "components/utils/Skeleton";
 import * as Sentry from "@sentry/react";
-import { retryPromise } from "utils/AppsmithUtils";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
-import withMeta, { WithMeta } from "widgets/MetaHOC";
+import React, { lazy, Suspense } from "react";
+
+import BaseWidget, { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import propertyConfig from "widgets/ChartWidget/propertyConfig";
-import { CustomFusionChartConfig } from "components/designSystems/appsmith/ChartComponent";
+import Skeleton from "components/utils/Skeleton";
+import withMeta, { WithMeta } from "widgets/MetaHOC";
+import { ChartComponentProps } from "components/designSystems/appsmith/ChartComponent";
+import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import { retryPromise } from "utils/AppsmithUtils";
+import { WidgetType } from "constants/WidgetConstants";
 
 const ChartComponent = lazy(() =>
   retryPromise(() =>
@@ -53,6 +54,7 @@ class ChartWidget extends BaseWidget<ChartWidgetProps, WidgetState> {
           customFusionChartConfig={this.props.customFusionChartConfig}
           isVisible={this.props.isVisible}
           key={this.props.widgetId}
+          labelOrientation={this.props.labelOrientation}
           onDataPointClick={this.onDataPointClick}
           widgetId={this.props.widgetId}
           xAxisName={this.props.xAxisName}
@@ -89,17 +91,12 @@ export interface ChartData {
   data: ChartDataPoint[];
 }
 
-export interface ChartWidgetProps extends WidgetProps, WithMeta {
-  chartType: ChartType;
-  chartData: AllChartData;
-  customFusionChartConfig: CustomFusionChartConfig;
-  xAxisName: string;
-  yAxisName: string;
-  chartName: string;
-  isVisible?: boolean;
-  allowHorizontalScroll: boolean;
+type ChartComponentPartialProps = Omit<ChartComponentProps, "onDataPointClick">;
+export interface ChartWidgetProps
+  extends WidgetProps,
+    WithMeta,
+    ChartComponentPartialProps {
   onDataPointClick?: string;
-  selectedDataPoint?: ChartDataPoint;
 }
 
 export default ChartWidget;

--- a/app/client/src/widgets/ChartWidget/propertyConfig.test.ts
+++ b/app/client/src/widgets/ChartWidget/propertyConfig.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import { isString, get } from "lodash";
+
 import config from "./propertyConfig";
+import { PropertyPaneControlConfig } from "constants/PropertyControlConstants";
 
 declare global {
   namespace jest {
@@ -85,6 +87,20 @@ describe("Validate Chart Widget's property config", () => {
     hiddenFns.forEach((fn: (props: any) => boolean) => {
       const result = fn({ chartType: "CUSTOM_FUSION_CHART" });
       expect(result).toBeTruthy();
+    });
+  });
+
+  it("Validates that axis labelOrientation is visible when chartType are LINE_CHART AREA_CHART COLUMN_CHART", () => {
+    const allowedChartsTypes = ["LINE_CHART", "AREA_CHART", "COLUMN_CHART"];
+
+    const axisSection = config.find((c) => c.sectionName === "Axis");
+    const labelOrientationProperty = ((axisSection?.children as unknown) as PropertyPaneControlConfig[]).find(
+      (p) => p.propertyName === "labelOrientation",
+    );
+
+    allowedChartsTypes.forEach((chartType) => {
+      const result = labelOrientationProperty?.hidden?.({ chartType }, "");
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/app/client/src/widgets/ChartWidget/propertyConfig.ts
+++ b/app/client/src/widgets/ChartWidget/propertyConfig.ts
@@ -2,6 +2,10 @@ import { ChartWidgetProps } from "widgets/ChartWidget";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 import { CUSTOM_CHART_TYPES } from "constants/CustomChartConstants";
+import {
+  isLabelOrientationApplicableFor,
+  LabelOrientation,
+} from "components/designSystems/appsmith/ChartComponent";
 
 export default [
   {
@@ -243,8 +247,36 @@ export default [
         controlType: "SWITCH",
         isBindProperty: false,
         isTriggerProperty: false,
-        hidden: (x: any) => x.chartType === "CUSTOM_FUSION_CHART",
+        hidden: (x: ChartWidgetProps) => x.chartType === "CUSTOM_FUSION_CHART",
         dependencies: ["chartType"],
+      },
+      {
+        helpText: "Changes the x-axis label orientation",
+        propertyName: "labelOrientation",
+        label: "x-axis Label Orientation",
+        hidden: (x: any) => isLabelOrientationApplicableFor(x.chartType),
+        isBindProperty: false,
+        isTriggerProperty: false,
+        dependencies: ["chartType"],
+        controlType: "DROP_DOWN",
+        options: [
+          {
+            label: "Auto",
+            value: LabelOrientation.AUTO,
+          },
+          {
+            label: "Slant",
+            value: LabelOrientation.SLANT,
+          },
+          {
+            label: "Rotate",
+            value: LabelOrientation.ROTATE,
+          },
+          {
+            label: "Stagger",
+            value: LabelOrientation.STAGGER,
+          },
+        ],
       },
     ],
   },

--- a/app/client/src/widgets/ChartWidget/propertyConfig.ts
+++ b/app/client/src/widgets/ChartWidget/propertyConfig.ts
@@ -254,7 +254,7 @@ export default [
         helpText: "Changes the x-axis label orientation",
         propertyName: "labelOrientation",
         label: "x-axis Label Orientation",
-        hidden: (x: any) => isLabelOrientationApplicableFor(x.chartType),
+        hidden: (x: any) => !isLabelOrientationApplicableFor(x.chartType),
         isBindProperty: false,
         isTriggerProperty: false,
         dependencies: ["chartType"],


### PR DESCRIPTION
## Description
Adds multiple label orientation to x-axis label
This option is only applicable to the following chart types:
- Line chart
- Area chart
- Column chart
<img width="788" alt="Screenshot 2021-08-19 at 10 29 17 AM" src="https://user-images.githubusercontent.com/88306433/130010477-ce6bf7a0-4049-436d-bb69-0f7d5c4f99f9.png">


Fixes #6620 

## Type of change

- Enhancement

## How Has This Been Tested?
- Tested locally 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
