### PR TITLE
Fix NPE in UQI migration

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3161,7 +3161,7 @@ public class DatabaseChangelog {
         );
 
         for (NewAction mongoAction : mongoActions) {
-            if (mongoAction.getUnpublishedAction() == null && mongoAction.getUnpublishedAction().getActionConfiguration() == null) {
+            if (mongoAction.getUnpublishedAction() == null || mongoAction.getUnpublishedAction().getActionConfiguration() == null) {
                 // No migrations required
                 continue;
             }


### PR DESCRIPTION
The UQI migration throws an NPE at 

https://github.com/appsmithorg/appsmith/blob/373f64c9ca98a67e2aa37e8721931a141ef812ac/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java#L3169

This PR fixes this NPE.
