### PR TITLE
fix: Firefox input widget text selection

### DIFF
--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -492,6 +492,18 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
   };
 
   handleFocusChange = (focusState: boolean) => {
+    /**
+     * Reason for disabling drag on focusState: true:
+     * 1. In Firefox, draggable="true" property on the parent element
+     *    or <input /> itself, interferes with some input element events
+     *    Bug Ref - https://bugzilla.mozilla.org/show_bug.cgi?id=800050
+     *              https://bugzilla.mozilla.org/show_bug.cgi?id=1189486
+     *
+     *  Eg - input with draggable="true", double clicking the text; won't highlight the text
+     *
+     * 2. Dragging across the text (for text selection) in input won't cause the widget to drag.
+     */
+    super.updateWidgetProperty("dragDisabled", focusState);
     this.props.updateWidgetMetaProperty("isFocused", focusState);
   };
 

--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -495,7 +495,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
     /**
      * Reason for disabling drag on focusState: true:
      * 1. In Firefox, draggable="true" property on the parent element
-     *    or <input /> itself, interferes with some input element events
+     *    or <input /> itself, interferes with some <input /> element's events
      *    Bug Ref - https://bugzilla.mozilla.org/show_bug.cgi?id=800050
      *              https://bugzilla.mozilla.org/show_bug.cgi?id=1189486
      *

--- a/app/client/src/widgets/InputWidget.tsx
+++ b/app/client/src/widgets/InputWidget.tsx
@@ -503,7 +503,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
      *
      * 2. Dragging across the text (for text selection) in input won't cause the widget to drag.
      */
-    super.updateWidgetProperty("dragDisabled", focusState);
+    this.props.updateWidgetMetaProperty("dragDisabled", focusState);
     this.props.updateWidgetMetaProperty("isFocused", focusState);
   };
 


### PR DESCRIPTION
## Description

Fixes #6723 

Cause - This is a very old issue that yet to be resolved by Mozilla
https://bugzilla.mozilla.org/show_bug.cgi?id=800050
https://bugzilla.mozilla.org/show_bug.cgi?id=1189486

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/6723-firefox-input-selection 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.85 **(-0.01)** | 36.79 **(-0.02)** | 33.55 **(-0.02)** | 55.44 **(-0.01)**
 :red_circle: | app/client/src/utils/helpers.tsx | 66.11 **(-1.67)** | 37.89 **(-3.16)** | 45.16 **(-3.23)** | 63.19 **(-1.39)**
 :red_circle: | app/client/src/widgets/InputWidget.tsx | 53.92 **(-0.54)** | 22.86 **(0)** | 59.09 **(0)** | 55.67 **(-0.58)**</details>