### PR TITLE
chore: removed duplicate else if JS-0034

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
@@ -179,7 +179,6 @@ export const getItemType = (item: SearchItem): SEARCH_ITEM_TYPES => {
     item.kind === SEARCH_ITEM_TYPES.category
   )
     type = item.kind;
-  else if (item.kind === SEARCH_ITEM_TYPES.page) type = SEARCH_ITEM_TYPES.page;
   else if (item.config?.pluginType === PluginType.JS)
     type = SEARCH_ITEM_TYPES.jsAction;
   else if (item.config?.name) type = SEARCH_ITEM_TYPES.action;


### PR DESCRIPTION
## Description

Per DeepSource there was a duplicate else if in the `app/client/src/components/editorComponents/GlobalSearch/utils.tsx` file. Verified that the check existed in prior if statement and removed duplicate.

Fixes #8355

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
