### PR TITLE
feat: Add form data body support for superuser signup API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UserController.java
@@ -75,13 +75,18 @@ public class UserController extends BaseController<UserService, User, String> {
         return userSignup.signupAndLoginFromFormData(exchange);
     }
 
-    @PostMapping("/super")
+    @PostMapping(value = "/super", consumes = {MediaType.APPLICATION_JSON_VALUE})
     public Mono<ResponseDTO<User>> createSuperUser(
             @Valid @RequestBody UserSignupRequestDTO resource,
             ServerWebExchange exchange
     ) {
         return userSignup.signupAndLoginSuper(resource, exchange)
                 .map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
+    }
+
+    @PostMapping(value = "/super", consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
+    public Mono<Void> createSuperUserFromFormData(ServerWebExchange exchange) {
+        return userSignup.signupAndLoginSuperFromFormData(exchange);
     }
 
     @PutMapping()


### PR DESCRIPTION
The superuser signup api available at `/users/super` currently only supports JSON payload. This PR adds support for form-data payload at the same endpoint, and makes it consistent with the normal user's signup API endpoint.

No user-facing changes in this PR.
