### PR TITLE
feat: Handle extra Java arguments to server Docker image

### DIFF
--- a/app/server/Dockerfile
+++ b/app/server/Dockerfile
@@ -16,11 +16,13 @@ ENV APPSMITH_SEGMENT_CE_KEY=${APPSMITH_SEGMENT_CE_KEY}
 #Create the plugins directory
 RUN mkdir -p /plugins
 
+# Add entrypoint script and make it executable.
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 #Add the jar to the container. Always keep this at the end. This is to ensure that all the things that can be taken
 #care of via the cache happens. The following statement would lead to copy because of change in hash value
-COPY entrypoint.sh /entrypoint.sh
 COPY ${JAR_FILE} server.jar
 COPY ${PLUGIN_JARS} /plugins/
 
-#Run the jar
-ENTRYPOINT ["/bin/sh", "-c" , "/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/app/server/entrypoint.sh
+++ b/app/server/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-java -Djava.security.egd="file:/dev/./urandom" -jar server.jar
+exec java -Djava.security.egd="file:/dev/./urandom" "$@" -jar server.jar


### PR DESCRIPTION
Currently, there's no way to specify custom memory settings to the server Docker image. The changes in this PR will allow providing any custom Java arguments as part of `CMD` for the server Docker image. This means custom memory settings can now be specified like:

```bash
docker run appsmith/appsmith-server -Xmx1024m
```
