### PR TITLE
fix: missing where key in plugin specified templates

### DIFF
--- a/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
@@ -63,7 +63,7 @@ function ActionForm(props: Props) {
    * NOTE:
    * Action object returned by getAction comes from state.entities.action
    * action api's payload is created from state.entities.action and response is saved in the same key
-   * Data passed to redux form is the merge of values present in editorConfig, settingsConfig, formConfigs and has the correct datastrucure
+   * Data passed to redux form is the merge of values present in state.entities.action, editorConfig, settingsConfig and has the correct datastrucure
    * Data structure in state.entities.action is not correct
    * Q. What does the following fix do?
    * A. It calculates the diff between merged values and state.entities.action and saves the same in state.entities.action
@@ -72,6 +72,7 @@ function ActionForm(props: Props) {
   if (!!props.difference) {
     let path = "";
     let value = "";
+    // Loop through the diff objects in difference Array
     for (let i = 0; i < props.difference.length; i++) {
       //kind = N indicates a newly added property/element
       //This property is present in initialValues but not in action object

--- a/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
@@ -59,21 +59,32 @@ function ActionForm(props: Props) {
   };
 
   if (!!props.difference) {
+    let path = "";
+    let value = "";
     for (let i = 0; i < props.difference.length; i++) {
-      let path = "";
-      path += props.difference[i].path.join(".");
-      const index = props.difference[i]?.index;
-      path += `[${index}]`;
-      if (index >= 0 && props.difference[i]?.item.kind === "N") {
-        const value = props.difference[i].item.rhs;
-        dispatch(
-          setActionProperty({
-            actionId: apiId,
-            propertyName: path,
-            value: value,
-          }),
+      if (props.difference[i]?.kind === "N") {
+        path = props.difference[i].path.reduce(
+          (acc: string, item: number | string) => {
+            if (typeof item === "string" && acc) {
+              acc += `${path}.${item}`;
+            } else if (typeof item === "string" && !acc) {
+              acc += `${item}`;
+            } else acc += `${path}[${item}]`;
+            return acc;
+          },
+          "",
         );
+        value = props.difference[i]?.rhs;
       }
+    }
+    if (value && path) {
+      dispatch(
+        setActionProperty({
+          actionId: apiId,
+          propertyName: path,
+          value: value,
+        }),
+      );
     }
   }
 

--- a/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
@@ -25,14 +25,14 @@ import {
   EditorJSONtoFormProps,
 } from "../QueryEditor/EditorJSONtoForm";
 import { getConfigInitialValues } from "components/formControls/utils";
-import { difference, merge, update } from "lodash";
+import { merge } from "lodash";
 import { Datasource } from "entities/Datasource";
 import {
   INTEGRATION_EDITOR_MODES,
   INTEGRATION_EDITOR_URL,
   INTEGRATION_TABS,
 } from "constants/routes";
-import { applyDiff, diff } from "deep-diff";
+import { diff } from "deep-diff";
 
 type StateAndRouteProps = EditorJSONtoFormProps & {
   difference?: any;

--- a/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx
@@ -58,11 +58,25 @@ function ActionForm(props: Props) {
     dispatch(deleteAction({ id: apiId, name: actionName }));
   };
 
+  //Following if block is the fix for the missing where key
+  /**
+   * NOTE:
+   * Action object returned by getAction comes from state.entities.action
+   * action api's payload is created from state.entities.action and response is saved in the same key
+   * Data passed to redux form is the merge of values present in editorConfig, settingsConfig, formConfigs and has the correct datastrucure
+   * Data structure in state.entities.action is not correct
+   * Q. What does the following fix do?
+   * A. It calculates the diff between merged values and state.entities.action and saves the same in state.entities.action
+   * There is another key form that holds the formData
+   */
   if (!!props.difference) {
     let path = "";
     let value = "";
     for (let i = 0; i < props.difference.length; i++) {
+      //kind = N indicates a newly added property/element
+      //This property is present in initialValues but not in action object
       if (props.difference[i]?.kind === "N") {
+        // Calculate path from path [] in diff
         path = props.difference[i].path.reduce(
           (acc: string, item: number | string) => {
             if (typeof item === "string" && acc) {
@@ -74,6 +88,7 @@ function ActionForm(props: Props) {
           },
           "",
         );
+        // get value from diff object
         value = props.difference[i]?.rhs;
       }
     }


### PR DESCRIPTION
## Description

Fixes #7843 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/where-key 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.79 **(-0.02)** | 36.91 **(-0.04)** | 33.8 **(0)** | 55.4 **(-0.02)**
 :red_circle: | app/client/src/pages/Editor/SaaSEditor/ActionForm.tsx | 20.29 **(-5.2)** | 0 **(0)** | 0 **(0)** | 21.54 **(-5.54)**</details>