### PR TITLE
feat: Consistent styling for widgets disabled state

### DIFF
--- a/app/client/src/components/designSystems/appsmith/CheckboxGroupComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/CheckboxGroupComponent.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import styled from "styled-components";
-import { Checkbox } from "@blueprintjs/core";
 
 import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
-import { ThemeProp } from "components/ads/common";
 import { generateReactKey } from "utils/generators";
+import { StyledCheckbox } from "components/designSystems/blueprint/CheckboxComponent";
+import { ThemeProp } from "components/ads/common";
 
 export interface CheckboxGroupContainerProps {
   inline?: boolean;
@@ -33,25 +33,6 @@ const CheckboxGroupContainer = styled.div<
   padding: 2px 4px;
 `;
 
-export interface StyledCheckboxProps {
-  disabled?: boolean;
-  rowspace: number;
-}
-
-const StyledCheckbox = styled(Checkbox)<ThemeProp & StyledCheckboxProps>`
-  height: ${({ rowspace }) => rowspace}px;
-
-  &.bp3-control input:checked ~ .bp3-control-indicator {
-    box-shadow: none;
-    background-image: none;
-    background-color: #03b365;
-  }
-
-  &.bp3-control.bp3-checkbox .bp3-control-indicator {
-    border-radius: 0;
-  }
-`;
-
 export interface OptionProps {
   /** Label text for this option. If omitted, `value` is used as the label. */
   label?: string;
@@ -70,7 +51,6 @@ export interface CheckboxGroupComponentProps extends ComponentProps {
   rowSpace: number;
   selectedValues: string[];
 }
-
 function CheckboxGroupComponent(props: CheckboxGroupComponentProps) {
   const {
     isDisabled,
@@ -94,7 +74,7 @@ function CheckboxGroupComponent(props: CheckboxGroupComponentProps) {
             key={generateReactKey()}
             label={option.label}
             onChange={onChange(option.value)}
-            rowspace={rowSpace}
+            rowSpace={rowSpace}
           />
         ))}
     </CheckboxGroupContainer>

--- a/app/client/src/components/designSystems/blueprint/CheckboxComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/CheckboxComponent.tsx
@@ -1,45 +1,65 @@
 import React from "react";
 import styled from "styled-components";
-import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
 import { Alignment, Checkbox, Classes } from "@blueprintjs/core";
-import { BlueprintControlTransform } from "constants/DefaultTheme";
+
+import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
 import { AlignWidget } from "widgets/SwitchWidget";
 
-const CheckboxContainer = styled.div<{ isValid: boolean }>`
+type StyledCheckboxProps = {
+  rowSpace: number;
+};
+
+type StyledCheckboxContainerProps = {
+  isValid: boolean;
+};
+
+const CheckboxContainer = styled.div<StyledCheckboxContainerProps>`
   && {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: flex-start;
     align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: flex-start;
+    width: 100%;
     &.${Alignment.RIGHT} {
       justify-content: flex-end;
     }
-    .bp3-control-indicator {
-      border: ${(props) =>
-        !props.isValid
-          ? `1px solid ${props.theme.colors.error} !important`
-          : `1px solid transparent`};
-    }
 
-    label {
-      margin: 0;
-      color: ${(props) =>
-        !props.isValid ? `${props.theme.colors.error}` : `inherit`};
+    & .bp3-control-indicator {
+      border: ${(props) =>
+        !props.isValid && `1px solid ${props.theme.colors.error} !important`};
     }
   }
-  ${BlueprintControlTransform}
 `;
+
+export const StyledCheckbox = styled(Checkbox)<StyledCheckboxProps>`
+  height: ${({ rowSpace }) => rowSpace}px;
+
+  &.bp3-control input:checked ~ .bp3-control-indicator {
+    background-color: #03b365;
+    background-image: none;
+    box-shadow: none;
+  }
+
+  &.bp3-control input:disabled ~ .bp3-control-indicator {
+    opacity: 0.5;
+  }
+
+  &.bp3-control.bp3-checkbox .bp3-control-indicator {
+    border-radius: 0;
+  }
+`;
+
 class CheckboxComponent extends React.Component<CheckboxComponentProps> {
   render() {
     const checkboxAlignClass =
       this.props.alignWidget === "RIGHT" ? Alignment.RIGHT : Alignment.LEFT;
+
     return (
       <CheckboxContainer
         className={checkboxAlignClass}
         isValid={!(this.props.isRequired && !this.props.isChecked)}
       >
-        <Checkbox
+        <StyledCheckbox
           alignIndicator={checkboxAlignClass}
           checked={this.props.isChecked}
           className={
@@ -48,7 +68,7 @@ class CheckboxComponent extends React.Component<CheckboxComponentProps> {
           disabled={this.props.isDisabled}
           label={this.props.label}
           onChange={this.onCheckChange}
-          style={{ borderRadius: 0 }}
+          rowSpace={this.props.rowSpace}
         />
       </CheckboxContainer>
     );
@@ -60,12 +80,13 @@ class CheckboxComponent extends React.Component<CheckboxComponentProps> {
 }
 
 export interface CheckboxComponentProps extends ComponentProps {
-  label: string;
+  alignWidget?: AlignWidget;
   isChecked: boolean;
-  onCheckChange: (isChecked: boolean) => void;
   isLoading: boolean;
   isRequired?: boolean;
-  alignWidget?: AlignWidget;
+  label: string;
+  onCheckChange: (isChecked: boolean) => void;
+  rowSpace: number;
 }
 
 export default CheckboxComponent;

--- a/app/client/src/components/designSystems/blueprint/RateComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/RateComponent.tsx
@@ -5,9 +5,10 @@ import styled from "styled-components";
 import Rating from "react-rating";
 import _ from "lodash";
 
+import TooltipComponent from "components/ads/Tooltip";
+import { disable } from "constants/DefaultTheme";
 import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
 import { RateSize, RATE_SIZES } from "constants/WidgetConstants";
-import TooltipComponent from "components/ads/Tooltip";
 
 /*
   Note:
@@ -18,6 +19,7 @@ import TooltipComponent from "components/ads/Tooltip";
 */
 
 interface RateContainerProps {
+  isDisabled: boolean;
   scrollable: boolean;
 }
 
@@ -32,6 +34,8 @@ export const RateContainer = styled.div<RateContainerProps>`
   > span {
     align-self: ${(props) => (props.scrollable ? "flex-start" : "center")};
   }
+
+  ${({ isDisabled }) => isDisabled && disable}
 `;
 
 export const Star = styled(Icon)`
@@ -97,6 +101,7 @@ function RateComponent(props: RateComponentProps) {
     bottomRow,
     inactiveColor,
     isAllowHalf,
+    isDisabled,
     leftColumn,
     maxCount,
     onValueChanged,
@@ -122,7 +127,11 @@ function RateComponent(props: RateComponentProps) {
   }, [leftColumn, rightColumn, topRow, bottomRow, maxCount, size]);
 
   return (
-    <RateContainer ref={rateContainerRef} scrollable={scrollable}>
+    <RateContainer
+      isDisabled={Boolean(isDisabled)}
+      ref={rateContainerRef}
+      scrollable={scrollable}
+    >
       <Rating
         emptySymbol={
           <Star

--- a/app/client/src/constants/Colors.tsx
+++ b/app/client/src/constants/Colors.tsx
@@ -121,6 +121,7 @@ export const Colors = {
   BOX_SHADOW_DEFAULT_VARIANT5: "rgba(0, 0, 0, 0.25)",
 
   BUTTON_CUSTOM_SOLID_DARK_TEXT_COLOR: "#333",
+  BUTTON_DISABLED: "#c2c5c7",
 
   SELECT_DISABLED: "#ced9e080",
   SELECT_PLACEHOLDER: "#bfbfbf",

--- a/app/client/src/constants/DefaultTheme.tsx
+++ b/app/client/src/constants/DefaultTheme.tsx
@@ -166,6 +166,13 @@ export const invisible = css`
   }
 `;
 
+export const disable = css`
+  & {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+`;
+
 export const BlueprintCSSTransform = css`
   &&&& {
     .${Classes.BUTTON} {

--- a/app/client/src/constants/DefaultTheme.tsx
+++ b/app/client/src/constants/DefaultTheme.tsx
@@ -1431,7 +1431,7 @@ export const dark: ColorType = {
       },
     },
     disabled: {
-      bgColor: Colors.DARK_GRAY,
+      bgColor: Colors.BUTTON_DISABLED,
       textColor: Colors.WHITE,
     },
     primary: {
@@ -2009,7 +2009,7 @@ export const light: ColorType = {
       },
     },
     disabled: {
-      bgColor: Colors.DARK_GRAY,
+      bgColor: Colors.BUTTON_DISABLED,
       textColor: Colors.WHITE,
     },
     primary: {

--- a/app/client/src/constants/DefaultTheme.tsx
+++ b/app/client/src/constants/DefaultTheme.tsx
@@ -168,8 +168,12 @@ export const invisible = css`
 
 export const disable = css`
   & {
-    opacity: 0.5;
-    pointer-events: none;
+    cursor: not-allowed;
+
+    & > * {
+      opacity: 0.5;
+      pointer-events: none;
+    }
   }
 `;
 

--- a/app/client/src/widgets/CheckboxWidget.tsx
+++ b/app/client/src/widgets/CheckboxWidget.tsx
@@ -133,6 +133,7 @@ class CheckboxWidget extends BaseWidget<CheckboxWidgetProps, WidgetState> {
         key={this.props.widgetId}
         label={this.props.label}
         onCheckChange={this.onCheckChange}
+        rowSpace={this.props.parentRowSpace}
         widgetId={this.props.widgetId}
       />
     );


### PR DESCRIPTION
## Description

Fixes #3294 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/3294-widget-disabled-state 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.99 **(0)** | 36.88 **(0)** | 33.86 **(0.01)** | 55.54 **(0)**
 :red_circle: | app/client/src/components/designSystems/appsmith/CheckboxGroupComponent.tsx | 42.86 **(1.68)** | 13.33 **(-10.2)** | 0 **(0)** | 50 **(0)**
 :green_circle: | app/client/src/components/designSystems/blueprint/CheckboxComponent.tsx | 94.44 **(0.32)** | 73.33 **(6.66)** | 80 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/components/designSystems/blueprint/RateComponent.tsx | 32.43 **(0.08)** | 18.18 **(-1.82)** | 0 **(0)** | 37.5 **(0.83)**
 :green_circle: | app/client/src/constants/DefaultTheme.tsx | 92.92 **(0.06)** | 90 **(0.53)** | 71.43 **(0)** | 91.75 **(0.08)**
 :green_circle: | app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx | 80.77 **(1.92)** | 89.66 **(0)** | 41.67 **(8.34)** | 79.17 **(2.09)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>