### PR TITLE
ci: Use separate artifacts for separate services

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -534,7 +534,7 @@ jobs:
           name: server-build
           path: app/server/dist
 
-      - name: Download the server build artifact
+      - name: Download the rts build artifact
         uses: actions/download-artifact@v2
         with:
           name: rts-build

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -122,12 +122,13 @@ jobs:
             REACT_APP_INTERCOM_APP_ID=${{ secrets.APPSMITH_INTERCOM_ID }} \
             REACT_APP_IS_APPSMITH_CLOUD=${{ secrets.IS_APPSMITH_CLOUD }} \
             yarn build
+          ls -l build
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload react build bundle
         uses: actions/upload-artifact@v2
         with:
-          name: build
+          name: client-build
           path: app/client/build/
 
   buildServer:
@@ -209,12 +210,13 @@ jobs:
             -DgenerateBackupPoms=false \
             -DprocessAllModules=true
           ./build.sh -DskipTests
+          ls -l dist
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle
         uses: actions/upload-artifact@v2
         with:
-          name: build
+          name: server-build
           path: app/server/dist/
 
   buildRts:
@@ -256,13 +258,15 @@ jobs:
           echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
 
       - name: Build
-        run: ./build.sh
+        run: |
+          ./build.sh
+          ls -l dist
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle
         uses: actions/upload-artifact@v2
         with:
-          name: build
+          name: rts-build
           path: app/rts/dist/
 
   ui-test:
@@ -321,7 +325,7 @@ jobs:
       - name: Download the server build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build
+          name: server-build
           path: app/server/dist
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
@@ -364,23 +368,20 @@ jobs:
           APPSMITH_CLOUD_SERVICES_USERNAME: ""
           APPSMITH_CLOUD_SERVICES_PASSWORD: ""
         run: |
-            ls -l
-            ls -l scripts/
-            ls -l dist/
-            nohup ./scripts/start-dev-server.sh 2>&1 &
+          ls -l
+          ls -l scripts/
+          ls -l dist/
+          nohup ./scripts/start-dev-server.sh 2>&1 &
 
-      - name: Wait for 30 seconds for server to start
+      - name: Wait for 30s and check if server is running
         run: |
           sleep 30s
-
-      - name: "Exit if Server hasn't started"
-        run: |
-          lsof -i :8080 || true;
-          if [[ `ps -ef | grep server | grep java |wc -l` == 0 ]]; then
-            echo "Server Not Started";
-            exit 1;
+          if lsof -i :8080; then
+            echo "Server Found"
           else
-            echo "Server Found";
+            echo "Server Not Started. Printing logs from server process"
+            cat app/server/nohup.out
+            exit 1
           fi
 
       - name: Use Node.js 14.15.4
@@ -412,7 +413,7 @@ jobs:
       - name: Download the react build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build
+          name: client-build
           path: app/client/build
 
       - name: Installing Yarn serve
@@ -524,19 +525,19 @@ jobs:
       - name: Download the react build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build
+          name: client-build
           path: app/client/build
 
       - name: Download the server build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build
+          name: server-build
           path: app/server/dist
 
       - name: Download the server build artifact
         uses: actions/download-artifact@v2
         with:
-          name: build
+          name: rts-build
           path: app/rts/dist
 
       # Here, the GITHUB_REF is of type /refs/head/<branch_name>. We extract branch_name from this by removing the


### PR DESCRIPTION
Currently, all three services' artifact names are set to `build`. This leads to a single artifact with files from all three services as siblings. This has two problems:

1. If there's an overlap in a filename among the files in build folder of two services, one of them will be overwritten with the other.
2. The same large artifact is downloaded every time we do a `download-artifact`, once for server, once for client, and once for RTS, the same large artifact is downloaded thrice before building the Docker images.

Here's a preview of how the artifact looks like currently. The marked ones are from server and the rest are from client (and RTS as well I think).

![Screenshot 2021-09-22 at 10 59 16](https://user-images.githubusercontent.com/120119/134288170-b0f55ee8-5c0d-4eeb-ac64-a2a48dfca998.png)
