### PR TITLE
fix: prevent autoselection of first hint when enter key is pressed

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicInput/autocomplete_user_experience_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicInput/autocomplete_user_experience_spec.js
@@ -1,0 +1,20 @@
+const dsl = require("../../../../fixtures/autocomp.json");
+const dynamicInputLocators = require("../../../../locators/DynamicInput.json");
+
+describe("Autocomplete user experience", () => {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+  it("Does not select first hint when Enter key is pressed", () => {
+    cy.openPropertyPane("buttonwidget");
+    cy.get(dynamicInputLocators.input)
+      .first()
+      .click({ force: true })
+      .type("{uparrow}", { parseSpecialCharSequences: true })
+      .type("{ctrl}{shift}{downarrow}", { parseSpecialCharSequences: true })
+      .type("{{")
+      .type("{enter}", { parseSpecialCharSequences: true });
+
+    cy.focused().should("have.text", "");
+  });
+});

--- a/app/client/src/components/editorComponents/CodeEditor/commandsHelper.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/commandsHelper.ts
@@ -133,6 +133,11 @@ export const commandsHelper: HintHelper = (editor, data: DataTree) => {
             },
           },
           completeSingle: false,
+          customKeys: {
+            Enter: (cm: CodeMirror.Editor) => {
+              cm.execCommand("newlineAndIndent");
+            },
+          },
         });
         return true;
       }

--- a/app/client/src/utils/autocomplete/TernServer.ts
+++ b/app/client/src/utils/autocomplete/TernServer.ts
@@ -131,7 +131,7 @@ class TernServer {
       },
       customKeys: {
         Enter: (cm: CodeMirror.Editor) => {
-          cm.replaceSelection("\n");
+          cm.execCommand("newlineAndIndent");
         },
       },
     });


### PR DESCRIPTION
## Description
- First hint isn't selected when enter key is pressed 
- One caveat of this fix is that the enter key no longer picks an hint.

Fixes #8495 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Cypress Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/prevent-autoselection-when-enter-is-pressed 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.79 **(-0.01)** | 36.5 **(-0.02)** | 33.42 **(-0.01)** | 55.33 **(-0.01)**
 :red_circle: | app/client/src/components/ads/Dropdown.tsx | 52.9 **(-0.31)** | 36.94 **(-0.56)** | 25.42 **(0)** | 51.06 **(-0.35)**
 :green_circle: | app/client/src/components/designSystems/appsmith/SearchComponent.tsx | 77.27 **(1.41)** | 66.67 **(-8.33)** | 60 **(10)** | 76.19 **(1.19)**
 :red_circle: | app/client/src/components/editorComponents/CodeEditor/commandsHelper.ts | 16.92 **(-0.27)** | 0 **(0)** | 9.09 **(-0.91)** | 17.54 **(-0.32)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 50.92 **(-0.11)** | 38.3 **(0)** | 32.76 **(-0.57)** | 54.86 **(-0.14)**
 :red_circle: | app/client/src/widgets/TableWidget/component/TableHeader.tsx | 48.72 **(-1.28)** | 51.06 **(-2)** | 30 **(0)** | 45.95 **(-1.42)**
 :red_circle: | app/client/src/widgets/TableWidget/component/TableStyledWrappers.tsx | 69.41 **(-0.83)** | 21.27 **(-0.16)** | 51.85 **(-0.98)** | 69.41 **(-0.83)**
 :red_circle: | app/client/src/widgets/TableWidget/component/TableUtilities.tsx | 36.53 **(-1.19)** | 22.43 **(0)** | 14.63 **(-0.75)** | 34.64 **(-1.31)**</details>