### PR TITLE
feat: [Feature] Add slug for applications and pages

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -59,6 +59,8 @@ public class Application extends BaseDomain {
 
     String icon;
 
+    private String slug;
+
     @JsonIgnore
     AppLayout unpublishedAppLayout;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
@@ -25,6 +25,8 @@ public class PageDTO {
 
     String name;
 
+    String slug;
+
     @Transient
     String applicationId;
 
@@ -40,8 +42,6 @@ public class PageDTO {
     Instant deletedAt = null;
 
     Boolean isHidden;
-
-    private String slug;
 
     @Transient
     Long lastUpdatedTime;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageDTO.java
@@ -41,6 +41,8 @@ public class PageDTO {
 
     Boolean isHidden;
 
+    private String slug;
+
     @Transient
     Long lastUpdatedTime;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
@@ -1,0 +1,22 @@
+package com.appsmith.server.helpers;
+
+import java.text.Normalizer;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public class TextUtils {
+    private static final Pattern NONLATIN = Pattern.compile("[^\\w-]");
+    private static final Pattern WHITESPACE = Pattern.compile("[\\s]");
+
+    /**
+     * Creates a slug from the inputText and returns it
+     * @param inputText String that'll be converted to slug
+     * @return String in the slug format
+     */
+    public static String getSlug(String inputText) {
+        String nowhitespace = WHITESPACE.matcher(inputText.trim()).replaceAll("-");
+        String normalized = Normalizer.normalize(nowhitespace, Normalizer.Form.NFD);
+        String slug = NONLATIN.matcher(normalized).replaceAll("");
+        return slug.toLowerCase(Locale.ENGLISH);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
@@ -17,6 +17,9 @@ public class TextUtils {
      * @return String, empty if failed due to encoding exception
      */
     public static String makeSlug(String inputText) {
+        if(inputText == null) {
+            return "";
+        }
         String noseparators = SEPARATORS.matcher(inputText).replaceAll("-");
         String normalized = Normalizer.normalize(noseparators, Normalizer.Form.NFD);
         String slug = NONLATIN.matcher(normalized).replaceAll("");

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
@@ -1,22 +1,32 @@
 package com.appsmith.server.helpers;
 
-import java.text.Normalizer;
-import java.util.Locale;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
+@Slf4j
 public class TextUtils {
-    private static final Pattern NONLATIN = Pattern.compile("[^\\w-]");
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]");
 
     /**
-     * Creates a slug from the inputText and returns it
-     * @param inputText String that'll be converted to slug
-     * @return String in the slug format
+     * Creates a human readable URL safe text from the input text. It considers the following:
+     * (1) It removes heading and trailing whitespaces and replace any other whitespace with `-`
+     * (2) If the input is in ascii, it converts to lowercase
+     * (3) If the input is unicode, it becomes URL encoded string
+     * Modern browsers displays the URL encoded string in decoded format so the URL will look clean i.e. no % symbols will be visible
+     * @param inputText String that'll be converted
+     * @return String, empty if failed due to encoding exception
      */
-    public static String getSlug(String inputText) {
-        String nowhitespace = WHITESPACE.matcher(inputText.trim()).replaceAll("-");
-        String normalized = Normalizer.normalize(nowhitespace, Normalizer.Form.NFD);
-        String slug = NONLATIN.matcher(normalized).replaceAll("");
-        return slug.toLowerCase(Locale.ENGLISH);
+    public static String toUrlSafeHumanReadableText(String inputText) {
+        String nowhitespaceInLowecase = WHITESPACE.matcher(inputText.trim()).replaceAll("-").toLowerCase();
+        try{
+            return URLEncoder.encode(nowhitespaceInLowecase, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException ex) {
+            log.error("failed to create slug from " + inputText, ex);
+            return "";
+        }
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
@@ -8,10 +8,22 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class TextUtils {
-    private static final Pattern NONLATIN = Pattern.compile("[^\\w_-]");
+    /*
+    * NON_LATIN regex matches any letter that is not a ASCII i.e. A-Za-z0-9, `-` and `_`
+    * It'll match the unicode letters.
+    * */
+    private static final Pattern NON_LATIN = Pattern.compile("[^\\w_-]");
+
+    /*
+    * The SEPARATORS pattern matches those characters which cane be replaced with `-`
+    * This includes Punctuation characters, `&`, space and not `-` itself. Details on `Punct`
+    * http://www.gnu.org/software/grep/manual/html_node/Character-Classes-and-Bracket-Expressions.html
+    * */
     private static final Pattern SEPARATORS = Pattern.compile("[\\s\\p{Punct}&&[^-]]");
+
     /**
      * Creates URL safe text aka slug from the input text. It supports english locale only.
+     * See the test cases for sample conversions
      * For other languages, it'll return empty.
      * @param inputText String that'll be converted
      * @return String, empty if failed due to encoding exception
@@ -20,9 +32,14 @@ public class TextUtils {
         if(inputText == null) {
             return "";
         }
+        // remove all the separators with a `-`
         String noseparators = SEPARATORS.matcher(inputText).replaceAll("-");
         String normalized = Normalizer.normalize(noseparators, Normalizer.Form.NFD);
-        String slug = NONLATIN.matcher(normalized).replaceAll("");
+
+        // remove any non ascii letter with empty
+        String slug = NON_LATIN.matcher(normalized).replaceAll("");
+        // convert to lower case, remove multiple consecutive `-` with single `-`
+        // if we've only `-` left and nothing else, replace it with empty string
         return slug.toLowerCase(Locale.ENGLISH).replaceAll("-{2,}","-").replaceAll("^-|-$","");
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -147,6 +147,9 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
 
     @Override
     public Mono<Application> save(Application application) {
+        if(!StringUtils.isEmpty(application.getName())) {
+            application.setSlug(TextUtils.getSlug(application.getName()));
+        }
         return repository.save(application)
                 .flatMap(this::setTransientFields);
     }
@@ -165,7 +168,9 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     @Override
     public Mono<Application> update(String id, Application application) {
         application.setIsPublic(null);
-        application.setSlug(TextUtils.getSlug(application.getName()));
+        if(!StringUtils.isEmpty(application.getName())) {
+            application.setSlug(TextUtils.getSlug(application.getName()));
+        }
         return repository.updateById(id, application, AclPermission.MANAGE_APPLICATIONS)
             .onErrorResume(error -> {
                 if (error instanceof DuplicateKeyException) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -19,6 +19,7 @@ import com.appsmith.server.dtos.ApplicationAccessDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.PolicyUtils;
+import com.appsmith.server.helpers.TextUtils;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.CommentThreadRepository;
 import com.jcraft.jsch.JSch;
@@ -156,13 +157,15 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     }
 
     @Override
-    public Mono<Application> createDefault(Application object) {
-        return super.create(object);
+    public Mono<Application> createDefault(Application application) {
+        application.setSlug(TextUtils.getSlug(application.getName()));
+        return super.create(application);
     }
 
     @Override
     public Mono<Application> update(String id, Application application) {
         application.setIsPublic(null);
+        application.setSlug(TextUtils.getSlug(application.getName()));
         return repository.updateById(id, application, AclPermission.MANAGE_APPLICATIONS)
             .onErrorResume(error -> {
                 if (error instanceof DuplicateKeyException) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -148,7 +148,7 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     @Override
     public Mono<Application> save(Application application) {
         if(!StringUtils.isEmpty(application.getName())) {
-            application.setSlug(TextUtils.toUrlSafeHumanReadableText(application.getName()));
+            application.setSlug(TextUtils.makeSlug(application.getName()));
         }
         return repository.save(application)
                 .flatMap(this::setTransientFields);
@@ -161,7 +161,7 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
 
     @Override
     public Mono<Application> createDefault(Application application) {
-        application.setSlug(TextUtils.toUrlSafeHumanReadableText(application.getName()));
+        application.setSlug(TextUtils.makeSlug(application.getName()));
         return super.create(application);
     }
 
@@ -169,7 +169,7 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     public Mono<Application> update(String id, Application application) {
         application.setIsPublic(null);
         if(!StringUtils.isEmpty(application.getName())) {
-            application.setSlug(TextUtils.toUrlSafeHumanReadableText(application.getName()));
+            application.setSlug(TextUtils.makeSlug(application.getName()));
         }
         return repository.updateById(id, application, AclPermission.MANAGE_APPLICATIONS)
             .onErrorResume(error -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -148,7 +148,7 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     @Override
     public Mono<Application> save(Application application) {
         if(!StringUtils.isEmpty(application.getName())) {
-            application.setSlug(TextUtils.getSlug(application.getName()));
+            application.setSlug(TextUtils.toUrlSafeHumanReadableText(application.getName()));
         }
         return repository.save(application)
                 .flatMap(this::setTransientFields);
@@ -161,7 +161,7 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
 
     @Override
     public Mono<Application> createDefault(Application application) {
-        application.setSlug(TextUtils.getSlug(application.getName()));
+        application.setSlug(TextUtils.toUrlSafeHumanReadableText(application.getName()));
         return super.create(application);
     }
 
@@ -169,7 +169,7 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     public Mono<Application> update(String id, Application application) {
         application.setIsPublic(null);
         if(!StringUtils.isEmpty(application.getName())) {
-            application.setSlug(TextUtils.getSlug(application.getName()));
+            application.setSlug(TextUtils.toUrlSafeHumanReadableText(application.getName()));
         }
         return repository.updateById(id, application, AclPermission.MANAGE_APPLICATIONS)
             .onErrorResume(error -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -386,7 +386,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
                 .flatMap(dbPage -> {
                     copyNewFieldValuesIntoOldObject(page, dbPage.getUnpublishedPage());
                     if(!StringUtils.isEmpty(page.getName())) {
-                        dbPage.getUnpublishedPage().setSlug(TextUtils.toUrlSafeHumanReadableText(page.getName()));
+                        dbPage.getUnpublishedPage().setSlug(TextUtils.makeSlug(page.getName()));
                     }
                     return this.update(id, dbPage);
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -129,9 +130,8 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
     public Mono<PageDTO> createDefault(PageDTO object) {
         NewPage newPage = new NewPage();
         newPage.setUnpublishedPage(object);
-        object.setSlug(TextUtils.getSlug(object.getName()));
-
         newPage.setApplicationId(object.getApplicationId());
+        newPage.getUnpublishedPage().setSlug(object.getName());
         newPage.setPolicies(object.getPolicies());
         if (newPage.getGitSyncId() == null) {
             newPage.setGitSyncId(newPage.getApplicationId() + "_" + Instant.now().toString());
@@ -385,7 +385,9 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.PAGE, id)))
                 .flatMap(dbPage -> {
                     copyNewFieldValuesIntoOldObject(page, dbPage.getUnpublishedPage());
-                    dbPage.getUnpublishedPage().setSlug(TextUtils.getSlug(page.getName()));
+                    if(!StringUtils.isEmpty(page.getName())) {
+                        dbPage.getUnpublishedPage().setSlug(TextUtils.getSlug(page.getName()));
+                    }
                     return this.update(id, dbPage);
                 })
                 .flatMap(savedPage -> applicationService.saveLastEditInformation(savedPage.getApplicationId())

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -386,7 +386,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
                 .flatMap(dbPage -> {
                     copyNewFieldValuesIntoOldObject(page, dbPage.getUnpublishedPage());
                     if(!StringUtils.isEmpty(page.getName())) {
-                        dbPage.getUnpublishedPage().setSlug(TextUtils.getSlug(page.getName()));
+                        dbPage.getUnpublishedPage().setSlug(TextUtils.toUrlSafeHumanReadableText(page.getName()));
                     }
                     return this.update(id, dbPage);
                 })

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewPageServiceImpl.java
@@ -131,7 +131,7 @@ public class NewPageServiceImpl extends BaseService<NewPageRepository, NewPage, 
         NewPage newPage = new NewPage();
         newPage.setUnpublishedPage(object);
         newPage.setApplicationId(object.getApplicationId());
-        newPage.getUnpublishedPage().setSlug(object.getName());
+        newPage.getUnpublishedPage().setSlug(TextUtils.makeSlug(object.getName()));
         newPage.setPolicies(object.getPolicies());
         if (newPage.getGitSyncId() == null) {
             newPage.setGitSyncId(newPage.getApplicationId() + "_" + Instant.now().toString());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
@@ -1,0 +1,17 @@
+package com.appsmith.server.helpers;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TextUtilsTest {
+    @Test
+    public void getSlug() {
+        assertThat(TextUtils.getSlug("Hello Darkness My Old Friend")).isEqualTo("hello-darkness-my-old-friend");
+        assertThat(TextUtils.getSlug("Page1")).isEqualTo("page1");
+        assertThat(TextUtils.getSlug("TestPage123")).isEqualTo("testpage123");
+        assertThat(TextUtils.getSlug("Page 1")).isEqualTo("page-1");
+        assertThat(TextUtils.getSlug(" Page 1 ")).isEqualTo("page-1");
+        assertThat(TextUtils.getSlug("Page  1")).isEqualTo("page--1");
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
@@ -6,21 +6,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TextUtilsTest {
     @Test
-    public void toUrlSafeHumanReadableText() {
-        assertThat(TextUtils.toUrlSafeHumanReadableText("Hello Darkness My Old Friend")).isEqualTo("hello-darkness-my-old-friend");
-        assertThat(TextUtils.toUrlSafeHumanReadableText("Page1")).isEqualTo("page1");
-        assertThat(TextUtils.toUrlSafeHumanReadableText("TestPage123")).isEqualTo("testpage123");
-        assertThat(TextUtils.toUrlSafeHumanReadableText("Page 1")).isEqualTo("page-1");
-        assertThat(TextUtils.toUrlSafeHumanReadableText(" Page 1 ")).isEqualTo("page-1");
-        assertThat(TextUtils.toUrlSafeHumanReadableText("Page  1")).isEqualTo("page--1");
-        assertThat(TextUtils.toUrlSafeHumanReadableText("_page 1")).isEqualTo("_page-1");
-        assertThat(TextUtils.toUrlSafeHumanReadableText("_page 1")).isEqualTo("_page-1");
-        assertThat(TextUtils.toUrlSafeHumanReadableText("Hello (new)")).isEqualTo("hello-%28new%29");
+    public void makeSlug() {
+        assertThat(TextUtils.makeSlug("Hello Darkness My Old Friend")).isEqualTo("hello-darkness-my-old-friend");
+        assertThat(TextUtils.makeSlug("Page1")).isEqualTo("page1");
+        assertThat(TextUtils.makeSlug("TestPage123")).isEqualTo("testpage123");
+        assertThat(TextUtils.makeSlug("Page 1")).isEqualTo("page-1");
+        assertThat(TextUtils.makeSlug(" Page 1 ")).isEqualTo("page-1");
+        assertThat(TextUtils.makeSlug("Page  1")).isEqualTo("page-1");
+        assertThat(TextUtils.makeSlug("_page 1")).isEqualTo("page-1");
+        assertThat(TextUtils.makeSlug("Hello (new)")).isEqualTo("hello-new");
         // text is hindi
-        assertThat(TextUtils.toUrlSafeHumanReadableText("परीक्षण पृष्ठ")).isEqualTo("%E0%A4%AA%E0%A4%B0%E0%A5%80%E0%A4%95%E0%A5%8D%E0%A4%B7%E0%A4%A3-%E0%A4%AA%E0%A5%83%E0%A4%B7%E0%A5%8D%E0%A4%A0");
+        assertThat(TextUtils.makeSlug("परीक्षण पृष्ठ")).isEqualTo("");
         // text is in spanish
-        assertThat(TextUtils.toUrlSafeHumanReadableText("página de prueba")).isEqualTo("p%C3%A1gina-de-prueba");
+        assertThat(TextUtils.makeSlug("página de prueba")).isEqualTo("pagina-de-prueba");
         // text in chinese
-        assertThat(TextUtils.toUrlSafeHumanReadableText("测试页")).isEqualTo("%E6%B5%8B%E8%AF%95%E9%A1%B5");
+        assertThat(TextUtils.makeSlug("测试页")).isEqualTo("");
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
@@ -18,6 +18,8 @@ public class TextUtilsTest {
         assertThat(TextUtils.makeSlug("page 1!")).isEqualTo("page-1");
         assertThat(TextUtils.makeSlug("page__1")).isEqualTo("page-1");
         assertThat(TextUtils.makeSlug("Hello (new)")).isEqualTo("hello-new");
+        assertThat(TextUtils.makeSlug("")).isEqualTo("");
+        assertThat(TextUtils.makeSlug(null)).isEqualTo("");
         // text is hindi
         assertThat(TextUtils.makeSlug("परीक्षण पृष्ठ")).isEqualTo("");
         // text is in spanish

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
@@ -6,12 +6,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TextUtilsTest {
     @Test
-    public void getSlug() {
-        assertThat(TextUtils.getSlug("Hello Darkness My Old Friend")).isEqualTo("hello-darkness-my-old-friend");
-        assertThat(TextUtils.getSlug("Page1")).isEqualTo("page1");
-        assertThat(TextUtils.getSlug("TestPage123")).isEqualTo("testpage123");
-        assertThat(TextUtils.getSlug("Page 1")).isEqualTo("page-1");
-        assertThat(TextUtils.getSlug(" Page 1 ")).isEqualTo("page-1");
-        assertThat(TextUtils.getSlug("Page  1")).isEqualTo("page--1");
+    public void toUrlSafeHumanReadableText() {
+        assertThat(TextUtils.toUrlSafeHumanReadableText("Hello Darkness My Old Friend")).isEqualTo("hello-darkness-my-old-friend");
+        assertThat(TextUtils.toUrlSafeHumanReadableText("Page1")).isEqualTo("page1");
+        assertThat(TextUtils.toUrlSafeHumanReadableText("TestPage123")).isEqualTo("testpage123");
+        assertThat(TextUtils.toUrlSafeHumanReadableText("Page 1")).isEqualTo("page-1");
+        assertThat(TextUtils.toUrlSafeHumanReadableText(" Page 1 ")).isEqualTo("page-1");
+        assertThat(TextUtils.toUrlSafeHumanReadableText("Page  1")).isEqualTo("page--1");
+        assertThat(TextUtils.toUrlSafeHumanReadableText("_page 1")).isEqualTo("_page-1");
+        assertThat(TextUtils.toUrlSafeHumanReadableText("_page 1")).isEqualTo("_page-1");
+        assertThat(TextUtils.toUrlSafeHumanReadableText("Hello (new)")).isEqualTo("hello-%28new%29");
+        // text is hindi
+        assertThat(TextUtils.toUrlSafeHumanReadableText("परीक्षण पृष्ठ")).isEqualTo("%E0%A4%AA%E0%A4%B0%E0%A5%80%E0%A4%95%E0%A5%8D%E0%A4%B7%E0%A4%A3-%E0%A4%AA%E0%A5%83%E0%A4%B7%E0%A5%8D%E0%A4%A0");
+        // text is in spanish
+        assertThat(TextUtils.toUrlSafeHumanReadableText("página de prueba")).isEqualTo("p%C3%A1gina-de-prueba");
+        // text in chinese
+        assertThat(TextUtils.toUrlSafeHumanReadableText("测试页")).isEqualTo("%E6%B5%8B%E8%AF%95%E9%A1%B5");
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
@@ -14,6 +14,9 @@ public class TextUtilsTest {
         assertThat(TextUtils.makeSlug(" Page 1 ")).isEqualTo("page-1");
         assertThat(TextUtils.makeSlug("Page  1")).isEqualTo("page-1");
         assertThat(TextUtils.makeSlug("_page 1")).isEqualTo("page-1");
+        assertThat(TextUtils.makeSlug("!page 1")).isEqualTo("page-1");
+        assertThat(TextUtils.makeSlug("page 1!")).isEqualTo("page-1");
+        assertThat(TextUtils.makeSlug("page__1")).isEqualTo("page-1");
         assertThat(TextUtils.makeSlug("Hello (new)")).isEqualTo("hello-new");
         // text is hindi
         assertThat(TextUtils.makeSlug("परीक्षण पृष्ठ")).isEqualTo("");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -174,7 +174,7 @@ public class ApplicationServiceTest {
                 .create(applicationMono)
                 .assertNext(application -> {
                     assertThat(application).isNotNull();
-                    assertThat(application.getSlug()).isEqualTo(TextUtils.getSlug(application.getName()));
+                    assertThat(application.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(application.getName()));
                     assertThat(application.isAppIsExample()).isFalse();
                     assertThat(application.getId()).isNotNull();
                     assertThat(application.getName().equals("ApplicationServiceTest TestApp"));
@@ -327,7 +327,7 @@ public class ApplicationServiceTest {
                     assertThat(t.getId()).isNotNull();
                     assertThat(t.getPolicies()).isNotEmpty();
                     assertThat(t.getName()).isEqualTo("NewValidUpdateApplication-Test");
-                    assertThat(t.getSlug()).isEqualTo(TextUtils.getSlug(t.getName()));
+                    assertThat(t.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(t.getName()));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -30,6 +30,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.helpers.PolicyUtils;
+import com.appsmith.server.helpers.TextUtils;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.NewPageRepository;
 import com.appsmith.server.repositories.PluginRepository;
@@ -173,6 +174,7 @@ public class ApplicationServiceTest {
                 .create(applicationMono)
                 .assertNext(application -> {
                     assertThat(application).isNotNull();
+                    assertThat(application.getSlug()).isEqualTo(TextUtils.getSlug(application.getName()));
                     assertThat(application.isAppIsExample()).isFalse();
                     assertThat(application.getId()).isNotNull();
                     assertThat(application.getName().equals("ApplicationServiceTest TestApp"));
@@ -325,6 +327,7 @@ public class ApplicationServiceTest {
                     assertThat(t.getId()).isNotNull();
                     assertThat(t.getPolicies()).isNotEmpty();
                     assertThat(t.getName()).isEqualTo("NewValidUpdateApplication-Test");
+                    assertThat(t.getSlug()).isEqualTo(TextUtils.getSlug(t.getName()));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -174,7 +174,7 @@ public class ApplicationServiceTest {
                 .create(applicationMono)
                 .assertNext(application -> {
                     assertThat(application).isNotNull();
-                    assertThat(application.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(application.getName()));
+                    assertThat(application.getSlug()).isEqualTo(TextUtils.makeSlug(application.getName()));
                     assertThat(application.isAppIsExample()).isFalse();
                     assertThat(application.getId()).isNotNull();
                     assertThat(application.getName().equals("ApplicationServiceTest TestApp"));
@@ -327,7 +327,7 @@ public class ApplicationServiceTest {
                     assertThat(t.getId()).isNotNull();
                     assertThat(t.getPolicies()).isNotEmpty();
                     assertThat(t.getName()).isEqualTo("NewValidUpdateApplication-Test");
-                    assertThat(t.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(t.getName()));
+                    assertThat(t.getSlug()).isEqualTo(TextUtils.makeSlug(t.getName()));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -168,7 +168,7 @@ public class PageServiceTest {
                     assertThat(page.getId()).isNotNull();
 
                     assertThat(page.getName()).isEqualTo("PageServiceTest TestApp");
-                    assertThat(page.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(page.getName()));
+                    assertThat(page.getSlug()).isEqualTo(TextUtils.makeSlug(page.getName()));
 
                     assertThat(page.getPolicies()).isNotEmpty();
                     assertThat(page.getPolicies()).containsOnly(managePagePolicy, readPagePolicy);
@@ -247,7 +247,7 @@ public class PageServiceTest {
                     assertThat(page).isNotNull();
                     assertThat(page.getId()).isNotNull();
                     assertThat(page.getName()).isEqualTo("New Page Name");
-                    assertThat(page.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(page.getName()));
+                    assertThat(page.getSlug()).isEqualTo(TextUtils.makeSlug(page.getName()));
 
                     // Check for the policy object not getting overwritten during update
                     assertThat(page.getPolicies()).isNotEmpty();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -168,7 +168,7 @@ public class PageServiceTest {
                     assertThat(page.getId()).isNotNull();
 
                     assertThat(page.getName()).isEqualTo("PageServiceTest TestApp");
-                    assertThat(page.getSlug()).isEqualTo(TextUtils.getSlug(page.getName()));
+                    assertThat(page.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(page.getName()));
 
                     assertThat(page.getPolicies()).isNotEmpty();
                     assertThat(page.getPolicies()).containsOnly(managePagePolicy, readPagePolicy);
@@ -247,7 +247,7 @@ public class PageServiceTest {
                     assertThat(page).isNotNull();
                     assertThat(page.getId()).isNotNull();
                     assertThat(page.getName()).isEqualTo("New Page Name");
-                    assertThat(page.getSlug()).isEqualTo(TextUtils.getSlug(page.getName()));
+                    assertThat(page.getSlug()).isEqualTo(TextUtils.toUrlSafeHumanReadableText(page.getName()));
 
                     // Check for the policy object not getting overwritten during update
                     assertThat(page.getPolicies()).isNotEmpty();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -19,6 +19,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.helpers.TextUtils;
 import com.appsmith.server.repositories.PluginRepository;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
@@ -165,7 +166,9 @@ public class PageServiceTest {
                 .assertNext(page -> {
                     assertThat(page).isNotNull();
                     assertThat(page.getId()).isNotNull();
-                    assertThat("PageServiceTest TestApp".equals(page.getName()));
+
+                    assertThat(page.getName()).isEqualTo("PageServiceTest TestApp");
+                    assertThat(page.getSlug()).isEqualTo(TextUtils.getSlug(page.getName()));
 
                     assertThat(page.getPolicies()).isNotEmpty();
                     assertThat(page.getPolicies()).containsOnly(managePagePolicy, readPagePolicy);
@@ -243,7 +246,8 @@ public class PageServiceTest {
                 .assertNext(page -> {
                     assertThat(page).isNotNull();
                     assertThat(page.getId()).isNotNull();
-                    assertThat("New Page Name".equals(page.getName()));
+                    assertThat(page.getName()).isEqualTo("New Page Name");
+                    assertThat(page.getSlug()).isEqualTo(TextUtils.getSlug(page.getName()));
 
                     // Check for the policy object not getting overwritten during update
                     assertThat(page.getPolicies()).isNotEmpty();


### PR DESCRIPTION
## Description
Generates and stores a slug from application name and page names when they are created or updated. Also adds a migration to set slug to existing applications and pages.

Fixes #8638

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- JUnit tests
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
