### PR TITLE
fix: Changes to introduce header prefix in API key authentication type

### DIFF
--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -71,6 +71,7 @@ export interface Basic {
 export interface ApiKey {
   authenticationType: AuthType.apiKey;
   label: string;
+  headerPrefix: string;
   value: string;
   addTo: string;
 }

--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -6,6 +6,7 @@ export interface DatasourceAuthentication {
   username?: string;
   password?: string;
   label?: string;
+  headerPrefix?: string;
   value?: string;
   addTo?: string;
   bearerToken?: string;

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -207,6 +207,9 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
     if (!authentication || !_.get(authentication, "addTo")) {
       this.props.change("authentication.addTo", ApiKeyAuthType.Header);
     }
+    if (!authentication || !_.get(authentication, "headerPrefix")) {
+      this.props.change("authentication.headerPefix", "ApiKeyAuthType.Header");
+    }
   };
 
   ensureOAuthDefaultsAreCorrect = () => {
@@ -467,6 +470,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
   };
 
   renderApiKey = () => {
+    const { authentication } = this.props.formData;
     return (
       <>
         <FormInputContainer>
@@ -481,6 +485,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
           <InputTextControl
             {...COMMON_INPUT_PROPS}
             configProperty="authentication.value"
+            encrypted
             label="Value"
             placeholderText="value"
           />
@@ -504,6 +509,16 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
             propertyValue=""
           />
         </FormInputContainer>
+        {_.get(authentication, "addTo") == "header" && (
+          <FormInputContainer>
+            <InputTextControl
+              {...COMMON_INPUT_PROPS}
+              configProperty="authentication.headerPrefix"
+              label="Header Prefix"
+              placeholderText="eg: Bearer "
+            />
+          </FormInputContainer>
+        )}
       </>
     );
   };
@@ -514,6 +529,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
         <InputTextControl
           {...COMMON_INPUT_PROPS}
           configProperty="authentication.bearerToken"
+          encrypted
           label="Bearer Token"
           placeholderText="Bearer Token"
         />

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -124,6 +124,7 @@ const formToDatasourceAuthentication = (
         authenticationType: AuthType.apiKey,
         label: authentication.label,
         value: authentication.value,
+        headerPrefix: authentication.headerPrefix,
         addTo: authentication.addTo,
       };
       return apiKey;
@@ -204,6 +205,7 @@ const datasourceToFormAuthentication = (
       authenticationType: AuthType.apiKey,
       label: authentication.label || "",
       value: authentication.value || "",
+      headerPrefix: authentication.headerPrefix || "",
       addTo: authentication.addTo || "",
     };
     return apiKey;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApiKeyAuth.java
@@ -30,6 +30,8 @@ public class ApiKeyAuth extends AuthenticationDTO {
     Type addTo;
     String label;
 
+    String headerPrefix;
+
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Encrypted
     String value;

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/connections/ApiKeyAuthenticationTest.java
@@ -15,7 +15,7 @@ public class ApiKeyAuthenticationTest {
         String label = "label";
         String value = "value";
         ApiKeyAuth.Type type = ApiKeyAuth.Type.QUERY_PARAMS;
-        ApiKeyAuth apiKeyAuthDTO = new ApiKeyAuth(type, label, value);
+        ApiKeyAuth apiKeyAuthDTO = new ApiKeyAuth(type, label, null, value);
         Mono<ApiKeyAuthentication> connectionMono = ApiKeyAuthentication.create(apiKeyAuthDTO);
         StepVerifier.create(connectionMono)
                 .assertNext(connection -> {

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -495,7 +495,7 @@ public class RestApiPluginTest {
     public void testRequestWithApiKeyHeader() {
         DatasourceConfiguration dsConfig = new DatasourceConfiguration();
         dsConfig.setUrl("https://postman-echo.com/post");
-        AuthenticationDTO authenticationDTO = new ApiKeyAuth(ApiKeyAuth.Type.HEADER, "api_key", "test");
+        AuthenticationDTO authenticationDTO = new ApiKeyAuth(ApiKeyAuth.Type.HEADER, "api_key", "Token", "test");
         dsConfig.setAuthentication(authenticationDTO);
 
         ActionConfiguration actionConfig = new ActionConfiguration();


### PR DESCRIPTION
When API key is used as a header, some endpoints might need to add a prefix to the value of the API key. For instance, Baserow needs the api keys to be prefixed by `Token`.

This fix introduces the field in REST API plugin and defaults it to empty for backward compatibility.
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/api-key-header-prefix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.75 **(0)** | 36.55 **(0)** | 33.8 **(0)** | 55.37 **(0.01)**
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx | 25 **(-0.4)** | 17.24 **(-0.94)** | 3.13 **(0)** | 27.98 **(-0.5)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>