### PR TITLE
feat: Generate and store ssh key to git meta data of application

### DIFF
--- a/app/server/appsmith-git/pom.xml
+++ b/app/server/appsmith-git/pom.xml
@@ -44,6 +44,22 @@
             <version>5.12.0.202106070339-r</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.ssh.jsch -->
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+            <version>5.12.0.202106070339-r</version>
+        </dependency>
+
+
+<!--        &lt;!&ndash; https://mvnrepository.com/artifact/com.jcraft/jsch &ndash;&gt;-->
+<!--        <dependency>-->
+<!--            <groupId>com.jcraft</groupId>-->
+<!--            <artifactId>jsch</artifactId>-->
+<!--            <version>0.1.55</version>-->
+<!--        </dependency>-->
+
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/SshTransportConfigCallback.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/SshTransportConfigCallback.java
@@ -1,0 +1,52 @@
+package com.appsmith.git.helpers;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.OpenSshConfig;
+import org.eclipse.jgit.transport.SshSessionFactory;
+import org.eclipse.jgit.transport.SshTransport;
+import org.eclipse.jgit.transport.Transport;
+import org.eclipse.jgit.util.FS;
+
+/**
+ * A custom TransportConfigCallback class that loads private key and public key from the provided strings in constructor.
+ * An instance of this class will be used as follows:
+ *
+ * TransportConfigCallback transportConfigCallback = new SshTransportConfigCallback(PVT_KEY_STRING, PUB_KEY_STRING);
+ * Git.open(gitRepoDirFile) // gitRepoDirFile is an instance of File
+ *    .push()
+ *    .setTransportConfigCallback(transportConfigCallback)
+ *    .call();
+ */
+public class SshTransportConfigCallback implements TransportConfigCallback {
+    private String privateKey;
+    private String publicKey;
+
+    public SshTransportConfigCallback(String privateKey, String publicKey) {
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
+    }
+
+    private final SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
+        @Override
+        protected void configure(OpenSshConfig.Host hc, Session session) {
+            session.setConfig("StrictHostKeyChecking", "no");
+        }
+
+        @Override
+        protected JSch createDefaultJSch(FS fs) throws JSchException {
+            JSch jSch = super.createDefaultJSch(fs);
+            jSch.addIdentity("id_rsa", privateKey.getBytes(), publicKey.getBytes(), "".getBytes());
+            return jSch;
+        }
+    };
+
+    @Override
+    public void configure(Transport transport) {
+        SshTransport sshTransport = (SshTransport) transport;
+        sshTransport.setSshSessionFactory(sshSessionFactory);
+    }
+}

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/StringOutputStream.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/StringOutputStream.java
@@ -1,0 +1,17 @@
+package com.appsmith.git.helpers;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class StringOutputStream extends OutputStream {
+    private StringBuilder string = new StringBuilder();
+
+    @Override
+    public void write(int b) throws IOException {
+        this.string.append((char) b );
+    }
+
+    public String toString() {
+        return this.string.toString();
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ApplicationController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ApplicationController.java
@@ -174,4 +174,9 @@ public class ApplicationController extends BaseController<ApplicationService, Ap
                 .map(fetchedResource -> new ResponseDTO<>(HttpStatus.OK.value(), fetchedResource, null));
     }
 
+    @PostMapping("/ssh-keypair/{applicationId}")
+    public Mono<ResponseDTO<String>> generateSSHKeyPair(@PathVariable String applicationId) {
+        return service.generateSshKeyPair(applicationId)
+                .map(created -> new ResponseDTO<>(HttpStatus.CREATED.value(), created, null));
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitAuth.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/GitAuth.java
@@ -1,14 +1,17 @@
 package com.appsmith.server.domains;
 
-import com.appsmith.external.annotations.encryption.Encrypted;
-import lombok.Getter;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
 
-@Getter
-@Setter
+import java.time.Instant;
+
+@Data
 public class GitAuth {
-    @Encrypted
+    @JsonIgnore
     String privateKey;
 
     String publicKey;
+
+    @JsonIgnore
+    Instant generatedAt;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationService.java
@@ -33,4 +33,5 @@ public interface ApplicationService extends CrudService<Application, String> {
     Mono<Application> getApplicationInViewMode(String applicationId);
 
     Mono<Application> saveLastEditInformation(String applicationId);
+    Mono<String> generateSshKeyPair(String applicationId);
 }


### PR DESCRIPTION
## Description
Added new API that generates a new ssh key pair and stores that inside the git meta data of an application. The key is generated in open ssh format. The private key is stored as encrypted in DB.

Fixes #6484

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
