### PR TITLE
fix: [Bug] The name of the Widget is 'TreeSelect' in Widget Pane and 'SingleSelectTree' in the canvas

### DIFF
--- a/app/client/src/widgets/SingleSelectTreeWidget/index.ts
+++ b/app/client/src/widgets/SingleSelectTreeWidget/index.ts
@@ -28,7 +28,7 @@ export const CONFIG = {
       { label: "Green", value: "GREEN" },
       { label: "Red", value: "RED" },
     ],
-    widgetName: "SingleSelectTree",
+    widgetName: "TreeSelect",
     defaultOptionValue: "BLUE",
     version: 1,
     isVisible: true,


### PR DESCRIPTION
## Description

Changed the ```SingleSelectTree``` displaying on canvas to ```TreeSelect``` ,
https://github.com/appsmithorg/appsmith/blob/a7a559cc62b302a860e52695a122bef2f9372f00/app/client/src/widgets/SingleSelectTreeWidget/index.ts#L31

Fixes #7990 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
