### PR TITLE
fix: Correcting the run button loading state on cancel in API pane

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
@@ -28,6 +28,27 @@ describe("API Panel Test Functionality", function() {
     cy.ClearSearch();
   });
 
+  it("Should update loading state after cancellation of confirmation for run query", function() {
+    cy.NavigateToAPI_Panel();
+    cy.log("Navigation to API Panel screen successful");
+    cy.CreateAPI("FirstAPI");
+    cy.get(".CodeMirror-placeholder")
+      .first()
+      .should("have.text", "https://mock-api.appsmith.com/users");
+    cy.log("Creation of FirstAPI Action successful");
+    cy.enterDatasourceAndPath(testdata.baseUrl, testdata.methods);
+    cy.get(apiwidget.settings).click({ force: true });
+    cy.get(apiwidget.confirmBeforeExecute).click();
+    cy.get(apiwidget.runQueryButton).click();
+    cy.get(".bp3-dialog")
+      .find("button")
+      .contains("Cancel")
+      .click();
+    cy.get(apiwidget.runQueryButton)
+      .children()
+      .should("have.length", 1);
+  });
+
   it("Should not crash on key delete", function() {
     cy.NavigateToAPI_Panel();
     cy.CreateAPI("CrashTestAPI");

--- a/app/client/cypress/locators/apiWidgetslocator.json
+++ b/app/client/cypress/locators/apiWidgetslocator.json
@@ -57,5 +57,7 @@
   "paramsTab": "//li//span[text()='Params']",
   "paramKey": ".t--actionConfiguration\\.queryParameters\\[0\\]\\.key\\.0",
   "paramValue": ".t--actionConfiguration\\.queryParameters\\[0\\]\\.value\\.0",
-  "multipartTypeDropdown":"button:contains('Type')"
+  "multipartTypeDropdown":"button:contains('Type')",
+  "confirmBeforeExecute": "[data-cy=confirmBeforeExecute]",
+  "runQueryButton": ".t--apiFormRunBtn"
 }

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -254,6 +254,17 @@ const actionsReducer = createReducer(initialState, {
 
       return a;
     }),
+  [ReduxActionTypes.RUN_ACTION_CANCELLED]: (
+    state: ActionDataState,
+    action: ReduxAction<{ id: string }>,
+  ): ActionDataState =>
+    state.map((a) => {
+      if (a.config.id === action.payload.id) {
+        return { ...a, isLoading: false };
+      }
+
+      return a;
+    }),
   [ReduxActionTypes.MOVE_ACTION_INIT]: (
     state: ActionDataState,
     action: ReduxAction<{

--- a/app/client/src/reducers/uiReducers/apiPaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/apiPaneReducer.ts
@@ -93,6 +93,16 @@ const apiPaneReducer = createReducer(initialState, {
       [action.payload.id]: false,
     },
   }),
+  [ReduxActionTypes.RUN_ACTION_CANCELLED]: (
+    state: ApiPaneReduxState,
+    action: ReduxAction<{ id: string }>,
+  ): ApiPaneReduxState => ({
+    ...state,
+    isRunning: {
+      ...state.isRunning,
+      [action.payload.id]: false,
+    },
+  }),
   [ReduxActionTypes.UPDATE_ACTION_PROPERTY]: (
     state: ApiPaneReduxState,
     action: ReduxAction<UpdateActionPropertyActionPayload>,


### PR DESCRIPTION
## Description

The run button status was updating to loading false by clicking on cancel button inside confirmation before running query pop up. So changed the apiPane and action loading to false when the request is cancelled.

Fixes #8457

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
 ### Steps to test
```
1. go to the query editor
2. click on the setting tab
3. enable Request confirmation before running query toggle
4. now click on run 
5. inside the confirmation pop up click on cancel 
6. Now the run button becomes active but previously it used to be in loading state even if the query editor was changed by switching queries.
```


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/run-button-loading 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.14 **(-0.01)** | 37.04 **(0)** | 34.02 **(-0.01)** | 55.66 **(-0.01)**
 :red_circle: | app/client/src/reducers/entityReducers/actionsReducer.tsx | 6.14 **(-0.22)** | 0 **(0)** | 0 **(0)** | 6.25 **(-0.23)**
 :red_circle: | app/client/src/reducers/uiReducers/apiPaneReducer.ts | 17.86 **(-0.66)** | 100 **(0)** | 0 **(0)** | 19.23 **(-0.77)**</details>