### PR TITLE
fix: safeguarding selected widgets saga

### DIFF
--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -479,3 +479,10 @@ export const MORE_OPTIONS = () => "More Options";
 export const ADD_REACTION = () => "Add Reaction";
 export const RESOLVE_THREAD = () => "Resolve Thread";
 export const EMOJI = () => "Emoji";
+
+// Sniping mode messages
+export const SNIPING_SELECT_WIDGET_AGAIN = () =>
+  "Unable to detect the widget, please select the widget again.";
+
+export const SNIPING_NOT_SUPPORTED = () =>
+  "Binding on selection is not supported for this type of widget!";

--- a/app/client/src/sagas/SnipingModeSagas.ts
+++ b/app/client/src/sagas/SnipingModeSagas.ts
@@ -16,6 +16,10 @@ import { RenderModes, WidgetTypes } from "../constants/WidgetConstants";
 import { Toaster } from "../components/ads/Toast";
 import { Variant } from "../components/ads/common";
 import AnalyticsUtil from "../utils/AnalyticsUtil";
+import {
+  SNIPING_NOT_SUPPORTED,
+  SNIPING_SELECT_WIDGET_AGAIN,
+} from "../constants/messages";
 
 export function* bindDataToWidgetSaga(
   action: ReduxAction<{
@@ -36,6 +40,14 @@ export function* bindDataToWidgetSaga(
   const selectedWidget = (yield select(getCanvasWidgets))[
     action.payload.widgetId
   ];
+
+  if (!selectedWidget || !selectedWidget.type) {
+    Toaster.show({
+      text: SNIPING_SELECT_WIDGET_AGAIN(),
+      variant: Variant.warning,
+    });
+    return;
+  }
 
   let propertyPath = "";
   let propertyValue: any = "";
@@ -143,7 +155,7 @@ export function* bindDataToWidgetSaga(
   } else {
     queryId &&
       Toaster.show({
-        text: "Binding on selection is not supported for this type of widget!",
+        text: SNIPING_NOT_SUPPORTED(),
         variant: Variant.warning,
       });
   }


### PR DESCRIPTION
## Description
added a check if selected widget even exists

Fixes #7119 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This is extremely rare case, couldn't find a way to reproduce and test.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/sniping-mode-saga-safeguarding 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.01 **(0)** | 36.88 **(0)** | 33.94 **(-0.01)** | 55.56 **(0)**
 :red_circle: | app/client/src/constants/messages.ts | 70.88 **(-0.03)** | 100 **(0)** | 12.16 **(-0.08)** | 78.55 **(-0.29)**
 :red_circle: | app/client/src/sagas/SnipingModeSagas.ts | 17.54 **(0.27)** | 3.45 **(-0.55)** | 40 **(0)** | 18.18 **(0.26)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 38.6 **(0.88)** | 36.21 **(0)** | 55.35 **(0.27)**</details>