### PR TITLE
fix: [Bugfix] Delete comments when unpublished page is deleted

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/PolicyGenerator.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/PolicyGenerator.java
@@ -30,6 +30,7 @@ import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_DATASOURCES;
 import static com.appsmith.server.acl.AclPermission.MANAGE_ORGANIZATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
+import static com.appsmith.server.acl.AclPermission.MANAGE_THREAD;
 import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_EXPORT_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_MANAGE_APPLICATIONS;
@@ -148,6 +149,7 @@ public class PolicyGenerator {
         lateralGraph.addEdge(COMMENT_ON_THREAD, READ_THREAD);
 
         hierarchyGraph.addEdge(COMMENT_ON_THREAD, READ_COMMENT);
+        hierarchyGraph.addEdge(MANAGE_APPLICATIONS, MANAGE_THREAD);
     }
 
     public Set<Policy> getLateralPolicies(AclPermission permission, Set<String> userNames, Class<? extends BaseDomain> destinationEntity) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/PolicyGenerator.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/PolicyGenerator.java
@@ -30,7 +30,6 @@ import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_DATASOURCES;
 import static com.appsmith.server.acl.AclPermission.MANAGE_ORGANIZATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
-import static com.appsmith.server.acl.AclPermission.MANAGE_THREAD;
 import static com.appsmith.server.acl.AclPermission.MANAGE_USERS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_EXPORT_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.ORGANIZATION_MANAGE_APPLICATIONS;
@@ -149,7 +148,6 @@ public class PolicyGenerator {
         lateralGraph.addEdge(COMMENT_ON_THREAD, READ_THREAD);
 
         hierarchyGraph.addEdge(COMMENT_ON_THREAD, READ_COMMENT);
-        hierarchyGraph.addEdge(MANAGE_APPLICATIONS, MANAGE_THREAD);
     }
 
     public Set<Policy> getLateralPolicies(AclPermission permission, Set<String> userNames, Class<? extends BaseDomain> destinationEntity) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/AbstractCommentDomain.java
