### PR TITLE
fix: small utility fixes for redirection to datasource and export app permissions

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -4,7 +4,11 @@ import { TreeDropdownOption } from "components/ads/TreeDropdown";
 import TreeStructure from "components/utils/TreeStructure";
 import { OnboardingStep } from "constants/OnboardingConstants";
 import { ReduxActionTypes } from "constants/ReduxActionConstants";
-import { INTEGRATION_EDITOR_URL, INTEGRATION_TABS } from "constants/routes";
+import {
+  INTEGRATION_EDITOR_MODES,
+  INTEGRATION_EDITOR_URL,
+  INTEGRATION_TABS,
+} from "constants/routes";
 import { PluginType } from "entities/Action";
 import { Datasource } from "entities/Datasource";
 import { keyBy } from "lodash";
@@ -552,7 +556,12 @@ function useIntegrationsOptionTree() {
           }
         } else {
           history.push(
-            INTEGRATION_EDITOR_URL(applicationId, pageId, INTEGRATION_TABS.NEW),
+            INTEGRATION_EDITOR_URL(
+              applicationId,
+              pageId,
+              INTEGRATION_TABS.NEW,
+              INTEGRATION_EDITOR_MODES.AUTO,
+            ),
           );
         }
       },

--- a/app/client/src/pages/Editor/EditorAppName/NavigationMenuData.ts
+++ b/app/client/src/pages/Editor/EditorAppName/NavigationMenuData.ts
@@ -1,4 +1,4 @@
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useHistory, useParams } from "react-router-dom";
 import { noop } from "lodash";
 
@@ -16,6 +16,11 @@ import { MenuItemData, MenuTypes } from "./NavigationMenuItem";
 import { useCallback } from "react";
 import { ExplorerURLParams } from "../Explorer/helpers";
 import { getExportAppAPIRoute } from "constants/ApiConstants";
+import {
+  isPermitted,
+  PERMISSION_TYPE,
+} from "../../Applications/permissionHelpers";
+import { getCurrentApplication } from "selectors/applicationSelectors";
 
 type NavigationMenuDataProps = ThemeProp & {
   applicationId: string | undefined;
@@ -34,9 +39,12 @@ export const GetNavigationMenuData = ({
   const isHideComments = useHideComments();
   const history = useHistory();
   const params = useParams<ExplorerURLParams>();
-
+  const currentApplication = useSelector(getCurrentApplication);
   const isApplicationIdPresent = !!(applicationId && applicationId.length > 0);
-
+  const hasExportPermission = isPermitted(
+    currentApplication?.userPermissions ?? [],
+    PERMISSION_TYPE.EXPORT_APPLICATION,
+  );
   const openExternalLink = useCallback((link: string) => {
     if (link) {
       window.open(link, "_blank");
@@ -158,7 +166,7 @@ export const GetNavigationMenuData = ({
       onClick: () =>
         applicationId && openExternalLink(getExportAppAPIRoute(applicationId)),
       type: MenuTypes.MENU,
-      isVisible: isApplicationIdPresent,
+      isVisible: isApplicationIdPresent && hasExportPermission,
     },
     {
       text: "Delete Application",


### PR DESCRIPTION
## Description
1. Automatically deciding, whether to show active tab or new tab on datasource page
2. Only admin users will be able to see the export menu for app in edit mode

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/property-pane-redirection-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.81 **(0)** | 36.95 **(0.01)** | 33.8 **(0)** | 55.43 **(0.01)**
 :green_circle: | app/client/src/pages/Editor/EditorAppName/NavigationMenuData.ts | 65.12 **(3.58)** | 40 **(30)** | 8.33 **(0)** | 64.29 **(3.76)**</details>