### PR TITLE
fix: only run onFilterUpdate when it's defined

### DIFF
--- a/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
@@ -253,13 +253,15 @@ class MultiSelectWidget extends BaseWidget<
   onFilterChange = (value: string) => {
     this.props.updateWidgetMetaProperty("filterText", value);
 
-    super.executeAction({
-      triggerPropertyName: "onFilterUpdate",
-      dynamicString: this.props.onFilterUpdate,
-      event: {
-        type: EventType.ON_FILTER_UPDATE,
-      },
-    });
+    if (this.props.onFilterUpdate) {
+      super.executeAction({
+        triggerPropertyName: "onFilterUpdate",
+        dynamicString: this.props.onFilterUpdate,
+        event: {
+          type: EventType.ON_FILTER_UPDATE,
+        },
+      });
+    }
   };
 
   static getWidgetType(): WidgetType {


### PR DESCRIPTION
## Description

only run onFilterUpdate when it's defined

Fixes #7512


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/multiselect-onFilterUpdate 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.89 **(0)** | 36.71 **(0.01)** | 34.21 **(0)** | 55.42 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**
 :red_circle: | app/client/src/widgets/MultiSelectWidget/widget/index.tsx | 48.98 **(-1.02)** | 0 **(0)** | 50 **(0)** | 50 **(-1.11)**</details>