### PR TITLE
feat: Adding support for Google Cloud Storage in our S3 plugin

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
@@ -39,6 +39,10 @@
               "value": "dream-objects"
             },
             {
+              "label": "Google Cloud Storage",
+              "value": "google-cloud-storage"
+            },
+            {
               "label": "Other",
               "value": "other"
             }
@@ -171,8 +175,23 @@
           "placeholderText": "de-fra1",
           "hidden": {
             "path": "datasourceConfiguration.properties[1].value",
-            "comparison": "EQUALS",
-            "value": "amazon-s3"
+            "comparison": "IN",
+            "value": [
+              "amazon-s3",
+              "google-cloud-storage"
+            ]
+          }
+        },
+        {
+          "label": "Default Bucket",
+          "configProperty": "datasourceConfiguration.properties[3].value",
+          "controlType": "INPUT_TEXT",
+          "initialValue": "",
+          "placeholderText": "bucket-name-to-which-you-have-access",
+          "hidden": {
+            "path": "datasourceConfiguration.properties[1].value",
+            "comparison": "NOT_EQUALS",
+            "value": "google-cloud-storage"
           }
         }
       ]


### PR DESCRIPTION
Fixes #6877 

Added Google Cloud Storage as one of the service providers. While configuration GS datasource, region has been removed from the form and default bucket has been added. This is because for GS, region is set to "auto" and the usual listbuckets command used for testing does not work on GS. Hence, a default bucket is taken as an input in the datasource form to ensure we can check if the configuration is correct. 