### PR TITLE
fix: Tabs widget - full height when showTabs is false

### DIFF
--- a/app/client/src/components/designSystems/appsmith/TabsComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/TabsComponent.tsx
@@ -42,7 +42,7 @@ const TabsContainerWrapper = styled.div<{
 `;
 
 const ChildrenWrapper = styled.div`
-  height: calc(100% - 40px);
+  height: 100%;
   width: 100%;
   position: relative;
   background: ${(props) => props.theme.colors.builderBodyBG};

--- a/app/client/src/components/designSystems/appsmith/TabsComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/TabsComponent.tsx
@@ -22,6 +22,12 @@ interface TabsComponentProps extends ComponentProps {
   }>;
 }
 
+type ChildrenWrapperProps = Pick<TabsComponentProps, "shouldShowTabs">;
+
+const TAB_CONTAINER_HEIGHT = "40px";
+const CHILDREN_WRAPPER_HEIGHT_WITH_TABS = `calc(100% - ${TAB_CONTAINER_HEIGHT})`;
+const CHILDREN_WRAPPER_HEIGHT_WITHOUT_TABS = "100%";
+
 const scrollContents = css`
   overflow-y: auto;
   position: absolute;
@@ -41,8 +47,11 @@ const TabsContainerWrapper = styled.div<{
   overflow: hidden;
 `;
 
-const ChildrenWrapper = styled.div`
-  height: 100%;
+const ChildrenWrapper = styled.div<ChildrenWrapperProps>`
+  height: ${({ shouldShowTabs }) =>
+    shouldShowTabs
+      ? CHILDREN_WRAPPER_HEIGHT_WITH_TABS
+      : CHILDREN_WRAPPER_HEIGHT_WITHOUT_TABS};
   width: 100%;
   position: relative;
   background: ${(props) => props.theme.colors.builderBodyBG};
@@ -66,7 +75,7 @@ const TabsContainer = styled.div`
   background: ${(props) => props.theme.colors.builderBodyBG};
   overflow: hidden;
   && {
-    height: 40px;
+    height: ${TAB_CONTAINER_HEIGHT};
     width: 100%;
     display: flex;
     justify-content: flex-start;
@@ -123,6 +132,7 @@ function TabsComponent(props: TabsComponentProps) {
       tabContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
     }
   }, [props.shouldScrollContents]);
+
   return (
     <TabsContainerWrapper ref={tabContainerRef}>
       {props.shouldShowTabs ? (
@@ -146,7 +156,7 @@ function TabsComponent(props: TabsComponentProps) {
       ) : (
         undefined
       )}
-      <ChildrenWrapper>
+      <ChildrenWrapper shouldShowTabs={props.shouldShowTabs}>
         <ScrollableCanvasWrapper
           {...remainingProps}
           className={`${


### PR DESCRIPTION
## Description

Fixes #4747 

<img width="1053" alt="Screenshot 2021-08-30 at 10 37 51 AM" src="https://user-images.githubusercontent.com/88306433/131288340-bb65a9d3-4713-4175-8929-5950a957ce18.png">

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/4747-tabs-widget-height 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55 **(0.01)** | 36.88 **(0)** | 33.87 **(0.01)** | 55.55 **(0.01)**
 :red_circle: | app/client/src/components/designSystems/appsmith/TabsComponent.tsx | 100 **(0)** | 83.33 **(-1.96)** | 100 **(0)** | 100 **(0)**</details>