### PR TITLE
chore: Expose Sentry object globally

### DIFF
--- a/app/client/src/configs/index.ts
+++ b/app/client/src/configs/index.ts
@@ -50,6 +50,7 @@ declare global {
   interface Window {
     APPSMITH_FEATURE_CONFIGS: INJECTED_CONFIGS;
     Intercom: any;
+    Sentry: any;
   }
 }
 

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -45,6 +45,7 @@ export const appInitializer = () => {
   const appsmithConfigs = getAppsmithConfigs();
 
   if (appsmithConfigs.sentry.enabled) {
+    window.Sentry = Sentry;
     Sentry.init({
       ...appsmithConfigs.sentry,
       beforeBreadcrumb(breadcrumb) {


### PR DESCRIPTION
## Description

To Integrate Smartlook and Sentry, we need to expose Sentry object globally according to [this article](https://help.smartlook.com/en/articles/3244594-sentry) from Sentry.

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: chore/expose-sentry-object 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/AppsmithUtils.tsx | 56.12 **(-0.29)** | 34.09 **(0)** | 34.88 **(0)** | 51.19 **(-0.31)**</details>