### PR TITLE
fix: evaluation popper z index

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -28,7 +28,7 @@ import {
 import * as Sentry from "@sentry/react";
 import { Severity } from "@sentry/react";
 import { CodeEditorExpected } from "components/editorComponents/CodeEditor/index";
-import { Layers } from "constants/Layers";
+import { Indices, Layers } from "constants/Layers";
 import { Variant } from "components/ads/common";
 
 const modifiers: IPopoverSharedProps["modifiers"] = {
@@ -185,6 +185,7 @@ interface Props {
   evaluationSubstitutionType?: EvaluationSubstitutionType;
   popperPlacement?: Placement;
   entity?: FieldEntityInformation;
+  popperZIndex?: Indices;
 }
 
 interface PopoverContentProps {
@@ -460,7 +461,7 @@ function EvaluatedValuePopup(props: Props) {
         modifiers={modifiers}
         placement={placement}
         targetNode={wrapperRef.current || undefined}
-        zIndex={Layers.evaluationPopper}
+        zIndex={props.popperZIndex || Layers.evaluationPopper}
       >
         <PopoverContent
           entity={props.entity}

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -82,6 +82,7 @@ import { getLintAnnotations } from "./lintHelpers";
 import getFeatureFlags from "utils/featureFlags";
 import { executeCommandAction } from "actions/apiPaneActions";
 import { SlashCommandPayload } from "entities/Action";
+import { Indices } from "constants/Layers";
 
 const AUTOCOMPLETE_CLOSE_KEY_CODES = [
   "Enter",
@@ -131,6 +132,7 @@ export type EditorStyleProps = {
   useValidationMessage?: boolean;
   evaluationSubstitutionType?: EvaluationSubstitutionType;
   popperPlacement?: Placement;
+  popperZIndex?: Indices;
 };
 
 export type EditorProps = EditorStyleProps &
@@ -634,6 +636,7 @@ class CodeEditor extends Component<Props, State> {
           hideEvaluatedValue={hideEvaluatedValue}
           isOpen={showEvaluatedValue}
           popperPlacement={this.props.popperPlacement}
+          popperZIndex={this.props.popperZIndex}
           theme={theme || EditorTheme.LIGHT}
           useValidationMessage={useValidationMessage}
         >

--- a/app/client/src/components/editorComponents/GlobalSearch/SnippetsDescription.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/SnippetsDescription.tsx
@@ -42,6 +42,7 @@ import { ReactComponent as CopyIcon } from "assets/icons/menu/copy-snippet.svg";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { getTypographyByKey } from "constants/DefaultTheme";
 import { SnippetAction } from "reducers/uiReducers/globalSearchReducer";
+import { Layers } from "constants/Layers";
 
 SyntaxHighlighter.registerLanguage("sql", sql);
 
@@ -333,6 +334,7 @@ export default function SnippetDescription({ item }: { item: Snippet }) {
                   isInvalid={evaluatedArguments[arg.name]?.isInvalid}
                   mode={EditorModes.TEXT_WITH_BINDING}
                   popperPlacement="right-start"
+                  popperZIndex={Layers.portals}
                   showLightningMenu={false}
                   size={EditorSize.EXTENDED}
                   tabBehaviour={TabBehaviour.INDENT}

--- a/app/client/src/constants/Layers.tsx
+++ b/app/client/src/constants/Layers.tsx
@@ -55,7 +55,7 @@ export const Layers = {
   appComments: Indices.Layer7,
   max: Indices.LayerMax,
   sideStickyBar: Indices.Layer7,
-  evaluationPopper: Indices.Layer9,
+  evaluationPopper: Indices.Layer3,
 };
 
 export const LayersContext = React.createContext(Layers);


### PR DESCRIPTION
## Description
Evaluation popper persist on top of portals when snippets/docs are trigger from it. Fixed evaluation popper z-index. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/evaluation_popper_zIndex 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.76 **(0.01)** | 36.58 **(0.02)** | 33.8 **(0)** | 55.37 **(0.01)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx | 65.35 **(0)** | 56.25 **(1.12)** | 36.11 **(0)** | 65.77 **(0)**
 :green_circle: | app/client/src/components/editorComponents/GlobalSearch/SnippetsDescription.tsx | 27.73 **(0.61)** | 3.77 **(0)** | 0 **(0)** | 30.19 **(0.67)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>