### PR TITLE
fix: Unable to group widgets

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/WidgetGrouping/WidgetGrouping_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/WidgetGrouping/WidgetGrouping_spec.js
@@ -1,11 +1,11 @@
 const dsl = require("../../../../fixtures/widgetSelection.json");
 
-describe("Widget Selection", function() {
+describe("Widget Grouping", function() {
   before(() => {
     cy.addDsl(dsl);
   });
 
-  it("Multi Select widgets using cmd + click", function() {
+  it("Select widgets using cmd + click and group using cmd + G", function() {
     // Selection
     cy.get(`#${dsl.dsl.children[2].widgetId}`).click({
       ctrlKey: true,

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/WidgetGrouping/WidgetGrouping_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/WidgetGrouping/WidgetGrouping_spec.js
@@ -1,0 +1,37 @@
+const dsl = require("../../../../fixtures/widgetSelection.json");
+
+describe("Widget Selection", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Multi Select widgets using cmd + click", function() {
+    // Selection
+    cy.get(`#${dsl.dsl.children[2].widgetId}`).click({
+      ctrlKey: true,
+    });
+    cy.get(`#${dsl.dsl.children[3].widgetId}`).click({
+      ctrlKey: true,
+    });
+    cy.get(`div[data-testid='t--selected']`).should("have.length", 2);
+    cy.get(`.t--multi-selection-box`).should("have.length", 1);
+
+    // Grouping
+    const isMac = Cypress.platform === "darwin";
+    if (isMac) {
+      cy.get("body").type("{cmd}{g}");
+    } else {
+      cy.get("body").type("{ctrl}{g}");
+    }
+
+    cy.get(`div[data-testid='t--selected']`)
+      .should("have.length", 1)
+      .as("group");
+    cy.get("body").click();
+    cy.get(`@group`)
+      .find(`[data-testid="test-widget"]`)
+      .should("have.length", 2);
+    cy.get(`@group`).find(`.t--draggable-buttonwidget`);
+    cy.get(`@group`).find(`.t--draggable-imagewidget`);
+  });
+});

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -707,7 +707,6 @@ export function calculateNewWidgetPosition(
  */
 function* pasteWidgetSaga(action: ReduxAction<{ groupWidgets: boolean }>) {
   let copiedWidgetGroups: CopiedWidgetGroup[] = yield getCopiedWidgets();
-  if (!copiedWidgetGroups.length) return;
   const shouldGroup: boolean = action.payload.groupWidgets;
 
   const newlyCreatedWidgetIds: string[] = [];
@@ -754,7 +753,7 @@ function* pasteWidgetSaga(action: ReduxAction<{ groupWidgets: boolean }>) {
   }
 
   // to avoid invoking old copied widgets
-  if (!Array.isArray(copiedWidgetGroups)) return;
+  if (!copiedWidgetGroups.length) return;
 
   const { topMostWidget } = getBoundaryWidgetsFromCopiedGroups(
     copiedWidgetGroups,

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -752,8 +752,12 @@ function* pasteWidgetSaga(action: ReduxAction<{ groupWidgets: boolean }>) {
     pastingIntoWidgetId = MAIN_CONTAINER_WIDGET_ID;
   }
 
-  // to avoid invoking old copied widgets
-  if (!copiedWidgetGroups.length) return;
+  if (
+    // to avoid invoking old way of copied widgets implementaion
+    !Array.isArray(copiedWidgetGroups) ||
+    !copiedWidgetGroups.length
+  )
+    return;
 
   const { topMostWidget } = getBoundaryWidgetsFromCopiedGroups(
     copiedWidgetGroups,

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -656,7 +656,7 @@ export const isSelectedWidgetsColliding = function*(
   copiedWidgetGroups: CopiedWidgetGroup[],
   pastingIntoWidgetId: string,
 ) {
-  if (!Array.isArray(copiedWidgetGroups)) return false;
+  if (!copiedWidgetGroups.length) return false;
 
   const {
     bottomMostWidget,


### PR DESCRIPTION
## Description

While working on #8954, I didn't realise `pasteWidgetSaga` is being used for widget grouping also. That caused this issue.
The issue is fixed and a test is added to avoid regression.

Fixes #9032

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Open editor on an incognito window. Make sure you didn't copied any widget.
Try grouping a couple of widgets

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/unable-to-group 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 53.97 **(0.02)** | 42.7 **(0.54)** | 53.19 **(0)** | 55.56 **(-0.27)**</details>