### PR TITLE
fix: fill dropdown selector UI to avoid text shrink

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -289,6 +289,7 @@ const SelectedDropDownHolder = styled.div`
   display: flex;
   align-items: center;
   min-width: 0;
+  width: 100%;
   overflow: hidden;
 
   & ${Text} {

--- a/app/client/src/pages/Editor/GeneratePage/components/DataSourceOption.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/DataSourceOption.tsx
@@ -16,7 +16,11 @@ export const CONNECT_NEW_DATASOURCE_OPTION_ID = _.uniqueId();
 
 //  ---------- Styles ----------
 
-const OptionWrapper = styled.div<{ disabled?: boolean; selected?: boolean }>`
+const OptionWrapper = styled.div<{
+  disabled?: boolean;
+  selected?: boolean;
+  width?: string;
+}>`
   padding: ${(props) =>
     props.selected
       ? `${props.theme.spaces[1]}px 0px`
@@ -25,6 +29,7 @@ const OptionWrapper = styled.div<{ disabled?: boolean; selected?: boolean }>`
   display: flex;
   align-items: center;
   user-select: none;
+  width: ${(props) => props.width};
 
   &&& svg {
     rect {
@@ -67,6 +72,7 @@ const OptionWrapper = styled.div<{ disabled?: boolean; selected?: boolean }>`
 
 const CreateIconWrapper = styled.div`
   margin: 0px 8px 0px 0px;
+  cursor: pointer;
 `;
 
 const ImageWrapper = styled.div`
@@ -84,6 +90,7 @@ const DatasourceImage = styled.img`
 
 interface DataSourceOptionType extends RenderDropdownOptionType {
   cypressSelector: string;
+  optionWidth?: string;
 }
 
 function DataSourceOption({
@@ -92,6 +99,7 @@ function DataSourceOption({
   isSelectedNode,
   option: dropdownOption,
   optionClickHandler,
+  optionWidth,
 }: DataSourceOptionType) {
   const { label } = dropdownOption;
   const { routeToCreateNewDatasource = () => null } = extraProps;
@@ -131,6 +139,7 @@ function DataSourceOption({
           }
         }}
         selected={isSelectedNode}
+        width={optionWidth}
       >
         {isConnectNewDataSourceBtn ? (
           <CreateIconWrapper>

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
@@ -600,6 +600,7 @@ function GeneratePageForm() {
                 key={option.id}
                 option={option}
                 optionClickHandler={optionClickHandler}
+                optionWidth={DROPDOWN_DIMENSION.WIDTH}
               />
             )}
             selected={selectedDatasource}


### PR DESCRIPTION
## Description

Fix text shirking of the dropdown selector

[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/8f7559dc6a474e5bb9dc63ccc5f332ab-00001.gif)](https://www.loom.com/share/8f7559dc6a474e5bb9dc63ccc5f332ab)

Fixes #6909 


## Type of change

- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

manually in local

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/dropdown-option-width 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.85 **(-0.01)** | 36.8 **(0)** | 33.55 **(0)** | 55.44 **(0)**
 :red_circle: | app/client/src/pages/Editor/GeneratePage/components/DataSourceOption.tsx | 34.04 **(-1.52)** | 22.22 **(0)** | 0 **(0)** | 35.56 **(-1.65)**</details>