### PR TITLE
fix: show readable error in Query response pane if present

### DIFF
--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -93,6 +93,7 @@ export interface ActionResponse {
   suggestedWidgets?: SuggestedWidget[];
   messages?: Array<string>;
   errorType?: string;
+  readableError?: string;
 }
 
 export interface MoveActionRequest {

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -73,6 +73,7 @@ import SearchSnippets from "components/ads/SnippetButton";
 import EntityBottomTabs from "components/editorComponents/EntityBottomTabs";
 import { setCurrentTab } from "actions/debuggerActions";
 import { DEBUGGER_TAB_KEYS } from "components/editorComponents/Debugger/helpers";
+import { getErrorAsString } from "sagas/ActionExecution/errorUtils";
 
 const QueryFormContainer = styled.form`
   flex: 1;
@@ -387,6 +388,7 @@ type QueryFormProps = {
     isExecutionSuccess?: boolean;
     messages?: Array<string>;
     suggestedWidgets?: SuggestedWidget[];
+    readableError?: string;
   };
   runErrorMessage: string | undefined;
   location: {
@@ -451,7 +453,9 @@ export function EditorJSONtoForm(props: Props) {
 
   if (executedQueryData) {
     if (!executedQueryData.isExecutionSuccess) {
-      error = String(executedQueryData.body);
+      error = executedQueryData.readableError
+        ? getErrorAsString(executedQueryData.readableError)
+        : getErrorAsString(executedQueryData.body);
     } else if (isString(executedQueryData.body)) {
       output = JSON.parse(executedQueryData.body);
     } else {

--- a/app/client/src/sagas/ActionExecution/errorUtils.ts
+++ b/app/client/src/sagas/ActionExecution/errorUtils.ts
@@ -8,6 +8,7 @@ import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
 import { ApiResponse } from "api/ApiResponses";
+import { isString } from "lodash";
 
 /*
  * The base trigger error that also logs the errors in the debugger.
@@ -108,3 +109,7 @@ export class UncaughtAppsmithPromiseError extends TriggerFailureError {
     super(message, triggerMeta, error);
   }
 }
+
+export const getErrorAsString = (error: unknown): string => {
+  return isString(error) ? error : JSON.stringify(error);
+};


### PR DESCRIPTION
## Description

- To make error messages more readable, a new attribute readableError has been added to ActionExecutionResult object that is returned to the client post action execution.

- Client checks if readableError attribute is non-empty and display it if so, otherwise go for default flow.

- In case of debugger, both the current error message and the readableError needs to be present, since the readableError may be malformed for certain errors.


Fixes #5557

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/improve-error-messages-in-query-pane 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.91 **(0)** | 36.58 **(-0.02)** | 33.86 **(0)** | 55.46 **(0)**
 :green_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 42.13 **(0.32)** | 31.37 **(-0.42)** | 0 **(0)** | 44.12 **(0.33)**
 :red_circle: | app/client/src/sagas/ActionExecution/PluginActionSaga.ts | 17.23 **(-0.22)** | 3.03 **(-0.16)** | 10.53 **(0)** | 19.8 **(-0.3)**
 :red_circle: | app/client/src/sagas/ActionExecution/errorUtils.ts | 64.81 **(0.81)** | 0 **(0)** | 42.86 **(-3.29)** | 52.5 **(1.15)**</details>