### PR TITLE
feat: set `modifiedBy` during create, clone, fork, import app

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -166,6 +166,8 @@ public class ApplicationServiceTest {
                     assertThat(application.getPolicies()).isNotEmpty();
                     assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
                     assertThat(application.getOrganizationId().equals(orgId));
+                    assertThat(application.getModifiedBy()).isEqualTo("api_user");
+                    assertThat(application.getUpdatedAt()).isNotNull();
                 })
                 .verifyComplete();
     }
@@ -625,7 +627,7 @@ public class ApplicationServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
-    public void createCloneApplication() {
+    public void cloneApplicationTest() {
         Application testApplication = new Application();
         testApplication.setName("ApplicationServiceTest Clone Source TestApp");
 
@@ -658,7 +660,7 @@ public class ApplicationServiceTest {
         StepVerifier
                 .create(Mono.zip(applicationMono, pageListMono))
                 .assertNext(tuple -> {
-                    Application application = tuple.getT1();
+                    Application application = tuple.getT1(); // cloned application
                     List<PageDTO> pageList = tuple.getT2();
                     assertThat(application).isNotNull();
                     assertThat(application.isAppIsExample()).isFalse();
@@ -666,6 +668,8 @@ public class ApplicationServiceTest {
                     assertThat(application.getName().equals("ApplicationServiceTest Clone Source TestApp Copy"));
                     assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
                     assertThat(application.getOrganizationId().equals(orgId));
+                    assertThat(application.getModifiedBy()).isEqualTo("api_user");
+                    assertThat(application.getUpdatedAt()).isNotNull();
                     List<ApplicationPage> pages = application.getPages();
                     Set<String> pageIdsFromApplication = pages.stream().map(page -> page.getId()).collect(Collectors.toSet());
                     Set<String> pageIdsFromDb = pageList.stream().map(page -> page.getId()).collect(Collectors.toSet());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -608,6 +608,8 @@ public class ImportExportApplicationServiceTests {
                 assertThat(application.getPages()).hasSize(2);
                 assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
                 assertThat(application.getPublishedPages()).hasSize(1);
+                assertThat(application.getModifiedBy()).isEqualTo("api_user");
+                assertThat(application.getUpdatedAt()).isNotNull();
 
                 assertThat(datasourceList).isNotEmpty();
                 datasourceList.forEach(datasource -> {


### PR DESCRIPTION
## Description

Adds `modifiedBy` field to application when an user create, duplicate, clone or import an application. This field is required by UI to show last who last updated an application in the new home page.

Fixes #7451 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Tested on local machine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
