### PR TITLE
ci: Build and push fat container in release workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -40,15 +40,11 @@ jobs:
             echo "::set-output name=is_beta::false"
           fi
 
-  build-client:
+  build:
     needs:
       - prelude
 
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: app/client
 
     steps:
       # Checkout the code
@@ -73,10 +69,12 @@ jobs:
             ${{ runner.OS }}-
 
         # Install all the dependencies
-      - name: Install dependencies
+      - name: Install client dependencies
+        working-directory: app/client
         run: yarn install
 
-      - name: Create the bundle
+      - name: Create client bundle
+        working-directory: app/client
         env:
           REACT_APP_ENVIRONMENT: 'PRODUCTION'
           REACT_APP_FUSIONCHARTS_LICENSE_KEY: '${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }}'
@@ -86,33 +84,6 @@ jobs:
         run: |
           REACT_APP_VERSION_RELEASE_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             yarn build
-
-      # Build Docker image and push to Docker Hub
-      - name: Push production image to Docker Hub with commit tag
-        run: |
-          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{needs.prelude.outputs.tag}} .
-          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{needs.prelude.outputs.tag}}
-
-          # Only build & tag with latest if the tag doesn't contain beta
-          if [[ ! ${{needs.prelude.outputs.tag}} == *"beta"* ]]; then
-            docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:latest .
-            docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:latest
-          fi
-
-  build-server:
-    needs:
-      - prelude
-
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: app/server
-
-    steps:
-      - name: Checkout the code
-        uses: actions/checkout@v2
 
       # Setup Java
       - name: Set up JDK 1.11
@@ -131,8 +102,8 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      # Build the code
-      - name: Build without running any tests
+      - name: Build server without running any tests
+        working-directory: app/server
         run: |
           mvn --batch-mode versions:set \
             -DnewVersion=${{ needs.prelude.outputs.tag }} \
@@ -140,8 +111,27 @@ jobs:
             -DprocessAllModules=true
           mvn --batch-mode package -DskipTests
 
-      # Build Docker image and push to Docker Hub
-      - name: Push image to Docker Hub
+      - name: Build RTS
+        working-directory: app/rts
+        run: |
+          ./build.sh
+          ls -l dist
+
+      - name: Build and push client image
+        working-directory: app/client
+        run: |
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{needs.prelude.outputs.tag}} .
+          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{needs.prelude.outputs.tag}}
+
+          # Only build & tag with latest if the tag doesn't contain beta
+          if [[ ! ${{needs.prelude.outputs.tag}} == *"beta"* ]]; then
+            docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:latest .
+            docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:latest
+          fi
+
+      - name: Build and push server image
+        working-directory: app/server
         run: |
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
           docker build --build-arg APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }} -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{needs.prelude.outputs.tag}} .
@@ -153,3 +143,18 @@ jobs:
             docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:latest
           fi
 
+      - name: Build and push RTS image
+        working-directory: app/rts
+        run: |
+          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{needs.prelude.outputs.tag}} .
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{needs.prelude.outputs.tag}}
+
+      - name: Build and push fat image
+        run: |
+          docker build \
+            --build-arg APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }} \
+            --tag ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{needs.prelude.outputs.tag}} \
+            .
+          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+          docker push --all-tags ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -40,15 +40,22 @@ jobs:
             echo "::set-output name=is_beta::false"
           fi
 
-  build:
+  buildClient:
     needs:
       - prelude
 
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        working-directory: app/client
+        shell: bash
+
     steps:
       # Checkout the code
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 14.15.4
         uses: actions/setup-node@v1
@@ -68,13 +75,10 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
 
-        # Install all the dependencies
-      - name: Install client dependencies
-        working-directory: app/client
+      - name: Install dependencies
         run: yarn install
 
-      - name: Create client bundle
-        working-directory: app/client
+      - name: Create the bundle
         env:
           REACT_APP_ENVIRONMENT: 'PRODUCTION'
           REACT_APP_FUSIONCHARTS_LICENSE_KEY: '${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }}'
@@ -84,12 +88,54 @@ jobs:
         run: |
           REACT_APP_VERSION_RELEASE_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             yarn build
+          ls -l build
 
-      # Setup Java
+      # Upload the build artifact so that it can be used by the test & deploy job in the workflow
+      - name: Upload react build bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: client-build
+          path: app/client/build/
+
+  buildServer:
+    needs:
+      - prelude
+
+    defaults:
+      run:
+        working-directory: app/server
+
+    runs-on: ubuntu-latest
+    # Only run this workflow for internally triggered events
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+
+    # Service containers to run with this job. Required for running tests
+    services:
+      # Label used to access the service container
+      redis:
+        # Docker Hub image for Redis
+        image: redis
+        ports:
+          # Opens tcp port 6379 on the host and service container
+          - 6379:6379
+      mongo:
+        image: mongo
+        ports:
+          - 27017:27017
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: "11.0.10"
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies
@@ -111,11 +157,87 @@ jobs:
             -DprocessAllModules=true
           mvn --batch-mode package -DskipTests
 
-      - name: Build RTS
+      - name: Test and Build package
+        env:
+          APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
+          APPSMITH_REDIS_URL: "redis://127.0.0.1:6379"
+          APPSMITH_ENCRYPTION_PASSWORD: "password"
+          APPSMITH_ENCRYPTION_SALT: "salt"
+          APPSMITH_IS_SELF_HOSTED: false
+        working-directory: app/server
+        run: |
+          mvn --batch-mode versions:set \
+            -DnewVersion=${{ needs.prelude.outputs.tag }} \
+            -DgenerateBackupPoms=false \
+            -DprocessAllModules=true
+          ./build.sh -DskipTests
+          ls -l dist
+
+      - name: Upload server build bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: server-build
+          path: app/server/dist/
+
+  buildRts:
+    needs:
+      - prelude
+
+    defaults:
+      run:
         working-directory: app/rts
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 14.15.4
+        uses: actions/setup-node@v1
+        with:
+          node-version: "14.15.4"
+
+      - name: Build
         run: |
           ./build.sh
           ls -l dist
+
+      # Upload the build artifact so that it can be used by the test & deploy job in the workflow
+      - name: Upload server build bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: rts-build
+          path: app/rts/dist/
+
+  package:
+    needs: [buildClient, buildServer, buildRts]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the merged commit from PR and base branch
+        uses: actions/checkout@v2
+
+      - name: Download the client build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: client-build
+          path: app/client/build
+
+      - name: Download the server build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: server-build
+          path: app/server/dist
+
+      - name: Download the rts build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: rts-build
+          path: app/rts/dist
 
       - name: Build and push client image
         working-directory: app/client


### PR DESCRIPTION
The GitHub release workflow currently doesn't build the fat container image. This PR adds support for this.
