### PR TITLE
feat: Removed unnecessary fields from exported application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -150,6 +150,9 @@ public class ImportExportApplicationService {
                 application.setPages(null);
                 application.setPublishedPages(null);
                 application.setModifiedBy(null);
+                application.setUpdatedAt(null);
+                application.setLastDeployedAt(null);
+                application.setGitApplicationMetadata(null);
                 examplesOrganizationCloner.makePristine(application);
                 applicationJson.setExportedApplication(application);
                 return newPageRepository.findByApplicationId(applicationId, AclPermission.MANAGE_PAGES)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -12,6 +12,7 @@ import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.ApplicationJson;
 import com.appsmith.server.domains.ApplicationPage;
 import com.appsmith.server.domains.Datasource;
+import com.appsmith.server.domains.GitApplicationMetadata;
 import com.appsmith.server.domains.Layout;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
@@ -60,6 +61,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -149,6 +151,11 @@ public class ImportExportApplicationServiceTests {
         Application testApplication = new Application();
         testApplication.setName("Export-Application-Test-Application");
         testApplication.setOrganizationId(orgId);
+        testApplication.setUpdatedAt(Instant.now());
+        testApplication.setLastDeployedAt(Instant.now());
+        testApplication.setModifiedBy("some-user");
+        testApplication.setGitApplicationMetadata(new GitApplicationMetadata());
+
         Application savedApplication = applicationPageService.createApplication(testApplication, orgId).block();
         testAppId = savedApplication.getId();
 
@@ -185,6 +192,23 @@ public class ImportExportApplicationServiceTests {
             .expectErrorMatches(throwable -> throwable instanceof AppsmithException &&
                 throwable.getMessage().equals(AppsmithError.INVALID_PARAMETER.getMessage(FieldName.APPLICATION_ID)))
             .verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void exportApplicationById_WhenContainsInternalFields_InternalFieldsNotExported() {
+        Mono<ApplicationJson> resultMono = importExportApplicationService.exportApplicationById(testAppId);
+
+        StepVerifier
+                .create(resultMono)
+                .assertNext(applicationJson -> {
+                    Application exportedApplication = applicationJson.getExportedApplication();
+                    assertThat(exportedApplication.getModifiedBy()).isNull();
+                    assertThat(exportedApplication.getLastUpdateTime()).isNull();
+                    assertThat(exportedApplication.getLastDeployedAt()).isNull();
+                    assertThat(exportedApplication.getGitApplicationMetadata()).isNull();
+                })
+                .verifyComplete();
     }
 
     @Test


### PR DESCRIPTION
## Description
Removes unnecessary fields from exported application. `updatedAt`, `lastDeployedAt` and `gitApplicationMetadata` are the fields that were removed from exported application.

Fixes #7196 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
