### PR TITLE
ci: The package job needs prelude

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -179,7 +179,7 @@ jobs:
           path: app/rts/dist/
 
   package:
-    needs: [buildClient, buildServer, buildRts]
+    needs: [prelude, buildClient, buildServer, buildRts]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The package job needs `prelude` to be declared as a dependency. Otherwise, we don't have access to variables from that job.
