### PR TITLE
fix: don't send hash on self hosted intercom

### DIFF
--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -471,7 +471,8 @@ export function bootIntercom(user?: User) {
     let name;
     if (!cloudHosting) {
       username = sha256(username || "");
-      email = sha256(email || "");
+      // keep email undefined so that users are prompted to enter it when they reach out on intercom
+      email = undefined;
     } else {
       name = user?.name;
     }


### PR DESCRIPTION

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/intercom 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/helpers.tsx | 59.25 **(0)** | 30.77 **(0.43)** | 45 **(0)** | 56.1 **(0)**</details>