### PR TITLE
fix: Fixes scenario where renaming actions was clearing debugger errors.

### DIFF
--- a/app/client/src/reducers/uiReducers/debuggerReducer.ts
+++ b/app/client/src/reducers/uiReducers/debuggerReducer.ts
@@ -81,7 +81,8 @@ const debuggerReducer = createReducer(initialState, {
       currentTab: action.payload,
     };
   },
-  [ReduxActionTypes.INIT_CANVAS_LAYOUT]: () => {
+  // Resetting debugger state after page switch
+  [ReduxActionTypes.SWITCH_CURRENT_PAGE_ID]: () => {
     return {
       ...initialState,
     };


### PR DESCRIPTION
## Description

Incorrect action type was used to check for the page switch event. The INIT_CANVAS_LAYOUT is called after renaming entity names as well. Updated the action type being used.

Fixes #7390 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/debugger-not-having-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.81 **(0)** | 36.95 **(0)** | 33.81 **(0.01)** | 55.43 **(0.01)**
 :green_circle: | app/client/src/reducers/uiReducers/debuggerReducer.ts | 50 **(5.56)** | 0 **(0)** | 25 **(12.5)** | 52.94 **(5.88)**</details>