### PR TITLE
feat: create js action default with js collection

### DIFF
--- a/app/client/src/actions/jsActionActions.ts
+++ b/app/client/src/actions/jsActionActions.ts
@@ -5,6 +5,7 @@ import {
   ReduxActionErrorTypes,
 } from "constants/ReduxActionConstants";
 import { JSCollection } from "entities/JSCollection";
+import { CreateJSCollectionRequest } from "api/JSActionAPI";
 
 export type FetchJSCollectionsPayload = {
   applicationId: string;
@@ -19,7 +20,9 @@ export const fetchJSCollections = (
   };
 };
 
-export const createJSCollectionRequest = (payload: Partial<JSCollection>) => {
+export const createJSCollectionRequest = (
+  payload: CreateJSCollectionRequest,
+) => {
   return {
     type: ReduxActionTypes.CREATE_JS_ACTION_INIT,
     payload,

--- a/app/client/src/api/JSActionAPI.tsx
+++ b/app/client/src/api/JSActionAPI.tsx
@@ -2,7 +2,8 @@ import API from "api/Api";
 import { AxiosPromise } from "axios";
 import { JSCollection } from "entities/JSCollection";
 import { ApiResponse, GenericApiResponse } from "./ApiResponses";
-
+import { Variable, JSAction } from "entities/JSCollection";
+import { PluginType } from "entities/Action";
 export interface JSCollectionCreateUpdateResponse extends ApiResponse {
   id: string;
 }
@@ -17,6 +18,18 @@ export interface UpdateJSObjectNameRequest {
   newName: string;
   oldName: string;
 }
+
+export interface CreateJSCollectionRequest {
+  name: string;
+  pageId: string;
+  organizationId: string;
+  pluginId: string;
+  body: string;
+  variables: Array<Variable>;
+  actions: Array<Partial<JSAction>>;
+  applicationId: string;
+  pluginType: PluginType;
+}
 class JSActionAPI extends API {
   static url = "v1/collections/actions";
 
@@ -27,15 +40,21 @@ class JSActionAPI extends API {
   }
 
   static createJSCollection(
-    apiConfig: Partial<JSCollection>,
+    jsConfig: CreateJSCollectionRequest,
   ): AxiosPromise<JSCollectionCreateUpdateResponse> {
-    return API.post(JSActionAPI.url, apiConfig);
+    return API.post(JSActionAPI.url, jsConfig);
+  }
+
+  static copyJSCollection(
+    jsConfig: Partial<JSCollection>,
+  ): AxiosPromise<JSCollectionCreateUpdateResponse> {
+    return API.post(JSActionAPI.url, jsConfig);
   }
 
   static updateJSCollection(
-    apiConfig: JSCollection,
+    jsConfig: JSCollection,
   ): AxiosPromise<JSCollectionCreateUpdateResponse> {
-    const jsAction = Object.assign({}, apiConfig);
+    const jsAction = Object.assign({}, jsConfig);
     return API.put(`${JSActionAPI.url}/${jsAction.id}`, jsAction);
   }
 

--- a/app/client/src/sagas/JSActionSagas.ts
+++ b/app/client/src/sagas/JSActionSagas.ts
@@ -58,6 +58,7 @@ import { GenericApiResponse } from "api/ApiResponses";
 import AppsmithConsole from "utils/AppsmithConsole";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import LOG_TYPE from "entities/AppsmithConsole/logtype";
+import { CreateJSCollectionRequest } from "api/JSActionAPI";
 
 export function* fetchJSCollectionsSaga(
   action: EvaluationReduxAction<FetchActionsPayload>,
@@ -78,7 +79,7 @@ export function* fetchJSCollectionsSaga(
 }
 
 export function* createJSCollectionSaga(
-  actionPayload: ReduxAction<Partial<JSCollection>>,
+  actionPayload: ReduxAction<CreateJSCollectionRequest>,
 ) {
   try {
     const payload = actionPayload.payload;
@@ -138,7 +139,7 @@ function* copyJSCollectionSaga(
       });
       copyJSCollection.actions = newJSSubActions;
     }
-    const response = yield JSActionAPI.createJSCollection(copyJSCollection);
+    const response = yield JSActionAPI.copyJSCollection(copyJSCollection);
 
     const isValidResponse = yield validateResponse(response);
     const pageName = yield select(getPageNameByPageId, response.data.pageId);

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -71,6 +71,20 @@ function* handleCreateNewJsActionSaga(action: ReduxAction<{ pageId: string }>) {
     const newJSCollectionName = createNewJSFunctionName(pageJSActions, pageId);
     const sampleBody =
       "export default {\n\tresults: [],\n\trun: () => {\n\t\t//write code here\n\t}\n}";
+    const sampleActions = [
+      {
+        name: "run",
+        pageId,
+        organizationId,
+        executeOnLoad: false,
+        actionConfiguration: {
+          body: "() => {\n\t\t//write code here\n\t}",
+          isAsync: false,
+          timeoutInMilliseconds: 0,
+          jsArguments: [],
+        },
+      },
+    ];
     yield put(
       createJSCollectionRequest({
         name: newJSCollectionName,
@@ -78,8 +92,13 @@ function* handleCreateNewJsActionSaga(action: ReduxAction<{ pageId: string }>) {
         organizationId,
         pluginId,
         body: sampleBody,
-        variables: [],
-        actions: [],
+        variables: [
+          {
+            name: "results",
+            value: [],
+          },
+        ],
+        actions: sampleActions,
         applicationId,
         pluginType: PluginType.JS,
       }),
@@ -264,16 +283,15 @@ function* handleExecuteJSFunctionSaga(
       ),
     );
   }
-  if (result) {
-    yield put({
-      type: ReduxActionTypes.EXECUTE_JS_FUNCTION_SUCCESS,
-      payload: {
-        results: result,
-        collectionId,
-        actionId,
-      },
-    });
-  }
+
+  yield put({
+    type: ReduxActionTypes.EXECUTE_JS_FUNCTION_SUCCESS,
+    payload: {
+      results: result,
+      collectionId,
+      actionId,
+    },
+  });
 }
 
 function* handleRefactorJSActionNameSaga(


### PR DESCRIPTION
## Description
create default js action and global variable inside js object

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: default-create-js-action 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.87 **(0)** | 36.88 **(0)** | 34.23 **(-0.01)** | 55.4 **(0)**
 :red_circle: | app/client/src/api/JSActionAPI.tsx | 60 **(-0.87)** | 100 **(0)** | 10 **(-1.11)** | 58.33 **(-0.76)**
 :green_circle: | app/client/src/sagas/JSPaneSagas.ts | 20.26 **(0)** | 1.54 **(0.02)** | 7.69 **(0)** | 24.41 **(0)**</details>