### PR TITLE
fix: tab component styles at the settings page

### DIFF
--- a/app/client/src/components/ads/Tabs.tsx
+++ b/app/client/src/components/ads/Tabs.tsx
@@ -66,6 +66,10 @@ const TabsWrapper = styled.div<{
       content: none;
     }
   }
+
+  .react-tabs__tab--selected {
+    background-color: transparent;
+  }
 `;
 
 export const TabTitle = styled.span`
@@ -74,6 +78,8 @@ export const TabTitle = styled.span`
   line-height: ${(props) => props.theme.typography.h5.lineHeight - 3}px;
   letter-spacing: ${(props) => props.theme.typography.h5.letterSpacing}px;
   margin: 0;
+  display: flex;
+  align-items: center;
 `;
 
 export const TabCount = styled.div`


### PR DESCRIPTION
## Description
fix tab component styles at the settings page (dark theme)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-tab-component-style-settings-page 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.05 **(0.01)** | 36.98 **(0.01)** | 33.72 **(0)** | 55.64 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>