### PR TITLE
fix: update on page load actions on action delete.

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ActionController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ActionController.java
@@ -103,7 +103,7 @@ public class ActionController {
     @DeleteMapping("/{id}")
     public Mono<ResponseDTO<ActionDTO>> deleteAction(@PathVariable String id) {
         log.debug("Going to delete unpublished action with id: {}", id);
-        return newActionService.deleteUnpublishedAction(id)
+        return layoutActionService.deleteUnpublishedAction(id)
                 .map(deletedResource -> new ResponseDTO<>(HttpStatus.OK.value(), deletedResource, null));
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionService.java
@@ -27,8 +27,6 @@ public interface LayoutActionService {
 
     Mono<ActionDTO> updateSingleAction(String id, ActionDTO action);
 
-    Mono<String> updatePageLayoutsGivenAction(String pageId);
-
     Mono<ActionDTO> setExecuteOnLoad(String id, Boolean isExecuteOnLoad);
 
     JSONObject unescapeMongoSpecialCharacters(Layout layout);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionService.java
@@ -27,6 +27,8 @@ public interface LayoutActionService {
 
     Mono<ActionDTO> updateSingleAction(String id, ActionDTO action);
 
+    Mono<String> updatePageLayoutsGivenAction(String pageId);
+
     Mono<ActionDTO> setExecuteOnLoad(String id, Boolean isExecuteOnLoad);
 
     JSONObject unescapeMongoSpecialCharacters(Layout layout);
@@ -36,4 +38,6 @@ public interface LayoutActionService {
     Mono<ActionDTO> createSingleAction(ActionDTO action);
 
     Mono<ActionDTO> createAction(ActionDTO action, AppsmithEventContext eventContext);
+
+    Mono<ActionDTO> deleteUnpublishedAction(String id);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -649,7 +649,7 @@ public class LayoutActionServiceImpl implements LayoutActionService {
                 });
     }
 
-    public Mono<String> updatePageLayoutsGivenAction(String pageId) {
+    private Mono<String> updatePageLayoutsGivenAction(String pageId) {
         return Mono.justOrEmpty(pageId)
                 // fetch the unpublished page
                 .flatMap(id -> newPageService.findPageById(id, MANAGE_PAGES, false))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -634,8 +634,18 @@ public class LayoutActionServiceImpl implements LayoutActionService {
 
                 });
     }
+    
+    public Mono<ActionDTO> deleteUnpublishedAction(String id) {
+        return newActionService.deleteUnpublishedAction(id)
+                .flatMap(actionDTO -> Mono.zip(Mono.just(actionDTO),
+                        updatePageLayoutsGivenAction(actionDTO.getPageId())))
+                .flatMap(tuple -> {
+                    ActionDTO actionDTO = tuple.getT1();
+                    return Mono.just(actionDTO);
+                });
+    }
 
-    private Mono<String> updatePageLayoutsGivenAction(String pageId) {
+    public Mono<String> updatePageLayoutsGivenAction(String pageId) {
         return Mono.justOrEmpty(pageId)
                 // fetch the unpublished page
                 .flatMap(id -> newPageService.findPageById(id, MANAGE_PAGES, false))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutActionServiceImpl.java
@@ -634,7 +634,11 @@ public class LayoutActionServiceImpl implements LayoutActionService {
 
                 });
     }
-    
+
+    /**
+     * - Delete action.
+     * - Update page layout since a deleted action cannot be marked as on page load.
+     */
     public Mono<ActionDTO> deleteUnpublishedAction(String id) {
         return newActionService.deleteUnpublishedAction(id)
                 .flatMap(actionDTO -> Mono.zip(Mono.just(actionDTO),

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -171,6 +171,49 @@ public class LayoutActionServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
+    public void testOnPageLoadActionsAfterActionDelete() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        ActionDTO action = new ActionDTO();
+        action.setName("query1");
+        action.setFullyQualifiedName(action.getName());
+        action.setPageId(testPage.getId());
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        action.setDatasource(datasource);
+
+        Mono<PageDTO> resultMono = layoutActionService
+                .createSingleAction(action)
+                .flatMap(savedAction -> {
+                    ActionDTO updates = new ActionDTO();
+
+                    // Configure action to execute on page load.
+                    updates.setExecuteOnLoad(true);
+
+                    updates.setPolicies(null);
+                    updates.setUserPermissions(null);
+                    updates.setDatasource(datasource);
+
+                    // Save updated configuration and re-compute on page load actions.
+                    return layoutActionService.updateSingleAction(savedAction.getId(), updates);
+                })
+                .flatMap(savedAction -> layoutActionService.deleteUnpublishedAction(savedAction.getId())) // Delete action
+                .flatMap(savedAction -> newPageService.findPageById(testPage.getId(), READ_PAGES, false)); // Get page info
+
+        StepVerifier
+                .create(resultMono)
+                .assertNext(page -> {
+                    assertThat(page.getLayouts()).hasSize(1);
+
+                    // Verify that no action is marked to run on page load.
+                    assertThat(page.getLayouts().get(0).getLayoutOnLoadActions()).hasSize(0);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
     public void updateActionUpdatesLayout() {
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
 


### PR DESCRIPTION
## Description
- Currently, the list of actions to be run on page load is not updated when an action object gets deleted. Hence, sometimes, a previously deleted action may be set to run on page load which throws an error when the application tries to run it on page load. 
- This PR updates the list of actions to be run on page load whenever any action gets deleted. 

Fixes #7345 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
