### PR TITLE
fix: convert message to string if it is not in debugger

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/LogItem.tsx
+++ b/app/client/src/components/editorComponents/Debugger/LogItem.tsx
@@ -12,6 +12,7 @@ import { getTypographyByKey } from "constants/DefaultTheme";
 import TooltipComponent from "components/ads/Tooltip";
 import { createMessage, TROUBLESHOOT_ISSUE } from "constants/messages";
 import ContextualMenu from "./ContextualMenu";
+import { isString } from "lodash";
 
 const Wrapper = styled.div<{ collapsed: boolean }>`
   padding: 9px 30px;
@@ -250,7 +251,9 @@ function LogItem(props: LogItemProps) {
                 <MessageWrapper key={e.message}>
                   <ContextualMenu error={e}>
                     <span className="debugger-message t--debugger-message">
-                      {e.message}
+                      {isString(e.message)
+                        ? e.message
+                        : JSON.stringify(e.message)}
                     </span>
                   </ContextualMenu>
                 </MessageWrapper>


### PR DESCRIPTION
App crashes when we try to render an object instead of a string

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/debugger-renders-objects 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.27 **(0)** | 36.32 **(0.01)** | 33.43 **(0)** | 54.81 **(0)**
 :green_circle: | app/client/src/components/editorComponents/Debugger/LogItem.tsx | 38.33 **(1.04)** | 23.81 **(-1.19)** | 0 **(0)** | 39.29 **(1.11)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>