### PR TITLE
fix: chart widget fix

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_spec.js
@@ -353,6 +353,9 @@ describe("Chart Widget Functionality", function() {
       "response.body.responseMeta.status",
       200,
     );
+    cy.get(viewWidgetsPage.Chartlabel + ":first-child", {
+      timeout: 10000,
+    }).should("have.css", "opacity", "1");
     //Verifying X-axis labels
     cy.get(viewWidgetsPage.chartWidget).should("have.css", "opacity", "1");
     const labels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul"];


### PR DESCRIPTION
## Description

Custom fusion chart was loading with some delay and cypress test cases were getting previous element to verify the x axis data. Added one more check to wait till the chart data is loaded before verifying.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>