### PR TITLE
feature:  remove region requirement from S3 plugin datasource

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
@@ -59,116 +59,11 @@
           "encrypted": true
         },
         {
-          "label": "Region",
-          "configProperty": "datasourceConfiguration.properties[0].value",
-          "controlType": "DROP_DOWN",
-          "isRequired": true,
-          "hidden": {
-            "path": "datasourceConfiguration.properties[1].value",
-            "comparison": "NOT_EQUALS",
-            "value": "amazon-s3"
-          },
-          "initialValue": "ap-south-1",
-          "options": [
-            {
-              "label": "ap-south-1",
-              "value": "ap-south-1"
-            },
-            {
-              "label": "us-gov-west-1",
-              "value": "us-gov-west-1"
-            },
-            {
-              "label": "us-east-1",
-              "value": "us-east-1"
-            },
-            {
-              "label": "us-east-2",
-              "value": "us-east-2"
-            },
-            {
-              "label": "us-west-1",
-              "value": "us-west-1"
-            },
-            {
-              "label": "us-west-2",
-              "value": "us-west-2"
-            },
-            {
-              "label": "eu-west-1",
-              "value": "eu-west-1"
-            },
-            {
-              "label": "eu-west-2",
-              "value": "eu-west-2"
-            },
-            {
-              "label": "eu-west-3",
-              "value": "eu-west-3"
-            },
-            {
-              "label": "eu-central-1",
-              "value": "eu-central-1"
-            },
-            {
-              "label": "ap-southeast-1",
-              "value": "ap-southeast-1"
-            },
-            {
-              "label": "ap-southeast-2",
-              "value": "ap-southeast-2"
-            },
-            {
-              "label": "ap-northeast-1",
-              "value": "ap-northeast-1"
-            },
-            {
-              "label": "ap-northeast-2",
-              "value": "ap-northeast-2"
-            },
-            {
-              "label": "sa-east-1",
-              "value": "sa-east-1"
-            },
-            {
-              "label": "cn-north-1",
-              "value": "cn-north-1"
-            },
-            {
-              "label": "cn-northwest-1",
-              "value": "cn-northwest-1"
-            },
-            {
-              "label": "ca-central-1",
-              "value": "ca-central-1"
-            }
-          ]
-        },
-        {
           "label": "Endpoint URL",
           "configProperty": "datasourceConfiguration.endpoints[0].host",
           "controlType": "INPUT_TEXT",
           "initialValue": "",
           "placeholderText": "user-storage.de-fra1.upcloudobjects.com",
-          "hidden": {
-            "path": "datasourceConfiguration.properties[1].value",
-            "comparison": "EQUALS",
-            "value": "amazon-s3"
-          }
-        },
-        {
-          "label": "Custom Endpoint URL Key",
-          "configProperty": "datasourceConfiguration.properties[2].key",
-          "controlType": "INPUT_TEXT",
-          "initialValue": "customRegion",
-          "hidden": true
-        },
-        {
-          "label": "Region",
-          "configProperty": "datasourceConfiguration.properties[2].value",
-          "controlType": "INPUT_TEXT",
-          "initialValue": "",
-          "placeholderText": "de-fra1",
           "hidden": {
             "path": "datasourceConfiguration.properties[1].value",
             "comparison": "EQUALS",


### PR DESCRIPTION
## Description
- Remove region requirement from S3 plugin datasource.
- tested with AWS S3, Dream Objects and Wasabi.
- TBD:
  - test with Upcloud, Dream Ocean Space
  - migration changes to remove properties against region field.
  - fix JUnit TCs

Fixes #6313

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
