### PR TITLE
[Bugfix] - Allow login with case insensitive emails

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
@@ -33,6 +33,7 @@ public class CustomFormLoginServiceImpl implements ReactiveUserDetailsService {
     @Override
     public Mono<UserDetails> findByUsername(String username) {
         return repository.findByEmail(username)
+                .switchIfEmpty(repository.findByCaseInsensitiveEmail(username))
                 .switchIfEmpty(Mono.error(new UsernameNotFoundException("Unable to find username: " + username)))
                 .onErrorMap(error -> {
                     log.error("Can't find user {}", username);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImplUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImplUnitTest.java
@@ -1,0 +1,57 @@
+package com.appsmith.server.authentication.handlers;
+
+import com.appsmith.server.domains.User;
+import com.appsmith.server.repositories.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class CustomFormLoginServiceImplUnitTest {
+    @MockBean
+    private UserRepository repository;
+
+    private ReactiveUserDetailsService reactiveUserDetailsService;
+
+    @Before
+    public void setUp() {
+        reactiveUserDetailsService = new CustomFormLoginServiceImpl(repository);
+    }
+
+    @Test
+    public void findByUsername_WhenUserNameNotFound_ThrowsException() {
+        String sampleEmail = "sample-email@example.com";
+        Mockito.when(repository.findByEmail(sampleEmail)).thenReturn(Mono.empty());
+        Mockito.when(repository.findByCaseInsensitiveEmail(sampleEmail)).thenReturn(Mono.empty());
+
+        StepVerifier.create(reactiveUserDetailsService.findByUsername(sampleEmail))
+                .expectError(UsernameNotFoundException.class)
+                .verify();
+    }
+
+    @Test
+    public void findByUsername_WhenUserNameExistsWithOtherCase_ReturnsUser() {
+        String sampleEmail2 = "sampleEmail@example.com";
+        User user = new User();
+        user.setPassword("1234");
+        user.setEmail(sampleEmail2.toLowerCase());
+
+        Mockito.when(repository.findByEmail(sampleEmail2)).thenReturn(Mono.empty());
+        Mockito.when(repository.findByCaseInsensitiveEmail(sampleEmail2)).thenReturn(Mono.just(user));
+
+        StepVerifier.create(reactiveUserDetailsService.findByUsername(sampleEmail2))
+                .assertNext(userDetails -> {
+                    assertThat(userDetails.getUsername()).isEqualTo(sampleEmail2.toLowerCase());
+                    assertThat(userDetails.getPassword()).isEqualTo("1234");
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Description
This PR checks for case insensitive email when no user found with a provided email address.

Fixes #5998 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit test
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
