### PR TITLE
fix: Effect the telemetry choice in welcome page

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/AnalyticsEvents.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/AnalyticsEvents.java
@@ -16,6 +16,7 @@ public enum AnalyticsEvents {
     CREATE_SUPERUSER,
     SUBSCRIBE_MARKETING_EMAILS,
     UNSUBSCRIBE_MARKETING_EMAILS,
+    INSTALLATION_TELEMETRY("Installation Telemetry"),
     ;
 
     private final String eventName;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/NetworkUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/NetworkUtils.java
@@ -1,0 +1,39 @@
+package com.appsmith.server.helpers;
+
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+public class NetworkUtils {
+
+    private static final URI GET_IP_URI = URI.create("https://api64.ipify.org");
+
+    private static String cachedAddress = null;
+
+    private NetworkUtils() {
+    }
+
+    /**
+     * This method hits an API endpoint that returns the external IP address of this server instance.
+     *
+     * @return A publisher that yields the IP address.
+     */
+    public static Mono<String> getExternalAddress() {
+        if (cachedAddress != null) {
+            return Mono.just(cachedAddress);
+        }
+
+        return WebClient
+                .create()
+                .get()
+                .uri(GET_IP_URI)
+                .retrieve()
+                .bodyToMono(String.class)
+                .map(address -> {
+                    cachedAddress = address;
+                    return address;
+                });
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsService.java
@@ -66,6 +66,10 @@ public class AnalyticsService {
     }
 
     public void sendEvent(String event, String userId, Map<String, Object> properties) {
+        sendEvent(event, userId, properties, true);
+    }
+
+    public void sendEvent(String event, String userId, Map<String, Object> properties, boolean hashUserId) {
         if (!isActive()) {
             return;
         }
@@ -77,7 +81,8 @@ public class AnalyticsService {
         Map<String, Object> analyticsProperties = properties == null ? new HashMap<>() : new HashMap<>(properties);
 
         // Hash usernames at all places for self-hosted instance
-        if (!commonConfig.isCloudHosting()
+        if (hashUserId
+                && !commonConfig.isCloudHosting()
                 // But send the email intact for the subscribe event, which is sent only if the user has explicitly agreed to it.
                 && !AnalyticsEvents.SUBSCRIBE_MARKETING_EMAILS.name().equals(event)) {
             final String hashedUserId = DigestUtils.sha256Hex(userId);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsService.java
@@ -99,12 +99,10 @@ public class AnalyticsService {
             userId = hashedUserId;
         }
 
-        if (!CollectionUtils.isEmpty(analyticsProperties) && commonConfig.isCloudHosting()) {
-            // Segment throws an NPE if any value in `properties` is null.
-            for (final Map.Entry<String, Object> entry : analyticsProperties.entrySet()) {
-                if (entry.getValue() == null) {
-                    analyticsProperties.put(entry.getKey(), "");
-                }
+        // Segment throws an NPE if any value in `properties` is null.
+        for (final Map.Entry<String, Object> entry : analyticsProperties.entrySet()) {
+            if (entry.getValue() == null) {
+                analyticsProperties.put(entry.getKey(), "");
             }
         }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/PingScheduledTask.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/PingScheduledTask.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.solutions;
 
 import com.appsmith.server.configurations.SegmentConfig;
+import com.appsmith.server.helpers.NetworkUtils;
 import com.appsmith.server.services.ConfigService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +15,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-import java.net.URI;
 import java.util.Map;
 
 /**
@@ -32,8 +32,6 @@ public class PingScheduledTask {
 
     private final SegmentConfig segmentConfig;
 
-    public static final URI GET_IP_URI = URI.create("https://api64.ipify.org");
-
     /**
      * Gets the external IP address of this server and pings a data point to indicate that this server instance is live.
      * We use an initial delay of two minutes to roughly wait for the application along with the migrations are finished
@@ -42,24 +40,10 @@ public class PingScheduledTask {
     // Number of milliseconds between the start of each scheduled calls to this method.
     @Scheduled(initialDelay = 2 * 60 * 1000 /* two minutes */, fixedRate = 6 * 60 * 60 * 1000 /* six hours */)
     public void pingSchedule() {
-        Mono.zip(configService.getInstanceId(), getAddress())
+        Mono.zip(configService.getInstanceId(), NetworkUtils.getExternalAddress())
                 .flatMap(tuple -> doPing(tuple.getT1(), tuple.getT2()))
                 .subscribeOn(Schedulers.single())
                 .subscribe();
-    }
-
-    /**
-     * This method hits an API endpoint that returns the external IP address of this server instance.
-     *
-     * @return A publisher that yields the IP address.
-     */
-    private Mono<String> getAddress() {
-        return WebClient
-                .create()
-                .get()
-                .uri(GET_IP_URI)
-                .retrieve()
-                .bodyToMono(String.class);
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -66,6 +66,7 @@ public class UserSignup {
     private final AnalyticsService analyticsService;
     private final PolicyUtils policyUtils;
     private final ApplicationPageService applicationPageService;
+    private final EnvManager envManager;
 
     private static final ServerRedirectStrategy redirectStrategy = new DefaultServerRedirectStrategy();
 
@@ -225,6 +226,10 @@ public class UserSignup {
                                             Map.of("disable-telemetry", !userFromRequest.isAllowCollectingAnonymousData()),
                                             false
                                     )),
+                            envManager.applyChanges(Map.of(
+                                    "APPSMITH_DISABLE_TELEMETRY",
+                                    String.valueOf(!userFromRequest.isAllowCollectingAnonymousData())
+                            )),
                             userDataService.updateForUser(user, userData),
                             configService.save(ConfigNames.USE_CASE, Map.of("value", userFromRequest.getUseCase())),
                             analyticsService.sendObjectEvent(AnalyticsEvents.CREATE_SUPERUSER, user, null)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserSignup.java
@@ -14,6 +14,7 @@ import com.appsmith.server.domains.UserState;
 import com.appsmith.server.dtos.UserSignupRequestDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.NetworkUtils;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.ApplicationPageService;
@@ -217,6 +218,13 @@ public class UserSignup {
                     }
 
                     return Mono.when(
+                            NetworkUtils.getExternalAddress()
+                                    .doOnSuccess(address -> analyticsService.sendEvent(
+                                            AnalyticsEvents.INSTALLATION_TELEMETRY.getEventName(),
+                                            address,
+                                            Map.of("disable-telemetry", !userFromRequest.isAllowCollectingAnonymousData()),
+                                            false
+                                    )),
                             userDataService.updateForUser(user, userData),
                             configService.save(ConfigNames.USE_CASE, Map.of("value", userFromRequest.getUseCase())),
                             analyticsService.sendObjectEvent(AnalyticsEvents.CREATE_SUPERUSER, user, null)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/UserSignupTest.java
@@ -45,6 +45,9 @@ public class UserSignupTest {
     @MockBean
     private ApplicationPageService applicationPageService;
 
+    @MockBean
+    private EnvManager envManager;
+
     private UserSignup userSignup;
 
     @Before
@@ -57,7 +60,8 @@ public class UserSignupTest {
                 configService,
                 analyticsService,
                 policyUtils,
-                applicationPageService
+                applicationPageService,
+                envManager
         );
     }
 


### PR DESCRIPTION
Solves for two things:

1. From the welcome page signup, depending on telemetry being enabled or disabled, we report.
2. When telemetry is changed from welcome page (which, it obviously will), we make the change persistent by writing to the env file.

