### PR TITLE
fix: Add migrations for all google sheet actions to turn off smart substitution for existing actions

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor.json
@@ -485,6 +485,13 @@
             ]
           },
           "placeholderText": "{{\n  Table1.selectedRows.map((row) => {\n    return { ...row, columnName: Input1.text }\n  })\n}}"
+        },
+        {
+          "label": "Smart JSON Substitution Key",
+          "configProperty": "actionConfiguration.pluginSpecifiedTemplates[13].key",
+          "hidden": true,
+          "controlType": "INPUT_TEXT",
+          "initialValue": "smartSubstitution"
         }
       ]
     }


### PR DESCRIPTION
Fixes #7513 