### PR TITLE
fix: send list of users to others when someone leaves the page edit

### DIFF
--- a/app/client/src/actions/appCollabActions.ts
+++ b/app/client/src/actions/appCollabActions.ts
@@ -35,9 +35,10 @@ export const collabStartSharingPointerEvent = (pageId: string) =>
     payload: pageId,
   });
 
-export const collabStopSharingPointerEvent = () =>
+export const collabStopSharingPointerEvent = (pageId?: string) =>
   pageLevelWebsocketWriteEvent({
     type: PAGE_LEVEL_SOCKET_EVENTS.STOP_EDITING_APP,
+    payload: pageId,
   });
 
 export const collabShareUserPointerEvent = (payload: any) =>

--- a/app/client/src/comments/ConcurrentPageEditorToast.tsx
+++ b/app/client/src/comments/ConcurrentPageEditorToast.tsx
@@ -36,12 +36,12 @@ const ActionElement = styled.span`
 // move existing toast below to make space for the warning toast
 const ToastStyle = createGlobalStyle`
   .Toastify__toast-container--top-right {
-    top: 10.5em !important;
+    top: 9.5em !important;
   }
 `;
 
 const getMessage = () => {
-  const msg = `Someone else is also editing this page. Your changes may get overwritten. Realtime Editing is coming soon.`;
+  const msg = `Other users editing this page may overwrite your changes. Realtime editing is coming soon!`;
   return msg;
 };
 

--- a/app/client/src/pages/Editor/index.tsx
+++ b/app/client/src/pages/Editor/index.tsx
@@ -61,7 +61,7 @@ type EditorProps = {
   updateCurrentPage: (pageId: string) => void;
   isPageLevelSocketConnected: boolean;
   collabStartSharingPointerEvent: (pageId: string) => void;
-  collabStopSharingPointerEvent: () => void;
+  collabStopSharingPointerEvent: (pageId?: string) => void;
 };
 
 type Props = EditorProps & RouteComponentProps<BuilderRouteParams>;
@@ -123,9 +123,10 @@ class Editor extends Component<Props> {
   }
 
   componentWillUnmount() {
+    const { pageId } = this.props.match.params || {};
     this.props.resetEditorRequest();
     if (typeof this.unlisten === "function") this.unlisten();
-    this.props.collabStopSharingPointerEvent();
+    this.props.collabStopSharingPointerEvent(pageId);
   }
 
   handleHistoryChange = (location: any) => {
@@ -200,8 +201,8 @@ const mapDispatchToProps = (dispatch: any) => {
     updateCurrentPage: (pageId: string) => dispatch(updateCurrentPage(pageId)),
     collabStartSharingPointerEvent: (pageId: string) =>
       dispatch(collabStartSharingPointerEvent(pageId)),
-    collabStopSharingPointerEvent: () =>
-      dispatch(collabStopSharingPointerEvent()),
+    collabStopSharingPointerEvent: (pageId?: string) =>
+      dispatch(collabStopSharingPointerEvent(pageId)),
   };
 };
 

--- a/app/rts/src/server.ts
+++ b/app/rts/src/server.ts
@@ -85,6 +85,7 @@ function main() {
 		if(room.startsWith(PAGE_ROOM_PREFIX)) { // someone left the page edit, notify others
 			io.of(PAGE_EDIT_NAMESPACE).to(room).emit(LEAVE_EDIT_EVENT_NAME, id);
 		}
+		sendCurrentUsers(io.of(PAGE_EDIT_NAMESPACE), room, PAGE_ROOM_PREFIX);
 	});
 
 	io.of(PAGE_EDIT_NAMESPACE).adapter.on("join-room", (room, id) => {


### PR DESCRIPTION
## Description
Fixes an issue in RTS - when someone leaves editing a page, it broadcast the list of users to others

Fixes # (issue)

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/nothify-after-leave-page 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.86 **(0)** | 36.89 **(0.01)** | 33.93 **(0)** | 55.46 **(0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**</details>