### PR TITLE
fix: update user names in notifications when users update their name

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentRepositoryImpl.java
@@ -66,8 +66,8 @@ public class CustomCommentRepositoryImpl extends BaseAppsmithRepositoryImpl<Comm
     public Mono<Void> updateAuthorNames(String authorId, String authorName) {
         return mongoOperations
                 .updateMulti(
-                        Query.query(Criteria.where("authorId").is(authorId)),
-                        Update.update("authorName", authorName),
+                        Query.query(Criteria.where(fieldName(QComment.comment.authorId)).is(authorId)),
+                        Update.update(fieldName(QComment.comment.authorName), authorName),
                         Comment.class
                 )
                 .then();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNotificationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNotificationRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface CustomNotificationRepository extends AppsmithRepository<Notification> {
     Mono<UpdateResult> updateIsReadByForUsernameAndIdList(String forUsername, List<String> idList, boolean isRead);
     Mono<UpdateResult> updateIsReadByForUsername(String forUsername, boolean isRead);
+    Mono<Void> updateCommentAuthorNames(String authorId, String authorName);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNotificationRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNotificationRepositoryImpl.java
@@ -1,10 +1,13 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.domains.Notification;
+import com.appsmith.server.domains.QComment;
 import com.appsmith.server.domains.QNotification;
 import com.mongodb.client.result.UpdateResult;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Mono;
 
@@ -38,5 +41,19 @@ public class CustomNotificationRepositoryImpl extends BaseAppsmithRepositoryImpl
                 new Update().set(fieldName(QNotification.notification.isRead), isRead),
                 Notification.class
         );
+    }
+
+    @Override
+    public Mono<Void> updateCommentAuthorNames(String authorId, String authorName) {
+        String whereFieldName = String.format("%s.%s", fieldName(QComment.comment), fieldName(QComment.comment.authorId));
+        String updateFieldName = String.format("%s.%s", fieldName(QComment.comment), fieldName(QComment.comment.authorName));
+
+        return mongoOperations
+                .updateMulti(
+                        Query.query(Criteria.where(whereFieldName).is(authorId)),
+                        Update.update(updateFieldName, authorName),
+                        Notification.class
+                )
+                .then();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/NotificationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/NotificationRepository.java
@@ -13,5 +13,4 @@ public interface NotificationRepository extends BaseRepository<Notification, Str
     Flux<Notification> findByForUsernameAndCreatedAtBefore(String userId, Instant instant, Pageable pageable);
     Mono<Long> countByForUsername(String userId);
     Mono<Long> countByForUsernameAndIsReadIsFalse(String userId);
-//    Mono<Void> updateCommentAuthorNames(String authorId, String authorName);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/NotificationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/NotificationRepository.java
@@ -13,4 +13,5 @@ public interface NotificationRepository extends BaseRepository<Notification, Str
     Flux<Notification> findByForUsernameAndCreatedAtBefore(String userId, Instant instant, Pageable pageable);
     Mono<Long> countByForUsername(String userId);
     Mono<Long> countByForUsernameAndIsReadIsFalse(String userId);
+//    Mono<Void> updateCommentAuthorNames(String authorId, String authorName);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -226,7 +226,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                 .switchIfEmpty(Mono.defer(() -> {
                     PasswordResetToken passwordResetToken = new PasswordResetToken();
                     passwordResetToken.setEmail(email);
-                    passwordResetToken.setRequestCount(1);
+                    passwordResetToken.setRequestCount(0);
                     passwordResetToken.setFirstRequestTime(Instant.now());
                     return Mono.just(passwordResetToken);
                 }))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserChangedHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/UserChangedHandler.java
@@ -4,6 +4,7 @@ import com.appsmith.server.domains.User;
 import com.appsmith.server.events.UserChangedEvent;
 import com.appsmith.server.events.UserPhotoChangedEvent;
 import com.appsmith.server.repositories.CommentRepository;
