### PR TITLE
fix: 8543 added disabled flag support in icon button table widget

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
@@ -95,6 +95,14 @@ describe("Table Widget property pane feature validation", function() {
         force: true,
       });
     cy.get(".t--widget-tablewidget .tbody .bp3-icon-add").should("exist");
+
+    // disabled icon btn
+    cy.CheckWidgetProperties(commonlocators.disableCheckbox);
+    cy.getTableDataSelector("0", "4").then((selector) => {
+      cy.get(selector + " button.bp3-disabled").should("exist");
+    });
+    cy.UncheckWidgetProperties(commonlocators.disableCheckbox);
+
     //Delete Column
     cy.get(".t--property-pane-back-btn").click({
       force: true,

--- a/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
+++ b/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
@@ -188,6 +188,7 @@ interface RenderIconButtonProps {
   boxShadowColor: string;
   onCommandClick: (dynamicTrigger: string, onComplete: () => void) => void;
   isCellVisible: boolean;
+  disabled: boolean;
 }
 export const renderIconButton = (
   props: RenderIconButtonProps,
@@ -212,6 +213,7 @@ export const renderIconButton = (
             boxShadowColor={props.boxShadowColor}
             buttonColor={props.buttonColor}
             buttonVariant={props.buttonVariant}
+            disabled={props.disabled}
             iconName={props.iconName}
             isSelected={props.isSelected}
             key={index}
@@ -232,6 +234,7 @@ function IconButton(props: {
   borderRadius: ButtonBorderRadius;
   boxShadow: ButtonBoxShadow;
   boxShadowColor: string;
+  disabled: boolean;
 }): JSX.Element {
   const [loading, setLoading] = useState(false);
   const onComplete = () => {
@@ -258,6 +261,7 @@ function IconButton(props: {
         boxShadowColor={props.boxShadowColor}
         buttonColor={props.buttonColor}
         buttonVariant={props.buttonVariant}
+        disabled={props.disabled}
         icon={props.iconName}
         loading={loading}
         onClick={handleClick}

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -245,6 +245,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
               boxShadow: cellProperties.boxShadow || "NONE",
               boxShadowColor: cellProperties.boxShadowColor || "",
               isCellVisible: cellProperties.isCellVisible ?? true,
+              disabled: !!cellProperties.isDisabled,
             };
             return renderIconButton(iconButtonProps, isHidden, cellProperties);
           } else {


### PR DESCRIPTION
## Description

> Added support for disabled flag in icon button table widget

Fixes #8543 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Tested locally. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>