### PR TITLE
fix: Migration to not load full actions into memory

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3258,10 +3258,10 @@ public class DatabaseChangelog {
         deletionUpdates.set(fieldName(QNewAction.newAction.deleted), true);
         deletionUpdates.set(fieldName(QNewAction.newAction.deletedAt), Instant.now());
 
-        final List<NewAction> actions = mongockTemplate.find(
-                query(where(fieldName(QNewAction.newAction.deleted)).ne(true)),
-                NewAction.class
-        );
+        final Query actionQuery = query(where(fieldName(QNewAction.newAction.deleted)).ne(true));
+        actionQuery.fields().include(fieldName(QNewAction.newAction.applicationId));
+
+        final List<NewAction> actions = mongockTemplate.find(actionQuery, NewAction.class);
 
         for (final NewAction action : actions) {
             final String applicationId = action.getApplicationId();


### PR DESCRIPTION
This migration is loading all non-deleted action documents in their full glory into memory, which breaches Java's set memory limit and so throws an OOM.

This PR changes this by loading just two pieces of information from the actions, the `applicationId` and the action's `_id`, since that's all we need for the logic here. This should significantly reduce the memory required for this operation.
