### PR TITLE
fix: sending collectionName instead id in refactor

### DIFF
--- a/app/client/src/actions/jsPaneActions.ts
+++ b/app/client/src/actions/jsPaneActions.ts
@@ -55,7 +55,7 @@ export const deleteJSObjectAction = (payload: {
 
 export const refactorJSCollectionAction = (payload: {
   actionId: string;
-  collectionId: string;
+  collectionName: string;
   pageId: string;
   oldName: string;
   newName: string;

--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -111,7 +111,7 @@ export interface UpdateActionNameRequest {
   layoutId: string;
   newName: string;
   oldName: string;
-  collectionId?: string;
+  collectionName?: string;
 }
 
 class ActionAPI extends API {

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -147,7 +147,7 @@ function* handleParseUpdateJSCollection(actionPayload: { body: string }) {
           yield put(
             refactorJSCollectionAction({
               actionId: data.nameChangedActions[i].id,
-              collectionId: data.nameChangedActions[i].collectionId || "",
+              collectionName: jsAction.name,
               pageId: data.nameChangedActions[i].pageId,
               oldName: data.nameChangedActions[i].oldName,
               newName: data.nameChangedActions[i].newName,
@@ -367,7 +367,7 @@ function* handleExecuteJSFunctionSaga(
 function* handleRefactorJSActionNameSaga(
   data: ReduxAction<{
     actionId: string;
-    collectionId: string;
+    collectionName: string;
     pageId: string;
     oldName: string;
     newName: string;
@@ -384,7 +384,7 @@ function* handleRefactorJSActionNameSaga(
     try {
       const refactorResponse = yield ActionAPI.updateActionName({
         layoutId,
-        collectionId: data.payload.collectionId,
+        collectionName: data.payload.collectionName,
         pageId: data.payload.pageId,
         oldName: data.payload.oldName,
         newName: data.payload.newName,


### PR DESCRIPTION
## Description
 Send collection Name instead of collection id for refactor js collection's action

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: refactor-js-action-change 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.82 **(0)** | 36.97 **(0.01)** | 33.8 **(0)** | 55.43 **(0)**
 :green_circle: | app/client/src/sagas/JSPaneSagas.ts | 18.9 **(0)** | 1.59 **(0.05)** | 7.14 **(0)** | 22.14 **(0)**</details>