### PR TITLE
chore: Invite user to org form input tab issue

### DIFF
--- a/app/client/src/components/ads/TagInputComponent.tsx
+++ b/app/client/src/components/ads/TagInputComponent.tsx
@@ -106,15 +106,13 @@ function TagInputComponent(props: TagInputProps) {
   const onKeyDown = (e: any) => {
     // Add new values to the tags on comma, return key, space and Tab press.
     if (
-      e.key === "," ||
-      e.key === "Enter" ||
-      e.key === " " ||
-      e.key === "Tab"
+      (e.key === "," ||
+        e.key === "Enter" ||
+        e.key === " " ||
+        e.key === "Tab") &&
+      e.target.value
     ) {
-      const newValues = [...values];
-      if (e.target.value) {
-        newValues.push(e.target.value);
-      }
+      const newValues = [...values, e.target.value];
       commitValues(newValues);
       setCurrentValue("");
       e.preventDefault();

--- a/app/client/src/components/ads/TagInputComponent.tsx
+++ b/app/client/src/components/ads/TagInputComponent.tsx
@@ -111,7 +111,10 @@ function TagInputComponent(props: TagInputProps) {
       e.key === " " ||
       e.key === "Tab"
     ) {
-      const newValues = [...values, e.target.value];
+      const newValues = [...values];
+      if (e.target.value) {
+        newValues.push(e.target.value);
+      }
       commitValues(newValues);
       setCurrentValue("");
       e.preventDefault();

--- a/app/client/src/components/ads/TagInputComponent.tsx
+++ b/app/client/src/components/ads/TagInputComponent.tsx
@@ -104,7 +104,8 @@ function TagInputComponent(props: TagInputProps) {
   };
 
   const onKeyDown = (e: any) => {
-    // Add new values to the tags on comma, return key, space and Tab press.
+    // Add new values to the tags on comma, return key, space and Tab press
+    // only if user has typed something on input
     if (
       (e.key === "," ||
         e.key === "Enter" ||


### PR DESCRIPTION
## Description

When user filling out email in invite user to org form, pressing tab adds empty value to the list as a result we end up with "invalid email" issue. This commit fixes that issue by not adding empty values to the list.

Fixes: #6785

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/invite-user-email-input 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/ads/TagInputComponent.tsx | 11.48 **(0)** | 5.13 **(-0.13)** | 0 **(0)** | 12.28 **(0)**</details>