### PR TITLE
fix: Tweak how we show errors for required and not required inputs

### DIFF
--- a/app/client/src/widgets/InputWidget/index.ts
+++ b/app/client/src/widgets/InputWidget/index.ts
@@ -10,7 +10,7 @@ export const CONFIG = {
   defaults: {
     inputType: "TEXT",
     rows: 1 * GRID_DENSITY_MIGRATION_V1,
-    label: "Label",
+    label: "",
     columns: 5 * GRID_DENSITY_MIGRATION_V1,
     widgetName: "Input",
     version: 1,

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -494,14 +494,14 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
     return {
       isValid: `{{
         function(){
-          if (typeof this.validation === "boolean" && !this.validation) {
-            return false;
-          }
           if (!this.isRequired && !this.text) {
             return true
           }
           if(this.isRequired && !this.text){
             return false
+          }
+          if (typeof this.validation === "boolean" && !this.validation) {
+            return false;
           }
           let parsedRegex = null;
           if (this.regex) {

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -497,6 +497,12 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
           if (typeof this.validation === "boolean" && !this.validation) {
             return false;
           }
+          if (!this.isRequired && !this.text) {
+            return true
+          }
+          if(this.isRequired && !this.text){
+            return false
+          }
           let parsedRegex = null;
           if (this.regex) {
             /*


### PR DESCRIPTION

## Description
Tweak how input fields validations for require, not required fields are handled when they are empty.

Fixes #6857

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue) 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/inconsistent-validations-input-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.89 **(0)** | 37.04 **(-0.01)** | 33.88 **(0)** | 55.5 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>