### PR TITLE
fix: Reset widget children by default

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -634,7 +634,7 @@ function renderField(props: {
       if (fieldType === FieldType.RESET_CHILDREN_FIELD) {
         label = "Reset Children";
         options = RESET_CHILDREN_OPTIONS;
-        defaultText = "false";
+        defaultText = "true";
       }
       if (fieldType === FieldType.WIDGET_NAME_FIELD) {
         label = "Widget";

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -250,7 +250,7 @@ const DATA_TREE_FUNCTIONS: Record<
       },
     ]);
   },
-  resetWidget: function(widgetName: string, resetChildren = false) {
+  resetWidget: function(widgetName: string, resetChildren = true) {
     return new AppsmithPromise([
       {
         type: ActionTriggerType.RESET_WIDGET_META_RECURSIVE_BY_NAME,


### PR DESCRIPTION
## Description
Update the default value for resetWidget's second argument(reset children) to `true`

Fixes #6859

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/reset-children-by-default 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.89 **(0)** | 36.72 **(0.01)** | 34.21 **(0)** | 55.43 **(0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**</details>