### PR TITLE
feat: Always return permanent url for s3 list action

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor.json
@@ -144,7 +144,7 @@
           "label": "Generate Un-signed URL",
           "configProperty": "actionConfiguration.pluginSpecifiedTemplates[8].value",
           "controlType": "DROP_DOWN",
-          "initialValue": "NO",
+          "initialValue": "YES",
           "options": [
             {
               "label": "Yes",


### PR DESCRIPTION
## Description
- Set the default setting for permanent / un-signed url for S3 list action to true. Ref: https://theappsmith.slack.com/archives/C01HXJPFWBC/p1631714575164700

Fixes #7702 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
