### PR TITLE
build: Release v1.5.18

### DIFF
--- a/app/client/src/pages/Editor/WidgetsEditor.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor.tsx
@@ -27,6 +27,7 @@ import { closePropertyPane, closeTableFilterPane } from "actions/widgetActions";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
 import { setCanvasSelectionFromEditor } from "actions/canvasSelectionActions";
 import CrudInfoModal from "./GeneratePage/components/CrudInfoModal";
+import { useAllowEditorDragToSelect } from "utils/hooks/useAllowEditorDragToSelect";
 
 const EditorWrapper = styled.div`
   display: flex;
@@ -113,15 +114,22 @@ function WidgetsEditor() {
   if (!isFetchingPage && widgets) {
     node = <Canvas dsl={widgets} pageId={params.pageId} />;
   }
-  const onDragStart = (e: any) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const startPoints = {
-      x: e.clientX,
-      y: e.clientY,
-    };
-    dispatch(setCanvasSelectionFromEditor(true, startPoints));
-  };
+  const allowDragToSelect = useAllowEditorDragToSelect();
+
+  const onDragStart = useCallback(
+    (e: any) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (allowDragToSelect) {
+        const startPoints = {
+          x: e.clientX,
+          y: e.clientY,
+        };
+        dispatch(setCanvasSelectionFromEditor(true, startPoints));
+      }
+    },
+    [allowDragToSelect],
+  );
 
   log.debug("Canvas rendered");
   PerformanceTracker.stopTracking();

--- a/app/client/src/pages/common/CanvasSelectionArena.tsx
+++ b/app/client/src/pages/common/CanvasSelectionArena.tsx
@@ -433,6 +433,7 @@ export function CanvasSelectionArena({
     currentPageId,
     mainContainer,
     isDragging,
+    isResizing,
     snapRows,
     snapColumnSpace,
     snapRowSpace,

--- a/app/client/src/utils/hooks/useAllowEditorDragToSelect.ts
+++ b/app/client/src/utils/hooks/useAllowEditorDragToSelect.ts
@@ -1,0 +1,34 @@
+import { AppState } from "reducers";
+import { commentModeSelector } from "selectors/commentsSelectors";
+import { snipingModeSelector } from "selectors/editorSelectors";
+import { useSelector } from "store";
+
+export const useAllowEditorDragToSelect = () => {
+  // This state tells us whether a `ResizableComponent` is resizing
+  const isResizing = useSelector(
+    (state: AppState) => state.ui.widgetDragResize.isResizing,
+  );
+
+  // This state tells us whether a `DraggableComponent` is dragging
+  const isDragging = useSelector(
+    (state: AppState) => state.ui.widgetDragResize.isDragging,
+  );
+
+  // This state tells us to disable dragging,
+  // This is usually true when widgets themselves implement drag/drop
+  // This flag resolves conflicting drag/drop triggers.
+  const isDraggingDisabled: boolean = useSelector(
+    (state: AppState) => state.ui.widgetDragResize.isDraggingDisabled,
+  );
+
+  // True when any widget is dragging or resizing, including this one
+  const isResizingOrDragging = !!isResizing || !!isDragging;
+  const isCommentMode = useSelector(commentModeSelector);
+  const isSnipingMode = useSelector(snipingModeSelector);
+  return (
+    !isResizingOrDragging &&
+    !isDraggingDisabled &&
+    !isCommentMode &&
+    !isSnipingMode
+  );
+};


### PR DESCRIPTION
Release v1.5.18
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:master and head branch: release-v1.5.18 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.25 **(0.02)** | 37.24 **(0.03)** | 34.29 **(0.03)** | 55.82 **(0.03)**
 :red_circle: | app/client/src/pages/Editor/WidgetsEditor.tsx | 92.86 **(0.32)** | 73.33 **(-1.67)** | 100 **(0)** | 92.54 **(0.35)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 77.88 **(1.92)** | 57.58 **(3.03)** | 68 **(0)** | 85.14 **(2.71)**
 :sparkles: :new: | **app/client/src/utils/hooks/useAllowEditorDragToSelect.ts** | **100** | **100** | **100** | **100**</details>