### PR TITLE
fix: add migration for removed table default selected row

### DIFF
--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -106,7 +106,7 @@ export const layoutConfigurations: LayoutConfigurations = {
   FLUID: { minWidth: -1, maxWidth: -1 },
 };
 
-export const LATEST_PAGE_VERSION = 35;
+export const LATEST_PAGE_VERSION = 37;
 
 export const GridDefaults = {
   DEFAULT_CELL_SIZE: 1,

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -106,7 +106,7 @@ export const layoutConfigurations: LayoutConfigurations = {
   FLUID: { minWidth: -1, maxWidth: -1 },
 };
 
-export const LATEST_PAGE_VERSION = 37;
+export const LATEST_PAGE_VERSION = 38;
 
 export const GridDefaults = {
   DEFAULT_CELL_SIZE: 1,

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -106,7 +106,7 @@ export const layoutConfigurations: LayoutConfigurations = {
   FLUID: { minWidth: -1, maxWidth: -1 },
 };
 
-export const LATEST_PAGE_VERSION = 38;
+export const LATEST_PAGE_VERSION = 37;
 
 export const GridDefaults = {
   DEFAULT_CELL_SIZE: 1,

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -106,7 +106,7 @@ export const layoutConfigurations: LayoutConfigurations = {
   FLUID: { minWidth: -1, maxWidth: -1 },
 };
 
-export const LATEST_PAGE_VERSION = 36;
+export const LATEST_PAGE_VERSION = 35;
 
 export const GridDefaults = {
   DEFAULT_CELL_SIZE: 1,

--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -329,7 +329,7 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       isVisibleDownload: true,
       isVisiblePagination: true,
       delimiter: ",",
-      version: 1,
+      version: 3,
     },
     DROP_DOWN_WIDGET: {
       rows: 1 * GRID_DENSITY_MIGRATION_V1,

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -823,7 +823,7 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
   }
 
   if (currentDSL.version === 32) {
-    currentDSL = migrateTableDefaultSelectedRow(currentDSL);
+    currentDSL = migrateTableVersion(currentDSL);
     currentDSL.version = 33;
   }
 
@@ -843,11 +843,6 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
   }
 
   if (currentDSL.version === 36) {
-    currentDSL = migrateTableVersion(currentDSL);
-    currentDSL.version = 37;
-  }
-
-  if (currentDSL.version === 37) {
     currentDSL = revertTableDefaultSelectedRow(currentDSL);
     currentDSL.version = LATEST_PAGE_VERSION;
   }
@@ -875,26 +870,13 @@ export const revertTableDefaultSelectedRow = (
 export const migrateTableVersion = (
   currentDSL: ContainerWidgetProps<WidgetProps>,
 ) => {
+  // this is done to stop reverse migrations for apps that did not use migrateTableDefaultSelectedRow to migrate
   if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
     currentDSL.version = 2;
   }
   if (currentDSL.children && currentDSL.children.length) {
     currentDSL.children = currentDSL.children.map((child) =>
       migrateTableVersion(child),
-    );
-  }
-  return currentDSL;
-};
-
-export const migrateTableDefaultSelectedRow = (
-  currentDSL: ContainerWidgetProps<WidgetProps>,
-) => {
-  if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
-    if (!currentDSL.defaultSelectedRow) currentDSL.defaultSelectedRow = "0";
-  }
-  if (currentDSL.children && currentDSL.children.length) {
-    currentDSL.children = currentDSL.children.map((child) =>
-      migrateTableDefaultSelectedRow(child),
     );
   }
   return currentDSL;

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -823,21 +823,16 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
   }
 
   if (currentDSL.version === 32) {
-    currentDSL = migrateTableDefaultSelectedRow(currentDSL);
+    currentDSL = migrateMenuButtonWidgetButtonProperties(currentDSL);
     currentDSL.version = 33;
   }
 
   if (currentDSL.version === 33) {
-    currentDSL = migrateMenuButtonWidgetButtonProperties(currentDSL);
+    currentDSL = migrateButtonWidgetValidation(currentDSL);
     currentDSL.version = 34;
   }
 
   if (currentDSL.version === 34) {
-    currentDSL = migrateButtonWidgetValidation(currentDSL);
-    currentDSL.version = 35;
-  }
-
-  if (currentDSL.version === 35) {
     currentDSL = migrateInputValidation(currentDSL);
     currentDSL.version = LATEST_PAGE_VERSION;
   }
@@ -884,20 +879,6 @@ export const migrateInputValidation = (
   if (currentDSL.children && currentDSL.children.length) {
     currentDSL.children = currentDSL.children.map((child) =>
       migrateInputValidation(child),
-    );
-  }
-  return currentDSL;
-};
-
-export const migrateTableDefaultSelectedRow = (
-  currentDSL: ContainerWidgetProps<WidgetProps>,
-) => {
-  if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
-    if (!currentDSL.defaultSelectedRow) currentDSL.defaultSelectedRow = "0";
-  }
-  if (currentDSL.children && currentDSL.children.length) {
-    currentDSL.children = currentDSL.children.map((child) =>
-      migrateTableDefaultSelectedRow(child),
     );
   }
   return currentDSL;

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -823,20 +823,58 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
   }
 
   if (currentDSL.version === 32) {
-    currentDSL = migrateMenuButtonWidgetButtonProperties(currentDSL);
+    currentDSL = migrateTableDefaultSelectedRow(currentDSL);
     currentDSL.version = 33;
   }
 
   if (currentDSL.version === 33) {
-    currentDSL = migrateButtonWidgetValidation(currentDSL);
+    currentDSL = migrateMenuButtonWidgetButtonProperties(currentDSL);
     currentDSL.version = 34;
   }
 
   if (currentDSL.version === 34) {
+    currentDSL = migrateButtonWidgetValidation(currentDSL);
+    currentDSL.version = 35;
+  }
+
+  if (currentDSL.version === 35) {
     currentDSL = migrateInputValidation(currentDSL);
+    currentDSL.version = 36;
+  }
+
+  if (currentDSL.version === 36) {
+    currentDSL = revertTableDefaultSelectedRow(currentDSL);
     currentDSL.version = LATEST_PAGE_VERSION;
   }
 
