### PR TITLE
fix: show keyword as type for JS keywords in autocomplete

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/EditorConfig.ts
@@ -80,7 +80,6 @@ export enum AUTOCOMPLETE_CLOSE_KEY {
   Semicolon,
   Space,
   Delete,
-  Backspace,
   "Ctrl+Backspace",
   OSLeft,
   "(",
@@ -108,6 +107,12 @@ export enum AUTOCOMPLETE_NAVIGATION {
   ArrowRight,
   ArrowLeft,
 }
+
+export const INDENTATION_CHARACTERS = {
+  " ": " ",
+  "\t": "\t",
+  "\n": "\n",
+};
 
 export const isNavKey = (key: any): key is AUTOCOMPLETE_NAVIGATION => {
   return AUTOCOMPLETE_NAVIGATION.hasOwnProperty(key);

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -41,6 +41,7 @@ import {
   FieldEntityInformation,
   Hinter,
   HintHelper,
+  INDENTATION_CHARACTERS,
   isCloseKey,
   isModifierKey,
   isNavKey,
@@ -461,9 +462,29 @@ class CodeEditor extends Component<Props, State> {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore: No types available
       cm.closeHint();
-    } else if (!isNavKey(event.code)) {
-      this.handleAutocompleteVisibility(cm);
+      return;
     }
+    const cursor = cm.getCursor();
+    const line = cm.getLine(cursor.line);
+    if (event.code === "Backspace") {
+      /*
+        Check if the character before cursor is completable to show autocomplete
+      */
+      // Return early if the cursor position is 0.
+      if (cursor.ch === 0) return;
+      const prevChar = line[cursor.ch - 1];
+      // Return early if previous character is indentation.
+      if (INDENTATION_CHARACTERS.hasOwnProperty(prevChar)) return;
+    }
+    if (key === "{") {
+      /* 
+        Autocomplete for { should show up only when a user attempts to write {{}} and not a code block.
+      */
+      const prevChar = line[cursor.ch - 2];
+      if (prevChar && prevChar !== "{") return;
+    }
+    if (isNavKey(event.code)) return;
+    this.handleAutocompleteVisibility(cm);
   };
 
   lintCode(editor: CodeMirror.Editor) {

--- a/app/client/src/globalStyles/CodemirrorHintStyles.ts
+++ b/app/client/src/globalStyles/CodemirrorHintStyles.ts
@@ -208,6 +208,13 @@ export const CodemirrorHintStyles = createGlobalStyle<{
   .CodeMirror-Tern-completion-bool:after {
     content: "Boolean";
   }
+  .CodeMirror-Tern-completion-keyword:before {
+    content: "K";
+    background: ${(props) => props.theme.colors.dataTypeBg.object};
+  }
+  .CodeMirror-Tern-completion-keyword[keyword]:after {
+    content: attr(keyword);
+  }
   .CodeMirror-Tern-tooltip {
     z-index: 20 !important;
   }

--- a/app/client/src/globalStyles/index.tsx
+++ b/app/client/src/globalStyles/index.tsx
@@ -5,7 +5,7 @@ import { CommentThreadPopoverStyles } from "./commentThreadPopovers";
 import { UppyStyles } from "./uppy";
 import { PortalStyles } from "./portals";
 import { DialogStyles } from "./dialogs";
-import { CodemirrorHintStyles } from "./CodmirrorHintStyles";
+import { CodemirrorHintStyles } from "./CodemirrorHintStyles";
 import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
 
 export default function GlobalStyles() {


### PR DESCRIPTION
## Description
-Show keyword as type for JS keywords in autocomplete
-Fixed typo in filename (CodmirrorHintStyles.ts -> CodemirrorHintStyles.ts)
-Added autocomplete support for backspace.
-Prevent autocomplete trigger when the intention is to write a code block

Fixes #8797 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
-Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/autocomplete_keywords 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.78 **(-0.02)** | 36.5 **(0)** | 33.46 **(0)** | 55.32 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 66.9 **(-3.47)** | 39.63 **(-3.13)** | 51.28 **(0)** | 67.57 **(-2.71)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.9 **(-0.13)** | 38.49 **(0.19)** | 32.76 **(-0.57)** | 54.92 **(-0.08)**</details>