### PR TITLE
fix: scroll for response tab list of functions

### DIFF
--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -34,6 +34,7 @@ import Callout from "components/ads/Callout";
 import { Variant } from "components/ads/common";
 import { EvaluationError } from "utils/DynamicBindingUtils";
 import { Severity } from "entities/AppsmithConsole";
+import { thinScrollbar } from "constants/DefaultTheme";
 
 const ResponseContainer = styled.div`
   ${ResizerCSS}
@@ -64,6 +65,9 @@ const ResponseTabActionsList = styled.ul`
   width: 20%;
   list-style: none;
   padding-left: 0;
+  ${thinScrollbar};
+  scrollbar-width: thin;
+  overflow: auto;
 `;
 
 const ResponseTabAction = styled.li`


### PR DESCRIPTION
## Description
In response tab on js editor page could not scroll to see all functions 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: thin-scroll-response-tab-js 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.86 **(-0.01)** | 36.99 **(-0.02)** | 33.86 **(0)** | 55.49 **(0)**
 :green_circle: | app/client/src/components/editorComponents/JSResponseView.tsx | 44.59 **(0.75)** | 20.78 **(0)** | 0 **(0)** | 47.14 **(0.76)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 78.23 **(-1.61)** | 54.41 **(-2.94)** | 70 **(0)** | 84.09 **(-2.27)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.47 **(-0.24)** | 38.26 **(-0.87)** | 36.21 **(0)** | 55.08 **(-0.27)**</details>