### PR TITLE
fix: close notifications list on clicking a list item

### DIFF
--- a/app/client/src/notifications/NotificationListItem.tsx
+++ b/app/client/src/notifications/NotificationListItem.tsx
@@ -6,7 +6,10 @@ import UserApi from "api/UserApi";
 import { AppsmithNotification, NotificationTypes } from "entities/Notification";
 import { getTypographyByKey } from "constants/DefaultTheme";
 import { getCommentThreadURL } from "comments/utils";
-import { markNotificationAsReadRequest } from "actions/notificationActions";
+import {
+  markNotificationAsReadRequest,
+  setIsNotificationsListVisible,
+} from "actions/notificationActions";
 
 import history from "utils/history";
 import { useDispatch } from "react-redux";
@@ -142,6 +145,7 @@ function CommentNotification(props: { notification: AppsmithNotification }) {
       mode,
       pageId,
     });
+    dispatch(setIsNotificationsListVisible(false));
     history.push(
       `${commentThreadUrl.pathname}${commentThreadUrl.search}${commentThreadUrl.hash}`,
     );
@@ -210,6 +214,8 @@ function CommentThreadNotification(props: {
       mode,
       pageId,
     });
+
+    dispatch(setIsNotificationsListVisible(false));
 
     history.push(
       `${commentThreadUrl.pathname}${commentThreadUrl.search}${commentThreadUrl.hash}`,


### PR DESCRIPTION
## Description
Close notifications list on clicking a list item

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: close-notifs-on-item-click 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.23 **(0)** | 37.21 **(0.01)** | 34.27 **(0)** | 55.79 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>