### PR TITLE
test: Make Cypress tests resilient to changes in app texts

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Search_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Search_spec.js
@@ -1,5 +1,3 @@
-const testdata = require("../../../../fixtures/testdata.json");
-
 describe("API Panel Test Functionality ", function() {
   it("Test Search API fetaure", function() {
     cy.log("Login Successful");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ExportApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ExportApplication_spec.js
@@ -58,7 +58,7 @@ describe("Export application as a JSON file", function() {
         "response.body.responseMeta.status",
         200,
       );
-      cy.get("h2").contains("Drag and drop a widget here");
+      cy.get("h2").contains(Cypress.env("MESSAGES").DRAG_AND_DROP_TEXT());
       cy.get(homePage.shareApp).click({ force: true });
       cy.shareApp(Cypress.env("TESTUSERNAME1"), homePage.adminRole);
 
@@ -108,7 +108,7 @@ describe("Export application as a JSON file", function() {
         "response.body.responseMeta.status",
         200,
       );
-      cy.get("h2").contains("Drag and drop a widget here");
+      cy.get("h2").contains(Cypress.env("MESSAGES").DRAG_AND_DROP_TEXT());
       cy.get(homePage.shareApp).click({ force: true });
       cy.shareApp(Cypress.env("TESTUSERNAME1"), homePage.developerRole);
 
@@ -158,7 +158,7 @@ describe("Export application as a JSON file", function() {
         "response.body.responseMeta.status",
         200,
       );
-      cy.get("h2").contains("Drag and drop a widget here");
+      cy.get("h2").contains(Cypress.env("MESSAGES").DRAG_AND_DROP_TEXT());
       cy.get(homePage.shareApp).click({ force: true });
       cy.shareApp(Cypress.env("TESTUSERNAME1"), homePage.viewerRole);
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ForkApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ForkApplication_spec.js
@@ -1,7 +1,6 @@
 const dsl = require("../../../../fixtures/basicDsl.json");
 const homePage = require("../../../../locators/HomePage.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 
 let forkedApplicationDsl;
 let parentApplicationDsl;

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/UpdateApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/UpdateApplication_spec.js
@@ -1,11 +1,9 @@
 const homePage = require("../../../../locators/HomePage.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
-import tinycolor from "tinycolor2";
 
 describe("Update Application", function() {
   let appname;
   let iconname;
-  let colorname;
   let veryLongAppName = `gnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionih1gnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionihgnerwihnireongionih1${Math.random()
     .toString(36)
     .slice(2, -1)}`;
@@ -25,7 +23,10 @@ describe("Update Application", function() {
       .first()
       .click({ force: true });
     cy.get(homePage.applicationName).type(`${appname} updated` + "{enter}");
-    cy.get(homePage.toastMessage).should("contain", "Application name updated");
+    cy.get(homePage.toastMessage).should(
+      "contain",
+      Cypress.env("MESSAGES").APPLICATION_NAME_UPDATE(),
+    );
     cy.wait("@updateApplication").should(
       "have.nested.property",
       "response.body.responseMeta.status",
@@ -82,7 +83,10 @@ describe("Update Application", function() {
       "response.body.data.name",
       `${appname} updated`,
     );
-    cy.get(homePage.toastMessage).should("contain", "Application name updated");
+    cy.get(homePage.toastMessage).should(
+      "contain",
+      Cypress.env("MESSAGES").APPLICATION_NAME_UPDATE(),
+    );
   });
 
   it("Updates the name of first application to very long name and checks whether update is reflected in the application card with a popover", function() {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_API_with_List_Widget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_API_with_List_Widget_spec.js
@@ -1,6 +1,5 @@
 const commonlocators = require("../../../../locators/commonlocators.json");
 const dsl = require("../../../../fixtures/listwidgetdsl.json");
-const pages = require("../../../../locators/Pages.json");
 const apiPage = require("../../../../locators/ApiEditor.json");
 const publishPage = require("../../../../locators/publishWidgetspage.json");
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_DatePicker_Text_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_DatePicker_Text_spec.js
@@ -126,7 +126,7 @@ describe("Binding the Datepicker and Text Widget", function() {
     cy.openPropertyPane("datepickerwidget");
     cy.get(commonlocators.onDateSelectedField).click();
     cy.get(commonlocators.singleSelectMenuItem)
-      .contains("Show message")
+      .contains(Cypress.env("MESSAGES").SHOW_MESSAGE())
       .click({ force: true });
     cy.getAlert(commonlocators.optionchangetextDatePicker);
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_JSObject_Postgress_Table_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_JSObject_Postgress_Table_spec.js
@@ -17,6 +17,7 @@ describe("Addwidget from Query and bind with other widgets", function() {
   beforeEach(() => {
     cy.startRoutesForDatasource();
   });
+
   it("Create a query and populate response by choosing addWidget and validate in Table Widget", () => {
     cy.createPostgresDatasource();
     cy.get("@createDatasource").then((httpResponse) => {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/ButtonWidgets_NavigateTo_validation_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/ButtonWidgets_NavigateTo_validation_spec.js
@@ -18,7 +18,7 @@ describe("Binding the button Widgets and validating NavigateTo Page functionalit
     cy.get(widgetsPage.actionSelect).click();
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("Navigate to")
+      .contains(Cypress.env("MESSAGES").NAVIGATE_TO())
       .click();
     cy.enterNavigatePageName(testdata.externalPage);
     cy.get(commonlocators.editPropCrossButton).click({ force: true });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/InputWidgets_NavigateTo_validation_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/InputWidgets_NavigateTo_validation_spec.js
@@ -19,7 +19,7 @@ describe("Binding the multiple Widgets and validating NavigateTo Page", function
       .click({ force: true });
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("Navigate to")
+      .contains(Cypress.env("MESSAGES").NAVIGATE_TO())
       .click();
     cy.enterNavigatePageName(pageid);
     cy.get(commonlocators.editPropCrossButton).click({ force: true });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/TableWidgets_NavigateTo_Validation_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/TableWidgets_NavigateTo_Validation_spec.js
@@ -20,7 +20,7 @@ describe("Table Widget and Navigate to functionality validation", function() {
     cy.get(widgetsPage.tableOnRowSelect).click();
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("Navigate to")
+      .contains(Cypress.env("MESSAGES").NAVIGATE_TO())
       .click();
     cy.enterNavigatePageName(pageid);
     cy.get(commonlocators.editPropCrossButton).click({ force: true });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Widget_loading_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Widget_loading_spec.js
@@ -36,6 +36,7 @@ describe("Binding the multiple widgets and validating default data", function() 
       datasourceName = httpResponse.response.body.data.name;
     });
   });
+
   it("Create and runs query", () => {
     cy.NavigateToQueryEditor();
     cy.contains(".t--datasource-name", datasourceName)

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/aTobAndbToaBasictest_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/aTobAndbToaBasictest_spec.js
@@ -1,8 +1,5 @@
 const commonlocators = require("../../../../locators/commonlocators.json");
-const formWidgetsPage = require("../../../../locators/FormWidgets.json");
 const dsl = require("../../../../fixtures/inputBindingdsl.json");
-const pages = require("../../../../locators/Pages.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const testdata = require("../../../../fixtures/testdata.json");
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
@@ -55,7 +55,7 @@ describe("Comments", function() {
     });
     cy.get(commonLocators.canvas);
     cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
-    cy.contains("SKIP").click({ force: true });
+    cy.contains(Cypress.env("MESSAGES").SKIP()).click({ force: true });
     cy.get("input[name='displayName']").type("Skip User");
     cy.get("button[type='submit']").click();
 
@@ -149,7 +149,7 @@ describe("Comments", function() {
       force: true,
     });
     // this is needed, as on CI we create new users
-    cy.contains("SKIP").click({ force: true });
+    cy.contains(Cypress.env("MESSAGES").SKIP()).click({ force: true });
     cy.get("input[name='displayName']").type("Skip User");
     cy.get("button[type='submit']").click();
     cy.get(

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/UnsubscribeEmail_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/UnsubscribeEmail_spec.js
@@ -3,10 +3,9 @@
 describe("Unsubscribe comment email test spec", function() {
   it("User can access unsubscribe page", function() {
     cy.visit("/unsubscribe/discussion/123456");
-    cy.contains("Unsubscribe");
     cy.get("button")
-      .contains("Unsubscribe me")
+      .contains(Cypress.env("MESSAGES").UNSUBSCRIBE_BUTTON_LABEL())
       .click();
-    cy.contains("successfully unsubscribed");
+    cy.contains(Cypress.env("MESSAGES").UNSUBSCRIBE_EMAIL_SUCCESS());
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Image_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Image_spec.js
@@ -66,6 +66,7 @@ describe("Image Widget Functionality", function() {
     cy.get(publish.imageWidget).should("be.visible");
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Map_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Map_spec.js
@@ -53,7 +53,7 @@ if (Cypress.env("APPSMITH_GOOGLE_MAPS_API_KEY")) {
       cy.get(viewWidgetsPage.mapSearch).should("be.visible");
       cy.get(viewWidgetsPage.mapSearch)
         .invoke("attr", "placeholder")
-        .should("contain", "Enter location to search");
+        .should("contain", Cypress.env("MESSAGES").MAP_WIDGET_PLACEHOLDER());
       /**
        * Enable the Pick Location checkbox and Validate the same in editor mode
        */
@@ -75,7 +75,7 @@ if (Cypress.env("APPSMITH_GOOGLE_MAPS_API_KEY")) {
       cy.get(publishPage.mapSearch).should("be.visible");
       cy.get(publishPage.mapSearch)
         .invoke("attr", "placeholder")
-        .should("contain", "Enter location to search");
+        .should("contain", Cypress.env("MESSAGES").MAP_WIDGET_PLACEHOLDER());
       cy.get(publishPage.pickMyLocation).should("exist");
       cy.get(publishPage.backToEditor).click();
     });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
@@ -23,7 +23,7 @@ describe("Table Widget property pane feature validation", function() {
     cy.get(widgetsPage.actionSelect).click();
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("Show message")
+      .contains(Cypress.env("MESSAGES").SHOW_MESSAGE())
       .click();
     cy.addSuccessMessage("Successful ".concat(testdata.currentRowEmail));
     // Close Property pane
@@ -143,7 +143,7 @@ describe("Table Widget property pane feature validation", function() {
     cy.get(widgetsPage.actionSelect).click();
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("Show message")
+      .contains(Cypress.env("MESSAGES").SHOW_MESSAGE())
       .click();
     cy.addSuccessMessage("Successful ".concat(testdata.currentRowEmail));
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_spec.js
@@ -27,7 +27,7 @@ describe("Table Widget Functionality", function() {
     //   .click({ force: true })
     //   .get(commonlocators.dropdownmenu)
     //   .children()
-    //   .contains("Navigate to")
+    //   .contains(Cypress.env("MESSAGES").NAVIGATE_TO())
     //   .click();
     // cy.wait("@updateLayout");
     // cy.get(widgetsPage.tableOnRowSelected)

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Text_new_feature_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Text_new_feature_spec.js
@@ -126,6 +126,7 @@ describe("Text Widget color/font/alignment Functionality", function() {
     cy.get(commonlocators.headingTextStyle).scrollIntoView({ duration: 2000 });
     cy.closePropertyPane();
   });
+
   it("Test border width, color and verity", function() {
     cy.testJsontext("borderwidth", "10");
     cy.get(

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Tree_Select_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Tree_Select_spec.js
@@ -9,6 +9,7 @@ describe("Tree Select Widget", function() {
     cy.get(".widgets").click();
     cy.get(".t--entity-name:contains(MultiSelectTree1)").click();
   });
+
   it("Open Existing SingleSelectTree from created Widgets list", () => {
     cy.get(".widgets").click();
     cy.get(".t--entity-name:contains(SingleSelectTree1)").click();

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicInput/autocomplete_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicInput/autocomplete_spec.js
@@ -43,12 +43,13 @@ describe("Dynamic input autocomplete", () => {
           .then(() => {
             cy.get(".CodeMirror-Tern-tooltip").should(
               "have.text",
-              "No suggestions",
+              Cypress.env("MESSAGES").AUTOCOMPLETE_NO_SUGGESTIONS(),
             );
           });
       });
     cy.evaluateErrorMessage("ReferenceError: garbage is not defined");
   });
+
   it("opens current value popup", () => {
     // Test on api pane
     cy.NavigateToAPI_Panel();

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicLayout/DynamicLayout_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DynamicLayout/DynamicLayout_spec.js
@@ -19,6 +19,7 @@ describe("Dynamic Layout Functionality", function() {
       .invoke("width")
       .should("be.eq", 450);
   });
+
   it("Dynamic Layout - New Page should have selected Layout", function() {
     cy.get(pages.AddPage)
       .first()

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
@@ -37,7 +37,10 @@ describe("Entity explorer tests related to query and datasource", function() {
       .clear()
       .type("download", { force: true })
       .blur();
-    cy.get(".Toastify").should("contain", "Invalid name");
+    cy.get(".Toastify").should(
+      "contain",
+      Cypress.env("MESSAGES").EDITOR_INVALID_NAME(),
+    );
 
     // checking a valid name
     cy.get(".t--edit-datasource-name").click();

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_spec.js
@@ -61,7 +61,11 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
   it("Datepicker default date validation message", function() {
     cy.openPropertyPane("datepickerwidget2");
     cy.testJsontext("defaultdate", "24-12-2021");
-    cy.evaluateErrorMessage("Value does not match: ISO 8601 date string");
+    cy.evaluateErrorMessage(
+      `Value does not match: ${Cypress.env(
+        "MESSAGES",
+      ).VALIDATION_ISO_8601_DATE_STRING()}`,
+    );
     cy.closePropertyPane();
   });
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_With_Switch_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_With_Switch_spec.js
@@ -10,6 +10,7 @@ describe("Switch Widget within Form widget Functionality", function() {
   before(() => {
     cy.addDsl(dsl);
   });
+
   it("Switch Widget Functionality check with success message", function() {
     cy.openPropertyPane("switchwidget");
     cy.widgetText(
@@ -34,7 +35,7 @@ describe("Switch Widget within Form widget Functionality", function() {
     cy.get(widgetsPage.actionSelect).click();
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("Reset widget")
+      .contains(Cypress.env("MESSAGES").RESET_WIDGET())
       .click();
     cy.get(widgetsPage.selectWidget).click({ force: true });
     cy.get(commonlocators.chooseAction)

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Dropdown_onOptionChange_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Dropdown_onOptionChange_spec.js
@@ -161,7 +161,7 @@ describe("Dropdown Widget Functionality", function() {
       .click();
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("No action")
+      .contains(Cypress.env("MESSAGES").NO_ACTION())
       .click();
   });
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FilePicker_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FilePicker_spec.js
@@ -40,7 +40,9 @@ describe("FilePicker Widget Functionality", function() {
     cy.get(".bp3-spinner").should("have.length", 1);
     //eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500);
-    cy.get("button").contains("1 files selected");
+    cy.get("button").contains(
+      Cypress.env("MESSAGES").FILEPICKER_WIDGET_FILES_SELECTED(1),
+    );
   });
 
   it("It checks the deletion of filepicker works as expected", function() {
@@ -51,7 +53,9 @@ describe("FilePicker Widget Functionality", function() {
     cy.get(commonlocators.filePickerUploadButton).click();
     //eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500);
-    cy.get("button").contains("1 files selected");
+    cy.get("button").contains(
+      Cypress.env("MESSAGES").FILEPICKER_WIDGET_FILES_SELECTED(1),
+    );
     cy.get(commonlocators.filePickerButton).click();
     //eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(200);
@@ -63,7 +67,9 @@ describe("FilePicker Widget Functionality", function() {
     cy.get(commonlocators.filePickerUploadButton).click();
     //eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500);
-    cy.get("button").contains("1 files selected");
+    cy.get("button").contains(
+      Cypress.env("MESSAGES").FILEPICKER_WIDGET_FILES_SELECTED(1),
+    );
   });
 
   afterEach(() => {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FormWidget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FormWidget_spec.js
@@ -10,6 +10,7 @@ describe("Form Widget Functionality", function() {
   before(() => {
     cy.addDsl(dsl);
   });
+
   it("Defult Form text,  Reset and Close button Validation", function() {
     cy.get(widgetsPage.textWidget).should("be.visible");
     cy.get(widgetsPage.formButtonWidget)
@@ -21,6 +22,7 @@ describe("Form Widget Functionality", function() {
       .scrollIntoView()
       .should("be.visible");
   });
+
   it("Add Multiple widgets in Form", function() {
     cy.get(explorer.addWidget).click();
     cy.get(commonlocators.entityExplorersearch).should("be.visible");
@@ -33,6 +35,7 @@ describe("Form Widget Functionality", function() {
     cy.get(widgetsPage.inputWidget).should("be.visible");
     cy.PublishtheApp();
   });
+
   it("Form_Widget Minimize and maximize General Validation", function() {
     cy.openPropertyPane("formwidget");
     cy.get(commonlocators.generalChevran).click({ force: true });
@@ -41,12 +44,14 @@ describe("Form Widget Functionality", function() {
     cy.get(commonlocators.generalSection).should("be.visible");
     cy.PublishtheApp();
   });
+
   it("Rename Form widget from Entity Explorer", function() {
     cy.GlobalSearchEntity("Form1");
     cy.RenameEntity("Form");
     cy.wait(1000);
     cy.get(".t--entity").should("contain", "Form");
   });
+
   it("Form Widget Functionality", function() {
     cy.openPropertyPane("formwidget");
     /**
@@ -83,12 +88,14 @@ describe("Form Widget Functionality", function() {
     // Close the form propert pane
     cy.get(commonlocators.editPropCrossButton).click({ force: true });
   });
+
   it("Form Widget Functionality To Verify The Colour", function() {
     cy.PublishtheApp();
     cy.get(formWidgetsPage.formD)
       .should("have.css", "background-color")
       .and("eq", "rgb(3, 179, 101)");
   });
+
   it("Form Widget Functionality To Unchecked Visible Widget", function() {
     cy.openPropertyPane("formwidget");
     // Uncheck the visble JS
@@ -98,6 +105,7 @@ describe("Form Widget Functionality", function() {
     cy.get(publish.formWidget).should("not.exist");
     cy.get(publish.backToEditor).click();
   });
+
   it("Form Widget Functionality To Check Visible Widget", function() {
     // Open property pone
     cy.openPropertyPane("formwidget");
@@ -108,6 +116,7 @@ describe("Form Widget Functionality", function() {
     cy.get(publish.formWidget).should("be.visible");
     cy.get(publish.backToEditor).click();
   });
+
   it("Toggle JS - Form-Unckeck Visible field Validation", function() {
     cy.openPropertyPane("formwidget");
     //Uncheck the disabled checkbox using JS and validate
@@ -150,6 +159,7 @@ describe("Form Widget Functionality", function() {
   });
   */
 });
+
 afterEach(() => {
   // put your clean up code if any
   cy.goToEditFromPublish();

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FormWithSwitch_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/FormWithSwitch_spec.js
@@ -29,14 +29,14 @@ describe("Switch Widget within Form widget Functionality", function() {
     cy.closePropertyPane();
   });
 
-  it("Form reset button valdiation with switch widget", function() {
+  it("Form reset button validation with switch widget", function() {
     // Open form button
     cy.SearchEntityandOpen("FormButton2");
     // Click on reset widget action
     cy.get(widgetsPage.actionSelect).click();
     cy.get(commonlocators.chooseAction)
       .children()
-      .contains("Reset widget")
+      .contains(Cypress.env("MESSAGES").RESET_WIDGET())
       .click();
     // click on toggler from actions
     cy.get(widgetsPage.selectWidget).click({ force: true });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Form_With_CheckBox_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Form_With_CheckBox_spec.js
@@ -44,6 +44,7 @@ describe("Checkbox Widget Functionality", function() {
     cy.get(publish.backToEditor).click();
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Input_MaxChar_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Input_MaxChar_spec.js
@@ -11,7 +11,7 @@ describe("Input Widget Max Char Functionality", function() {
     cy.get(widgetsPage.innertext).click();
     cy.get(".bp3-popover-content").should(($x) => {
       expect($x).contain(
-        "Default Text length must be less than Max Chars allowed",
+        Cypress.env("MESSAGES").INPUT_DEFAULT_TEXT_MAX_CHAR_ERROR(),
       );
     });
   });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Input_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Input_spec.js
@@ -70,6 +70,7 @@ describe("Input Widget Functionality", function() {
     );
     cy.PublishtheApp();
   });
+
   it("Input Widget Functionality To Validate Default Text and Placeholder", function() {
     cy.get(publish.inputWidget + " " + "input")
       .invoke("attr", "value")
@@ -79,6 +80,7 @@ describe("Input Widget Functionality", function() {
       .should("contain", this.data.placeholder);
     cy.get(publish.backToEditor).click({ force: true });
   });
+
   it("Input Widget Functionality To Check Disabled Widget", function() {
     cy.openPropertyPane("inputwidget");
     cy.togglebar(commonlocators.Disablejs + " " + "input");
@@ -86,6 +88,7 @@ describe("Input Widget Functionality", function() {
     cy.get(publish.inputWidget + " " + "input").should("be.disabled");
     cy.get(publish.backToEditor).click({ force: true });
   });
+
   it("Input Widget Functionality To Check Enabled Widget", function() {
     cy.openPropertyPane("inputwidget");
     cy.togglebarDisable(commonlocators.Disablejs + " " + "input");
@@ -93,6 +96,7 @@ describe("Input Widget Functionality", function() {
     cy.get(publish.inputWidget + " " + "input").should("be.enabled");
     cy.get(publish.backToEditor).click({ force: true });
   });
+
   it("Input Functionality To Unchecked Visible Widget", function() {
     cy.openPropertyPane("inputwidget");
     cy.togglebarDisable(commonlocators.visibleCheckbox);
@@ -100,6 +104,7 @@ describe("Input Widget Functionality", function() {
     cy.get(publish.inputWidget + " " + "input").should("not.exist");
     cy.get(publish.backToEditor).click({ force: true });
   });
+
   it("Input Functionality To Check Visible Widget", function() {
     cy.openPropertyPane("inputwidget");
     cy.togglebar(commonlocators.visibleCheckbox);
@@ -215,6 +220,7 @@ describe("Input Widget Functionality", function() {
       });
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/MultiSelect_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/MultiSelect_spec.js
@@ -10,6 +10,7 @@ describe("MultiSelect Widget Functionality", function() {
   before(() => {
     cy.addDsl(dsl);
   });
+
   it("Selects value with invalid default value", () => {
     cy.openPropertyPane("multiselectwidget");
     cy.testJsontext("options", JSON.stringify(data.input));
@@ -28,6 +29,7 @@ describe("MultiSelect Widget Functionality", function() {
       .first()
       .should("have.text", "Option 3");
   });
+
   it("Selects value with enter in default value", () => {
     cy.testJsontext("defaultvalue", "3\n");
     cy.get(formWidgetsPage.multiselectWidget)
@@ -35,11 +37,13 @@ describe("MultiSelect Widget Functionality", function() {
       .first()
       .should("have.text", "Option 3");
   });
+
   it("Dropdown Functionality To Validate Options", function() {
     cy.get(formWidgetsPage.mulitiselectInput).click({ force: true });
     cy.get(formWidgetsPage.mulitiselectInput).type("Option");
     cy.dropdownMultiSelectDynamic("Option 2");
   });
+
   it("Dropdown Functionality To Unchecked Visible Widget", function() {
     cy.togglebarDisable(commonlocators.visibleCheckbox);
     cy.PublishtheApp();
@@ -48,6 +52,7 @@ describe("MultiSelect Widget Functionality", function() {
     );
     cy.get(publish.backToEditor).click();
   });
+
   it("Dropdown Functionality To Check Visible Widget", function() {
     cy.openPropertyPane("multiselectwidget");
     cy.togglebar(commonlocators.visibleCheckbox);
@@ -58,6 +63,7 @@ describe("MultiSelect Widget Functionality", function() {
     cy.get(publish.backToEditor).click();
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Multi_Select_Tree_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Multi_Select_Tree_spec.js
@@ -7,6 +7,7 @@ describe("MultiSelectTree Widget Functionality", function() {
   before(() => {
     cy.addDsl(dsl);
   });
+
   it("Selects value with enter in default value", () => {
     cy.openPropertyPane("multiselecttreewidget");
     cy.testJsontext("defaultvalue", "RED\n");
@@ -15,6 +16,7 @@ describe("MultiSelectTree Widget Functionality", function() {
       .first()
       .should("have.text", "Red");
   });
+
   it(" To Validate Options", function() {
     cy.get(formWidgetsPage.treeSelectInput)
       .first()
@@ -24,6 +26,7 @@ describe("MultiSelectTree Widget Functionality", function() {
       .type("light");
     cy.treeSelectDropdown("Light Blue");
   });
+
   it("To Unchecked Visible Widget", function() {
     cy.togglebarDisable(commonlocators.visibleCheckbox);
     cy.PublishtheApp();
@@ -32,6 +35,7 @@ describe("MultiSelectTree Widget Functionality", function() {
     ).should("not.exist");
     cy.get(publish.backToEditor).click();
   });
+
   it(" To Check Visible Widget", function() {
     cy.openPropertyPane("multiselecttreewidget");
     cy.togglebar(commonlocators.visibleCheckbox);
@@ -42,6 +46,7 @@ describe("MultiSelectTree Widget Functionality", function() {
     cy.get(publish.backToEditor).click();
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Radio_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Radio_spec.js
@@ -52,6 +52,7 @@ describe("Radio Widget Functionality", function() {
       .type("2");
     cy.PublishtheApp();
   });
+
   it("Radio Functionality To Unchecked Visible Widget", function() {
     cy.get(publish.backToEditor).click();
     cy.openPropertyPane("radiogroupwidget");
@@ -60,12 +61,14 @@ describe("Radio Widget Functionality", function() {
     cy.get(publish.radioWidget + " " + "input").should("not.exist");
     cy.get(publish.backToEditor).click();
   });
+
   it("Radio Functionality To Check Visible Widget", function() {
     cy.openPropertyPane("radiogroupwidget");
     cy.togglebar(commonlocators.visibleCheckbox);
     cy.PublishtheApp();
     cy.get(publish.radioWidget + " " + "input").should("be.checked");
   });
+
   it("Radio Functionality To Button Text", function() {
     cy.get(publish.radioWidget + " " + "label")
       .eq(1)
@@ -73,6 +76,7 @@ describe("Radio Widget Functionality", function() {
     cy.get(publish.backToEditor).click();
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Single_Select_Tree_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Single_Select_Tree_spec.js
@@ -7,6 +7,7 @@ describe("MultiSelectTree Widget Functionality", function() {
   before(() => {
     cy.addDsl(dsl);
   });
+
   it("Selects value with enter in default value", () => {
     cy.openPropertyPane("singleselecttreewidget");
     cy.testJsontext("defaultvalue", "RED\n");
@@ -15,6 +16,7 @@ describe("MultiSelectTree Widget Functionality", function() {
       .first()
       .should("have.text", "Red");
   });
+
   it(" To Validate Options", function() {
     cy.get(formWidgetsPage.treeSelectInput)
       .last()
@@ -24,6 +26,7 @@ describe("MultiSelectTree Widget Functionality", function() {
       .type("light");
     cy.treeSelectDropdown("Light Blue");
   });
+
   it("To Unchecked Visible Widget", function() {
     cy.togglebarDisable(commonlocators.visibleCheckbox);
     cy.PublishtheApp();
@@ -32,6 +35,7 @@ describe("MultiSelectTree Widget Functionality", function() {
     ).should("not.exist");
     cy.get(publish.backToEditor).click();
   });
+
   it(" To Check Visible Widget", function() {
     cy.openPropertyPane("singleselecttreewidget");
     cy.togglebar(commonlocators.visibleCheckbox);
@@ -42,6 +46,7 @@ describe("MultiSelectTree Widget Functionality", function() {
     cy.get(publish.backToEditor).click();
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Switch_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Switch_spec.js
@@ -10,6 +10,7 @@ describe("Switch Widget Functionality", function() {
   before(() => {
     cy.addDsl(dsl);
   });
+
   it("Switch Widget Functionality", function() {
     cy.openPropertyPane("switchwidget");
     /**
@@ -37,6 +38,7 @@ describe("Switch Widget Functionality", function() {
     cy.getAlert(commonlocators.optionchangetextSwitch);
     cy.PublishtheApp();
   });
+
   it("Switch Functionality To Switch Label", function() {
     cy.get(publish.switchwidget + " " + "label").should(
       "have.text",
@@ -44,6 +46,7 @@ describe("Switch Widget Functionality", function() {
     );
     cy.get(publish.backToEditor).click();
   });
+
   it("Switch Functionality To Check Disabled Widget", function() {
     cy.openPropertyPane("switchwidget");
     cy.togglebar(commonlocators.Disablejs + " " + "input");
@@ -51,6 +54,7 @@ describe("Switch Widget Functionality", function() {
     cy.get(publish.switchwidget + " " + "input").should("be.disabled");
     cy.get(publish.backToEditor).click();
   });
+
   it("Switch Functionality To Check Enabled Widget", function() {
     cy.openPropertyPane("switchwidget");
     cy.togglebarDisable(commonlocators.Disablejs + " " + "input");
@@ -58,6 +62,7 @@ describe("Switch Widget Functionality", function() {
     cy.get(publish.switchwidget + " " + "input").should("be.enabled");
     cy.get(publish.backToEditor).click();
   });
+
   it("Switch Functionality To Unchecked Visible Widget", function() {
     cy.openPropertyPane("switchwidget");
     cy.togglebarDisable(commonlocators.visibleCheckbox);
@@ -65,6 +70,7 @@ describe("Switch Widget Functionality", function() {
     cy.get(publish.switchwidget + " " + "input").should("not.exist");
     cy.get(publish.backToEditor).click();
   });
+
   it("Switch Functionality To Check Visible Widget", function() {
     cy.openPropertyPane("switchwidget");
     cy.togglebar(commonlocators.visibleCheckbox);
@@ -87,6 +93,7 @@ describe("Switch Widget Functionality", function() {
     cy.get(publish.backToEditor).click();
   });
 });
+
 afterEach(() => {
   // put your clean up code if any
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GenerateCRUD/Postgres_CRUD_Spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GenerateCRUD/Postgres_CRUD_Spec.js
@@ -3,6 +3,8 @@ const generatePage = require("../../../../locators/GeneratePage.json");
 import homePage from "../../../../locators/HomePage.json";
 import datasource from "../../../../locators/DatasourcesEditor.json";
 
+import { FAKE_DATASOURCE_OPTION } from "../../../../../src/pages/Editor/GeneratePage/components/GeneratePageForm/hooks";
+
 describe("Generate New CRUD Page Inside from entity explorer", function() {
   let datasourceName;
 
@@ -87,7 +89,9 @@ describe("Generate New CRUD Page Inside from entity explorer", function() {
 
     cy.get(generatePage.selectDatasourceDropdown).click();
 
-    cy.contains("Connect New Datasource").click();
+    cy.contains(
+      FAKE_DATASOURCE_OPTION.CONNECT_NEW_DATASOURCE_OPTION.label,
+    ).click();
 
     cy.get(datasource.PostgreSQL).click();
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/LayoutWidgets/Container_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/LayoutWidgets/Container_spec.js
@@ -53,6 +53,7 @@ describe("Container Widget Functionality", function() {
     cy.get(commonlocators.editPropCrossButton).click({ force: true });
     cy.PublishtheApp();
   });
+
   it("Container Widget Functionality To Verify The Colour", function() {
     cy.get(widgetsPage.containerD)
       .eq(0)

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/LayoutWidgets/Tab_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/LayoutWidgets/Tab_spec.js
@@ -52,6 +52,7 @@ describe("Tab widget test", function() {
     cy.get(commonlocators.crossbutton).click({ force: true });
     cy.PublishtheApp();
   });
+
   it("Tab Widget Functionality To Select Tabs", function() {
     cy.get(publish.tabWidget)
       .contains(this.data.tabName)
@@ -59,6 +60,7 @@ describe("Tab widget test", function() {
       .should("be.selected");
     cy.get(publish.backToEditor).click();
   });
+
   it("Tab Widget Functionality To Unchecked Visible Widget", function() {
     cy.openPropertyPane("tabswidget");
     cy.togglebarDisable(commonlocators.visibleCheckbox);
@@ -66,6 +68,7 @@ describe("Tab widget test", function() {
     cy.get(publish.tabWidget).should("not.exist");
     cy.get(publish.backToEditor).click();
   });
+
   it("Tab Widget Functionality To Check Visible Widget", function() {
     cy.openPropertyPane("tabswidget");
     cy.togglebar(commonlocators.visibleCheckbox);

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/Onboarding_spec.js
@@ -2,6 +2,10 @@
 // const explorer = require("../../../../locators/explorerlocators.json");
 const homePage = require("../../../../locators/HomePage.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
+import {
+  OnboardingConfig,
+  OnboardingStep,
+} from "../../../../../src/constants/OnboardingConstants.tsx";
 
 describe("Onboarding", function() {
   it("Onboarding flow - manual without using do it for me option", function() {
@@ -78,12 +82,14 @@ describe("Onboarding", function() {
         cy.dragAndDropToCanvas("inputwidget", { x: 360, y: 40 });
         cy.get(".t--property-control-onsubmit .t--open-dropdown-Select-Action")
           .click({ force: true })
-          .selectOnClickOption("Execute a query")
-          .selectOnClickOption("Create New Query");
+          .selectOnClickOption(Cypress.env("MESSAGES").EXECUTE_A_QUERY())
+          .selectOnClickOption(
+            Cypress.env("MESSAGES").LIGHTNING_MENU_QUERY_CREATE_NEW(),
+          );
 
         cy.contains(
           ".t--onboarding-helper-title",
-          "Deploy the Standup Dashboard",
+          OnboardingConfig[OnboardingStep.DEPLOY].helper.title,
         );
         cy.get(".t--close--button").should("not.exist");
       });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OrganisationTests/LeaveOrganizationTest_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OrganisationTests/LeaveOrganizationTest_spec.js
@@ -14,7 +14,7 @@ describe("Leave organization test spec", function() {
       newOrgId = interception.response.body.data.name;
       cy.visit("/applications");
       cy.openOrgOptionsPopup(newOrganizationName);
-      cy.contains("Leave Organization");
+      cy.contains(Cypress.env("MESSAGES").ORGANIZATION_LEAVE_ORGANIZATION());
     });
   });
 
@@ -26,8 +26,10 @@ describe("Leave organization test spec", function() {
       newOrgId = interception.response.body.data.name;
       cy.visit("/applications");
       cy.openOrgOptionsPopup(newOrganizationName);
-      cy.contains("Leave Organization").click();
-      cy.contains("Are you sure").click();
+      cy.contains(
+        Cypress.env("MESSAGES").ORGANIZATION_LEAVE_ORGANIZATION(),
+      ).click();
+      cy.contains(Cypress.env("MESSAGES").ORGANIZATION_ARE_YOU_SURE()).click();
       cy.wait("@leaveOrgApiCall").then((httpResponse) => {
         expect(httpResponse.status).to.equal(400);
       });
@@ -56,7 +58,7 @@ describe("Leave organization test spec", function() {
         .find("a")
         .should("have.length", 1)
         .first()
-        .contains("Leave Organization");
+        .contains(Cypress.env("MESSAGES").ORGANIZATION_LEAVE_ORGANIZATION());
     });
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OrganisationTests/OrgImportApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OrganisationTests/OrgImportApplication_spec.js
@@ -55,7 +55,7 @@ describe("Organization Import Application", function() {
               );
               cy.get(homePage.toastMessage).should(
                 "contain",
-                "Application imported successfully",
+                Cypress.env("MESSAGES").APPLICATION_IMPORTED_SUCCESSFULLY(),
               );
               cy.url().should(
                 "include",

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Page_Load_Spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Page_Load_Spec.js
@@ -13,8 +13,9 @@ describe("Page Load tests", () => {
 
     cy.skipGenerateCRUDPage();
 
-    cy.get("h2").contains("Drag and drop a widget here");
+    cy.get("h2").contains(Cypress.env("MESSAGES").DRAG_AND_DROP_TEXT());
   });
+
   it("Published page loads correctly", () => {
     //add page within page
     cy.addDsl(dsl);
@@ -66,6 +67,7 @@ describe("Page Load tests", () => {
       "This is Page 1",
     );
   });
+
   it("Hide Page and validate published app", () => {
     cy.get(publish.backToEditor).click();
     cy.GlobalSearchEntity("Page1");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Pages_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Pages_spec.js
@@ -45,7 +45,7 @@ describe("Pages", function() {
   it("Checks if 404 is showing correct route", () => {
     cy.visit("/route-that-does-not-exist");
     cy.get(".bold-text").should(($x) => {
-      expect($x).contain("Page not found");
+      expect($x).contain(Cypress.env("MESSAGES").PAGE_NOT_FOUND());
     });
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ProductUpdates/ProductUpdates_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ProductUpdates/ProductUpdates_spec.js
@@ -17,7 +17,9 @@ describe("Check for product updates button and modal", function() {
             .click({ force: true });
           //eslint-disable-next-line cypress/no-unnecessary-waiting
           cy.wait(500); // modal transition
-          cy.get(".bp3-dialog-container").contains("Product Updates");
+          cy.get(".bp3-dialog-container").contains(
+            Cypress.env("MESSAGES").PRODUCT_UPDATES_TITLE(),
+          );
           cy.get("[data-cy=t--product-updates-close-btn]").click({
             force: true,
           });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/ShareAppTests_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/ShareAppTests_spec.js
@@ -26,7 +26,7 @@ describe("Create new org and share with a user", function() {
         "response.body.responseMeta.status",
         200,
       );
-      cy.get("h2").contains("Drag and drop a widget here");
+      cy.get("h2").contains(Cypress.env("MESSAGES").DRAG_AND_DROP_TEXT());
       cy.get(homePage.shareApp).click({ force: true });
       cy.shareApp(Cypress.env("TESTUSERNAME1"), homePage.viewerRole);
     });
@@ -62,7 +62,7 @@ describe("Create new org and share with a user", function() {
       "response.body.responseMeta.status",
       200,
     );
-    cy.get("h2").contains("Drag and drop a widget here");
+    cy.get("h2").contains(Cypress.env("MESSAGES").DRAG_AND_DROP_TEXT());
     cy.get(homePage.shareApp).click();
     cy.enablePublicAccess();
     cy.PublishtheApp();
@@ -124,7 +124,7 @@ describe("Create new org and share with a user", function() {
       "response.body.responseMeta.status",
       200,
     );
-    cy.get("h2").contains("Drag and drop a widget here");
+    cy.get("h2").contains(Cypress.env("MESSAGES").DRAG_AND_DROP_TEXT());
     cy.get(homePage.shareApp).click();
     cy.enablePublicAccess();
     cy.LogOut();

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -996,7 +996,9 @@ Cypress.Commands.add("CreationOfUniqueAPIcheck", (apiname) => {
     .type(apiname, { force: true, delay: 500 })
     .should("have.value", apiname);
   cy.get(".error-message").should(($x) => {
-    expect($x).contain(apiname.concat(" is already being used."));
+    expect($x).contain(
+      Cypress.env("MESSAGES").VALIDATION_ALREADY_BEING_USED(apiname),
+    );
   });
   cy.get(apiwidget.apiTxt).blur();
 });
@@ -1081,13 +1083,17 @@ Cypress.Commands.add("CreateApiAndValidateUniqueEntityName", (apiname) => {
     .type(apiname, { force: true })
     .should("have.value", apiname);
   cy.get(".t--nameOfApi .error-message").should(($x) => {
-    expect($x).contain(apiname.concat(" is already being used."));
+    expect($x).contain(
+      Cypress.env("MESSAGES").VALIDATION_ALREADY_BEING_USED(apiname),
+    );
   });
 });
 
 Cypress.Commands.add("validateMessage", (value) => {
   cy.get(".bp3-popover-content").should(($x) => {
-    expect($x).contain(value.concat(" is already being used."));
+    expect($x).contain(
+      Cypress.env("MESSAGES").VALIDATION_ALREADY_BEING_USED(value),
+    );
   });
 });
 
@@ -1150,7 +1156,7 @@ Cypress.Commands.add("AddActionWithModal", () => {
     .last()
     .click();
   cy.get(".single-select")
-    .contains("Open modal")
+    .contains(Cypress.env("MESSAGES").OPEN_MODAL())
     .click({ force: true });
   cy.get(modalWidgetPage.selectModal).click();
   cy.get(modalWidgetPage.createModalButton).click({ force: true });
@@ -1161,7 +1167,7 @@ Cypress.Commands.add("createModal", (ModalName) => {
   cy.get(widgetsPage.actionSelect)
     .first()
     .click({ force: true });
-  cy.selectOnClickOption("Open modal");
+  cy.selectOnClickOption(Cypress.env("MESSAGES").OPEN_MODAL());
   cy.get(modalWidgetPage.selectModal).click();
   cy.get(modalWidgetPage.createModalButton).click({ force: true });
 
@@ -1261,11 +1267,14 @@ Cypress.Commands.add("editColName", (text) => {
 
 Cypress.Commands.add("invalidWidgetText", () => {
   // checking invalid widget name
+  const widgetName = "download";
   cy.get(commonlocators.editWidgetName)
     .click({ force: true })
-    .type("download")
+    .type(widgetName)
     .type("{enter}");
-  cy.get(commonlocators.toastmsg).contains("download is already being used.");
+  cy.get(commonlocators.toastmsg).contains(
+    Cypress.env("MESSAGES").VALIDATION_ALREADY_BEING_USED(widgetName),
+  );
 });
 
 Cypress.Commands.add("EvaluateDataType", (dataType) => {
@@ -1590,7 +1599,7 @@ Cypress.Commands.add("addAction", (value) => {
     .click();
   cy.get(commonlocators.chooseAction)
     .children()
-    .contains("Show message")
+    .contains(Cypress.env("MESSAGES").SHOW_MESSAGE())
     .click();
   cy.enterActionValue(value);
 });
@@ -1601,7 +1610,7 @@ Cypress.Commands.add("onTableAction", (value, value1, value2) => {
     .click();
   cy.get(commonlocators.chooseAction)
     .children()
-    .contains("Show message")
+    .contains(Cypress.env("MESSAGES").SHOW_MESSAGE())
     .click();
   cy.testJsontext(value1, value2);
 });
@@ -1609,7 +1618,7 @@ Cypress.Commands.add("onTableAction", (value, value1, value2) => {
 Cypress.Commands.add("selectShowMsg", () => {
   cy.get(commonlocators.chooseAction)
     .children()
-    .contains("Show message")
+    .contains(Cypress.env("MESSAGES").SHOW_MESSAGE())
     .click();
 });
 
@@ -1867,7 +1876,7 @@ Cypress.Commands.add("getAlert", (alertcss) => {
   cy.get(widgetsPage.menubar)
     .contains("Show Alert")
     .click({ force: true })
-    .should("have.text", "Show Alert");
+    .should("have.text", "d");
 
   cy.get(alertcss)
     .click({ force: true })
@@ -1896,7 +1905,7 @@ Cypress.Commands.add(
       .first()
       .click({ force: true });
     cy.get(widgetsPage.menubar)
-      .contains("Show message")
+      .contains(Cypress.env("MESSAGES").SHOW_MESSAGE())
       .click({ force: true });
 
     cy.get(alertcss)
@@ -1913,7 +1922,7 @@ Cypress.Commands.add("addQueryFromLightningMenu", (QueryName) => {
   cy.get(commonlocators.dropdownSelectButton)
     .first()
     .click({ force: true })
-    .selectOnClickOption("Execute a query")
+    .selectOnClickOption(Cypress.env("MESSAGES").EXECUTE_A_QUERY())
     .selectOnClickOption(QueryName);
 });
 
@@ -1921,7 +1930,7 @@ Cypress.Commands.add("addAPIFromLightningMenu", (ApiName) => {
   cy.get(commonlocators.dropdownSelectButton)
     .first()
     .click({ force: true })
-    .selectOnClickOption("Execute a query")
+    .selectOnClickOption(Cypress.env("MESSAGES").EXECUTE_A_QUERY())
     .selectOnClickOption(ApiName);
 });
 
@@ -2391,7 +2400,7 @@ Cypress.Commands.add("executeDbQuery", (queryName) => {
     .click({ force: true })
     .get("ul.bp3-menu")
     .children()
-    .contains("Execute a query")
+    .contains(Cypress.env("MESSAGES").EXECUTE_A_QUERY())
     .click({ force: true })
     .get("ul.bp3-menu")
     .children()
@@ -2475,10 +2484,10 @@ Cypress.Commands.add("onClickActions", (forSuccess, forFailure, endp) => {
   // For Success
   cy.get(".code-highlight", { timeout: 10000 })
     .children()
-    .contains("No action")
+    .contains(Cypress.env("MESSAGES").NO_ACTION())
     .first()
     .click({ force: true })
-    .selectOnClickOption("Show message")
+    .selectOnClickOption(Cypress.env("MESSAGES").SHOW_MESSAGE())
     .get("div.t--property-control-" + endp + " div.CodeMirror-lines")
     .click()
     .type(forSuccess)
@@ -2491,10 +2500,10 @@ Cypress.Commands.add("onClickActions", (forSuccess, forFailure, endp) => {
   // For Failure
   cy.get(".code-highlight")
     .children()
-    .contains("No action")
+    .contains(Cypress.env("MESSAGES").NO_ACTION())
     .last()
     .click({ force: true })
-    .selectOnClickOption("Show message")
+    .selectOnClickOption(Cypress.env("MESSAGES").SHOW_MESSAGE())
     .get("div.t--property-control-" + endp + " div.CodeMirror-lines")
     .last()
     .click()
@@ -2670,17 +2679,13 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("GET", "/api/v1/plugins").as("getPlugins");
   cy.route("POST", "/api/v1/logout").as("postLogout");
 
-  cy.route("GET", "/api/v1/datasources?organizationId=*").as(
-    "getDataSources",
-  );
+  cy.route("GET", "/api/v1/datasources?organizationId=*").as("getDataSources");
   cy.route("GET", "/api/v1/pages/application/*").as("getPagesForCreateApp");
   cy.route("GET", "/api/v1/applications/view/*").as("getPagesForViewApp");
 
   cy.route("POST");
   cy.route("GET", "/api/v1/pages/*").as("getPage");
-  cy.route("GET", "/api/v1/applications/*/pages/*/edit").as(
-    "getAppPageEdit",
-  );
+  cy.route("GET", "/api/v1/applications/*/pages/*/edit").as("getAppPageEdit");
   cy.route("GET", "/api/v1/actions*").as("getActions");
   cy.route("GET", "api/v1/providers/categories").as("getCategories");
   cy.route("GET", "api/v1/import/templateCollections").as(
@@ -2699,9 +2704,7 @@ Cypress.Commands.add("startServerAndRoutes", () => {
     "datasourceQuery",
   );
 
-  cy.route("PUT", "/api/v1/pages/crud-page/*").as(
-    "replaceLayoutWithCRUDPage",
-  );
+  cy.route("PUT", "/api/v1/pages/crud-page/*").as("replaceLayoutWithCRUDPage");
   cy.route("POST", "/api/v1/pages/crud-page").as("generateCRUDPage");
 
   cy.route("GET", "/api/v1/organizations").as("organizations");
@@ -2715,14 +2718,11 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("PUT", "/api/v1/actions/executeOnLoad/*").as("setExecuteOnLoad");
 
   cy.route("POST", "/api/v1/actions").as("createNewApi");
-  cy.route("POST", "/api/v1/import?type=CURL&pageId=*&name=*").as(
-    "curlImport",
-  );
+  cy.route("POST", "/api/v1/import?type=CURL&pageId=*&name=*").as("curlImport");
   cy.route("DELETE", "/api/v1/actions/*").as("deleteAction");
-  cy.route(
-    "GET",
-    "/api/v1/marketplace/providers?category=*&page=*&size=*",
-  ).as("get3PProviders");
+  cy.route("GET", "/api/v1/marketplace/providers?category=*&page=*&size=*").as(
+    "get3PProviders",
+  );
   cy.route("GET", "/api/v1/marketplace/templates?providerId=*").as(
     "get3PProviderTemplates",
   );
@@ -2732,17 +2732,13 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("POST", "/api/v1/datasources").as("createDatasource");
   cy.route("DELETE", "/api/v1/datasources/*").as("deleteDatasource");
   cy.route("DELETE", "/api/v1/applications/*").as("deleteApplication");
-  cy.route("POST", "/api/v1/applications/?orgId=*").as(
-    "createNewApplication",
-  );
+  cy.route("POST", "/api/v1/applications/?orgId=*").as("createNewApplication");
   cy.route("PUT", "/api/v1/applications/*").as("updateApplication");
   cy.route("PUT", "/api/v1/actions/*").as("saveAction");
   cy.route("PUT", "/api/v1/actions/move").as("moveAction");
 
   cy.route("POST", "/api/v1/organizations").as("createOrg");
-  cy.route("POST", "api/v1/applications/import/*").as(
-    "importNewApplication",
-  );
+  cy.route("POST", "api/v1/applications/import/*").as("importNewApplication");
   cy.route("GET", "api/v1/applications/export/*").as("exportApplication");
   cy.route("GET", "/api/v1/organizations/roles?organizationId=*").as(
     "getRoles",
@@ -2757,9 +2753,7 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("POST", "/api/v1/organizations/*/logo").as("updateLogo");
   cy.route("DELETE", "/api/v1/organizations/*/logo").as("deleteLogo");
   cy.route("POST", "/api/v1/applications/*/fork/*").as("postForkAppOrg");
-  cy.route("PUT", "/api/v1/users/leaveOrganization/*").as(
-    "leaveOrgApiCall",
-  );
+  cy.route("PUT", "/api/v1/users/leaveOrganization/*").as("leaveOrgApiCall");
 
   cy.route("POST", "/api/v1/comments/threads").as("createNewThread");
   cy.route("POST", "/api/v1/comments?threadId=*").as("createNewComment");
@@ -2767,16 +2761,10 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("POST", "api/v1/git/connect/*").as("connectGitRepo");
   cy.route("POST", "api/v1/git/commit/*").as("commit");
 
-  cy.route("PUT", "api/v1/collections/actions/refactor").as(
-    "renameJsAction",
-  );
+  cy.route("PUT", "api/v1/collections/actions/refactor").as("renameJsAction");
 
-  cy.route("POST", "/api/v1/collections/actions").as(
-    "createNewJSCollection",
-  );
-  cy.route("DELETE", "/api/v1/collections/actions/*").as(
-    "deleteJSCollection",
-  );
+  cy.route("POST", "/api/v1/collections/actions").as("createNewJSCollection");
+  cy.route("DELETE", "/api/v1/collections/actions/*").as("deleteJSCollection");
 
   cy.intercept("POST", "/api/v1/users/super").as("createSuperUser");
 });
@@ -2907,7 +2895,7 @@ Cypress.Commands.add("callApi", (apiname) => {
     .first()
     .click({ force: true });
   cy.get(commonlocators.singleSelectMenuItem)
-    .contains("Execute a query")
+    .contains(Cypress.env("MESSAGES").EXECUTE_A_QUERY())
     .click({ force: true });
   cy.get(commonlocators.selectMenuItem)
     .contains(apiname)

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -19,6 +19,7 @@ let appId;
 // Import commands.js using ES2015 syntax:
 import "./commands";
 import { initLocalstorage } from "./commands";
+import * as MESSAGES from "../../../app/client/src/constants/messages.ts";
 
 Cypress.on("uncaught:exception", (err, runnable) => {
   // returning false here prevents Cypress from
@@ -29,6 +30,9 @@ Cypress.on("uncaught:exception", (err, runnable) => {
 Cypress.on("fail", (error, runnable) => {
   throw error; // throw error to have test still fail
 });
+
+// Configure global MESSAGES variable
+Cypress.env("MESSAGES", MESSAGES);
 
 before(function() {
   initLocalstorage();

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -19,7 +19,7 @@ let appId;
 // Import commands.js using ES2015 syntax:
 import "./commands";
 import { initLocalstorage } from "./commands";
-import * as MESSAGES from "../../../app/client/src/constants/messages.ts";
+import * as MESSAGES from "../../../client/src/constants/messages.ts";
 
 Cypress.on("uncaught:exception", (err, runnable) => {
   // returning false here prevents Cypress from

--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -25,6 +25,10 @@ import { Classes } from "@blueprintjs/core";
 import { OnboardingStep } from "constants/OnboardingConstants";
 import log from "loglevel";
 import { JSCollectionData } from "reducers/entityReducers/jsActionsReducer";
+import {
+  VALIDATION_ALREADY_BEING_USED,
+  VALIDATION_ENTER_VALID_NAME,
+} from "constants/messages";
 
 const ApiNameWrapper = styled.div<{ page?: string }>`
   min-width: 50%;
@@ -115,12 +119,12 @@ export function ActionNameEditor(props: ActionNameEditorProps) {
   const isInvalidActionName = useCallback(
     (name: string): string | boolean => {
       if (!name || name.trim().length === 0) {
-        return "Please enter a valid name";
+        return VALIDATION_ENTER_VALID_NAME();
       } else if (
         name !== currentActionConfig?.name &&
         hasActionNameConflict(name)
       ) {
-        return `${name} is already being used.`;
+        return VALIDATION_ALREADY_BEING_USED(name);
       }
       return false;
     },

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -27,6 +27,7 @@ import {
 import { getOccupiedSpacesSelectorForContainer } from "selectors/editorSelectors";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
 import { getDragDetails } from "sagas/selectors";
+import { DRAG_AND_DROP_TEXT } from "constants/messages";
 
 type DropTargetComponentProps = WidgetProps & {
   children?: ReactNode;
@@ -57,9 +58,7 @@ const StyledOnboardingMessage = styled.h2`
 function Onboarding() {
   return (
     <StyledOnboardingWrapper>
-      <StyledOnboardingMessage>
-        Drag and drop a widget here
-      </StyledOnboardingMessage>
+      <StyledOnboardingMessage>{DRAG_AND_DROP_TEXT()}</StyledOnboardingMessage>
     </StyledOnboardingWrapper>
   );
 }

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -9,6 +9,7 @@ import ErrorTooltip from "./ErrorTooltip";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
 import Icon, { IconSize } from "components/ads/Icon";
+import { EDITOR_INVALID_NAME } from "constants/messages";
 
 export enum EditInteractionKind {
   SINGLE,
@@ -139,7 +140,7 @@ export function EditableText(props: EditableTextProps) {
         setIsEditing(false);
       } else {
         Toaster.show({
-          text: "Invalid name",
+          text: EDITOR_INVALID_NAME(),
           variant: Variant.danger,
         });
       }

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -14,6 +14,8 @@ export const ERROR_MESSAGE_NAME_EMPTY = () => `Please select a name`;
 export const ERROR_MESSAGE_CREATE_APPLICATION = () =>
   `We could not create the Application`;
 export const APPLICATION_NAME_UPDATE = () => `Application name updated`;
+export const APPLICATION_IMPORTED_SUCCESSFULLY = () =>
+  `Application imported successfully`;
 export const ERROR_EMPTY_APPLICATION_NAME = () =>
   `Application name can't be empty`;
 export const API_PATH_START_WITH_SLASH_ERROR = () => `Path cannot start with /`;
@@ -452,6 +454,7 @@ export const JS_OBJECT_BODY_INVALID = () => "JS object could not be parsed";
 
 //Editor Page
 export const EDITOR_HEADER_SAVE_INDICATOR = () => "Saved";
+export const EDITOR_INVALID_NAME = () => "Invalid name";
 
 //undo redo
 export const WIDGET_REMOVED = (widgetName: string) =>
@@ -596,6 +599,9 @@ export const PASTE_SSH_URL_INFO = () =>
 export const GENERATE_KEY = () => "Generate Key";
 export const UPDATE_CONFIG = () => "UPDATE CONFIG";
 export const CONNECT_BTN_LABEL = () => "CONNECT";
+
+// Drag and Drop component
+export const DRAG_AND_DROP_TEXT = () => "Drag and drop a widget here";
 
 // JS Snippets
 export const SNIPPET_DESCRIPTION = () =>
@@ -790,13 +796,13 @@ export const NOTIFICATIONS_TOOLTIP = () => "Notifications";
 export const DEPLOY_MENU_OPTION = () => "Deploy";
 export const CURRENT_DEPLOY_PREVIEW_OPTION = () => "Current Deployed Version";
 export const CONNECT_TO_GIT_OPTION = () => "Connect to Git Repository";
-//
 export const GO_TO_PAGE = () => "Go to page";
 export const DEFAULT_PAGE_TOOLTIP = () => "Default page";
 export const HIDDEN_TOOLTIP = () => "Hidden";
 export const CLONE_TOOLTIP = () => "Clone";
 export const DELETE_TOOLTIP = () => "Delete";
 export const SETTINGS_TOOLTIP = () => "Settings";
+
 //settings
 export const ADMIN_SETTINGS = () => "Admin Settings";
 export const RESTART_BANNER_BODY = () => "We will notify you once we are done!";
@@ -807,8 +813,32 @@ export const RESTART_ERROR_HEADER = () => "Restart failed";
 export const INFO_VERSION_MISMATCH_FOUND_RELOAD_REQUEST = () =>
   "Hey! There is a new version of Appsmith available. Please consider refreshing your window.";
 
+// Welcome messages
 export const WELCOME_FORM_NON_SUPER_USER_ROLE_DROPDOWN = () =>
   "Tell us more about what you do at work?";
 export const WELCOME_FORM_NON_SUPER_USER_ROLE = () => "Role";
 export const WELCOME_FORM_NON_SUPER_USER_USE_CASE = () =>
   "What are you planning to use Appsmith for?";
+
+// Map widget
+export const MAP_WIDGET_PLACEHOLDER = () => "Enter location to search";
+
+// Filepicker widget
+export const FILEPICKER_WIDGET_FILES_SELECTED = (filesQty: number) =>
+  `${filesQty} files selected`;
+
+// Autocomplete
+export const AUTOCOMPLETE_NO_SUGGESTIONS = () => "No suggestions";
+
+// Validation messages
+export const VALIDATION_ISO_8601_DATE_STRING = () => "ISO 8601 date string";
+export const VALIDATION_ENTER_VALID_NAME = () => "Please enter a valida name.";
+export const VALIDATION_ALREADY_BEING_USED = (name: string) =>
+  `${name} is already being used.`;
+
+// Organization messages
+export const ORGANIZATION_LEAVE_ORGANIZATION = () => "Leave organization";
+export const ORGANIZATION_ARE_YOU_SURE = () => "Are you sure?";
+
+// Product updates modal
+export const PRODUCT_UPDATES_TITLE = () => "Product Updates";

--- a/app/client/src/pages/Applications/ProductUpdatesModal/index.tsx
+++ b/app/client/src/pages/Applications/ProductUpdatesModal/index.tsx
@@ -12,6 +12,7 @@ import { HelpIcons } from "icons/HelpIcons";
 import ReleaseComponent, { Release, StyledSeparator } from "./ReleaseComponent";
 import { withTheme } from "styled-components";
 import { Color } from "constants/Colors";
+import { PRODUCT_UPDATES_TITLE } from "constants/messages";
 
 const CloseIcon = HelpIcons.CLOSE_ICON;
 
@@ -66,7 +67,7 @@ const Header = withTheme(
   ({ onClose, theme }: { onClose: () => void; theme: any }) => (
     <>
       <HeaderContents>
-        <Heading>Product Updates</Heading>
+        <Heading>{PRODUCT_UPDATES_TITLE()}</Heading>
         <HeaderRight>
           <ViewInGithubLink
             href="https://github.com/appsmithorg/appsmith/releases"

--- a/app/client/src/pages/Applications/index.tsx
+++ b/app/client/src/pages/Applications/index.tsx
@@ -87,6 +87,8 @@ import {
   SEARCH_APPS,
   WELCOME_TOUR,
   NO_APPS_FOUND,
+  ORGANIZATION_LEAVE_ORGANIZATION,
+  ORGANIZATION_ARE_YOU_SURE,
 } from "constants/messages";
 import { ReactComponent as NoAppsFoundIcon } from "assets/svg/no-apps-icon.svg";
 
@@ -863,8 +865,8 @@ function ApplicationsSection(props: any) {
                           }
                           text={
                             !warnLeavingOrganization
-                              ? "Leave Organization"
-                              : "Are you sure?"
+                              ? ORGANIZATION_LEAVE_ORGANIZATION()
+                              : ORGANIZATION_ARE_YOU_SURE()
                           }
                           type={
                             !warnLeavingOrganization ? undefined : "warning"

--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -14,6 +14,10 @@ import { saveDatasourceName } from "actions/datasourceActions";
 import { Spinner } from "@blueprintjs/core";
 import { checkCurrentStep } from "sagas/OnboardingSagas";
 import { OnboardingStep } from "constants/OnboardingConstants";
+import {
+  VALIDATION_ALREADY_BEING_USED,
+  VALIDATION_ENTER_VALID_NAME,
+} from "constants/messages";
 
 const Wrapper = styled.div`
   margin-left: 10px;
@@ -73,9 +77,9 @@ function FormTitle(props: FormTitleProps) {
   const isInvalidDatasourceName = React.useCallback(
     (name: string): string | boolean => {
       if (!name || name.trim().length === 0) {
-        return "Please enter a valid name";
+        return VALIDATION_ENTER_VALID_NAME();
       } else if (hasNameConflict(name)) {
-        return `${name} is already being used.`;
+        return VALIDATION_ALREADY_BEING_USED(name);
       }
       return false;
     },

--- a/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
@@ -25,6 +25,7 @@ import { isEllipsisActive, removeSpecialChars } from "utils/helpers";
 
 import WidgetFactory from "utils/WidgetFactory";
 import { TOOLTIP_HOVER_ON_DELAY } from "constants/AppConstants";
+import { VALIDATION_ALREADY_BEING_USED } from "constants/messages";
 const WidgetTypes = WidgetFactory.widgetTypes;
 
 export const searchHighlightSpanClassName = "token";
@@ -173,7 +174,7 @@ export const EntityName = forwardRef(
         if (!newName || newName.trim().length === 0) {
           return "Please enter a name";
         } else if (newName !== name && hasNameConflict(newName, tabs)) {
-          return `${newName} is already being used.`;
+          return VALIDATION_ALREADY_BEING_USED(newName);
         }
         return false;
       },

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -17,6 +17,10 @@ import { Classes } from "@blueprintjs/core";
 import log from "loglevel";
 import { Action } from "entities/Action";
 import { saveJSObjectName } from "actions/jsActionActions";
+import {
+  VALIDATION_ALREADY_BEING_USED,
+  VALIDATION_ENTER_VALID_NAME,
+} from "constants/messages";
 
 const JSObjectNameWrapper = styled.div<{ page?: string }>`
   min-width: 50%;
@@ -102,12 +106,12 @@ export function JSObjectNameEditor(props: ActionNameEditorProps) {
   const isInvalidJSObjectName = useCallback(
     (name: string): string | boolean => {
       if (!name || name.trim().length === 0) {
-        return "Please enter a valid name";
+        return VALIDATION_ENTER_VALID_NAME();
       } else if (
         name !== currentJSObjectConfig?.name &&
         hasNameConflict(name)
       ) {
-        return `${name} is already being used.`;
+        return VALIDATION_ALREADY_BEING_USED(name);
       }
       return false;
     },

--- a/app/client/src/sagas/ApplicationSagas.tsx
+++ b/app/client/src/sagas/ApplicationSagas.tsx
@@ -47,6 +47,7 @@ import {
 } from "actions/applicationActions";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import {
+  APPLICATION_IMPORTED_SUCCESSFULLY,
   APPLICATION_NAME_UPDATE,
   createMessage,
   DELETING_APPLICATION,
@@ -600,7 +601,7 @@ export function* importApplicationSaga(
         });
         history.push(pageURL);
         Toaster.show({
-          text: "Application imported successfully",
+          text: APPLICATION_IMPORTED_SUCCESSFULLY(),
           variant: Variant.success,
         });
       }

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -107,6 +107,7 @@ import {
 import { fetchJSCollectionsForPage } from "actions/jsActionActions";
 
 import WidgetFactory from "utils/WidgetFactory";
+import { VALIDATION_ALREADY_BEING_USED } from "constants/messages";
 
 const WidgetTypes = WidgetFactory.widgetTypes;
 
@@ -790,7 +791,9 @@ export function* updateWidgetNameSaga(
           type: ReduxActionErrorTypes.UPDATE_WIDGET_NAME_ERROR,
           payload: {
             error: {
-              message: `Entity name: ${action.payload.newName} is already being used.`,
+              message: `Entity name: ${VALIDATION_ALREADY_BEING_USED(
+                action.payload.newName,
+              )}`,
             },
           },
         });

--- a/app/client/src/utils/autocomplete/TernServer.ts
+++ b/app/client/src/utils/autocomplete/TernServer.ts
@@ -21,6 +21,7 @@ import { FieldEntityInformation } from "components/editorComponents/CodeEditor/E
 import { ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
 import SortRules from "./dataTypeSortRules";
 import _ from "lodash";
+import { AUTOCOMPLETE_NO_SUGGESTIONS } from "constants/messages";
 
 const DEFS: Def[] = [
   GLOBAL_FUNCTIONS,
@@ -162,7 +163,7 @@ class TernServer {
   requestCallback(error: any, data: any, cm: CodeMirror.Editor, resolve: any) {
     if (error) return this.showError(cm, error);
     if (data.completions.length === 0) {
-      return this.showError(cm, "No suggestions");
+      return this.showError(cm, AUTOCOMPLETE_NO_SUGGESTIONS());
     }
     const doc = this.findDoc(cm.getDoc());
     const cursor = cm.getCursor();

--- a/app/client/src/utils/validation/common.ts
+++ b/app/client/src/utils/validation/common.ts
@@ -1,4 +1,8 @@
-import { createMessage, FIELD_REQUIRED_ERROR } from "constants/messages";
+import {
+  createMessage,
+  FIELD_REQUIRED_ERROR,
+  VALIDATION_ISO_8601_DATE_STRING,
+} from "constants/messages";
 import { ValidationConfig } from "constants/PropertyControlConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import moment from "moment";
@@ -63,7 +67,7 @@ export function getExpectedValue(
       };
     case ValidationTypes.DATE_ISO_STRING:
       return {
-        type: "ISO 8601 date string",
+        type: VALIDATION_ISO_8601_DATE_STRING(),
         example: moment().toISOString(true),
         autocompleteDataType: AutocompleteDataType.STRING,
       };

--- a/app/client/src/widgets/FilePickerWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/component/index.tsx
@@ -5,6 +5,7 @@ import "@uppy/dashboard/dist/style.css";
 import "@uppy/webcam/dist/style.css";
 import { BaseButton } from "widgets/ButtonWidget/component";
 import { Colors } from "../../../constants/Colors";
+import { FILEPICKER_WIDGET_FILES_SELECTED } from "constants/messages";
 
 class FilePickerComponent extends React.Component<
   FilePickerComponentProps,
@@ -26,7 +27,7 @@ class FilePickerComponent extends React.Component<
   render() {
     let label = this.props.label;
     if (this.props.files && this.props.files.length) {
-      label = `${this.props.files.length} files selected`;
+      label = FILEPICKER_WIDGET_FILES_SELECTED(this.props.files.length);
     }
     return (
       <BaseButton

--- a/app/client/src/widgets/FilepickerWidget/component/index.tsx
+++ b/app/client/src/widgets/FilepickerWidget/component/index.tsx
@@ -5,6 +5,7 @@ import "@uppy/dashboard/dist/style.css";
 import "@uppy/webcam/dist/style.css";
 import { BaseButton } from "widgets/ButtonWidget/component";
 import { Colors } from "constants/Colors";
+import { FILEPICKER_WIDGET_FILES_SELECTED } from "constants/messages";
 
 class FilePickerComponent extends React.Component<
   FilePickerComponentProps,
@@ -26,7 +27,7 @@ class FilePickerComponent extends React.Component<
   render() {
     let label = this.props.label;
     if (this.props.files && this.props.files.length) {
-      label = `${this.props.files.length} files selected`;
+      label = FILEPICKER_WIDGET_FILES_SELECTED(this.props.files.length);
     }
     return (
       <BaseButton

--- a/app/client/src/widgets/MapWidget/component/index.tsx
+++ b/app/client/src/widgets/MapWidget/component/index.tsx
@@ -6,6 +6,7 @@ import PickMyLocation from "./PickMyLocation";
 import styled from "styled-components";
 import { useScript, ScriptStatus, AddScriptTo } from "utils/hooks/useScript";
 import { getBorderCSSShorthand } from "constants/DefaultTheme";
+import { MAP_WIDGET_PLACEHOLDER } from "constants/messages";
 
 interface MapComponentProps {
   apiKey: string;
@@ -138,7 +139,7 @@ const MyMapComponent = withGoogleMap((props: any) => {
           onPlacesChanged={onPlacesChanged}
           ref={searchBox}
         >
-          <StyledInput placeholder="Enter location to search" type="text" />
+          <StyledInput placeholder={MAP_WIDGET_PLACEHOLDER()} type="text" />
         </SearchBox>
       )}
       {Array.isArray(props.markers) &&

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -3,6 +3,7 @@ import { WidgetProps } from "widgets/BaseWidget";
 import { RenderModes } from "constants/WidgetConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import moment from "moment";
+import { VALIDATION_ISO_8601_DATE_STRING } from "constants/messages";
 
 const DUMMY_WIDGET: WidgetProps = {
   bottomRow: 0,
@@ -746,17 +747,23 @@ describe("Validate Validators", () => {
       {
         isValid: false,
         parsed: defaultDate,
-        messages: ["Value does not match: ISO 8601 date string"],
+        messages: [
+          `Value does not match: ${VALIDATION_ISO_8601_DATE_STRING()}`,
+        ],
       },
       {
         isValid: false,
         parsed: defaultDate,
-        messages: ["Value does not match: ISO 8601 date string"],
+        messages: [
+          `Value does not match: ${VALIDATION_ISO_8601_DATE_STRING()}`,
+        ],
       },
       {
         isValid: false,
-        messages: ["Value does not match: ISO 8601 date string"],
         parsed: defaultDate,
+        messages: [
+          `Value does not match: ${VALIDATION_ISO_8601_DATE_STRING()}`,
+        ],
       },
     ];
 

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -20,6 +20,7 @@ import { ValidationConfig } from "constants/PropertyControlConstants";
 import evaluate from "./evaluate";
 
 import getIsSafeURL from "utils/validation/getIsSafeURL";
+import { VALIDATION_ISO_8601_DATE_STRING } from "constants/messages";
 export const UNDEFINED_VALIDATION = "UNDEFINED_VALIDATION";
 
 const flat = (array: Record<string, any>[], uniqueParam: string) => {
@@ -241,7 +242,7 @@ export function getExpectedType(config?: ValidationConfig): string | undefined {
     case ValidationTypes.REGEX:
       return "regExp";
     case ValidationTypes.DATE_ISO_STRING:
-      return "ISO 8601 date string";
+      return VALIDATION_ISO_8601_DATE_STRING();
     case ValidationTypes.BOOLEAN:
       return "boolean";
     case ValidationTypes.NUMBER:


### PR DESCRIPTION
We are now resorting to fetching the texts from `constants.ts` instead of hardcoding the messages expected from the app.

Fixes #8389

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
