### PR TITLE
chore: Minor refactoring changes for RTS

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -88,7 +88,7 @@
     "lodash": "^4.17.21",
     "lodash-es": "4.17.14",
     "lodash-move": "^1.1.1",
-    "loglevel": "^1.6.7",
+    "loglevel": "^1.7.1",
     "lottie-web": "^5.7.4",
     "marked": "^2.0.0",
     "moment": "^2.24.0",

--- a/app/client/src/constants/WebsocketConstants.tsx
+++ b/app/client/src/constants/WebsocketConstants.tsx
@@ -15,3 +15,5 @@ export const websocketDisconnectedEvent = () => ({
 export const websocketConnectedEvent = () => ({
   type: WEBSOCKET_EVENTS.CONNECTED,
 });
+
+export const RTS_BASE_PATH = "/rts";

--- a/app/client/src/pages/Editor/Canvas.tsx
+++ b/app/client/src/pages/Editor/Canvas.tsx
@@ -17,6 +17,7 @@ import {
   APP_COLLAB_EVENTS,
   NAMESPACE_COLLAB_PAGE_EDIT,
 } from "constants/AppCollabConstants";
+import { RTS_BASE_PATH } from "constants/WebsocketConstants";
 import { isMultiplayerEnabledForUser as isMultiplayerEnabledForUserSelector } from "selectors/appCollabSelectors";
 
 interface CanvasProps {
@@ -25,7 +26,9 @@ interface CanvasProps {
 }
 
 // This auto connects the socket
-const pageEditSocket = io(NAMESPACE_COLLAB_PAGE_EDIT);
+const pageEditSocket = io(NAMESPACE_COLLAB_PAGE_EDIT, {
+  path: RTS_BASE_PATH,
+});
 
 const shareMousePointer = (e: any, pageId: string) => {
   if (store.getState().ui.appCollab.editors.length < 2) return;

--- a/app/client/src/sagas/WebsocketSagas/WebsocketSagas.ts
+++ b/app/client/src/sagas/WebsocketSagas/WebsocketSagas.ts
@@ -15,6 +15,7 @@ import {
 } from "constants/ReduxActionConstants";
 import {
   WEBSOCKET_EVENTS,
+  RTS_BASE_PATH,
   websocketDisconnectedEvent,
   websocketConnectedEvent,
 } from "constants/WebsocketConstants";
@@ -29,7 +30,9 @@ import { isMultiplayerEnabledForUser } from "selectors/appCollabSelectors";
 import { areCommentsEnabledForUserAndApp } from "selectors/commentsSelectors";
 
 function connect() {
-  const socket = io();
+  const socket = io({
+    path: RTS_BASE_PATH,
+  });
 
   return new Promise((resolve) => {
     socket.on("connect", () => {

--- a/app/rts/.env.example
+++ b/app/rts/.env.example
@@ -1,0 +1,2 @@
+APPSMITH_MONGODB_URI=mongodb://localhost:27017/appsmith
+APPSMITH_API_BASE_URL=http://localhost:8080/api/v1

--- a/app/rts/package.json
+++ b/app/rts/package.json
@@ -6,11 +6,16 @@
   "author": "Appsmith Team",
   "license": "Apache-2.0",
   "private": true,
+  "engines": {
+    "node": "^14.15.4",
+    "npm": "^6.14.10"
+  },
   "devDependencies": {
     "@types/express": "^4.17.11",
     "@types/mongodb": "^3.6.10",
     "axios": "^0.21.1",
     "express": "^4.17.1",
+    "loglevel": "^1.7.1",
     "mongodb": "^3.6.4",
     "socket.io": "^4.1.3",
     "socket.io-adapter": "^2.3.2",

--- a/app/rts/src/server.ts
+++ b/app/rts/src/server.ts
@@ -5,6 +5,8 @@ import { Server, Socket } from "socket.io"
 import { MongoClient, ObjectId } from "mongodb"
 import type mongodb from "mongodb"
 import axios from "axios"
+import { LogLevelDesc } from "loglevel";
+import log from "loglevel";
 import { AppUser, CurrentEditorsEvent, Policy, Comment, CommentThread, MousePointerEvent } from "./models"
 
 const APP_ROOM_PREFIX : string = "app:"
@@ -17,16 +19,19 @@ const START_EDIT_EVENT_NAME : string = "collab:start_edit"
 const LEAVE_EDIT_EVENT_NAME : string = "collab:leave_edit"
 const MOUSE_POINTER_EVENT_NAME : string = "collab:mouse_pointer"
 
+// Setting the logLevel for all log messages
+const logLevel : LogLevelDesc = (process.env.APPSMITH_LOG_LEVEL || "debug") as LogLevelDesc
+log.setLevel(logLevel);
 
 const MONGODB_URI = process.env.APPSMITH_MONGODB_URI
 if (MONGODB_URI == null || MONGODB_URI === "" || !MONGODB_URI.startsWith("mongodb")) {
-	console.error("Please provide a valid value for `APPSMITH_MONGODB_URI`.")
+	log.error("Please provide a valid value for `APPSMITH_MONGODB_URI`.")
 	process.exit(1)
 }
 
 const API_BASE_URL = process.env.APPSMITH_API_BASE_URL
 if (API_BASE_URL == null || API_BASE_URL === "") {
-	console.error("Please provide a valid value for `APPSMITH_API_BASE_URL`.")
+	log.error("Please provide a valid value for `APPSMITH_API_BASE_URL`.")
 	process.exit(1)
 }
 
@@ -34,6 +39,8 @@ main()
 
 function main() {
 	const app = express()
+	//Disable x-powered-by header to prevent information disclosure
+	app.disable("x-powered-by");
 	const server = new http.Server(app)
 	const io = new Server(server, {
 		// TODO: Remove this CORS configuration.
@@ -51,38 +58,38 @@ function main() {
 	io.on("connection", (socket: Socket) => {
 		subscribeToEditEvents(socket, APP_ROOM_PREFIX)
 		onAppSocketConnected(socket)
-			.catch((error) => console.error("Error in socket connected handler", error))
+			.catch((error) => log.error("Error in socket connected handler", error))
 	})
 
 	io.of(PAGE_EDIT_NAMESPACE).on("connection", (socket: Socket) => {
 		subscribeToEditEvents(socket, PAGE_ROOM_PREFIX);
 		onPageSocketConnected(socket, io)
-			.catch((error) => console.error("Error in socket connected handler", error))
+			.catch((error) => log.error("Error in socket connected handler", error))
 	});
 
 	io.of(ROOT_NAMESPACE).adapter.on("leave-room", (room, id) => {
-		console.log(`ns:${ROOT_NAMESPACE}# socket ${id} left the room ${room}`)
+		log.debug(`ns:${ROOT_NAMESPACE}# socket ${id} left the room ${room}`)
 		sendCurrentUsers(io, room, APP_ROOM_PREFIX);
 	});
 	
 	io.of(ROOT_NAMESPACE).adapter.on("join-room", (room, id) => {
-		console.log(`ns:${ROOT_NAMESPACE}# socket ${id} joined the room ${room}`)
+		log.debug(`ns:${ROOT_NAMESPACE}# socket ${id} joined the room ${room}`)
 		sendCurrentUsers(io, room, APP_ROOM_PREFIX);
 	});
 
 	io.of(PAGE_EDIT_NAMESPACE).adapter.on("leave-room", (room, id) => {
-		console.log(`ns:${PAGE_EDIT_NAMESPACE}# socket ${id} left the room ${room}`)
+		log.debug(`ns:${PAGE_EDIT_NAMESPACE}# socket ${id} left the room ${room}`)
 		if(room.startsWith(PAGE_ROOM_PREFIX)) { // someone left the page edit, notify others
 			io.of(PAGE_EDIT_NAMESPACE).to(room).emit(LEAVE_EDIT_EVENT_NAME, id);
 		}
 	});
 
 	watchMongoDB(io)
-		.catch((error) => console.error("Error watching MongoDB", error))
+		.catch((error) => log.error("Error watching MongoDB", error))
 
 	app.use(express.static(path.join(__dirname, "static")))
 	server.listen(port, () => {
-		console.log(`RTS running at http://localhost:${port}`)
+		log.info(`RTS running at http://localhost:${port}`)
 	})
 }
 
@@ -145,7 +152,7 @@ async function tryAuth(socket:Socket) {
 			try {
 				response = await axios.request({
 					method: "GET",
-					url: API_BASE_URL + "/applications/new",
+					url: API_BASE_URL + "/users/me",
 					headers: {
 						Cookie: sessionCookie,
 					},
@@ -154,9 +161,9 @@ async function tryAuth(socket:Socket) {
 				if (error.response?.status === 401) {
 					console.info("401 received when authenticating user with cookie: " + sessionCookie)
 				} else if(error.response) {
-					console.error("Error response received while authentication: ", error.response)
+					log.error("Error response received while authentication: ", error.response)
 				} else {
-					console.error("Error authenticating", error)
+					log.error("Error authenticating", error)
 				}
 				return false
 			}
@@ -251,7 +258,7 @@ async function watchMongoDB(io) {
 		
 		if (thread == null) {
 			// This happens when `event.operationType === "drop"`, when a comment is deleted.
-			console.error("Null document recieved for comment change event", event)
+			log.error("Null document recieved for comment change event", event)
 			return
 		}
 
@@ -295,7 +302,7 @@ async function watchMongoDB(io) {
 
 		if (notification == null) {
 			// This happens when `event.operationType === "drop"`, when a notification is deleted.
-			console.error("Null document recieved for notification change event", event)
+			log.error("Null document recieved for notification change event", event)
 			return
 		}
 
@@ -308,11 +315,11 @@ async function watchMongoDB(io) {
 	})
 
 	process.on('uncaughtExceptionMonitor', (err, origin) => {
-		console.error(`Caught exception: ${err}\n` + `Exception origin: ${origin}`);
+		log.error(`Caught exception: ${err}\n` + `Exception origin: ${origin}`);
 	});
 
 	process.on('unhandledRejection', (reason, promise) => {
-		console.log('Unhandled Rejection at:', promise, 'reason:', reason);
+		log.debug('Unhandled Rejection at:', promise, 'reason:', reason);
 	});
 
 	process.on("exit", () => {
@@ -321,7 +328,7 @@ async function watchMongoDB(io) {
 			.finally("Fin")
 	})
 
-	console.log("Watching MongoDB")
+	log.debug("Watching MongoDB")
 }
 
 function findPolicyEmails(policies: Policy[], permission: string): string[] {

--- a/app/rts/src/server.ts
+++ b/app/rts/src/server.ts
@@ -170,7 +170,13 @@ async function tryAuth(socket:Socket) {
 		
 			const email = response.data.data.user.email
 			const name = response.data.data.user.name ? response.data.data.user.name : email;
-		
+
+			// If the session check API succeeds & the email/name is anonymousUser, then the user is not authenticated
+			// and we should not allow them to join any rooms
+			if (email === "anonymousUser" || name === "anonymousUser") {
+				return false;
+			}
+
 			socket.data.email = email
 			socket.data.name = name
 			

--- a/app/rts/yarn.lock
+++ b/app/rts/yarn.lock
@@ -395,6 +395,11 @@ isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+loglevel@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
+  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"


### PR DESCRIPTION
## Description

* Adding logLevel library to RTS. Helps us control the logging level for RTS in different environments. 
* Moving the session login check to `/users/me` API instead of the data heavy `/applications/new`
* Removing the information about express header. This is a security loophole.

## Type of change

Chore PR

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: refactor-rts 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/constants/WebsocketConstants.tsx | 72.73 **(2.73)** | 100 **(0)** | 0 **(0)** | 100 **(0)**
 :green_circle: | app/client/src/pages/Editor/Canvas.tsx | 65.85 **(0.85)** | 28.57 **(0)** | 50 **(0)** | 66.67 **(0.88)**</details>