### PR TITLE
fix: restrict third party dependency keywords from being used as widget names

### DIFF
--- a/app/client/src/constants/WidgetValidation.ts
+++ b/app/client/src/constants/WidgetValidation.ts
@@ -148,3 +148,10 @@ export const WINDOW_OBJECT_METHODS = {
   setTimeout: "setTimeout",
   stop: "stop",
 };
+
+export const THIRD_PARTY_DEPENDENCY_KEYWORDS = {
+  _: "_",
+  moment: "moment",
+  xmlParser: "xmlParser",
+  forge: "forge",
+};

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -7,6 +7,7 @@ import successAnimation from "assets/lottie/success-animation.json";
 import {
   DATA_TREE_KEYWORDS,
   JAVASCRIPT_KEYWORDS,
+  THIRD_PARTY_DEPENDENCY_KEYWORDS,
   WINDOW_OBJECT_METHODS,
   WINDOW_OBJECT_PROPERTIES,
 } from "constants/WidgetValidation";
@@ -286,6 +287,7 @@ export const isNameValid = (
     name in GLOBAL_FUNCTIONS ||
     name in WINDOW_OBJECT_PROPERTIES ||
     name in WINDOW_OBJECT_METHODS ||
+    name in THIRD_PARTY_DEPENDENCY_KEYWORDS ||
     name in invalidNames
   );
 };


### PR DESCRIPTION
* _
* moment
* xmlParser
* forge

Fixes #8881 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/reserved-keywords-widget-name 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.81 **(0)** | 36.53 **(-0.01)** | 33.47 **(0)** | 55.35 **(0)**
 :red_circle: | app/client/src/utils/helpers.tsx | 60 **(0)** | 31.25 **(-0.22)** | 45 **(0)** | 57.07 **(0)**</details>