### PR TITLE
fix: Don't trigger onpause on onend in audio widget

### DIFF
--- a/app/client/src/widgets/AudioWidget/widget/index.tsx
+++ b/app/client/src/widgets/AudioWidget/widget/index.tsx
@@ -135,7 +135,7 @@ class AudioWidget extends BaseWidget<AudioWidgetProps, WidgetState> {
             if (
               this._player.current &&
               this._player.current.getDuration() ===
-                this._player.current?.getCurrentTime()
+                this._player.current.getCurrentTime()
             ) {
               return;
             }


### PR DESCRIPTION
## Description

Audio element used by react player triggers pause event along with end event when the player reaches end of the resource. So we're restricting pause event from getting triggered  on end.

Fixes #8338 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/audio-widget-pause-end 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.78 **(-0.02)** | 36.49 **(-0.06)** | 33.42 **(-0.03)** | 55.31 **(-0.03)**
 :red_circle: | app/client/src/widgets/AudioWidget/widget/index.tsx | 60.47 **(-2.94)** | 22.22 **(-17.78)** | 46.15 **(0)** | 75.76 **(-4.89)**
 :red_circle: | app/client/src/widgets/TableWidget/widget/derived.js | 52.04 **(-5.8)** | 50.68 **(-6.91)** | 37.5 **(-6.4)** | 51.4 **(-6.35)**</details>