@@ -20,6 +20,6 @@ public abstract class AbstractCommentDomain extends BaseDomain {
     String orgId;
 
     /** Edit/Published Mode */
-    String mode;
+    CommentMode mode;
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentMode.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/CommentMode.java
@@ -1,0 +1,5 @@
+package com.appsmith.server.domains;
+
+public enum CommentMode {
+    EDIT, PUBLISHED
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/CommentThreadFilterDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/CommentThreadFilterDTO.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.dtos;
 
+import com.appsmith.server.domains.CommentMode;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
@@ -9,4 +10,5 @@ public class CommentThreadFilterDTO {
     @NotNull
     private String applicationId;
     private Boolean resolved;
+    private CommentMode mode;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
@@ -51,6 +51,7 @@ public class PolicyUtils {
     public <T extends BaseDomain> T addPoliciesToExistingObject(Map<String, Policy> policyMap, T obj) {
         // Making a deep copy here so we don't modify the `policyMap` object.
         // TODO: Investigate a solution without using deep-copy.
+        // TODO: Do we need to return the domain object?
         final Map<String, Policy> policyMap1 = new HashMap<>();
         for (Map.Entry<String, Policy> entry : policyMap.entrySet()) {
             Policy entryValue = entry.getValue();
@@ -80,6 +81,16 @@ public class PolicyUtils {
 
         obj.getPolicies().addAll(policyMap1.values());
         return obj;
+    }
+
+    public void addPolicyToExistingSet(Set<Policy> policySet, Policy newPolicy) {
+        // Append the user to the existing permission policy if it already exists.
+        for (Policy policy : policySet) {
+            String permission = policy.getPermission();
+            if (permission.equals(newPolicy.getPermission())) {
+                policy.getUsers().addAll(newPolicy.getUsers());
+            }
+        }
     }
 
     public <T extends BaseDomain> T removePoliciesFromExistingObject(Map<String, Policy> policyMap, T obj) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
@@ -1,13 +1,13 @@
 package com.appsmith.server.helpers;
 
 import com.appsmith.external.models.BaseDomain;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.Policy;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.acl.PolicyGenerator;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.CommentThread;
-import com.appsmith.external.models.Datasource;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.domains.User;
@@ -81,16 +81,6 @@ public class PolicyUtils {
 
         obj.getPolicies().addAll(policyMap1.values());
         return obj;
-    }
-
-    public void addPolicyToExistingSet(Set<Policy> policySet, Policy newPolicy) {
-        // Append the user to the existing permission policy if it already exists.
-        for (Policy policy : policySet) {
-            String permission = policy.getPermission();
-            if (permission.equals(newPolicy.getPermission())) {
-                policy.getUsers().addAll(newPolicy.getUsers());
-            }
-        }
     }
 
     public <T extends BaseDomain> T removePoliciesFromExistingObject(Map<String, Policy> policyMap, T obj) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
@@ -158,20 +158,13 @@ public abstract class BaseAppsmithRepositoryImpl<T extends BaseDomain> {
                 });
     }
 
-    public Mono<UpdateResult> updateByCriteria(Criteria criteria, Update updateObj, AclPermission permission) {
+    public Mono<UpdateResult> updateByCriteria(Criteria criteria, Update updateObj) {
         if (criteria == null) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "criteria"));
         }
-
-        return ReactiveSecurityContextHolder.getContext()
-                .map(ctx -> ctx.getAuthentication())
-                .map(auth -> auth.getPrincipal())
-                .flatMap(principal -> {
-                    User user = (User) principal;
-                    Query query = new Query(criteria);
-                    query.addCriteria(new Criteria().andOperator(notDeleted(), userAcl(user, permission)));
-                    return mongoOperations.updateMulti(query, updateObj, this.genericDomain);
-                });
+        Query query = new Query(criteria);
+        query.addCriteria(new Criteria().andOperator(notDeleted()));
+        return mongoOperations.updateMulti(query, updateObj, this.genericDomain);
     }
 
     protected Mono<T> queryOne(List<Criteria> criterias, AclPermission aclPermission) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.domains.CommentMode;
 import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.dtos.CommentThreadFilterDTO;
 import com.mongodb.client.result.UpdateResult;
@@ -16,5 +17,5 @@ public interface CustomCommentThreadRepository extends AppsmithRepository<Commen
     Mono<UpdateResult> removeSubscriber(String threadId, String username);
     Mono<CommentThread> findPrivateThread(String applicationId);
     Mono<Long> countUnreadThreads(String applicationId, String userEmail);
-    Mono<UpdateResult> archiveByPageId(String pageId);
+    Mono<UpdateResult> archiveByPageId(String pageId, CommentMode commentMode);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepository.java
@@ -16,4 +16,5 @@ public interface CustomCommentThreadRepository extends AppsmithRepository<Commen
     Mono<UpdateResult> removeSubscriber(String threadId, String username);
     Mono<CommentThread> findPrivateThread(String applicationId);
     Mono<Long> countUnreadThreads(String applicationId, String userEmail);
+    Mono<UpdateResult> archiveByPageId(String pageId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.repositories;
 
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.domains.CommentMode;
 import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.domains.QCommentThread;
 import com.appsmith.server.dtos.CommentThreadFilterDTO;
@@ -67,14 +68,16 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
     }
 
     @Override
-    public Mono<UpdateResult> archiveByPageId(String pageId) {
+    public Mono<UpdateResult> archiveByPageId(String pageId, CommentMode commentMode) {
         // create an update object that'll be applied
         Update update = new Update();
         update.set(fieldName(QCommentThread.commentThread.deleted), true);
         update.set(fieldName(QCommentThread.commentThread.deletedAt), Instant.now());
 
         // create a criteria for pageId. The permission criteria will be added by updateByCriteria method
-        Criteria criteria = where(fieldName(QCommentThread.commentThread.pageId)).is(pageId);
+        Criteria criteria = where(fieldName(QCommentThread.commentThread.pageId)).is(pageId)
+                .and(fieldName(QCommentThread.commentThread.mode)).is(commentMode);
+
         return this.updateByCriteria(criteria, update, AclPermission.MANAGE_THREAD);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -78,7 +78,7 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
         Criteria criteria = where(fieldName(QCommentThread.commentThread.pageId)).is(pageId)
                 .and(fieldName(QCommentThread.commentThread.mode)).is(commentMode);
 
-        return this.updateByCriteria(criteria, update, AclPermission.MANAGE_THREAD);
+        return this.updateByCriteria(criteria, update, AclPermission.COMMENT_ON_THREAD);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -63,6 +64,18 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
     public Mono<UpdateResult> removeSubscriber(String threadId, String username) {
         Update update = new Update().pull(fieldName(QCommentThread.commentThread.subscribers), username);
         return this.updateById(threadId, update, AclPermission.READ_THREAD);
+    }
+
+    @Override
+    public Mono<UpdateResult> archiveByPageId(String pageId) {
+        // create an update object that'll be applied
+        Update update = new Update();
+        update.set(fieldName(QCommentThread.commentThread.deleted), true);
+        update.set(fieldName(QCommentThread.commentThread.deletedAt), Instant.now());
+
+        // create a criteria for pageId. The permission criteria will be added by updateByCriteria method
+        Criteria criteria = where(fieldName(QCommentThread.commentThread.pageId)).is(pageId);
+        return this.updateByCriteria(criteria, update, AclPermission.MANAGE_THREAD);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -107,6 +107,9 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
             );
             criteriaList.add(where(fieldKey).is(commentThreadFilterDTO.getResolved()));
         }
+        if(commentThreadFilterDTO.getMode() != null) {
+            criteriaList.add(where(fieldName(QCommentThread.commentThread.mode)).is(commentThreadFilterDTO.getMode()));
+        }
         return queryAll(criteriaList, permission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImpl.java
@@ -78,7 +78,7 @@ public class CustomCommentThreadRepositoryImpl extends BaseAppsmithRepositoryImp
         Criteria criteria = where(fieldName(QCommentThread.commentThread.pageId)).is(pageId)
                 .and(fieldName(QCommentThread.commentThread.mode)).is(commentMode);
 
-        return this.updateByCriteria(criteria, update, AclPermission.COMMENT_ON_THREAD);
+        return this.updateByCriteria(criteria, update);
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -10,6 +10,7 @@ import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.ApplicationPage;
+import com.appsmith.server.domains.CommentMode;
 import com.appsmith.server.domains.GitApplicationMetadata;
 import com.appsmith.server.domains.Layout;
 import com.appsmith.server.domains.NewAction;
@@ -591,7 +592,9 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                 return newActionService.deleteUnpublishedAction(action.getId());
                             }).collectList();
 
-                    Mono<UpdateResult> archiveCommentThreadMono = commentThreadRepository.archiveByPageId(id);
+                    Mono<UpdateResult> archiveCommentThreadMono = commentThreadRepository.archiveByPageId(
+                            id, CommentMode.EDIT
+                    );
 
                     /**
                      *  Only delete unpublished action collection and not the entire action collection.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -26,6 +26,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.repositories.ApplicationRepository;
+import com.appsmith.server.repositories.CommentThreadRepository;
 import com.appsmith.server.repositories.OrganizationRepository;
 import com.google.common.base.Strings;
 import com.mongodb.client.result.UpdateResult;
@@ -74,6 +75,7 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
     private final NewActionService newActionService;
     private final ActionCollectionService actionCollectionService;
     private final GitFileUtils gitFileUtils;
+    private final CommentThreadRepository commentThreadRepository;
 
     public Mono<PageDTO> createPage(PageDTO page) {
         if (page.getId() != null) {
@@ -589,6 +591,8 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                 return newActionService.deleteUnpublishedAction(action.getId());
                             }).collectList();
 
+                    Mono<UpdateResult> archiveCommentThreadMono = commentThreadRepository.archiveByPageId(id);
+
                     /**
                      *  Only delete unpublished action collection and not the entire action collection.
                      */
@@ -598,7 +602,7 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                 return actionCollectionService.deleteUnpublishedActionCollection(actionCollection.getId());
                             }).collectList();
 
