### PR TITLE
fix: 8430 - icon missing on execute query submenu

### DIFF
--- a/app/client/src/components/ads/TreeDropdown.tsx
+++ b/app/client/src/components/ads/TreeDropdown.tsx
@@ -13,7 +13,7 @@ import {
 import styled from "styled-components";
 import { Colors } from "constants/Colors";
 import { DropdownOption } from "components/constants";
-import Icon, { IconName, IconSize } from "components/ads/Icon";
+import Icon, { IconSize } from "components/ads/Icon";
 
 export type TreeDropdownOption = DropdownOption & {
   onSelect?: (value: TreeDropdownOption, setter?: Setter) => void;
@@ -144,10 +144,6 @@ function getSelectedOption(
   return selectedOption;
 }
 
-const getMoreIcons = (icon: React.ReactNode) => {
-  return <Icon name={icon as IconName} size={IconSize.XXL} />;
-};
-
 export default function TreeDropdown(props: TreeDropdownProps) {
   const {
     defaultText,
@@ -184,7 +180,7 @@ export default function TreeDropdown(props: TreeDropdownProps) {
       <MenuItem
         active={isSelected}
         className={option.className || "single-select"}
-        icon={getMoreIcons(option.icon)}
+        icon={option.icon}
         intent={option.intent}
         key={option.value}
         onClick={
@@ -218,7 +214,7 @@ export default function TreeDropdown(props: TreeDropdownProps) {
         className={`t--open-dropdown-${defaultText.split(" ").join("-")} ${
           selectedLabelModifier ? "code-highlight" : ""
         }`}
-        rightIcon={getMoreIcons("downArrow")}
+        rightIcon={<Icon name="downArrow" size={IconSize.XXL} />}
         text={
           selectedLabelModifier
             ? selectedLabelModifier(selectedOption, displayValue)


### PR DESCRIPTION
## Description

> fixed icon missing

Fixes #8430 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please refer linked issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/8430-icon-missing-query-subment 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/ads/TreeDropdown.tsx | 59.62 **(-1.49)** | 58.82 **(0)** | 38.89 **(-3.22)** | 58 **(-1.62)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 79.84 **(1.61)** | 57.35 **(2.94)** | 70 **(0)** | 86.36 **(2.27)**</details>