### PR TITLE
docs: Fixed URL / Link in README.md that is resulting in page not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Check out some real applications that can be built with Appsmith:
 
 Here are the latest tutorials and videos for you to learn more about Appsmith:
 
-1. [Build an Investor CRM using Appsmith on Google Sheets](https://blog.appsmith.com/build-an-investor-crm-using-appsmith-on-google-sheets-1)
+1. [Build an Investor CRM using Appsmith on Google Sheets](https://blog.appsmith.com/build-an-investor-crm-using-appsmith-on-google-sheets)
 2. [Building an Admin Panel on MongoDB using Appsmith](https://blog.appsmith.com/building-an-admin-panel-with-mongodb-using-appsmith) ([Video](https://www.youtube.com/watch?v=tisUaIgI86k))
 3. [Building a Discount Management Dashboard With Postgres](https://blog.appsmith.com/building-a-discount-management-dashboard-with-postgres)
 4. [Building a Customer Support Dashboard in Appsmith](https://www.youtube.com/watch?v=-O_6OLREEzo)


### PR DESCRIPTION
URL / Link associated with Build an Investor CRM using Appsmith on Google Sheets was wrong.

## Description

URL in the Readme.md file is incorrect and leading to page not found.

Fixes # (issue)

Fixed the link.

## Type of change

Probably, this change requires a documentation update

## How Has This Been Tested?

The link now open the said documentation referred to and not the page not found. 

## Checklist:

Not applicable.
