### PR TITLE
fix: Display Tooltip for Scroll Content Label

### DIFF
--- a/app/client/src/widgets/ContainerWidget/widget/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/widget/index.tsx
@@ -44,6 +44,7 @@ class ContainerWidget extends BaseWidget<
             validation: { type: ValidationTypes.BOOLEAN },
           },
           {
+            helpText: "Enables scrolling for content inside the widget",
             propertyName: "shouldScrollContents",
             label: "Scroll Contents",
             controlType: "SWITCH",

--- a/app/client/src/widgets/ModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/ModalWidget/widget/index.tsx
@@ -29,6 +29,7 @@ export class ModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
         sectionName: "General",
         children: [
           {
+            helpText: "Enables scrolling for content inside the widget",
             propertyName: "shouldScrollContents",
             label: "Scroll Contents",
             controlType: "SWITCH",

--- a/app/client/src/widgets/StatboxWidget/widget/index.tsx
+++ b/app/client/src/widgets/StatboxWidget/widget/index.tsx
@@ -32,6 +32,7 @@ class StatboxWidget extends ContainerWidget {
             validation: { type: ValidationTypes.BOOLEAN },
           },
           {
+            helpText: "Enables scrolling for content inside the widget",
             propertyName: "shouldScrollContents",
             label: "Scroll Contents",
             controlType: "SWITCH",

--- a/app/client/src/widgets/TabsMigrator/widget/index.tsx
+++ b/app/client/src/widgets/TabsMigrator/widget/index.tsx
@@ -90,6 +90,7 @@ class TabsMigratorWidget extends BaseWidget<
             dependencies: ["tabsObj", "tabs"],
           },
           {
+            helpText: "Enables scrolling for content inside the widget",
             propertyName: "shouldScrollContents",
             label: "Scroll Contents",
             controlType: "SWITCH",

--- a/app/client/src/widgets/TabsWidget/widget/index.tsx
+++ b/app/client/src/widgets/TabsWidget/widget/index.tsx
@@ -136,6 +136,7 @@ class TabsWidget extends BaseWidget<
             isTriggerProperty: false,
           },
           {
+            helpText: "Enables scrolling for content inside the widget",
             propertyName: "shouldScrollContents",
             label: "Scroll Contents",
             controlType: "SWITCH",


### PR DESCRIPTION
## Description

This PR adds the _"Enables scrolling for content inside the widget"_ tooltip when hovering over the "Scroll Content" label. 

The updated widgets are:
1. `ContainerWidget` 
2. `TabsWidget`
3. `TabsMigratorWidget`
4. `StatboxWidget`
5. `ModalWidget`

Fixes #6148 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- This has been tested manually by adding a variety of widgets that contain the "Scroll Content" label and ensuring that hovering over the label displays the proper copy.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
