### PR TITLE
fix: Correcting the duplication of headers from datasource to newer APIs

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
@@ -72,10 +72,12 @@ function NewActionButton(props: NewActionButtonProps) {
             ? createNewQueryName(actions, currentPageId || "")
             : createNewApiName(actions, currentPageId || "");
 
-        const headers = datasource?.datasourceConfiguration?.headers ?? [];
+        /* Removed Datasource Headers because they already exists in inherited headers so should not be duplicated to Newer APIs creation as datasource is already attached to it. While for older APIs we can start showing message on the UI from the API from messages key in Actions object. */
+        // const headers = datasource?.datasourceConfiguration?.headers ?? [];
         const defaultApiActionConfig: ApiActionConfig = {
           ...DEFAULT_API_ACTION_CONFIG,
-          headers: headers.length ? headers : DEFAULT_API_ACTION_CONFIG.headers,
+          // headers: headers.length ? headers : DEFAULT_API_ACTION_CONFIG.headers,
+          headers: DEFAULT_API_ACTION_CONFIG.headers,
         };
         let payload = {
           name: newActionName,

--- a/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx
@@ -73,10 +73,8 @@ function NewActionButton(props: NewActionButtonProps) {
             : createNewApiName(actions, currentPageId || "");
 
         /* Removed Datasource Headers because they already exists in inherited headers so should not be duplicated to Newer APIs creation as datasource is already attached to it. While for older APIs we can start showing message on the UI from the API from messages key in Actions object. */
-        // const headers = datasource?.datasourceConfiguration?.headers ?? [];
         const defaultApiActionConfig: ApiActionConfig = {
           ...DEFAULT_API_ACTION_CONFIG,
-          // headers: headers.length ? headers : DEFAULT_API_ACTION_CONFIG.headers,
           headers: DEFAULT_API_ACTION_CONFIG.headers,
         };
         let payload = {


### PR DESCRIPTION
## Description

When an API was created from the datasource having some headers attached to it, then the created API used to get duplicated headers one from datasource (derived headers) and the other from its own headers. 

Fixes #6278

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Steps to reproduce :

1.  Add an API
2.  Save as data source
3.  Add Header in the Datasource
4.  Save the data source
5.  Create an API from the data source observe the header section
6. In the previous version the headers were duplicated but now the datasource headers are present only in the derived headers section.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/multiple-headers-api 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.15 **(0)** | 37.06 **(0.01)** | 34.03 **(0)** | 55.67 **(0)**
 :green_circle: | app/client/src/pages/Editor/DataSourceEditor/NewActionButton.tsx | 38.46 **(0.96)** | 4.55 **(1.1)** | 0 **(0)** | 41.67 **(1.13)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>