### PR TITLE
fix: Different Widget Names in Widget Pane and Canvas]

### DIFF
--- a/app/client/cypress/fixtures/TreeSelectDsl.json
+++ b/app/client/cypress/fixtures/TreeSelectDsl.json
@@ -21,7 +21,7 @@
       "leftColumn":0,
       "children":[
          {
-            "widgetName":"MultiSelectTree1",
+            "widgetName":"MultiTreeSelect",
             "displayName":"Multi TreeSelect",
             "iconSVG":"/static/media/icon.f264210c.svg",
             "labelText":"Label",


### PR DESCRIPTION
> refs: #8306

## Description

> Updated the name from "MultiSelectTree1" to "MultiTreeSelect" in cypress/fixtures/TreeSelectDsl.json.
> This is my first pull request. I hope I meet the contribution requirements and wish to get this pull request merged as well.
> Thank you.

Fixes # (issue)

> Fixed Issue #8306

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
