### PR TITLE
fix: omit props passing to DOM element

### DIFF
--- a/app/client/src/comments/CommentThread/CommentThread.tsx
+++ b/app/client/src/comments/CommentThread/CommentThread.tsx
@@ -30,7 +30,8 @@ import { getViewModePageList } from "selectors/editorSelectors";
 import { APP_MODE } from "entities/App";
 
 const ThreadContainer = styled(animated.div).withConfig({
-  shouldForwardProp: (prop) => !["visible", "inline"].includes(prop),
+  shouldForwardProp: (prop) =>
+    !["visible", "inline", "maxHeight"].includes(prop),
 })<{
   visible?: boolean;
   inline?: boolean;

--- a/app/client/src/components/ads/TextInput.tsx
+++ b/app/client/src/components/ads/TextInput.tsx
@@ -10,6 +10,7 @@ import {
 import { isEmail } from "utils/formhelpers";
 
 import { AsyncControllableInput } from "@blueprintjs/core/lib/esm/components/forms/asyncControllableInput";
+import _ from "lodash";
 
 export type Validator = (
   value: string,
@@ -85,16 +86,26 @@ const boxStyles = (
 
 const StyledInput = styled((props) => {
   // we are removing non input related props before passing them in the components
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { dataType, inputRef, inputStyle, theme, ...inputProps } = props;
+  // eslint-disable @typescript-eslint/no-unused-vars
+  const { dataType, inputRef, ...inputProps } = props;
+
+  const omitProps = [
+    "inputStyle",
+    "rightSideComponentWidth",
+    "theme",
+    "validator",
+    "isValid",
+    "cypressSelector",
+  ];
+
   return props.asyncControl ? (
     <AsyncControllableInput
-      {...inputProps}
-      dataType={dataType}
+      {..._.omit(inputProps, omitProps)}
+      datatype={dataType}
       inputRef={inputRef}
     />
   ) : (
-    <input ref={inputRef} {...inputProps} />
+    <input ref={inputRef} {..._.omit(inputProps, omitProps)} />
   );
 })<
   TextInputProps & {

--- a/app/client/src/components/designSystems/appsmith/IconButtonComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/IconButtonComponent.tsx
@@ -7,6 +7,7 @@ import { IconName } from "@blueprintjs/icons";
 import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
 import { ThemeProp } from "components/ads/common";
 import { WIDGET_PADDING } from "constants/WidgetConstants";
+import _ from "lodash";
 import {
   ButtonBorderRadius,
   ButtonBorderRadiusTypes,
@@ -34,7 +35,19 @@ export interface ButtonStyleProps {
   hasOnClickAction?: boolean;
 }
 
-export const StyledButton = styled(Button)<ThemeProp & ButtonStyleProps>`
+export const StyledButton = styled((props) => (
+  <Button
+    {..._.omit(props, [
+      "buttonVariant",
+      "buttonStyle",
+      "borderRadius",
+      "boxShadow",
+      "boxShadowColor",
+      "dimension",
+      "hasOnClickAction",
+    ])}
+  />
+))<ThemeProp & ButtonStyleProps>`
 
   background-image: none !important;
   height: ${({ dimension }) => (dimension ? `${dimension}px` : "auto")};

--- a/app/client/src/components/designSystems/blueprint/ButtonComponent.tsx
+++ b/app/client/src/components/designSystems/blueprint/ButtonComponent.tsx
@@ -23,6 +23,7 @@ import {
 import { ThemeProp, Variant } from "components/ads/common";
 import { Toaster } from "components/ads/Toast";
 import ReCAPTCHA from "react-google-recaptcha";
+import _ from "lodash";
 import {
   ButtonBoxShadow,
   ButtonBoxShadowTypes,
@@ -163,7 +164,19 @@ const ButtonContainer = styled.div`
   }
 `;
 
-const StyledButton = styled(Button)<ThemeProp & ButtonStyleProps>`
+const StyledButton = styled((props) => (
+  <Button
+    {..._.omit(props, [
+      "prevButtonStyle",
+      "borderRadius",
+      "boxShadow",
+      "boxShadowColor",
+      "buttonColor",
+      "buttonStyle",
+      "buttonVariant",
+    ])}
+  />
+))<ThemeProp & ButtonStyleProps>`
   height: 100%;
   background-image: none !important;
   font-weight: ${(props) => props.theme.fontWeights[2]};

--- a/app/client/src/components/designSystems/blueprint/InputComponent/index.tsx
+++ b/app/client/src/components/designSystems/blueprint/InputComponent/index.tsx
@@ -52,7 +52,20 @@ import {
  */
 
 const InputComponentWrapper = styled((props) => (
-  <ControlGroup {..._.omit(props, ["hasError", "numeric"])} />
+  <ControlGroup
+    {..._.omit(props, [
+      "hasError",
+      "numeric",
+      "labelTextColor",
+      "allowCurrencyChange",
+      "compactMode",
+      "labelStyle",
+      "labelTextSize",
+      "multiline",
+      "numeric",
+      "inputType",
+    ])}
+  />
 ))<{
   numeric: boolean;
   multiline: string;


### PR DESCRIPTION
## Description

This change avoids to passing of parent props to DOM element.

Fixes #7146


- Refactor

## How Has This Been Tested?

- Jest test in local

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/avoid_props_passing_DOM 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.23 **(0.01)** | 37.21 **(0.01)** | 34.26 **(0)** | 55.79 **(0)**
 :green_circle: | app/client/src/components/ads/TextInput.tsx | 73.17 **(0.67)** | 44.9 **(0)** | 85.71 **(0)** | 71.43 **(0.76)**
 :red_circle: | app/client/src/components/designSystems/appsmith/IconButtonComponent.tsx | 48.84 **(0.06)** | 7.84 **(0)** | 20 **(-2.22)** | 61.76 **(1.15)**
 :green_circle: | app/client/src/components/designSystems/blueprint/ButtonComponent.tsx | 50.41 **(0.82)** | 23.04 **(0)** | 40.74 **(2.28)** | 49.09 **(0.47)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>