### PR TITLE
[Feature] - Add lastDeployedAt date to application object

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ApplicationController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ApplicationController.java
@@ -78,7 +78,7 @@ public class ApplicationController extends BaseController<ApplicationService, Ap
 
     @PostMapping("/publish/{applicationId}")
     public Mono<ResponseDTO<Boolean>> publish(@PathVariable String applicationId) {
-        return applicationPageService.publish(applicationId)
+        return applicationPageService.publish(applicationId, true)
                 .flatMap(application ->
                         // This event should parallel a similar event sent from the client, so we want it to be sent by the
                         // controller and not the service method.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -15,8 +15,11 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.appsmith.server.helpers.DateUtils.ISO_FORMATTER;
 
 @Getter
 @Setter
@@ -63,6 +66,16 @@ public class Application extends BaseDomain {
     AppLayout publishedAppLayout;
 
     Boolean forkingEnabled;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    Instant lastDeployedAt; // when this application was last deployed
+
+    public String getLastDeployedAt() {
+        if(lastDeployedAt != null) {
+            return ISO_FORMATTER.format(lastDeployedAt);
+        }
+        return null;
+    }
 
     // This constructor is used during clone application. It only deeply copies selected fields. The rest are either
     // initialized newly or is left up to the calling function to set.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageService.java
@@ -34,7 +34,7 @@ public interface ApplicationPageService {
 
     Mono<PageDTO> deleteUnpublishedPage(String id);
 
-    Mono<Application> publish(String applicationId);
+    Mono<Application> publish(String applicationId, boolean isPublishedManually);
 
     void generateAndSetPagePolicies(Application application, PageDTO page);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -271,7 +271,7 @@ public class ExamplesOrganizationCloner {
                 // view mode for the newly created user.
                 .then(Mono.just(newApplicationIds))
                 .flatMapMany(Flux::fromIterable)
-                .flatMap(appId -> applicationPageService.publish(appId).thenReturn(appId))
+                .flatMap(appId -> applicationPageService.publish(appId, true).thenReturn(appId))
                 .collectList();
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ExamplesOrganizationCloner.java
@@ -271,7 +271,7 @@ public class ExamplesOrganizationCloner {
                 // view mode for the newly created user.
                 .then(Mono.just(newApplicationIds))
                 .flatMapMany(Flux::fromIterable)
-                .flatMap(appId -> applicationPageService.publish(appId, true).thenReturn(appId))
+                .flatMap(appId -> applicationPageService.publish(appId, false).thenReturn(appId))
                 .collectList();
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionServiceTest.java
@@ -732,7 +732,7 @@ public class ActionServiceTest {
         Mono<List<ActionViewDTO>> actionsListMono = layoutActionService.createAction(action)
                 .then(layoutActionService.createAction(action1))
                 .then(layoutActionService.createAction(action2))
-                .then(applicationPageService.publish(testPage.getApplicationId()))
+                .then(applicationPageService.publish(testPage.getApplicationId(), true))
                 .then(newActionService.getActionsForViewMode(testApp.getId()).collectList());
 
         StepVerifier
@@ -843,7 +843,7 @@ public class ActionServiceTest {
         Mono<ActionDTO> createActionMono = layoutActionService.createAction(action);
         Mono<List<ActionViewDTO>> actionViewModeListMono = createActionMono
                 // Publish the application before fetching the action in view mode
-                .then(applicationPageService.publish(testApp.getId()))
+                .then(applicationPageService.publish(testApp.getId(), true))
                 .then(newActionService.getActionsForViewMode(testApp.getId()).collectList());
 
         StepVerifier.create(actionViewModeListMono)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -729,7 +729,7 @@ public class ApplicationServiceTest {
         testApplication.setName(appName);
         testApplication.setAppLayout(new Application.AppLayout(Application.AppLayout.Type.DESKTOP));
         Mono<Application> applicationMono = applicationPageService.createApplication(testApplication, orgId)
-                .flatMap(application -> applicationPageService.publish(application.getId()))
+                .flatMap(application -> applicationPageService.publish(application.getId(), true))
                 .then(applicationService.findByName(appName, MANAGE_APPLICATIONS))
                 .cache();
 
@@ -780,7 +780,7 @@ public class ApplicationServiceTest {
                     page.setLayouts(layouts);
                     return applicationPageService.createPage(page);
                 })
-                .flatMap(page -> applicationPageService.publish(page.getApplicationId()))
+                .flatMap(page -> applicationPageService.publish(page.getApplicationId(), true))
                 .then(applicationService.findByName(appName, MANAGE_APPLICATIONS))
                 .cache();
 
@@ -826,7 +826,7 @@ public class ApplicationServiceTest {
                     page.setLayouts(layouts);
                     return applicationPageService.createPage(page);
                 })
-                .flatMap(page -> applicationPageService.publish(page.getApplicationId()))
+                .flatMap(page -> applicationPageService.publish(page.getApplicationId(), true))
                 .then(applicationService.findByName(appName, MANAGE_APPLICATIONS))
                 .cache();
 
@@ -890,7 +890,7 @@ public class ApplicationServiceTest {
                     page.setLayouts(layouts);
                     return applicationPageService.createPage(page);
                 })
-                .flatMap(page -> applicationPageService.publish(page.getApplicationId()))
+                .flatMap(page -> applicationPageService.publish(page.getApplicationId(), true))
                 .then(applicationService.findByName(appName, MANAGE_APPLICATIONS))
                 .cache();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -295,7 +295,7 @@ public class LayoutActionServiceTest {
         layout.setDsl(layoutActionService.unescapeMongoSpecialCharacters(layout));
         LayoutDTO firstLayout = layoutActionService.updateLayout(testPage.getId(), layout.getId(), layout).block();
 
-        applicationPageService.publish(testPage.getApplicationId()).block();
+        applicationPageService.publish(testPage.getApplicationId(), true).block();
 
         newActionService.deleteUnpublishedAction(firstAction.getId()).block();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -10,7 +10,6 @@ import com.appsmith.server.domains.Layout;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.User;
-import com.appsmith.server.domains.ApplicationPage;
 import com.appsmith.server.dtos.ActionDTO;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.LayoutDTO;
@@ -47,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
 import static com.appsmith.server.acl.AclPermission.READ_ACTIONS;
@@ -362,7 +360,7 @@ public class PageServiceTest {
         PageDTO firstPage = applicationPageService.createPage(testPage).block();
 
         // Publish the application
-        applicationPageService.publish(application.getId());
+        applicationPageService.publish(application.getId(), true);
 
         //Delete Page in edit mode
         applicationPageService.deleteUnpublishedPage(firstPage.getId()).block();


### PR DESCRIPTION
## Description
This PR will store the date time of when an application is deployed. It adds a new field `lastDeployedAt` to the application object. This field is updated when user clicks the deploy button.

Fixes #6543 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
