### PR TITLE
fix: Promise action backwards compatibility

### DIFF
--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -213,7 +213,7 @@ export const ERROR_DATEPICKER_MAX_DATE = () =>
   `Min date cannot be greater than current widget value`;
 export const ERROR_WIDGET_DOWNLOAD = (err: string) => `Download failed. ${err}`;
 export const ERROR_PLUGIN_ACTION_EXECUTE = (actionName: string) =>
-  `${actionName} failed to execute. Please check it's configuration`;
+  `${actionName} failed to execute`;
 export const ERROR_FAIL_ON_PAGE_LOAD_ACTIONS = () =>
   `Failed to execute actions during page load`;
 export const ERROR_ACTION_EXECUTE_FAIL = (actionName: string) =>

--- a/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
@@ -34,12 +34,18 @@ export function* executeActionTriggers(
   trigger: ActionDescription,
   eventType: EventType,
 ) {
+  // when called via a promise, a trigger can return some value to be used in .then
+  let response: unknown[] = [];
   switch (trigger.type) {
     case ActionTriggerType.PROMISE:
       yield call(executePromiseSaga, trigger.payload, eventType);
       break;
     case ActionTriggerType.RUN_PLUGIN_ACTION:
-      yield call(executePluginActionTriggerSaga, trigger.payload, eventType);
+      response = yield call(
+        executePluginActionTriggerSaga,
+        trigger.payload,
+        eventType,
+      );
       break;
     case ActionTriggerType.CLEAR_PLUGIN_ACTION:
       yield put(clearActionResponse(trigger.payload.actionId));
@@ -72,6 +78,7 @@ export function* executeActionTriggers(
       log.error("Trigger type unknown", trigger);
       throw Error("Trigger type unknown");
   }
+  return response;
 }
 
 export function* executeAppAction(payload: ExecuteTriggerPayload) {

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -84,7 +84,7 @@ import {
 import { SAAS_EDITOR_API_ID_URL } from "pages/Editor/SaaSEditor/constants";
 import { RunPluginActionDescription } from "entities/DataTree/actionTriggers";
 import { ApiResponse } from "api/ApiResponses";
-import { TriggerFailureError } from "sagas/ActionExecution/PromiseActionSaga";
+import { PluginTriggerFailureError } from "sagas/ActionExecution/PromiseActionSaga";
 import { APP_MODE } from "entities/App";
 import FileDataTypes from "widgets/FileDataTypes";
 import { hideDebuggerErrors } from "actions/debuggerActions";
@@ -152,7 +152,7 @@ function* readBlob(blobUrl: string): any {
   const [url, fileType] = parseBlobUrl(blobUrl);
   const file = yield fetch(url).then((r) => r.blob());
 
-  const data = yield new Promise((resolve) => {
+  return yield new Promise((resolve) => {
     const reader = new FileReader();
     if (fileType === FileDataTypes.Base64) {
       reader.readAsDataURL(file);
@@ -165,7 +165,6 @@ function* readBlob(blobUrl: string): any {
       resolve(reader.result);
     };
   });
-  return data;
 }
 
 /**
@@ -277,7 +276,6 @@ export default function* executePluginActionTriggerSaga(
 
   let payload = EMPTY_RESPONSE;
   let isError = true;
-  let error = "";
   try {
     const executePluginActionResponse: ExecutePluginActionResponse = yield call(
       executePluginActionSaga,
@@ -291,7 +289,6 @@ export default function* executePluginActionTriggerSaga(
     if (e instanceof UserCancelledActionExecutionError) {
       return;
     }
-    error = e.message;
   }
 
   if (isError) {
@@ -312,14 +309,9 @@ export default function* executePluginActionTriggerSaga(
         },
       ],
     });
-    Toaster.show({
-      text: createMessage(ERROR_PLUGIN_ACTION_EXECUTE, action.name),
-      variant: Variant.danger,
-      showDebugButton: true,
-    });
-    throw new TriggerFailureError(
-      "Failed to execute plugin action",
-      new Error(error),
+    throw new PluginTriggerFailureError(
+      createMessage(ERROR_PLUGIN_ACTION_EXECUTE, action.name),
+      [payload.body, params],
     );
   } else {
     AppsmithConsole.info({
@@ -337,6 +329,7 @@ export default function* executePluginActionTriggerSaga(
       },
     });
   }
+  return [payload.body, params];
 }
 
 function* runActionShortcutSaga() {

--- a/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
@@ -10,6 +10,7 @@ import { getAppMode } from "selectors/entitiesSelector";
 import { APP_MODE } from "entities/App";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
+import { ACTION_ANONYMOUS_FUNC_REGEX } from "components/editorComponents/ActionCreator/Fields";
 
 export class TriggerFailureError extends Error {
   error?: Error;
@@ -19,24 +20,37 @@ export class TriggerFailureError extends Error {
   }
 }
 
+export class PluginTriggerFailureError extends TriggerFailureError {
+  responseData: unknown[] = [];
+  constructor(reason: string, responseData: unknown[]) {
+    super(reason);
+    this.responseData = responseData;
+  }
+}
+
 export default function* executePromiseSaga(
   trigger: AppsmithPromisePayload,
   eventType: EventType,
 ): any {
   try {
-    yield all(
+    const responses = yield all(
       trigger.executor.map((executionTrigger) =>
         call(executeActionTriggers, executionTrigger, eventType),
       ),
     );
     if (trigger.then) {
       if (trigger.then.length) {
+        let responseData: unknown[] = [];
+        if (responses.length === 1) {
+          responseData = responses[0];
+        }
         for (const thenable of trigger.then) {
-          yield call(executeAppAction, {
+          responseData = yield call(executeAppAction, {
             dynamicString: thenable,
             event: {
               type: eventType,
             },
+            responseData,
           });
         }
       }
@@ -44,20 +58,28 @@ export default function* executePromiseSaga(
   } catch (e) {
     log.error(e);
     const appMode = yield select(getAppMode);
-    if (appMode === APP_MODE.EDIT) {
+    if (appMode === APP_MODE.EDIT && !trigger.catch) {
       Toaster.show({
-        text: "There was an error while executing",
+        text: e.message || "There was an error while executing",
         variant: Variant.danger,
         showDebugButton: true,
       });
     }
     if (trigger.catch) {
+      let responseData = [e.message];
+      if (e instanceof PluginTriggerFailureError) {
+        responseData = e.responseData;
+      }
+      const catchArguments = ACTION_ANONYMOUS_FUNC_REGEX.test(trigger.catch)
+        ? responseData
+        : undefined;
+
       yield call(executeAppAction, {
         dynamicString: trigger.catch,
         event: {
           type: eventType,
         },
-        responseData: [e.message],
+        responseData: catchArguments,
       });
     } else {
       throw new TriggerFailureError("Uncaught promise rejection", e);

--- a/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
@@ -57,8 +57,7 @@ export default function* executePromiseSaga(
     }
   } catch (e) {
     log.error(e);
-    const appMode = yield select(getAppMode);
-    if (appMode === APP_MODE.EDIT && !trigger.catch) {
+    if (!trigger.catch) {
       Toaster.show({
         text: e.message || "There was an error while executing",
         variant: Variant.danger,
@@ -70,6 +69,7 @@ export default function* executePromiseSaga(
       if (e instanceof PluginTriggerFailureError) {
         responseData = e.responseData;
       }
+      // if the catch callback is not an anonymous function, passing arguments will cause errors in execution
       const catchArguments = ACTION_ANONYMOUS_FUNC_REGEX.test(trigger.catch)
         ? responseData
         : undefined;

--- a/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
@@ -3,11 +3,9 @@ import {
   executeActionTriggers,
   executeAppAction,
 } from "sagas/ActionExecution/ActionExecutionSagas";
-import { all, call, select } from "redux-saga/effects";
+import { all, call } from "redux-saga/effects";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import log from "loglevel";
-import { getAppMode } from "selectors/entitiesSelector";
-import { APP_MODE } from "entities/App";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
 import { ACTION_ANONYMOUS_FUNC_REGEX } from "components/editorComponents/ActionCreator/Fields";

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -59,8 +59,8 @@ describe("Add functions", () => {
             },
           },
         ],
-        then: [`{{ () => "success" }}`],
-        catch: `{{ () => "failure" }}`,
+        then: [`{{ function() { return "success" } }}`],
+        catch: `{{ function() { return "failure" } }}`,
       },
     });
 

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -37,12 +37,8 @@ describe("Add functions", () => {
     ]);
 
     // Action run
-    const onSuccess = () => {
-      /* success run */
-    };
-    const onError = () => {
-      /* failure run */
-    };
+    const onSuccess = () => "success";
+    const onError = () => "failure";
     const actionParams = { param1: "value1" };
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -63,14 +59,8 @@ describe("Add functions", () => {
             },
           },
         ],
-        then: [
-          `{{ () => {
-      /* success run */
-    } }}`,
-        ],
-        catch: `{{ () => {
-      /* failure run */
-    } }}`,
+        then: [`{{ () => "success" }}`],
+        catch: `{{ () => "failure" }}`,
       },
     });
 

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -63,8 +63,14 @@ describe("Add functions", () => {
             },
           },
         ],
