### PR TITLE
fix: redirect anonymous users to login page if they visit non public app

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/ShareAppTests_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OrganisationTests/ShareAppTests_spec.js
@@ -141,6 +141,16 @@ describe("Create new org and share with a user", function() {
     cy.LogOut();
   });
 
+  it("visit the app as anonymous user and validate redirection to login page", function() {
+    cy.visit(currentUrl);
+    cy.wait("@viewApp").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      404,
+    );
+    cy.contains("Sign in to your account").should("be.visible");
+  });
+
   it("login as owner and delete App ", function() {
     cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
     cy.visit("/applications");

--- a/app/client/src/sagas/ApplicationSagas.tsx
+++ b/app/client/src/sagas/ApplicationSagas.tsx
@@ -212,7 +212,7 @@ export function* fetchApplicationSaga(action: FetchApplicationReduxAction) {
 
     yield put({
       type: ReduxActionTypes.SET_APP_VERSION_ON_WORKER,
-      payload: response.data.evaluationVersion,
+      payload: response.data?.evaluationVersion,
     });
 
     if (action.onSuccessCallback) {


### PR DESCRIPTION
## Description
Null check was missing,

Fixes #9083 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/on-404-redirect-appviewer-to-login 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.59 **(0.01)** | 36.44 **(0)** | 33.22 **(0)** | 55.11 **(0)**
 :red_circle: | app/client/src/sagas/ApplicationSagas.tsx | 14.88 **(0)** | 1.15 **(-0.05)** | 4 **(0)** | 17.73 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.26 **(0.22)** | 41.25 **(0.83)** | 34.48 **(0)** | 56.22 **(0.26)**</details>