### PR TITLE
fix: Fixed installation for multiple plugins into organizations

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/encryption/EncryptionHandler.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/annotations/encryption/EncryptionHandler.java
@@ -121,7 +121,7 @@ public class EncryptionHandler {
 
                         field.setAccessible(true);
                         Object fieldValue = ReflectionUtils.getField(field, source);
-                        List<?> list = (List<?>) fieldValue;
+                        Collection<?> list = (Collection<?>) fieldValue;
 
                         if (list == null || list.isEmpty()) {
                             finalCandidateFields.add(new CandidateField(field, CandidateField.Type.APPSMITH_LIST_UNKNOWN));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Organization.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Organization.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import javax.validation.constraints.NotBlank;
 import java.util.List;
+import java.util.Set;
 
 
 @Getter
@@ -29,7 +30,7 @@ public class Organization extends BaseDomain {
 
     private String email;
 
-    private List<OrganizationPlugin> plugins;
+    private Set<OrganizationPlugin> plugins;
 
     private String slug;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -183,7 +183,7 @@ public class DatabaseChangelog {
     private void installPluginToAllOrganizations(MongockTemplate mongockTemplate, String pluginId) {
         for (Organization organization : mongockTemplate.findAll(Organization.class)) {
             if (CollectionUtils.isEmpty(organization.getPlugins())) {
-                organization.setPlugins(new ArrayList<>());
+                organization.setPlugins(new HashSet<>());
             }
 
             final Set<String> installedPlugins = organization.getPlugins()
@@ -452,7 +452,7 @@ public class DatabaseChangelog {
 
         for (Organization organization : mongoTemplate.findAll(Organization.class)) {
             if (CollectionUtils.isEmpty(organization.getPlugins())) {
-                organization.setPlugins(new ArrayList<>());
+                organization.setPlugins(new HashSet<>());
             }
 
             final Set<String> installedPlugins = organization.getPlugins()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomOrganizationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomOrganizationRepository.java
@@ -17,4 +17,6 @@ public interface CustomOrganizationRepository extends AppsmithRepository<Organiz
     Mono<Long> nextSlugNumber(String slugPrefix);
 
     Mono<Void> updateUserRoleNames(String userId, String userName);
+
+    Flux<Organization> findAllOrganizations();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomOrganizationRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomOrganizationRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.acl.AclPermission;
-import com.appsmith.server.domains.Comment;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.QOrganization;
 import lombok.extern.slf4j.Slf4j;
@@ -77,5 +76,10 @@ public class CustomOrganizationRepositoryImpl extends BaseAppsmithRepositoryImpl
                         Organization.class
                 )
                 .then();
+    }
+
+    @Override
+    public Flux<Organization> findAllOrganizations() {
+        return mongoOperations.find(new Query(), Organization.class);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/OrganizationServiceImpl.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_ORGANIZATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_INVITE_USERS;
@@ -171,7 +172,7 @@ public class OrganizationServiceImpl extends BaseService<OrganizationRepository,
                  */
                 .flatMap(org -> pluginRepository.findByDefaultInstall(true)
                         .map(obj -> new OrganizationPlugin(obj.getId(), OrganizationPluginStatus.FREE))
-                        .collectList()
+                        .collect(Collectors.toSet())
                         .map(pluginList -> {
                             org.setPlugins(pluginList);
                             return org;
@@ -340,7 +341,7 @@ public class OrganizationServiceImpl extends BaseService<OrganizationRepository,
 
     @Override
     public Flux<Organization> getAll() {
-        return repository.findAll();
+        return repository.findAllOrganizations();
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PluginServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/PluginServiceImpl.java
@@ -48,13 +48,14 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -220,7 +221,7 @@ public class PluginServiceImpl extends BaseService<PluginRepository, Plugin, Str
                 //i.e. the rest of the code flow would only happen when there is a plugin found for the organization that can
                 //be uninstalled.
                 .flatMap(organization -> {
-                    List<OrganizationPlugin> organizationPluginList = organization.getPlugins();
+                    Set<OrganizationPlugin> organizationPluginList = organization.getPlugins();
                     organizationPluginList.removeIf(listPlugin -> listPlugin.getPluginId().equals(pluginDTO.getPluginId()));
                     organization.setPlugins(organizationPluginList);
                     return organizationService.save(organization);
@@ -262,9 +263,9 @@ public class PluginServiceImpl extends BaseService<PluginRepository, Plugin, Str
                             .then(organizationService.getById(pluginDTO.getOrganizationId()))
                             .flatMap(organization -> {
 
-                                List<OrganizationPlugin> organizationPluginList = organization.getPlugins();
+                                Set<OrganizationPlugin> organizationPluginList = organization.getPlugins();
                                 if (organizationPluginList == null) {
-                                    organizationPluginList = new ArrayList<>();
+                                    organizationPluginList = new HashSet<>();
                                 }
 
                                 OrganizationPlugin organizationPlugin = new OrganizationPlugin();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/SeedMongoData.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/SeedMongoData.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_ORGANIZATIONS;
@@ -177,12 +178,12 @@ public class SeedMongoData {
         Flux<Organization> organizationFlux = mongoTemplate
                 .find(new Query().addCriteria(where("name").in(pluginData[0][0], pluginData[1][0], pluginData[2][0])), Plugin.class)
                 .map(plugin -> new OrganizationPlugin(plugin.getId(), OrganizationPluginStatus.FREE))
-                .collectList()
+                .collect(Collectors.toSet())
                 .cache()
                 .repeat()
                 .zipWithIterable(List.of(orgData))
                 .map(tuple -> {
-                    final List<OrganizationPlugin> orgPlugins = tuple.getT1();
+                    final Set<OrganizationPlugin> orgPlugins = tuple.getT1();
                     final Object[] orgArray = tuple.getT2();
 
                     Organization organization = new Organization();


### PR DESCRIPTION
The default installs were failing for existing organizations because the findAll function was expecting a user context. This fix uses a query without such an expectation.