-                    return Mono.zip(archivedPageMono, archivedActionsMono, archivedActionCollectionsMono, applicationMono)
+                    return Mono.zip(archivedPageMono, archivedActionsMono, archivedActionCollectionsMono, applicationMono, archiveCommentThreadMono)
                             .map(tuple -> {
                                 PageDTO page1 = tuple.getT1();
                                 List<ActionDTO> actions = tuple.getT2();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -663,7 +663,9 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                     Mono<List<Boolean>> archivePageListMono;
                     if (!publishedPageIds.isEmpty()) {
                         archivePageListMono = Flux.fromStream(publishedPageIds.stream())
-                                .flatMap(id -> newPageService.archiveById(id))
+                                .flatMap(id -> commentThreadRepository.archiveByPageId(id, CommentMode.PUBLISHED)
+                                        .then(newPageService.archiveById(id))
+                                )
                                 .collectList();
                     } else {
                         archivePageListMono = Mono.just(new ArrayList<>());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -583,7 +583,7 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
             ).get(AclPermission.MANAGE_THREAD.getValue());
 
             // merge the policy with existing ones
-            policyUtils.addPolicyToExistingSet(policies, managePolicyForCreator);
+            policies.add(managePolicyForCreator);
 
             commentSeq = sequenceService.getNext(CommentThread.class, application.getId());
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -575,10 +575,16 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                     Application.class,
                     CommentThread.class
             ));
