### PR TITLE
feat: Keep the table schema in the table name for the generated CRUD page 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolution.java
@@ -292,7 +292,7 @@ public class CreateDBTablePageSolution {
                 }
 
                 // Map table names : public.templateTable => <"templateTable","userTable">
-                mappedColumnsAndTableName.put(templateTableRef, tableRef);
+                mappedColumnsAndTableName.put(templateTableRef, tableName);
 
                 Set<String> deletedWidgets = new HashSet<>();
                 layout.setDsl(


### PR DESCRIPTION
## Description

> Generated CRUD page was showing only the table name on the canvas, this PR will keep the parent schema along with the DB table name 

Fixes #6870

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Tested manually on local instance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
