### PR TITLE
fix: Dynamic canvas height escaping un-wanted migrations.

### DIFF
--- a/app/client/src/utils/DSLMigrations.ts
+++ b/app/client/src/utils/DSLMigrations.ts
@@ -703,13 +703,17 @@ export const migrateInitialValues = (
 
 // A rudimentary transform function which updates the DSL based on its version.
 // A more modular approach needs to be designed.
-export const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
+export const transformDSL = (
+  currentDSL: ContainerWidgetProps<WidgetProps>,
+  newPage = false,
+) => {
   if (currentDSL.version === undefined) {
     // Since this top level widget is a CANVAS_WIDGET,
     // DropTargetComponent needs to know the minimum height the canvas can take
     // See DropTargetUtils.ts
     currentDSL.minHeight = calculateDynamicHeight();
-
+    currentDSL.bottomRow =
+      currentDSL.minHeight - GridDefaults.DEFAULT_GRID_ROW_HEIGHT;
     // For the first time the DSL is created, remove one row from the total possible rows
     // to adjust for padding and margins.
     currentDSL.snapRows =
@@ -718,14 +722,14 @@ export const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
 
     // Force the width of the canvas to 1224 px
     currentDSL.rightColumn = 1224;
-    // The canvas is a CANVAS_WIDGET whichdoesn't have a background or borders by default
+    // The canvas is a CANVAS_WIDGET which doesn't have a background or borders by default
     currentDSL.backgroundColor = "none";
     currentDSL.containerStyle = "none";
     currentDSL.type = "CANVAS_WIDGET";
     currentDSL.detachFromLayout = true;
     currentDSL.canExtend = true;
 
-    // Update version to make sure this doesn't run everytime.
+    // Update version to make sure this doesn't run every time.
     currentDSL.version = 1;
   }
 
@@ -821,7 +825,9 @@ export const transformDSL = (currentDSL: ContainerWidgetProps<WidgetProps>) => {
       currentDSL.bottomRow,
       currentDSL.detachFromLayout || false,
     );
-    currentDSL = migrateToNewLayout(currentDSL);
+    if (!newPage) {
+      currentDSL = migrateToNewLayout(currentDSL);
+    }
     currentDSL.version = 20;
   }
 

--- a/app/client/src/utils/WidgetPropsUtils.tsx
+++ b/app/client/src/utils/WidgetPropsUtils.tsx
@@ -33,8 +33,11 @@ const defaultDSL = defaultTemplate;
 export const extractCurrentDSL = (
   fetchPageResponse?: FetchPageResponse,
 ): DSLWidget => {
-  const currentDSL = fetchPageResponse?.data.layouts[0].dsl || defaultDSL;
-  return transformDSL(currentDSL);
+  const newPage = !fetchPageResponse;
+  const currentDSL = fetchPageResponse?.data.layouts[0].dsl || {
+    ...defaultDSL,
+  };
+  return transformDSL(currentDSL, newPage);
 };
 
 export const getDropZoneOffsets = (


### PR DESCRIPTION
Run layout migrations only for existing apps not for newly created apps.

Fixes #5053

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/dynamicCanvas 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/DSLMigrations.ts | 74.29 **(0.12)** | 65.33 **(-0.11)** | 69.66 **(0)** | 74.11 **(0.13)**
 :green_circle: | app/client/src/utils/WidgetPropsUtils.tsx | 87.06 **(0.16)** | 76 **(0)** | 84.62 **(0)** | 83.82 **(0.24)**</details>