### PR TITLE
fix: Check if event.target is defined before accessing the value

### DIFF
--- a/app/client/src/components/propertyControls/ComputeTablePropertyControl.tsx
+++ b/app/client/src/components/propertyControls/ComputeTablePropertyControl.tsx
@@ -147,7 +147,7 @@ class ComputeTablePropertyControl extends BaseControl<
   onTextChange = (event: React.ChangeEvent<HTMLTextAreaElement> | string) => {
     let value = "";
     if (typeof event !== "string") {
-      value = event.target.value;
+      value = event.target?.value;
     } else {
       value = event;
     }


### PR DESCRIPTION

## Description
Fixes app crash on Visible property JS option for Table widget.
This is a patch, should see what triggered this issue.



Fixes #8418 


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/patch/table-column/visible-property/8418 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/propertyControls/ComputeTablePropertyControl.tsx | 32.76 **(0)** | 13.79 **(-2.21)** | 22.22 **(0)** | 32.14 **(0)**</details>