### PR TITLE
fix: Set thread mode to comment mode when comments created

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
@@ -18,4 +18,8 @@ public abstract class AbstractCommentDomain extends BaseDomain {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     String authorUsername; // username i.e. email of the user, who authored this comment or thread.
     String orgId;
+
+    /** Edit/Published Mode */
+    String mode;
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
@@ -29,9 +29,6 @@ public class Comment extends AbstractCommentDomain {
 
     Body body;
 
-    /** Edit/Published Mode */
-    String mode;
-
     List<Reaction> reactions;
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThread.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentThread.java
@@ -42,8 +42,6 @@ public class CommentThread extends AbstractCommentDomain {
     @JsonIgnore
     Set<String> subscribers;
 
-    /** Edit/Published Mode */
-    String mode;
 
     @Transient
     Boolean isViewed;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -183,6 +183,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
         comment.setApplicationName(commentThread.getApplicationName());
         comment.setPageId(commentThread.getPageId());
         comment.setOrgId(commentThread.getOrgId());
+        comment.setMode(commentThread.getMode());
 
         final Set<Policy> policies = policyGenerator.getAllChildPolicies(
                 commentThread.getPolicies(),


### PR DESCRIPTION
## Description
When a comment is created along with a thread, the comment has no mode set. This change will set the mode of thread to comment.

Fixes #7264 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
