### PR TITLE
fix: update spacings and debugger error badge padding/font-size

### DIFF
--- a/app/client/src/comments/ConcurrentPageEditorToast.tsx
+++ b/app/client/src/comments/ConcurrentPageEditorToast.tsx
@@ -31,6 +31,7 @@ const ActionElement = styled.span`
   display: inline-block;
   width: 100%;
   text-align: right;
+  margin-top: ${(props) => props.theme.spaces[1]}px;
 `;
 
 // move existing toast below to make space for the warning toast

--- a/app/client/src/components/editorComponents/Debugger/index.tsx
+++ b/app/client/src/components/editorComponents/Debugger/index.tsx
@@ -44,9 +44,9 @@ const TriggerContainer = styled.div<{
 
   .debugger-count {
     color: ${Colors.WHITE};
-    ${(props) => getTypographyByKey(props, "p3")}
-    height: 16px;
-    width: 16px;
+    ${(props) => getTypographyByKey(props, "btnSmall")}
+    height: 20px;
+    width: 20px;
     background-color: ${(props) =>
       props.errorCount + props.warningCount > 0
         ? props.errorCount === 0

--- a/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
+++ b/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
@@ -127,6 +127,7 @@ const StyledIcon = styled(GitCommitLine)`
   & path {
     fill: ${Colors.DARK_GRAY};
   }
+  margin-right: ${(props) => props.theme.spaces[3]}px;
 `;
 
 const PlaceholderButton = styled.div`


### PR DESCRIPTION
## Description
- update spacings: git connect placeholder icon margin, toast dismiss btn top margin
- debugger error badge padding/font-size

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: minor-ui-changes 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.81 **(0)** | 36.83 **(0)** | 33.9 **(0.01)** | 55.41 **(0)**
 :green_circle: | app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx | 72.73 **(0.51)** | 55 **(0)** | 41.18 **(3.68)** | 74.07 **(0.49)**</details>