### PR TITLE
fix: set max-width for Toast message

### DIFF
--- a/app/client/src/components/ads/Toast.tsx
+++ b/app/client/src/components/ads/Toast.tsx
@@ -60,6 +60,7 @@ const ToastBody = styled.div<{
   width?: string;
 }>`
   width: ${(props) => props.width || "fit-content"};
+  max-width: 500px;
   margin-left: auto;
   background: ${(props) => props.theme.colors.toast.bg};
   padding: ${(props) => props.theme.spaces[4]}px

--- a/app/client/src/components/ads/Toast.tsx
+++ b/app/client/src/components/ads/Toast.tsx
@@ -24,6 +24,7 @@ export type ToastProps = ToastOptions &
     hideProgressBar?: boolean;
     hideActionElementSpace?: boolean;
     width?: string;
+    maxWidth?: string;
   };
 
 const WrappedToastContainer = styled.div`
@@ -58,9 +59,10 @@ const ToastBody = styled.div<{
   isUndo?: boolean;
   dispatchableAction?: { type: ReduxActionType; payload: any };
   width?: string;
+  maxWidth?: string;
 }>`
   width: ${(props) => props.width || "fit-content"};
-  max-width: 500px;
+  max-width: ${(props) => props.maxWidth || "264px"};
   margin-left: auto;
   background: ${(props) => props.theme.colors.toast.bg};
   padding: ${(props) => props.theme.spaces[4]}px
@@ -145,6 +147,7 @@ export function ToastComponent(
       className="t--toast-action"
       dispatchableAction={props.dispatchableAction}
       isUndo={!!props.onUndo}
+      maxWidth={props.maxWidth}
       variant={props.variant || Variant.info}
       width={props.width}
     >

--- a/app/client/src/utils/replayHelpers.tsx
+++ b/app/client/src/utils/replayHelpers.tsx
@@ -88,6 +88,7 @@ export const showUndoRedoToast = (
   Toaster.show({
     text,
     actionElement,
+    maxWidth: "500px",
   });
 };
 


### PR DESCRIPTION
## Description

Set max-width for Toast.

Fixes #9049 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Use `showAlert` to create a lengthy message

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/toast-lengthy-content 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.77 **(0)** | 36.62 **(-0.01)** | 33.48 **(0.01)** | 55.3 **(-0.01)**
 :green_circle: | app/client/src/components/ads/Toast.tsx | 77.78 **(0.42)** | 63.64 **(1.14)** | 80.95 **(0.95)** | 77.78 **(0.42)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.04 **(-0.22)** | 40.42 **(-0.83)** | 34.48 **(0)** | 55.96 **(-0.26)**</details>