### PR TITLE
fix: make the row click event trigger when table button is clicked

### DIFF
--- a/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
+++ b/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
@@ -322,7 +322,6 @@ function TableAction(props: {
     <ActionWrapper
       background={props.backgroundColor}
       buttonLabelColor={props.buttonLabelColor}
-      onClick={stopClickEventPropagation}
     >
       {props.isCellVisible ? (
         <Button

--- a/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
+++ b/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
@@ -322,6 +322,11 @@ function TableAction(props: {
     <ActionWrapper
       background={props.backgroundColor}
       buttonLabelColor={props.buttonLabelColor}
+      onClick={(e) => {
+        if (props.isSelected) {
+          e.stopPropagation();
+        }
+      }}
     >
       {props.isCellVisible ? (
         <Button

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -245,7 +245,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
               ? this.props.selectedRowIndices.includes(rowIndex)
               : this.props.selectedRowIndex === rowIndex;
             const buttonProps = {
-              isSelected: isSelected, //!!props.row.isSelected,
+              isSelected: isSelected,
               onCommandClick: (action: string, onComplete: () => void) =>
                 this.onCommandClick(rowIndex, action, onComplete),
               backgroundColor: cellProperties.buttonColor || "rgb(3, 179, 101)",

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -242,7 +242,8 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           );
           if (columnProperties.columnType === "button") {
             const isSelected = this.props.multiRowSelection
-              ? this.props.selectedRowIndices?.includes(rowIndex)
+              ? this.props.selectedRowIndices &&
+                this.props.selectedRowIndices.includes(rowIndex)
               : this.props.selectedRowIndex === rowIndex;
             const buttonProps = {
               isSelected: isSelected,

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -240,10 +240,12 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
             columnProperties,
             originalIndex,
           );
-
           if (columnProperties.columnType === "button") {
+            const isSelected = this.props.multiRowSelection
+              ? this.props.selectedRowIndices.includes(rowIndex)
+              : this.props.selectedRowIndex === rowIndex;
             const buttonProps = {
-              isSelected: !!props.row.isSelected,
+              isSelected: isSelected, //!!props.row.isSelected,
               onCommandClick: (action: string, onComplete: () => void) =>
                 this.onCommandClick(rowIndex, action, onComplete),
               backgroundColor: cellProperties.buttonColor || "rgb(3, 179, 101)",
@@ -971,6 +973,9 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
             type: EventType.ON_ROW_SELECTED,
           },
         });
+      } else {
+        //reset selected row
+        this.props.updateWidgetMetaProperty("selectedRowIndex", -1);
       }
     }
   };

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -241,10 +241,14 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
             originalIndex,
           );
           if (columnProperties.columnType === "button") {
-            const isSelected = this.props.multiRowSelection
-              ? this.props.selectedRowIndices &&
-                this.props.selectedRowIndices.includes(rowIndex)
-              : this.props.selectedRowIndex === rowIndex;
+            let isSelected = false;
+            if (this.props.multiRowSelection) {
+              isSelected =
+                Array.isArray(this.props.selectedRowIndices) &&
+                this.props.selectedRowIndices.includes(rowIndex);
+            } else {
+              isSelected = this.props.selectedRowIndex === rowIndex;
+            }
             const buttonProps = {
               isSelected: isSelected,
               onCommandClick: (action: string, onComplete: () => void) =>

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -971,9 +971,6 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
             type: EventType.ON_ROW_SELECTED,
           },
         });
-      } else {
-        //reset selected row
-        this.props.updateWidgetMetaProperty("selectedRowIndex", -1);
       }
     }
   };

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -242,7 +242,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
           );
           if (columnProperties.columnType === "button") {
             const isSelected = this.props.multiRowSelection
-              ? this.props.selectedRowIndices.includes(rowIndex)
+              ? this.props.selectedRowIndices?.includes(rowIndex)
               : this.props.selectedRowIndex === rowIndex;
             const buttonProps = {
               isSelected: isSelected,


### PR DESCRIPTION
## Description

makes the click event on the button propagate to the row so that the event handler for the row gets triggered.

Fixes #7838 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

tested manually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/table-widget-button-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.83 **(0)** | 36.98 **(0)** | 33.81 **(-0.01)** | 55.44 **(-0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**
 :red_circle: | app/client/src/widgets/TableWidget/component/TableUtilities.tsx | 40.56 **(-0.57)** | 23.3 **(-0.46)** | 16.22 **(-0.45)** | 39.23 **(-0.61)**
 :red_circle: | app/client/src/widgets/TableWidget/widget/index.tsx | 26.6 **(-0.27)** | 5.79 **(-0.07)** | 26.92 **(0)** | 26.34 **(-0.29)**</details>