### PR TITLE
Fix: Add support for optional chaining and null coalescing in Linting

### DIFF
--- a/app/client/src/workers/lint.ts
+++ b/app/client/src/workers/lint.ts
@@ -61,7 +61,7 @@ export const getLintingErrors = (
 
   const options = {
     indent: 2,
-    esversion: 8, // For async/await support
+    esversion: 11, // For optional chaining and null coalescing support
     eqeqeq: false, // Not necessary to use ===
     curly: false, // Blocks can be added without {}, eg if (x) return true
     freeze: true, // Overriding inbuilt classes like Array is not allowed


### PR DESCRIPTION
## Description

To support optional chaining and null coalescing, the esversion of the Linting config option was updated to support ECMAScript 11

Fixes #8446

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>