### PR TITLE
fix: Use Image from backend for crud success popup

### DIFF
--- a/app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx
@@ -108,12 +108,17 @@ const STEP = {
   SHOW_INFO: "show_info",
 };
 
+const getInfoImage = (): string =>
+  `${S3_BUCKET_URL}/crud/working-flow-chart.png`;
+
 function InfoContent({
   onClose,
+  successImageUrl,
   successMessage,
 }: {
   onClose: () => void;
   successMessage: string;
+  successImageUrl: string;
 }) {
   return (
     <>
@@ -126,7 +131,10 @@ function InfoContent({
           type={TextType.P1}
         />
         <ImageWrapper>
-          <InfoImage alt="CRUD Info" src={getInfoImage()} />
+          <InfoImage
+            alt="CRUD Info"
+            src={successImageUrl ? successImageUrl : getInfoImage()}
+          />
         </ImageWrapper>
       </Content>
 
@@ -143,8 +151,6 @@ function InfoContent({
     </>
   );
 }
-const getInfoImage = (): string =>
-  `${S3_BUCKET_URL}/crud/working-flow-chart.png`;
 
 function GenCRUDSuccessModal(props: Props) {
   const { crudInfoModalOpen, generateCRUDSuccessInfo } = props;

--- a/app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx
@@ -131,10 +131,7 @@ function InfoContent({
           type={TextType.P1}
         />
         <ImageWrapper>
-          <InfoImage
-            alt="CRUD Info"
-            src={successImageUrl ? successImageUrl : getInfoImage()}
-          />
+          <InfoImage alt="CRUD Info" src={successImageUrl} />
         </ImageWrapper>
       </Content>
 
@@ -167,6 +164,10 @@ function GenCRUDSuccessModal(props: Props) {
     (generateCRUDSuccessInfo && generateCRUDSuccessInfo.successMessage) ||
     createMessage(GEN_CRUD_INFO_DIALOG_SUBTITLE);
 
+  const successImageUrl =
+    (generateCRUDSuccessInfo && generateCRUDSuccessInfo.successImageUrl) ||
+    getInfoImage();
+
   useEffect(() => {
     const timerId = setTimeout(() => {
       setStep(STEP.SHOW_INFO);
@@ -192,7 +193,11 @@ function GenCRUDSuccessModal(props: Props) {
           </SuccessContentWrapper>
         ) : null}
         {step === STEP.SHOW_INFO ? (
-          <InfoContent onClose={onClose} successMessage={successMessage} />
+          <InfoContent
+            onClose={onClose}
+            successImageUrl={successImageUrl}
+            successMessage={successMessage}
+          />
         ) : null}
       </Wrapper>
     </Dialog>


### PR DESCRIPTION
## Description

Use `successImgUrl` instead of hardcoded image URL for CRUD generation success Popup.

Fixes #7579

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
