### PR TITLE
fix: bottom padding at the api editor

### DIFF
--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -73,7 +73,7 @@ const ResponseTabWrapper = styled.div`
 `;
 
 const TabbedViewWrapper = styled.div<{ isCentered: boolean }>`
-  height: calc(100% - 30px);
+  height: 100%;
 
   &&& {
     ul.react-tabs__tab-list {
@@ -93,6 +93,12 @@ const TabbedViewWrapper = styled.div<{ isCentered: boolean }>`
     }
   `
       : null}
+
+  & {
+    .react-tabs__tab-panel {
+      height: calc(100% - 32px);
+    }
+  }
 `;
 
 const SectionDivider = styled.div`
@@ -112,7 +118,7 @@ const Flex = styled.div`
 `;
 
 const NoResponseContainer = styled.div`
-  height: 100%;
+  flex: 1;
   width: 100%;
   display: flex;
   align-items: center;
@@ -153,8 +159,8 @@ const InlineButton = styled(Button)`
 `;
 
 const HelpSection = styled.div`
-  margin-bottom: 5px;
-  margin-top: 10px;
+  padding-bottom: 5px;
+  padding-top: 10px;
 `;
 
 interface ReduxStateProps {
@@ -186,6 +192,16 @@ export const EMPTY_RESPONSE: ActionResponse = {
 const StatusCodeText = styled(BaseText)<{ code: string }>`
   color: ${(props) =>
     props.code.startsWith("2") ? props.theme.colors.primaryOld : Colors.RED};
+`;
+
+const ResponseDataContainer = styled.div`
+  flex: 1;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  & .CodeEditorTarget {
+    overflow: hidden;
+  }
 `;
 
 function ApiResponseView(props: Props) {
@@ -222,13 +238,14 @@ function ApiResponseView(props: Props) {
   const initialIndex = useSelector(getActionTabsInitialIndex);
   const [selectedIndex, setSelectedIndex] = useState(initialIndex);
   const messages = response?.messages;
+
   const tabs = [
     {
       key: "body",
       title: "Response Body",
       panelComponent: (
         <ResponseTabWrapper>
-          {messages && (
+          {Array.isArray(messages) && messages.length > 0 && (
             <HelpSection>
               {messages.map((msg, i) => (
                 <Callout fill key={i} text={msg} variant={Variant.warning} />
@@ -250,33 +267,35 @@ function ApiResponseView(props: Props) {
               variant={Variant.danger}
             />
           )}
-          {_.isEmpty(response.statusCode) ? (
-            <NoResponseContainer>
-              <Icon name="no-response" />
-              <Text type={TextType.P1}>
-                {EMPTY_RESPONSE_FIRST_HALF()}
-                <InlineButton
-                  isLoading={isRunning}
-                  onClick={onRunClick}
-                  size={Size.medium}
-                  tag="button"
-                  text="Run"
-                  type="button"
-                />
-                {EMPTY_RESPONSE_LAST_HALF()}
-              </Text>
-            </NoResponseContainer>
-          ) : (
-            <ReadOnlyEditor
-              folding
-              height={"100%"}
-              input={{
-                value: response.body
-                  ? JSON.stringify(response.body, null, 2)
-                  : "",
-              }}
-            />
-          )}
+          <ResponseDataContainer>
+            {_.isEmpty(response.statusCode) ? (
+              <NoResponseContainer>
+                <Icon name="no-response" />
+                <Text type={TextType.P1}>
+                  {EMPTY_RESPONSE_FIRST_HALF()}
+                  <InlineButton
+                    isLoading={isRunning}
+                    onClick={onRunClick}
+                    size={Size.medium}
+                    tag="button"
+                    text="Run"
+                    type="button"
+                  />
+                  {EMPTY_RESPONSE_LAST_HALF()}
+                </Text>
+              </NoResponseContainer>
+            ) : (
+              <ReadOnlyEditor
+                folding
+                height={"100%"}
+                input={{
+                  value: response.body
+                    ? JSON.stringify(response.body, null, 2)
+                    : "",
+                }}
+              />
+            )}
+          </ResponseDataContainer>
         </ResponseTabWrapper>
       ),
     },

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -190,7 +190,7 @@ const Link = styled.a`
 const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
-  height: calc(100% - 126px);
+  height: calc(100% - 118px);
   position: relative;
 `;
 interface APIFormProps {


### PR DESCRIPTION
## Description
Fix: bottom padding at the api editor

Currently on release:
![image](https://user-images.githubusercontent.com/1944800/131887722-4da81c2a-ac19-4a18-9784-b8a0ceb48528.png)

Fixed:
![image](https://user-images.githubusercontent.com/1944800/131890343-92d332ae-4704-47e8-a71d-081a063e9bcd.png)


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-bottom-padding-api-editor 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55 **(0)** | 36.89 **(0.01)** | 33.89 **(0)** | 55.55 **(0)**
 :green_circle: | app/client/src/components/editorComponents/ApiResponseView.tsx | 51.22 **(0.6)** | 37.33 **(1.22)** | 0 **(0)** | 52.5 **(0.6)**</details>