### PR TITLE
fix: Delete action collections on deleting page

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomActionCollectionRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomActionCollectionRepository.java
@@ -14,4 +14,6 @@ public interface CustomActionCollectionRepository extends AppsmithRepository<Act
     Flux<ActionCollection> findByApplicationIdAndViewMode(String applicationId, boolean viewMode, AclPermission aclPermission);
 
     Flux<ActionCollection> findAllActionCollectionsByNameAndPageIdsAndViewMode(String name, List<String> pageIds, boolean viewMode, AclPermission aclPermission, Sort sort);
+
+    Flux<ActionCollection> findByPageId(String pageId, AclPermission permission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionCollectionService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionCollectionService.java
@@ -39,4 +39,5 @@ public interface ActionCollectionService extends CrudService<ActionCollection, S
 
     Mono<ActionCollectionDTO> findActionCollectionDTObyIdAndViewMode(String id, Boolean viewMode, AclPermission permission);
 
+    Flux<ActionCollection> findByPageId(String pageId, AclPermission permission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionCollectionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ActionCollectionServiceImpl.java
@@ -267,6 +267,11 @@ public class ActionCollectionServiceImpl extends BaseService<ActionCollectionRep
     }
 
     @Override
+    public Flux<ActionCollection> findByPageId(String pageId, AclPermission permission) {
+        return repository.findByPageId(pageId, permission);
+    }
+
+    @Override
     public Mono<ActionCollection> delete(String id) {
         Mono<ActionCollection> actionCollectionMono = repository.findById(id)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.ACTION, id)))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -16,6 +16,7 @@ import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.Page;
 import com.appsmith.server.domains.User;
+import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.ActionDTO;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.PageDTO;
@@ -558,12 +559,22 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                 return newActionService.deleteUnpublishedAction(action.getId());
                             }).collectList();
 
-                    return Mono.zip(archivedPageMono, archivedActionsMono, applicationMono)
+                    /**
+                     *  Only delete unpublished action collection and not the entire action collection.
+                     */
+                    Mono<List<ActionCollectionDTO>> archivedActionCollectionsMono = actionCollectionService.findByPageId(page.getId(), MANAGE_ACTIONS)
+                            .flatMap(actionCollection -> {
+                                log.debug("Going to archive actionCollectionId: {} for applicationId: {}", actionCollection.getId(), id);
+                                return actionCollectionService.deleteUnpublishedActionCollection(actionCollection.getId());
+                            }).collectList();
+
+                    return Mono.zip(archivedPageMono, archivedActionsMono, archivedActionCollectionsMono, applicationMono)
                             .map(tuple -> {
                                 PageDTO page1 = tuple.getT1();
                                 List<ActionDTO> actions = tuple.getT2();
-                                Application application = tuple.getT3();
-                                log.debug("Archived pageId: {} and {} actions for applicationId: {}", page1.getId(), actions.size(), application.getId());
+                                final List<ActionCollectionDTO> actionCollections = tuple.getT3();
+                                Application application = tuple.getT4();
+                                log.debug("Archived pageId: {} , {} actions and {} action collections for applicationId: {}", page1.getId(), actions.size(), actionCollections.size(), application.getId());
                                 return page1;
                             });
                 });

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationService.java
@@ -162,7 +162,7 @@ public class ImportExportApplicationService {
                     application.setGitApplicationMetadata(null);
                     examplesOrganizationCloner.makePristine(application);
                     applicationJson.setExportedApplication(application);
-                    // TODO @Abhijeet please take a look at the ACL permissions
+
                     return newPageRepository.findByApplicationId(applicationId, AclPermission.MANAGE_PAGES)
                             .collectList()
                             .flatMap(newPageList -> {


### PR DESCRIPTION
Fixes an issue with import/export that retained deleted collections. Root cause was that action collections were not getting deleted on deleting pages