### PR TITLE
fix: Generate Page using Empty Table error 

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -386,7 +386,7 @@ export function RenderDropdownOptions(props: DropdownOptionsProps) {
     setOptions(filteredOptions);
     onSearch && onSearch(searchStr);
   };
-  return (
+  return options.length > 0 ? (
     <DropdownWrapper
       className="ads-dropdown-options-wrapper"
       width={props.optionWidth || "260px"}
@@ -452,7 +452,7 @@ export function RenderDropdownOptions(props: DropdownOptionsProps) {
         })}
       </DropdownOptionsWrapper>
     </DropdownWrapper>
-  );
+  ) : null;
 }
 
 export default function Dropdown(props: DropdownProps) {
@@ -489,7 +489,7 @@ export default function Dropdown(props: DropdownProps) {
     [onSelect],
   );
 
-  const disabled = props.disabled || isLoading || !!errorMsg;
+  const disabled = props.disabled || isLoading;
   const downIconColor = errorMsg ? Colors.POMEGRANATE2 : Colors.DARK_GRAY;
 
   const dropdownHeight = props.height ? props.height : "38px";

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
@@ -383,7 +383,7 @@ function GeneratePageForm() {
       selectedDatasource.value &&
       !isFetchingDatasourceStructure
     ) {
-      // On finished fetching datasource structure
+      // when finished fetching datasource structure
       const selectedDatasourceStructure =
         datasourcesStructure[selectedDatasource.id] || {};
 

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
@@ -147,7 +147,7 @@ function GeneratePageSubmitBtn({
       data-cy="t--generate-page-form-submit"
       disabled={disabled}
       isLoading={isLoading}
-      onClick={onSubmit}
+      onClick={() => !disabled && onSubmit()}
       size={Size.large}
       text="Generate Page"
       type="button"
@@ -193,6 +193,10 @@ function GeneratePageForm() {
 
   const [selectedDatasource, selectDataSource] = useState<DropdownOption>(
     DEFAULT_DROPDOWN_OPTION,
+  );
+
+  const [isSelectedTableEmpty, setIsSelectedTableEmpty] = useState<boolean>(
+    false,
   );
 
   const selectedDatasourcePluginId: string = selectedDatasource.data?.pluginId;
@@ -296,24 +300,26 @@ function GeneratePageForm() {
           const { data } = TableObj;
 
           if (Array.isArray(data.columns)) {
-            const newSelectedTableColumnOptions: DropdownOption[] = [];
-            data.columns.map((column) => {
-              if (
-                column.type &&
-                ALLOWED_SEARCH_DATATYPE.includes(column.type.toLowerCase())
-              ) {
-                newSelectedTableColumnOptions.push({
-                  id: column.name,
-                  label: column.name,
-                  value: column.name,
-                  subText: column.type,
-                  icon: columnIcon,
-                  iconSize: IconSize.LARGE,
-                  iconColor: Colors.GOLD,
-                });
-              }
-            });
-            if (newSelectedTableColumnOptions) {
+            if (data.columns.length === 0) setIsSelectedTableEmpty(true);
+            else {
+              if (isSelectedTableEmpty) setIsSelectedTableEmpty(false);
+              const newSelectedTableColumnOptions: DropdownOption[] = [];
+              data.columns.map((column) => {
+                if (
+                  column.type &&
+                  ALLOWED_SEARCH_DATATYPE.includes(column.type.toLowerCase())
+                ) {
+                  newSelectedTableColumnOptions.push({
+                    id: column.name,
+                    label: column.name,
+                    value: column.name,
+                    subText: column.type,
+                    icon: columnIcon,
+                    iconSize: IconSize.LARGE,
+                    iconColor: Colors.GOLD,
+                  });
+                }
+              });
               setSelectedTableColumnOptions(newSelectedTableColumnOptions);
             }
           } else {
@@ -323,9 +329,11 @@ function GeneratePageForm() {
       }
     },
     [
+      isSelectedTableEmpty,
       selectTable,
       setSelectedTableColumnOptions,
       selectColumn,
+      setIsSelectedTableEmpty,
       isGoogleSheetPlugin,
       isS3Plugin,
     ],
@@ -513,7 +521,6 @@ function GeneratePageForm() {
     history.push(redirectURL);
   };
 
-  const submitButtonDisable = !selectedTable.value;
   // if the datasource has basic information to connect to db it is considered as a valid structure hence isValid true.
   const isValidDatasourceConfig = selectedDatasource.data?.isValid;
 
@@ -546,6 +553,9 @@ function GeneratePageForm() {
     if (fetchingDatasourceConfigError) {
       tableDropdownErrorMsg = `Failed fetching datasource structure, Please check your datasource configuration`;
     }
+    if (isSelectedTableEmpty) {
+      tableDropdownErrorMsg = `Couldn't find any columns, Please select table with columns.`;
+    }
   }
 
   const showEditDatasourceBtn =
@@ -557,10 +567,15 @@ function GeneratePageForm() {
     !!selectedTable.value &&
     PLUGIN_PACKAGE_NAME.S3 !== selectedDatasourcePluginPackageName;
 
-  const showSubmitButton = selectedTable.value && !showEditDatasourceBtn;
-  !fetchingDatasourceConfigs &&
-    fetchingDatasourceConfigError &&
+  const showSubmitButton =
+    selectedTable.value &&
+    !showEditDatasourceBtn &&
+    !fetchingDatasourceConfigs &&
+    !fetchingDatasourceConfigError &&
     !!selectedDatasource.value;
+
+  const submitButtonDisable =
+    !selectedTable.value || !showSubmitButton || isSelectedTableEmpty;
 
   return (
     <div>


### PR DESCRIPTION
## Description



Fixes #6824 &  #6239


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/gen-crud-disable-empty-table 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.11 **(-0.01)** | 37.23 **(-0.04)** | 33.77 **(-0.01)** | 55.7 **(-0.01)**
 :red_circle: | app/client/src/components/ads/Dropdown.tsx | 52.94 **(0)** | 37.7 **(-0.76)** | 25 **(0)** | 51.22 **(0)**
 :red_circle: | app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx | 17.49 **(-0.65)** | 10.71 **(-0.61)** | 0 **(0)** | 19.6 **(-0.4)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>