### PR TITLE
chore: Make port customizable from env variable

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.port=${PORT:8080}
+
 # This property allows us to override beans during testing. This is useful when we want to set different configurations
 # and different parameters during test as compared to production. If this property is disabled, some tests will fail.
 spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
For the API server, port is not currently customizable with a `PORT` environment variable. This PR adds support for this.