### PR TITLE
fix: Include a default value for server proxy pass

### DIFF
--- a/app/client/Dockerfile
+++ b/app/client/Dockerfile
@@ -4,6 +4,8 @@ COPY ./build /var/www/appsmith
 
 EXPOSE 80
 
+ENV APPSMITH_SERVER_PROXY_PASS="http://appsmith-internal-server:8080"
+
 # This is the default nginx template file inside the container.
 # This is replaced by the install.sh script during a deployment
 # COPY ./docker/templates/nginx-app.conf.template /nginx.conf.template


### PR DESCRIPTION
The env variable APPSMITH_SERVER_PROXY_PASS is missing a default value, and the start script in client image requires this. But since this env variable is not set on any _existing_ installations, they will break. So to fix that, we are adding an initial value to this variable to a sensible default.

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/client-image-on-existing-installations 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.94 **(0)** | 36.81 **(0.01)** | 33.69 **(0)** | 55.49 **(0.01)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>