### PR TITLE
fix: show tooltips for action buttons in comment card

### DIFF
--- a/app/client/src/comments/CommentCard/CommentContextMenu.tsx
+++ b/app/client/src/comments/CommentCard/CommentContextMenu.tsx
@@ -9,12 +9,14 @@ import {
   UNPIN_COMMENT,
   createMessage,
   EDIT_COMMENT,
+  MORE_OPTIONS,
 } from "constants/messages";
 import { noop } from "lodash";
 
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 
 import { Popover2 } from "@blueprintjs/popover2";
+import Tooltip from "components/ads/Tooltip";
 
 // render over popover portals
 const Container = styled.div``;
@@ -149,7 +151,9 @@ function CommentContextMenu({
       placement={"bottom-end"}
       portalClassName="comment-context-menu"
     >
-      <StyledIcon name="comment-context-menu" size={IconSize.LARGE} />
+      <Tooltip content={createMessage(MORE_OPTIONS)}>
+        <StyledIcon name="comment-context-menu" size={IconSize.LARGE} />
+      </Tooltip>
     </Popover2>
   );
 }

--- a/app/client/src/comments/CommentCard/ResolveCommentButton.tsx
+++ b/app/client/src/comments/CommentCard/ResolveCommentButton.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import styled, { withTheme } from "styled-components";
 import Icon, { IconSize } from "components/ads/Icon";
 import { Theme } from "constants/DefaultTheme";
+import Tooltip from "components/ads/Tooltip";
+import { createMessage, RESOLVE_THREAD } from "constants/messages";
 
 const Container = styled.div`
   display: flex;
@@ -52,14 +54,16 @@ const ResolveCommentButton = withTheme(
 
     return (
       <Container onClick={_handleClick}>
-        <StyledResolveIcon
-          fillColor={fillColor}
-          keepColors
-          name="oval-check"
-          size={IconSize.XXL}
-          strokeColorCircle={strokeColorCircle}
-          strokeColorPath={strokeColorPath}
-        />
+        <Tooltip content={createMessage(RESOLVE_THREAD)}>
+          <StyledResolveIcon
+            fillColor={fillColor}
+            keepColors
+            name="oval-check"
+            size={IconSize.XXL}
+            strokeColorCircle={strokeColorCircle}
+            strokeColorPath={strokeColorPath}
+          />
+        </Tooltip>
       </Container>
     );
   },

--- a/app/client/src/components/ads/EmojiPicker.tsx
+++ b/app/client/src/components/ads/EmojiPicker.tsx
@@ -7,6 +7,8 @@ import { withTheme } from "styled-components";
 import { Theme } from "constants/DefaultTheme";
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 import "emoji-mart/css/emoji-mart.css";
+import Tooltip from "components/ads/Tooltip";
+import { ADD_REACTION, createMessage, EMOJI } from "constants/messages";
 
 const EmojiPicker = withTheme(
   ({
@@ -50,12 +52,14 @@ const EmojiPicker = withTheme(
         }}
         portalClassName="emoji-picker-portal"
       >
-        <Icon
-          fillColor={theme.colors.comments.emojiPicker}
-          keepColors
-          name={iconName || "emoji"}
-          size={iconSize || IconSize.XXXL}
-        />
+        <Tooltip content={createMessage(iconName ? ADD_REACTION : EMOJI)}>
+          <Icon
+            fillColor={theme.colors.comments.emojiPicker}
+            keepColors
+            name={iconName || "emoji"}
+            size={iconSize || IconSize.XXXL}
+          />
+        </Tooltip>
       </Popover2>
     );
   },

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -469,3 +469,9 @@ export const MERGE_CHANGES = () => "Merge Changes";
 export const SELECT_BRANCH_TO_MERGE = () => "Select branch to merge";
 
 export const DOWNLOAD_FILE_NAME_ERROR = () => "File name was not provided";
+
+// Comment card tooltips
+export const MORE_OPTIONS = () => "More Options";
+export const ADD_REACTION = () => "Add Reaction";
+export const RESOLVE_THREAD = () => "Resolve Thread";
+export const EMOJI = () => "Emoji";


### PR DESCRIPTION
## Description
Added tooltips for - Reaction, Resolve thread and More options action buttons

Fixes #4994 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/4994-show-tooltips-in-comment-cards 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.93 **(0.02)** | 36.81 **(0)** | 33.59 **(0.03)** | 55.46 **(0)**
 :green_circle: | app/client/src/comments/CommentCard/CommentContextMenu.tsx | 80 **(0.41)** | 81.82 **(0)** | 33.33 **(0)** | 80.85 **(0.42)**
 :green_circle: | app/client/src/comments/CommentCard/ResolveCommentButton.tsx | 92.86 **(0.55)** | 70 **(0)** | 80 **(0)** | 92.31 **(0.64)**
 :green_circle: | app/client/src/components/ads/EmojiPicker.tsx | 86.96 **(1.25)** | 100 **(0)** | 33.33 **(0)** | 85.71 **(1.5)**
 :green_circle: | app/client/src/constants/messages.ts | 70.86 **(0.41)** | 100 **(0)** | 12.07 **(1.23)** | 78.37 **(0.22)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>