### PR TITLE
feat: [Feature] Use photo asset id instead of email address for profile picture in comments

### DIFF
--- a/app/client/src/comments/CommentCard/CommentCard.tsx
+++ b/app/client/src/comments/CommentCard/CommentCard.tsx
@@ -32,7 +32,7 @@ import history from "utils/history";
 import { getAppMode } from "selectors/applicationSelectors";
 import { widgetsMapWithParentModalId } from "selectors/entitiesSelector";
 
-import { USER_PHOTO_URL, USER_PHOTO_ASSET_URL } from "constants/userConstants";
+import { USER_PHOTO_ASSET_URL } from "constants/userConstants";
 
 import { getCommentThreadURL } from "../utils";
 
@@ -278,13 +278,7 @@ function CommentCard({
   const [isHovered, setIsHovered] = useState(false);
   const [cardMode, setCardMode] = useState(CommentCardModes.VIEW);
   const dispatch = useDispatch();
-  const {
-    authorName,
-    authorPhotoId,
-    authorUsername,
-    body,
-    id: commentId,
-  } = comment;
+  const { authorName, authorPhotoId, body, id: commentId } = comment;
   const contentState = convertFromRaw(body as RawDraftContentState);
   const editorState = EditorState.createWithContent(contentState, decorator);
   const commentThread = useSelector(commentThreadsSelector(commentThreadId));
@@ -422,7 +416,7 @@ function CommentCard({
   const hasReactions = !!reactions && Object.keys(reactions).length > 0;
   const profilePhotoUrl = authorPhotoId
     ? `/api/${USER_PHOTO_ASSET_URL}/${authorPhotoId}`
-    : `/api/${USER_PHOTO_URL}/${authorUsername}`;
+    : "";
 
   return (
     <StyledContainer

--- a/app/client/src/comments/CommentCard/CommentCard.tsx
+++ b/app/client/src/comments/CommentCard/CommentCard.tsx
@@ -32,7 +32,7 @@ import history from "utils/history";
 import { getAppMode } from "selectors/applicationSelectors";
 import { widgetsMapWithParentModalId } from "selectors/entitiesSelector";
 
-import { USER_PHOTO_URL } from "constants/userConstants";
+import { USER_PHOTO_URL, USER_PHOTO_ASSET_URL } from "constants/userConstants";
 
 import { getCommentThreadURL } from "../utils";
 
@@ -278,7 +278,13 @@ function CommentCard({
   const [isHovered, setIsHovered] = useState(false);
   const [cardMode, setCardMode] = useState(CommentCardModes.VIEW);
   const dispatch = useDispatch();
-  const { authorName, authorUsername, body, id: commentId } = comment;
+  const {
+    authorName,
+    authorPhotoId,
+    authorUsername,
+    body,
+    id: commentId,
+  } = comment;
   const contentState = convertFromRaw(body as RawDraftContentState);
   const editorState = EditorState.createWithContent(contentState, decorator);
   const commentThread = useSelector(commentThreadsSelector(commentThreadId));
@@ -414,6 +420,9 @@ function CommentCard({
     (showOptions || !!resolved) && isParentComment && toggleResolved;
 
   const hasReactions = !!reactions && Object.keys(reactions).length > 0;
+  const profilePhotoUrl = authorPhotoId
+    ? `/api/${USER_PHOTO_ASSET_URL}/${authorPhotoId}`
+    : `/api/${USER_PHOTO_URL}/${authorUsername}`;
 
   return (
     <StyledContainer
@@ -443,7 +452,7 @@ function CommentCard({
         <HeaderSection>
           <ProfileImage
             side={25}
-            source={`/api/${USER_PHOTO_URL}/${authorUsername}`}
+            source={profilePhotoUrl}
             userName={authorName || ""}
           />
           <UserName>{authorName}</UserName>

--- a/app/client/src/constants/userConstants.ts
+++ b/app/client/src/constants/userConstants.ts
@@ -30,3 +30,4 @@ export const DefaultCurrentUserDetails: User = {
 
 // TODO keeping it here instead of the USER_API since it leads to cyclic deps errors during tests
 export const USER_PHOTO_URL = "v1/users/photo";
+export const USER_PHOTO_ASSET_URL = "v1/assets";

--- a/app/client/src/entities/Comments/CommentsInterfaces.ts
+++ b/app/client/src/entities/Comments/CommentsInterfaces.ts
@@ -59,6 +59,7 @@ export type Reaction = {
 export type Comment = CreateCommentRequest & {
   id: string;
   authorName?: string;
+  authorPhotoId?: string;
   authorUsername?: string;
   updationTime?: string;
   creationTime?: string;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Constraint.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Constraint.java
@@ -2,4 +2,5 @@ package com.appsmith.server.constants;
 
 public class Constraint {
     public static final int ORGANIZATION_LOGO_SIZE_KB = 250;
+    public static final int PROFILE_PHOTO_DIMENSION = 128;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Constraint.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Constraint.java
@@ -2,5 +2,5 @@ package com.appsmith.server.constants;
 
 public class Constraint {
     public static final int ORGANIZATION_LOGO_SIZE_KB = 250;
-    public static final int PROFILE_PHOTO_DIMENSION = 128;
+    public static final int THUMBNAIL_PHOTO_DIMENSION = 128;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/AssetController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/AssetController.java
@@ -4,6 +4,7 @@ import com.appsmith.server.constants.Url;
 import com.appsmith.server.services.AssetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,7 @@ public class AssetController {
 
     @GetMapping("/{id}")
     public Mono<Void> getById(@PathVariable String id, ServerWebExchange exchange) {
+        exchange.getResponse().getHeaders().set(HttpHeaders.CACHE_CONTROL, "public, max-age=7776000, immutable");
         return service.makeImageResponse(exchange, id);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
@@ -17,7 +17,6 @@ public abstract class AbstractCommentDomain extends BaseDomain {
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     String authorUsername; // username i.e. email of the user, who authored this comment or thread.
-    String authorPhotoId;
     String orgId;
 
     /** Edit/Published Mode */

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
@@ -17,6 +17,7 @@ public abstract class AbstractCommentDomain extends BaseDomain {
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     String authorUsername; // username i.e. email of the user, who authored this comment or thread.
+    String authorPhotoId;
     String orgId;
 
     /** Edit/Published Mode */

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Comment.java
@@ -26,6 +26,7 @@ public class Comment extends AbstractCommentDomain {
      */
     @JsonIgnore
     String authorId;
+    String authorPhotoId;
 
     Body body;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/events/UserPhotoChangedEvent.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/events/UserPhotoChangedEvent.java
@@ -1,0 +1,11 @@
+package com.appsmith.server.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserPhotoChangedEvent {
+    private String userId;
+    private String photoAssetId;
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepository.java
@@ -12,4 +12,5 @@ public interface CustomCommentRepository extends AppsmithRepository<Comment> {
 
     Mono<Void> updateAuthorNames(String authorId, String authorName);
 
+    Mono<Void> updatePhotoId(String authorId, String photoId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -72,4 +73,25 @@ public class CustomCommentRepositoryImpl extends BaseAppsmithRepositoryImpl<Comm
                 .then();
     }
 
+    /**
+     * This method updates the authorPhotoId property of comments.
+     * If the photoId is null, it'll remove the property from comments.
+     * If not null and not empty, new value will be set to the comments.
+     * @param authorId id of the user who added the comment
+     * @param photoId id of the image asset
+     * @return void
+     */
+    @Override
+    public Mono<Void> updatePhotoId(String authorId, String photoId) {
+        Update update = new Update();
+        if(StringUtils.isEmpty(photoId)) {
+            update.unset(fieldName(QComment.comment.authorPhotoId));
+        } else {
+            update.set(fieldName(QComment.comment.authorPhotoId), photoId);
+        }
+
+        return mongoOperations
+                .updateMulti(Query.query(Criteria.where("authorId").is(authorId)), update, Comment.class)
+                .then();
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AssetService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AssetService.java
@@ -9,7 +9,7 @@ public interface AssetService {
 
     Mono<Asset> getById(String id);
 
-    Mono<Asset> upload(Part filePart, int i);
+    Mono<Asset> upload(Part filePart, int i, boolean isThumbnail);
 
     Mono<Void> remove(String assetId);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AssetServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AssetServiceImpl.java
@@ -80,7 +80,7 @@ public class AssetServiceImpl implements AssetService {
                         e.printStackTrace();
                         return Mono.error(new AppsmithException(AppsmithError.GENERIC_BAD_REQUEST, "Upload image"));
                     }
-                    return repository.save(new Asset(contentType, bytes));
+                    return repository.save(new Asset(MediaType.IMAGE_JPEG, bytes)); // we create jpeg after image
                 })
                 .flatMap(analyticsService::sendCreateEvent);
     }
@@ -109,6 +109,7 @@ public class AssetServiceImpl implements AssetService {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         ImageIO.write(imageBuff, "jpg", buffer);
         byte[] data = buffer.toByteArray();
+        buffer.close();
         DataBufferUtils.release(dataBuffer);
         return data;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -115,7 +115,12 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
             } else {
                 return Mono.just(user);
             }
-        });
+        }).flatMap(user ->
+                userDataRepository.findByUserId(user.getId()).map(userData -> {
+                    comment.setAuthorPhotoId(userData.getProfilePhotoAssetId());
+                    return user;
+                })
+        );
 
         return userMono.flatMap(user ->
             threadRepository
@@ -183,6 +188,9 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
         comment.setApplicationName(commentThread.getApplicationName());
         comment.setPageId(commentThread.getPageId());
         comment.setOrgId(commentThread.getOrgId());
+        comment.setAuthorUsername(user.getUsername());
+        String authorName = user.getName() != null ? user.getName() : user.getUsername();
+        comment.setAuthorName(authorName);
         comment.setMode(commentThread.getMode());
 
         final Set<Policy> policies = policyGenerator.getAllChildPolicies(
@@ -195,10 +203,6 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                 user
         ).get(AclPermission.MANAGE_COMMENT.getValue()));
         comment.setPolicies(policies);
-
-        String authorName = user.getName() != null ? user.getName() : user.getUsername();
-        comment.setAuthorUsername(user.getUsername());
-        comment.setAuthorName(authorName);
 
         Mono<Comment> commentMono;
         if (!TRUE.equals(commentThread.getIsPrivate())) {
@@ -253,65 +257,67 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                 return Mono.just(user);
             }
         });
-        return userMono.flatMap(user -> {
-            return userDataRepository.findByUserId(user.getId())
-                    .defaultIfEmpty(new UserData(user.getId()))
-                    .zipWith(applicationService.findById(applicationId, AclPermission.COMMENT_ON_APPLICATIONS))
-                    .switchIfEmpty(Mono.error(new AppsmithException(
-                            AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION, applicationId)
-                    ))
-                    .flatMap(tuple -> {
-                        final UserData userData = tuple.getT1();
-                        final Application application = tuple.getT2();
-                        boolean shouldCreateBotThread = policyUtils.isPermissionPresentForUser(
-                                application.getPolicies(), MANAGE_APPLICATIONS.getValue(), user.getUsername()
-                        ) && !CommentUtils.isAnyoneMentioned(commentThread.getComments().get(0));
+        return userMono.flatMap(user ->
+                userDataRepository.findByUserId(user.getId())
+                .defaultIfEmpty(new UserData(user.getId()))
+                .zipWith(applicationService.findById(applicationId, AclPermission.COMMENT_ON_APPLICATIONS))
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.APPLICATION, applicationId)
+                ))
+                .flatMap(tuple -> {
+                    final UserData userData = tuple.getT1();
+                    final Application application = tuple.getT2();
+                    commentThread.setAuthorPhotoId(userData.getProfilePhotoAssetId());
 
-                        // check whether this thread should be converted to bot thread
-                        if (userData.getLatestCommentEvent() == null) {
-                            commentThread.setIsPrivate(shouldCreateBotThread);
-                            userData.setLatestCommentEvent(CommentBotEvent.COMMENTED);
-                            return userDataRepository.save(userData).then(
-                                    saveCommentThread(commentThread, application, user)
-                            );
-                        }
-                        return saveCommentThread(commentThread, application, user);
-                    })
-                    .flatMap(thread -> {
-                        if(thread.getWidgetType() != null) {
-                            return analyticsService.sendCreateEvent(
-                                    thread, Map.of("widgetType", thread.getWidgetType())
-                            );
-                        } else {
-                            return analyticsService.sendCreateEvent(thread);
-                        }
-                    })
-                    .flatMapMany(thread -> {
-                        List<Mono<Comment>> commentSaverMonos = new ArrayList<>();
+                    boolean shouldCreateBotThread = policyUtils.isPermissionPresentForUser(
+                            application.getPolicies(), MANAGE_APPLICATIONS.getValue(), user.getUsername()
+                    ) && !CommentUtils.isAnyoneMentioned(commentThread.getComments().get(0));
 
-                        if (!CollectionUtils.isEmpty(thread.getComments())) {
-                            thread.getComments().get(0).setLeading(true);
-                            for (final Comment comment : thread.getComments()) {
-                                comment.setId(null);
-                                commentSaverMonos.add(create(thread, user, comment, originHeader));
-                            }
-                        }
+                    // check whether this thread should be converted to bot thread
+                    if (userData.getLatestCommentEvent() == null) {
+                        commentThread.setIsPrivate(shouldCreateBotThread);
+                        userData.setLatestCommentEvent(CommentBotEvent.COMMENTED);
+                        return userDataRepository.save(userData).then(
+                                saveCommentThread(commentThread, application, user)
+                        );
+                    }
+                    return saveCommentThread(commentThread, application, user);
+                })
+                .flatMap(thread -> {
+                    if(thread.getWidgetType() != null) {
+                        return analyticsService.sendCreateEvent(
+                                thread, Map.of("widgetType", thread.getWidgetType())
+                        );
+                    } else {
+                        return analyticsService.sendCreateEvent(thread);
+                    }
+                })
+                .flatMapMany(thread -> {
+                    List<Mono<Comment>> commentSaverMonos = new ArrayList<>();
 
-                        if (TRUE.equals(thread.getIsPrivate())) {
-                            // this is the first thread by this user, add a bot comment also
-                            commentSaverMonos.add(createBotComment(thread, user, CommentBotEvent.COMMENTED));
+                    if (!CollectionUtils.isEmpty(thread.getComments())) {
+                        thread.getComments().get(0).setLeading(true);
+                        for (final Comment comment : thread.getComments()) {
+                            comment.setId(null);
+                            comment.setAuthorPhotoId(thread.getAuthorPhotoId());
+                            commentSaverMonos.add(create(thread, user, comment, originHeader));
                         }
-                        // Using `concat` here so that the comments are saved one after the other, so that their `createdAt`
-                        // value is meaningful.
-                        return Flux.concat(commentSaverMonos);
-                    })
-                    .collectList()
-                    .map(commentList -> {
-                        commentThread.setComments(commentList);
-                        commentThread.setIsViewed(true);
-                        return commentThread;
-                    });
-        });
+                    }
+
+                    if (TRUE.equals(thread.getIsPrivate())) {
+                        // this is the first thread by this user, add a bot comment also
+                        commentSaverMonos.add(createBotComment(thread, user, CommentBotEvent.COMMENTED));
+                    }
+                    // Using `concat` here so that the comments are saved one after the other, so that their `createdAt`
+                    // value is meaningful.
+                    return Flux.concat(commentSaverMonos);
+                })
+                .collectList()
+                .map(commentList -> {
+                    commentThread.setComments(commentList);
+                    commentThread.setIsViewed(true);
+                    return commentThread;
+                }));
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -267,8 +267,11 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                 .flatMap(tuple -> {
                     final UserData userData = tuple.getT1();
                     final Application application = tuple.getT2();
-                    commentThread.setAuthorPhotoId(userData.getProfilePhotoAssetId());
 
+                    // set the profile asset id from user data to comment
+                    for(Comment comment : commentThread.getComments()) {
+                        comment.setAuthorPhotoId(userData.getProfilePhotoAssetId());
+                    }
                     boolean shouldCreateBotThread = policyUtils.isPermissionPresentForUser(
                             application.getPolicies(), MANAGE_APPLICATIONS.getValue(), user.getUsername()
                     ) && !CommentUtils.isAnyoneMentioned(commentThread.getComments().get(0));
@@ -299,7 +302,6 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                         thread.getComments().get(0).setLeading(true);
                         for (final Comment comment : thread.getComments()) {
                             comment.setId(null);
-                            comment.setAuthorPhotoId(thread.getAuthorPhotoId());
                             commentSaverMonos.add(create(thread, user, comment, originHeader));
                         }
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -143,7 +143,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
      */
     private Mono<CommentThread> updateThreadOnAddComment(CommentThread commentThread, Comment comment, User user) {
         commentThread.setViewedByUsers(Set.of(user.getUsername()));
-        if(commentThread.getResolvedState().getActive() == TRUE) {
+        if(commentThread.getResolvedState() != null && commentThread.getResolvedState().getActive() == TRUE) {
             commentThread.getResolvedState().setActive(FALSE);
         }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.services;
 
-import com.appsmith.external.models.BaseDomain;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.acl.AppsmithRole;
 import com.appsmith.server.acl.RoleGraph;
@@ -36,7 +35,6 @@ import javax.validation.Validator;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -300,7 +298,7 @@ public class OrganizationServiceImpl extends BaseService<OrganizationRepository,
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.ORGANIZATION, organizationId)));
 
         // We don't execute the upload Mono if we don't find the organization.
-        final Mono<Asset> uploadAssetMono = assetService.upload(filePart, Constraint.ORGANIZATION_LOGO_SIZE_KB);
+        final Mono<Asset> uploadAssetMono = assetService.upload(filePart, Constraint.ORGANIZATION_LOGO_SIZE_KB, false);
 
         return findOrganizationMono
                 .flatMap(organization -> Mono.zip(Mono.just(organization), uploadAssetMono))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataService.java
@@ -17,8 +17,6 @@ public interface UserDataService {
 
     Mono<UserData> getForUserEmail(String email);
 
-    Mono<UserData> updateForCurrentUser(UserData updates);
-
     Mono<UserData> updateForUser(User user, UserData updates);
 
     Mono<User> setViewedCurrentVersionReleaseNotes(User user);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
@@ -185,7 +185,7 @@ public class UserDataServiceImpl extends BaseService<UserDataRepository, UserDat
         final Mono<String> prevAssetIdMono = getForCurrentUser()
                 .map(userData -> ObjectUtils.defaultIfNull(userData.getProfilePhotoAssetId(), ""));
 
-        final Mono<Asset> uploaderMono = assetService.upload(filePart, MAX_PROFILE_PHOTO_SIZE_KB);
+        final Mono<Asset> uploaderMono = assetService.upload(filePart, MAX_PROFILE_PHOTO_SIZE_KB, true);
 
         return Mono.zip(prevAssetIdMono, uploaderMono)
                 .flatMap(tuple -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserDataServiceImpl.java
@@ -201,7 +201,11 @@ public class UserDataServiceImpl extends BaseService<UserDataRepository, UserDat
     @Override
     public Mono<Void> deleteProfilePhoto() {
         return getForCurrentUser()
-                .flatMap(userData -> Mono.justOrEmpty(userData.getProfilePhotoAssetId()))
+                .flatMap(userData -> {
+                    String profilePhotoAssetId = userData.getProfilePhotoAssetId();
+                    userData.setProfilePhotoAssetId(null);
+                    return repository.save(userData).thenReturn(profilePhotoAssetId);
+                })
                 .flatMap(assetService::remove);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserChangedHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserChangedHandler.java
@@ -2,6 +2,7 @@ package com.appsmith.server.solutions;
 
 import com.appsmith.server.domains.User;
 import com.appsmith.server.events.UserChangedEvent;
+import com.appsmith.server.events.UserPhotoChangedEvent;
 import com.appsmith.server.repositories.CommentRepository;
 import com.appsmith.server.repositories.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,10 @@ public class UserChangedHandler {
         return user;
     }
 
+    public void publish(String userId, String photoAssetId) {
+        applicationEventPublisher.publishEvent(new UserPhotoChangedEvent(userId, photoAssetId));
+    }
+
     @Async
     @EventListener
     public void handle(UserChangedEvent event) {
@@ -42,6 +47,15 @@ public class UserChangedHandler {
                 .subscribe();
     }
 
+    @Async
+    @EventListener
+    public void handle(UserPhotoChangedEvent event) {
+        log.debug("Handling user photo changes {}", event.getUserId());
+        updatePhotoIdInComments(event.getUserId(), event.getPhotoAssetId())
+                .subscribeOn(Schedulers.elastic())
+                .subscribe();
+    }
+
     private Mono<Void> updateNameInComments(User user) {
         if (user.getId() == null) {
             log.warn("Attempt to update name in comments for user with null ID.");
@@ -50,6 +64,16 @@ public class UserChangedHandler {
 
         log.debug("Updating name in comments for user {}", user.getId());
         return commentRepository.updateAuthorNames(user.getId(), user.getName());
+    }
+
+    private Mono<Void> updatePhotoIdInComments(String userId, String photoId) {
+        if (userId == null) {
+            log.warn("Attempt to photo id in comments for user with null ID.");
+            return Mono.empty();
+        }
+
+        log.debug("Updating photo id in comments for user {}", userId);
+        return commentRepository.updatePhotoId(userId, photoId);
     }
 
     private Mono<Void> updateNameInUserRoles(User user) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
@@ -1070,10 +1070,6 @@ public class OrganizationServiceTest {
 
                     final Asset asset = tuple.getT2();
                     assertThat(asset).isNotNull();
-                    DataBuffer buffer = DataBufferUtils.join(dataBufferFlux).block(Duration.ofSeconds(3));
-                    byte[] res = new byte[buffer.readableByteCount()];
-                    buffer.read(res);
-                    assertThat(asset.getData()).isEqualTo(res);
                 })
                 .verifyComplete();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserDataServiceTest.java
@@ -6,6 +6,7 @@ import com.appsmith.server.domains.UserData;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.repositories.AssetRepository;
 import com.appsmith.server.repositories.UserDataRepository;
+import com.appsmith.server.solutions.UserChangedHandler;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -48,6 +50,9 @@ public class UserDataServiceTest {
 
     @Autowired
     private AssetRepository assetRepository;
+
+    @MockBean
+    private UserChangedHandler userChangedHandler;
 
     private Mono<User> userMono;
 
@@ -226,6 +231,9 @@ public class UserDataServiceTest {
                 .assertNext(objects -> {
                     assertThat(objects.getT1().getProfilePhotoAssetId()).isNull();
                     assertThat(objects.getT2().getId()).isNull();
+                    Mockito.verify(userChangedHandler, Mockito.times(1)).publish(
+                            objects.getT1().getUserId(), null
+                    );
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
Added the following changes in this PR. They are:
- Set author photo id in comments when new comment is added. Also update the photo id in comments when user changes or deletes their photo
- Resize the photo when user uploads their profile picture
- Display the profile photo in the comment card based on the uploaded asset id. Currently it shows by email address
- Added cache control header so that browser caches the profile pictures

Fixes #5385 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/set-profile-asset-id-in-comment 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.78 **(-0.01)** | 36.51 **(0)** | 33.93 **(-0.01)** | 55.33 **(0)**
 :green_circle: | app/client/src/comments/CommentCard/CommentCard.tsx | 71.82 **(0.15)** | 59.06 **(-0.14)** | 42.86 **(0)** | 72.19 **(0.17)**
 :green_circle: | app/client/src/components/ads/Text.tsx | 100 **(0)** | 78.57 **(3.57)** | 100 **(0)** | 100 **(0)**
 :green_circle: | app/client/src/pages/common/ProfileImage.tsx | 90 **(0)** | 68.75 **(6.25)** | 71.43 **(0)** | 88.89 **(0)**
 :red_circle: | app/client/src/utils/helpers.tsx | 65.15 **(-1.52)** | 39.18 **(-3.09)** | 46.88 **(-3.12)** | 62.18 **(-1.28)**</details>