### PR TITLE
fix: Actions not being deleted when app is deleted

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3265,11 +3265,8 @@ public class DatabaseChangelog {
 
         for (final NewAction action : actions) {
             final String applicationId = action.getApplicationId();
-            if (StringUtils.isEmpty(applicationId)) {
-                continue;
-            }
 
-            final boolean isAppDeleted = mongockTemplate.exists(
+            final boolean shouldDelete = StringUtils.isEmpty(applicationId) || mongockTemplate.exists(
                     query(
                             where(fieldName(QApplication.application.id)).is(applicationId)
                                     .and(fieldName(QApplication.application.deleted)).is(true)
@@ -3277,7 +3274,7 @@ public class DatabaseChangelog {
                     Application.class
             );
 
-            if (isAppDeleted) {
+            if (shouldDelete) {
                 mongockTemplate.updateFirst(
                         query(where(fieldName(QNewAction.newAction.id)).is(action.getId())),
                         deletionUpdates,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3251,4 +3251,40 @@ public class DatabaseChangelog {
                         .unique().named("plugin_name_package_name_version_index")
         );
     }
+
+    @ChangeSet(order = "090", id = "delete-orphan-actions", author = "")
+    public void deleteOrphanActions(MongockTemplate mongockTemplate) {
+        final Update deletionUpdates = new Update();
+        deletionUpdates.set(fieldName(QNewAction.newAction.deleted), true);
+        deletionUpdates.set(fieldName(QNewAction.newAction.deletedAt), Instant.now());
+
+        final List<NewAction> actions = mongockTemplate.find(
+                query(where(fieldName(QNewAction.newAction.deleted)).ne(true)),
+                NewAction.class
+        );
+
+        for (final NewAction action : actions) {
+            final String applicationId = action.getApplicationId();
+            if (StringUtils.isEmpty(applicationId)) {
+                continue;
+            }
+
+            final boolean isAppDeleted = mongockTemplate.exists(
+                    query(
+                            where(fieldName(QApplication.application.id)).is(applicationId)
+                                    .and(fieldName(QApplication.application.deleted)).is(true)
+                    ),
+                    Application.class
+            );
+
+            if (isAppDeleted) {
+                mongockTemplate.updateFirst(
+                        query(where(fieldName(QNewAction.newAction.id)).is(action.getId())),
+                        deletionUpdates,
+                        NewAction.class
+                );
+            }
+        }
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Set;
 
 public interface CustomNewActionRepository extends AppsmithRepository<NewAction> {
+    Flux<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission);
+
     Mono<NewAction> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission aclPermission);
 
     Flux<NewAction> findByPageId(String pageId, AclPermission aclPermission);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
@@ -34,6 +34,12 @@ public class CustomNewActionRepositoryImpl extends BaseAppsmithRepositoryImpl<Ne
     }
 
     @Override
+    public Flux<NewAction> findByApplicationId(String applicationId, AclPermission aclPermission) {
+        Criteria applicationIdCriteria = where(fieldName(QNewAction.newAction.applicationId)).is(applicationId);
+        return queryAll(List.of(applicationIdCriteria), aclPermission);
+    }
+
+    @Override
     public Mono<NewAction> findByUnpublishedNameAndPageId(String name, String pageId, AclPermission aclPermission) {
         Criteria nameCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.name)).is(name);
         Criteria pageCriteria = where(fieldName(QNewAction.newAction.unpublishedAction) + "." + fieldName(QNewAction.newAction.unpublishedAction.pageId)).is(pageId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -303,8 +303,10 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, id)))
                 .flatMap(application -> {
                     log.debug("Archiving pages for applicationId: {}", id);
-                    return newPageService.archivePagesByApplicationId(id, MANAGE_PAGES)
-                            .thenReturn(application);
+                    return Mono.when(
+                            newPageService.archivePagesByApplicationId(id, MANAGE_PAGES),
+                            newActionService.archiveActionsByApplicationId(id, MANAGE_ACTIONS)
+                    ).thenReturn(application);
                 })
                 .flatMap(applicationService::archive);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionService.java
@@ -71,6 +71,8 @@ public interface NewActionService extends CrudService<NewAction, String> {
 
     Mono<NewAction> archive(String id);
 
+    Mono<List<NewAction>> archiveActionsByApplicationId(String applicationId, AclPermission permission);
+
     List<String> extractMustacheKeysInOrder(String query);
 
     String replaceMustacheWithQuestionMark(String query, List<String> mustacheBindings);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -1254,6 +1254,13 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
                 .flatMap(analyticsService::sendArchiveEvent);
     }
 
+    @Override
+    public Mono<List<NewAction>> archiveActionsByApplicationId(String applicationId, AclPermission permission) {
+        return repository.findByApplicationId(applicationId, permission)
+                .flatMap(repository::archive)
+                .collectList();
+    }
+
     public List<String> extractMustacheKeysInOrder(String query) {
         return MustacheHelper.extractMustacheKeysInOrder(query);
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -1,13 +1,13 @@
 package com.appsmith.server.services;
 
 import com.appsmith.external.models.ActionConfiguration;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Policy;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.ApplicationPage;
-import com.appsmith.external.models.Datasource;
 import com.appsmith.server.domains.GitApplicationMetadata;
 import com.appsmith.server.domains.GitAuth;
 import com.appsmith.server.domains.Layout;
@@ -29,6 +29,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.NewPageRepository;
+import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.solutions.ApplicationFetcher;
 import com.appsmith.server.solutions.ReleaseNotesService;
 import lombok.extern.slf4j.Slf4j;
@@ -116,6 +117,9 @@ public class ApplicationServiceTest {
 
     @Autowired
     private PolicyUtils policyUtils;
+
+    @Autowired
+    private PluginRepository pluginRepository;
 
     @MockBean
     ReleaseNotesService releaseNotesService;
@@ -1348,4 +1352,61 @@ public class ApplicationServiceTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void deleteApplicationWithPagesAndActions() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Application testApplication = new Application();
+        String appName = "deleteApplicationWithPagesAndActions";
+        testApplication.setName(appName);
+
+        Mono<NewAction> resultMono = applicationPageService.createApplication(testApplication, orgId)
+                .flatMap(application -> {
+                    PageDTO page = new PageDTO();
+                    page.setName("New Page");
+                    page.setApplicationId(application.getId());
+                    Layout defaultLayout = newPageService.createDefaultLayout();
+                    List<Layout> layouts = new ArrayList<>();
+                    layouts.add(defaultLayout);
+                    page.setLayouts(layouts);
+                    return Mono.zip(
+                            applicationPageService.createPage(page),
+                            pluginRepository.findByPackageName("installed-plugin")
+                    );
+                })
+                .flatMap(tuple -> {
+                    final PageDTO page = tuple.getT1();
+                    final Plugin installedPlugin = tuple.getT2();
+
+                    final Datasource datasource = new Datasource();
+                    datasource.setName("Default Database");
+                    datasource.setOrganizationId(orgId);
+                    datasource.setPluginId(installedPlugin.getId());
+                    datasource.setDatasourceConfiguration(new DatasourceConfiguration());
+
+                    ActionDTO action = new ActionDTO();
+                    action.setName("validAction");
+                    action.setPageId(page.getId());
+                    action.setExecuteOnLoad(true);
+                    ActionConfiguration actionConfiguration = new ActionConfiguration();
+                    actionConfiguration.setHttpMethod(HttpMethod.GET);
+                    action.setActionConfiguration(actionConfiguration);
+                    action.setDatasource(datasource);
+
+                    return layoutActionService.createSingleAction(action)
+                            .flatMap(action1 -> {
+                                return applicationService.findById(page.getApplicationId(), MANAGE_APPLICATIONS)
+                                        .flatMap(application -> applicationPageService.deleteApplication(application.getId()))
+                                        .flatMap(ignored -> newActionService.findById(action1.getId()));
+                            });
+                });
+
+        StepVerifier
+                .create(resultMono)
+                // Since the action should be deleted, we exmpty the Mono to complete empty.
+                .verifyComplete();
+    }
+
 }


### PR DESCRIPTION
Fixes #4609.

Testing:

1. Create new organization, called `org1`.
2. Create an application in this, called `app1`.
3. Create a datasource called `ds1`, and an action for that datasource, in `app1`.
4. Now create another application in `org1`, called `app2`.
5. Now delete the application `app1`.
6. Go to `app2`, try to delete the datasource `ds1`.

- Before this PR: The deletion is not allowed because there's one action currently using it.
- After this PR: The deletion is successful because that other action is deleted when `app1` is deleted.
