### PR TITLE
fix: Rating widget crashing when put inside the list widget

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -309,6 +309,12 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
             set(widget, path, evaluatedValue);
             set(widget, `validationMessages.${path}`, "");
             set(widget, `invalidProps.${path}`, "");
+          } else if (
+            validationPath?.type === ValidationTypes.ARRAY ||
+            validationPath?.type === ValidationTypes.OBJECT_ARRAY
+          ) {
+            const value = Array.isArray(evaluatedValue) ? evaluatedValue : [];
+            set(widget, path, value);
           } else {
             set(widget, path, toString(evaluatedValue));
           }


### PR DESCRIPTION
Rate widget was crashing inside a list widget as it wasn't getting the sanitised value in case of array. This pr ensures it gets the correct value

Fixes #7132

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change


- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/rate-widget-inside-list-issue-7132 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.78 **(-0.01)** | 36.46 **(-0.04)** | 33.98 **(0)** | 55.33 **(-0.02)**
 :red_circle: | app/client/src/components/formControls/DynamicInputTextControl.tsx | 96.55 **(1.43)** | 50 **(-16.67)** | 80 **(-3.33)** | 95.83 **(0.83)**
 :red_circle: | app/client/src/widgets/ListWidget/widget/index.tsx | 50 **(-0.59)** | 24.84 **(-2.5)** | 44.44 **(0)** | 48.36 **(-0.6)**</details>