### PR TITLE
fix: Added selector for drop down component, increased width

### DIFF
--- a/app/client/src/components/formControls/FieldArrayControl.tsx
+++ b/app/client/src/components/formControls/FieldArrayControl.tsx
@@ -42,9 +42,10 @@ const SecondaryBox = styled.div`
     width: 20vw !important;
   }
 
+  & > .t--form-control-DROP_DOWN,
   & > .t--form-control-DROP_DOWN > div > div,
   & > .t--form-control-DROP_DOWN > div > div > div > div {
-    width: 8vw;
+    width: 12vw;
   }
 `;
 


### PR DESCRIPTION
The old where clause component was overflowing due to changes in the drop-down element. Updated CSS selector to fix this.

## Description

Fixes #9144 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>