### PR TITLE
chore: widget help links from the property pane

### DIFF
--- a/app/client/src/pages/Editor/PropertyPaneHelpButton.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneHelpButton.tsx
@@ -21,7 +21,7 @@ const PropertyPaneHelpButton = withTheme(({ theme }: Props) => {
   const selectedWidgetType = selectedWidget?.type || "";
   const dispatch = useDispatch();
   const displayName =
-    WidgetFactory.widgetConfigMap.get(selectedWidgetType)?.name || "";
+    WidgetFactory.widgetConfigMap.get(selectedWidgetType)?.displayName || "";
 
   const openHelpModal = useCallback(() => {
     dispatch(setGlobalSearchQuery(displayName));


### PR DESCRIPTION

## Description
Fixes the default search text linked from the property pane's help button, for widgets.

Fixes #7522 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually (This would ideally need a cypress test #7528) 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/widget-help-link 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.9 **(0.01)** | 36.73 **(0.02)** | 34.22 **(0.01)** | 55.44 **(0.02)**
 :red_circle: | app/client/src/pages/Editor/PropertyPaneHelpButton.tsx | 85 **(0)** | 66.67 **(-8.33)** | 50 **(0)** | 84.21 **(0)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**
 :green_circle: | app/client/src/utils/helpers.tsx | 66.67 **(1.52)** | 42.27 **(3.09)** | 50 **(3.12)** | 63.46 **(1.28)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>