### PR TITLE
fix: empty checkbox removed when errors in select options

### DIFF
--- a/app/client/src/widgets/DropdownWidget/component/index.tsx
+++ b/app/client/src/widgets/DropdownWidget/component/index.tsx
@@ -168,7 +168,7 @@ class DropDownComponent extends React.Component<DropDownComponentProps> {
   render() {
     return (
       <DropdownContainer>
-        <DropdownStyles />
+        {!!this.props.options.length && <DropdownStyles />}
         <StyledControlGroup
           fill
           haslabel={!!this.props.label ? "true" : "false"}


### PR DESCRIPTION


## Description

- The empty container rendering issue when the select options have an error.

Fixes # (issue)

- closes #7800 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- This has been fixed with a null check
-
[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/93f760f3ebfb40aabd65cc210da2738f-00001.gif)](https://www.loom.com/share/93f760f3ebfb40aabd65cc210da2738f)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
