### PR TITLE
fix: Clicking on button in table widget when no action is configured throws error

### DIFF
--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -898,16 +898,19 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
       const modifiedAction = jsSnippets.reduce((prev: string, next: string) => {
         return prev + `{{(currentRow) => { ${next} }}} `;
       }, "");
-
-      super.executeAction({
-        triggerPropertyName: "onClick",
-        dynamicString: modifiedAction,
-        event: {
-          type: EventType.ON_CLICK,
-          callback: onComplete,
-        },
-        responseData: rowData,
-      });
+      if (modifiedAction) {
+        super.executeAction({
+          triggerPropertyName: "onClick",
+          dynamicString: modifiedAction,
+          event: {
+            type: EventType.ON_CLICK,
+            callback: onComplete,
+          },
+          responseData: rowData,
+        });
+      } else {
+        onComplete();
+      }
     } catch (error) {
       log.debug("Error parsing row action", error);
     }


### PR DESCRIPTION
## Description
Fix clicking on button in table widget when no action is configured.

Fixes #6892 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/table-button-column-no-action-click 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/widgets/TableWidget/widget/index.tsx | 26.67 **(-0.13)** | 5.9 **(-0.04)** | 26.42 **(0)** | 26.49 **(-0.14)**</details>