### PR TITLE
fix: on comment thread show mention suggestions when user discards the invitation flow 

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
@@ -53,7 +53,7 @@ describe("Comments", function() {
       .its("length")
       .should("eq", 2);
   });
-  it("Can invite new collaborators, with substring emails", () => {
+  it("Can discard invitation flow and still see the suggestions", () => {
     cy.get(commentsLocators.mentionsInput)
       .type("@appsmith", {
         delay: 100,
@@ -67,109 +67,109 @@ describe("Comments", function() {
       .type("{movetoend}");
     cy.contains("support@appsmith.com").should("be.visible");
   });
-  // it("Completing comments tour adds bot comment in first thread", function() {
-  //   cy.generateUUID().then((uid) => {
-  //     cy.Signup(`${uid}@appsmithtest.com`, uid);
-  //   });
-  //   cy.NavigateToHome();
-  //
-  //   cy.generateUUID().then((uid) => {
-  //     appName = uid;
-  //     orgName = uid;
-  //     cy.createOrg();
-  //     cy.wait("@createOrg").then((interception) => {
-  //       const newOrganizationName = interception.response.body.data.name;
-  //       cy.renameOrg(newOrganizationName, orgName);
-  //     });
-  //     cy.CreateAppForOrg(orgName, appName);
-  //     cy.addDsl(dsl);
-  //   });
-  //   cy.get(commonLocators.canvas);
-  //   cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
-  //   cy.contains("NEXT").click({ force: true });
-  //   cy.contains("NEXT").click({ force: true });
-  //   cy.get("input[name='displayName']").type("Touring User");
-  //   cy.get("button[type='submit']").click();
-  //
-  //   // wait for comment mode to be set
-  //   cy.wait(1000);
-  //   cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
-  //   cy.get(commonLocators.canvas).click(50, 50);
-  //
-  //   typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
-  //   cy.get(commentsLocators.mentionsInput).type("{enter}");
-  //   cy.get("[data-cy=comments-card-header]")
-  //     .its("length")
-  //     .should("eq", 3);
-  //   cy.contains("Appsmith Bot").should("be.visible");
-  // });
-  //
-  // // create another comment since the first one is a private bot thread
-  // it("another comment can be created after dismissing the first one", () => {
-  //   cy.get(commonLocators.canvas).click(10, 10);
-  //   // wait for transition to be completed
-  //   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  //   cy.wait(300);
-  //   typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
-  //   cy.get(commentsLocators.mentionsInput).type("{enter}");
-  //   cy.wait("@createNewThread").then((response) => {
-  //     commentThreadId = response.response.body.data.id;
-  //   });
-  // });
-  //
-  // it("unread indicator is visible for another app user when a new comment is added", () => {
-  //   // share app with TESTUSERNAME2
-  //   cy.get(homePage.shareApp).click({ force: true });
-  //   cy.shareApp(Cypress.env("TESTUSERNAME2"), homePage.adminRole);
-  //   cy.LogintoApp(Cypress.env("TESTUSERNAME2"), Cypress.env("TESTPASSWORD2"));
-  //
-  //   // launch the editor
-  //   cy.get(homePage.searchInput).type(appName);
-  //   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  //   cy.wait(2000);
-  //   cy.get(homePage.applicationCard)
-  //     .first()
-  //     .trigger("mouseover");
-  //   cy.get(homePage.appEditIcon)
-  //     .first()
-  //     .click({ force: true });
-  //   cy.get("#loading").should("not.exist");
-  //
-  //   // unread indicator should be visible since a new comment was added
-  //   cy.get(commentsLocators.toggleCommentModeOnUnread).should("exist");
-  //   cy.get(commentsLocators.toggleCommentModeOn).should("not.exist");
-  // });
-  //
-  // it("is visible for the other app users in edit mode", () => {
-  //   cy.get(commentsLocators.switchToCommentModeBtn).click({
-  //     force: true,
-  //   });
-  //   // this is needed, as on CI we create new users
-  //   cy.contains("SKIP").click({ force: true });
-  //   cy.get("input[name='displayName']").type("Skip User");
-  //   cy.get("button[type='submit']").click();
-  //   cy.get(
-  //     `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
-  //   ).click({ force: true });
-  //   cy.contains(newCommentText1);
-  // });
-  //
-  // it("unread indicator should be hidden once all comment threads are marked as read", () => {
-  //   // thread should be marked as read by clicking before, unread indicator should not be visible
-  //   cy.get(commentsLocators.toggleCommentModeOnUnread).should("not.exist");
-  //   cy.get(commentsLocators.toggleCommentModeOn).should("exist");
-  // });
-  //
-  // it("is visible in the published mode", () => {
-  //   cy.PublishtheApp();
-  //   // wait for the published page to load
-  //   cy.get(commonLocators.viewerPage);
-  //   cy.get(commentsLocators.switchToCommentModeBtn).click({
-  //     force: true,
-  //   });
-  //   cy.get(
-  //     `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
-  //   ).click({ force: true });
-  //   cy.contains(newCommentText1);
-  // });
+  it("Completing comments tour adds bot comment in first thread", function() {
+    cy.generateUUID().then((uid) => {
+      cy.Signup(`${uid}@appsmithtest.com`, uid);
+    });
+    cy.NavigateToHome();
+
+    cy.generateUUID().then((uid) => {
+      appName = uid;
+      orgName = uid;
+      cy.createOrg();
+      cy.wait("@createOrg").then((interception) => {
+        const newOrganizationName = interception.response.body.data.name;
+        cy.renameOrg(newOrganizationName, orgName);
+      });
+      cy.CreateAppForOrg(orgName, appName);
+      cy.addDsl(dsl);
+    });
+    cy.get(commonLocators.canvas);
+    cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
+    cy.contains("NEXT").click({ force: true });
+    cy.contains("NEXT").click({ force: true });
+    cy.get("input[name='displayName']").type("Touring User");
+    cy.get("button[type='submit']").click();
+
+    // wait for comment mode to be set
+    cy.wait(1000);
+    cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
+    cy.get(commonLocators.canvas).click(50, 50);
+
+    typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
+    cy.get(commentsLocators.mentionsInput).type("{enter}");
+    cy.get("[data-cy=comments-card-header]")
+      .its("length")
+      .should("eq", 3);
+    cy.contains("Appsmith Bot").should("be.visible");
+  });
+
+  // create another comment since the first one is a private bot thread
+  it("another comment can be created after dismissing the first one", () => {
+    cy.get(commonLocators.canvas).click(10, 10);
+    // wait for transition to be completed
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(300);
+    typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
+    cy.get(commentsLocators.mentionsInput).type("{enter}");
+    cy.wait("@createNewThread").then((response) => {
+      commentThreadId = response.response.body.data.id;
+    });
+  });
+
+  it("unread indicator is visible for another app user when a new comment is added", () => {
+    // share app with TESTUSERNAME2
+    cy.get(homePage.shareApp).click({ force: true });
+    cy.shareApp(Cypress.env("TESTUSERNAME2"), homePage.adminRole);
+    cy.LogintoApp(Cypress.env("TESTUSERNAME2"), Cypress.env("TESTPASSWORD2"));
+
+    // launch the editor
+    cy.get(homePage.searchInput).type(appName);
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000);
+    cy.get(homePage.applicationCard)
+      .first()
+      .trigger("mouseover");
+    cy.get(homePage.appEditIcon)
+      .first()
+      .click({ force: true });
+    cy.get("#loading").should("not.exist");
+
+    // unread indicator should be visible since a new comment was added
+    cy.get(commentsLocators.toggleCommentModeOnUnread).should("exist");
+    cy.get(commentsLocators.toggleCommentModeOn).should("not.exist");
+  });
+
+  it("is visible for the other app users in edit mode", () => {
+    cy.get(commentsLocators.switchToCommentModeBtn).click({
+      force: true,
+    });
+    // this is needed, as on CI we create new users
+    cy.contains("SKIP").click({ force: true });
+    cy.get("input[name='displayName']").type("Skip User");
+    cy.get("button[type='submit']").click();
+    cy.get(
+      `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
+    ).click({ force: true });
+    cy.contains(newCommentText1);
+  });
+
+  it("unread indicator should be hidden once all comment threads are marked as read", () => {
+    // thread should be marked as read by clicking before, unread indicator should not be visible
+    cy.get(commentsLocators.toggleCommentModeOnUnread).should("not.exist");
+    cy.get(commentsLocators.toggleCommentModeOn).should("exist");
+  });
+
+  it("is visible in the published mode", () => {
+    cy.PublishtheApp();
+    // wait for the published page to load
+    cy.get(commonLocators.viewerPage);
+    cy.get(commentsLocators.switchToCommentModeBtn).click({
+      force: true,
+    });
+    cy.get(
+      `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
+    ).click({ force: true });
+    cy.contains(newCommentText1);
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
@@ -10,6 +10,23 @@ let appName;
 let orgName;
 
 describe("Comments", function() {
+  before(() => {
+    return cy.wrap(null).then(async () => {
+      cy.NavigateToHome();
+
+      cy.generateUUID().then((uid) => {
+        appName = uid;
+        orgName = uid;
+        cy.createOrg();
+        cy.wait("@createOrg").then((interception) => {
+          const newOrganizationName = interception.response.body.data.name;
+          cy.renameOrg(newOrganizationName, orgName);
+        });
+        cy.CreateAppForOrg(orgName, appName);
+        cy.addDsl(dsl);
+      });
+    });
+  });
   /**
    * create new comment thread
    * share app with an admin user

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Comments/AddComments_spec.js
@@ -10,24 +10,6 @@ let appName;
 let orgName;
 
 describe("Comments", function() {
-  before(() => {
-    return cy.wrap(null).then(async () => {
-      cy.NavigateToHome();
-
-      cy.generateUUID().then((uid) => {
-        appName = uid;
-        orgName = uid;
-        cy.createOrg();
-        cy.wait("@createOrg").then((interception) => {
-          const newOrganizationName = interception.response.body.data.name;
-          cy.renameOrg(newOrganizationName, orgName);
-        });
-        cy.CreateAppForOrg(orgName, appName);
-        cy.addDsl(dsl);
-      });
-    });
-  });
-
   /**
    * create new comment thread
    * share app with an admin user
@@ -71,109 +53,123 @@ describe("Comments", function() {
       .its("length")
       .should("eq", 2);
   });
-  it("Completing comments tour adds bot comment in first thread", function() {
-    cy.generateUUID().then((uid) => {
-      cy.Signup(`${uid}@appsmithtest.com`, uid);
-    });
-    cy.NavigateToHome();
-
-    cy.generateUUID().then((uid) => {
-      appName = uid;
-      orgName = uid;
-      cy.createOrg();
-      cy.wait("@createOrg").then((interception) => {
-        const newOrganizationName = interception.response.body.data.name;
-        cy.renameOrg(newOrganizationName, orgName);
-      });
-      cy.CreateAppForOrg(orgName, appName);
-      cy.addDsl(dsl);
-    });
-    cy.get(commonLocators.canvas);
-    cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
-    cy.contains("NEXT").click({ force: true });
-    cy.contains("NEXT").click({ force: true });
-    cy.get("input[name='displayName']").type("Touring User");
-    cy.get("button[type='submit']").click();
-
-    // wait for comment mode to be set
+  it("Can invite new collaborators, with substring emails", () => {
+    cy.get(commentsLocators.mentionsInput)
+      .type("@appsmith", {
+        delay: 100,
+      })
+      .type("{enter}");
+    cy.contains("support@appsmith.com").should("be.visible");
+    cy.get(homePage.closeBtn).click();
     cy.wait(1000);
-    cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
-    cy.get(commonLocators.canvas).click(50, 50);
-
-    typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
-    cy.get(commentsLocators.mentionsInput).type("{enter}");
-    cy.get("[data-cy=comments-card-header]")
-      .its("length")
-      .should("eq", 3);
-    cy.contains("Appsmith Bot").should("be.visible");
+    cy.get(commentsLocators.mentionsInput)
+      .focus()
+      .type("{movetoend}");
+    cy.contains("support@appsmith.com").should("be.visible");
   });
-
-  // create another comment since the first one is a private bot thread
-  it("another comment can be created after dismissing the first one", () => {
-    cy.get(commonLocators.canvas).click(10, 10);
-    // wait for transition to be completed
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(300);
-    typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
-    cy.get(commentsLocators.mentionsInput).type("{enter}");
-    cy.wait("@createNewThread").then((response) => {
-      commentThreadId = response.response.body.data.id;
-    });
-  });
-
-  it("unread indicator is visible for another app user when a new comment is added", () => {
-    // share app with TESTUSERNAME2
-    cy.get(homePage.shareApp).click({ force: true });
-    cy.shareApp(Cypress.env("TESTUSERNAME2"), homePage.adminRole);
-    cy.LogintoApp(Cypress.env("TESTUSERNAME2"), Cypress.env("TESTPASSWORD2"));
-
-    // launch the editor
-    cy.get(homePage.searchInput).type(appName);
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000);
-    cy.get(homePage.applicationCard)
-      .first()
-      .trigger("mouseover");
-    cy.get(homePage.appEditIcon)
-      .first()
-      .click({ force: true });
-    cy.get("#loading").should("not.exist");
-
-    // unread indicator should be visible since a new comment was added
-    cy.get(commentsLocators.toggleCommentModeOnUnread).should("exist");
-    cy.get(commentsLocators.toggleCommentModeOn).should("not.exist");
-  });
-
-  it("is visible for the other app users in edit mode", () => {
-    cy.get(commentsLocators.switchToCommentModeBtn).click({
-      force: true,
-    });
-    // this is needed, as on CI we create new users
-    cy.contains("SKIP").click({ force: true });
-    cy.get("input[name='displayName']").type("Skip User");
-    cy.get("button[type='submit']").click();
-    cy.get(
-      `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
-    ).click({ force: true });
-    cy.contains(newCommentText1);
-  });
-
-  it("unread indicator should be hidden once all comment threads are marked as read", () => {
-    // thread should be marked as read by clicking before, unread indicator should not be visible
-    cy.get(commentsLocators.toggleCommentModeOnUnread).should("not.exist");
-    cy.get(commentsLocators.toggleCommentModeOn).should("exist");
-  });
-
-  it("is visible in the published mode", () => {
-    cy.PublishtheApp();
-    // wait for the published page to load
-    cy.get(commonLocators.viewerPage);
-    cy.get(commentsLocators.switchToCommentModeBtn).click({
-      force: true,
-    });
-    cy.get(
-      `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
-    ).click({ force: true });
-    cy.contains(newCommentText1);
-  });
+  // it("Completing comments tour adds bot comment in first thread", function() {
+  //   cy.generateUUID().then((uid) => {
+  //     cy.Signup(`${uid}@appsmithtest.com`, uid);
+  //   });
+  //   cy.NavigateToHome();
+  //
+  //   cy.generateUUID().then((uid) => {
+  //     appName = uid;
+  //     orgName = uid;
+  //     cy.createOrg();
+  //     cy.wait("@createOrg").then((interception) => {
+  //       const newOrganizationName = interception.response.body.data.name;
+  //       cy.renameOrg(newOrganizationName, orgName);
+  //     });
+  //     cy.CreateAppForOrg(orgName, appName);
+  //     cy.addDsl(dsl);
+  //   });
+  //   cy.get(commonLocators.canvas);
+  //   cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
+  //   cy.contains("NEXT").click({ force: true });
+  //   cy.contains("NEXT").click({ force: true });
+  //   cy.get("input[name='displayName']").type("Touring User");
+  //   cy.get("button[type='submit']").click();
+  //
+  //   // wait for comment mode to be set
+  //   cy.wait(1000);
+  //   cy.get(commentsLocators.switchToCommentModeBtn).click({ force: true });
+  //   cy.get(commonLocators.canvas).click(50, 50);
+  //
+  //   typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
+  //   cy.get(commentsLocators.mentionsInput).type("{enter}");
+  //   cy.get("[data-cy=comments-card-header]")
+  //     .its("length")
+  //     .should("eq", 3);
+  //   cy.contains("Appsmith Bot").should("be.visible");
+  // });
+  //
+  // // create another comment since the first one is a private bot thread
+  // it("another comment can be created after dismissing the first one", () => {
+  //   cy.get(commonLocators.canvas).click(10, 10);
+  //   // wait for transition to be completed
+  //   // eslint-disable-next-line cypress/no-unnecessary-waiting
+  //   cy.wait(300);
+  //   typeIntoDraftEditor(commentsLocators.mentionsInput, newCommentText1);
+  //   cy.get(commentsLocators.mentionsInput).type("{enter}");
+  //   cy.wait("@createNewThread").then((response) => {
+  //     commentThreadId = response.response.body.data.id;
+  //   });
+  // });
+  //
+  // it("unread indicator is visible for another app user when a new comment is added", () => {
+  //   // share app with TESTUSERNAME2
+  //   cy.get(homePage.shareApp).click({ force: true });
+  //   cy.shareApp(Cypress.env("TESTUSERNAME2"), homePage.adminRole);
+  //   cy.LogintoApp(Cypress.env("TESTUSERNAME2"), Cypress.env("TESTPASSWORD2"));
+  //
+  //   // launch the editor
+  //   cy.get(homePage.searchInput).type(appName);
+  //   // eslint-disable-next-line cypress/no-unnecessary-waiting
+  //   cy.wait(2000);
+  //   cy.get(homePage.applicationCard)
+  //     .first()
+  //     .trigger("mouseover");
+  //   cy.get(homePage.appEditIcon)
+  //     .first()
+  //     .click({ force: true });
+  //   cy.get("#loading").should("not.exist");
+  //
+  //   // unread indicator should be visible since a new comment was added
+  //   cy.get(commentsLocators.toggleCommentModeOnUnread).should("exist");
+  //   cy.get(commentsLocators.toggleCommentModeOn).should("not.exist");
+  // });
+  //
+  // it("is visible for the other app users in edit mode", () => {
+  //   cy.get(commentsLocators.switchToCommentModeBtn).click({
+  //     force: true,
+  //   });
+  //   // this is needed, as on CI we create new users
+  //   cy.contains("SKIP").click({ force: true });
+  //   cy.get("input[name='displayName']").type("Skip User");
+  //   cy.get("button[type='submit']").click();
+  //   cy.get(
+  //     `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
+  //   ).click({ force: true });
+  //   cy.contains(newCommentText1);
+  // });
+  //
+  // it("unread indicator should be hidden once all comment threads are marked as read", () => {
+  //   // thread should be marked as read by clicking before, unread indicator should not be visible
+  //   cy.get(commentsLocators.toggleCommentModeOnUnread).should("not.exist");
+  //   cy.get(commentsLocators.toggleCommentModeOn).should("exist");
+  // });
+  //
+  // it("is visible in the published mode", () => {
+  //   cy.PublishtheApp();
+  //   // wait for the published page to load
+  //   cy.get(commonLocators.viewerPage);
+  //   cy.get(commentsLocators.switchToCommentModeBtn).click({
+  //     force: true,
+  //   });
+  //   cy.get(
+  //     `${commentsLocators.inlineCommentThreadPin}${commentThreadId}`,
+  //   ).click({ force: true });
+  //   cy.contains(newCommentText1);
+  // });
 });

--- a/app/client/cypress/locators/commentsLocators.json
+++ b/app/client/cypress/locators/commentsLocators.json
@@ -4,5 +4,6 @@
   "postButtonAddComment": "[data-cy='add-comment-submit']",
   "inlineCommentThreadPin": ".t--inline-comment-pin-trigger-",
   "toggleCommentModeOnUnread": ".t--toggle-comment-mode-on--unread",
-  "toggleCommentModeOn": ".t--toggle-comment-mode-on"
+  "toggleCommentModeOn": ".t--toggle-comment-mode-on",
+  "cancelCommentButton": "[data-cy='add-comment-cancel']"
 }

--- a/app/client/src/comments/inlineComments/InlineCommentPin.tsx
+++ b/app/client/src/comments/inlineComments/InlineCommentPin.tsx
@@ -267,6 +267,11 @@ function InlineCommentPin(props: Props) {
           if (nextOpenState) {
             dispatch(setVisibleThread(commentThreadId));
           } else {
+            const currentURL = new URL(window.location.href);
+            const searchParams = currentURL.searchParams;
+            const isInviting = searchParams.get("inviting");
+            // Don't close the comment thread if user goes on to invite someone else.
+            if (isInviting) return;
             const shouldPersistComment = e?.type === "mousedown";
             dispatch(resetVisibleThread(commentThreadId, shouldPersistComment));
             resetCommentThreadIdInURL(commentThreadId);

--- a/app/client/src/pages/organization/OrgInviteUsersForm.tsx
+++ b/app/client/src/pages/organization/OrgInviteUsersForm.tsx
@@ -40,6 +40,7 @@ import ProfileImage from "pages/common/ProfileImage";
 import ManageUsers from "./ManageUsers";
 import ScrollIndicator from "components/ads/ScrollIndicator";
 import UserApi from "api/UserApi";
+import history from "utils/history";
 
 const OrgInviteTitle = styled.div`
   padding: 10px 0px;
@@ -203,6 +204,28 @@ const validate = (values: any) => {
 
 const { mailEnabled } = getAppsmithConfigs();
 
+export const initializeInviteFromComment = () => {
+  const currentURL = new URL(window.location.href);
+  const searchParams = currentURL.searchParams;
+  searchParams.append("inviting", "true");
+  history.replace({
+    ...window.location,
+    pathname: currentURL.pathname,
+    search: searchParams.toString(),
+  });
+};
+
+export const finalizeInviteFromComment = () => {
+  const currentURL = new URL(window.location.href);
+  const searchParams = currentURL.searchParams;
+  searchParams.delete("inviting");
+  history.replace({
+    ...window.location,
+    pathname: currentURL.pathname,
+    search: searchParams.toString(),
+  });
+};
+
 function OrgInviteUsersForm(props: any) {
   const [emailError, setEmailError] = useState("");
   const userRef = React.createRef<HTMLDivElement>();
@@ -231,6 +254,12 @@ function OrgInviteUsersForm(props: any) {
     userOrgPermissions,
     PERMISSION_TYPE.MANAGE_ORGANIZATION,
   );
+
+  // set the "inviting" query param in URL
+  useEffect(() => {
+    initializeInviteFromComment();
+    return () => finalizeInviteFromComment();
+  }, []);
 
   useEffect(() => {
     fetchUser(props.orgId);


### PR DESCRIPTION
## Description
Updating the comment value object to discard the mention tag for current invitation candidate.

Fixes #8193


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- automated test added

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/select-mentions-on-discard-share-modal 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.75 **(-0.01)** | 36.62 **(0)** | 33.45 **(-0.02)** | 55.28 **(-0.02)**
 :red_circle: | app/client/src/comments/inlineComments/AddCommentInput.tsx | 60.56 **(-4.44)** | 19.82 **(-0.18)** | 56 **(-4.87)** | 62.18 **(-4.97)**
 :red_circle: | app/client/src/comments/inlineComments/InlineCommentPin.tsx | 86.96 **(-0.4)** | 75 **(-0.76)** | 94.44 **(0)** | 89.29 **(0.54)**
 :red_circle: | app/client/src/pages/organization/OrgInviteUsersForm.tsx | 38.71 **(-1.48)** | 24 **(0)** | 0 **(0)** | 39.32 **(-2.43)**</details>