### PR TITLE
feat: Show profile picture from the uploaded photo id of the user

### DIFF
--- a/app/client/src/constants/userConstants.ts
+++ b/app/client/src/constants/userConstants.ts
@@ -15,6 +15,7 @@ export type User = {
   gender: Gender;
   emptyInstance?: boolean;
   commentOnboardingState?: CommentsOnboardingState | null;
+  photoId?: string;
 };
 
 export interface UserApplication {

--- a/app/client/src/pages/common/PageHeader.tsx
+++ b/app/client/src/pages/common/PageHeader.tsx
@@ -94,7 +94,11 @@ export function PageHeader(props: PageHeaderProps) {
                 text="Sign In"
               />
             ) : (
-              <ProfileDropdown name={user.name} userName={user.username} />
+              <ProfileDropdown
+                name={user.name}
+                photoId={user.photoId}
+                userName={user.username}
+              />
             )}
           </StyledDropDownContainer>
         </>

--- a/app/client/src/pages/common/ProfileDropdown.tsx
+++ b/app/client/src/pages/common/ProfileDropdown.tsx
@@ -14,16 +14,17 @@ import { ReduxActionTypes } from "constants/ReduxActionConstants";
 import ProfileImage from "./ProfileImage";
 import { PopperModifiers } from "@blueprintjs/core";
 import { PROFILE } from "constants/routes";
-import UserApi from "api/UserApi";
 import { Colors } from "constants/Colors";
 import TooltipComponent from "components/ads/Tooltip";
 import { ACCOUNT_TOOLTIP, createMessage } from "constants/messages";
 import { TOOLTIP_HOVER_ON_DELAY } from "constants/AppConstants";
+
 type TagProps = CommonComponentProps & {
   onClick?: (text: string) => void;
   userName?: string;
   name: string;
   modifiers?: PopperModifiers;
+  photoId?: string;
 };
 
 const StyledMenuItem = styled(MenuItem)`
@@ -90,7 +91,7 @@ export default function ProfileDropdown(props: TagProps) {
       position={Position.BOTTOM_RIGHT}
     >
       <ProfileImage
-        source={`/api/${UserApi.photoURL}`}
+        source={props.photoId ? `/api/v1/assets/${props.photoId}` : ""}
         userName={props.name || props.userName}
       />
     </TooltipComponent>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
@@ -32,6 +32,8 @@ public class UserProfileDTO {
 
     CommentOnboardingState commentOnboardingState;
 
+    String photoId;
+
     String role;
 
     String useCase;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -903,6 +903,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                     profile.setCommentOnboardingState(userData.getCommentOnboardingState());
                     profile.setRole(userData.getRole());
                     profile.setUseCase(userData.getUseCase());
+                    profile.setPhotoId(userData.getProfilePhotoAssetId());
 
                     profile.setSuperUser(policyUtils.isPermissionPresentForUser(
                             userFromDb.getPolicies(),


### PR DESCRIPTION
## Description
Sends photoId in user profile response. Shows profile picture from the uploaded photo id instead of email address.

Fixes #7305 (partially)

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/update-profile-image-after-upload 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/pages/common/ProfileDropdown.tsx | 71.43 **(-0.98)** | 60 **(-15)** | 0 **(0)** | 71.43 **(-0.98)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**</details>