### PR TITLE
fix: allow api error interceptor to handle api call failure

### DIFF
--- a/app/client/src/api/ApiResponses.tsx
+++ b/app/client/src/api/ApiResponses.tsx
@@ -12,7 +12,7 @@ export type ResponseMeta = {
 export type ApiResponse = {
   responseMeta: ResponseMeta;
   data: any;
-  isAxiosError?: boolean;
+  code?: string;
 };
 
 export type GenericApiResponse<T> = {

--- a/app/client/src/sagas/ErrorSagas.tsx
+++ b/app/client/src/sagas/ErrorSagas.tsx
@@ -25,6 +25,7 @@ import {
 } from "constants/messages";
 
 import * as Sentry from "@sentry/react";
+import { axiosConnectionAbortedCode } from "../api/ApiUtils";
 
 /**
  * making with error message with action name
@@ -71,8 +72,8 @@ export function* validateResponse(response: ApiResponse | any, show = true) {
     throw Error("");
   }
 
-  // if there is an error during api call, then letting `apiFailureResponseInterceptor` handle it
-  if (response?.isAxiosError) {
+  // letting `apiFailureResponseInterceptor` handle it this case
+  if (response?.code === axiosConnectionAbortedCode) {
     return false;
   }
 


### PR DESCRIPTION
## Description
In case of aborted api call we would see misleading error message `Error: We could not connect to our servers. Please check your network connection`. Added a condition to `validateResponse` to check if the call was aborted.

Fixes https://github.com/appsmithorg/appsmith/issues/7368

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual
> There is no consistent way to reproduce this bug

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/aborted-api-requests 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/sagas/ErrorSagas.tsx | 57.76 **(0.24)** | 41.18 **(2.47)** | 38.89 **(0)** | 57.14 **(0.28)**</details>