### PR TITLE
Update appsmith_templates.md

### DIFF
--- a/appsmith_templates.md
+++ b/appsmith_templates.md
@@ -1,14 +1,14 @@
 ## Appsmith Example Applications and Templates
 
-Our team and the community have created a few **example** applications that can be used as is, or as a template which can serve as a starting point for your application.
+Our team and the community have created a few **example** applications that can be used as-is, or as a template that can serve as a starting point for your application.
 
 You can use the applications for yourself following the simple steps below:
 
 1. Click on the application of your choice
-2. On the top right hand corner, you will see an option to `fork` the application
+2. On the top right-hand corner, you will see an option to `fork` the application
 4. Click on `fork` application 
 5. Log in to Appsmith, if not already
-6. Select organization to which the application should be forked
+6. Select the organization to which the application should be forked
 7. Change datasource credentials to connect to your backend
 8. You now have a fully functional app to use or build on top of
 
@@ -27,7 +27,7 @@ Would you like to contribute your app? Just write in to akshay@appsmith.com.
 
 3. [Founder/Investor CRM](https://app.appsmith.com/applications/6098bdc65864501cc39c3d2f/pages/6098bdc65864501cc39c3d31)
 
-> A pragmatic CRM that helps founders keep track of the investor conversations they have had, and details about the investor, fund and files shared. You can use it to mark next steps and prioritize conversations. We have found this system very useful personally for our fundraises. We chose to use a Google Sheets backend as that's where foudners end up keeping these notes usually. You can just [authorize a sheet](https://docs.appsmith.com/how-to-guides/oauth2-authorization-for-google-sheets) to get it working.
+> A pragmatic CRM that helps founders keep track of the investor conversations they have had, and details about the investor, fund and files shared. You can use it to mark the next steps and prioritize conversations. We have found this system very useful personally for our fundraises. We chose to use a Google Sheets backend as that's where founders end up keeping these notes usually. You can just [authorize a sheet](https://docs.appsmith.com/how-to-guides/oauth2-authorization-for-google-sheets) to get it working.
 > 
 
 Watch out for more! If you'd like to contribute a template, please write in to akshay@appsmith.com! 


### PR DESCRIPTION
## Description
 - "as is" and "right hand" are compound phrases and need a hyphen
 - "organization" and "next step" need an article
 - "founders" is misspelled

## Type of change

Documentation change