### PR TITLE
fix: Fix sessions being cleared after fat container is restarted

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -141,9 +141,8 @@ configure_supervisord() {
 	fi
 	if [[ "$APPSMITH_REDIS_URL" = "redis://127.0.0.1:6379" ]]; then
 		cp "$SUPERVISORD_CONF_PATH/redis.conf" /etc/supervisor/conf.d/
-    # Enable saving Redis session data to disk, so session aren't cleared on restart.
-    awk 'found == 0 && /^# save ""/ {found=1} found == 1 && /^$/ {print "save 60 1"; found = 2} {print}' /etc/redis/redis.conf > /tmp/redis.conf
-    mv /tmp/redis.conf /etc/redis/redis.conf
+		# Enable saving Redis session data to disk more often, so recent sessions aren't cleared on restart.
+		sed -i 's/^# save 60 10000$/save 60 1/g' /etc/redis/redis.conf
 	fi
 }
 

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -141,6 +141,9 @@ configure_supervisord() {
 	fi
 	if [[ "$APPSMITH_REDIS_URL" = "redis://127.0.0.1:6379" ]]; then
 		cp "$SUPERVISORD_CONF_PATH/redis.conf" /etc/supervisor/conf.d/
+    # Enable saving Redis session data to disk, so session aren't cleared on restart.
+    awk 'found == 0 && /^# save ""/ {found=1} found == 1 && /^$/ {print "save 60 1"; found = 2} {print}' /etc/redis/redis.conf > /tmp/redis.conf
+    mv /tmp/redis.conf /etc/redis/redis.conf
 	fi
 }
 


### PR DESCRIPTION
This awk command finds the following section in the default `redis.conf` file provided by Debian:

```ini
################################ SNAPSHOTTING  ################################

# Save the DB to disk.
#
# save <seconds> <changes>
#
# Redis will save the DB if both the given number of seconds and the given
# number of write operations against the DB occurred.
#
# Snapshotting can be completely disabled with a single empty string argument
# as in following example:
#
# save ""
#
# Unless specified otherwise, by default Redis will save the DB:
#   * After 3600 seconds (an hour) if at least 1 key changed
#   * After 300 seconds (5 minutes) if at least 100 keys changed
#   * After 60 seconds if at least 10000 keys changed
#
# You can set these explicitly by uncommenting the three following lines.
#
# save 3600 1
# save 300 100
# save 60 10000

```

After this section, it appends `save 60 1` so that Redis writes all data to disk every minute, if there's any changes in that minute.
