### PR TITLE
fix: Refresh current user in edit profile

### DIFF
--- a/app/client/src/pages/UserProfile/General.tsx
+++ b/app/client/src/pages/UserProfile/General.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import Text, { TextType } from "components/ads/Text";
 import { debounce } from "lodash";
@@ -20,6 +20,7 @@ import {
   Loader,
   TextLoader,
 } from "./StyledComponents";
+import { getCurrentUser as refreshCurrentUser } from "actions/authActions";
 
 const ForgotPassword = styled.a`
   margin-top: 12px;
@@ -62,6 +63,10 @@ function General() {
   const isFetchingUser = useSelector(
     (state: AppState) => state.ui.users.loadingStates.fetchingUser,
   );
+
+  useEffect(() => {
+    dispatch(refreshCurrentUser());
+  }, []);
 
   return (
     <Wrapper>


### PR DESCRIPTION
## Description
This PR is to fix issue #7217 which user name is not reflected in other instances. This is because in the edit profile page, the user state is not updated. So, I change it so that whenever we enter edit profile, it will update with the latest current user state.

Fixes #7217 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I repeat the same steps as recorded in the issue and I am not sure how to write Cypress/Jest for this. If tests is needed, please guide me on this.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
