### PR TITLE
fix: Remove snippet and doc icon from property pane

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_PropertyPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_PropertyPane_spec.js
@@ -70,19 +70,6 @@ describe("Table Widget property pane feature validation", function() {
     cy.get(publish.backToEditor).click();
   });
 
-  it("Explore Widget related documents Verification", function() {
-    // Open property pane
-    cy.openPropertyPane("tablewidget");
-    // Click on "Explore widget related docs" button
-    cy.get(widgetsPage.exploreWidget).click();
-    // Verify the widget related document
-    cy.get(widgetsPage.widgetRelatedDocument).should("contain", "Table");
-    cy.wait(2000);
-    cy.get(widgetsPage.header).click();
-    cy.wait(1000);
-    cy.PublishtheApp();
-  });
-
   it("Check open section and column data in property pane", function() {
     cy.openPropertyPane("tablewidget");
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FormWidget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FormWidget_spec.js
@@ -124,17 +124,6 @@ describe("Form Widget Functionality", function() {
     cy.PublishtheApp();
     cy.get(publish.formWidget).should("be.visible");
   });
-  it("Explore Widget related documents Verification", function() {
-    // Open property pane
-    cy.openPropertyPane("formwidget");
-    // Click on "Explore widget related docs" button
-    cy.get(widgetsPage.exploreWidget).click();
-    // Verify the widget related document
-    cy.get(widgetsPage.widgetRelatedDocument).should("contain", "Form");
-    cy.wait(500);
-    cy.get(widgetsPage.header).click();
-    cy.PublishtheApp();
-  });
   it("Form-Copy Verification", function() {
     cy.openPropertyPane("formwidget");
     const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";

--- a/app/client/src/pages/Editor/PropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/index.tsx
@@ -168,20 +168,6 @@ function PropertyPaneView(
         ),
       },
       {
-        tooltipContent: <span>Explore widget related docs</span>,
-        icon: <PropertyPaneHelpButton />,
-      },
-      {
-        tooltipContent: <span>Search related snippets</span>,
-        icon: (
-          <SearchSnippets
-            entityId={widgetProperties.widgetId}
-            entityType={ENTITY_TYPE.WIDGET}
-            showIconOnly
-          />
-        ),
-      },
-      {
         tooltipContent: "Close",
         icon: (
           <Icon

--- a/app/client/src/pages/Editor/PropertyPane/index.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/index.tsx
@@ -32,15 +32,12 @@ import { deleteSelectedWidget, copyWidget } from "actions/widgetActions";
 import { selectWidgetInitAction } from "actions/widgetSelectionActions";
 import { ControlIcons } from "icons/ControlIcons";
 import { FormIcons } from "icons/FormIcons";
-import PropertyPaneHelpButton from "pages/Editor/PropertyPaneHelpButton";
 import { getProppanePreference } from "selectors/usersSelectors";
 import { PropertyPanePositionConfig } from "reducers/uiReducers/usersReducer";
 import { get } from "lodash";
 import { Layers } from "constants/Layers";
 import ConnectDataCTA, { actionsExist } from "./ConnectDataCTA";
 import PropertyPaneConnections from "./PropertyPaneConnections";
-import SearchSnippets from "components/ads/SnippetButton";
-import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
 import { WidgetType } from "constants/WidgetConstants";
 
 const PropertyPaneWrapper = styled(PaneWrapper)<{


### PR DESCRIPTION
## Description
Remove snippet and docs icon from property pane.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/remove_icons_pp 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.86 **(-0.03)** | 36.98 **(-0.04)** | 33.87 **(-0.01)** | 55.46 **(-0.04)**
 :red_circle: | app/client/src/components/ads/Icon.tsx | 54.69 **(-0.65)** | 37.21 **(-0.77)** | 100 **(0)** | 54.55 **(-0.64)**
 :red_circle: | app/client/src/components/ads/SnippetButton.tsx | 75 **(-18.75)** | 33.33 **(-50)** | 0 **(-50)** | 75 **(-18.75)**
 :red_circle: | app/client/src/pages/Editor/PropertyPane/index.tsx | 83.19 **(-0.43)** | 69.3 **(0)** | 70.37 **(0)** | 84.91 **(-0.41)**
 :red_circle: | app/client/src/sagas/selectors.tsx | 75 **(-1)** | 58.33 **(-4.17)** | 54.84 **(0)** | 69.74 **(-1.31)**
 :x: | ~~app/client/src/pages/Editor/PropertyPaneHelpButton.tsx~~ | ~~85~~ | ~~66.67~~ | ~~50~~ | ~~84.21~~</details>