### PR TITLE
added a function on missing where key on update action

### DIFF
--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -120,6 +120,7 @@ import {
 import { Plugin } from "api/PluginApi";
 import { FlattenedWidgetProps } from "reducers/entityReducers/canvasWidgetsReducer";
 import { SnippetAction } from "reducers/uiReducers/globalSearchReducer";
+import { fixMissingWhereKey } from "utils/WhereClauseFix";
 
 export function* createActionSaga(
   actionPayload: ReduxAction<
@@ -311,6 +312,8 @@ export function* updateActionSaga(actionPayload: ReduxAction<{ id: string }>) {
     if (isApi) {
       action = transformRestAction(action);
     }
+
+    action = fixMissingWhereKey(action);
 
     const response: GenericApiResponse<Action> = yield ActionAPI.updateAction(
       action,

--- a/app/client/src/utils/WhereClauseFix.ts
+++ b/app/client/src/utils/WhereClauseFix.ts
@@ -1,0 +1,23 @@
+import { Action } from "entities/Action";
+
+//Fix for where clause issue: add missing where key in the action.config.pluginSpecifiedTemplates
+//Required for queries in edit mode
+//Called on Update Action
+export function fixMissingWhereKey(
+  actionObject: Action | undefined,
+): Action | undefined {
+  if (!actionObject) return undefined;
+
+  const fixedActionObject = {
+    ...actionObject,
+    pluginSpecifiedTemplates: actionObject.actionConfiguration.pluginSpecifiedTemplates.map(
+      (template: { key: string; value: any }) => {
+        if (template && template.value && !template.key) {
+          template["key"] = "where";
+        }
+        return template;
+      },
+    ),
+  };
+  return fixedActionObject;
+}


### PR DESCRIPTION
## Description

In PluginspecifiedTemplates `key:where` was missing due which the query with where clause was failing.
Added a function called `fixMissingWhereKey` that adds this key dynamically. 
`fixMissingWhereKey()` is called on update Action.

Fixes #7843

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

Tested manually with where clause.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/missing-where-key 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.86 **(-0.01)** | 36.98 **(-0.02)** | 33.86 **(-0.01)** | 55.48 **(-0.01)**
 :green_circle: | app/client/src/sagas/ActionSagas.ts | 11.2 **(0.21)** | 0.69 **(0)** | 3.7 **(0)** | 13.61 **(0.23)**
 :sparkles: :new: | **app/client/src/utils/WhereClauseFix.ts** | **12.5** | **0** | **0** | **14.29**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>