-        then: ["{{ () => {\n" + "      /* success run */\n" + "    } }}"],
-        catch: "{{ () => {\n" + "      /* failure run */\n" + "    } }}",
+        then: [
+          `{{ () => {
+      /* success run */
+    } }}`,
+        ],
+        catch: `{{ () => {
+      /* failure run */
+    } }}`,
       },
     });
 

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -37,9 +37,13 @@ describe("Add functions", () => {
     ]);
 
     // Action run
-    const onSuccess = "() => {successRun()}";
-    const onError = "() => {failureRun()}";
-    const actionParams = "{ param1: value1 }";
+    const onSuccess = () => {
+      /* success run */
+    };
+    const onError = () => {
+      /* failure run */
+    };
+    const actionParams = { param1: "value1" };
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const actionRunResponse = dataTreeWithFunctions.action1.run(
@@ -55,12 +59,34 @@ describe("Add functions", () => {
             type: "RUN_PLUGIN_ACTION",
             payload: {
               actionId: "123",
-              params: "{ param1: value1 }",
+              params: { param1: "value1" },
             },
           },
         ],
-        then: ["{{ new Promise(() => {successRun()}) }}"],
-        catch: "{{ new Promise(() => {failureRun()}) }}",
+        then: ["{{ () => {\n" + "      /* success run */\n" + "    } }}"],
+        catch: "{{ () => {\n" + "      /* failure run */\n" + "    } }}",
+      },
+    });
+
+    // New syntax for action run with params passed as first argument
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const actionNewRunResponse = dataTreeWithFunctions.action1.run(
+      actionParams,
+    );
+    expect(actionNewRunResponse.action).toStrictEqual({
+      type: "PROMISE",
+      payload: {
+        executor: [
+          {
+            type: "RUN_PLUGIN_ACTION",
+            payload: {
+              actionId: "123",
+              params: { param1: "value1" },
+            },
+          },
+        ],
+        then: [],
       },
     });
 

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -59,8 +59,8 @@ describe("Add functions", () => {
             },
           },
         ],
