### PR TITLE
ci: Add retries when getting page from GitBook

### DIFF
--- a/app/client/gitbook-algolia-lambda.js
+++ b/app/client/gitbook-algolia-lambda.js
@@ -56,6 +56,17 @@ function getPage(pageId) {
   });
 }
 
+async function getPageRetry(pageId, retries) {
+  while (retries-- > 0) {
+    try {
+      return await getPage(pageId);
+    } catch (error) {
+      continue;
+    }
+  }
+  throw new Error("Tried getting page " + retries + " times, but failed.");
+}
+
 const pages = [];
 
 
@@ -100,7 +111,7 @@ exports.handler = async (event, context, callback) => {
 
           pages.push(masterPage);
 
-          let promises = pages.map(page => page.uid).map(getPage);
+          let promises = pages.map(page => page.uid).map(pageId => getPageRetry(pageId, 3));
 
           Promise.all(promises).then(updatedPages => {
 


### PR DESCRIPTION
GitBook API occasionally throws a 500 when trying to get a page. This makes our whole sync Lambda fail.

This PR adds a retry step, that will wait a second and retry the GitBook API, with retries capped to three, so the Lambda is a little more resilient to random 500s from GitBook API.
