### PR TITLE
fix: put the connect widget btn (sniping mode) on top

### DIFF
--- a/app/client/src/components/editorComponents/ActionRightPane/index.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/index.tsx
@@ -263,13 +263,6 @@ function ActionSidebar({
           entityDependencies={entityDependencies}
         />
       )}
-      {showSuggestedWidgets && (
-        <SuggestedWidgets
-          actionName={actionName}
-          hasWidgets={hasWidgets}
-          suggestedWidgets={suggestedWidgets as SuggestedWidget[]}
-        />
-      )}
       {hasResponse && Object.keys(widgets).length > 1 && (
         <Collapsible label="Connect Widget">
           {/*<div className="description">Go to canvas and select widgets</div>*/}
@@ -286,6 +279,13 @@ function ActionSidebar({
             />
           </SnipingWrapper>
         </Collapsible>
+      )}
+      {showSuggestedWidgets && (
+        <SuggestedWidgets
+          actionName={actionName}
+          hasWidgets={hasWidgets}
+          suggestedWidgets={suggestedWidgets as SuggestedWidget[]}
+        />
       )}
     </SideBar>
   );


### PR DESCRIPTION
## Description
- Sniping mode btn on top

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feat/liftup-select-widgets-btn 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.02 **(0.01)** | 36.89 **(0.01)** | 33.95 **(0)** | 55.57 **(0.01)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>