### PR TITLE
fix: fix Arangodb plugin response on update commands

### DIFF
--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11674,9 +11674,14 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loglevel@^1.6.7, loglevel@^1.6.8:
+loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz"
+
+loglevel@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
+  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
 loglevelnext@^1.0.1:
   version "1.0.5"

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -11674,14 +11674,9 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loglevel@^1.6.8:
+loglevel@^1.6.7, loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz"
-
-loglevel@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
-  integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
 loglevelnext@^1.0.1:
   version "1.0.5"

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -138,10 +138,10 @@ public class ArangoDBPlugin extends BasePlugin {
         }
 
         /**
-         * - In ArangoDB query language, any non-update query is indicated by the use of keyword "RETURN".
-         * - This method checks if the query provided by user has the "RETURN" keyword or not. To do so, it first
-         * removes any string present inside double or single quotes. It then matches the remaining words with the
-         * keyword "RETURN".
+         * - In ArangoDB query language, any non-update query is indicated by the use of keyword RETURN.
+         * - This method checks if the query provided by user has the RETURN keyword or not. To do so, it first
+         * removes any string present inside double or single quotes (to remove any usage of the keyword as a value).
+         * It then matches the remaining words with the keyword RETURN.
          * - Quoting from ArangoDB doc:
          * ```
          * An AQL query must either return a result (indicated by usage of the RETURN keyword) or execute a

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -56,6 +56,16 @@ public class ArangoDBPlugin extends BasePlugin {
     private static String WRITES_EXECUTED_KEY = "writesExecuted";
     private static String WRITES_IGNORED_KEY = "writesIgnored";
     private static String RETURN_KEY = "return";
+
+    /**
+     * - Regex to match everything inside double or single quotes, including the quotes.
+     * - e.g. Earth "revolves'" '"around"' "the" 'sun' will match:
+     * (1) "revolves'"
+     * (2) '"around"'
+     * (3) "the"
+     * (4) 'sun'
+     * - ref: https://stackoverflow.com/questions/171480/regex-grabbing-values-between-quotation-marks
+     */
     private static String MATCH_QUOTED_WORDS_REGEX = "([\\\"'])(?:(?=(\\\\?))\\2.)*?\\1";
 
     public ArangoDBPlugin(PluginWrapper wrapper) {

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -86,6 +86,9 @@ public class ArangoDBPlugin extends BasePlugin {
 
             return Mono.fromCallable(() -> {
                 ArangoCursor<Map> cursor = db.query(query, null, null, Map.class);
+                // TODO: remove it.
+                System.out.println("devtest: executed: " + cursor.getStats().getWritesExecuted());
+                System.out.println("devtest: ignored: " + cursor.getStats().getWritesIgnored());
                 List<Map> docList = new ArrayList<>();
                 docList.addAll(cursor.asListRemaining());
                 ActionExecutionResult result = new ActionExecutionResult();

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/plugins/ArangoDBPlugin.java
@@ -150,7 +150,7 @@ public class ArangoDBPlugin extends BasePlugin {
          * ref: https://www.arangodb.com/docs/stable/aql/fundamentals-syntax.html
          */
         private boolean isUpdateQuery(String query) {
-            String queryKeyWordsOnly = query.replace(MATCH_QUOTED_WORDS_REGEX, "");
+            String queryKeyWordsOnly = query.replaceAll(MATCH_QUOTED_WORDS_REGEX, "");
             return !Arrays.stream(queryKeyWordsOnly.split("\\s"))
                     .anyMatch(word -> RETURN_KEY.equals(word.trim().toLowerCase()));
         }

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
@@ -245,6 +245,7 @@ public class ArangoDBPluginTest {
                 " name: 'John Smith'," +
                 " email: ['john@appsmith.com](mailto:%22john@appsmith.com)']," +
                 " gender: 'M'," +
+                " testKeyWord: ' Return '," +
                 " age: 50" +
                 " } INTO users");
         Mono<Object> executeMono = dsConnectionMono.flatMap(conn -> pluginExecutor.execute(conn, dsConfig, actionConfiguration));

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/test/java/com/external/plugins/ArangoDBPluginTest.java
@@ -255,10 +255,10 @@ public class ArangoDBPluginTest {
                     assertNotNull(result);
                     assertTrue(result.getIsExecutionSuccess());
                     assertNotNull(result.getBody());
-
-                    // On a successful update the server returns an empty array
-                    assertEquals(0, ((ArrayNode) result.getBody()).size());
-
+                    ArrayNode node = (ArrayNode) result.getBody();
+                    assertEquals(1, node.size());
+                    assertEquals(1, (node.get(0)).get("writesExecuted").asInt());
+                    assertEquals(0, (node.get(0)).get("writesIgnored").asInt());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
- ArangoDB has two types of command - one that fetches a response and the other that updates a document. Currently, ArangoDB plugin treats all cmds like the one that returns a response, hence when update cmds are run then an empty response is returned to the client since there is nothing to fetch. This PR adds a check to fetch the response based on the type of cmd. Hence, for an update cmd the number of writes succeeded or failed would be returned as a response. 
- From ArangoDB doc: 
```
An AQL query must either return a result (indicated by usage of the RETURN keyword) or execute a data-modification operation (indicated by usage of one of the keywords INSERT, UPDATE, REPLACE, REMOVE or UPSERT). The AQL parser will return an error if it detects more than one data-modification operation in the same query or if it cannot figure out if the query is meant to be a data retrieval or a modification operation.

AQL only allows one query in a single query string; thus semicolons to indicate the end of one query and separate multiple queries (as seen in SQL) are not allowed.
```
 
Fixes #6055 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
