### PR TITLE
fix: Treat missing server proxy endpoing as a warning

### DIFF
--- a/app/client/docker/start-nginx.sh
+++ b/app/client/docker/start-nginx.sh
@@ -6,7 +6,8 @@ set -o errexit
 set -o xtrace
 
 if [ -z "$APPSMITH_SERVER_PROXY_PASS" ]; then
-  echo "!!! WARNING: Missing APPSMITH_SERVER_PROXY_PASS env variable. Please point it to where server is avilable." >&2
+  export APPSMITH_SERVER_PROXY_PASS='http://localhost:8080'
+  echo "No explicit value for APPSMITH_SERVER_PROXY_PASS, using '$APPSMITH_SERVER_PROXY_PASS'."
 fi
 
 cp /nginx-root.conf.template /etc/nginx/nginx.conf

--- a/app/client/docker/start-nginx.sh
+++ b/app/client/docker/start-nginx.sh
@@ -6,8 +6,7 @@ set -o errexit
 set -o xtrace
 
 if [ -z "$APPSMITH_SERVER_PROXY_PASS" ]; then
-  echo "Missing APPSMITH_SERVER_PROXY_PASS env variable. Please point it to where server is avilable." >&2
-  exit 1
+  echo "!!! WARNING: Missing APPSMITH_SERVER_PROXY_PASS env variable. Please point it to where server is avilable." >&2
 fi
 
 cp /nginx-root.conf.template /etc/nginx/nginx.conf


### PR DESCRIPTION
Currently, in the editor Docker image, if the `APPSMITH_SERVER_PROXY_PASS` env variable is missing or set to empty, then the service will notify the user and refuses to start. This PR will change this behaviour to notify the user with a warning message, but don't refuse to start.


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>