### PR TITLE
fix: check with url path when redirecting to default application url

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/AuthenticationSuccessHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/AuthenticationSuccessHandler.java
@@ -184,7 +184,8 @@ public class AuthenticationSuccessHandler implements ServerAuthenticationSuccess
 
         boolean addFirstTimeExperienceParam = false;
         if (isFromSignup) {
-            if(redirectUrl.endsWith(RedirectHelper.DEFAULT_REDIRECT_URL) && defaultApplication != null) {
+            URI redirectUri = URI.create(redirectUrl);
+            if(redirectUri.getPath().endsWith(RedirectHelper.DEFAULT_REDIRECT_URL) && defaultApplication != null) {
                 addFirstTimeExperienceParam = true;
                 HttpHeaders headers = exchange.getRequest().getHeaders();
                 redirectUrl = redirectHelper.buildApplicationUrl(defaultApplication, headers);
@@ -204,13 +205,16 @@ public class AuthenticationSuccessHandler implements ServerAuthenticationSuccess
                 .flatMap(redirectHelper::getRedirectUrl)
                 .map(s -> {
                     String url = s;
-                    boolean addFirstTimeExperienceParam = false;
-                    if(s.endsWith(RedirectHelper.DEFAULT_REDIRECT_URL) && defaultApplication != null) {
-                        addFirstTimeExperienceParam = true;
-                        HttpHeaders headers = exchange.getRequest().getHeaders();
-                        url = redirectHelper.buildApplicationUrl(defaultApplication, headers);
-                    }
                     if (isFromSignup) {
+                        URI redirectUri = URI.create(url);
+                        boolean addFirstTimeExperienceParam = false;
+
+                        // only redirect to default application if the redirectUrl contains no other url
+                        if(redirectUri.getPath().endsWith(RedirectHelper.DEFAULT_REDIRECT_URL) && defaultApplication != null) {
+                            addFirstTimeExperienceParam = true;
+                            HttpHeaders headers = exchange.getRequest().getHeaders();
+                            url = redirectHelper.buildApplicationUrl(defaultApplication, headers);
+                        }
                         // This redirectUrl will be used by the client to redirect after showing a welcome page.
                         url = buildSignupSuccessUrl(url, addFirstTimeExperienceParam);
                     }


### PR DESCRIPTION
## Description
When deciding whether to redirect to default application or the redirect url provided during signup, it'll compare with url path now. Earlier it was considering any query params added to the redirect url.

Fixes #8200 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
