### PR TITLE
fix: Snippet execution changes

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/SnippetsDescription.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/SnippetsDescription.tsx
@@ -236,7 +236,7 @@ export default function SnippetDescription({ item }: { item: Snippet }) {
     );
     dispatch(
       evaluateSnippet({
-        expression: getSnippet(template, selectedArgs),
+        expression: removeDynamicBinding(getSnippet(template, selectedArgs)),
         dataType: dataType,
         isTrigger,
       }),
@@ -335,15 +335,17 @@ export default function SnippetDescription({ item }: { item: Snippet }) {
                 </div>
               ))}
               <div className="actions-container">
-                <Button
-                  className="t--apiFormRunBtn"
-                  disabled={executionInProgress}
-                  onClick={handleRun}
-                  size={Size.medium}
-                  tag="button"
-                  text="Run"
-                  type="button"
-                />
+                {language === "javascript" && (
+                  <Button
+                    className="t--apiFormRunBtn"
+                    disabled={executionInProgress}
+                    onClick={handleRun}
+                    size={Size.medium}
+                    tag="button"
+                    text="Run"
+                    type="button"
+                  />
+                )}
               </div>
               <div id="snippet-evaluator">
                 {evaluatedSnippet && (


### PR DESCRIPTION
## Description
Now {{ }} is a part of the snippet and needs to be removed before evaluation.
Execute snippet only for JS snippets and remove default dynamic binding before execute.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/execute-snippet 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.44 **(0)** | 36.26 **(0)** | 33.57 **(0.01)** | 55 **(0)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 78.23 **(-1.61)** | 54.41 **(-2.94)** | 70 **(0)** | 84.09 **(-2.27)**
 :green_circle: | app/client/src/utils/helpers.tsx | 65.45 **(1.58)** | 41.05 **(3.16)** | 48.39 **(3.23)** | 62.25 **(1.32)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>