### PR TITLE
fix: Added support for multiple files in multipart REST

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
@@ -155,6 +155,7 @@ public class DataUtils {
                             try {
                                 populateFileTypeBodyBuilder(bodyBuilder, property, outputMessage);
                             } catch (JsonProcessingException e) {
+                                e.printStackTrace();
                                 throw new AppsmithPluginException(
                                         AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
                                         "Unable to parse content. Expected to receive an array or object of multipart data"

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
@@ -26,6 +26,8 @@ import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -150,26 +152,11 @@ public class DataUtils {
                         if (MultipartFormDataType.TEXT.equals(multipartFormDataType)) {
                             bodyBuilder.part(key, property.getValue());
                         } else if (MultipartFormDataType.FILE.equals(multipartFormDataType)) {
-
-                            MultipartFormDataDTO multipartFormDataDTO = null;
                             try {
-                                multipartFormDataDTO = objectMapper.readValue(
-                                        String.valueOf(property.getValue()),
-                                        MultipartFormDataDTO.class);
+                                populateFileTypeBodyBuilder(bodyBuilder, property, outputMessage);
                             } catch (JsonProcessingException e) {
                                 e.printStackTrace();
                             }
-                            final MultipartFormDataDTO finalMultipartFormDataDTO = multipartFormDataDTO;
-                            Flux<DataBuffer> data = DataBufferUtils.readInputStream(
-                                    () -> new ByteArrayInputStream(String
-                                            .valueOf(finalMultipartFormDataDTO.getData())
-                                            .getBytes(StandardCharsets.UTF_8)),
-                                    outputMessage.bufferFactory(),
-                                    4096);
-
-                            bodyBuilder.asyncPart(key, data, DataBuffer.class)
-                                    .filename(multipartFormDataDTO.getName())
-                                    .contentType(MediaType.valueOf(multipartFormDataDTO.getType()));
                         }
                     }
 
@@ -179,6 +166,38 @@ public class DataUtils {
                     return multipartInserter
                             .insert(outputMessage, context);
                 });
+    }
+
+    private void populateFileTypeBodyBuilder(MultipartBodyBuilder bodyBuilder, Property property, ClientHttpRequest outputMessage)
+            throws JsonProcessingException {
+        final Object fileValue = property.getValue();
+        final String key = property.getKey();
+        List<MultipartFormDataDTO> multipartFormDataDTOs = new ArrayList<>();
+        try {
+            multipartFormDataDTOs = Arrays.asList(
+                    objectMapper.readValue(
+                            String.valueOf(fileValue),
+                            MultipartFormDataDTO[].class));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            final MultipartFormDataDTO multipartFormDataDTO = objectMapper.readValue(String.valueOf(fileValue),
+                    MultipartFormDataDTO.class);
+            multipartFormDataDTOs.add(multipartFormDataDTO);
+        }
+        multipartFormDataDTOs.forEach(multipartFormDataDTO -> {
+            final MultipartFormDataDTO finalMultipartFormDataDTO = multipartFormDataDTO;
+            Flux<DataBuffer> data = DataBufferUtils.readInputStream(
+                    () -> new ByteArrayInputStream(String
+                            .valueOf(finalMultipartFormDataDTO.getData())
+                            .getBytes(StandardCharsets.UTF_8)),
+                    outputMessage.bufferFactory(),
+                    4096);
+
+            bodyBuilder.asyncPart(key, data, DataBuffer.class)
+                    .filename(multipartFormDataDTO.getName())
+                    .contentType(MediaType.valueOf(multipartFormDataDTO.getType()));
+        });
+
     }
 
     /**

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
@@ -155,7 +155,10 @@ public class DataUtils {
                             try {
                                 populateFileTypeBodyBuilder(bodyBuilder, property, outputMessage);
                             } catch (JsonProcessingException e) {
-                                e.printStackTrace();
+                                throw new AppsmithPluginException(
+                                        AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
+                                        "Unable to parse content. Expected to receive an array or object of multipart data"
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
## Description
This fix retains support for single uploads as well as adds support for an array of files. This means that existing actions do not have to be migrated and future actions continue to have the option of using an array of files or just a single file.

Fixes #8985 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Tested manually
- JUnit case

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
