### PR TITLE
fix: Added checks to ensure that the configs are valid before starting eval

### DIFF
--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -96,12 +96,24 @@ function* getFormEvaluation(formId: string, actionConfiguration: any): any {
 function* setFormEvaluationSaga(type: string, payload: any) {
   if (type === ReduxActionTypes.INIT_FORM_EVALUATION) {
     finalEvalObj = {};
-    payload.editorConfig.forEach((config: any) => {
-      generateInitialEvalState(config);
-    });
-    payload.settingConfig.forEach((config: any) => {
-      generateInitialEvalState(config);
-    });
+    if (
+      "editorConfig" in payload &&
+      !!payload.editorConfig &&
+      payload.editorConfig.length > 0
+    ) {
+      payload.editorConfig.forEach((config: any) => {
+        generateInitialEvalState(config);
+      });
+    }
+    if (
+      "settingConfig" in payload &&
+      !!payload.settingConfig &&
+      payload.settingConfig.length > 0
+    ) {
+      payload.settingConfig.forEach((config: any) => {
+        generateInitialEvalState(config);
+      });
+    }
     yield put({
       type: ReduxActionTypes.SET_FORM_EVALUATION,
       payload: {


### PR DESCRIPTION
## Description

We are facing an issue when the editor and settings config is showing as undefined before evaluations start. To prevent this, added the check. The root cause for the configs being undefined is still not found.

Fixes #7605 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/7605-check-config-befor-evaluations 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.81 **(0)** | 36.93 **(-0.02)** | 33.8 **(0)** | 55.42 **(0)**
 :red_circle: | app/client/src/sagas/FormEvaluationSaga.ts | 22.54 **(-0.65)** | 11.9 **(-3.73)** | 25 **(0)** | 25.4 **(-0.83)**</details>