### PR TITLE
fix: center alignment for profile placeholder

### DIFF
--- a/app/client/src/pages/common/ProfileImage.tsx
+++ b/app/client/src/pages/common/ProfileImage.tsx
@@ -14,6 +14,7 @@ export const Profile = styled.div<{ backgroundColor?: string; side?: number }>`
   background-color: ${(props) => props.backgroundColor};
   && span {
     color: ${(props) => props.theme.colors.text.highlight};
+    letter-spacing: normal;
   }
 
   img {


### PR DESCRIPTION
## Description
fix center alignment for profile placeholder

before:
![image](https://user-images.githubusercontent.com/1944800/132327320-6f323bdb-d43b-491b-951c-341088f8e3ec.png)

after:
![image](https://user-images.githubusercontent.com/1944800/132327448-e5461e20-848e-478e-931a-5e3ce8378736.png)




## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
