### PR TITLE
fix: Revert "[skip_changelog] Update error message for import flow"

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -77,7 +77,7 @@ public enum AppsmithError {
 
     REMOVE_LAST_ORG_ADMIN_ERROR(400, 4037, "The last admin can not be removed from an organization", AppsmithErrorAction.DEFAULT, null, ErrorType.INTERNAL_ERROR),
     INVALID_CRUD_PAGE_REQUEST(400, 4038, "Unable to process page generation request, {0}", AppsmithErrorAction.DEFAULT, null, ErrorType.BAD_REQUEST),
-    INVALID_IMPORTED_FILE_ERROR(400, 4039, "You seem to have imported an application from an older version of Appsmith. This is not supported. Please export your application again from your Appsmith server before importing it again.", AppsmithErrorAction.DEFAULT, null, ErrorType.BAD_REQUEST),
+    INVALID_IMPORTED_FILE_ERROR(400, 4039, "Provided file is from different version, please wait till Appsmith gets auto-updated to latest version. This may take a day or two. We are really sorry for the inconvenience caused", AppsmithErrorAction.DEFAULT, null, ErrorType.INTERNAL_ERROR),
     INTERNAL_SERVER_ERROR(500, 5000, "Internal server error while processing request", AppsmithErrorAction.LOG_EXTERNALLY, null, ErrorType.INTERNAL_ERROR),
     REPOSITORY_SAVE_FAILED(500, 5001, "Failed to save the repository. Try again.", AppsmithErrorAction.DEFAULT, null, ErrorType.INTERNAL_ERROR),
     PLUGIN_INSTALLATION_FAILED_DOWNLOAD_ERROR(500, 5002, "Plugin installation failed due to an error while " +

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -357,8 +357,14 @@ public class ImportExportApplicationService {
         
         if(!errorField.isEmpty()) {
             return Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, errorField, INVALID_JSON_FILE));
-        } else if(importedDoc.getAppsmithVersion() == null
-            || !releaseNotesService.getReleasedVersion().equals(importedDoc.getAppsmithVersion())) {
+        } else if(importedDoc.getAppsmithVersion() == null) {
+            return Mono.error(
+                new AppsmithException(
+                    AppsmithError.JSON_PROCESSING_ERROR,
+                    ": Unable to find version field in the uploaded file. Can you please try exporting the " +
+                        "application from source Appsmith server and then importing it once again"
+                ));
+        } else if(!releaseNotesService.getReleasedVersion().equals(importedDoc.getAppsmithVersion())) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_IMPORTED_FILE_ERROR));
         }
         

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -481,7 +481,7 @@ public class ImportExportApplicationServiceTests {
                 final List<Datasource> datasourceList = tuple.getT2();
                 final List<ActionDTO> actionDTOS = tuple.getT3();
                 final List<PageDTO> pageList = tuple.getT4();
-
+                
                 assertThat(application.getName()).isEqualTo("valid_application");
                 assertThat(application.getOrganizationId()).isNotNull();
                 assertThat(application.getPages()).hasSize(2);
@@ -543,7 +543,7 @@ public class ImportExportApplicationServiceTests {
         StepVerifier
             .create(resultMono)
             .expectErrorMatches(throwable -> throwable instanceof AppsmithException &&
-                throwable.getMessage().equals(AppsmithError.INVALID_IMPORTED_FILE_ERROR.getMessage()))
+                throwable.getMessage().contains(AppsmithError.JSON_PROCESSING_ERROR.getMessage(": Unable to find version field in the uploaded file.")))
             .verify();
     }
 


### PR DESCRIPTION
Reverts appsmithorg/appsmith#6779

We are disabling the version check from import-export flow as this is causing more interruptions in the feature than greater good. More focus will be given to implement the DSL versioning/handle the errors caused by the DSL versions to avoid the data version issues that we are facing in the import-export feature. 