### PR TITLE
fix: Bugfix for duplicated application throws page not found error if opened in view mode

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationPageServiceImpl.java
@@ -528,6 +528,11 @@ public class ApplicationPageServiceImpl implements ApplicationPageService {
                                         savedApplication.setPages(clonedPages);
                                         return applicationService.save(savedApplication);
                                     })
+                                    // Publish is required so that user can open cloned app in view mode without
+                                    // manually deploying it.
+                                    // Here we are assuming user will have the control on edit version only so it's safe
+                                    // to assume that published version will be a replica of unpublished version.
+                                    .flatMap(clonedApplication -> this.publish(clonedApplication.getId(), false))
                             );
                 });
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -698,16 +698,21 @@ public class ApplicationServiceTest {
                     assertThat(application).isNotNull();
                     assertThat(application.isAppIsExample()).isFalse();
                     assertThat(application.getId()).isNotNull();
-                    assertThat(application.getName().equals("ApplicationServiceTest Clone Source TestApp Copy"));
+                    assertThat(application.getName()).isEqualTo("ApplicationServiceTest Clone Source TestApp Copy");
                     assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
-                    assertThat(application.getOrganizationId().equals(orgId));
+                    assertThat(application.getOrganizationId()).isEqualTo(orgId);
                     assertThat(application.getModifiedBy()).isEqualTo("api_user");
                     assertThat(application.getUpdatedAt()).isNotNull();
                     List<ApplicationPage> pages = application.getPages();
-                    Set<String> pageIdsFromApplication = pages.stream().map(page -> page.getId()).collect(Collectors.toSet());
-                    Set<String> pageIdsFromDb = pageList.stream().map(page -> page.getId()).collect(Collectors.toSet());
+                    List<ApplicationPage> publishedPages = application.getPublishedPages();
+                    Set<String> pageIdsFromApplication = pages.stream().map(ApplicationPage::getId).collect(Collectors.toSet());
+                    Set<String> publishedPageIdsFromApplication = pages.stream().map(ApplicationPage::getId).collect(Collectors.toSet());
+                    Set<String> pageIdsFromDb = pageList.stream().map(PageDTO::getId).collect(Collectors.toSet());
 
-                    assertThat(pageIdsFromApplication.containsAll(pageIdsFromDb));
+                    assertThat(pageIdsFromApplication.containsAll(pageIdsFromDb)).isTrue();
+                    assertThat(publishedPageIdsFromApplication.containsAll(pageIdsFromDb)).isTrue();
+                    assertThat(publishedPages).isNotEmpty();
+                    assertThat(publishedPages.equals(pages)).isTrue();
 
                     assertThat(pageList).isNotEmpty();
                     for (PageDTO page : pageList) {


### PR DESCRIPTION
## Description

> When the application is cloned and the user tries to open the app in view mode directly it fails with a page not found error. This PR assumes that after duplicate application action user won't be having the control over published app version so it's safe to assume both published and unpublished versions should be in sync. To address this application will be automatically published so that users won't face the page not found error even if opened in view mode.    

Fixes #8697 
Fixes #7799 
Fixes #7965

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- JUnit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
