### PR TITLE
ci: Package release even if tests fail

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -507,8 +507,9 @@ jobs:
     defaults:
       run:
         working-directory: app/client
-    # Run this job only if all the previous steps are a success and the reference if the release or master branch
-    if: (success() && github.ref == 'refs/heads/release') || github.ref == 'refs/heads/master'
+
+    # Run this job irrespective of tests failing, if this is the release branch; or only if the tests pass, if this is the master branch.
+    if: (success() && github.ref == 'refs/heads/master') || github.ref == 'refs/heads/release'
 
     steps:
       # Checkout the code


### PR DESCRIPTION
Changes the CI packaging flow from:

- Package irrespective of test failures, if on `master` branch.
- Package only if tests pass, if on `release` branch.

To:

- Package irrespective of test failures, if on `release` branch.
- Package only if tests pass, if on `master` branch.
