### PR TITLE
fix: debug button message shown in query pane

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/DebuggerMessage.tsx
+++ b/app/client/src/components/editorComponents/Debugger/DebuggerMessage.tsx
@@ -1,4 +1,4 @@
-import { CLICK_ON, createMessage, OPEN_THE_DEBUGGER } from "constants/messages";
+import { CLICK_ON, createMessage } from "constants/messages";
 import React from "react";
 import styled from "styled-components";
 import { DebugButton } from "./DebugCTA";
@@ -12,12 +12,17 @@ const Container = styled.div`
   color: ${(props) => props.theme.colors.debugger.messageTextColor};
 `;
 
-function DebuggerMessage(props: any) {
+type DebuggerMessageProps = {
+  onClick: () => void;
+  secondHalfText: string;
+};
+
+function DebuggerMessage(props: DebuggerMessageProps) {
   return (
     <Container>
       {createMessage(CLICK_ON)}
       <StyledButton className="message" onClick={props.onClick} />
-      {createMessage(OPEN_THE_DEBUGGER)}
+      {props.secondHalfText}
     </Container>
   );
 }

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -345,6 +345,8 @@ export const SKIP = () => "SKIP";
 export const CLICK_ON = () => "🙌 Click on ";
 export const PRESS = () => "🎉 Press ";
 export const OPEN_THE_DEBUGGER = () => " to show / hide the debugger";
+export const DEBUGGER_QUERY_RESPONSE_SECOND_HALF = () =>
+  " to see more info in the debugger";
 export const NO_LOGS = () => "No logs to show";
 export const NO_ERRORS = () => "No signs of trouble here!";
 export const DEBUGGER_ERRORS = () => "Errors";

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -49,6 +49,7 @@ import {
   createMessage,
   DEBUGGER_ERRORS,
   DEBUGGER_LOGS,
+  DEBUGGER_QUERY_RESPONSE_SECOND_HALF,
   DOCUMENTATION,
   DOCUMENTATION_TOOLTIP,
   INSPECT_ENTITY,
@@ -627,6 +628,9 @@ export function EditorJSONtoForm(props: Props) {
                   });
                   setSelectedIndex(1);
                 }}
+                secondHalfText={createMessage(
+                  DEBUGGER_QUERY_RESPONSE_SECOND_HALF,
+                )}
               />
             </ErrorContainer>
           )}


### PR DESCRIPTION

## Description

Update text

Fixes #6969 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/query-message 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.88 **(-0.01)** | 36.85 **(-0.01)** | 34.38 **(-0.02)** | 55.4 **(0)**
 :red_circle: | app/client/src/constants/messages.ts | 75.2 **(-0.03)** | 100 **(0)** | 26.08 **(-0.07)** | 81.13 **(-0.12)**
 :red_circle: | app/client/src/utils/helpers.tsx | 63.87 **(-1.58)** | 37.89 **(-3.16)** | 45.16 **(-3.23)** | 60.93 **(-1.32)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>