### PR TITLE
fix: List Widget shows cyclic dependency error when children widgets with bindings in action are deleted

### DIFF
--- a/app/client/src/sagas/WidgetOperationUtils.test.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.test.ts
@@ -4,6 +4,7 @@ import {
   handleSpecificCasesWhilePasting,
   doesTriggerPathsContainPropertyPath,
   checkIfPastingIntoListWidget,
+  updateListWidgetPropertiesOnChildDelete,
 } from "./WidgetOperationUtils";
 
 describe("WidgetOperationSaga", () => {
@@ -455,5 +456,129 @@ describe("WidgetOperationSaga", () => {
     );
 
     expect(result?.type).toStrictEqual("LIST_WIDGET");
+  });
+
+  it("should return widgets after executing updateListWidgetPropertiesOnChildDelete", () => {
+    const result = updateListWidgetPropertiesOnChildDelete(
+      {
+        list1: {
+          widgetId: "list1",
+          type: "LIST_WIDGET",
+          widgetName: "List1",
+          parentId: "0",
+          renderMode: "CANVAS",
+          parentColumnSpace: 2,
+          parentRowSpace: 3,
+          leftColumn: 2,
+          rightColumn: 3,
+          topRow: 1,
+          bottomRow: 3,
+          isLoading: false,
+          listData: [],
+          version: 16,
+          disablePropertyPane: false,
+          template: {},
+          enhancements: {},
+          dynamicBindingPathList: [{ key: "template.ButtonWidget1.text" }],
+          dynamicTriggerPathList: [
+            {
+              key: "template.ButtonWidget1.onClick",
+            },
+          ],
+        },
+        buttonWidget1: {
+          type: "BUTTON_WIDGET",
+          widgetId: "buttonWidget1",
+          widgetName: "buttonWidget1",
+          version: 16,
+          parentColumnSpace: 2,
+          parentRowSpace: 3,
+          leftColumn: 2,
+          rightColumn: 3,
+          topRow: 1,
+          bottomRow: 3,
+          renderMode: "CANVAS",
+          isLoading: false,
+          parentId: "list1",
+        },
+        0: {
+          type: "CANVAS_WIDGET",
+          widgetId: "0",
+          widgetName: "MainContainer",
+          version: 16,
+          parentColumnSpace: 2,
+          parentRowSpace: 3,
+          leftColumn: 2,
+          rightColumn: 3,
+          topRow: 1,
+          bottomRow: 3,
+          renderMode: "CANVAS",
+          isLoading: false,
+          parentId: "list1",
+        },
+      },
+      "buttonWidget1",
+      "ButtonWidget1",
+    );
+
+    const expected = updateListWidgetPropertiesOnChildDelete(
+      {
+        list1: {
+          widgetId: "list1",
+          type: "LIST_WIDGET",
+          widgetName: "List1",
+          parentId: "0",
+          renderMode: "CANVAS",
+          parentColumnSpace: 2,
+          parentRowSpace: 3,
+          leftColumn: 2,
+          rightColumn: 3,
+          topRow: 1,
+          bottomRow: 3,
+          isLoading: false,
+          listData: [],
+          version: 16,
+          disablePropertyPane: false,
+          template: {},
+          enhancements: {},
+          dynamicBindingPathList: [],
+          dynamicTriggerPathList: [],
+        },
+        buttonWidget1: {
+          type: "BUTTON_WIDGET",
+          widgetId: "buttonWidget1",
+          widgetName: "buttonWidget1",
+          version: 16,
+          parentColumnSpace: 2,
+          parentRowSpace: 3,
+          leftColumn: 2,
+          rightColumn: 3,
+          topRow: 1,
+          bottomRow: 3,
+          renderMode: "CANVAS",
+          isLoading: false,
+          parentId: "list1",
+        },
+        0: {
+          type: "CANVAS_WIDGET",
+          widgetId: "0",
+          widgetName: "MainContainer",
+          version: 16,
+          parentColumnSpace: 2,
+          parentRowSpace: 3,
+          leftColumn: 2,
+          rightColumn: 3,
+          topRow: 1,
+          bottomRow: 3,
+          renderMode: "CANVAS",
+          isLoading: false,
+          parentId: "list1",
+        },
+      },
+      "buttonWidget1",
+      "ButtonWidget1",
+    );
+
+    expect(result).toStrictEqual(expected);
   });
 });

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -4,7 +4,7 @@ import {
   getWidgetMetaProps,
   getWidgets,
 } from "./selectors";
