### PR TITLE
fix: allow omnibar and debugger hotkeys from input boxes

### DIFF
--- a/app/client/src/pages/Editor/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.tsx
@@ -118,14 +118,14 @@ class GlobalHotKeys extends React.Component<Props> {
           }}
         />
         <Hotkey
-          allowInInput={false}
+          allowInInput
           combo="mod + k"
           global
           label="Show omnibar"
           onKeyDown={(e) => this.onOnmnibarHotKeyDown(e)}
         />
         <Hotkey
-          allowInInput={false}
+          allowInInput
           combo="mod + j"
           global
           label="Show omnibar"
@@ -134,7 +134,7 @@ class GlobalHotKeys extends React.Component<Props> {
           }
         />
         <Hotkey
-          allowInInput={false}
+          allowInInput
           combo="mod + l"
           global
           label="Show omnibar"
@@ -143,7 +143,7 @@ class GlobalHotKeys extends React.Component<Props> {
           }
         />
         <Hotkey
-          allowInInput={false}
+          allowInInput
           combo="mod + p"
           global
           label="Show omnibar"
@@ -152,6 +152,7 @@ class GlobalHotKeys extends React.Component<Props> {
           }
         />
         <Hotkey
+          allowInInput
           combo="mod + d"
           global
           group="Canvas"


### PR DESCRIPTION
## Description
Enabled the `allowInInput` flag in the hotkeys blueprint component
 
Fixes #8511

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- manual (this is a ui lib option change, don't need automated tests)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>