### PR TITLE
feat: added API to get unread comment thread count in an application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/CommentController.java
@@ -113,4 +113,10 @@ public class CommentController extends BaseController<CommentService, Comment, S
         return service.unsubscribeThread(threadId)
                 .map(updated -> new ResponseDTO<>(HttpStatus.OK.value(), updated, null));
     }
+
+    @GetMapping("/threads/{applicationId}/count/unread")
+    public Mono<ResponseDTO<Long>> countUnreadCommentThreads(@PathVariable String applicationId) {
+        return service.getUnreadCount(applicationId)
+                .map(threads -> new ResponseDTO<>(HttpStatus.OK.value(), threads, null));
+    }
 }


### PR DESCRIPTION
## Description
Add API to get unread comment thread count for an application.

Fixes #7974

## Type of change
- New feature (non-breaking change which adds functionality)


## How Has This Been Tested

- Manually


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
