### PR TITLE
fix: stop creating private thread if someone tagged a user in their f…

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -264,10 +264,11 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                         final Application application = tuple.getT2();
                         boolean shouldCreateBotThread = policyUtils.isPermissionPresentForUser(
                                 application.getPolicies(), MANAGE_APPLICATIONS.getValue(), user.getUsername()
-                        );
+                        ) && !CommentUtils.isAnyoneMentioned(commentThread.getComments().get(0));
+
                         // check whether this thread should be converted to bot thread
-                        if (userData.getLatestCommentEvent() == null && shouldCreateBotThread) {
-                            commentThread.setIsPrivate(true);
+                        if (userData.getLatestCommentEvent() == null) {
+                            commentThread.setIsPrivate(shouldCreateBotThread);
                             userData.setLatestCommentEvent(CommentBotEvent.COMMENTED);
                             return userDataRepository.save(userData).then(
                                     saveCommentThread(commentThread, application, user)


### PR DESCRIPTION
## Description
When users adds their very first comment, we were making it a private thread adding a bot comment in that thread. If user tags someone in their very first comment, then the tagged user can not see it as it's private. This PR changes this behavior so that if someone is tagged in a first comment, that thread does not become private.

Fixes #7167 


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit test
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
