### PR TITLE
fix: Undoing delete widget does not restore the errors in the debugger

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Debugger/Widget_Error_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Debugger/Widget_Error_spec.js
@@ -1,5 +1,6 @@
 const dsl = require("../../../../fixtures/buttondsl.json");
 const debuggerLocators = require("../../../../locators/Debugger.json");
+const commonlocators = require("../../../../locators/commonlocators.json");
 
 describe("Widget error state", function() {
   before(() => {
@@ -26,7 +27,7 @@ describe("Widget error state", function() {
   it("All errors should be expanded by default", function() {
     cy.testJsontext("label", "{{[]}}");
 
-    cy.get(".t--debugger-message")
+    cy.get(debuggerLocators.errorMessage)
       .should("be.visible")
       .should("have.length", 2);
   });
@@ -36,5 +37,16 @@ describe("Widget error state", function() {
       .first()
       .click();
     cy.get(debuggerLocators.menuItem).should("be.visible");
+  });
+
+  it("Undoing widget deletion should show errors if present", function() {
+    cy.deleteWidget();
+    cy.get(debuggerLocators.errorMessage).should("not.exist");
+    cy.get(commonlocators.toastAction)
+      .contains("UNDO")
+      .click({ force: true });
+    cy.get(debuggerLocators.errorMessage)
+      .should("be.visible")
+      .should("have.length", 2);
   });
 });

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -522,23 +522,25 @@ export function* deleteAllSelectedWidgetsSaga(
           },
         },
       });
+
+      // Notify debugger that widgets were deleted
+      falttendedWidgets.map((widget: any) => {
+        AppsmithConsole.info({
+          logType: LOG_TYPE.ENTITY_DELETED,
+          text: "Widget was deleted",
+          source: {
+            name: widget.widgetName,
+            type: ENTITY_TYPE.WIDGET,
+            id: widget.widgetId,
+          },
+          analytics: {
+            widgetType: widget.type,
+          },
+        });
+      });
       setTimeout(() => {
         if (bulkDeleteKey) {
           flushDeletedWidgets(bulkDeleteKey);
-          falttendedWidgets.map((widget: any) => {
-            AppsmithConsole.info({
-              logType: LOG_TYPE.ENTITY_DELETED,
-              text: "Widget was deleted",
-              source: {
-                name: widget.widgetName,
-                type: ENTITY_TYPE.WIDGET,
-                id: widget.widgetId,
-              },
-              analytics: {
-                widgetType: widget.type,
-              },
-            });
-          });
         }
       }, WIDGET_DELETE_UNDO_TIMEOUT);
     }
@@ -646,23 +648,24 @@ export function* deleteSaga(deleteAction: ReduxAction<WidgetDelete>) {
           },
         });
 
+        otherWidgetsToDelete.map((widget) => {
+          AppsmithConsole.info({
+            logType: LOG_TYPE.ENTITY_DELETED,
+            text: "Widget was deleted",
+            source: {
+              name: widget.widgetName,
+              type: ENTITY_TYPE.WIDGET,
+              id: widget.widgetId,
+            },
+            analytics: {
+              widgetType: widget.type,
+            },
+          });
+        });
+
         setTimeout(() => {
           if (widgetId) {
             flushDeletedWidgets(widgetId);
-            otherWidgetsToDelete.map((widget) => {
-              AppsmithConsole.info({
-                logType: LOG_TYPE.ENTITY_DELETED,
-                text: "Widget was deleted",
-                source: {
-                  name: widget.widgetName,
-                  type: ENTITY_TYPE.WIDGET,
-                  id: widget.widgetId,
-                },
-                analytics: {
-                  widgetType: widget.type,
-                },
-              });
-            });
           }
         }, WIDGET_DELETE_UNDO_TIMEOUT);
       }


### PR DESCRIPTION
Previously errors were simply getting removed after widget deletion even after undoing.

Moved widget deletion notifier outside timeout, which removes the errors immediately on delete. When the widgets are added back, there is an eval which then adds the errors back

## Description

Fixes #6782 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>