### PR TITLE
fix: [UQI] Fix for generating action from datasource structure for UQI plugins

### DIFF
--- a/app/client/src/entities/Datasource/index.ts
+++ b/app/client/src/entities/Datasource/index.ts
@@ -29,6 +29,7 @@ export interface DatasourceStructure {
 }
 
 export interface QueryTemplate {
+  configuration: Record<string, unknown>;
   title: string;
   body: string;
   pluginSpecifiedTemplates?: Array<{ key?: string; value?: unknown }>;

--- a/app/client/src/pages/Editor/Explorer/Datasources/QueryTemplates.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/QueryTemplates.tsx
@@ -51,6 +51,7 @@ export function QueryTemplates(props: QueryTemplatesProps) {
         actionConfiguration: {
           body: template.body,
           pluginSpecifiedTemplates: template.pluginSpecifiedTemplates,
+          formData: template.configuration,
         },
       };
 


### PR DESCRIPTION
Fixes #7470 
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>