### PR TITLE
chore: minor styling fixes for debugger

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/DebugCTA.tsx
+++ b/app/client/src/components/editorComponents/Debugger/DebugCTA.tsx
@@ -11,17 +11,17 @@ import Icon, { IconSize } from "components/ads/Icon";
 import { Message } from "entities/AppsmithConsole";
 import ContextualMenu from "./ContextualMenu";
 import { Position } from "@blueprintjs/core";
-import { SeverityIconColor } from "./helpers";
 import { Colors } from "constants/Colors";
 
 const EVDebugButton = styled.button`
   ${(props) => getTypographyByKey(props, "btnSmall")};
   display: flex;
   padding: ${(props) => props.theme.spaces[1]}px;
-  border: 1px solid ${SeverityIconColor.error};
+  border: 1px solid
+    ${(props) => props.theme.colors.debugger.error.hoverIconColor};
   width: fit-content;
   background-color: transparent;
-  color: ${SeverityIconColor.error};
+  color: ${(props) => props.theme.colors.debugger.error.hoverIconColor};
   align-items: center;
   justify-content: center;
   cursor: pointer;
@@ -59,7 +59,13 @@ export function EvaluatedValueDebugButton(props: {
         error={props.error}
         modifiers={{
           offset: {
-            offset: "0, 0",
+            enabled: true,
+            options: {
+              offset: [0, 5],
+            },
+          },
+          arrow: {
+            enabled: false,
           },
         }}
         position={Position.BOTTOM_RIGHT}

--- a/app/client/src/components/editorComponents/Debugger/LogItem.tsx
+++ b/app/client/src/components/editorComponents/Debugger/LogItem.tsx
@@ -1,4 +1,5 @@
 import { Collapse, Position } from "@blueprintjs/core";
+import { Classes as BPPopover2Classes } from "@blueprintjs/popover2";
 import { isString } from "lodash";
 import { Classes } from "components/ads/common";
 import Icon, { IconName, IconSize } from "components/ads/Icon";
@@ -7,7 +8,7 @@ import React, { useState } from "react";
 import ReactJson from "react-json-view";
 import styled from "styled-components";
 import EntityLink, { DebuggerLinkUI } from "./EntityLink";
-import { SeverityIcon, SeverityIconColor } from "./helpers";
+import { SeverityIcon } from "./helpers";
 import Text, { TextType } from "components/ads/Text";
 import { getTypographyByKey } from "constants/DefaultTheme";
 import TooltipComponent from "components/ads/Tooltip";
@@ -28,6 +29,25 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
       props.theme.colors.debugger.error.backgroundColor};
     border-bottom: 1px solid
       ${(props) => props.theme.colors.debugger.error.borderBottom};
+
+    .${Classes.ICON}.search-menu {
+      path {
+        fill: ${(props) => props.theme.colors.debugger.error.iconColor};
+      }
+      &:hover {
+        path {
+          fill: ${(props) => props.theme.colors.debugger.error.hoverIconColor};
+        }
+      }
+    }
+
+    .${BPPopover2Classes.POPOVER2_OPEN} {
+      .${Classes.ICON}.search-menu {
+        path {
+          fill: ${(props) => props.theme.colors.debugger.error.hoverIconColor};
+        }
+      }
+    }
   }
 
   &.${Severity.WARNING} {
@@ -35,6 +55,26 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
       props.theme.colors.debugger.warning.backgroundColor};
     border-bottom: 1px solid
       ${(props) => props.theme.colors.debugger.warning.borderBottom};
+    .${Classes.ICON}.search-menu {
+      path {
+        fill: ${(props) => props.theme.colors.debugger.warning.iconColor};
+      }
+      &:hover {
+        path {
+          fill: ${(props) =>
+            props.theme.colors.debugger.warning.hoverIconColor};
+        }
+      }
+    }
+    
+    .${BPPopover2Classes.POPOVER2_OPEN} {
+      .${Classes.ICON}.search-menu {
+        path {
+          fill: ${(props) =>
+            props.theme.colors.debugger.warning.hoverIconColor};
+        }
+      }
+    }
   }
 
   .bp3-popover-target {
@@ -126,12 +166,6 @@ const StyledSearchIcon = styled(Icon)`
   && {
     margin-left: 10px;
     vertical-align: middle;
-
-    &:hover {
-      path {
-        fill: ${(props) => props.fillColor};
-      }
-    }
   }
 `;
 
@@ -142,7 +176,6 @@ const MessageWrapper = styled.div`
 export const getLogItemProps = (e: Log) => {
   return {
     icon: SeverityIcon[e.severity] as IconName,
-    iconColor: SeverityIconColor[e.severity],
     timestamp: e.timestamp,
     source: e.source,
     label: e.text,
@@ -157,7 +190,6 @@ export const getLogItemProps = (e: Log) => {
 
 type LogItemProps = {
   icon: IconName;
-  iconColor: string;
   timestamp: string;
   label: string;
   timeTaken: string;
@@ -230,13 +262,11 @@ function LogItem(props: LogItemProps) {
                   {createMessage(TROUBLESHOOT_ISSUE)}
                 </Text>
               }
-              hoverOpenDelay={1000}
               minimal
               position={Position.BOTTOM_LEFT}
             >
               <StyledSearchIcon
-                className={Classes.ICON}
-                fillColor={props.iconColor}
+                className={`${Classes.ICON} search-menu`}
                 name={"wand"}
                 size={IconSize.MEDIUM}
               />

--- a/app/client/src/components/editorComponents/Debugger/helpers.tsx
+++ b/app/client/src/components/editorComponents/Debugger/helpers.tsx
@@ -54,12 +54,6 @@ export const SeverityIcon: Record<Severity, string> = {
   [Severity.WARNING]: "warning",
 };
 
-export const SeverityIconColor: Record<Severity, string> = {
-  [Severity.INFO]: "#03B365",
-  [Severity.ERROR]: "#F22B2B",
-  [Severity.WARNING]: "rgb(224, 179, 14)",
-};
-
 export function getDependenciesFromInverseDependencies(
   deps: DependencyMap,
   entityName: string | null,

--- a/app/client/src/constants/DefaultTheme.tsx
+++ b/app/client/src/constants/DefaultTheme.tsx
@@ -1171,10 +1171,14 @@ type ColorType = {
     warning: {
       borderBottom: string;
       backgroundColor: string;
+      iconColor: string;
+      hoverIconColor: string;
     };
     error: {
       borderBottom: string;
       backgroundColor: string;
+      iconColor: string;
+      hoverIconColor: string;
     };
     jsonIcon: string;
     message: string;
@@ -1997,10 +2001,14 @@ export const dark: ColorType = {
       borderBottom: "black",
     },
     warning: {
+      iconColor: "#f3cc3e",
+      hoverIconColor: "#e0b30e",
       borderBottom: "black",
       backgroundColor: "#29251A",
     },
     error: {
+      iconColor: "#f56060",
+      hoverIconColor: "#F22B2B",
       borderBottom: "black",
       backgroundColor: "#291B1D",
     },
@@ -2587,10 +2595,14 @@ export const light: ColorType = {
       borderBottom: "rgba(0, 0, 0, 0.05)",
     },
     warning: {
+      iconColor: "#f3cc3e",
+      hoverIconColor: "#e0b30e",
       borderBottom: "white",
       backgroundColor: "rgba(254, 184, 17, 0.1)",
     },
     error: {
+      iconColor: "#f56060",
+      hoverIconColor: "#F22B2B",
       borderBottom: "white",
       backgroundColor: "rgba(242, 43, 43, 0.08)",
     },


### PR DESCRIPTION
# Description
Using popover2 as it fixes the issue where clicking on a popover target doesn't dismiss the tooltip associated with the target.
Moved wand icon color styles to theme.

Fixes #7380

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/minor-debugger-ux 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.78 **(-0.01)** | 36.51 **(0.01)** | 33.95 **(-0.03)** | 55.34 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/ContextualMenu.tsx | 44.3 **(-1.03)** | 19.61 **(3.28)** | 10.53 **(-1.97)** | 44.3 **(-1.03)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/DebugCTA.tsx | 51.35 **(-4.21)** | 60 **(0)** | 0 **(0)** | 52.78 **(-4.36)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/LogItem.tsx | 36.36 **(-1.97)** | 21.74 **(0)** | 0 **(0)** | 37.1 **(-2.19)**
 :red_circle: | app/client/src/components/editorComponents/Debugger/helpers.tsx | 76.67 **(-0.38)** | 72.73 **(0)** | 33.33 **(0)** | 78 **(-0.43)**</details>