### PR TITLE
fix: upgraded socket.io client package to latest stable version

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -148,7 +148,7 @@
     "shallowequal": "^1.1.0",
     "showdown": "^1.9.1",
     "smartlook-client": "^4.5.1",
-    "socket.io-client": "^4.0.0",
+    "socket.io-client": "4.2.0",
     "styled-components": "^5.2.0",
     "styled-system": "^5.1.5",
     "tern": "^0.21.0",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -148,7 +148,7 @@
     "shallowequal": "^1.1.0",
     "showdown": "^1.9.1",
     "smartlook-client": "^4.5.1",
-    "socket.io-client": "4.2.0",
+    "socket.io-client": "^4.2.0",
     "styled-components": "^5.2.0",
     "styled-system": "^5.1.5",
     "tern": "^0.21.0",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -7381,7 +7381,7 @@ debug@^4.3.0:
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.2, debug@~4.3.1:
+debug@^4.3.2, debug@~4.3.1, debug@~4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -7949,9 +7949,10 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.4"
 
-engine.io-client@~5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/engine.io-client/-/engine.io-client-5.0.0.tgz"
+engine.io-client@~5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-5.2.0.tgz#ae38c79a4af16258c0300e6819c0ea8ecc1597cd"
+  integrity sha512-BcIBXGBkT7wKecwnfrSV79G2X5lSUSgeAGgoo60plXf8UsQEvCQww/KMwXSMhVjb98fFYNq20CC5eo8IOAPqsg==
   dependencies:
     base64-arraybuffer "0.1.4"
     component-emitter "~1.3.0"
@@ -7961,6 +7962,7 @@ engine.io-client@~5.0.0:
     parseqs "0.0.6"
     parseuri "0.0.6"
     ws "~7.4.2"
+    xmlhttprequest-ssl "~2.0.0"
     yeast "0.1.2"
 
 engine.io-parser@~4.0.1:
@@ -16716,15 +16718,16 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-socket.io-client@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.0.0.tgz"
+socket.io-client@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.2.0.tgz#195feed3de40283b1ae3f7d02cf91d3eb2c905c1"
+  integrity sha512-3GJ2KMh7inJUNAOjgf8NaKJZJa9uRyfryh2LrVJyKyxmzoXlfW9DeDNqylJn0ovOFt4e/kRLNWzMt/YqqEWYSA==
   dependencies:
     "@types/component-emitter" "^1.2.10"
     backo2 "~1.0.2"
     component-emitter "~1.3.0"
-    debug "~4.3.1"
-    engine.io-client "~5.0.0"
+    debug "~4.3.2"
+    engine.io-client "~5.2.0"
     parseuri "0.0.6"
     socket.io-parser "~4.0.4"
 
@@ -18871,6 +18874,11 @@ xml@^1.0.0:
 xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz"
+
+xmlhttprequest-ssl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz#91360c86b914e67f44dce769180027c0da618c67"
+  integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Description
package upgrade from v4.0.0 to v4.2.0

Fixes #7710 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- already have automated test



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/socket-io-client-package-upgrade 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.86 **(0)** | 37 **(0.01)** | 33.86 **(0)** | 55.49 **(0.01)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.71 **(0.24)** | 39.13 **(0.87)** | 36.21 **(0)** | 55.35 **(0.27)**</details>