### PR TITLE
perf: improve widget property update

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -323,7 +323,7 @@ function getPropertiesToUpdate(
   const widgetConfig = WidgetFactory.getWidgetPropertyPaneConfig(widget.type);
   const {
     triggerPaths: triggerPathsFromPropertyConfig = {},
-  } = getAllPathsFromPropertyConfig(widget, widgetConfig, {});
+  } = getAllPathsFromPropertyConfig(widgetWithUpdates, widgetConfig, {});
 
   Object.keys(updatePaths).forEach((propertyPath) => {
     const propertyValue = _.get(updates, propertyPath);


### PR DESCRIPTION
## Description

Improves performance for an update of large objects as widget's property value.

`isPropertyATriggerPath` gets called in every iteration of `updatePaths`. If the value (object) has 150 key-value, then the loop would run 150 times, triggering `isPropertyATriggerPath` which inturn would trigger `getAllPathsFromPropertyConfig` which is an expensive computation.

This change would call `getAllPathsFromPropertyConfig` only once and use it as a cached value to run checks.

Fixes #8783 

## Type of change

- Performance improvement

## How Has This Been Tested?

Profiled property updates for large objects before and after the change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/widget-batch-update-binding-paths 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.82 **(0.01)** | 36.55 **(0)** | 33.46 **(0)** | 55.36 **(0.01)**
 :green_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 53.99 **(0.59)** | 41.99 **(0.09)** | 53.19 **(1.11)** | 55.74 **(0.7)**</details>