### PR TITLE
fixes flashing cursor not shown on inputbox when sign-in details are picked from saved credentials 

### DIFF
--- a/app/client/src/components/ads/TextInput.tsx
+++ b/app/client/src/components/ads/TextInput.tsx
@@ -105,6 +105,7 @@ const StyledInput = styled((props) => {
 >`
   width: ${(props) => (props.fill ? "100%" : "320px")};
   border-radius: 0;
+  caret-color:white;
   outline: 0;
   box-shadow: none;
   border: 1px solid ${(props) => props.inputStyle.borderColor};


### PR DESCRIPTION

## Description

>  Flashing cursor was not appearing while credential were picked up from saved credential due to background color of inputbox. I added the property  " caret-color :white " which now work perfectly.


Fixes #6680 


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

> after changing code i once again picked up saved credentials and this time it was showing flashing cursor.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings


