### PR TITLE
fix: remove duplicate case for context menu

### DIFF
--- a/app/client/src/components/ads/Icon.tsx
+++ b/app/client/src/components/ads/Icon.tsx
@@ -55,7 +55,6 @@ import { ReactComponent as SendButton } from "assets/icons/comments/send-button.
 import { ReactComponent as Emoji } from "assets/icons/comments/emoji.svg";
 import { ReactComponent as Pin } from "assets/icons/comments/pin.svg";
 import { ReactComponent as OvalCheck } from "assets/icons/comments/check-oval.svg";
-import { ReactComponent as ContextMenu } from "assets/icons/ads/context-menu.svg";
 import { ReactComponent as Trash } from "assets/icons/comments/trash.svg";
 import { ReactComponent as ReadPin } from "assets/icons/comments/read-pin.svg";
 import { ReactComponent as UnreadPin } from "assets/icons/comments/unread-pin.svg";
@@ -463,10 +462,6 @@ const Icon = forwardRef(
       case "PARAGRAPH_TWO":
         const ControlIcon = ControlIcons[props.name];
         returnIcon = <ControlIcon height={24} width={24} />;
-        break;
-
-      case "context-menu":
-        returnIcon = <ContextMenu />;
         break;
 
       case "read-pin":


### PR DESCRIPTION
## Description

Removed duplicate case for context-menu in `Icon.tsx`

Fixes #7951

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
