### PR TITLE
fix: link for resolved comment does not show a comment thread

### DIFF
--- a/app/client/src/comments/AppComments/AppCommentThreads.tsx
+++ b/app/client/src/comments/AppComments/AppCommentThreads.tsx
@@ -29,7 +29,7 @@ const Container = styled.div`
 
 function AppCommentThreads() {
   const dispatch = useDispatch();
-  const commentThreadIdInUrl = useSelectCommentThreadUsingQuery();
+  const commentThreadIdFromUrl = useSelectCommentThreadUsingQuery();
   const applicationId = useSelector(getCurrentApplicationId) as string;
   const appCommentThreadsByRefMap = useSelector(
     applicationCommentsSelector(applicationId),
@@ -64,12 +64,12 @@ function AppCommentThreads() {
     // if user is visiting a comment thread link which is already resolved,
     // we'll activate the resolved comments filter
     if (
-      commentThreadIdInUrl &&
-      !commentThreadIds.includes(commentThreadIdInUrl)
+      commentThreadIdFromUrl &&
+      !commentThreadIds.includes(commentThreadIdFromUrl)
     ) {
       dispatch(setShouldShowResolvedComments(true));
     }
-  }, [commentThreadIdInUrl]);
+  }, [commentThreadIdFromUrl]);
 
   return (
     <Container>

--- a/app/client/src/comments/AppComments/AppCommentThreads.tsx
+++ b/app/client/src/comments/AppComments/AppCommentThreads.tsx
@@ -19,6 +19,9 @@ import { getCurrentUser } from "selectors/usersSelectors";
 import { Virtuoso } from "react-virtuoso";
 import { setShouldShowResolvedComments } from "actions/commentActions";
 import { useSelectCommentThreadUsingQuery } from "../inlineComments/Comments";
+import { Toaster } from "components/ads/Toast";
+import { Variant } from "components/ads/common";
+import { COMMENT_HAS_BEEN_DELETED, createMessage } from "constants/messages";
 
 const Container = styled.div`
   display: flex;
@@ -67,7 +70,13 @@ function AppCommentThreads() {
       commentThreadIdFromUrl &&
       !commentThreadIds.includes(commentThreadIdFromUrl)
     ) {
-      dispatch(setShouldShowResolvedComments(true));
+      if (appCommentThreadIds.includes(commentThreadIdFromUrl))
+        dispatch(setShouldShowResolvedComments(true));
+      else
+        Toaster.show({
+          text: createMessage(COMMENT_HAS_BEEN_DELETED),
+          variant: Variant.warning,
+        });
     }
   }, [commentThreadIdFromUrl]);
 

--- a/app/client/src/comments/AppComments/AppCommentThreads.tsx
+++ b/app/client/src/comments/AppComments/AppCommentThreads.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 
 import {
@@ -17,6 +17,8 @@ import AppCommentsPlaceholder from "./AppCommentsPlaceholder";
 import { getCurrentUser } from "selectors/usersSelectors";
 
 import { Virtuoso } from "react-virtuoso";
+import { setShouldShowResolvedComments } from "actions/commentActions";
+import { useSelectCommentThreadUsingQuery } from "../inlineComments/Comments";
 
 const Container = styled.div`
   display: flex;
@@ -26,6 +28,8 @@ const Container = styled.div`
 `;
 
 function AppCommentThreads() {
+  const dispatch = useDispatch();
+  const commentThreadIdInUrl = useSelectCommentThreadUsingQuery();
   const applicationId = useSelector(getCurrentApplicationId) as string;
   const appCommentThreadsByRefMap = useSelector(
     applicationCommentsSelector(applicationId),
@@ -55,6 +59,17 @@ function AppCommentThreads() {
       currentUsername,
     ],
   );
+
+  useEffect(() => {
+    // if user is visiting a comment thread link which is already resolved,
+    // we'll activate the resolved comments filter
+    if (
+      commentThreadIdInUrl &&
+      !commentThreadIds.includes(commentThreadIdInUrl)
+    ) {
+      dispatch(setShouldShowResolvedComments(true));
+    }
+  }, [commentThreadIdInUrl]);
 
   return (
     <Container>

--- a/app/client/src/comments/inlineComments/AddCommentInput.tsx
+++ b/app/client/src/comments/inlineComments/AddCommentInput.tsx
@@ -337,7 +337,6 @@ function AddCommentInput({
               className={"cancel-button"}
               onClick={_onCancel}
               text={createMessage(CANCEL)}
-              type="button"
             />
             <Button
               category={Category.primary}
@@ -345,7 +344,6 @@ function AddCommentInput({
               disabled={!editorState.getCurrentContent().hasText()}
               onClick={handleSubmit}
               text={createMessage(POST)}
-              type="button"
             />
           </Row>
         </Row>

--- a/app/client/src/comments/inlineComments/Comments.tsx
+++ b/app/client/src/comments/inlineComments/Comments.tsx
@@ -43,7 +43,7 @@ function InlinePageCommentPin({
 
 const MemoisedInlinePageCommentPin = React.memo(InlinePageCommentPin);
 
-const useSelectCommentThreadUsingQuery = () => {
+export const useSelectCommentThreadUsingQuery = () => {
   const location = useLocation();
   const [commentThreadIdInUrl, setCommentThreadIdInUrl] = useState<
     string | null

--- a/app/client/src/components/designSystems/appsmith/CenteredWrapper.tsx
+++ b/app/client/src/components/designSystems/appsmith/CenteredWrapper.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export default styled.div`
-  height: 100%;
+  height: ${(props) => `calc(100vh - ${props.theme.smallHeaderHeight})`};
   width: 100%;
   display: flex;
   justify-content: center;

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -308,6 +308,7 @@ export const PIN_COMMENT = () => "Pin Comment";
 export const UNPIN_COMMENT = () => "Unpin Comment";
 export const COPY_LINK = () => "Copy Link";
 export const DELETE_COMMENT = () => "Delete Comment";
+export const COMMENT_HAS_BEEN_DELETED = () => "Comment not found";
 export const DELETE_THREAD = () => "Delete Thread";
 export const EDIT_COMMENT = () => "Edit Comment";
 export const COMMENTS = () => "Comments";


### PR DESCRIPTION
## Description
When user tries to open a link of resolved comment thread, we'll enforce the `show resolved comments` filter

Fixes #5811 
Fixes #5434 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/5811-link-for-resolved-thread-not-visible 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.92 **(0)** | 36.82 **(0)** | 33.64 **(-0.01)** | 55.46 **(-0.01)**
 :green_circle: | app/client/src/comments/inlineComments/Comments.tsx | 97.22 **(0.08)** | 90 **(0)** | 100 **(0)** | 100 **(0)**
 :red_circle: | app/client/src/components/designSystems/appsmith/CenteredWrapper.tsx | 66.67 **(-33.33)** | 100 **(0)** | 0 **(-100)** | 66.67 **(-33.33)**
 :red_circle: | app/client/src/constants/messages.ts | 70.84 **(-0.02)** | 100 **(0)** | 12.03 **(-0.04)** | 78.43 **(0.06)**</details>