### PR TITLE
fix: MenuItem overflow

### DIFF
--- a/app/client/src/components/ads/TreeDropdown.tsx
+++ b/app/client/src/components/ads/TreeDropdown.tsx
@@ -58,7 +58,7 @@ const StyledMenu = styled(Menu)`
   .${Classes.MENU_ITEM} {
     border-radius: 0px;
     font-size: 14px;
-    line-height: ${(props) => props.theme.typography.p2.lineHeight}px;
+    line-height: ${(props) => props.theme.typography.p1.lineHeight}px;
     display: flex;
     align-items: center;
     height: 30px;


### PR DESCRIPTION
## Description

Sets the `line-height` of menu item from `17px` to `19px` so that letters such as "g" won't be truncated

Fixes #6548 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In windows OS, set the zoom level to 125% and check the Action selector items

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/menu-item-overflow 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.63 **(0)** | 36.35 **(0.01)** | 33.09 **(0)** | 55.15 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.26 **(0.22)** | 41.25 **(0.83)** | 34.48 **(0)** | 56.22 **(0.26)**</details>