### PR TITLE
fix: Modified unique index for plugin collection

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3240,4 +3240,15 @@ public class DatabaseChangelog {
             mongoTemplate.save(mongoAction);
         }
     }
+
+    @ChangeSet(order = "089", id = "update-plugin-package-name-index", author = "")
+    public void updatePluginPackageNameIndexToPluginNamePackageNameAndVersion(MongockTemplate mongockTemplate) {
+        MongoTemplate mongoTemplate = mongockTemplate.getImpl();
+        dropIndexIfExists(mongoTemplate, Plugin.class, "packageName");
+
+        ensureIndexes(mongoTemplate, Plugin.class,
+                makeIndex("pluginName", "packageName", "version")
+                        .unique().named("plugin_name_package_name_version_index")
+        );
+    }
 }


### PR DESCRIPTION
With SaaS plugins coming in, package names for plugins will not be unique anymore. Multiple plugins will point to the SaaS package, while maintaining separate identities. Further, since we want to support versioning for these plugins, the version should also be included as a unique identifier for the plugin.

I have still included package name for plugin identification in case we need to support deep integrations as a separate route for plugins to take (alternative to light weight SaaS).