### PR TITLE
chore: Removing redundant toast message in action creation & deletion flow

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -8,8 +8,6 @@ export function createMessage(
 export const ERROR_MESSAGE_SELECT_ACTION = () => `Please select an action`;
 export const ERROR_MESSAGE_SELECT_ACTION_TYPE = () =>
   `Please select an action type`;
-export const ACTION_CREATED_SUCCESS = (actionName: string) =>
-  `${actionName} action created successfully`;
 export const ERROR_ADD_API_INVALID_URL = () =>
   `Unable to create API. Try adding a URL to the datasource`;
 export const ERROR_MESSAGE_NAME_EMPTY = () => `Please select a name`;
@@ -218,8 +216,6 @@ export const ERROR_FAIL_ON_PAGE_LOAD_ACTIONS = () =>
   `Failed to execute actions during page load`;
 export const ERROR_ACTION_EXECUTE_FAIL = (actionName: string) =>
   `${actionName} action returned an error response`;
-export const ACTION_DELETE_SUCCESS = (actionName: string) =>
-  `${actionName} action deleted successfully`;
 export const ACTION_MOVE_SUCCESS = (actionName: string, pageName: string) =>
   `${actionName} action moved to page ${pageName} successfully`;
 export const ERROR_ACTION_MOVE_FAIL = (actionName: string) =>

--- a/app/client/src/sagas/ErrorSagas.tsx
+++ b/app/client/src/sagas/ErrorSagas.tsx
@@ -78,23 +78,22 @@ export function* validateResponse(response: ApiResponse | any, show = true) {
   }
   if (response.responseMeta.success) {
     return true;
-  } else {
-    if (
-      response.responseMeta.error.code ===
-      SERVER_ERROR_CODES.INCORRECT_BINDING_LIST_OF_WIDGET
-    ) {
-      throw new IncorrectBindingError(response.responseMeta.error.message);
-    } else {
-      yield put({
-        type: ReduxActionErrorTypes.API_ERROR,
-        payload: {
-          error: response.responseMeta.error,
-          show,
-        },
-      });
-      throw Error(response.responseMeta.error.message);
-    }
   }
+  if (
+    response.responseMeta.error.code ===
+    SERVER_ERROR_CODES.INCORRECT_BINDING_LIST_OF_WIDGET
+  ) {
+    throw new IncorrectBindingError(response.responseMeta.error.message);
+  }
+
+  yield put({
+    type: ReduxActionErrorTypes.API_ERROR,
+    payload: {
+      error: response.responseMeta.error,
+      show,
+    },
+  });
+  throw Error(response.responseMeta.error.message);
 }
 
 export function getResponseErrorMessage(response: ApiResponse) {


### PR DESCRIPTION
## Description

When creating/deleting actions, the client displays success toast messages that don't add value to the developer's workflow. Hence removing them. Also minor refactoring in the `ErrorSagas` to simplify code flow making it easier to understand.

## Type of change

- Chore

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: remove-redundant-toast-message 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.9 **(0)** | 36.79 **(0.01)** | 33.63 **(0)** | 55.45 **(0.01)**
 :green_circle: | app/client/src/constants/messages.ts | 70.89 **(0.03)** | 100 **(0)** | 12.15 **(0.08)** | 78.66 **(0.29)**
 :green_circle: | app/client/src/sagas/ActionSagas.ts | 10.96 **(0.06)** | 0.78 **(0.02)** | 3.7 **(0)** | 13.31 **(0.08)**
 :green_circle: | app/client/src/sagas/ErrorSagas.tsx | 57.52 **(0)** | 38.71 **(0.61)** | 38.89 **(0)** | 56.86 **(0)**</details>