### PR TITLE
fix: Preventing evaluations reset on page change unless it is the first load

### DIFF
--- a/app/client/src/reducers/evaluationReducers/formEvaluationReducer.ts
+++ b/app/client/src/reducers/evaluationReducers/formEvaluationReducer.ts
@@ -1,5 +1,6 @@
 import { createReducer } from "utils/AppsmithUtils";
 import { ReduxAction, ReduxActionTypes } from "constants/ReduxActionConstants";
+import { FetchPageRequest } from "api/PageApi";
 
 export type FormEvaluationState = Record<string, any>;
 
@@ -10,7 +11,15 @@ const formEvaluation = createReducer(initialState, {
     state: FormEvaluationState,
     action: ReduxAction<Set<string>>,
   ): FormEvaluationState => action.payload,
-  [ReduxActionTypes.FETCH_PAGE_INIT]: () => initialState,
+  [ReduxActionTypes.FETCH_PAGE_INIT]: (
+    state: FormEvaluationState,
+    action: ReduxAction<FetchPageRequest>,
+  ) => {
+    // Init the state on first page load
+    if (!!action.payload && action.payload.isFirstLoad) return initialState;
+    // Do not touch state on subsequent page loads
+    return state;
+  },
 });
 
 export default formEvaluation;

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -75,21 +75,23 @@ function* evaluate(
   return currentEvalState;
 }
 
+// Fetches current evaluation and runs a new one based on the new data
 function* getFormEvaluation(formId: string, actionConfiguration: any): any {
   const currentEvalState: any = yield select(getFormEvaluationState);
 
-  if (currentEvalState.hasOwnProperty(formId)) {
+  // Only change the form evaluation state if the form ID is same or the evaluation state is present
+  if (!!currentEvalState && currentEvalState.hasOwnProperty(formId)) {
     currentEvalState[formId] = yield call(
       evaluate,
       actionConfiguration,
       currentEvalState[formId],
     );
-  }
 
-  yield put({
-    type: ReduxActionTypes.SET_FORM_EVALUATION,
-    payload: currentEvalState,
-  });
+    yield put({
+      type: ReduxActionTypes.SET_FORM_EVALUATION,
+      payload: currentEvalState,
+    });
+  }
 }
 
 // Filter function to assign a function to the Action dispatched


### PR DESCRIPTION
## Description

During page change, the `FETCH_INIT_PAGE` call was resetting the state due to the implementation. Have made it conditional to only set it for the first time app loads. Also, subsequent evaluation runs are now stopped if the current action id is not present or the state is empty.

Fixes #8055 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/8055-prevent-state-reset-on-page-change 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.85 **(0)** | 36.9 **(0.01)** | 33.93 **(0)** | 55.45 **(0)**
 :red_circle: | app/client/src/reducers/evaluationReducers/formEvaluationReducer.ts | 77.78 **(-7.93)** | 75 **(-25)** | 50 **(0)** | 75 **(-10.71)**
 :red_circle: | app/client/src/sagas/FormEvaluationSaga.ts | 22.54 **(0)** | 11.63 **(-0.27)** | 25 **(0)** | 25.4 **(0)**</details>