### PR TITLE
fix: Confirm when server endpoint ends with a slash

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -52,12 +52,9 @@ default_linux_client_proxy="http://localhost:3000"
 # default server to internal docker
 server_proxy_pass="${1:-$default_server_proxy}"
 if [[ $server_proxy_pass =~ /$ ]]; then
-    read -r -p "Server proxy ends with a '/'. This is most likely unintended. Are you sure? [y/N] " proceed
-    if [[ ! $proceed =~ ^[Yy]([eE][sS])?$ ]]; then
-        echo "Exiting. Please run again, removing the trailing slash(es) for the server proxy endpoint." >&2
-        exit 1
-    fi
-    unset proceed
+    echo "The given server proxy ($1) ends with a '/'. This will change Nginx's behavior in unintended ways." >&2
+    echo "Exiting. Please run again, removing the trailing slash(es) for the server proxy endpoint." >&2
+    exit 1
 fi
 
 # Stop and remove existing container


### PR DESCRIPTION
A potential contributor getting started with the client codebase ran into a problem, when they executed the following command:

```
./start-https.sh https://release.app.appsmith.com/
```

This doesn't work (notice the extra `/` at the end). This sets the `proxy_pass` directive in the generated Nginx configuration, pointing to `https://release.app.appsmith.com/`. Seeing that this ends with a `/`, Nginx strips the path from the incoming request.

This is part that gets generated:

```nginx
    location /api {
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Host $host;
        proxy_pass https://release.app.appsmith.com/;
    }
```

With this configuration, the URL `https://localhost/api/v1/users/me` will be forwarded to `https://release.app.appsmith.com/v1/users/me` (notice missing `/api`). This is by design, and is a feature of Nginx.

The solution is **not** have the trailing `/` in the proxy endpoint. Since this is such an easy pitfall and hard to troubleshoot, I've added a small check in the script to catch this particular case and warn the user.


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>