### PR TITLE
Fix mismatch arguments in AMI init script

### DIFF
--- a/deploy/aws_ami/first-time-setup.sh
+++ b/deploy/aws_ami/first-time-setup.sh
@@ -112,7 +112,7 @@ echo "Generating the configuration files from the templates"
 bash "$templates_dir/nginx_app.conf.sh" "$NGINX_SSL_CMNT" "$custom_domain" > nginx_app.conf
 bash "$templates_dir/docker-compose.yml.sh" "$mongo_root_user" "$mongo_root_password" "$mongo_database" > docker-compose.yml
 bash "$templates_dir/mongo-init.js.sh" "$mongo_root_user" "$mongo_root_password" > mongo-init.js
-bash "$templates_dir/docker.env.sh" "$mongo_root_user" "$mongo_root_password" "$mongo_host" "$disable_telemetry" > docker.env
+bash "$templates_dir/docker.env.sh" "$mongo_database" "$mongo_root_user" "$mongo_root_password" "$mongo_host" "$disable_telemetry" > docker.env
 bash "$templates_dir/encryption.env.sh" "$user_encryption_password" "$user_encryption_salt" > encryption.env
 
 move_file "data/nginx/app.conf.template" "nginx_app.conf"


### PR DESCRIPTION
## Description

- Due to the change in the docker.env.sh template, it cause an issue in the AMI init script
- This fix is about putting correct arguments when generating docker.env from docker.env.sh file in the init script

Fixes # (issue)

- Fail to run Appsmith using AMI from AWS Marketplace

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- This fix had been tested on EC2 instance which we launch using new AMI 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
