### PR TITLE
fix: Bug in evaluated value for falsy value checks

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -327,7 +327,7 @@ export const CurrentValueViewer = memo(
         <Collapse isOpen={openEvaluatedValue}>
           <CurrentValueWrapper colorTheme={props.theme}>
             {content}
-            {"evaluatedValue" in props && (
+            {props.hasOwnProperty("evaluatedValue") && (
               <CopyIconWrapper
                 colorTheme={props.theme}
                 minimal

--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -327,7 +327,7 @@ export const CurrentValueViewer = memo(
         <Collapse isOpen={openEvaluatedValue}>
           <CurrentValueWrapper colorTheme={props.theme}>
             {content}
-            {props.evaluatedValue && (
+            {"evaluatedValue" in props && (
               <CopyIconWrapper
                 colorTheme={props.theme}
                 minimal


### PR DESCRIPTION
## Description

Falsy evaluated value would fail the if check and not render the copy button

fixes #7646

<img width="468" alt="Screenshot 2021-10-05 at 1 44 03 PM" src="https://user-images.githubusercontent.com/12022471/135985702-96bfbfb2-d846-4057-b9db-e0a8d959b36a.png">



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/evaluated-value-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.82 **(0)** | 36.82 **(-0.01)** | 33.9 **(0.01)** | 55.41 **(0)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx | 65.87 **(0.79)** | 57.5 **(1.25)** | 38.89 **(2.78)** | 66.36 **(0.91)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 78.23 **(-1.61)** | 54.41 **(-2.94)** | 70 **(0)** | 84.09 **(-2.27)**</details>