-            policies.add(policyUtils.generatePolicyFromPermission(
+
+            // generate manage permission policy for the author
+            Policy managePolicyForCreator = policyUtils.generatePolicyFromPermission(
                     Set.of(AclPermission.MANAGE_THREAD),
                     user
-            ).get(AclPermission.MANAGE_THREAD.getValue()));
+            ).get(AclPermission.MANAGE_THREAD.getValue());
+
+            // merge the policy with existing ones
+            policyUtils.addPolicyToExistingSet(policies, managePolicyForCreator);
+
             commentSeq = sequenceService.getNext(CommentThread.class, application.getId());
         }
         commentThread.setPolicies(policies);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -579,7 +579,6 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                     Set.of(AclPermission.MANAGE_THREAD),
                     user
             ).get(AclPermission.MANAGE_THREAD.getValue()));
-
             commentSeq = sequenceService.getNext(CommentThread.class, application.getId());
         }
         commentThread.setPolicies(policies);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -575,15 +575,10 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
                     Application.class,
                     CommentThread.class
             ));
-
-            // generate manage permission policy for the author
-            Policy managePolicyForCreator = policyUtils.generatePolicyFromPermission(
+            policies.add(policyUtils.generatePolicyFromPermission(
                     Set.of(AclPermission.MANAGE_THREAD),
                     user
-            ).get(AclPermission.MANAGE_THREAD.getValue());
-
-            // merge the policy with existing ones
-            policies.add(managePolicyForCreator);
+            ).get(AclPermission.MANAGE_THREAD.getValue()));
 
             commentSeq = sequenceService.getNext(CommentThread.class, application.getId());
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CommentServiceImpl.java
@@ -444,7 +444,9 @@ public class CommentServiceImpl extends BaseService<CommentRepository, Comment, 
     @Override
     public Mono<List<CommentThread>> getThreadsByApplicationId(CommentThreadFilterDTO commentThreadFilterDTO) {
         return applicationService.findById(commentThreadFilterDTO.getApplicationId(), AclPermission.READ_APPLICATIONS)
-                .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.INVALID_CURL_COMMAND)))
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, FieldName.APPLICATION_ID
+                )))
                 .zipWith(sessionUserService.getCurrentUser())
                 .flatMap(objects -> {
                     Application application = objects.getT1();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/repositories/CustomCommentThreadRepositoryImplTest.java
@@ -2,6 +2,7 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.external.models.Policy;
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.domains.CommentMode;
 import com.appsmith.server.domains.CommentThread;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.CommentThreadFilterDTO;
@@ -48,6 +49,7 @@ public class CustomCommentThreadRepositoryImplTest {
         CommentThread thread = new CommentThread();
         thread.setPageId(pageId);
         thread.setApplicationId(applicationId);
+        thread.setMode(CommentMode.EDIT);
         User user = new User();
         user.setEmail(userEmail);
 
@@ -252,7 +254,7 @@ public class CustomCommentThreadRepositoryImplTest {
 
         Mono<Map<String, Collection<CommentThread>>> pageIdThreadMono = commentThreadRepository.saveAll(threads)
                 .collectList()
-                .then(commentThreadRepository.archiveByPageId(pageOneId))
+                .then(commentThreadRepository.archiveByPageId(pageOneId, CommentMode.EDIT))
                 .thenMany(commentThreadRepository.findByApplicationId(applicationId, AclPermission.READ_THREAD))
                 .collectMultimap(CommentThread::getPageId);
 
@@ -285,7 +287,7 @@ public class CustomCommentThreadRepositoryImplTest {
         thread.getPolicies().add(policyForCurrentUser);
 
         Mono<Map<String, Collection<CommentThread>>> pageIdThreadMono = commentThreadRepository.save(thread)
-                .then(commentThreadRepository.archiveByPageId(testPageId))
+                .then(commentThreadRepository.archiveByPageId(testPageId, CommentMode.EDIT))
                 .thenMany(commentThreadRepository.findByApplicationId(applicationId, AclPermission.READ_THREAD))
                 .collectMultimap(CommentThread::getPageId);
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationPageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationPageServiceTest.java
@@ -1,0 +1,85 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.domains.Comment;
+import com.appsmith.server.domains.CommentMode;
+import com.appsmith.server.domains.CommentThread;
+import com.appsmith.server.domains.Organization;
+import com.appsmith.server.dtos.CommentThreadFilterDTO;
+import com.appsmith.server.dtos.PageDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Slf4j
+@DirtiesContext
+public class ApplicationPageServiceTest {
+    @Autowired
+    ApplicationPageService applicationPageService;
+
+    @Autowired
+    OrganizationService organizationService;
+
+    @Autowired
+    CommentService commentService;
+
+    private CommentThread createCommentThread(CommentMode commentMode, PageDTO pageDTO) {
+        CommentThread commentThread = new CommentThread();
+        commentThread.setPageId(pageDTO.getId());
+        commentThread.setApplicationId(pageDTO.getApplicationId());
+        commentThread.setMode(commentMode);
+        Comment comment = new Comment();
+        commentThread.setComments(List.of(comment));
+        return commentThread;
+    }
+
+    @Test
+    @WithUserDetails("api_user")
+    public void deleteUnpublishedPage_WhenPageDeleted_EditModeCommentsDeleted() {
+        Organization unsavedOrg = new Organization();
+        unsavedOrg.setName("ApplicationPageServiceTestOrg");
+
+        Mono<List<CommentThread>> getThreadMono = organizationService.create(unsavedOrg)
+                .flatMap(organization -> {
+                    Application application = new Application();
+                    application.setName("ApplicationPageServiceTestApp");
+                    return applicationPageService.createApplication(application, organization.getId());
+                })
+                .flatMap(application -> {
+                    PageDTO page = new PageDTO();
+                    page.setName("Test page");
+                    page.setApplicationId(application.getId());
+                    return applicationPageService.createPage(page);
+                }).flatMap(pageDTO -> {
+                    CommentThread editModeCommentThread = createCommentThread(CommentMode.EDIT, pageDTO);
+                    CommentThread piublishedModeCommentThread = createCommentThread(CommentMode.PUBLISHED, pageDTO);
+
+                    return commentService.createThread(editModeCommentThread, "app.appsmith.com")
+                            .then(commentService.createThread(piublishedModeCommentThread, "app.appsmith.com"))
+                            .then(applicationPageService.deleteUnpublishedPage(pageDTO.getId()))
+                            .thenReturn(pageDTO);
+                }).flatMap(pageDTO -> {
+                    CommentThreadFilterDTO filterDTO = new CommentThreadFilterDTO();
+                    filterDTO.setApplicationId(pageDTO.getApplicationId());
+                    return commentService.getThreadsByApplicationId(filterDTO);
+                });
+
+        StepVerifier.create(getThreadMono).assertNext(commentThreads -> {
+            assertThat(commentThreads.size()).isEqualTo(1);
+            assertThat(commentThreads.get(0).getMode()).isEqualTo(CommentMode.PUBLISHED);
+        }).verifyComplete();
+    }
+}


### PR DESCRIPTION
## Description

When a page is deleted, the comment threads in that page should also be deleted and should not appear to user. 
The Edit mode comments should not be visible to app viewers.

Fixes #7830

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


- JUnit tests
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
