### PR TITLE
fix: Fixes mouse click for slash commands

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -350,7 +350,8 @@ class CodeEditor extends Component<Props, State> {
     const entityInformation = this.getEntityInformation();
     if (
       entityInformation.entityType === ENTITY_TYPE.WIDGET &&
-      this.editor.getValue().length === 0
+      this.editor.getValue().length === 0 &&
+      !this.editor.state.completionActive
     )
       this.handleAutocompleteVisibility(this.editor);
   };
@@ -388,8 +389,7 @@ class CodeEditor extends Component<Props, State> {
     const inputValue = this.props.input.value || "";
     if (
       this.props.input.onChange &&
-      (value !== inputValue ||
-        _.get(this.editor, "state.completionActive.startLen") === 0) &&
+      value !== inputValue &&
       this.state.isFocused
     ) {
       this.props.input.onChange(value);


### PR DESCRIPTION
## Description
Fixes slash command mouse click in property pane.

Fixes #6976 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/slash-command-click-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.92 **(-0.01)** | 36.82 **(-0.01)** | 33.65 **(0)** | 55.47 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>