+  return currentDSL;
+};
+
+export const revertTableDefaultSelectedRow = (
+  currentDSL: ContainerWidgetProps<WidgetProps>,
+) => {
+  if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
+    currentDSL.defaultSelectedRow = undefined;
+  }
+  if (currentDSL.children && currentDSL.children.length) {
+    currentDSL.children = currentDSL.children.map((child) =>
+      revertTableDefaultSelectedRow(child),
+    );
+  }
+  return currentDSL;
+};
+
+export const migrateTableDefaultSelectedRow = (
+  currentDSL: ContainerWidgetProps<WidgetProps>,
+) => {
+  if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
+    if (!currentDSL.defaultSelectedRow) currentDSL.defaultSelectedRow = "0";
+  }
+  if (currentDSL.children && currentDSL.children.length) {
+    currentDSL.children = currentDSL.children.map((child) =>
+      migrateTableDefaultSelectedRow(child),
+    );
+  }
   return currentDSL;
 };
 

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -843,6 +843,11 @@ const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
   }
 
   if (currentDSL.version === 36) {
+    currentDSL = migrateTableVersion(currentDSL);
+    currentDSL.version = 37;
+  }
+
+  if (currentDSL.version === 37) {
     currentDSL = revertTableDefaultSelectedRow(currentDSL);
     currentDSL.version = LATEST_PAGE_VERSION;
   }
@@ -854,12 +859,28 @@ export const revertTableDefaultSelectedRow = (
   currentDSL: ContainerWidgetProps<WidgetProps>,
 ) => {
   if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
-    if (currentDSL.defaultSelectedRow === "0")
+    if (currentDSL.version === 1 && currentDSL.defaultSelectedRow === "0")
       currentDSL.defaultSelectedRow = undefined;
+    // update version to 3 for all table dsl
+    currentDSL.version = 3;
   }
   if (currentDSL.children && currentDSL.children.length) {
     currentDSL.children = currentDSL.children.map((child) =>
       revertTableDefaultSelectedRow(child),
+    );
+  }
+  return currentDSL;
+};
+
+export const migrateTableVersion = (
+  currentDSL: ContainerWidgetProps<WidgetProps>,
+) => {
+  if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
+    currentDSL.version = 2;
+  }
+  if (currentDSL.children && currentDSL.children.length) {
+    currentDSL.children = currentDSL.children.map((child) =>
+      migrateTableVersion(child),
     );
   }
   return currentDSL;

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -854,7 +854,8 @@ export const revertTableDefaultSelectedRow = (
   currentDSL: ContainerWidgetProps<WidgetProps>,
 ) => {
   if (currentDSL.type === WidgetTypes.TABLE_WIDGET) {
-    currentDSL.defaultSelectedRow = undefined;
+    if (currentDSL.defaultSelectedRow === "0")
+      currentDSL.defaultSelectedRow = undefined;
   }
   if (currentDSL.children && currentDSL.children.length) {
     currentDSL.children = currentDSL.children.map((child) =>


### PR DESCRIPTION
## Description

> Add migration for removed default selected row in the table.

Fixes #7258

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: bug/revert-table-row-migration 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.29 **(0.02)** | 36.34 **(0.02)** | 33.45 **(0.02)** | 54.83 **(0.02)**
 :green_circle: | app/client/src/utils/WidgetPropsUtils.tsx | 75.89 **(0.3)** | 66.91 **(0.24)** | 71.72 **(0.59)** | 75 **(0.33)**</details>