### PR TITLE
fix: icon path fillColor issue

### DIFF
--- a/app/client/src/components/ads/Icon.tsx
+++ b/app/client/src/components/ads/Icon.tsx
@@ -304,7 +304,7 @@ export const IconWrapper = styled.span<IconProps>`
           ? `
             fill: ${props.hoverFillColor || ""};
             path {
-              fill: ${props.fillColor || ""};
+              fill: ${props.hoverFillColor || ""};
             }
           `
           : ""}


### PR DESCRIPTION
## Description

This changes will undo the changes made in `Icon.tsx`, which led to  
#8294 



Fixes #8294 


## Type of change

- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually in Local

## Review & QA Guidelines

@RakshaKShetty As this change touches a common `Icon.tsx` component, A sanity check on all the system icons might be needed.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/gen_crud_actionIcon 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.97 **(0)** | 36.69 **(0.01)** | 33.93 **(0)** | 55.54 **(0)**
 :green_circle: | app/client/src/components/ads/Icon.tsx | 50.83 **(0)** | 33.77 **(1.8)** | 100 **(0)** | 50.69 **(0)**</details>