### PR TITLE
feat: [Feature] Add API to send test email

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManager.java
@@ -329,7 +329,7 @@ public class EnvManager {
     }
 
     public Mono<Boolean> sendTestEmail() {
-        return sessionUserService.getCurrentUser()
+        return verifyCurrentUserIsSuper()
                 .flatMap(user -> emailSender.sendMail(
                         user.getEmail(),
                         "Test email from Appsmith",


### PR DESCRIPTION
## Description
Adds an API for super user to test the email configuration by sending a test email to himself.

Fixes #8840 
## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Unit tests
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
