### PR TITLE
fix: make property pane control example to be one of the allowed values

### DIFF
--- a/app/client/src/utils/validation/common.ts
+++ b/app/client/src/utils/validation/common.ts
@@ -2,6 +2,7 @@ import { createMessage, FIELD_REQUIRED_ERROR } from "constants/messages";
 import { ValidationConfig } from "constants/PropertyControlConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import moment from "moment";
+import { sample } from "lodash";
 import { CodeEditorExpected } from "components/editorComponents/CodeEditor";
 import { AutocompleteDataType } from "utils/autocomplete/TernServer";
 
@@ -47,6 +48,7 @@ export function getExpectedValue(
       if (config.params?.allowedValues) {
         const allowed = config.params.allowedValues.join(" | ");
         result.type = result.type + ` ( ${allowed} )`;
+        result.example = sample(config.params.allowedValues) as string;
       }
       if (config.params?.expected?.type)
         result.type = config.params?.expected.type;


### PR DESCRIPTION
## Description

Shows the propertyPane control example as one of the values from allowedValues rather than providing "abc"

Fixes #7674 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Created a buttonWidget, enable JS editable option for buttonVariant. Then clicked on the buttonVariant value input field.
Checked the example provided in "EXPECTED STRUCTURE - EXAMPLE" section.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
