### PR TITLE
fix: Added default cs url for netlify builds

### DIFF
--- a/app/client/netlify.toml
+++ b/app/client/netlify.toml
@@ -21,20 +21,19 @@
     SENTRY_ORG = "appsmith"
     SENTRY_PROJECT = "appsmith"
     SENTRY_LOG_LEVEL = "info"
+    REACT_APP_CLOUD_SERVICES_BASE_URL = "https://release-cs.appsmith.com"
 
 [context.deploy-preview]
   [context.deploy-preview.environment]
     REACT_APP_ENVIRONMENT = "STAGING"
     REACT_APP_SENTRY_ENVIRONMENT = "Development"
     REACT_APP_BASE_URL = "https://release.app.appsmith.com"
-    REACT_APP_CLOUD_SERVICES_BASE_URL = "https://release-cs.appsmith.com"
     # Not adding an APP_HOST here because the URL is dynamic in nature and cannot be determined.
 
 [context.develop]
   [context.develop.environment]
     REACT_APP_ENVIRONMENT = "STAGING"
     REACT_APP_BASE_URL = "https://release.app.appsmith.com"
-    REACT_APP_CLOUD_SERVICES_BASE_URL = "https://release-cs.appsmith.com"
     APP_HOST = "develop.app.appsmith.com"
 
 [[headers]]


### PR DESCRIPTION
Netlify DPs are currently not configured with a cloud services url, which makes it default to prod. This change introduces the environment variable as a build time config.
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>