-        then: [`{{ function() { return "success" } }}`],
-        catch: `{{ function() { return "failure" } }}`,
+        then: [`{{ function () { return "success"; } }}`],
+        catch: `{{ function () { return "failure"; } }}`,
       },
     });
 


### PR DESCRIPTION
Fixes to get promise actions working with backwards compatibility

Fixes: #6975

If any handing for a failure is done, a default message for action execution failure is not shown
Fixes: #4669



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/overloadin-action-run 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.99 **(-0.01)** | 36.88 **(0)** | 33.88 **(0)** | 55.54 **(-0.01)**
 :red_circle: | app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts | 28.75 **(-1.12)** | 2.78 **(-0.08)** | 28.57 **(0)** | 27.63 **(-0.75)**
 :green_circle: | app/client/src/sagas/ActionExecution/PluginActionSaga.ts | 18.65 **(0.22)** | 3 **(-0.03)** | 17.39 **(0)** | 20.56 **(0.28)**
 :red_circle: | app/client/src/sagas/ActionExecution/PromiseActionSaga.ts | 34.09 **(-4.62)** | 0 **(0)** | 33.33 **(8.33)** | 29.73 **(-7.31)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**
 :green_circle: | app/client/src/workers/Actions.ts | 76.86 **(0.59)** | 55 **(6.85)** | 86.21 **(0)** | 76.19 **(0.94)**</details>