### PR TITLE
fix: Fetch all the schemas present in the postgres DB 

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -142,7 +142,6 @@ public class PostgresPlugin extends BasePlugin {
                         "  and not a.attisdropped\n" +
                         "  and n.nspname not in ('information_schema', 'pg_catalog')\n" +
                         "  and c.relkind in ('r', 'v')\n" +
-                        "  and pg_catalog.pg_table_is_visible(a.attrelid)\n" +
                         "order by c.relname, a.attnum;";
 
         public static final String KEYS_QUERY =


### PR DESCRIPTION
## Description

> Due to the constraint to fetch schemas which are present in the search path for postgres table query, in most of the cases only public schemas were getting fetched which is present in the search path by default. This PR will remove the constraint to fetch all the schemas and the related tables within the DB.  

Fixes #7120 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested manually with local DB

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
