### PR TITLE
chore: Fix for duplicate messages in PR

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,13 +20,13 @@ jobs:
         continue-on-error: true
 
       - name: Run step when a file changes
-        uses: actions-ecosystem/action-create-comment@v1
+        uses: mshick/add-pr-comment@v1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         if: |
           contains(steps.changed-files.outputs.files_modified, 'cypress') == false &&
           contains(steps.changed-files.outputs.files_modified, 'test') == false
         with:
-          github_token: ${{ secrets.github_token }}
-          body: |
+          message: |
             Unable to find test scripts. Please add necessary tests to the PR.
+          allow-repeats: false


### PR DESCRIPTION
Changed github actions plugin to avoid duplicate comment


## Description

PR lableler spams PR

Fixes #8917


## Type of change



- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested in fork
## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
