### PR TITLE
fix: try making create new thread transition better

### DIFF
--- a/app/client/src/sagas/CommentSagas/index.ts
+++ b/app/client/src/sagas/CommentSagas/index.ts
@@ -58,7 +58,6 @@ function* createUnpublishedCommentThread(
 
 function* createCommentThread(action: ReduxAction<CreateCommentThreadPayload>) {
   try {
-    yield put(removeUnpublishedCommentThreads());
     const newCommentThreadPayload = transformUnpublishCommentThreadToCreateNew(
       action.payload,
     );
@@ -76,6 +75,7 @@ function* createCommentThread(action: ReduxAction<CreateCommentThreadPayload>) {
     if (isValidResponse) {
       yield put(createCommentThreadSuccess(response.data));
       yield put(setVisibleThread(response.data.id));
+      yield put(removeUnpublishedCommentThreads());
     }
   } catch (error) {
     yield put({


### PR DESCRIPTION
## Description
try making create new thread transition better:
we used to remove the unpublished thread before rendering the newly created thread
removing it later makes the transition better as the pin and the card are not completely removed during the process

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: try-making-create-new-thread-smoother 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.26 **(0)** | 37.23 **(-0.01)** | 34.27 **(0)** | 55.81 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>