### PR TITLE
fix: Converting headers safely into jsonnode

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -778,7 +778,7 @@ public class NewActionServiceImpl extends BaseService<NewActionRepository, NewAc
         }
 
         if (request.getHeaders() != null) {
-            JsonNode headers = (JsonNode) request.getHeaders();
+            JsonNode headers = objectMapper.convertValue(request.getHeaders(), JsonNode.class);
             try {
                 String headersAsString = objectMapper.writeValueAsString(headers);
                 request.setHeaders(headersAsString);


### PR DESCRIPTION
The conversion here was typecasting the object type into JsonNode. However, when populating headers it is also possible for it to be a map, which is not a valid cast. This changes makes the conversion more liberal.