### PR TITLE
fix: Default type of where conditions converted to array

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
@@ -89,7 +89,7 @@ public class MethodConfig {
                         this.rowObjects = propertyValue;
                         break;
                     case "where":
-                        if (property.getValue() != null) {
+                        if (property.getValue() != null && !((List<Object>) property.getValue()).isEmpty()) {
                             this.whereConditions = Condition.generateFromConfiguration((List<Object>) property.getValue());
                         }
                         break;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor.json
@@ -406,6 +406,7 @@
               }
             ]
           },
+          "initialValue": [],
           "schema": [
             {
               "label": "Column Name",


### PR DESCRIPTION
Generate CRUD page fails since it does not use the `where` condition and defaults it to an empty string. This fix mandates that default to be an empty array.