### PR TITLE
docs: Update tutorials link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   •
   <a href="https://community.appsmith.com/">Community</a>
   •
-  <a href="https://github.com/appsmithorg/appsmith/tree/update/readme#tutorials">Tutorials</a>
+  <a href="https://docs.appsmith.com/tutorials">Tutorials</a>
   •
   <a href="https://app.appsmith.com/applications/602b8aef12ba0d29d3ec151c/pages/602b8aef12ba0d29d3ec151e">Events</a>
   •


### PR DESCRIPTION
## Description

Update the tutorials link on the readme

Fixes #8118 

## Type of change

Changed the link for tutorials in readme from https://github.com/appsmithorg/appsmith/tree/update/readme#tutorials to https://docs.appsmith.com/tutorials

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
