### PR TITLE
fix(Dropdown): remove empty dropdown in case of no options

### DIFF
--- a/app/client/src/widgets/DropdownWidget/component/index.tsx
+++ b/app/client/src/widgets/DropdownWidget/component/index.tsx
@@ -200,7 +200,7 @@ class DropDownComponent extends React.Component<DropDownComponentProps> {
             }
             itemRenderer={this.renderSingleSelectItem}
             items={this.props.options}
-            noResults={<MenuItem disabled text="No Results" />}
+            noResults={<MenuItem disabled text="No Results Found" />}
             onItemSelect={this.onItemSelect}
             onQueryChange={
               this.props.serverSideFiltering ? this.serverSideSearch : undefined

--- a/app/client/src/widgets/DropdownWidget/widget/index.test.tsx
+++ b/app/client/src/widgets/DropdownWidget/widget/index.test.tsx
@@ -77,6 +77,6 @@ describe("<DropdownWidget />", () => {
     const selectElement = screen.getByText("-- Select --");
     fireEvent.click(selectElement);
 
-    expect(screen.getByText("No Results")).toBeInTheDocument();
+    expect(screen.getByText("No Results Found")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

The PR fixes a bug in case an empty options array is passed to the Select widget. Earlier, it used to render an empty wrapper.

Fixes #7921 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Run the client app
2. Drag a select widget from the side nav and pass empty options (`[]`)
3. Click on `-- Select --`
3. There **should be no** empty wrapper below the select 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - NA
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
