### PR TITLE
fix: Calling form eval init on form change

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -126,7 +126,8 @@ class QueryEditor extends React.Component<Props> {
         PerformanceTransactionName.RUN_QUERY_CLICK,
       );
     }
-    // Update the page and evaluations when the queryID is changed
+    // Update the page and evaluations when the queryID is changed by changing the
+    // URL or selecting new query from the query pane
     if (prevProps.match.params.queryId !== this.props.match.params.queryId) {
       this.props.changeQueryPage(this.props.match.params.queryId);
       this.props.initFormEvaluation(

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -86,6 +86,7 @@ type Props = StateAndRouteProps & ReduxDispatchProps & ReduxStateProps;
 class QueryEditor extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
+    // Call the first evaluations when the page loads
     this.props.initFormEvaluation(
       this.props.editorConfig,
       this.props.settingConfig,
@@ -125,8 +126,14 @@ class QueryEditor extends React.Component<Props> {
         PerformanceTransactionName.RUN_QUERY_CLICK,
       );
     }
+    // Update the page and evaluations when the queryID is changed
     if (prevProps.match.params.queryId !== this.props.match.params.queryId) {
       this.props.changeQueryPage(this.props.match.params.queryId);
+      this.props.initFormEvaluation(
+        this.props.editorConfig,
+        this.props.settingConfig,
+        this.props.match.params.queryId,
+      );
     }
     // If statement to debounce and track changes in the formData to update evaluations
     if (


### PR DESCRIPTION
## Description

Minor fix to update evals when the query is changed from the query pane. Issue is related to the new UQI changes and won't be visible if the changes from the backend are not made.

Fixes #7370 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/7370-update-evals-on-query-change 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.88 **(-0.01)** | 36.85 **(-0.01)** | 34.39 **(0)** | 55.4 **(-0.01)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/index.tsx | 31.37 **(-0.31)** | 9.3 **(0)** | 6.25 **(0)** | 32.98 **(-0.35)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 78.23 **(-1.61)** | 54.41 **(-2.94)** | 70 **(0)** | 84.09 **(-2.27)**</details>