### PR TITLE
fix: Added js object body as dependency for js functions

### DIFF
--- a/app/client/src/entities/DataTree/dataTreeFactory.ts
+++ b/app/client/src/entities/DataTree/dataTreeFactory.ts
@@ -70,6 +70,7 @@ export interface DataTreeJSAction {
   dynamicBindingPathList: DynamicPath[];
   bindingPaths: Record<string, EvaluationSubstitutionType>;
   listVariables: Array<string>;
+  dependencyMap: DependencyMap;
 }
 
 export interface MetaArgs {

--- a/app/client/src/entities/DataTree/dataTreeJSAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeJSAction.ts
@@ -5,6 +5,7 @@ import {
 } from "entities/DataTree/dataTreeFactory";
 import { JSCollectionData } from "reducers/entityReducers/jsActionsReducer";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
+import { DependencyMap } from "utils/DynamicBindingUtils";
 
 export const generateDataTreeJSAction = (
   js: JSCollectionData,
@@ -16,6 +17,8 @@ export const generateDataTreeJSAction = (
   let result: Record<string, unknown> = {};
   const variables = js.config.variables;
   const listVariables: Array<string> = [];
+  dynamicBindingPathList.push({ key: "body" });
+  bindingPaths["body"] = EvaluationSubstitutionType.SMART_SUBSTITUTE;
   if (variables) {
     for (let i = 0; i < variables.length; i++) {
       const variable = variables[i];
@@ -23,6 +26,8 @@ export const generateDataTreeJSAction = (
       listVariables.push(variable.name);
     }
   }
+  const dependencyMap: DependencyMap = {};
+  dependencyMap["body"] = [];
   const actions = js.config.actions;
   const subActionsObject: any = {};
   if (actions) {
@@ -38,6 +43,7 @@ export const generateDataTreeJSAction = (
       };
       bindingPaths[action.name] = EvaluationSubstitutionType.SMART_SUBSTITUTE;
       dynamicBindingPathList.push({ key: action.name });
+      dependencyMap["body"].push(action.name);
     }
   }
   result = {
@@ -52,6 +58,7 @@ export const generateDataTreeJSAction = (
     bindingPaths: bindingPaths,
     dynamicBindingPathList: dynamicBindingPathList,
     variables: listVariables,
+    dependencyMap: dependencyMap,
   };
 
   return Object.assign(result, subActionsObject);

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -248,7 +248,6 @@ export function* clearEvalPropertyCache(propertyPath: string) {
 }
 
 export function* parseJSCollection(body: string, jsAction: JSCollection) {
-  // const path = jsAction.name + ".body";
   const workerResponse = yield call(
     worker.request,
     EVAL_WORKER_ACTIONS.PARSE_JS_FUNCTION_BODY,
@@ -258,9 +257,6 @@ export function* parseJSCollection(body: string, jsAction: JSCollection) {
     },
   );
   const { errors, result } = workerResponse;
-  // const dataTree = yield select(getDataTree);
-  // const updates = diff(dataTree, evalTree) || [];
-  // yield put(setEvaluatedTree(evalTree, updates));
   if (errors) {
     yield call(evalErrorHandler, errors);
   }

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -248,7 +248,7 @@ export function* clearEvalPropertyCache(propertyPath: string) {
 }
 
 export function* parseJSCollection(body: string, jsAction: JSCollection) {
-  const path = jsAction.name + ".body";
+  // const path = jsAction.name + ".body";
   const workerResponse = yield call(
     worker.request,
     EVAL_WORKER_ACTIONS.PARSE_JS_FUNCTION_BODY,
@@ -257,11 +257,13 @@ export function* parseJSCollection(body: string, jsAction: JSCollection) {
       jsAction,
     },
   );
-  const { evalTree, result } = workerResponse;
-  const dataTree = yield select(getDataTree);
-  const updates = diff(dataTree, evalTree) || [];
-  yield put(setEvaluatedTree(evalTree, updates));
-  yield call(evalErrorHandler, [], evalTree, [path]);
+  const { errors, result } = workerResponse;
+  // const dataTree = yield select(getDataTree);
+  // const updates = diff(dataTree, evalTree) || [];
+  // yield put(setEvaluatedTree(evalTree, updates));
+  if (errors) {
+    yield call(evalErrorHandler, errors);
+  }
   return result;
 }
 

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -157,29 +157,36 @@ function logLatestEvalPropertyErrors(
             ? propertyPath
             : entityName;
           // Add or update
-          AppsmithConsole.addError(
-            {
-              id: debuggerKey,
-              logType: isWarning ? LOG_TYPE.EVAL_WARNING : LOG_TYPE.EVAL_ERROR,
-              // Unless the intention is to change the message shown in the debugger please do not
-              // change the text shown here
-              text: isJSAction(entity)
-                ? createMessage(JS_OBJECT_BODY_INVALID)
-                : createMessage(VALUE_IS_INVALID, propertyPath),
-              messages: errorMessages,
-              source: {
-                id: idField,
-                name: nameField,
-                type: entityType,
-                propertyPath: logPropertyPath,
+          if (
+            !isJSAction(entity) ||
+            (isJSAction(entity) && propertyPath === "body")
+          ) {
+            AppsmithConsole.addError(
+              {
+                id: debuggerKey,
+                logType: isWarning
+                  ? LOG_TYPE.EVAL_WARNING
+                  : LOG_TYPE.EVAL_ERROR,
+                // Unless the intention is to change the message shown in the debugger please do not
+                // change the text shown here
+                text: isJSAction(entity)
+                  ? createMessage(JS_OBJECT_BODY_INVALID)
+                  : createMessage(VALUE_IS_INVALID, propertyPath),
+                messages: errorMessages,
+                source: {
+                  id: idField,
+                  name: nameField,
+                  type: entityType,
+                  propertyPath: logPropertyPath,
+                },
+                state: {
+                  [logPropertyPath]: evaluatedValue,
+                },
+                analytics: analyticsData,
               },
-              state: {
-                [logPropertyPath]: evaluatedValue,
-              },
-              analytics: analyticsData,
-            },
-            isWarning ? Severity.WARNING : Severity.ERROR,
-          );
+              isWarning ? Severity.WARNING : Severity.ERROR,
+            );
+          }
         } else if (debuggerKey in updatedDebuggerErrors) {
           AppsmithConsole.deleteError(debuggerKey);
         }
@@ -268,6 +275,12 @@ export function* evalErrorHandler(
           extra: {
             request: error.context,
           },
+        });
+        break;
+      }
+      case EvalErrorTypes.PARSE_JS_ERROR: {
+        AppsmithConsole.error({
+          text: `${error.message} at: ${error.context?.propertyPath}`,
         });
         break;
       }

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -74,7 +74,7 @@ export function getDynamicStringSegments(dynamicString: string): string[] {
 //{{}}{{}}}
 export const getDynamicBindings = (
   dynamicString: string,
-  entity?: DataTreeEntity,
+  entity?: DataTreeEntity | undefined,
 ): { stringSegments: string[]; jsSnippets: string[] } => {
   // Protect against bad string parse
   if (!dynamicString || !_.isString(dynamicString)) {

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -680,6 +680,7 @@ export default class DataTreeEvaluator {
             data,
             resolvedFunctions,
             callBackData,
+            entity && isJSAction(entity),
           );
           if (fullPropertyPath && result.errors.length) {
             addErrorToEntityProperty(result.errors, data, fullPropertyPath);

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -9,7 +9,6 @@ import {
   EvalErrorTypes,
   EvaluationError,
   PropertyEvaluationErrorType,
-  EVAL_ERROR_PATH,
 } from "utils/DynamicBindingUtils";
 import {
   CrashingError,
@@ -22,8 +21,6 @@ import {
 import DataTreeEvaluator from "workers/DataTreeEvaluator";
 import ReplayDSL from "workers/ReplayDSL";
 import evaluate, { setupEvaluationEnvironment } from "workers/evaluate";
-import { Severity } from "entities/AppsmithConsole";
-import _ from "lodash";
 
 const ctx: Worker = self as any;
 
@@ -251,31 +248,28 @@ ctx.addEventListener(
           ? dataTreeEvaluator.evalTree
           : {};
         try {
-          const { evalTree, result } = parseJSCollection(
+          const { errors, result } = parseJSCollection(
             body,
             jsAction,
             currentEvalTree,
           );
           return {
-            evalTree,
             result,
+            errors,
           };
         } catch (e) {
           const errors = [
             {
-              errorType: PropertyEvaluationErrorType.PARSE,
-              raw: "",
-              severity: Severity.ERROR,
-              errorMessage: e.message,
+              type: EvalErrorTypes.PARSE_JS_ERROR,
+              context: {
+                entity: jsAction,
+                propertyPath: jsAction.name + ".body",
+              },
+              message: e.message,
             },
           ];
-          _.set(
-            currentEvalTree,
-            `${jsAction.name}.${EVAL_ERROR_PATH}.body`,
-            errors,
-          );
           return {
-            currentEvalTree,
+            errors,
           };
         }
       }

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -7,6 +7,7 @@ import {
   isChildPropertyPath,
   isDynamicValue,
   PropertyEvaluationErrorType,
+  EvalErrorTypes,
 } from "utils/DynamicBindingUtils";
 import { validate } from "./validations";
 import { Diff } from "deep-diff";
@@ -552,12 +553,6 @@ export const parseJSCollection = (
         undefined,
         true,
       );
-      const errorsList = errors && errors.length ? errors : [];
-      _.set(
-        evalTree,
-        `${jsCollection.name}.${EVAL_ERROR_PATH}.body`,
-        errorsList,
-      );
       const parsedLength = Object.keys(result).length;
       const actions = [];
       const variables = [];
@@ -582,29 +577,40 @@ export const parseJSCollection = (
         }
       }
       return {
-        evalTree,
+        errors,
         result: {
           actions: actions,
           variables: variables,
         },
       };
     } catch (e) {
+      const errors = [
+        {
+          type: EvalErrorTypes.PARSE_JS_ERROR,
+          context: {
+            entity: jsCollection,
+            propertyPath: jsCollection.name + ".body",
+          },
+          message: e.message,
+        },
+      ];
       return {
-        evalTree,
+        errors,
       };
     }
   } else {
     const errors = [
       {
-        errorType: PropertyEvaluationErrorType.PARSE,
-        raw: "",
-        severity: Severity.ERROR,
-        errorMessage: "Start object with export default",
+        type: EvalErrorTypes.PARSE_JS_ERROR,
+        context: {
+          entity: jsCollection,
+          propertyPath: jsCollection.name + ".body",
+        },
+        message: "Start object with export default",
       },
     ];
-    _.set(evalTree, `${jsCollection.name}.${EVAL_ERROR_PATH}.body`, errors);
     return {
-      evalTree,
+      errors,
     };
   }
 };


### PR DESCRIPTION
## Description
Added body as a dependency because
1. on the first load if the js objects has js errors should be shown
2. if widget/API is created after mention, js object should be valid and vice versa 


Fixes # (issue)

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: depency-js-editor 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.72 **(0)** | 36.4 **(0.01)** | 33.51 **(0)** | 55.27 **(0)**
 :red_circle: | app/client/src/entities/DataTree/dataTreeJSAction.ts | 11.11 **(-1.79)** | 0 **(0)** | 0 **(0)** | 9.09 **(-1.62)**
 :green_circle: | app/client/src/sagas/EvaluationsSaga.ts | 24.26 **(0.47)** | 5.49 **(-0.13)** | 12.5 **(0)** | 27.17 **(0.47)**
 :red_circle: | app/client/src/sagas/PostEvaluationSagas.ts | 17.24 **(-0.37)** | 0 **(0)** | 0 **(0)** | 21.01 **(-0.54)**
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 81.74 **(-0.19)** | 63.33 **(0.19)** | 80 **(0)** | 81.25 **(-0.2)**
 :green_circle: | app/client/src/workers/evaluationUtils.ts | 73.84 **(0.53)** | 61.43 **(1.71)** | 74.42 **(0)** | 71.91 **(0.6)**</details>