-import _, { isString } from "lodash";
+import _, { isString, remove } from "lodash";
 import {
   GridDefaults,
   MAIN_CONTAINER_WIDGET_ID,
@@ -29,6 +29,7 @@ import {
 } from "utils/DynamicBindingUtils";
 import { getNextEntityName } from "utils/AppsmithUtils";
 import WidgetFactory from "utils/WidgetFactory";
+import { getParentWithEnhancementFn } from "./WidgetEnhancementHelpers";
 
 export interface CopiedWidgetGroup {
   widgetId: string;
@@ -816,4 +817,46 @@ export function* getParentWidgetIdForGrouping(
   }
 
   return pastingIntoWidgetId;
+}
+
+/**
+ * this saga clears out the enhancementMap, template and dynamicBindingPathList when a child
+ * is deleted in list widget
+ *
+ * @param widgets
+ * @param widgetId
+ * @param widgetName
+ * @param parentId
+ */
+export function updateListWidgetPropertiesOnChildDelete(
+  widgets: CanvasWidgetsReduxState,
+  widgetId: string,
+  widgetName: string,
+) {
+  const clone = JSON.parse(JSON.stringify(widgets));
+
+  const parentWithEnhancementFn = getParentWithEnhancementFn(widgetId, clone);
+
+  if (parentWithEnhancementFn?.type === "LIST_WIDGET") {
+    const listWidget = parentWithEnhancementFn;
+
+    // delete widget in template of list
+    if (listWidget && widgetName in listWidget.template) {
+      listWidget.template[widgetName] = undefined;
+    }
+
+    // delete dynamic binding path if any
+    remove(listWidget?.dynamicBindingPathList || [], (path: any) =>
+      path.key.startsWith(`template.${widgetName}`),
+    );
+
+    // delete dynamic trigger path if any
+    remove(listWidget?.dynamicTriggerPathList || [], (path: any) =>
+      path.key.startsWith(`template.${widgetName}`),
+    );
+
+    return clone;
+  }
+
+  return clone;
 }

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -820,7 +820,7 @@ export function* getParentWidgetIdForGrouping(
 }
 
 /**
- * this saga clears out the enhancementMap, template and dynamicBindingPathList when a child
+ * this saga clears out the enhancementMap, template, dynamicBindingPathList and dynamicTriggerPathList when a child
  * is deleted in list widget
  *
  * @param widgets


### PR DESCRIPTION
Fixes #8862 

## Type of change
- Bug fix

## How Has This Been Tested?
- Added jest test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/list-widget-trigger-path-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.84 **(0.03)** | 36.59 **(0.05)** | 33.48 **(0.03)** | 55.37 **(0.02)**
 :green_circle: | app/client/src/sagas/WidgetDeletionSagas.ts | 40.94 **(2.43)** | 25 **(4.76)** | 42.11 **(4.01)** | 42.42 **(2.56)**
 :green_circle: | app/client/src/sagas/WidgetEnhancementHelpers.ts | 38.36 **(1.37)** | 27.45 **(1.96)** | 14.29 **(0)** | 40.91 **(1.52)**
 :green_circle: | app/client/src/sagas/WidgetOperationUtils.ts | 60.78 **(1.3)** | 41.94 **(2.97)** | 57.14 **(2.79)** | 60 **(1.56)**</details>