### PR TITLE
feat: Add horizontal tabs in gitSync Modal

### DIFF
--- a/app/client/src/components/ads/TabItemBackgroundFill.tsx
+++ b/app/client/src/components/ads/TabItemBackgroundFill.tsx
@@ -9,19 +9,22 @@ type WrapperProps = {
   theme: Theme;
 };
 
-const getSelectedStyles = (props: WrapperProps) =>
-  props.selected
-    ? `color: ${props.theme.colors.tabItemBackgroundFill.highlightTextColor};
-      font-weight: 500;
-      border-bottom: 2px solid ${props.theme.colors.info.light};
-     `
-    : `color: ${props.theme.colors.tabItemBackgroundFill.textColor};
-      `;
+const getFocusedStyles = (props: WrapperProps) => `
+  background-color: ${props.theme.colors.tabItemBackgroundFill.highlightBackground};
+  color: ${props.theme.colors.tabItemBackgroundFill.highlightTextColor};
+  font-weight: 500;
+`;
 
 const Wrapper = styled.div<WrapperProps>`
   display: flex;
-  ${(props) => getTypographyByKey(props, "p1")};
-  ${(props) => getSelectedStyles(props)};
+  ${(props) => getTypographyByKey(props, "p1")}
+
+  ${(props) =>
+    props.selected
+      ? getFocusedStyles(props)
+      : `
+      color: ${props.theme.colors.tabItemBackgroundFill.textColor};  
+    `};
 
   &:hover,
   &:focus {
@@ -29,7 +32,8 @@ const Wrapper = styled.div<WrapperProps>`
       props.theme.colors.tabItemBackgroundFill.highlightTextColor};
   }
 
-  padding: ${(props) => `${props.theme.spaces[5]}px 0px`};
+  padding: ${(props) =>
+    `${props.theme.spaces[5] - 1}px ${props.theme.spaces[11]}px`};
 
   width: 100%;
 `;
@@ -41,7 +45,7 @@ export default function TabItemBackgroundFill(props: {
 }) {
   const { selected, tab, vertical } = props;
   return (
-    <Wrapper key={tab.title} selected={selected} vertical={vertical}>
+    <Wrapper selected={selected} vertical={vertical}>
       {tab.title}
     </Wrapper>
   );

--- a/app/client/src/components/ads/TabItemBackgroundFill.tsx
+++ b/app/client/src/components/ads/TabItemBackgroundFill.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { TabProp } from "./Tabs";
 import { getTypographyByKey, Theme } from "constants/DefaultTheme";
+import { Colors } from "../../constants/Colors";
 
 type WrapperProps = {
   selected: boolean;
@@ -9,31 +10,27 @@ type WrapperProps = {
   theme: Theme;
 };
 
-const getFocusedStyles = (props: WrapperProps) => `
-  background-color: ${props.theme.colors.tabItemBackgroundFill.highlightBackground};
-  color: ${props.theme.colors.tabItemBackgroundFill.highlightTextColor};
-  font-weight: 500;
-`;
+const getSelectedStyles = (props: WrapperProps) =>
+  props.selected
+    ? `color: ${props.theme.colors.tabItemBackgroundFill.highlightTextColor};
+      font-weight: 500;
+      border-bottom: 2px solid ${props.theme.colors.info.light};
+     `
+    : `color: ${props.theme.colors.tabItemBackgroundFill.textColor};
+      `;
 
 const Wrapper = styled.div<WrapperProps>`
   display: flex;
-  ${(props) => getTypographyByKey(props, "p1")}
-
-  ${(props) =>
-    props.selected
-      ? getFocusedStyles(props)
-      : `
-      color: ${props.theme.colors.tabItemBackgroundFill.textColor};  
-    `};
+  ${(props) => getTypographyByKey(props, "p1")};
+  ${(props) => getSelectedStyles(props)};
 
   &:hover,
   &:focus {
     color: ${(props) =>
-      props.theme.colors.tabItemBackgroundFill.highlightTextColor};}
+      props.theme.colors.tabItemBackgroundFill.highlightTextColor};
   }
 
