### PR TITLE
Add eslint rule to disallow console.log

### DIFF
--- a/app/client/.eslintrc.json
+++ b/app/client/.eslintrc.json
@@ -35,7 +35,10 @@
     "react/jsx-sort-props": "error",
     "react/jsx-fragments": "error",
     "react/jsx-no-useless-fragment": "error",
-    "sort-destructure-keys/sort-destructure-keys": ["error", {"caseSensitive": false}]
+    "sort-destructure-keys/sort-destructure-keys": ["error", {"caseSensitive": false}],
+    "no-console": ["error", {
+      "allow": ["error"]
+    }]
   },
   "settings": {
     "react": {

--- a/app/client/src/api/ApiUtils.ts
+++ b/app/client/src/api/ApiUtils.ts
@@ -139,6 +139,6 @@ export const apiFailureResponseInterceptor = (error: any) => {
     // Something happened in setting up the request that triggered an Error
     log.error("Error", error.message);
   }
-  console.log(error.config);
+  log.debug(error.config);
   return Promise.resolve(error);
 };

--- a/app/client/src/comments/AppComments/AppCommentsFilterPopover.tsx
+++ b/app/client/src/comments/AppComments/AppCommentsFilterPopover.tsx
@@ -17,6 +17,7 @@ import {
 } from "actions/commentActions";
 
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
+import log from "loglevel";
 
 export const options = [
   { label: "Show all comments", value: "show-all" },
@@ -49,7 +50,7 @@ const useSetResolvedFilterFromQuery = () => {
   useEffect(() => {
     const url = new URL(window.location.href);
     const searchParams = url.searchParams;
-    console.log(window.location.href, "window.location.href");
+    log.debug(window.location.href, "window.location.href");
     if (searchParams.get("isResolved")) {
       dispatch(setShouldShowResolvedComments(true));
     }

--- a/app/client/src/components/designSystems/appsmith/IconButtonComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/IconButtonComponent.tsx
@@ -226,7 +226,6 @@ function IconButtonComponent(props: IconButtonComponentProps) {
    * we will use that for the dimension of the widget
    */
   const dimension = useMemo(() => {
-    console.log({ width, height });
     if (width > height) {
       return height - WIDGET_PADDING * 2;
     }

--- a/app/client/src/components/designSystems/blueprint/InputComponent.test.tsx
+++ b/app/client/src/components/designSystems/blueprint/InputComponent.test.tsx
@@ -5,6 +5,7 @@ import InputComponent from "components/designSystems/blueprint/InputComponent";
 import { Provider } from "react-redux";
 import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
+import { noop } from "utils/AppsmithUtils";
 
 let container: HTMLDivElement | null;
 
@@ -30,15 +31,9 @@ describe("<InputComponent />", () => {
               isLoading={false}
               label="label"
               multiline
-              onCurrencyTypeChange={(code?: string) => {
-                console.log(code);
-              }}
-              onFocusChange={(state: boolean) => {
-                console.log(state);
-              }}
-              onValueChange={(valueAsString: string) => {
-                console.log(valueAsString);
-              }}
+              onCurrencyTypeChange={noop}
+              onFocusChange={noop}
+              onValueChange={noop}
               showError={false}
               value="something"
               widgetId="24234r35"

--- a/app/client/src/components/propertyControls/IconSelectControl.tsx
+++ b/app/client/src/components/propertyControls/IconSelectControl.tsx
@@ -101,10 +101,6 @@ class IconSelectControl extends BaseControl<
   componentDidMount() {
     this.timer = setTimeout(() => {
       const iconSelectTargetElement = this.iconSelectTargetRef.current;
-      console.log(
-        `target width: => `,
-        iconSelectTargetElement?.getBoundingClientRect().width,
-      );
       this.setState((prevState: IconSelectControlState) => {
         return {
           ...prevState,

--- a/app/client/src/components/stories/FilePicker.stories.tsx
+++ b/app/client/src/components/stories/FilePicker.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import FilePicker, { CloudinaryUploader, FileType } from "../ads/FilePicker";
+import log from "loglevel";
 
 export default {
   title: "FilePicker",
@@ -7,7 +8,7 @@ export default {
 };
 
 function ShowUploadedFile(data: any) {
-  console.log(data);
+  log.debug(data);
 }
 
 export const withDynamicProps = () => (

--- a/app/client/src/components/stories/Table.stories.tsx
+++ b/app/client/src/components/stories/Table.stories.tsx
@@ -5,6 +5,7 @@ import Icon, { IconSize } from "components/ads/Icon";
 import TableDropdown from "components/ads/TableDropdown";
 import { Position } from "@blueprintjs/core/lib/esm/common/position";
 import { StoryWrapper, Variant } from "components/ads/common";
+import { noop } from "utils/AppsmithUtils";
 
 export default {
   title: "Table",
@@ -59,7 +60,7 @@ const data = [
     col2: "dustin_01@jlegue.com",
     col3: (
       <TableDropdown
-        onSelect={(selectedValue) => console.log(selectedValue)}
+        onSelect={noop}
         options={options}
         position={Position.BOTTOM}
         selectedIndex={0}
@@ -81,7 +82,7 @@ const data = [
     col2: "dustin_02@jlegue.com",
     col3: (
       <TableDropdown
-        onSelect={(selectedValue) => console.log(selectedValue)}
+        onSelect={noop}
         options={options}
         position={Position.BOTTOM}
         selectedIndex={1}
@@ -103,7 +104,7 @@ const data = [
     col2: "dustin_03@jlegue.com",
     col3: (
       <TableDropdown
-        onSelect={(selectedValue) => console.log(selectedValue)}
+        onSelect={noop}
         options={options}
         position={Position.BOTTOM}
         selectedIndex={2}

--- a/app/client/src/components/stories/TableDropdown.stories.tsx
+++ b/app/client/src/components/stories/TableDropdown.stories.tsx
@@ -4,6 +4,7 @@ import { withDesign } from "storybook-addon-designs";
 import TableDropdown from "components/ads/TableDropdown";
 import { Position } from "@blueprintjs/core/lib/esm/common/position";
 import { StoryWrapper } from "components/ads/common";
+import { noop } from "utils/AppsmithUtils";
 
 export default {
   title: "Dropdown",
@@ -36,7 +37,7 @@ export function TableDropdownStory() {
       }}
     >
       <TableDropdown
-        onSelect={(selectedValue) => console.log(selectedValue)}
+        onSelect={noop}
         options={options}
         position={select("position", Object.values(Position), Position.BOTTOM)}
         selectedIndex={0}

--- a/app/client/src/components/stories/TextInput.stories.tsx
+++ b/app/client/src/components/stories/TextInput.stories.tsx
@@ -3,6 +3,7 @@ import { withKnobs, boolean, text } from "@storybook/addon-knobs";
 import TextInput from "components/ads/TextInput";
 import { action } from "@storybook/addon-actions";
 import { StoryWrapper } from "components/ads/common";
+import { noop } from "utils/AppsmithUtils";
 
 export default {
   title: "Text Input",
@@ -46,7 +47,7 @@ export function ErrorTextInputStory() {
         defaultValue={text("defaultValue", "This is wrong")}
         disabled={boolean("disabled", false)}
         fill={boolean("fill", true)}
-        onChange={(value) => console.log(value)}
+        onChange={noop}
         placeholder={text("placeholder", "Your name")}
         validator={() => callValidator2()}
       />

--- a/app/client/src/pages/Editor/GeneratePage/components/GoogleSheetForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GoogleSheetForm.tsx
@@ -15,6 +15,7 @@ import {
   executeDatasourceQuerySuccessPayload,
 } from "../../../../actions/datasourceActions";
 import { DropdownOptions, DatasourceTableDropdownOption } from "./constants";
+import log from "loglevel";
 
 // const GOOGLE_SHEET_METHODS = {
 //   GET_ALL_SPREADSHEETS: "LIST", // Get all the spreadsheets
@@ -149,7 +150,7 @@ function GoogleSheetForm(props: Props) {
 
   // TODO :- Create loading state and set Loading state false on success or error
   const onFetchAllSpreadsheetFailure = (error: any) => {
-    console.log({ error });
+    log.error(error);
   };
 
   const onFetchAllSpreadsheetSuccess = (

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -1821,7 +1821,7 @@ function* addSuggestedWidget(action: ReduxAction<Partial<WidgetProps>>) {
     );
     yield put(forceOpenPropertyPane(newWidget.newWidgetId));
   } catch (error) {
-    console.log(error, "Error");
+    log.error(error);
   }
 }
 

--- a/app/client/src/utils/storage.ts
+++ b/app/client/src/utils/storage.ts
@@ -23,7 +23,8 @@ export const resetAuthExpiration = () => {
     .add(1, "h")
     .format();
   store.setItem(STORAGE_KEYS.AUTH_EXPIRATION, expireBy).catch((error) => {
-    console.log("Unable to set expiration time", error);
+    log.error("Unable to set expiration time");
+    log.error(error);
   });
 };
 


### PR DESCRIPTION
## Description

Add eslint rule to disallow console.log and console.warn. We should use log.debug instead
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/remove-console-eslint 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.93 **(0.01)** | 36.95 **(0.02)** | 33.24 **(0)** | 55.52 **(0.01)**
 :green_circle: | app/client/src/comments/AppComments/AppCommentsFilterPopover.tsx | 46.15 **(1.41)** | 66.67 **(0)** | 0 **(0)** | 48.65 **(1.43)**
 :green_circle: | app/client/src/components/designSystems/appsmith/IconButtonComponent.tsx | 59.18 **(1.18)** | 12 **(0)** | 36.36 **(0)** | 69.05 **(1.61)**
 :green_circle: | app/client/src/components/propertyControls/IconSelectControl.tsx | 42.37 **(0.7)** | 26.67 **(3.14)** | 20 **(0)** | 44.44 **(0.8)**
 :green_circle: | app/client/src/pages/Editor/GeneratePage/components/GoogleSheetForm.tsx | 38.46 **(1.62)** | 25 **(0)** | 0 **(0)** | 40.54 **(1.65)**
 :red_circle: | app/client/src/utils/storage.ts | 36.96 **(-0.27)** | 13.64 **(0)** | 16.67 **(0)** | 29.7 **(-0.3)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>