### PR TITLE
fix: Close Redshift connections every time

### DIFF
--- a/app/server/appsmith-plugins/redshiftPlugin/pom.xml
+++ b/app/server/appsmith-plugins/redshiftPlugin/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <version>2.0.0.4</version>
+            <version>2.1.0.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/app/server/appsmith-plugins/redshiftPlugin/src/main/java/com/external/plugins/RedshiftPlugin.java
+++ b/app/server/appsmith-plugins/redshiftPlugin/src/main/java/com/external/plugins/RedshiftPlugin.java
@@ -210,7 +210,7 @@ public class RedshiftPlugin extends BasePlugin {
          *    can be triggered.
          */
         private void checkConnectionValidity(Connection connection) throws SQLException {
-            if (connection == null || connection.isClosed() || !connection.isValid(VALIDITY_CHECK_TIMEOUT)) {
+            if (connection == null || connection.isClosed()) {
                 throw new StaleConnectionException();
             }
         }
@@ -287,6 +287,13 @@ public class RedshiftPlugin extends BasePlugin {
                             log.warn("Error closing Redshift Statement", e);
                         }
                     }
+
+                    try {
+                        connection.close();
+                    } catch (SQLException e) {
+                        log.warn("Error closing Redshift Connection", e);
+                    }
+
                 }
 
                 ActionExecutionResult result = new ActionExecutionResult();
@@ -667,6 +674,14 @@ public class RedshiftPlugin extends BasePlugin {
                 } catch (AppsmithPluginException e) {
                     e.printStackTrace();
                     return Mono.error(e);
+
+                } finally {
+                    try {
+                        connection.close();
+                    } catch (SQLException e) {
+                        log.warn("Error closing Redshift Connection", e);
+                    }
+
                 }
 
                 structure.setTables(new ArrayList<>(tablesByName.values()));


### PR DESCRIPTION
Please revert this change after Redshift fixes JDBC connections to multi-node clusters.

## Problem description

The `Connection.isValid()` method returns `false` for valid connections, if the Redshift cluster has more than one node. For clusters with a single node, this method returns the appropriate value. This is a problem in communication between Redshift cluster and the JDBC driver.
