### PR TITLE
fix: wrapped header text in AutotooltipComponent

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -123,6 +123,7 @@ export const TableWrapper = styled.div`
     width: 100%;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
     color: ${Colors.OXFORD_BLUE};
     font-weight: 500;
     padding-left: 10px;
@@ -292,7 +293,9 @@ function Table(props: TableProps) {
                               : "hidden-header"
                           }
                         >
-                          {column.render("Header")}
+                          <AutoToolTipComponent title={column.render("Header")}>
+                            {column.render("Header")}
+                          </AutoToolTipComponent>
                         </div>
                       </div>
                     ),


### PR DESCRIPTION
## Description

Issue - Table header text gets truncated due to small column width. 
Solution- Wrap the text in `AutotooltipComponent`.

Fixes #6057 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Full text in  table header is now displayed in tootip. Tooltip shows up in case of text overflow only.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/6057-add-tooltip-table-header 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.23 **(0)** | 37.2 **(-0.01)** | 34.26 **(0.01)** | 55.79 **(0)**
 :green_circle: | app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx | 80.77 **(1.92)** | 89.66 **(0)** | 41.67 **(8.34)** | 79.17 **(2.09)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>