### PR TITLE
fix: Fixing the previous page pagination for Firestore

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -656,7 +656,12 @@ public class FirestorePlugin extends BasePlugin {
                         return Mono.just(query1);
                     })
                     // Apply limit, always provided, since without it we can inadvertently end up processing too much data.
-                    .map(query1 -> query1.limit(limit))
+                    .map(query1 -> {
+                        if (PaginationField.PREV.equals(paginationField) && !CollectionUtils.isEmpty(endBefore)) {
+                            return query1.limitToLast(limit);
+                        }
+                        return query1.limit(limit);
+                    })
                     // Run the Firestore query to get a Future of the results.
                     .map(Query::get)
                     // Consume the future to get the actual results.


### PR DESCRIPTION
## Description

The problem was that the pagination was designed & tested with only 2 pages. Firestore has a different function `limitToLast` which solves for previous page pagination commands.

Fixes #7111

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- JUnit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
