### PR TITLE
fix: dont validate the email during comments onboarding if the email exists on the user object

### DIFF
--- a/app/client/src/comments/CommentsShowcaseCarousel/ProfileForm.tsx
+++ b/app/client/src/comments/CommentsShowcaseCarousel/ProfileForm.tsx
@@ -24,7 +24,7 @@ const Container = styled.div`
 
 export const PROFILE_FORM = "PROFILE_FORM";
 
-const fieldNames = {
+export const fieldNames = {
   displayName: "displayName",
   emailAddress: "emailAddress",
 };

--- a/app/client/src/comments/CommentsShowcaseCarousel/index.tsx
+++ b/app/client/src/comments/CommentsShowcaseCarousel/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import Text, { TextType } from "components/ads/Text";
 import ShowcaseCarousel, { Steps } from "components/ads/ShowcaseCarousel";
-import ProfileForm, { PROFILE_FORM } from "./ProfileForm";
+import ProfileForm, { PROFILE_FORM, fieldNames } from "./ProfileForm";
 import CommentsCarouselModal from "./CommentsCarouselModal";
 import ProgressiveImage, {
   Container as ProgressiveImageContainer,
@@ -204,13 +204,23 @@ export default function CommentsShowcaseCarousel() {
   const dispatch = useDispatch();
   const isIntroCarouselVisible = useSelector(isIntroCarouselVisibleSelector);
   const profileFormValues = useSelector(getFormValues(PROFILE_FORM));
-  const profileFormErrors = useSelector(getFormSyncErrors("PROFILE_FORM"));
-  const isSubmitDisabled = Object.keys(profileFormErrors).length !== 0;
+  const profileFormErrors = useSelector(
+    getFormSyncErrors("PROFILE_FORM"),
+  ) as Partial<typeof fieldNames>;
 
   const [isSkipped, setIsSkipped] = useState(false);
 
   const currentUser = useSelector(getCurrentUser);
   const { email, name } = currentUser || {};
+  const emailDisabled = !!email;
+
+  // don't validate email address if it already exists on the user object
+  // this is to unblock the comments feature for github users where email is
+  // actually the github username
+  const isSubmitDisabled = !!(
+    profileFormErrors.displayName ||
+    (profileFormErrors.emailAddress && !emailDisabled)
+  );
 
   const initialProfileFormValues = { emailAddress: email, displayName: name };
   const onSubmitProfileForm = () => {
@@ -265,7 +275,7 @@ export default function CommentsShowcaseCarousel() {
     isSubmitDisabled,
     finalSubmit,
     initialProfileFormValues,
-    !!email,
+    emailDisabled,
     canManage,
     onSkip,
     isSkipped,


### PR DESCRIPTION
## Description
fix: dont validate the email during comments onboarding if the email exists on the user object

Fixes #8850

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually, automating this test for github signup would need some more efforts

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-comments-onboarding-github-users 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.81 **(0.01)** | 36.56 **(0.01)** | 33.45 **(0)** | 55.35 **(0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**</details>