### PR TITLE
feat: `mod + s` hotkey to suppress default page save and show toast message

### DIFF
--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -193,6 +193,9 @@ export const SHOW_REQUEST = () => `Show Request`;
 export const TABLE_FILTER_COLUMN_TYPE_CALLOUT = () =>
   `Change column datatype to see filter operators`;
 
+export const SAVE_HOTKEY_TOASTER_MESSAGE = () =>
+  "Don't worry about saving, we've got you covered!";
+
 export const WIDGET_SIDEBAR_TITLE = () => `Widgets`;
 export const WIDGET_SIDEBAR_CAPTION = () =>
   `To add a widget, please drag and drop a widget on the canvas to the right`;

--- a/app/client/src/pages/Editor/GlobalHotKeys.test.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.test.tsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { Slide } from "react-toastify";
+
 import {
   buildChildren,
   widgetCanvasFactory,
 } from "test/factories/WidgetFactoryUtils";
-import { act, render, fireEvent } from "test/testUtils";
+import { act, render, fireEvent, waitFor } from "test/testUtils";
 import GlobalHotKeys from "./GlobalHotKeys";
 import MainContainer from "./MainContainer";
 import { MemoryRouter } from "react-router-dom";
@@ -21,6 +23,9 @@ import {
 import { MockCanvas } from "test/testMockedWidgets";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { generateReactKey } from "utils/generators";
+import { StyledToastContainer } from "components/ads/Toast";
+import { createMessage, SAVE_HOTKEY_TOASTER_MESSAGE } from "constants/messages";
+
 describe("Canvas Hot Keys", () => {
   const mockGetIsFetchingPage = jest.spyOn(utilities, "getIsFetchingPage");
   const spyGetCanvasWidgetDsl = jest.spyOn(utilities, "getCanvasWidgetDsl");
@@ -516,5 +521,40 @@ describe("Cut/Copy/Paste hotkey", () => {
 
     selectedWidgets = await component.queryAllByTestId("t--selected");
     expect(selectedWidgets.length).toBe(2);
+  });
+});
+
+describe("cmd + s hotkey", () => {
+  it("Should render toast message", async () => {
+    const component = render(
+      <>
+        <StyledToastContainer
+          autoClose={5000}
+          closeButton={false}
+          draggable={false}
+          hideProgressBar
+          pauseOnHover={false}
+          transition={Slide}
+        />
+        <GlobalHotKeys>
+          <div />
+        </GlobalHotKeys>
+      </>,
+    );
+
+    dispatchTestKeyboardEventWithCode(
+      component.container,
+      "keydown",
+      "s",
+      83,
+      false,
+      true,
+    );
+
+    await waitFor(() => {
+      expect(
+        component.getByText(createMessage(SAVE_HOTKEY_TOASTER_MESSAGE)),
+      ).toBeDefined();
+    });
   });
 });

--- a/app/client/src/pages/Editor/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.tsx
@@ -36,12 +36,15 @@ import {
   SearchCategory,
   SEARCH_CATEGORY_ID,
 } from "components/editorComponents/GlobalSearch/utils";
+import { Toaster } from "components/ads/Toast";
+import { Variant } from "components/ads/common";
 
 import { getAppMode } from "selectors/applicationSelectors";
 import { APP_MODE } from "entities/App";
 
 import { commentModeSelector } from "selectors/commentsSelectors";
 import getFeatureFlags from "utils/featureFlags";
+import { createMessage, SAVE_HOTKEY_TOASTER_MESSAGE } from "constants/messages";
 
 type Props = {
   copySelectedWidget: () => void;
@@ -276,6 +279,19 @@ class GlobalHotKeys extends React.Component<Props> {
               this.props.groupSelectedWidget();
             }
           }}
+        />
+        <Hotkey
+          combo="mod + s"
+          global
+          label="Save progress"
+          onKeyDown={() => {
+            Toaster.show({
+              text: createMessage(SAVE_HOTKEY_TOASTER_MESSAGE),
+              variant: Variant.info,
+            });
+          }}
+          preventDefault
+          stopPropagation
         />
       </Hotkeys>
     );


### PR DESCRIPTION
## Description

Fixes #6424

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/override-meta-s-hotkey 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.91 **(0.05)** | 36.88 **(0.06)** | 33.72 **(0.15)** | 55.5 **(0.05)**
 :green_circle: | app/client/src/components/ads/Text.tsx | 100 **(4.65)** | 75 **(3.57)** | 100 **(0)** | 100 **(4.76)**
 :green_circle: | app/client/src/components/ads/Toast.tsx | 78.26 **(30.43)** | 61.11 **(27.78)** | 88.24 **(76.48)** | 78.26 **(30.43)**
 :green_circle: | app/client/src/constants/messages.ts | 70.31 **(0.11)** | 100 **(0)** | 10.39 **(0.32)** | 77.63 **(0.12)**
 :green_circle: | app/client/src/pages/Editor/GlobalHotKeys.tsx | 66.35 **(1.35)** | 29.73 **(0)** | 55.56 **(1.27)** | 65 **(1.46)**
 :red_circle: | app/client/src/utils/helpers.tsx | 66.11 **(-1.67)** | 37.89 **(-3.16)** | 45.16 **(-3.23)** | 63.19 **(-1.39)**</details>