### PR TITLE
fix: change validation rule for data in list widget

### DIFF
--- a/app/client/src/widgets/ListWidget/ListPropertyPaneConfig.ts
+++ b/app/client/src/widgets/ListWidget/ListPropertyPaneConfig.ts
@@ -19,7 +19,7 @@ const PropertyPaneConfig = [
         inputType: "ARRAY",
         isBindProperty: true,
         isTriggerProperty: false,
-        validation: { type: ValidationTypes.OBJECT_ARRAY },
+        validation: { type: ValidationTypes.ARRAY },
         evaluationSubstitutionType: EvaluationSubstitutionType.SMART_SUBSTITUTE,
       },
       {


### PR DESCRIPTION
The current validation is OBJECT_ARRAY due to which data like array of strings, or array of objects don't work in list widget now.
This PR changes the rule to ARRAY.

Fixes #7024 

## Type of change
- Bug fix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>