-  padding: ${(props) =>
-    `${props.theme.spaces[5] - 1}px ${props.theme.spaces[11]}px`};
+  padding: ${(props) => `${props.theme.spaces[5]}px 0px`};
 
   width: 100%;
 `;
@@ -45,7 +42,7 @@ export default function TabItemBackgroundFill(props: {
 }) {
   const { selected, tab, vertical } = props;
   return (
-    <Wrapper selected={selected} vertical={vertical}>
+    <Wrapper key={tab.title} selected={selected} vertical={vertical}>
       {tab.title}
     </Wrapper>
   );

--- a/app/client/src/components/ads/TabItemBackgroundFill.tsx
+++ b/app/client/src/components/ads/TabItemBackgroundFill.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import { TabProp } from "./Tabs";
 import { getTypographyByKey, Theme } from "constants/DefaultTheme";
-import { Colors } from "../../constants/Colors";
 
 type WrapperProps = {
   selected: boolean;

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -430,7 +430,7 @@ export const SNIPPET_EXECUTION_FAILED = () => `Snippet execution failed.`;
 export const SEARCH_ITEM_SELECT = () => `Hit ⏎ to insert`;
 export const APPLY_SEARCH_CATEGORY = () => `⏎ Jump`;
 // Git sync
-export const GIT_CONNECTION = () => "GIT Connection";
+export const GIT_CONNECTION = () => "Git Connections";
 export const DEPLOY = () => "Deploy";
 export const MERGE = () => "Merge";
 export const SHARE_APPLICATION = () => "Share Application";

--- a/app/client/src/pages/Editor/gitSync/GitSyncModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/GitSyncModal.tsx
@@ -48,9 +48,9 @@ const CloseBtnContainer = styled.div`
   border-radius: ${(props) => props.theme.radii[1]}px;
 `;
 
-function NoopComponent() {
-  return <div />;
-}
+// function NoopComponent() {
+//   return <div />;
+// }
 
 const ComponentsByTab = {
   [MENU_ITEM.GIT_CONNECTION]: GitConnection,

--- a/app/client/src/pages/Editor/gitSync/GitSyncModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/GitSyncModal.tsx
@@ -15,9 +15,10 @@ import { Colors } from "constants/Colors";
 import { Classes } from "./constants";
 
 const Container = styled.div`
-  height: 70vh;
+  height: 660px;
   width: 100%;
   display: flex;
+  flex-direction: column;
   position: relative;
   overflow-y: hidden;
 `;
@@ -32,17 +33,14 @@ const BodyContainer = styled.div`
 `;
 
 const MenuContainer = styled.div`
-  flex: 1;
-  height: 100%;
-  background-color: ${(props) =>
-    props.theme.colors.gitSyncModal.menuBackgroundColor};
-  padding-top: ${(props) => props.theme.spaces[15]}px;
+  padding: ${(props) =>
+    `${props.theme.spaces[12]}px ${props.theme.spaces[10]}px ${props.theme.spaces[6]}px;`};
 `;
 
 const CloseBtnContainer = styled.div`
   position: absolute;
-  right: 55px;
-  top: 53px;
+  right: 10px;
+  top: 10px;
   &:hover {
     background-color: ${(props) => props.theme.colors.modal.hoverState};
   }
