### PR TITLE
feat: conditionally load plausible on Appsmith cloud

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -105,15 +105,9 @@ jobs:
           else
             REACT_APP_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           fi
-          if [[ $GITHUB_REF == "refs/heads/release" ]]; then
-            REACT_APP_PLAUSIBLE_DOMAIN=${{ secrets.PLAUSIBLE_DOMAIN_RELEASE }}
-          elif [[ $GITHUB_REF == "refs/heads/master" ]]; then
-            REACT_APP_PLAUSIBLE_DOMAIN=${{ secrets.PLAUSIBLE_DOMAIN_MASTER }}
-          fi
           REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} \
             REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \
             REACT_APP_SEGMENT_CE_KEY="$REACT_APP_SEGMENT_CE_KEY" \
-            REACT_APP_PLAUSIBLE_DOMAIN="$REACT_APP_PLAUSIBLE_DOMAIN" \
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_ID=${{ steps.vars.outputs.version }} \
             REACT_APP_VERSION_RELEASE_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ') \

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -43,12 +43,10 @@
     const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__");
 
     // Initialize plausible
-    const plausibleDomain = parseConfig("%REACT_APP_PLAUSIBLE_DOMAIN%");
-    const shouldLoadPlausible = plausibleDomain && CLOUD_HOSTING;
-    if (shouldLoadPlausible) {
+    if (CLOUD_HOSTING) {
       const script = document.createElement('script');
       script.defer = true;
-      script.dataset.domain = plausibleDomain;
+      script.dataset.domain = location.hostname;
       script.src = "https://plausible.io/js/plausible.js";
       document.getElementsByTagName('head')[0].appendChild(script);
     }


### PR DESCRIPTION
## Description
Conditionally load plausible on Appsmith cloud
ref: https://plausible.io/docs/google-tag-manager#do-you-want-to-use-a-custom-script-such-as-the-ability-to-send-stats-to-multiple-dashboards-at-the-same-time








## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: add-plausible-analytics 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.91 **(0)** | 36.6 **(0.01)** | 33.86 **(0)** | 55.46 **(0)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**</details>