### PR TITLE
ci: Upload build artifacts to S3

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -292,7 +292,10 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          tar -vcaf full-dist.tar.gz client/build server/dist rts/{dist,node_modules}
+          date --utc --iso-8601=seconds > package_time.txt
+          git rev-parse HEAD > commit_hash.txt
+          echo ${{ github.event.number }} > pr_number.txt
+          tar -vcaf full-dist.tar.gz client/build server/dist rts/{dist,node_modules} *.txt
           aws s3 cp full-dist.tar.gz "s3://${{ secrets.DP_PACKAGE_AWS_S3_BUCKET_PATH }}/${{ github.event.number }}.tar.gz"
 
   ui-test:


### PR DESCRIPTION
Nothing fancy, just package up built artifacts into a single archive and copy it to an S3 bucket. These uploaded packages are used in generating light-weight deploy previews for PRs.

I'll set the required secrets after this PR is approved, and before it is merged.
