### PR TITLE
fix: Revert redux update perf improvements

### DIFF
--- a/app/client/src/reducers/evaluationReducers/treeReducer.ts
+++ b/app/client/src/reducers/evaluationReducers/treeReducer.ts
@@ -18,7 +18,7 @@ const evaluatedTreeReducer = createImmerReducer(initialState, {
     }>,
   ) => {
     const { dataTree, updates } = action.payload;
-    if (Object.keys(dataTree).length) {
+    if (updates.length === 0) {
       return dataTree;
     }
     for (const update of updates) {

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -72,7 +72,6 @@ function* evaluateTreeSaga(
     evaluationOrder,
     logs,
     unEvalUpdates,
-    updates,
   } = workerResponse;
   PerformanceTracker.stopAsyncTracking(
     PerformanceTransactionName.DATA_TREE_EVALUATION,
@@ -80,18 +79,16 @@ function* evaluateTreeSaga(
   PerformanceTracker.startAsyncTracking(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
+  const oldDataTree = yield select(getDataTree);
+
+  const updates = diff(oldDataTree, dataTree) || [];
+
   yield put(setEvaluatedTree(dataTree, updates));
   PerformanceTracker.stopAsyncTracking(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
 
   const updatedDataTree = yield select(getDataTree);
-
-  const postDiffs = diff(updatedDataTree, dataTree);
-  if (postDiffs && postDiffs.length) {
-    debugger;
-    yield put(setEvaluatedTree(dataTree, []));
-  }
 
   log.debug({ dataTree: updatedDataTree });
   logs.forEach((evalLog: any) => log.debug(evalLog));

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -43,6 +43,7 @@ import {
 } from "./PostEvaluationSagas";
 import { getAppMode } from "selectors/applicationSelectors";
 import { APP_MODE } from "entities/App";
+import { diff } from "deep-diff";
 
 let widgetTypeConfigMap: WidgetTypeConfigMap;
 
@@ -85,6 +86,12 @@ function* evaluateTreeSaga(
   );
 
   const updatedDataTree = yield select(getDataTree);
+
+  const postDiffs = diff(updatedDataTree, dataTree);
+  if (postDiffs && postDiffs.length) {
+    debugger;
+    yield put(setEvaluatedTree(dataTree, []));
+  }
 
   log.debug({ dataTree: updatedDataTree });
   logs.forEach((evalLog: any) => log.debug(evalLog));

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -123,11 +123,9 @@ export default class DataTreeEvaluator {
   updateDataTree(
     unEvalTree: DataTree,
   ): {
-    updates: Diff<DataTree, DataTree>[];
     evaluationOrder: string[];
     unEvalUpdates: DataTreeDiff[];
   } {
-    const oldEvalTree = _.cloneDeep(this.evalTree);
     const totalStart = performance.now();
     // Calculate diff
     const diffCheckTimeStart = performance.now();
@@ -136,7 +134,6 @@ export default class DataTreeEvaluator {
     // We want to check if no diffs are present and bail out early
     if (differences.length === 0) {
       return {
-        updates: [],
         evaluationOrder: [],
         unEvalUpdates: [],
       };
@@ -197,8 +194,6 @@ export default class DataTreeEvaluator {
 
     const evalTreeDiffsStart = performance.now();
 
-    const evaluationChanges = diff(oldEvalTree, newEvalTree);
-
     const evalTreeDiffsStop = performance.now();
 
     const totalEnd = performance.now();
@@ -220,7 +215,6 @@ export default class DataTreeEvaluator {
     };
     this.logs.push({ timeTakenForSubTreeEval });
     return {
-      updates: evaluationChanges || [],
       evaluationOrder,
       unEvalUpdates: translatedDiffs,
     };

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -68,6 +68,7 @@ ctx.addEventListener(
             updates = JSON.parse(JSON.stringify(updateResponse.updates));
             evaluationOrder = updateResponse.evaluationOrder;
             unEvalUpdates = updateResponse.unEvalUpdates;
+            dataTree = dataTreeEvaluator.evalTree;
           }
           dependencies = dataTreeEvaluator.inverseDependencyMap;
           errors = dataTreeEvaluator.errors;

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -18,7 +18,6 @@ import {
   validateWidgetProperty,
 } from "./evaluationUtils";
 import DataTreeEvaluator from "workers/DataTreeEvaluator";
-import { Diff } from "deep-diff";
 
 const ctx: Worker = self as any;
 
@@ -51,7 +50,6 @@ ctx.addEventListener(
         let errors: EvalError[] = [];
         let logs: any[] = [];
         let dependencies: DependencyMap = {};
-        let updates: Diff<DataTree, DataTree>[] = [];
         let evaluationOrder: string[] = [];
         let unEvalUpdates: DataTreeDiff[] = [];
         try {
@@ -65,10 +63,9 @@ ctx.addEventListener(
           } else {
             dataTree = {};
             const updateResponse = dataTreeEvaluator.updateDataTree(unevalTree);
-            updates = JSON.parse(JSON.stringify(updateResponse.updates));
             evaluationOrder = updateResponse.evaluationOrder;
             unEvalUpdates = updateResponse.unEvalUpdates;
-            dataTree = dataTreeEvaluator.evalTree;
+            dataTree = JSON.parse(JSON.stringify(dataTreeEvaluator.evalTree));
           }
           dependencies = dataTreeEvaluator.inverseDependencyMap;
           errors = dataTreeEvaluator.errors;
@@ -96,7 +93,6 @@ ctx.addEventListener(
           errors,
           evaluationOrder,
           logs,
-          updates,
           unEvalUpdates,
         };
       }


### PR DESCRIPTION
## Description
To improve the redux update of app state (data tree) we had implemented a optimised update of the state. This did not seem to work properly as many updates were not getting reflected. Till the time a proper RCA is done, we will be reverting this fix

Reverts #5594

Fixes #6807

## Type of change

- Bug fix (non-breaking change which fixes an issue)



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/data-tree-update 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.54 **(0)** | 36.41 **(0.01)** | 32.88 **(0)** | 55.15 **(0)**
 :green_circle: | app/client/src/sagas/EvaluationsSaga.ts | 21.24 **(0.14)** | 2.94 **(-0.19)** | 6.67 **(0)** | 24.74 **(0.27)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**
 :green_circle: | app/client/src/workers/DataTreeEvaluator.ts | 88.45 **(-0.04)** | 76.19 **(0.27)** | 87.14 **(0)** | 88.29 **(-0.05)**</details>