### PR TITLE
fix: [Bug] The name of the Widget is 'MultiTreeSelect' in Widget Pane…

### DIFF
--- a/app/client/src/widgets/MultiSelectTreeWidget/index.ts
+++ b/app/client/src/widgets/MultiSelectTreeWidget/index.ts
@@ -29,7 +29,7 @@ export const CONFIG = {
       { label: "Green", value: "GREEN" },
       { label: "Red", value: "RED" },
     ],
-    widgetName: "Multi TreeSelect",
+    widgetName: "MultiTreeSelect",
     defaultOptionValue: ["GREEN"],
     version: 1,
     isVisible: true,


### PR DESCRIPTION

## Description
Change MultiSelectTree to Multi Tree Select on the canvas

Fixes #8306

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
