### PR TITLE
fix: Added new key propertyName to uniquely store evals in state

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -524,6 +524,12 @@ export function EditorJSONtoForm(props: Props) {
     ) {
       let allowToRender = true;
       if (
+        section.hasOwnProperty("propertyName") &&
+        props.formEvaluationState.hasOwnProperty(section.propertyName)
+      ) {
+        allowToRender =
+          props?.formEvaluationState[section.propertyName].visible;
+      } else if (
         section.hasOwnProperty("configProperty") &&
         props.formEvaluationState.hasOwnProperty(section.configProperty)
       ) {

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -27,8 +27,10 @@ const generateInitialEvalState = (formConfig: any) => {
   if (formConfig.hasOwnProperty("conditionals")) {
     let key = "unknowns";
 
-    // A unique key is used to refer the object in the eval state, can be configProperty or serverLabel
-    if (formConfig.hasOwnProperty("configProperty")) {
+    // A unique key is used to refer the object in the eval state, can be propertyName, configProperty or identifier
+    if (formConfig.hasOwnProperty("propertyName")) {
+      key = formConfig.propertyName;
+    } else if (formConfig.hasOwnProperty("configProperty")) {
       key = formConfig.configProperty;
     } else if (formConfig.hasOwnProperty("identifier")) {
       key = formConfig.identifier;


### PR DESCRIPTION
## Description

Added new key in objects to allow for uniquely storing evaluations for each object. This was needed to handle the case when the `configProperty` is the same for 2 or more objects.  Now the priority is in the following order
`propertyName` > `config property > `identifier`

Fixes #7428 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
