### PR TITLE
fix: fix missed out errorType field for debugger error analytics

### DIFF
--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -92,6 +92,7 @@ export interface ActionResponse {
   isExecutionSuccess?: boolean;
   suggestedWidgets?: SuggestedWidget[];
   messages?: Array<string>;
+  errorType?: string;
 }
 
 export interface MoveActionRequest {

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -309,6 +309,7 @@ export default function* executePluginActionTriggerSaga(
         {
           message: payload.body as string,
           type: PLATFORM_ERROR.PLUGIN_EXECUTION,
+          subType: payload.errorType,
         },
       ],
     });
@@ -452,6 +453,7 @@ function* runActionSaga(
         {
           message: error,
           type: PLATFORM_ERROR.PLUGIN_EXECUTION,
+          subType: payload.errorType,
         },
       ],
       state: payload.request,
@@ -549,7 +551,13 @@ function* executePageLoadAction(pageAction: PageAction) {
         id: pageAction.id,
       },
       state: payload.request,
-      messages: [{ message: error, type: PLATFORM_ERROR.PLUGIN_EXECUTION }],
+      messages: [
+        {
+          message: error,
+          type: PLATFORM_ERROR.PLUGIN_EXECUTION,
+          subType: payload.errorType,
+        },
+      ],
     });
 
     yield put(


### PR DESCRIPTION
The errorType field was missed out in https://github.com/appsmithorg/appsmith/pull/6253 changes. Adding it to send the same for debugger error analytics

## Description

Related to https://github.com/appsmithorg/appsmith/pull/6754

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/action-subtype-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.94 **(0)** | 36.83 **(0)** | 33.62 **(-0.01)** | 55.48 **(-0.01)**
 :red_circle: | app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx | 78.85 **(-1.92)** | 89.66 **(0)** | 33.33 **(-8.34)** | 77.08 **(-2.09)**</details>