### PR TITLE
fix: fixed missing toast

### DIFF
--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -78,6 +78,7 @@ export interface Datasource extends BaseDatasource {
   invalids?: string[];
   structure?: DatasourceStructure;
   messages?: string[];
+  success?: boolean;
 }
 
 export interface MockDatasource {

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -500,6 +500,12 @@ function* testDatasourceSaga(actionPayload: ReduxAction<Datasource>) {
         }
         if (responseData.messages && responseData.messages.length) {
           messages = responseData.messages;
+          if (responseData.success) {
+            Toaster.show({
+              text: createMessage(DATASOURCE_VALID, payload.name),
+              variant: Variant.success,
+            });
+          }
         }
         yield put({
           type: ReduxActionErrorTypes.TEST_DATASOURCE_ERROR,


### PR DESCRIPTION
## Description

Added `success` key in interface `Datasource`.
Fixed missing toast incase of localhost as hostaddress.

Fixes #4488 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Success toast is now shown incase of localhost

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/4488-toast-missing-localhost 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.01 **(0)** | 36.92 **(0.01)** | 33.9 **(0)** | 55.56 **(0)**
 :red_circle: | app/client/src/sagas/DatasourcesSagas.ts | 12.85 **(-0.08)** | 1.68 **(-0.03)** | 8.33 **(0)** | 15.21 **(-0.12)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>