### PR TITLE
fix: comment pins related issues

### DIFF
--- a/app/client/src/comments/AppComments/AppCommentThreads.tsx
+++ b/app/client/src/comments/AppComments/AppCommentThreads.tsx
@@ -3,12 +3,12 @@ import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 
 import {
-  getSortedAndFilteredAppCommentThreadIds,
-  applicationCommentsSelector,
   allCommentThreadsMap,
-  getAppCommentThreads,
-  shouldShowResolved as shouldShowResolvedSelector,
   appCommentsFilter as appCommentsFilterSelector,
+  applicationCommentsSelector,
+  getAppCommentThreads,
+  getSortedAndFilteredAppCommentThreadIds,
+  shouldShowResolved as shouldShowResolvedSelector,
 } from "selectors/commentsSelectors";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
 
@@ -30,10 +30,7 @@ const Container = styled.div`
   overflow: auto;
 `;
 
-function AppCommentThreads() {
-  const dispatch = useDispatch();
-  const commentThreadIdFromUrl = useSelectCommentThreadUsingQuery();
-  const applicationId = useSelector(getCurrentApplicationId) as string;
+export const useSortedCommentThreadIds = (applicationId: string) => {
   const appCommentThreadsByRefMap = useSelector(
     applicationCommentsSelector(applicationId),
   );
@@ -45,7 +42,7 @@ function AppCommentThreads() {
   const currentUser = useSelector(getCurrentUser);
   const currentUsername = currentUser?.username;
 
-  const commentThreadIds = useMemo(
+  return useMemo(
     () =>
       getSortedAndFilteredAppCommentThreadIds(
         appCommentThreadIds,
@@ -62,6 +59,18 @@ function AppCommentThreads() {
       currentUsername,
     ],
   );
+};
+
+function AppCommentThreads() {
+  const dispatch = useDispatch();
+  const commentThreadIdFromUrl = useSelectCommentThreadUsingQuery();
+  const applicationId = useSelector(getCurrentApplicationId) as string;
+  const appCommentThreadsByRefMap = useSelector(
+    applicationCommentsSelector(applicationId),
+  );
+  const appCommentThreadIds = getAppCommentThreads(appCommentThreadsByRefMap);
+
+  const commentThreadIds = useSortedCommentThreadIds(applicationId);
 
   useEffect(() => {
     // if user is visiting a comment thread link which is already resolved,

--- a/app/client/src/comments/AppComments/AppCommentThreads.tsx
+++ b/app/client/src/comments/AppComments/AppCommentThreads.tsx
@@ -30,11 +30,10 @@ const Container = styled.div`
   overflow: auto;
 `;
 
-export const useSortedCommentThreadIds = (applicationId: string) => {
-  const appCommentThreadsByRefMap = useSelector(
-    applicationCommentsSelector(applicationId),
-  );
-  const appCommentThreadIds = getAppCommentThreads(appCommentThreadsByRefMap);
+export const useSortedCommentThreadIds = (
+  applicationId: string,
+  commentThreadIds: string[],
+) => {
   const commentThreadsMap = useSelector(allCommentThreadsMap);
   const shouldShowResolved = useSelector(shouldShowResolvedSelector);
   const appCommentsFilter = useSelector(appCommentsFilterSelector);
@@ -45,14 +44,14 @@ export const useSortedCommentThreadIds = (applicationId: string) => {
   return useMemo(
     () =>
       getSortedAndFilteredAppCommentThreadIds(
-        appCommentThreadIds,
+        commentThreadIds,
         commentThreadsMap,
         shouldShowResolved,
         appCommentsFilter,
         currentUsername,
       ),
     [
-      appCommentThreadIds,
+      commentThreadIds,
       commentThreadsMap,
       shouldShowResolved,
       appCommentsFilter,
@@ -70,7 +69,10 @@ function AppCommentThreads() {
   );
   const appCommentThreadIds = getAppCommentThreads(appCommentThreadsByRefMap);
 
-  const commentThreadIds = useSortedCommentThreadIds(applicationId);
+  const commentThreadIds = useSortedCommentThreadIds(
+    applicationId,
+    appCommentThreadIds,
+  );
 
   useEffect(() => {
     // if user is visiting a comment thread link which is already resolved,

--- a/app/client/src/comments/AppComments/AppCommentThreads.tsx
+++ b/app/client/src/comments/AppComments/AppCommentThreads.tsx
@@ -30,10 +30,7 @@ const Container = styled.div`
   overflow: auto;
 `;
 
-export const useSortedCommentThreadIds = (
-  applicationId: string,
-  commentThreadIds: string[],
-) => {
+export const useSortedCommentThreadIds = (commentThreadIds: string[]) => {
   const commentThreadsMap = useSelector(allCommentThreadsMap);
   const shouldShowResolved = useSelector(shouldShowResolvedSelector);
   const appCommentsFilter = useSelector(appCommentsFilterSelector);
@@ -69,10 +66,7 @@ function AppCommentThreads() {
   );
   const appCommentThreadIds = getAppCommentThreads(appCommentThreadsByRefMap);
 
-  const commentThreadIds = useSortedCommentThreadIds(
-    applicationId,
-    appCommentThreadIds,
-  );
+  const commentThreadIds = useSortedCommentThreadIds(appCommentThreadIds);
 
   useEffect(() => {
     // if user is visiting a comment thread link which is already resolved,

--- a/app/client/src/comments/inlineComments/Comments.tsx
+++ b/app/client/src/comments/inlineComments/Comments.tsx
@@ -80,13 +80,15 @@ function Comments({ refId }: { refId: string }) {
   return (
     <>
       {Array.isArray(commentThreadIds) &&
-        commentThreadIds.map((commentsThreadId: any) => (
-          <MemoisedInlinePageCommentPin
-            commentThreadId={commentsThreadId}
-            focused={commentThreadIdInUrl === commentsThreadId}
-            key={commentsThreadId}
-          />
-        ))}
+        commentThreadIds
+          .reverse()
+          .map((commentsThreadId: any) => (
+            <MemoisedInlinePageCommentPin
+              commentThreadId={commentsThreadId}
+              focused={commentThreadIdInUrl === commentsThreadId}
+              key={commentsThreadId}
+            />
+          ))}
       {/**
        * Exists in store, not yet created in db
        * Its kept separately in state to reset easily

--- a/app/client/src/comments/inlineComments/Comments.tsx
+++ b/app/client/src/comments/inlineComments/Comments.tsx
@@ -70,7 +70,6 @@ function Comments({ refId }: { refId: string }) {
     refCommentThreadsSelector(refId, applicationId),
   );
   const commentThreadIds = useSortedCommentThreadIds(
-    applicationId,
     commentThreadIdsByRef as string[],
   );
   const unpublishedCommentThread = useSelector(

--- a/app/client/src/comments/inlineComments/Comments.tsx
+++ b/app/client/src/comments/inlineComments/Comments.tsx
@@ -71,7 +71,8 @@ function Comments({ refId }: { refId: string }) {
   );
   const commentThreadIds = useSortedCommentThreadIds(
     applicationId,
-  ).filter((id) => (commentThreadIdsByRef as string[]).includes(id));
+    commentThreadIdsByRef as string[],
+  );
   const unpublishedCommentThread = useSelector(
     unpublishedCommentThreadSelector(refId),
   );
@@ -81,6 +82,7 @@ function Comments({ refId }: { refId: string }) {
     <>
       {Array.isArray(commentThreadIds) &&
         commentThreadIds
+          .slice()
           .reverse()
           .map((commentsThreadId: any) => (
             <MemoisedInlinePageCommentPin

--- a/app/client/src/comments/inlineComments/Comments.tsx
+++ b/app/client/src/comments/inlineComments/Comments.tsx
@@ -76,11 +76,7 @@ function Comments({ refId }: { refId: string }) {
     unpublishedCommentThreadSelector(refId),
   );
   const commentThreadIdInUrl = useSelectCommentThreadUsingQuery();
-  // eslint-disable-next-line no-console
-  console.log({
-    commentsThreadIds:
-      Array.isArray(commentThreadIds) && commentThreadIds.reverse(),
-  });
+
   return (
     <>
       {Array.isArray(commentThreadIds) &&

--- a/app/client/src/comments/inlineComments/Comments.tsx
+++ b/app/client/src/comments/inlineComments/Comments.tsx
@@ -14,6 +14,7 @@ import {
 } from "selectors/editorSelectors";
 import { useLocation } from "react-router";
 import { AppState } from "reducers";
+import { useSortedCommentThreadIds } from "../AppComments/AppCommentThreads";
 
 // TODO refactor application comment threads by page id to optimise
 // if lists turn out to be expensive
@@ -64,19 +65,26 @@ export const useSelectCommentThreadUsingQuery = () => {
  * Children set their position themselves
  */
 function Comments({ refId }: { refId: string }) {
-  const applicationId = useSelector(getCurrentApplicationId);
-  const commentsThreadIds = useSelector(
+  const applicationId = useSelector(getCurrentApplicationId) as string;
+  const commentThreadIdsByRef = useSelector(
     refCommentThreadsSelector(refId, applicationId),
   );
+  const commentThreadIds = useSortedCommentThreadIds(
+    applicationId,
+  ).filter((id) => (commentThreadIdsByRef as string[]).includes(id));
   const unpublishedCommentThread = useSelector(
     unpublishedCommentThreadSelector(refId),
   );
   const commentThreadIdInUrl = useSelectCommentThreadUsingQuery();
-
+  // eslint-disable-next-line no-console
+  console.log({
+    commentsThreadIds:
+      Array.isArray(commentThreadIds) && commentThreadIds.reverse(),
+  });
   return (
     <>
-      {Array.isArray(commentsThreadIds) &&
-        commentsThreadIds.map((commentsThreadId: any) => (
+      {Array.isArray(commentThreadIds) &&
+        commentThreadIds.map((commentsThreadId: any) => (
           <MemoisedInlinePageCommentPin
             commentThreadId={commentsThreadId}
             focused={commentThreadIdInUrl === commentsThreadId}

--- a/app/client/src/comments/inlineComments/InlineCommentPin.tsx
+++ b/app/client/src/comments/inlineComments/InlineCommentPin.tsx
@@ -224,8 +224,7 @@ function InlineCommentPin(props: Props) {
   };
 
   if (!commentThread) return null;
-  // eslint-disable-next-line no-console
-  console.log({ seq: commentThread.sequenceId, id: commentThreadId });
+
   return isPinVisible ? (
     <CommentTriggerContainer
       data-cy="inline-comment-pin"

--- a/app/client/src/comments/inlineComments/InlineCommentPin.tsx
+++ b/app/client/src/comments/inlineComments/InlineCommentPin.tsx
@@ -224,7 +224,8 @@ function InlineCommentPin(props: Props) {
   };
 
   if (!commentThread) return null;
-
+  // eslint-disable-next-line no-console
+  console.log({ seq: commentThread.sequenceId, id: commentThreadId });
   return isPinVisible ? (
     <CommentTriggerContainer
       data-cy="inline-comment-pin"

--- a/app/client/src/comments/inlineComments/UnpublishedCommentThread.tsx
+++ b/app/client/src/comments/inlineComments/UnpublishedCommentThread.tsx
@@ -28,7 +28,7 @@ const CommentTriggerContainer = styled.div<{
 }>`
   position: absolute;
   ${(props) => getPosition(props)}
-
+  z-index: 1;
   & svg {
     width: 30px;
     height: 30px;

--- a/app/client/src/pages/Editor/MainContainerLayoutControl.tsx
+++ b/app/client/src/pages/Editor/MainContainerLayoutControl.tsx
@@ -55,7 +55,9 @@ const AppsmithLayouts: AppsmithLayoutConfigOption[] = [
 ];
 
 const LayoutControlWrapper = styled.div`
-  height: 40px;
+  position: absolute;
+  height: ${(props) => props.theme.spaces[15]}px;
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/app/client/src/pages/Editor/WidgetsEditor.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor.tsx
@@ -140,10 +140,10 @@ function WidgetsEditor() {
         onClick={handleWrapperClick}
         onDragStart={onDragStart}
       >
-        <MainContainerLayoutControl />
         <CanvasContainer className={getCanvasClassName()} key={currentPageId}>
           {node}
         </CanvasContainer>
+        <MainContainerLayoutControl />
         <Debugger />
         <CrudInfoModal />
       </EditorWrapper>

--- a/app/client/src/pages/common/ArtBoard.tsx
+++ b/app/client/src/pages/common/ArtBoard.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 export default styled.div<{ width: number }>`
   width: ${(props) => props.width}px;
-  margin: 0 auto;
+  margin: ${(props) => props.theme.spaces[15]}px auto 0;
   position: relative;
   background: ${(props) => {
     return props.theme.colors.artboard;


### PR DESCRIPTION
## Description
- [x] latest pin should be on top: this is the render order issue. Reused the sorting mech employed for listing the comment cards on left sidebar
- [x] unpublished pin z - index problem
- [x] pin cutoff problem at the top of canvas

Fixes #5100 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
* manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/collab-z-index-issues 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.12 **(0.11)** | 37.03 **(0.15)** | 34.04 **(0.09)** | 55.67 **(0.11)**
 :sparkles: :new: | **app/client/src/comments/AppComments/AppCommentThreads.tsx** | **65.79** | **31.25** | **40** | **64.86**
 :sparkles: :new: | **app/client/src/comments/AppComments/AppCommentsPlaceholder.tsx** | **75** | **100** | **0** | **75**
 :sparkles: :new: | **app/client/src/comments/CommentThread/connectedCommentThread.tsx** | **75** | **100** | **0** | **75**
 :green_circle: | app/client/src/comments/inlineComments/Comments.tsx | 97.37 **(0.15)** | 90 **(0)** | 100 **(0)** | 100 **(0)**
 :green_circle: | app/client/src/pages/Editor/MainContainerLayoutControl.tsx | 86.21 **(0.5)** | 50 **(0)** | 57.14 **(7.14)** | 86.21 **(0.5)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 76.85 **(29.63)** | 52.17 **(40.58)** | 69.23 **(26.92)** | 82.89 **(40.78)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>