### PR TITLE
bugfix: remove append isCommentMode=false when hitting esc key 

### DIFF
--- a/app/client/src/pages/Editor/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.tsx
@@ -242,8 +242,8 @@ class GlobalHotKeys extends React.Component<Props> {
                 source: "HOTKEY",
                 combo: "esc",
               });
+              setCommentModeInUrl(false);
             }
-            setCommentModeInUrl(false);
             this.props.resetSnipingMode();
             this.props.deselectAllWidgets();
             this.props.closeProppane();


### PR DESCRIPTION
## Description
currently on the editor view, if you hit the esc key it appends isCommentMode=false to the URL, we change this to be appended only when the actual view is the comment view

Fixes # (issue)

https://github.com/appsmithorg/appsmith/issues/7887

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- go to url /applications/{id}/pages/{id}/edit
- press the esc key (nothing should change on the URL)
- toggle the comment mode (C)
- url changes to isCommentMode=true
- press esc key 
- url should change to isCommentMode=false

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
