### PR TITLE
feat: Adding input type to BSON fields in Mongo Plugin

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/aggregate.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/aggregate.json
@@ -26,6 +26,7 @@
           "label": "Array of Pipelines",
           "configProperty": "actionConfiguration.formData.aggregate.arrayPipelines",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText" : "[{ $project: { tags: 1 } }, { $unwind: \"$tags\" }, { $group: { _id: \"$tags\", count: { $sum : 1 } } }  ]"
         }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/count.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/count.json
@@ -26,6 +26,7 @@
           "label": "Query",
           "configProperty": "actionConfiguration.formData.count.query",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText" : "{rating : {$gte : 9}}"
         }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/delete.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/delete.json
@@ -26,6 +26,7 @@
           "label": "Query",
           "configProperty": "actionConfiguration.formData.delete.query",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText" : "{rating : {$gte : 9}}"
         },

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/distinct.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/distinct.json
@@ -26,6 +26,7 @@
           "label": "Query",
           "configProperty": "actionConfiguration.formData.distinct.query",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText" : "{rating : {$gte : 9}}"
         },

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/find.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/find.json
@@ -26,6 +26,7 @@
           "label": "Query",
           "configProperty": "actionConfiguration.formData.find.query",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{rating : {$gte : 9}}"
         },
@@ -33,6 +34,7 @@
           "label": "Sort",
           "configProperty": "actionConfiguration.formData.find.sort",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{name : 1}"
         },
@@ -40,6 +42,7 @@
           "label": "Projection",
           "configProperty": "actionConfiguration.formData.find.projection",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{name : 1}"
         },

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/insert.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/insert.json
@@ -26,6 +26,7 @@
           "label": "Documents",
           "configProperty": "actionConfiguration.formData.insert.documents",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText" : "[ { _id: 1, user: \"abc123\", status: \"A\" } ]"
         }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/update.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/update.json
@@ -26,6 +26,7 @@
           "label": "Query",
           "configProperty": "actionConfiguration.formData.updateMany.query",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText" : "{rating : {$gte : 9}}"
         },
@@ -33,6 +34,7 @@
           "label": "Update",
           "configProperty": "actionConfiguration.formData.updateMany.update",
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "inputType": "JSON",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText" : "{ $inc: { score: 1 } }"
         },


### PR DESCRIPTION
Adding input type to BSON fields to ensure future client side validations can be added to these fields