### PR TITLE
feat: updated widget meta key reset logic

### DIFF
--- a/app/client/src/reducers/entityReducers/metaReducer.ts
+++ b/app/client/src/reducers/entityReducers/metaReducer.ts
@@ -65,7 +65,7 @@ export const metaReducer = createReducer(initialState, {
         ...state[widgetId],
       };
       Object.keys(resetData).forEach((key: string) => {
-        resetData[key] = undefined;
+        delete resetData[key];
       });
       return { ...state, [widgetId]: { ...resetData } };
     }

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -12,7 +12,7 @@ import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { DerivedPropertiesMap } from "utils/WidgetFactory";
 import Dashboard from "@uppy/dashboard";
 import shallowequal from "shallowequal";
-import _, { findIndex } from "lodash";
+import _, { findIndex, size } from "lodash";
 import FileDataTypes from "../constants";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 import { createBlobUrl, isBlobUrl } from "utils/AppsmithUtils";
@@ -417,9 +417,8 @@ class FilePickerWidget extends BaseWidget<
   componentDidUpdate(prevProps: FilePickerWidgetProps) {
     super.componentDidUpdate(prevProps);
     if (
-      prevProps.selectedFiles &&
-      prevProps.selectedFiles.length > 0 &&
-      this.props.selectedFiles === undefined
+      size(prevProps.selectedFiles) > 0 &&
+      size(this.props.selectedFiles) === 0
     ) {
       this.state.uppy.reset();
     } else if (


### PR DESCRIPTION
> Clear file picker's previous file uploads on reset widget

Fixes #6124 

Fixes #743

## Type of change

- Bugfix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

