### PR TITLE
fix: always assume onSuccess, onError, .then, .catch to be callbacks

### DIFF
--- a/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
@@ -8,7 +8,6 @@ import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import log from "loglevel";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
-import { ACTION_ANONYMOUS_FUNC_REGEX } from "components/editorComponents/ActionCreator/Fields";
 
 export class TriggerFailureError extends Error {
   error?: Error;
@@ -38,7 +37,7 @@ export default function* executePromiseSaga(
     );
     if (trigger.then) {
       if (trigger.then.length) {
-        let responseData: unknown[] = [];
+        let responseData: unknown[] = [{}];
         if (responses.length === 1) {
           responseData = responses[0];
         }
@@ -67,9 +66,7 @@ export default function* executePromiseSaga(
       if (e instanceof PluginTriggerFailureError) {
         responseData = e.responseData;
       }
-      // if the catch callback is not an anonymous function, passing arguments will cause errors in execution
-      const matches = [...trigger.catch.matchAll(ACTION_ANONYMOUS_FUNC_REGEX)];
-      const catchArguments = matches.length ? responseData : undefined;
+      const catchArguments = responseData || [{}];
 
       yield call(executeAppAction, {
         dynamicString: trigger.catch,


### PR DESCRIPTION
## Description

We were doing a regex search to figure our callback functions but we should always assume that onSuccess, onError, .then, .catch will be callbacks because that is the correct syntax

Fixes #7322


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/anon-func-regex 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.88 **(0.01)** | 36.88 **(0.01)** | 34.23 **(0)** | 55.4 **(0.01)**
 :red_circle: | app/client/src/sagas/ActionExecution/PromiseActionSaga.ts | 32.56 **(-0.77)** | 0 **(0)** | 33.33 **(0)** | 27.78 **(-1.17)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>