### PR TITLE
test: S3Crud test fix

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GenerateCRUD/S3_CRUDPage_Spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GenerateCRUD/S3_CRUDPage_Spec.js
@@ -58,10 +58,5 @@ describe("Generate New CRUD Page Inside from entity explorer", function() {
       "response.body.responseMeta.status",
       200,
     );
-    cy.wait("@postExecute").should(
-      "have.nested.property",
-      "response.body.responseMeta.status",
-      200,
-    );
   });
 });

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -2632,7 +2632,6 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("GET", "/api/v1/organizations").as("organizations");
   cy.route("GET", "/api/v1/organizations/*").as("getOrganisation");
 
-  cy.route("POST", "/api/v1/actions/execute").as("executeAction");
   cy.route("POST", "/api/v1/applications/publish/*").as("publishApp");
   cy.route("PUT", "/api/v1/layouts/*/pages/*").as("updateLayout");
 


### PR DESCRIPTION
Added an extra route validation to avoid flakiness

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>