### PR TITLE
Revert "fix: back btn navigation problems"

### DIFF
--- a/app/client/src/components/editorComponents/CloseEditor.tsx
+++ b/app/client/src/components/editorComponents/CloseEditor.tsx
@@ -6,6 +6,19 @@ import { Icon } from "@blueprintjs/core";
 import PerformanceTracker, {
   PerformanceTransactionName,
 } from "utils/PerformanceTracker";
+import {
+  BUILDER_PAGE_URL,
+  INTEGRATION_EDITOR_URL,
+  INTEGRATION_TABS,
+  getGenerateTemplateFormURL,
+} from "../../constants/routes";
+import { useSelector } from "react-redux";
+import { getQueryParams } from "../../utils/AppsmithUtils";
+import { getIsGeneratePageInitiator } from "utils/GenerateCrudUtil";
+import {
+  getCurrentApplicationId,
+  getCurrentPageId,
+} from "../../selectors/editorSelectors";
 
 const IconContainer = styled.div`
   //width: 100%;
@@ -20,6 +33,28 @@ const IconContainer = styled.div`
 
 function CloseEditor() {
   const history = useHistory();
+  const applicationId = useSelector(getCurrentApplicationId);
+  const pageId = useSelector(getCurrentPageId);
+  const params: string = location.search;
+
+  const searchParamsInstance = new URLSearchParams(params);
+  const redirectTo = searchParamsInstance.get("from");
+
+  const isGeneratePageInitiator = getIsGeneratePageInitiator();
+  let integrationTab = INTEGRATION_TABS.ACTIVE;
+
+  if (isGeneratePageInitiator) {
+    // When users routes to Integrations page via generate CRUD page form
+    // the INTEGRATION_TABS.ACTIVE is hidden and
+    // hence when routing back, user should go back to INTEGRATION_TABS.NEW tab.
+    integrationTab = INTEGRATION_TABS.NEW;
+  }
+  // if it is a generate CRUD page flow from which user came here
+  // then route user back to `/generate-page/form`
+  // else go back to BUILDER_PAGE
+  const redirectURL = isGeneratePageInitiator
+    ? getGenerateTemplateFormURL(applicationId, pageId)
+    : BUILDER_PAGE_URL(applicationId, pageId);
 
   const handleClose = (e: React.MouseEvent) => {
     PerformanceTracker.startTracking(
@@ -27,7 +62,18 @@ function CloseEditor() {
       { path: location.pathname },
     );
     e.stopPropagation();
-    history.goBack();
+
+    const URL =
+      redirectTo === "datasources"
+        ? INTEGRATION_EDITOR_URL(
+            applicationId,
+            pageId,
+            integrationTab,
+            "",
+            getQueryParams(),
+          )
+        : redirectURL;
+    history.push(URL);
   };
 
   return (

--- a/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/helpers.tsx
@@ -65,11 +65,11 @@ export const ACTION_PLUGIN_MAP: Array<ActionGroupConfig | undefined> = [
       pluginType: PluginType,
       plugin?: Plugin,
     ) => {
-      if (pluginType === PluginType.SAAS) {
+      if (!!plugin && pluginType === PluginType.SAAS) {
         return `${SAAS_EDITOR_API_ID_URL(
           applicationId,
           pageId,
-          !!plugin ? plugin.packageName : "",
+          plugin.packageName,
           id,
         )}`;
       } else if (


### PR DESCRIPTION
Reverts appsmithorg/appsmith#7692

This fix only worked for navigation which was done through routing. Following cases are problematic -
1. In some cases we are using state change for showing different components and not using navigation -> this is impossible to handle from outside
2. There are double routing issues in some places, which pushes back btn in a loop

Will formalise the navigation a bit better and then take care of this.

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: revert-7692-fix/back-btn-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.74 **(-0.01)** | 36.55 **(-0.02)** | 33.8 **(0)** | 55.35 **(-0.02)**
 :red_circle: | app/client/src/components/editorComponents/CloseEditor.tsx | 41.94 **(-11.39)** | 25 **(-75)** | 0 **(0)** | 41.94 **(-11.39)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>