### PR TITLE
fix: allow multiple draggable popper to co-exist

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/PropertyPane/Draggable_PropertyPane_Widgets_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/PropertyPane/Draggable_PropertyPane_Widgets_spec.js
@@ -26,14 +26,14 @@ describe("Widget property pane draggable", function() {
   it("Property pane initial position same untill it is dragged", function() {
     for (const testWidget of widgetList) {
       cy.openPropertyPane(testWidget);
-      cy.get("#popper-draghandler").then((oldPorpPane) => {
+      cy.get("[data-cy=t--property-pane-drag-handle]").then((oldPorpPane) => {
         const oldPropPanePosition = oldPorpPane[0].getBoundingClientRect();
         cy.get(commonlocators.collapsesection)
           .first()
           .click();
         cy.get(commonlocators.editPropCrossButton).click({ force: true });
         cy.openPropertyPane(testWidget);
-        cy.get("#popper-draghandler").then((newPropPane) => {
+        cy.get("[data-cy=t--property-pane-drag-handle]").then((newPropPane) => {
           const newPropPanePosition = newPropPane[0].getBoundingClientRect();
           cy.get(commonlocators.editPropCrossButton).click({ force: true });
           expect(oldPropPanePosition.top).to.be.equal(newPropPanePosition.top);
@@ -47,15 +47,15 @@ describe("Widget property pane draggable", function() {
   it("Property pane position should stay same after dragging down", () => {
     for (const testWidget of widgetList) {
       cy.openPropertyPane(testWidget);
-      cy.get("#popper-draghandler")
+      cy.get("[data-cy=t--property-pane-drag-handle]")
         .trigger("mousedown", { which: 1 })
         .trigger("mousemove", { clientX: 400, clientY: 500 })
         .trigger("mouseup", { force: true });
-      cy.get("#popper-draghandler").then((oldPorpPane) => {
+      cy.get("[data-cy=t--property-pane-drag-handle]").then((oldPorpPane) => {
         const oldPropPanePosition = oldPorpPane[0].getBoundingClientRect();
         cy.get(commonlocators.editPropCrossButton).click({ force: true });
         cy.openPropertyPane("containerwidget");
-        cy.get("#popper-draghandler").then((newPropPane) => {
+        cy.get("[data-cy=t--property-pane-drag-handle]").then((newPropPane) => {
           const newPropPanePosition = newPropPane[0].getBoundingClientRect();
           cy.get(commonlocators.editPropCrossButton).click({ force: true });
           expect(oldPropPanePosition.top).to.be.equal(newPropPanePosition.top);
@@ -70,20 +70,20 @@ describe("Widget property pane draggable", function() {
   it("Property pane should come back into view if forced to drop out of view", () => {
     for (const testWidget of widgetList) {
       cy.openPropertyPane(testWidget);
-      cy.get("#popper-draghandler")
+      cy.get("[data-cy=t--property-pane-drag-handle]")
         .trigger("mousedown", { which: 1 })
         .trigger("mousemove", { clientX: -10, clientY: -20 })
         .trigger("mouseup", { force: true });
-      cy.get("#popper-draghandler").then((porpPane) => {
+      cy.get("[data-cy=t--property-pane-drag-handle]").then((porpPane) => {
         const propPanePosition = porpPane[0].getBoundingClientRect();
         expect(propPanePosition.top).to.be.greaterThan(0);
         expect(propPanePosition.left).to.be.gte(0);
       });
-      cy.get("#popper-draghandler")
+      cy.get("[data-cy=t--property-pane-drag-handle]")
         .trigger("mousedown", { which: 1 })
         .trigger("mousemove", { clientX: 1600, clientY: 800 })
         .trigger("mouseup", { force: true });
-      cy.get("#popper-draghandler").then((porpPane) => {
+      cy.get("[data-cy=t--property-pane-drag-handle]").then((porpPane) => {
         const propPanePosition = porpPane[0].getBoundingClientRect();
         cy.get(commonlocators.editPropCrossButton).click({ force: true });
         expect(propPanePosition.top).to.be.lessThan(

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/PropertyPane/Draggable_PropertyPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/PropertyPane/Draggable_PropertyPane_spec.js
@@ -8,14 +8,14 @@ describe("Table Widget property pane feature validation", function() {
 
   it("Property pane initial position same untill it is dragged", function() {
     cy.openPropertyPane("tablewidget");
-    cy.get("#popper-draghandler").then((oldPorpPane) => {
+    cy.get("[data-cy=t--property-pane-drag-handle]").then((oldPorpPane) => {
       const oldPropPanePosition = oldPorpPane[0].getBoundingClientRect();
       cy.get(commonlocators.collapsesection)
         .first()
         .click();
       cy.get(commonlocators.editPropCrossButton).click({ force: true });
       cy.openPropertyPane("tablewidget");
-      cy.get("#popper-draghandler").then((newPropPane) => {
+      cy.get("[data-cy=t--property-pane-drag-handle]").then((newPropPane) => {
         const newPropPanePosition = newPropPane[0].getBoundingClientRect();
         cy.get(commonlocators.editPropCrossButton).click({ force: true });
         expect(oldPropPanePosition.top).to.be.equal(newPropPanePosition.top);
@@ -26,15 +26,15 @@ describe("Table Widget property pane feature validation", function() {
 
   it("Property pane position should stay same after dragging down", () => {
     cy.openPropertyPane("tablewidget");
-    cy.get("#popper-draghandler")
+    cy.get("[data-cy=t--property-pane-drag-handle]")
       .trigger("mousedown", { which: 1 })
       .trigger("mousemove", { clientX: 400, clientY: 500 })
       .trigger("mouseup", { force: true });
-    cy.get("#popper-draghandler").then((oldPorpPane) => {
+    cy.get("[data-cy=t--property-pane-drag-handle]").then((oldPorpPane) => {
       const oldPropPanePosition = oldPorpPane[0].getBoundingClientRect();
       cy.get(commonlocators.editPropCrossButton).click({ force: true });
       cy.openPropertyPane("containerwidget");
-      cy.get("#popper-draghandler").then((newPropPane) => {
+      cy.get("[data-cy=t--property-pane-drag-handle]").then((newPropPane) => {
         const newPropPanePosition = newPropPane[0].getBoundingClientRect();
         cy.get(commonlocators.editPropCrossButton).click({ force: true });
         expect(oldPropPanePosition.top).to.be.equal(newPropPanePosition.top);
@@ -45,20 +45,20 @@ describe("Table Widget property pane feature validation", function() {
 
   it("Property pane should come back into view if forced to drop out of view", () => {
     cy.openPropertyPane("tablewidget");
-    cy.get("#popper-draghandler")
+    cy.get("[data-cy=t--property-pane-drag-handle]")
       .trigger("mousedown", { which: 1 })
       .trigger("mousemove", { clientX: -10, clientY: -20 })
       .trigger("mouseup", { force: true });
-    cy.get("#popper-draghandler").then((porpPane) => {
+    cy.get("[data-cy=t--property-pane-drag-handle]").then((porpPane) => {
       const propPanePosition = porpPane[0].getBoundingClientRect();
       expect(propPanePosition.top).to.be.greaterThan(0);
       expect(propPanePosition.left).to.be.gte(0);
     });
-    cy.get("#popper-draghandler")
+    cy.get("[data-cy=t--property-pane-drag-handle]")
       .trigger("mousedown", { which: 1 })
       .trigger("mousemove", { clientX: 1600, clientY: 800 })
       .trigger("mouseup", { force: true });
-    cy.get("#popper-draghandler").then((porpPane) => {
+    cy.get("[data-cy=t--property-pane-drag-handle]").then((porpPane) => {
       const propPanePosition = porpPane[0].getBoundingClientRect();
       cy.get(commonlocators.editPropCrossButton).click({ force: true });
       expect(propPanePosition.top).to.be.lessThan(

--- a/app/client/src/pages/Editor/Popper.tsx
+++ b/app/client/src/pages/Editor/Popper.tsx
@@ -6,6 +6,7 @@ import { AppState } from "reducers";
 import { getThemeDetails, ThemeMode } from "selectors/themeSelectors";
 import styled, { ThemeProvider } from "styled-components";
 import { noop } from "utils/AppsmithUtils";
+import { generateReactKey } from "utils/generators";
 // import { PopperDragHandle } from "./PropertyPane/PropertyPaneConnections";
 import { draggableElement } from "./utils";
 
@@ -65,6 +66,9 @@ export function PopperDragHandle() {
 /* eslint-disable react/display-name */
 export default (props: PopperProps) => {
   const contentRef = useRef(null);
+  const popperIdRef = useRef(generateReactKey());
+  const popperId = popperIdRef.current;
+
   const {
     isDraggable = false,
     disablePopperEvents = false,
@@ -132,7 +136,7 @@ export default (props: PopperProps) => {
       if (isDraggable) {
         disablePopperEvents && _popper.disableEventListeners();
         draggableElement(
-          "popper",
+          `${popperId}-popper`,
           _popper.popper,
           onPositionChange,
           position,

--- a/app/client/src/pages/Editor/Popper.tsx
+++ b/app/client/src/pages/Editor/Popper.tsx
@@ -27,6 +27,7 @@ export type PopperProps = {
   modifiers?: Partial<PopperOptions["modifiers"]>;
   isDraggable?: boolean;
   disablePopperEvents?: boolean;
+  cypressSelectorDragHandle?: string;
   position?: {
     top: number;
     left: number;
@@ -77,6 +78,7 @@ export default (props: PopperProps) => {
     onPositionChange = noop,
     themeMode = props.themeMode || ThemeMode.LIGHT,
     renderDragBlockPositions,
+    cypressSelectorDragHandle,
   } = props;
   // Meomoizing to avoid rerender of draggable icon.
   // What is the cost of memoizing?
@@ -149,6 +151,7 @@ export default (props: PopperProps) => {
                 <PopperDragHandle />
               </ThemeProvider>
             ),
+          cypressSelectorDragHandle,
         );
       }
 

--- a/app/client/src/pages/Editor/PropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/index.tsx
@@ -251,6 +251,7 @@ class PropertyPane extends Component<PropertyPaneProps, PropertyPaneState> {
       )[0];
       return (
         <Popper
+          cypressSelectorDragHandle="t--property-pane-drag-handle"
           disablePopperEvents={this.props?.propPanePreference?.isMoved}
           isDraggable
           isOpen

--- a/app/client/src/pages/Editor/utils.ts
+++ b/app/client/src/pages/Editor/utils.ts
@@ -15,6 +15,7 @@ export const draggableElement = (
     position?: string;
   },
   dragHandle?: () => JSX.Element,
+  cypressSelectorDragHandle?: string,
 ) => {
   let newXPos = 0,
     newYPos = 0,
@@ -131,6 +132,7 @@ export const draggableElement = (
         element,
         dragHandle,
         renderDragBlockPositions,
+        cypressSelectorDragHandle,
       );
     }
     if (initPostion) {
@@ -154,6 +156,7 @@ const createDragHandler = (
     zIndex?: string;
     position?: string;
   },
+  cypressSelectorDragHandle?: string,
 ) => {
   const oldDragHandler = document.getElementById(`${id}-draghandler`);
   const dragElement = document.createElement("div");
@@ -162,6 +165,11 @@ const createDragHandler = (
   dragElement.style.left = renderDragBlockPositions?.left ?? "135px";
   dragElement.style.top = renderDragBlockPositions?.top ?? "0px";
   dragElement.style.zIndex = renderDragBlockPositions?.zIndex ?? "3";
+
+  if (cypressSelectorDragHandle) {
+    dragElement.setAttribute("data-cy", cypressSelectorDragHandle);
+  }
+
   oldDragHandler
     ? el.replaceChild(dragElement, oldDragHandler)
     : el.appendChild(dragElement);


### PR DESCRIPTION
## Description

Fixes #7154 

Steps to reproduce
1. Add a table
2. Bind any data sources
3. Open filter pane
4. Click the datasource (in the sidebar) that was used in the table (make sure not to close the filter pane while moving to datasource)
5. Select the table in the outgoing widgets section.
6. The property pane should be open and in the `Table Data` try introducing some random error like `api.data` -> `api.datta`
7. The app should crash.

Reason - 
When we moved from step 3 to step 4, the `tableFilterPane` `isVisible` is true and the state remains the same when we move from step 4 to step 5.
Now both table filter pane and property pane are open and the drag handle shares the same id `popper-draghandler`. The filter pane tries to replace its drag handle and the error occurs.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/7154-popper-replaceChild-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/pages/Editor/Popper.tsx | 86.05 **(1.05)** | 72.5 **(0)** | 88.89 **(0)** | 86.05 **(1.05)**
 :green_circle: | app/client/src/pages/Editor/utils.ts | 40.91 **(1.1)** | 38.67 **(0.31)** | 16.67 **(0)** | 42.16 **(1.16)**</details>