### PR TITLE
fix: DSL versions during client migrations

### DIFF
--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -104,7 +104,7 @@ export const layoutConfigurations: LayoutConfigurations = {
   FLUID: { minWidth: -1, maxWidth: -1 },
 };
 
-export const LATEST_PAGE_VERSION = 33;
+export const LATEST_PAGE_VERSION = 34;
 
 export const GridDefaults = {
   DEFAULT_CELL_SIZE: 1,

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -831,6 +831,7 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
     currentDSL = migrateMenuButtonWidgetButtonProperties(currentDSL);
     currentDSL.version = LATEST_PAGE_VERSION;
   }
+
   return currentDSL;
 };
 

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -819,15 +819,15 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
 
   if (currentDSL.version === 31) {
     currentDSL = migrateIsDisabledToButtonColumn(currentDSL);
-    currentDSL.version = 31;
-  }
-
-  if (currentDSL.version === 31) {
-    currentDSL = migrateTableDefaultSelectedRow(currentDSL);
-    currentDSL.version = LATEST_PAGE_VERSION;
+    currentDSL.version = 32;
   }
 
   if (currentDSL.version === 32) {
+    currentDSL = migrateTableDefaultSelectedRow(currentDSL);
+    currentDSL.version = 33;
+  }
+
+  if (currentDSL.version === 33) {
     currentDSL = migrateMenuButtonWidgetButtonProperties(currentDSL);
     currentDSL.version = LATEST_PAGE_VERSION;
   }


### PR DESCRIPTION

## Description
Fixes incorrect DSL versions in the migrations list.


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/dsl-versions 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.92 **(0.02)** | 36.82 **(0.04)** | 33.64 **(0.03)** | 55.46 **(0.02)**
 :green_circle: | app/client/src/utils/WidgetPropsUtils.tsx | 74.88 **(0.33)** | 66.47 **(0)** | 69.89 **(0)** | 73.91 **(0.34)**
 :green_circle: | app/client/src/utils/migrations/MenuButtonWidget.ts | 69.23 **(46.15)** | 66.67 **(66.67)** | 100 **(100)** | 66.67 **(50)**</details>