### PR TITLE
fix: hide comments mode toggle for anonymous users

### DIFF
--- a/app/client/src/pages/Editor/ToggleModeButton.tsx
+++ b/app/client/src/pages/Editor/ToggleModeButton.tsx
@@ -325,11 +325,17 @@ const useShowCommentDiscoveryTooltip = (): [boolean, typeof noop] => {
 export const useHideComments = () => {
   const [shouldHide, setShouldHide] = useState(false);
   const location = useLocation();
+  const currentUser = useSelector(getCurrentUser);
   useEffect(() => {
     const pathName = window.location.pathname;
     const shouldShow = matchBuilderPath(pathName) || matchViewerPath(pathName);
-    setShouldHide(!shouldShow);
-  }, [location]);
+    // Disable comment mode toggle for anonymous users
+    setShouldHide(
+      !shouldShow ||
+        !currentUser ||
+        currentUser.username === ANONYMOUS_USERNAME,
+    );
+  }, [location, currentUser]);
 
   return shouldHide;
 };


### PR DESCRIPTION
## Description
Removed the toggle button

Fixes #7884 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/remove-comment-toggle-option-for-public-apps 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/pages/Editor/ToggleModeButton.tsx | 80 **(0.14)** | 54.41 **(-0.97)** | 80 **(0)** | 79.7 **(0.15)**</details>