### PR TITLE
fix: Added hover state to the black-colored Launch button on Applications Page.

### DIFF
--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -97,19 +97,19 @@ const NameWrapper = styled((props: HTMLDivProps & NameWrapperProps) => (
                 z-index: 1;
 
                 & .t--application-view-link {
-                  border: 2px solid #000;
-                  background-color: #000;
-                  color: #fff;
+                  border: 2px solid ${Colors.BLACK};
+                  background-color: ${Colors.BLACK};
+                  color: ${Colors.WHITE};
                 }
 
                 & .t--application-view-link:hover {
                   background-color: transparent;
-                  border: 2px solid #000;
-                  color: #000;
+                  border: 2px solid ${Colors.BLACK};
+                  color: ${Colors.BLACK};
 
                   svg {
                     path {
-                      fill: #000;
+                      fill: ${Colors.BLACK};
                     }
                   }
                 }
@@ -122,7 +122,7 @@ const NameWrapper = styled((props: HTMLDivProps & NameWrapperProps) => (
                       width: 16px;
                       height: 16px;
                       path {
-                        fill: #fff;
+                        fill: ${Colors.WHITE};
                       }
                     }
                   }


### PR DESCRIPTION
## Description

The black button didn't exhibit hover changes while the orange Edit button did
because the Button base component made the buttons darker, and the launch button
was already dark.
Custom CSS was included in ApplicationCard.tsx for hover state background-color
change.

Fixes #7621 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Hover on Launch button to get hover feedback

## Screenshots for change
![Screenshot from 2021-10-06 15-18-36](https://user-images.githubusercontent.com/20724224/136342786-5666bd5f-2b66-4d7b-a1f0-26befe455183.png)
![Screenshot from 2021-10-06 15-30-13](https://user-images.githubusercontent.com/20724224/136342823-cd5927a3-c541-4b73-8d68-0fed102bccb1.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
