### PR TITLE
fix: center align emoji for non-retina displays

### DIFF
--- a/app/client/src/components/ads/EmojiReactions.tsx
+++ b/app/client/src/components/ads/EmojiReactions.tsx
@@ -32,8 +32,6 @@ const Bubble = styled.div<{ active?: boolean }>`
   margin-top: ${(props) => `${props.theme.radii[1]}px`};
 
   & span.emoji {
-    min-width: 20px;
-    text-align: center;
     /*
     * center align emoji for non-retina displays
     * https://bugs.chromium.org/p/chromium/issues/detail?id=551420#c15
@@ -60,6 +58,7 @@ const Count = styled.div<{ active?: boolean }>`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  margin-left: 2px;
 `;
 
 const ReactionsByContainer = styled.span`

--- a/app/client/src/components/ads/EmojiReactions.tsx
+++ b/app/client/src/components/ads/EmojiReactions.tsx
@@ -31,10 +31,22 @@ const Bubble = styled.div<{ active?: boolean }>`
   margin-right: ${(props) => `${props.theme.radii[1]}px`};
   margin-top: ${(props) => `${props.theme.radii[1]}px`};
 
-  /* At times the rendered emoji has width as 16px */
   & span.emoji {
     min-width: 20px;
     text-align: center;
+    /*
+    * center align emoji for non-retina displays
+    * https://bugs.chromium.org/p/chromium/issues/detail?id=551420#c15
+    * ref: https://stackoverflow.com/a/31578187/1543567 (mq for non-retina displays)
+    */
+    @media not screen and (-webkit-min-device-pixel-ratio: 2),
+      not screen and (min--moz-device-pixel-ratio: 2),
+      not screen and (-o-min-device-pixel-ratio: 2/1),
+      not screen and (min-device-pixel-ratio: 2),
+      not screen and (min-resolution: 192dpi),
+      not screen and (min-resolution: 2dppx) {
+      margin-right: 3px;
+    }
   }
 `;
 


### PR DESCRIPTION
## Description
Unicode emojis are not center aligned horizontally on non-retina displays
Add a margin to fix that

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix-emoji-alignment-non-retina-display 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.94 **(0)** | 36.8 **(-0.01)** | 33.69 **(0)** | 55.48 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>