### PR TITLE
fix: remove outermost quotes from redis plugin result

### DIFF
--- a/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
+++ b/app/server/appsmith-plugins/redisPlugin/src/test/java/com/external/plugins/RedisPluginTest.java
@@ -268,11 +268,11 @@ public class RedisPluginTest {
                     Assert.assertNotNull(actionExecutionResult.getBody());
                     final JsonNode node = ((ArrayNode) actionExecutionResult.getBody());
                     Assert.assertEquals("value", node.get(0).get("result").asText());
-                    Assert.assertEquals("\"value\"", node.get(1).get("result").asText());
-                    Assert.assertEquals("\"my value\"", node.get(2).get("result").asText());
-                    Assert.assertEquals("'value'", node.get(3).get("result").asText());
-                    Assert.assertEquals("'my value'", node.get(4).get("result").asText());
-                    Assert.assertEquals("'{\"a\":\"b\"}'", node.get(5).get("result").asText());
+                    Assert.assertEquals("value", node.get(1).get("result").asText());
+                    Assert.assertEquals("my value", node.get(2).get("result").asText());
+                    Assert.assertEquals("value", node.get(3).get("result").asText());
+                    Assert.assertEquals("my value", node.get(4).get("result").asText());
+                    Assert.assertEquals("{\"a\":\"b\"}", node.get(5).get("result").asText());
                 }).verifyComplete();
     }
 


### PR DESCRIPTION
## Description
- This method removes the outermost quotes - single or double quotes - so that end users don't have to do it via javascript inside widget fields where they are meant to be bound.
- Some examples of old and new outputs:
  - `"my val"` -> `my val`
  - `'my val'` -> `my val`
  - `'{"key": "val"}'` -> `{"key": "val"}`

Fixes #5853 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
