### PR TITLE
fix: Restrict e as input for table header index

### DIFF
--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
@@ -322,7 +322,6 @@ function GoogleSheetForm(props: Props) {
                 </Tooltip>
               </TooltipWrapper>
             </Row>
-
             <TextInput
               dataType="text"
               fill

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
@@ -324,7 +324,7 @@ function GoogleSheetForm(props: Props) {
             </Row>
 
             <TextInput
-              dataType="number"
+              dataType="text"
               fill
               onChange={tableHeaderIndexChangeHandler}
               placeholder="Table Header Index"


### PR DESCRIPTION
## Description

Fixes # (issue)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually in local

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>