### PR TITLE
fix: Number of digits after decimal in input widget

### DIFF
--- a/app/client/src/widgets/InputWidget/component/index.tsx
+++ b/app/client/src/widgets/InputWidget/component/index.tsx
@@ -238,14 +238,22 @@ class InputComponent extends React.Component<
       ) {
         let value = valueAsString.split(",").join("");
         if (value) {
-          if (currentIndexOfDecimal !== indexOfDecimal) {
-            value = value.substr(0, currentIndexOfDecimal + fractionDigits + 1);
-          }
           const locale = navigator.languages?.[0] || "en-US";
           const formatter = new Intl.NumberFormat(locale, {
             style: "decimal",
             minimumFractionDigits: fractionDigits,
           });
+          const decimalValueArray = value.split(".");
+          //remove extra digits after decimal point
+          if (
+            this.props.decimalsInCurrency &&
+            decimalValueArray[1].length > this.props.decimalsInCurrency
+          ) {
+            value =
+              decimalValueArray[0] +
+              "." +
+              decimalValueArray[1].substr(0, this.props.decimalsInCurrency);
+          }
           const formattedValue = formatter.format(parseFloat(value));
           this.props.onValueChange(formattedValue);
         } else {


### PR DESCRIPTION
## Description
Fix number of digits after decimal points in input widget

Fixes #6317

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/decimal-digits-input 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/widgets/InputWidget/component/index.tsx | 58.59 **(-0.47)** | 45.24 **(-0.54)** | 63.41 **(0)** | 57.26 **(-0.46)**</details>