### PR TITLE
fix: Reset table widget page number when applying filters and show empty cell when date is empty

### DIFF
--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -404,7 +404,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
                 } catch (e) {
                   isValidDate = false;
                 }
-                if (isValidDate) {
+                if (isValidDate && value) {
                   try {
                     if (outputFormat === "SAME_AS_INPUT") {
                       outputFormat = inputFormat;
@@ -757,6 +757,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
   applyFilters = (filters: ReactTableFilter[]) => {
     this.resetSelectedRowIndex();
     this.props.updateWidgetMetaProperty("filters", filters);
+    this.props.updateWidgetMetaProperty("pageNo", 1);
   };
 
   toggleDrag = (disable: boolean) => {


### PR DESCRIPTION
## Description
Reset table widget page number when applying filters and show empty cell when date is NULL/undefined

Fixes #7457 

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
