### PR TITLE
fix: Display for action response for imported app with SQL datasource

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -723,10 +723,13 @@ public class ImportExportApplicationService {
                 //Mapping ds name in id field
                 ds.setId(datasourceMap.get(ds.getId()));
                 ds.setOrganizationId(null);
-                ds.setPluginId(null);
+                if (ds.getPluginId() != null) {
+                    ds.setPluginId(pluginMap.get(ds.getPluginId()));
+                }
                 return ds.getId();
             } else {
-                // This means we don't have regular datasource it can be simple REST_API
+                // This means we don't have regular datasource it can be simple REST_API and will also be used when
+                // importing the action to populate the data
                 ds.setOrganizationId(organizationId);
                 ds.setPluginId(pluginMap.get(ds.getPluginId()));
                 return "";

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -384,8 +384,9 @@ public class ImportExportApplicationServiceTests {
                     assertThat(validAction.getOrganizationId()).isNull();
                     assertThat(validAction.getPolicies()).isNull();
                     assertThat(validAction.getId()).isNotNull();
-                    assertThat(validAction.getUnpublishedAction().getPageId())
-                            .isEqualTo(defaultPage.getUnpublishedPage().getName());
+                    ActionDTO unpublishedAction = validAction.getUnpublishedAction();
+                    assertThat(unpublishedAction.getPageId()).isEqualTo(defaultPage.getUnpublishedPage().getName());
+                    assertThat(unpublishedAction.getDatasource().getPluginId()).isEqualTo(installedPlugin.getPackageName());
 
                     assertThat(datasourceList).hasSize(1);
                     Datasource datasource = datasourceList.get(0);


### PR DESCRIPTION
## Description

> This PR fixes the action response display issue for the imported application, when we run the action from SQL datasource instead of tabluar format we used to see the response in JSON format. 

Fixes #6228

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> JUnit TC update
> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
