### PR TITLE
fix: widget refactor actions fetch change

### DIFF
--- a/app/client/cypress/fixtures/buttonApiDsl.json
+++ b/app/client/cypress/fixtures/buttonApiDsl.json
@@ -1,0 +1,51 @@
+{
+    "dsl": {
+        "widgetName": "MainContainer",
+        "backgroundColor": "none",
+        "rightColumn": 966,
+        "snapColumns": 64,
+        "detachFromLayout": true,
+        "widgetId": "0",
+        "topRow": 0,
+        "bottomRow": 360,
+        "containerStyle": "none",
+        "snapRows": 125,
+        "parentRowSpace": 1,
+        "type": "CANVAS_WIDGET",
+        "canExtend": true,
+        "version": 38,
+        "minHeight": 370,
+        "parentColumnSpace": 1,
+        "dynamicTriggerPathList": [],
+        "dynamicBindingPathList": [],
+        "leftColumn": 0,
+        "children": [
+            {
+                "isVisible": true,
+                "text": "Submit",
+                "buttonStyle": "PRIMARY",
+                "buttonVariant": "SOLID",
+                "widgetName": "Button1",
+                "isDisabled": false,
+                "isDefaultClickDisabled": true,
+                "recaptchaV2": false,
+                "version": 1,
+                "type": "BUTTON_WIDGET",
+                "hideCard": false,
+                "displayName": "Button",
+                "key": "s0e87p33u7",
+                "iconSVG": "/static/media/icon.c8f649ed.svg",
+                "widgetId": "ut5ew4t3wa",
+                "renderMode": "CANVAS",
+                "isLoading": false,
+                "parentColumnSpace": 14.90625,
+                "parentRowSpace": 10,
+                "leftColumn": 18,
+                "rightColumn": 26,
+                "topRow": 24,
+                "bottomRow": 28,
+                "parentId": "0"
+            }
+        ]
+    }
+}

--- a/app/client/cypress/fixtures/testdata.json
+++ b/app/client/cypress/fixtures/testdata.json
@@ -40,6 +40,7 @@
   "invalidValue": "invalid",
   "Put": "PUT",
   "Get": "GET",
+  "buttonName": "TestNew",
   "next": "?page=2&pageSize=10",
   "prev": "?page=1&pageSize=10",
   "apiFormDataBodyType": "x-www-form-urlencoded",

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_Button_with_API_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_Button_with_API_spec.js
@@ -1,0 +1,63 @@
+const commonlocators = require("../../../../locators/commonlocators.json");
+const dsl = require("../../../../fixtures/buttonApiDsl.json");
+const pages = require("../../../../locators/Pages.json");
+const apiPage = require("../../../../locators/ApiEditor.json");
+const apiwidget = require("../../../../locators/apiWidgetslocator.json");
+const publishPage = require("../../../../locators/publishWidgetspage.json");
+const widgetsPage = require("../../../../locators/Widgets.json");
+const testdata = require("../../../../fixtures/testdata.json");
+
+describe("Bind a button and Api usecase", function() {
+  let apiData;
+  let valueToTest;
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Add an API by binding a button in its header", function() {
+    cy.createAndFillApi(this.data.userApi, "/users");
+    cy.get(apiwidget.headerKey)
+      .first()
+      .click({ force: true })
+      .type("key", { parseSpecialCharSequences: true });
+    cy.get(apiwidget.headerValue)
+      .first()
+      .click({ force: true })
+      .type("{{Button1.text", { parseSpecialCharSequences: true });
+    cy.RunAPI();
+    cy.get(apiPage.responseBody)
+      .contains("name")
+      .siblings("span")
+      .invoke("text")
+      .then((text) => {
+        valueToTest = `${text
+          .match(/"(.*)"/)[0]
+          .split('"')
+          .join("")}`;
+        cy.log(valueToTest);
+        apiData = valueToTest;
+        cy.log("val1:" + valueToTest);
+      });
+  });
+
+  it("Button-Name updation", function() {
+    cy.SearchEntityandOpen("Button1");
+    //changing the Button Name
+    cy.widgetText(
+      testdata.buttonName,
+      widgetsPage.buttonWidget,
+      widgetsPage.buttonWidget + " " + commonlocators.widgetNameTag,
+    );
+  });
+
+  it("API datasource binding with button name validation", function() {
+    cy.SearchEntityandOpen("Api1");
+    cy.get(apiwidget.headerValue)
+      .first()
+      .invoke("text")
+      .then((text) => {
+        const someText = text;
+        expect(someText).to.contains(testdata.buttonName);
+      });
+  });
+});

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -581,7 +581,6 @@ export function* refactorActionName(
       });
       if (currentPageId === pageId) {
         yield updateCanvasWithDSL(refactorResponse.data, pageId, layoutId);
-        yield put(fetchActionsForPage(pageId));
       } else {
         yield put(fetchActionsForPage(pageId));
       }

--- a/app/client/src/sagas/JSActionSagas.ts
+++ b/app/client/src/sagas/JSActionSagas.ts
@@ -352,7 +352,6 @@ export function* refactorJSObjectName(
       });
       if (currentPageId === pageId) {
         yield updateCanvasWithDSL(refactorResponse.data, pageId, layoutId);
-        yield put(fetchJSCollectionsForPage(pageId));
       } else {
         yield put(fetchJSCollectionsForPage(pageId));
       }

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -104,6 +104,7 @@ import {
   getIsFirstTimeUserOnboardingEnabled,
   getFirstTimeUserOnboardingApplicationId,
 } from "selectors/onboardingSelectors";
+import { fetchJSCollectionsForPage } from "actions/jsActionActions";
 
 import WidgetFactory from "utils/WidgetFactory";
 const WidgetTypes = WidgetFactory.widgetTypes;
@@ -765,7 +766,6 @@ export function* updateWidgetNameSaga(
         const isValidResponse: boolean = yield validateResponse(response);
         if (isValidResponse) {
           yield updateCanvasWithDSL(response.data, pageId, layoutId);
-
           yield put(updateWidgetNameSuccess());
           // Add this to the page DSLs for entity explorer
           yield put({
@@ -815,6 +815,8 @@ export function* updateCanvasWithDSL(
     widgets: normalizedWidgets.entities.canvasWidgets,
   };
   yield put(initCanvasLayout(canvasWidgetsPayload));
+  yield put(fetchActionsForPage(pageId));
+  yield put(fetchJSCollectionsForPage(pageId));
 }
 
 export function* setDataUrl() {


### PR DESCRIPTION
## Description

Widget refactor was not reflected in API pane

Fixes #7627

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fetch-actions-after-update-canvas 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.8 **(0)** | 36.55 **(-0.01)** | 33.93 **(0)** | 55.35 **(0)**
 :green_circle: | app/client/src/sagas/ActionSagas.ts | 10.88 **(0.03)** | 0.78 **(0)** | 3.7 **(0)** | 13.14 **(0.04)**
 :green_circle: | app/client/src/sagas/JSActionSagas.ts | 16.17 **(0.1)** | 2.04 **(0)** | 6.67 **(0)** | 19.12 **(0.14)**
 :green_circle: | app/client/src/sagas/PageSagas.tsx | 23.95 **(0.08)** | 5.95 **(0)** | 14.29 **(0)** | 25.78 **(0.08)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>