+import com.appsmith.server.repositories.NotificationRepository;
 import com.appsmith.server.repositories.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ public class UserChangedHandler {
 
     private final ApplicationEventPublisher applicationEventPublisher;
     private final CommentRepository commentRepository;
+    private final NotificationRepository notificationRepository;
     private final OrganizationRepository organizationRepository;
 
     public User publish(User user) {
@@ -45,6 +47,10 @@ public class UserChangedHandler {
         updateNameInUserRoles(user)
                 .subscribeOn(Schedulers.elastic())
                 .subscribe();
+
+        updateNameInNotifications(user)
+                .subscribeOn(Schedulers.elastic())
+                .subscribe();
     }
 
     @Async
@@ -64,6 +70,16 @@ public class UserChangedHandler {
 
         log.debug("Updating name in comments for user {}", user.getId());
         return commentRepository.updateAuthorNames(user.getId(), user.getName());
+    }
+
+    private Mono<Void> updateNameInNotifications(User user) {
+        if (user.getId() == null) {
+            log.warn("Attempt to update name in notifications for user with null ID.");
+            return Mono.empty();
+        }
+
+        log.debug("Updating name in notifications for user {}", user.getId());
+        return notificationRepository.updateCommentAuthorNames(user.getId(), user.getName());
     }
 
     private Mono<Void> updatePhotoIdInComments(String userId, String photoId) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomNotificationRepositoryImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomNotificationRepositoryImplTest.java
@@ -1,5 +1,7 @@
 package com.appsmith.server.repositories;
 
+import com.appsmith.server.domains.Comment;
+import com.appsmith.server.domains.CommentNotification;
 import com.appsmith.server.domains.Notification;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
@@ -17,6 +19,10 @@ import reactor.util.function.Tuple3;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RunWith(SpringRunner.class)
@@ -160,5 +166,63 @@ public class CustomNotificationRepositoryImplTest {
                 Assert.assertEquals(true, notification.getIsRead());
             });
         }).verifyComplete();
+    }
+
+    private CommentNotification createCommentNotification(String authorId, String authorName) {
+        CommentNotification commentNotification = new CommentNotification();
+        commentNotification.setComment(new Comment());
+        commentNotification.getComment().setAuthorId(authorId);
+        commentNotification.getComment().setAuthorName(authorName);
+        return commentNotification;
+    }
+
+    @Test
+    public void updateCommentAuthorNames_WhenNameChanged_NamesUpdated() {
+        String authorOneId = "author-1",
+                authorTwoId = "author-2",
+                oldName = "Old name",
+                updatedName = "New name";
+
+        List<Notification> notificationList = List.of(
+                createCommentNotification(authorOneId, oldName),
+                createCommentNotification(authorOneId, oldName),
+                createCommentNotification(authorTwoId, oldName)
+        );
+
+        Mono<Map<String, Collection<Notification>>> mapMono = notificationRepository
+                .saveAll(notificationList)// save the above 3 notifications
+                .collectList()
+                .flatMap(notifications ->
+                        // update the author names
+                        notificationRepository.updateCommentAuthorNames(authorOneId, updatedName)
+                                .then(Mono.just(notifications)) // return the saved objects
+                )
+                .flatMap(notifications -> {
+                    // now fetch the saved notifications again by id
+                    Stream<String> idStream = notifications.stream().map(notification -> notification.getId());
+                    List<String> idList = idStream.collect(Collectors.toList()); // get the list of id from objects
+                    return notificationRepository.findAllById(idList)
+                            .collectMultimap(notification ->
+                                    // create a map of author id and list of objects for better assertions
+                                    ((CommentNotification) notification).getComment().getAuthorId()
+                            );
+                });
+
+        StepVerifier.create(mapMono).assertNext(authorIdNotificationMap -> {
+            assertThat(authorIdNotificationMap.size()).isEqualTo(2);
+            assertThat(authorIdNotificationMap.get(authorOneId).size()).isEqualTo(2);
+            for(Notification notification: authorIdNotificationMap.get(authorOneId)) {
+                CommentNotification commentNotification = (CommentNotification) notification;
+                // should have updated name
+                assertThat(commentNotification.getComment().getAuthorName()).isEqualTo("New name");
+            }
+            assertThat(authorIdNotificationMap.get(authorTwoId).size()).isEqualTo(1);
+            for(Notification notification: authorIdNotificationMap.get(authorTwoId)) {
+                CommentNotification commentNotification = (CommentNotification) notification;
+                // name should be unchanged
+                assertThat(commentNotification.getComment().getAuthorName()).isEqualTo(oldName);
+            }
+        }).verifyComplete();
+
     }
 }


### PR DESCRIPTION
## Description
Updates the username in notifications when users update their name. Also includes some refactoring and a tiny bug fix.

Fixes #7286 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually
- Unit test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
