### PR TITLE
style: Fixed Null comparisons without type-checking

### DIFF
--- a/app/rts/src/server.ts
+++ b/app/rts/src/server.ts
@@ -164,7 +164,7 @@ async function tryAuth(socket:Socket) {
 	/* ********************************************************* */
 
 	const connectionCookie = socket.handshake.headers.cookie;
-	if (connectionCookie != null && connectionCookie !== "") {
+	if (connectionCookie !== null && connectionCookie !== "") {
 		const matchedCookie = connectionCookie.match(/\bSESSION=\S+/)
 		if(matchedCookie) {
 			const sessionCookie = matchedCookie[0]
@@ -282,7 +282,7 @@ async function watchMongoDB(io) {
 			eventName = 'delete' + ":" + event.ns.coll  // emit delete event if deleted=true
 		}
 		
-		if (thread == null) {
+		if (thread === null) {
 			// This happens when `event.operationType === "drop"`, when a comment is deleted.
 			log.error("Null document recieved for comment change event", event)
 			return
@@ -326,7 +326,7 @@ async function watchMongoDB(io) {
 	notificationsStream.on("change", async (event: mongodb.ChangeEventCR) => {
 		const notification = event.fullDocument
 
-		if (notification == null) {
+		if (notification === null) {
 			// This happens when `event.operationType === "drop"`, when a notification is deleted.
 			log.error("Null document recieved for notification change event", event)
 			return


### PR DESCRIPTION
## Description

Fixed warning for Null comparisons without type-checking operators may not work as intended JS-0059 as found by https://deepsource.io/gh/appsmithorg/appsmith/issue/JS-0059/occurrences

Fixes # (issue)

https://deepsource.io/gh/appsmithorg/appsmith/issue/JS-0059/occurrences

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
