### PR TITLE
fix: app is publicly accessible event if it's not public

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -457,6 +457,8 @@ public class ApplicationServiceImpl extends BaseService<ApplicationRepository, A
     @Override
     public Mono<Application> saveLastEditInformation(String applicationId) {
         Application application = new Application();
+        // need to set isPublic=null because it has a `false` as it's default value in domain class
+        application.setIsPublic(null);
         /*
           We're not setting updatedAt and modifiedBy fields to the application DTO because these fields will be set
           by the updateById method of the BaseAppsmithRepositoryImpl

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -1296,6 +1296,7 @@ public class ApplicationServiceTest {
         Application testApplication = new Application();
         testApplication.setName("SaveLastEditInformation TestApp");
         testApplication.setModifiedBy("test-user");
+        testApplication.setIsPublic(true);
 
         Mono<Application> updatedApplication = applicationPageService.createApplication(testApplication, orgId)
                 .flatMap(application ->
@@ -1305,6 +1306,7 @@ public class ApplicationServiceTest {
             assertThat(application.getLastUpdateTime()).isNotNull();
             assertThat(application.getPolicies()).isNotNull().isNotEmpty();
             assertThat(application.getModifiedBy()).isEqualTo("api_user");
+            assertThat(application.getIsPublic()).isTrue();
         }).verifyComplete();
     }
 


### PR DESCRIPTION
## Description

When a public app is edited by someone,`isPublic=false` is set to it even the app is not public. This PR fixes that issue.

Fixes #8999 
Fixes #8894

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually
- JUnit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
