### PR TITLE
fix: Switched image to latest release image to avoid breaks while developing

### DIFF
--- a/app/server/docker-compose.yml
+++ b/app/server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   appsmith-internal-server:
-    image: appsmith/appsmith-server
+    image: appsmith/appsmith-server:release
     env_file: envs/docker.env
     environment:
       APPSMITH_REDIS_URL: "redis://redis:6379"


### PR DESCRIPTION
A lot of the front end folks are facing failures because of unmet expectations between release-client and prod-server. We should use the release image for development.