### PR TITLE
test: fixing the Cypress test for input spec

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Input_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Input_spec.js
@@ -203,9 +203,10 @@ describe("Input Widget Functionality", function() {
 
   it("Input value of number type should reflect the default text value 0", () => {
     cy.selectDropdownValue(commonlocators.dataType, "Number");
-    cy.get(widgetsPage.defaultInput)
+    /*cy.get(widgetsPage.defaultInput)
       .click({ force: true })
-      .type("0");
+      .type("0");*/
+    cy.testJsontext("defaulttext", "0");
     cy.closePropertyPane("inputwidget");
     cy.get(widgetsPage.innertext)
       .invoke("val")


### PR DESCRIPTION
There was another issue with input spec but the failure was seen in CI alone.
I have updated that part
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>