### PR TITLE
fix: closing hint menu when space/semicolon is entered

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -87,6 +87,8 @@ const AUTOCOMPLETE_CLOSE_KEY_CODES = [
   "Escape",
   "Comma",
   "Backspace",
+  "Semicolon",
+  "Space",
 ];
 
 interface ReduxStateProps {


### PR DESCRIPTION
## Description

Added "Space" and "Semicolon" to the list of characters that trigger the closeHint function on the editor.

Fixes #6243


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Manual testing


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>