### PR TITLE
fix: Rename user company to user's useCase

### DIFF
--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11673,9 +11673,14 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loglevel@^1.6.7, loglevel@^1.6.8:
+loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz"
+
+loglevel@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
+  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
 loglevelnext@^1.0.1:
   version "1.0.5"

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11673,14 +11673,9 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loglevel@^1.6.8:
+loglevel@^1.6.7, loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz"
-
-loglevel@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
-  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
 loglevelnext@^1.0.1:
   version "1.0.5"

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ConfigNames.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ConfigNames.java
@@ -5,7 +5,7 @@ package com.appsmith.server.constants;
  */
 public class ConfigNames {
 
-    public static final String COMPANY_NAME = "company-name";
+    public static final String USE_CASE = "use-case";
 
     // Disallow instantiation of this class.
     private ConfigNames() {}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserSignupRequestDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserSignupRequestDTO.java
@@ -21,7 +21,7 @@ public class UserSignupRequestDTO {
 
     private String role;
 
-    private String companyName;
+    private String useCase;
 
     private boolean allowCollectingAnonymousData;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -218,7 +218,7 @@ public class UserSignup {
 
                     return Mono.when(
                             userDataService.updateForUser(user, userData),
-                            configService.save(ConfigNames.COMPANY_NAME, Map.of("value", userFromRequest.getCompanyName())),
+                            configService.save(ConfigNames.USE_CASE, Map.of("value", userFromRequest.getUseCase())),
                             analyticsService.sendObjectEvent(AnalyticsEvents.CREATE_SUPERUSER, user, null)
                     ).thenReturn(user);
                 });
@@ -240,7 +240,7 @@ public class UserSignup {
                         user.setRole(formData.getFirst("role"));
                     }
                     if (formData.containsKey("companyName")) {
-                        user.setCompanyName(formData.getFirst("companyName"));
+                        user.setUseCase(formData.getFirst("companyName"));
                     }
                     if (formData.containsKey("allowCollectingAnonymousData")) {
                         user.setAllowCollectingAnonymousData("true".equals(formData.getFirst("allowCollectingAnonymousData")));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -239,8 +239,8 @@ public class UserSignup {
                     if (formData.containsKey("role")) {
                         user.setRole(formData.getFirst("role"));
                     }
-                    if (formData.containsKey("companyName")) {
-                        user.setUseCase(formData.getFirst("companyName"));
+                    if (formData.containsKey("userCase")) {
+                        user.setUseCase(formData.getFirst("userCase"));
                     }
                     if (formData.containsKey("allowCollectingAnonymousData")) {
                         user.setAllowCollectingAnonymousData("true".equals(formData.getFirst("allowCollectingAnonymousData")));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -239,8 +239,8 @@ public class UserSignup {
                     if (formData.containsKey("role")) {
                         user.setRole(formData.getFirst("role"));
                     }
-                    if (formData.containsKey("userCase")) {
-                        user.setUseCase(formData.getFirst("userCase"));
+                    if (formData.containsKey("useCase")) {
+                        user.setUseCase(formData.getFirst("useCase"));
                     }
                     if (formData.containsKey("allowCollectingAnonymousData")) {
                         user.setAllowCollectingAnonymousData("true".equals(formData.getFirst("allowCollectingAnonymousData")));


### PR DESCRIPTION
We're not going to be collecting the company name for the self-hosted installation, but instead we'll be collecting the use-case that is being solved with Appsmith.

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: chore/rename-user-company-to-usecase 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.02 **(0)** | 36.91 **(-0.01)** | 33.91 **(0)** | 55.57 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>