### PR TITLE
feat: Updating render according to new json structure

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -1,7 +1,7 @@
 import React, { RefObject, useRef, useState } from "react";
 import { InjectedFormProps } from "redux-form";
 import { Icon, Tag } from "@blueprintjs/core";
-import { isString, uniqueId } from "lodash";
+import { isString } from "lodash";
 import {
   components,
   MenuListComponentProps,

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -25,13 +25,13 @@ const generateInitialEvalState = (formConfig: any) => {
 
   // Any element is only added to the eval state if they have a conditional statement present, if not they are allowed to be rendered
   if (formConfig.hasOwnProperty("conditionals")) {
-    let key = "unkowns";
+    let key = "unknowns";
 
     // A unique key is used to refer the object in the eval state, can be configProperty or serverLabel
     if (formConfig.hasOwnProperty("configProperty")) {
       key = formConfig.configProperty;
-    } else if (formConfig.hasOwnProperty("serverLabel")) {
-      key = formConfig.serverLabel;
+    } else if (formConfig.hasOwnProperty("identifier")) {
+      key = formConfig.identifier;
     }
 
     // Conditionals are stored in the eval state itself for quick access


### PR DESCRIPTION
## Description

1. The new JSON structure for editor JSON forms has made it easy for new contributors to add plugins. 
2. The changes also remove the issue of always having a strict structure that sections have to be root elements, allowing any element to be present at any level.
3. These changes also add error handling for improper JSON elements.
4. The changes will not be visible until the backend enables them by updating the UIComponentTypes options.


Fixes #7187 

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/7187-updating-render-according-to-new-json-structure 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.22 **(-0.01)** | 37.2 **(-0.01)** | 34.26 **(0)** | 55.78 **(-0.01)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 39.66 **(-0.69)** | 33.57 **(-0.23)** | 0 **(0)** | 42.07 **(-1.06)**</details>