### PR TITLE
feat: show relationships mapping in api/query pane as soon as user makes a binding

### DIFF
--- a/app/client/src/components/editorComponents/ActionRightPane/index.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/index.tsx
@@ -177,14 +177,41 @@ export function Collapsible({
   );
 }
 
+export function useEntityDependencies(actionName: string) {
+  const deps = useSelector((state: AppState) => state.evaluations.dependencies);
+  const entityDependencies = useMemo(
+    () =>
+      getDependenciesFromInverseDependencies(
+        deps.inverseDependencyMap,
+        actionName,
+      ),
+    [actionName, deps.inverseDependencyMap],
+  );
+  const hasDependencies =
+    entityDependencies &&
+    (entityDependencies?.directDependencies.length > 0 ||
+      entityDependencies?.inverseDependencies.length > 0);
+  return {
+    hasDependencies,
+    entityDependencies,
+  };
+}
+
 function ActionSidebar({
   actionName,
+  entityDependencies,
+  hasConnections,
   hasResponse,
   suggestedWidgets,
 }: {
   actionName: string;
   hasResponse: boolean;
+  hasConnections: boolean | null;
   suggestedWidgets?: SuggestedWidgetsType[];
+  entityDependencies: {
+    directDependencies: string[];
+    inverseDependencies: string[];
+  } | null;
 }) {
   const dispatch = useDispatch();
   const widgets = useSelector(getWidgets);
@@ -206,19 +233,6 @@ function ActionSidebar({
   };
   const hasWidgets = Object.keys(widgets).length > 1;
 
-  const deps = useSelector((state: AppState) => state.evaluations.dependencies);
-  const entityDependencies = useMemo(
-    () =>
-      getDependenciesFromInverseDependencies(
-        deps.inverseDependencyMap,
-        actionName,
-      ),
-    [actionName, deps.inverseDependencyMap],
-  );
-  const hasConnections =
-    entityDependencies &&
-    (entityDependencies?.directDependencies.length > 0 ||
-      entityDependencies?.inverseDependencies.length > 0);
   const showSuggestedWidgets =
     hasResponse && suggestedWidgets && !!suggestedWidgets.length;
   const showSnipingMode = hasResponse && hasWidgets;

--- a/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
@@ -9,7 +9,9 @@ import Text, { FontWeight, TextType } from "components/ads/Text";
 import { TabbedViewContainer } from "./Form";
 import get from "lodash/get";
 import { getQueryParams } from "../../../utils/AppsmithUtils";
-import ActionRightPane from "components/editorComponents/ActionRightPane";
+import ActionRightPane, {
+  useEntityDependencies,
+} from "components/editorComponents/ActionRightPane";
 
 const EmptyDatasourceContainer = styled.div`
   display: flex;
@@ -123,6 +125,9 @@ export const getDatasourceInfo = (datasource: any): string => {
 
 export default function ApiRightPane(props: any) {
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const { entityDependencies, hasDependencies } = useEntityDependencies(
+    props.actionName,
+  );
   useEffect(() => {
     if (!!props.hasResponse) setSelectedIndex(1);
   }, [props.hasResponse]);
@@ -207,6 +212,8 @@ export default function ApiRightPane(props: any) {
                 <SomeWrapper>
                   <ActionRightPane
                     actionName={props.actionName}
+                    entityDependencies={entityDependencies}
+                    hasConnections={hasDependencies}
                     hasResponse={props.hasResponse}
                     suggestedWidgets={props.suggestedWidgets}
                   />

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -60,7 +60,9 @@ import { ExplorerURLParams } from "../Explorer/helpers";
 import MoreActionsMenu from "../Explorer/Actions/MoreActionsMenu";
 import Button, { Size } from "components/ads/Button";
 import { thinScrollbar } from "constants/DefaultTheme";
-import ActionRightPane from "components/editorComponents/ActionRightPane";
+import ActionRightPane, {
+  useEntityDependencies,
+} from "components/editorComponents/ActionRightPane";
 import { SuggestedWidget } from "api/ActionAPI";
 import { getActionTabsInitialIndex } from "selectors/editorSelectors";
 import { UIComponentTypes } from "../../../api/PluginApi";
@@ -707,6 +709,9 @@ export function EditorJSONtoForm(props: Props) {
 
     setSelectedIndex(index);
   };
+  const { entityDependencies, hasDependencies } = useEntityDependencies(
+    props.actionName,
+  );
 
   return (
     <>
@@ -862,9 +867,11 @@ export function EditorJSONtoForm(props: Props) {
               />
             </TabbedViewContainer>
           </SecondaryWrapper>
-          <SidebarWrapper show={!!output}>
+          <SidebarWrapper show={hasDependencies || !!output}>
             <ActionRightPane
               actionName={actionName}
+              entityDependencies={entityDependencies}
+              hasConnections={hasDependencies}
               hasResponse={!!output}
               suggestedWidgets={executedQueryData?.suggestedWidgets}
             />


### PR DESCRIPTION
## Description
Regardless, if user has ran a query/api or not, if the relationship maps are available we'll show them to the user.

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
-manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/show-connections-asap 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.89 **(-0.01)** | 36.79 **(-0.01)** | 33.56 **(0)** | 55.44 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/ActionRightPane/index.tsx | 34.07 **(-0.41)** | 25 **(0)** | 0 **(0)** | 36.9 **(-0.6)**
 :red_circle: | app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx | 44.23 **(-2.71)** | 47.06 **(0)** | 0 **(0)** | 48.89 **(-1.11)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 39.55 **(-0.68)** | 33.33 **(-0.47)** | 0 **(0)** | 42.17 **(-0.25)**</details>