### PR TITLE
fix: Removed duplicate else if condition

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
@@ -179,7 +179,6 @@ export const getItemType = (item: SearchItem): SEARCH_ITEM_TYPES => {
     item.kind === SEARCH_ITEM_TYPES.category
   )
     type = item.kind;
-  else if (item.kind === SEARCH_ITEM_TYPES.page) type = SEARCH_ITEM_TYPES.page;
   else if (item.config?.pluginType === PluginType.JS)
     type = SEARCH_ITEM_TYPES.jsAction;
   else if (item.config?.name) type = SEARCH_ITEM_TYPES.action;


### PR DESCRIPTION
## Description

This condition is already handled in the OR conditions. 
_else if (item.kind === SEARCH_ITEM_TYPES.page) type = SEARCH_ITEM_TYPES.page;_

Fixes # (issue)

https://deepsource.io/gh/appsmithorg/appsmith/issue/JS-0034/occurrences

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?



- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
