### PR TITLE
fix: Show recent errors first in the debugger error tab

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Debugger/Widget_Error_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Debugger/Widget_Error_spec.js
@@ -22,14 +22,22 @@ describe("Widget error state", function() {
     cy.contains(".react-tabs__tab", "Errors").click();
 
     cy.get(debuggerLocators.debuggerLogState).contains("Test");
+    cy.get(".t--close-debugger").click();
   });
 
   it("All errors should be expanded by default", function() {
     cy.testJsontext("label", "{{[]}}");
+    cy.get(debuggerLocators.debuggerIcon).click();
 
     cy.get(debuggerLocators.errorMessage)
       .should("be.visible")
       .should("have.length", 2);
+  });
+
+  it("Recent errors are shown at the top of the list when the debugger is opened", function() {
+    cy.get(debuggerLocators.debuggerLogState)
+      .first()
+      .contains("text");
   });
 
   it("Clicking on a message should open the search menu", function() {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Debugger/Widget_Error_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Debugger/Widget_Error_spec.js
@@ -22,19 +22,17 @@ describe("Widget error state", function() {
     cy.contains(".react-tabs__tab", "Errors").click();
 
     cy.get(debuggerLocators.debuggerLogState).contains("Test");
-    cy.get(".t--close-debugger").click();
   });
 
   it("All errors should be expanded by default", function() {
     cy.testJsontext("label", "{{[]}}");
-    cy.get(debuggerLocators.debuggerIcon).click();
 
     cy.get(debuggerLocators.errorMessage)
       .should("be.visible")
       .should("have.length", 2);
   });
 
-  it("Recent errors are shown at the top of the list when the debugger is opened", function() {
+  it("Recent errors are shown at the top of the list", function() {
     cy.get(debuggerLocators.debuggerLogState)
       .first()
       .contains("text");

--- a/app/client/src/components/editorComponents/Debugger/DebuggerTabs.tsx
+++ b/app/client/src/components/editorComponents/Debugger/DebuggerTabs.tsx
@@ -86,7 +86,7 @@ function DebuggerTabs(props: DebuggerTabsProps) {
         tabs={DEBUGGER_TABS}
       />
       <Icon
-        className="close-debugger"
+        className="close-debugger t--close-debugger"
         name="cross"
         onClick={onClose}
         size={IconSize.SMALL}

--- a/app/client/src/reducers/uiReducers/debuggerReducer.ts
+++ b/app/client/src/reducers/uiReducers/debuggerReducer.ts
@@ -42,13 +42,23 @@ const debuggerReducer = createReducer(initialState, {
   ) => {
     if (!action.payload.id) return state;
 
+    if (state.isOpen) {
+      return {
+        ...state,
+        errors: {
+          ...state.errors,
+          [action.payload.id]: action.payload,
+        },
+      };
+    }
+    // Moving recent update to the top of the error list
+    const errors = omit(state.errors, action.payload.id);
     return {
       ...state,
       errors: {
-        ...state.errors,
         [action.payload.id]: action.payload,
+        ...errors,
       },
-      expandId: action.payload.id,
     };
   },
   [ReduxActionTypes.DEBUGGER_DELETE_ERROR_LOG]: (

--- a/app/client/src/reducers/uiReducers/debuggerReducer.ts
+++ b/app/client/src/reducers/uiReducers/debuggerReducer.ts
@@ -42,15 +42,6 @@ const debuggerReducer = createReducer(initialState, {
   ) => {
     if (!action.payload.id) return state;
 
-    if (state.isOpen) {
-      return {
-        ...state,
-        errors: {
-          ...state.errors,
-          [action.payload.id]: action.payload,
-        },
-      };
-    }
     // Moving recent update to the top of the error list
     const errors = omit(state.errors, action.payload.id);
     return {


### PR DESCRIPTION
Shows recent errors first in the debugger error tab.

## Description

Fixes #6715 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/recent-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.87 **(-0.01)** | 36.87 **(-0.01)** | 34.23 **(0)** | 55.39 **(-0.01)**
 :red_circle: | app/client/src/reducers/uiReducers/debuggerReducer.ts | 43.75 **(-2.92)** | 0 **(0)** | 14.29 **(0)** | 46.67 **(-3.33)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>