### PR TITLE
Fix: Handle Enter Key press on Confirm pop-up of API setting

### DIFF
--- a/app/client/src/pages/Editor/ConfirmRunModal.tsx
+++ b/app/client/src/pages/Editor/ConfirmRunModal.tsx
@@ -23,13 +23,25 @@ class ConfirmRunModal extends React.Component<Props> {
       dispatch(cancelRunActionConfirmModal());
     };
 
+    const handleKeyDownToConfirm = (
+      e: React.KeyboardEvent<HTMLInputElement>,
+    ) => {
+      if (e.key === "Enter") {
+        dispatch(acceptRunActionConfirmModal());
+        handleClose();
+      }
+    };
+
     return (
       <Dialog isOpen={isModalOpen} onClose={handleClose} title="Confirm Action">
         <div className={Classes.DIALOG_BODY}>
           Are you sure you want to perform this action?
         </div>
         <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <div
+            className={Classes.DIALOG_FOOTER_ACTIONS}
+            onKeyDown={handleKeyDownToConfirm}
+          >
             <Button
               filled
               onClick={() => {


### PR DESCRIPTION
## Description
> This fixes the issue where the confirm pop-up of API Setting wasn't getting handled on the press of the Enter Key.

Fixes #5111 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
