### PR TITLE
fix: 8234 - issue of edit icon none displayed beside of api name

### DIFF
--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -170,7 +170,6 @@ export function ActionNameEditor(props: ActionNameEditorProps) {
           editInteractionKind={NewEditInteractionKind.SINGLE}
           fill
           forceDefault={forceUpdate}
-          hideEditIcon
           isEditingDefault={isNew && !hideEditIcon}
           isInvalid={isInvalidActionName}
           onBlur={handleAPINameChange}


### PR DESCRIPTION
## Description

> disabled hideEditIcon props on it.

Fixes #8234 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please refer linked issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>