### PR TITLE
fix: linting error for list widget

### DIFF
--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -876,11 +876,19 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
 
             const js = combineDynamicBindings(jsSnippets, stringSegments);
 
-            value = `{{${parentProps.widgetName}.listData.map((currentItem, currentIndex) => {
-              return (function(){
+            value = `{{${parentProps.widgetName}.listData.map((currentItem) => {
+              return (function(currentItem){
                 return  ${js};
-              })();
+              })(currentItem);
             })}}`;
+
+            if (isString(value) && value.indexOf("currentIndex") > -1) {
+              value = `{{${parentProps.widgetName}.listData.map((currentItem, currentIndex) => {
+                return (function(currentItem, currentIndex){
+                  return  ${js};
+                })(currentItem, currentIndex);
+              })}}`;
+            }
 
             if (!js) {
               value = propertyValue;


### PR DESCRIPTION
The list widget children were giving a linting error when currentIndex was not used in the binding.

Fixes #7190 
## Type of change

> Please delete options that are not relevant.

- Bug fix

## How Has This Been Tested?
- manually tested


## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/list-widget-linting-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/mockResponses/WidgetConfigResponse.tsx | 14.55 **(-0.26)** | 0 **(0)** | 0 **(0)** | 15.53 **(-0.31)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>