@@ -58,8 +56,8 @@ const ComponentsByTab = {
   [MENU_ITEM.GIT_CONNECTION]: GitConnection,
   [MENU_ITEM.DEPLOY]: Deploy,
   [MENU_ITEM.MERGE]: Merge,
-  [MENU_ITEM.SHARE_APPLICATION]: NoopComponent,
-  [MENU_ITEM.SETTINGS]: NoopComponent,
+  // [MENU_ITEM.SHARE_APPLICATION]: NoopComponent,
+  // [MENU_ITEM.SETTINGS]: NoopComponent,
 };
 
 function GitSyncModal() {
@@ -81,7 +79,7 @@ function GitSyncModal() {
       isOpen={isModalOpen}
       maxWidth={"900px"}
       onClose={handleClose}
-      width={"60vw"}
+      width={"600px"}
     >
       <Container>
         <MenuContainer>

--- a/app/client/src/pages/Editor/gitSync/Menu.tsx
+++ b/app/client/src/pages/Editor/gitSync/Menu.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { TabComponent } from "components/ads/Tabs";
 import { MENU_ITEMS } from "./constants";
-import TabItemBackgroundFill from "components/ads/TabItemBackgroundFill";
 import styled from "styled-components";
 import { Colors } from "constants/Colors";
+import TabItem from "./components/TabItem";
 
 type Props = {
   activeTabIndex: number;
@@ -26,7 +26,7 @@ export default function Menu(props: Props) {
       <TabComponent
         onSelect={props.onSelect}
         selectedIndex={props.activeTabIndex || 0}
-        tabItemComponent={TabItemBackgroundFill}
+        tabItemComponent={TabItem}
         tabs={MENU_ITEMS}
       />
     </TabWrapper>

--- a/app/client/src/pages/Editor/gitSync/Menu.tsx
+++ b/app/client/src/pages/Editor/gitSync/Menu.tsx
@@ -2,20 +2,33 @@ import React from "react";
 import { TabComponent } from "components/ads/Tabs";
 import { MENU_ITEMS } from "./constants";
 import TabItemBackgroundFill from "components/ads/TabItemBackgroundFill";
+import styled from "styled-components";
+import { Colors } from "constants/Colors";
 
 type Props = {
   activeTabIndex: number;
   onSelect: (index: number) => void;
 };
 
+const TabWrapper = styled.div`
+  .react-tabs {
+    border-bottom: 1px solid ${Colors.ALTO2};
+  }
+  .react-tabs__tab {
+    margin-right: 0px;
+    padding-right: ${(props) => props.theme.spaces[8]}px;
+  }
+`;
+
 export default function Menu(props: Props) {
   return (
-    <TabComponent
-      onSelect={props.onSelect}
-      selectedIndex={props.activeTabIndex || 0}
-      tabItemComponent={TabItemBackgroundFill}
-      tabs={MENU_ITEMS}
-      vertical
-    />
+    <TabWrapper>
+      <TabComponent
+        onSelect={props.onSelect}
+        selectedIndex={props.activeTabIndex || 0}
+        tabItemComponent={TabItemBackgroundFill}
+        tabs={MENU_ITEMS}
+      />
+    </TabWrapper>
   );
 }

--- a/app/client/src/pages/Editor/gitSync/components/TabItem.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/TabItem.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import styled from "styled-components";
+import { getTypographyByKey, Theme } from "constants/DefaultTheme";
+import { TabProp } from "components/ads/Tabs";
+
+type WrapperProps = {
+  selected: boolean;
+  vertical: boolean;
+  theme: Theme;
+};
+
+const getSelectedStyles = (props: WrapperProps) =>
+  props.selected
+    ? `color: ${props.theme.colors.tabItemBackgroundFill.highlightTextColor};
+      font-weight: 500;
+      border-bottom: 2px solid ${props.theme.colors.info.light};
+     `
+    : `color: ${props.theme.colors.tabItemBackgroundFill.textColor};
+      `;
+
+const Wrapper = styled.div<WrapperProps>`
+  display: flex;
+  ${(props) => getTypographyByKey(props, "p1")};
+  ${(props) => getSelectedStyles(props)};
+
+  &:hover,
+  &:focus {
+    color: ${(props) =>
+      props.theme.colors.tabItemBackgroundFill.highlightTextColor};
+  }
+
+  padding: ${(props) => `${props.theme.spaces[5]}px 0px`};
+
+  width: 100%;
+`;
+
+export default function TabItem(props: {
+  tab: TabProp;
+  selected: boolean;
+  vertical: boolean;
+}) {
+  const { selected, tab, vertical } = props;
+  return (
+    <Wrapper key={tab.title} selected={selected} vertical={vertical}>
+      {tab.title}
+    </Wrapper>
+  );
+}

--- a/app/client/src/pages/Editor/gitSync/constants.ts
+++ b/app/client/src/pages/Editor/gitSync/constants.ts
@@ -12,8 +12,8 @@ export enum MENU_ITEM {
   GIT_CONNECTION = "GIT_CONNECTION",
   DEPLOY = "DEPLOY",
   MERGE = "MERGE",
-  SHARE_APPLICATION = "SHARE_APPLICATION",
-  SETTINGS = "SETTINGS",
+  // SHARE_APPLICATION = "SHARE_APPLICATION",
+  // SETTINGS = "SETTINGS",
 }
 
 export const MENU_ITEMS: TabProp[] = [
@@ -29,14 +29,14 @@ export const MENU_ITEMS: TabProp[] = [
     key: MENU_ITEM.MERGE,
     title: createMessage(MERGE),
   },
-  {
-    key: MENU_ITEM.SHARE_APPLICATION,
-    title: createMessage(SHARE_APPLICATION),
-  },
-  {
-    key: MENU_ITEM.SETTINGS,
-    title: createMessage(SETTINGS),
-  },
+  // {
+  //   key: MENU_ITEM.SHARE_APPLICATION,
+  //   title: createMessage(SHARE_APPLICATION),
+  // },
+  // {
+  //   key: MENU_ITEM.SETTINGS,
+  //   title: createMessage(SETTINGS),
+  // },
 ];
 
 export enum AUTH_TYPE {

--- a/app/client/src/pages/Editor/gitSync/constants.ts
+++ b/app/client/src/pages/Editor/gitSync/constants.ts
@@ -4,8 +4,8 @@ import {
   GIT_CONNECTION,
   DEPLOY,
   MERGE,
-  SHARE_APPLICATION,
-  SETTINGS,
+  // SHARE_APPLICATION,
+  // SETTINGS,
 } from "constants/messages";
 
 export enum MENU_ITEM {


### PR DESCRIPTION
## Description

This change adds horizontal tabs in gitSync Modal as per the new [design](https://www.figma.com/file/lqtUfzJO50RpEhxKttYeOg/Local-Dev-Main?node-id=1913%3A51585).

<img width="1440" alt="Screenshot 2021-09-02 at 1 37 29 PM" src="https://user-images.githubusercontent.com/23132741/131806873-71284ddb-bf1a-409e-914d-a509899b7f99.png">


Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually in local

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/git-sync-ui 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.02 **(0)** | 36.9 **(-0.01)** | 33.89 **(0)** | 55.56 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>