### PR TITLE
fix: listen to page id param at the parent editor component

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Pages_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Pages_spec.js
@@ -20,9 +20,10 @@ describe("Pages", function() {
     );
 
     // to check if apis are cloned
-    cy.get(".bp3-icon-caret-right ~ .t--entity-name:contains(Page1)").click({
-      multiple: true,
-    });
+    cy.get(".t--entity-name:contains(Page1)")
+      .its("length")
+      .should("be.gt", 1);
+
     cy.get(
       ".bp3-icon-caret-right ~ .t--entity-name:contains(Datasources)",
     ).click({

--- a/app/client/src/pages/Editor/Explorer/Actions/ActionEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/ActionEntity.tsx
@@ -8,10 +8,8 @@ import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
 import PerformanceTracker, {
   PerformanceTransactionName,
 } from "utils/PerformanceTracker";
-import { fetchPage } from "actions/pageActions";
 import { useParams } from "react-router";
 import { ExplorerURLParams } from "../helpers";
-import { useDispatch } from "react-redux";
 
 const getUpdateActionNameReduxAction = (id: string, name: string) => {
   return saveActionName({ id, name });
@@ -29,16 +27,11 @@ type ExplorerActionEntityProps = {
 
 export const ExplorerActionEntity = memo((props: ExplorerActionEntityProps) => {
   const { pageId } = useParams<ExplorerURLParams>();
-  const dispatch = useDispatch();
   const switchToAction = useCallback(() => {
     PerformanceTracker.startTracking(PerformanceTransactionName.OPEN_ACTION, {
       url: props.url,
     });
     props.url && history.push(props.url);
-
-    if (pageId !== props.pageId) {
-      dispatch(fetchPage(props.pageId));
-    }
   }, [props.url, pageId, props.pageId]);
 
   const contextMenu = (

--- a/app/client/src/pages/Editor/GeneratePage/components/ActionCards.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/ActionCards.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ActionCard from "./ActionCard";
 import { FormIcons } from "icons/FormIcons";
 import history from "utils/history";
@@ -14,9 +14,6 @@ import {
   BUILD_FROM_SCRATCH_ACTION_TITLE,
   BUILD_FROM_SCRATCH_ACTION_SUBTITLE,
 } from "constants/messages";
-import { useDispatch, useSelector } from "react-redux";
-import { getCurrentPageId } from "selectors/editorSelectors";
-import { fetchPage } from "actions/pageActions";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 
 type routeId = {
@@ -38,17 +35,6 @@ const goToGenPageForm = ({ applicationId, pageId }: routeId): void => {
 };
 
 function ActionCards() {
-  const params = useParams<{ applicationId: string; pageId: string }>();
-  const dispatch = useDispatch();
-
-  const currentPageId = useSelector(getCurrentPageId);
-
-  // Switch page
-  useEffect(() => {
-    if (currentPageId !== params.pageId && !!params.pageId) {
-      dispatch(fetchPage(params.pageId));
-    }
-  }, [currentPageId, params.pageId, dispatch]);
   const { applicationId, pageId } = useParams<ExplorerURLParams>();
 
   return (

--- a/app/client/src/pages/Editor/WidgetsEditor.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor.tsx
@@ -16,7 +16,6 @@ import * as log from "loglevel";
 import { getCanvasClassName } from "utils/generators";
 import { flashElementsById } from "utils/helpers";
 import { useParams } from "react-router";
-import { fetchPage } from "actions/pageActions";
 import PerformanceTracker, {
   PerformanceTransactionName,
 } from "utils/PerformanceTracker";
@@ -69,13 +68,6 @@ function WidgetsEditor() {
   useEffect(() => {
     PerformanceTracker.stopTracking(PerformanceTransactionName.CLOSE_SIDE_PANE);
   });
-
-  // Switch page
-  useEffect(() => {
-    if (currentPageId !== params.pageId && !!params.pageId) {
-      dispatch(fetchPage(params.pageId));
-    }
-  }, [currentPageId, params.pageId, dispatch]);
 
   // log page load
   useEffect(() => {

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -36,6 +36,8 @@ import CommentShowCaseCarousel from "comments/CommentsShowcaseCarousel";
 import GitSyncModal from "pages/Editor/gitSync/GitSyncModal";
 
 import history from "utils/history";
+import { fetchPage } from "actions/pageActions";
+import * as log from "loglevel";
 
 type EditorProps = {
   currentApplicationId?: string;
@@ -53,6 +55,7 @@ type EditorProps = {
   lightTheme: Theme;
   resetEditorRequest: () => void;
   handlePathUpdated: (location: typeof window.location) => void;
+  fetchPage: (pageId: string) => void;
 };
 
 type Props = EditorProps & RouteComponentProps<BuilderRouteParams>;
@@ -80,6 +83,7 @@ class Editor extends Component<Props> {
     return (
       nextProps.currentApplicationName !== this.props.currentApplicationName ||
       nextProps.currentPageId !== this.props.currentPageId ||
+      nextProps.match?.params?.pageId !== this.props.currentPageId ||
       nextProps.currentApplicationId !== this.props.currentApplicationId ||
       nextProps.isEditorInitialized !== this.props.isEditorInitialized ||
       nextProps.isPublishing !== this.props.isPublishing ||
@@ -91,6 +95,14 @@ class Editor extends Component<Props> {
         this.props.creatingOnboardingDatabase ||
       nextState.registered !== this.state.registered
     );
+  }
+
+  componentDidUpdate() {
+    const { pageId } = this.props.match.params;
+    const { currentPageId } = this.props;
+    if (pageId !== currentPageId) {
+      this.props.fetchPage(pageId);
+    }
   }
 
   componentWillUnmount() {
@@ -165,6 +177,7 @@ const mapDispatchToProps = (dispatch: any) => {
     resetEditorRequest: () => dispatch(resetEditorRequest()),
     handlePathUpdated: (location: typeof window.location) =>
       dispatch(handlePathUpdated(location)),
+    fetchPage: (pageId: string) => dispatch(fetchPage(pageId)),
   };
 };
 

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -10,7 +10,6 @@ import { DndProvider } from "react-dnd";
 import TouchBackend from "react-dnd-touch-backend";
 import {
   getCurrentApplicationId,
-  getCurrentPageId,
   getIsEditorInitialized,
   getIsEditorLoading,
   getIsPublishingApplication,
@@ -40,7 +39,6 @@ import { fetchPage, updateCurrentPage } from "actions/pageActions";
 
 type EditorProps = {
   currentApplicationId?: string;
-  currentPageId?: string;
   currentApplicationName?: string;
   initEditor: (applicationId: string, pageId: string) => void;
   isPublishing: boolean;
@@ -82,7 +80,7 @@ class Editor extends Component<Props> {
   shouldComponentUpdate(nextProps: Props, nextState: { registered: boolean }) {
     return (
       nextProps.currentApplicationName !== this.props.currentApplicationName ||
-      nextProps.match?.params?.pageId !== this.props.currentPageId ||
+      nextProps.match?.params?.pageId !== this.props.match?.params?.pageId ||
       nextProps.currentApplicationId !== this.props.currentApplicationId ||
       nextProps.isEditorInitialized !== this.props.isEditorInitialized ||
       nextProps.isPublishing !== this.props.isPublishing ||
@@ -96,10 +94,10 @@ class Editor extends Component<Props> {
     );
   }
 
-  componentDidUpdate() {
-    const { pageId } = this.props.match.params;
-    const { currentPageId } = this.props;
-    if (pageId !== currentPageId) {
+  componentDidUpdate(prevProps: Props) {
+    const { pageId } = this.props.match.params || {};
+    const { pageId: prevPageId } = prevProps.match.params || {};
+    if (pageId && pageId !== prevPageId) {
       this.props.updateCurrentPage(pageId);
       this.props.fetchPage(pageId);
     }
@@ -158,7 +156,6 @@ class Editor extends Component<Props> {
 
 const mapStateToProps = (state: AppState) => ({
   currentApplicationId: getCurrentApplicationId(state),
-  currentPageId: getCurrentPageId(state),
   errorPublishing: getPublishingError(state),
   isPublishing: getIsPublishingApplication(state),
   isEditorLoading: getIsEditorLoading(state),

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -36,7 +36,7 @@ import CommentShowCaseCarousel from "comments/CommentsShowcaseCarousel";
 import GitSyncModal from "pages/Editor/gitSync/GitSyncModal";
 
 import history from "utils/history";
-import { fetchPage } from "actions/pageActions";
+import { fetchPage, updateCurrentPage } from "actions/pageActions";
 
 type EditorProps = {
   currentApplicationId?: string;
@@ -55,6 +55,7 @@ type EditorProps = {
   resetEditorRequest: () => void;
   handlePathUpdated: (location: typeof window.location) => void;
   fetchPage: (pageId: string) => void;
+  updateCurrentPage: (pageId: string) => void;
 };
 
 type Props = EditorProps & RouteComponentProps<BuilderRouteParams>;
@@ -99,6 +100,7 @@ class Editor extends Component<Props> {
     const { pageId } = this.props.match.params;
     const { currentPageId } = this.props;
     if (pageId !== currentPageId) {
+      this.props.updateCurrentPage(pageId);
       this.props.fetchPage(pageId);
     }
   }
@@ -176,6 +178,7 @@ const mapDispatchToProps = (dispatch: any) => {
     handlePathUpdated: (location: typeof window.location) =>
       dispatch(handlePathUpdated(location)),
     fetchPage: (pageId: string) => dispatch(fetchPage(pageId)),
+    updateCurrentPage: (pageId: string) => dispatch(updateCurrentPage(pageId)),
   };
 };
 

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -81,7 +81,6 @@ class Editor extends Component<Props> {
   shouldComponentUpdate(nextProps: Props, nextState: { registered: boolean }) {
     return (
       nextProps.currentApplicationName !== this.props.currentApplicationName ||
-      nextProps.currentPageId !== this.props.currentPageId ||
       nextProps.match?.params?.pageId !== this.props.currentPageId ||
       nextProps.currentApplicationId !== this.props.currentApplicationId ||
       nextProps.isEditorInitialized !== this.props.isEditorInitialized ||

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -37,7 +37,6 @@ import GitSyncModal from "pages/Editor/gitSync/GitSyncModal";
 
 import history from "utils/history";
 import { fetchPage } from "actions/pageActions";
-import * as log from "loglevel";
 
 type EditorProps = {
   currentApplicationId?: string;


### PR DESCRIPTION
## Description
Moving the effect at the parent component to make sure we track pageId from url params

Fixes #6996

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-current-page-id-not-tracking-pageid-param 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.01 **(0.01)** | 36.92 **(0.01)** | 33.87 **(-0.01)** | 55.55 **(0)**
 :green_circle: | app/client/src/pages/Editor/WidgetsEditor.tsx | 92.65 **(0.98)** | 75 **(3.12)** | 100 **(0)** | 92.31 **(1.01)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Actions/ActionEntity.tsx | 65 **(5)** | 0 **(0)** | 0 **(0)** | 65 **(5)**
 :green_circle: | app/client/src/pages/Editor/GeneratePage/components/ActionCards.tsx | 44.83 **(2.72)** | 100 **(100)** | 0 **(0)** | 54.17 **(5.69)**</details>