### PR TITLE
fix: Don't send LINT and Parse errors to Sentry

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -257,11 +257,11 @@ export function* parseJSCollection(body: string, jsAction: JSCollection) {
       jsAction,
     },
   );
-  const { errors, evalTree, result } = workerResponse;
+  const { evalTree, result } = workerResponse;
   const dataTree = yield select(getDataTree);
   const updates = diff(dataTree, evalTree) || [];
   yield put(setEvaluatedTree(evalTree, updates));
-  yield call(evalErrorHandler, errors, evalTree, [path]);
+  yield call(evalErrorHandler, [], evalTree, [path]);
   return result;
 }
 

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -240,13 +240,12 @@ ctx.addEventListener(
           return true;
         }
         try {
-          const { errors, evalTree, result } = parseJSCollection(
+          const { evalTree, result } = parseJSCollection(
             body,
             jsAction,
             dataTreeEvaluator.evalTree,
           );
           return {
-            errors,
             evalTree,
             result,
           };
@@ -262,7 +261,6 @@ ctx.addEventListener(
           ];
           _.set(evalTree, `${jsAction.name}.${EVAL_ERROR_PATH}.body`, errors);
           return {
-            errors,
             evalTree,
           };
         }

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -579,7 +579,6 @@ export const parseJSCollection = (
         actions: actions,
         variables: variables,
       },
-      errors: errorsList,
     };
   } else {
     const errors = [
@@ -593,7 +592,6 @@ export const parseJSCollection = (
     _.set(evalTree, `${jsCollection.name}.${EVAL_ERROR_PATH}.body`, errors);
     return {
       evalTree,
-      errors: errors,
     };
   }
 };


### PR DESCRIPTION
## Description
During parsing js object we are getting only linting and parsing errors which are set in evalTree. Because sending these errors(errorType: LINT/PARSE) to errorHandler, errorHandler is posting it to Sentry.

Fixes # (issue)
Part of 6872

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: stop-sentry-js-editor-errors 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.82 **(0)** | 36.96 **(-0.01)** | 33.8 **(0)** | 55.43 **(-0.01)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 78.23 **(-1.61)** | 54.41 **(-2.94)** | 70 **(0)** | 84.09 **(-2.27)**</details>