### PR TITLE
chore: Update TCs to check fork app is possible for user with VIEW permission

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
@@ -1,10 +1,15 @@
 package com.appsmith.server.solutions;
 
+import com.appsmith.external.models.Datasource;
+import com.appsmith.external.services.EncryptionService;
+import com.appsmith.server.acl.AppsmithRole;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
-import com.appsmith.external.models.Datasource;
 import com.appsmith.server.domains.Organization;
 import com.appsmith.server.dtos.ActionDTO;
+import com.appsmith.server.dtos.InviteUsersDTO;
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.PluginRepository;
@@ -12,16 +17,18 @@ import com.appsmith.server.services.ActionCollectionService;
 import com.appsmith.server.services.ApplicationPageService;
 import com.appsmith.server.services.ApplicationService;
 import com.appsmith.server.services.DatasourceService;
-import com.appsmith.external.services.EncryptionService;
 import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.services.NewActionService;
 import com.appsmith.server.services.NewPageService;
 import com.appsmith.server.services.OrganizationService;
 import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.services.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,8 +52,16 @@ import static com.appsmith.server.acl.AclPermission.READ_DATASOURCES;
 import static com.appsmith.server.acl.AclPermission.READ_PAGES;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Always run the complete test suite here as TCs have dependency between them. We are controlling this with
+ * FixMethodOrder(MethodSorters.NAME_ASCENDING) to run the TCs in a sequence. Running TC in a sequence is a bad
+ * practice for unit TCs but here we are actually executing a integration test where we are first inviting user and then
+ * forking the application
+ *
+ */
 @Slf4j
 @RunWith(SpringRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @SpringBootTest
 @DirtiesContext
 public class ApplicationForkingServiceTests {
@@ -93,6 +108,52 @@ public class ApplicationForkingServiceTests {
     @Autowired
     private NewPageService newPageService;
 
+    @Autowired
+    private UserService userService;
+
+    private static String sourceAppId;
+
+    private static String testUserOrgId;
+
+    private static boolean isSetupDone = false;
+
+    @Before
+    public void setup() {
+
+        // Run setup only once
+        if (isSetupDone) {
+            return;
+        }
+
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Organization sourceOrganization = new Organization();
+        sourceOrganization.setName("Source Organization");
+        organizationService.create(sourceOrganization).map(Organization::getId).block();
+
+        Application app1 = new Application();
+        app1.setName("1 - public app");
+        app1.setOrganizationId(sourceOrganization.getId());
+        app1.setForkingEnabled(true);
+        applicationPageService.createApplication(app1).block();
+        sourceAppId = app1.getId();
+
+        // Invite "usertest@usertest.com" with VIEW access, api_user will be the admin of sourceOrganization and we are
+        // controlling this with @FixMethodOrder(MethodSorters.NAME_ASCENDING) to run the TCs in a sequence.
+        // Running TC in a sequence is a bad practice for unit TCs but here we are testing the invite user and then fork
+        // application as a part of this flow.
+        // We need to test with VIEW user access so that any user should be able to fork template applications
+        InviteUsersDTO inviteUsersDTO = new InviteUsersDTO();
+        ArrayList<String> users = new ArrayList<>();
+        users.add("usertest@usertest.com");
+        inviteUsersDTO.setUsernames(users);
+        inviteUsersDTO.setOrgId(sourceOrganization.getId());
+        inviteUsersDTO.setRoleName(AppsmithRole.ORGANIZATION_VIEWER.getName());
+        userService.inviteUsers(inviteUsersDTO, "http://localhost:8080").block();
+
+        isSetupDone = true;
+    }
+
     private static class OrganizationData {
         Organization organization;
         List<Application> applications = new ArrayList<>();
@@ -118,40 +179,38 @@ public class ApplicationForkingServiceTests {
                 .thenReturn(data);
     }
 
-    @Before
-    public void setup() {
-        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
-    }
-
     @Test
     @WithUserDetails(value = "api_user")
-    public void cloneOrganizationWithItsContents() {
-        Organization sourceOrganization = new Organization();
-        sourceOrganization.setName("Source Organization");
+    public void test1_cloneOrganizationWithItsContents() {
 
         Organization targetOrganization = new Organization();
         targetOrganization.setName("Target Organization");
 
-        final Mono<Application> resultMono = Mono
-                .zip(
-                        organizationService.create(sourceOrganization).map(Organization::getId),
-                        organizationService.create(targetOrganization).map(Organization::getId),
-                        sessionUserService.getCurrentUser()
-                )
-                .flatMap(tuple -> {
-                    final String organizationId = tuple.getT1();
-                    Application app1 = new Application();
-                    app1.setName("1 - public app");
-                    app1.setOrganizationId(organizationId);
-                    app1.setForkingEnabled(true);
+        final Mono<Application> resultMono = organizationService.create(targetOrganization)
+                .map(Organization::getId)
+                .flatMap(targetOrganizationId ->
+                        applicationForkingService.forkApplicationToOrganization(sourceAppId, targetOrganizationId)
+                );
 
-                    return applicationPageService.createApplication(app1)
-                            .flatMap(app ->
-                                    applicationForkingService.forkApplicationToOrganization(
-                                            app.getId(),
-                                            tuple.getT2()
-                                    )
-                            );
+        StepVerifier.create(resultMono)
+                .assertNext(application -> {
+                    assertThat(application).isNotNull();
+                    assertThat(application.getName()).isEqualTo("1 - public app");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "usertest@usertest.com")
+    public void test2_forkApplicationWithReadApplicationUserAccess() {
+
+        Organization targetOrganization = new Organization();
+        targetOrganization.setName("test-user-organization");
+
+        final Mono<Application> resultMono = organizationService.create(targetOrganization)
+                .flatMap(organization -> {
+                    testUserOrgId = organization.getId();
+                    return applicationForkingService.forkApplicationToOrganization(sourceAppId, organization.getId());
                 });
 
         StepVerifier.create(resultMono)
@@ -160,6 +219,18 @@ public class ApplicationForkingServiceTests {
                     assertThat(application.getName()).isEqualTo("1 - public app");
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void test3_failForkApplicationWithInvalidPermission() {
+
+        final Mono<Application> resultMono = applicationForkingService.forkApplicationToOrganization(sourceAppId, testUserOrgId);
+
+        StepVerifier.create(resultMono)
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException &&
+                        throwable.getMessage().equals(AppsmithError.ACL_NO_RESOURCE_FOUND.getMessage(FieldName.ORGANIZATION, testUserOrgId)))
+                .verify();
     }
 
     private Flux<ActionDTO> getActionsInOrganization(Organization organization) {


### PR DESCRIPTION
## Description

> For forking the template applications we need to allow users with `READ_APPLICATIONS`. To avoid the updating the ACL permission adding a TC with this PR.  

Fixes #8078

## Type of change

- Improve TC coverage

## How Has This Been Tested?

- JUnit TCs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
