### PR TITLE
fix: Disallows entity name to be any extra library name

### DIFF
--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -996,7 +996,7 @@ Cypress.Commands.add("CreationOfUniqueAPIcheck", (apiname) => {
     .type(apiname, { force: true, delay: 500 })
     .should("have.value", apiname);
   cy.get(".error-message").should(($x) => {
-    expect($x).contain(apiname.concat(" is already being used."));
+    expect($x).contain(apiname.concat(" is already being used or is a restricted keyword."));
   });
   cy.get(apiwidget.apiTxt).blur();
 });
@@ -1081,7 +1081,7 @@ Cypress.Commands.add("CreateApiAndValidateUniqueEntityName", (apiname) => {
     .type(apiname, { force: true })
     .should("have.value", apiname);
   cy.get(".t--nameOfApi .error-message").should(($x) => {
-    expect($x).contain(apiname.concat(" is already being used."));
+    expect($x).contain(apiname.concat(" is already being used or is a restricted keyword."));
   });
 });
 

--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -120,7 +120,7 @@ export function ActionNameEditor(props: ActionNameEditorProps) {
         name !== currentActionConfig?.name &&
         hasActionNameConflict(name)
       ) {
-        return `${name} is already being used.`;
+        return `${name} is already being used or is a restricted keyword.`;
       }
       return false;
     },

--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -75,7 +75,7 @@ function FormTitle(props: FormTitleProps) {
       if (!name || name.trim().length === 0) {
         return "Please enter a valid name";
       } else if (hasNameConflict(name)) {
-        return `${name} is already being used.`;
+        return `${name} is already being used or is a restricted keyword.`;
       }
       return false;
     },

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -107,7 +107,7 @@ export function JSObjectNameEditor(props: ActionNameEditorProps) {
         name !== currentJSObjectConfig?.name &&
         hasNameConflict(name)
       ) {
-        return `${name} is already being used.`;
+        return `${name} is already being used or is a restricted keyword.`;
       }
       return false;
     },

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -790,7 +790,7 @@ export function* updateWidgetNameSaga(
           type: ReduxActionErrorTypes.UPDATE_WIDGET_NAME_ERROR,
           payload: {
             error: {
-              message: `Entity name: ${action.payload.newName} is already being used.`,
+              message: `Entity name: ${action.payload.newName} is already being used or is a restricted keyword.`,
             },
           },
         });

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -192,6 +192,19 @@ export const extraLibraries: ExtraLibrary[] = [
   },
 ];
 
+/**
+ * creates dynamic list of constants based on
+ * current list of extra libraries i.e lodash("_"), moment etc
+ * to be used in widget and entity name validations
+ */
+export const extraLibrariesNames = extraLibraries.reduce(
+  (prev: any, curr: any) => {
+    prev[curr.accessor] = curr.accessor;
+    return prev;
+  },
+  {},
+);
+
 export interface DynamicPath {
   key: string;
   value?: string;

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -22,6 +22,7 @@ import { getAppsmithConfigs } from "configs";
 import { sha256 } from "js-sha256";
 import moment from "moment";
 import log from "loglevel";
+import { extraLibraries } from "./DynamicBindingUtils";
 
 const { cloudHosting, intercomAppID } = getAppsmithConfigs();
 
@@ -265,6 +266,16 @@ export const convertArrayToSentence = (arr: string[]) => {
 };
 
 /**
+ * creates dynamic list of constants based on
+ * current list of extra libraries i.e lodash("_"), moment etc
+ */
+export const EXTRA_LIBRARIES = () =>
+  extraLibraries.reduce((prev: any, curr: any) => {
+    prev[curr.accessor] = curr.accessor;
+    return prev;
+  }, {});
+
+/**
  * checks if the name is conflicting with
  * 1. API names,
  * 2. Queries name
@@ -286,6 +297,7 @@ export const isNameValid = (
     name in GLOBAL_FUNCTIONS ||
     name in WINDOW_OBJECT_PROPERTIES ||
     name in WINDOW_OBJECT_METHODS ||
+    name in EXTRA_LIBRARIES() ||
     name in invalidNames
   );
 };

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -22,7 +22,7 @@ import { getAppsmithConfigs } from "configs";
 import { sha256 } from "js-sha256";
 import moment from "moment";
 import log from "loglevel";
-import { extraLibraries } from "./DynamicBindingUtils";
+import { extraLibrariesNames } from "./DynamicBindingUtils";
 
 const { cloudHosting, intercomAppID } = getAppsmithConfigs();
 
@@ -266,16 +266,6 @@ export const convertArrayToSentence = (arr: string[]) => {
 };
 
 /**
- * creates dynamic list of constants based on
- * current list of extra libraries i.e lodash("_"), moment etc
- */
-export const EXTRA_LIBRARIES = () =>
-  extraLibraries.reduce((prev: any, curr: any) => {
-    prev[curr.accessor] = curr.accessor;
-    return prev;
-  }, {});
-
-/**
  * checks if the name is conflicting with
  * 1. API names,
  * 2. Queries name
@@ -297,7 +287,7 @@ export const isNameValid = (
     name in GLOBAL_FUNCTIONS ||
     name in WINDOW_OBJECT_PROPERTIES ||
     name in WINDOW_OBJECT_METHODS ||
-    name in EXTRA_LIBRARIES() ||
+    name in extraLibrariesNames ||
     name in invalidNames
   );
 };


### PR DESCRIPTION
## Description

This PR disallows entity names to be any name already used by extra libraries in Appsmith, such as _ , moment, forge, etc. It accomplishes this by creating a dynamic list of constants based on `accessor`s of `extraLibraries` .

Fixes #8580
Fixes #8881 
Fixes #8460
Fixes #9033 

## Type of change

- Bug fix 

## How Has This Been Tested?

- Test A: Tested manually on my local machine by trying to give a widget a name used by an extra library
- Test B: I also tested manually on my local machine by trying to give an API query a name used by an extra library

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
