### PR TITLE
fix: add null check for current application at new comment thread event

### DIFF
--- a/app/client/src/sagas/WebsocketSagas/handleSocketEvent.ts
+++ b/app/client/src/sagas/WebsocketSagas/handleSocketEvent.ts
@@ -32,7 +32,7 @@ export default function* handleSocketEvent(event: any) {
 
       const { thread } = event.payload[0];
       const isForCurrentApplication =
-        thread?.applicationId === currentApplication.id;
+        thread?.applicationId === currentApplication?.id;
 
       const isCreatedByMe = thread?.authorUsername === currentUser.username;
       if (!isCreatedByMe && isForCurrentApplication)


### PR DESCRIPTION
## Description
Current application can be null at the `/applications` page, so we'd need to handle it

Fixes #6880

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
