### PR TITLE
fix: Update error message for form login when OAuth login is present

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/CustomFormLoginServiceImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.server.domains.LoginSource;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.WordUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
@@ -49,7 +50,9 @@ public class CustomFormLoginServiceImpl implements ReactiveUserDetailsService {
                         // We can have a implementation to give which login method user should use but this will
                         // expose the sign-in source for external world and in turn to spammers
                         throw new InternalAuthenticationServiceException(
-                            AppsmithError.INVALID_LOGIN_METHOD.getMessage(user.getSource().toString())
+                            AppsmithError.INVALID_LOGIN_METHOD.getMessage(
+                                WordUtils.capitalize(user.getSource().toString().toLowerCase())
+                            )
                         );
                     }
                     return user;


### PR DESCRIPTION
## Description

This PR will update the login source capitalization in the error message displayed for a user who is trying to login using form when OAuth source is present. For example in case of google OAuth error message will be changed as follows: 
Before : Please use **GOOGLE** authentication to login to Appsmith
After : Please use **Google** authentication to login to Appsmith

Fixes #6890

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested manually on local instance

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
