### PR TITLE
fix: Filter columns which has a column accessor

### DIFF
--- a/app/client/src/widgets/TableWidget/derived.js
+++ b/app/client/src/widgets/TableWidget/derived.js
@@ -177,7 +177,7 @@ export default {
       const columnData = columnProperties;
       columns.push(columnData);
     }
-    return columns.filter((column) => column.accessor);
+    return columns.filter((column) => column.id);
   },
   //
   getFilteredTableData: (props, moment, _) => {

--- a/app/client/src/widgets/TableWidget/derived.js
+++ b/app/client/src/widgets/TableWidget/derived.js
@@ -177,7 +177,7 @@ export default {
       const columnData = columnProperties;
       columns.push(columnData);
     }
-    return columns;
+    return columns.filter((column) => column.accessor);
   },
   //
   getFilteredTableData: (props, moment, _) => {


### PR DESCRIPTION
## Description
Filter columns which does not have an accessor property

Fixes #6968 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/table-crash-column 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.01 **(-0.01)** | 36.91 **(-0.01)** | 33.91 **(0.01)** | 55.56 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 37.72 **(-0.88)** | 36.21 **(0)** | 55.08 **(-0.27)**
 :green_circle: | app/client/src/widgets/TableWidget/derived.js | 54.5 **(0.24)** | 53.57 **(0)** | 39.47 **(1.63)** | 54.07 **(0)**</details>