### PR TITLE
chore: show canvas when user selects widgets tab during signposting flow

### DIFF
--- a/app/client/src/components/editorComponents/Sidebar.tsx
+++ b/app/client/src/components/editorComponents/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
 } from "selectors/editorSelectors";
 import { BUILDER_PAGE_URL } from "constants/routes";
 import history from "utils/history";
+import { toggleInOnboardingWidgetSelection } from "actions/onboardingActions";
 
 const SidebarWrapper = styled.div<{ inOnboarding: boolean }>`
   background-color: ${Colors.WHITE};
@@ -54,6 +55,9 @@ export const Sidebar = memo(() => {
   const dispatch = useDispatch();
   const applicationId = useSelector(getCurrentApplicationId);
   const pageId = useSelector(getCurrentPageId);
+  const isFirstTimeUserOnboardingEnabled = useSelector(
+    getIsFirstTimeUserOnboardingEnabled,
+  );
   const switches = [
     {
       id: "explorer",
@@ -68,6 +72,9 @@ export const Sidebar = memo(() => {
           BUILDER_PAGE_URL(applicationId, pageId) === window.location.pathname
         ) && history.push(BUILDER_PAGE_URL(applicationId, pageId));
         setTimeout(() => dispatch(forceOpenWidgetPanel(true)), 0);
+        if (isFirstTimeUserOnboardingEnabled) {
+          dispatch(toggleInOnboardingWidgetSelection(true));
+        }
       },
     },
   ];


### PR DESCRIPTION
## Description

show canvas when user selects widgets tab during signposting flow

Fixes #8203 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/signposting-widget-step 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.83 **(0.01)** | 36.85 **(0)** | 33.89 **(0)** | 55.42 **(0)**
 :red_circle: | app/client/src/components/editorComponents/Sidebar.tsx | 88.68 **(-3.16)** | 64.71 **(-8.62)** | 70 **(0)** | 90 **(-3.48)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**</details>