### PR TITLE
fix: Added graceful check for failure in mock data endpoint

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -112,7 +112,8 @@ public enum AppsmithError {
     AUTHENTICATION_FAILURE(500, 5010, "Authentication failed with error: {0}", AppsmithErrorAction.DEFAULT, null, ErrorType.AUTHENTICATION_ERROR),
     INSTANCE_REGISTRATION_FAILURE(500, 5011, "Registration for instance failed with error: {0}", AppsmithErrorAction.LOG_EXTERNALLY, null, ErrorType.INTERNAL_ERROR),
     TOO_MANY_REQUESTS(429, 4039, "Too many requests received. Please try later.", AppsmithErrorAction.DEFAULT, "Too many requests", ErrorType.INTERNAL_ERROR),
-    INVALID_JS_ACTION(400, 4040, "Something went wrong while trying to parse this action. Please check the JS object for errors.", AppsmithErrorAction.DEFAULT, null, ErrorType.BAD_REQUEST)
+    INVALID_JS_ACTION(400, 4040, "Something went wrong while trying to parse this action. Please check the JS object for errors.", AppsmithErrorAction.DEFAULT, null, ErrorType.BAD_REQUEST),
+    CLOUD_SERVICES_ERROR(500, 5012, "Received error from cloud services {0}", AppsmithErrorAction.DEFAULT, null, ErrorType.INTERNAL_ERROR),
     ;
 
     private final Integer httpErrorCode;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/MockDataServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/MockDataServiceImpl.java
@@ -78,7 +78,7 @@ public class MockDataServiceImpl implements MockDataService {
                         });
                     } else {
                         return Mono.error(new AppsmithException(
-                                AppsmithError.INTERNAL_SERVER_ERROR,
+                                AppsmithError.CLOUD_SERVICES_ERROR,
                                 "Unable to connect to cloud-services with error status {}", response.statusCode()));
                     }
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/MockDataServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/MockDataServiceImpl.java
@@ -2,13 +2,13 @@ package com.appsmith.server.services;
 
 import com.appsmith.external.models.Connection;
 import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.SSLDetails;
 import com.appsmith.server.configurations.CloudServicesConfig;
 import com.appsmith.server.constants.AnalyticsEvents;
-import com.appsmith.external.models.Datasource;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.MockDataCredentials;
 import com.appsmith.server.dtos.MockDataDTO;
@@ -68,12 +68,21 @@ public class MockDataServiceImpl implements MockDataService {
             return Mono.justOrEmpty(mockData);
         }
 
-        return  WebClient
-                .create( baseUrl + "/api/v1/mocks")
+        return WebClient
+                .create(baseUrl + "/api/v1/mocks")
                 .get()
                 .exchange()
-                .flatMap(response -> response.bodyToMono(new ParameterizedTypeReference<ResponseDTO<MockDataDTO>>() {}))
-                .map(result -> result.getData())
+                .flatMap(response -> {
+                    if (response.statusCode().is2xxSuccessful()) {
+                        return response.bodyToMono(new ParameterizedTypeReference<ResponseDTO<MockDataDTO>>() {
+                        });
+                    } else {
+                        return Mono.error(new AppsmithException(
+                                AppsmithError.INTERNAL_SERVER_ERROR,
+                                "Unable to connect to cloud-services with error status {}", response.statusCode()));
+                    }
+                })
+                .map(ResponseDTO::getData)
                 .map(config -> {
                     mockData = config;
                     cacheExpiryTime = Instant.now().plusSeconds(2 * 60 * 60);


### PR DESCRIPTION
Fixes #8189 

The issue here was that the endpoint was returning a 502 with text/html content type from nginx itself. Instead of forcing conversion, this fix handles conversions only for 2xx status codes and errors out otherwise.