### PR TITLE
fix(handle-enter-confirm-popup): added key action to confirm popup wi…

### DIFF
--- a/app/client/src/pages/Editor/ConfirmRunModal.tsx
+++ b/app/client/src/pages/Editor/ConfirmRunModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { AppState } from "reducers";
+import { Keys } from "@blueprintjs/core";
 import {
   showRunActionConfirmModal,
   cancelRunActionConfirmModal,
@@ -33,19 +34,51 @@ const ModalFooter = styled.div`
 `;
 
 class ConfirmRunModal extends React.Component<Props> {
+  addEventListener = () => {
+    document.addEventListener("keydown", this.onKeyUp);
+  };
+
+  removeEventListener = () => {
+    document.removeEventListener("keydown", this.onKeyUp);
+  };
+
+  onKeyUp = (event: KeyboardEvent) => {
+    const { isModalOpen } = this.props;
+    if (event.keyCode === Keys.ENTER && isModalOpen) {
+      this.onConfirm();
+    }
+  };
+
+  onConfirm = () => {
+    const { dispatch } = this.props;
+    dispatch(acceptRunActionConfirmModal());
+    this.handleClose();
+  };
+
+  handleClose = () => {
+    const { dispatch } = this.props;
+    dispatch(showRunActionConfirmModal(false));
+    dispatch(cancelRunActionConfirmModal());
+  };
+
+  componentDidUpdate() {
+    const { isModalOpen } = this.props;
+    if (isModalOpen) {
+      this.addEventListener();
+    } else {
+      this.removeEventListener();
+    }
+  }
+
   render() {
     const { dispatch, isModalOpen } = this.props;
-    const handleClose = () => {
-      dispatch(showRunActionConfirmModal(false));
-
-      dispatch(cancelRunActionConfirmModal());
-    };
 
     return (
       <DialogComponent
+        canEscapeKeyClose
         isOpen={isModalOpen}
         maxHeight={"80vh"}
-        onClose={handleClose}
+        onClose={this.handleClose}
         title="Confirm Action"
         width={"580px"}
       >
@@ -55,7 +88,7 @@ class ConfirmRunModal extends React.Component<Props> {
             category={Category.tertiary}
             onClick={() => {
               dispatch(cancelRunActionConfirmModal());
-              handleClose();
+              this.handleClose();
             }}
             size={Size.medium}
             tag="button"
@@ -64,10 +97,7 @@ class ConfirmRunModal extends React.Component<Props> {
           />
           <Button
             category={Category.primary}
-            onClick={() => {
-              dispatch(acceptRunActionConfirmModal());
-              handleClose();
-            }}
+            onClick={this.onConfirm}
             size={Size.medium}
             tag="button"
             text="Confirm"

--- a/app/client/src/pages/Editor/ConfirmRunModal.tsx
+++ b/app/client/src/pages/Editor/ConfirmRunModal.tsx
@@ -43,8 +43,7 @@ class ConfirmRunModal extends React.Component<Props> {
   };
 
   onKeyUp = (event: KeyboardEvent) => {
-    const { isModalOpen } = this.props;
-    if (event.keyCode === Keys.ENTER && isModalOpen) {
+    if (event.keyCode === Keys.ENTER) {
       this.onConfirm();
     }
   };


### PR DESCRIPTION
…th class functions

## Description

Keyboard "Enter" key was not functional on confirm pop up. Added an event listener for key down event  whenever the modal is opened and remove when the modal is closed.

Fixes # (issue)
[#5111 ](https://github.com/appsmithorg/appsmith/issues/5111)



## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added an API source and enabled `Request confirmation before running API` settings for it. Now when the API is run, it asks for confirmation, press enter to confirm and esc to close.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/handle-enter-confirm-popup 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.15 **(0)** | 37.04 **(-0.01)** | 34.03 **(0)** | 55.67 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>