### PR TITLE
feat: Show evaluated value in embeddedDatasource url

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
@@ -1,5 +1,6 @@
 const testdata = require("../../../../fixtures/testdata.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
+const commonlocators = require("../../../../locators/commonlocators.json");
 
 describe("API Panel Test Functionality", function() {
   it("Test Search API fetaure", function() {
@@ -72,5 +73,16 @@ describe("API Panel Test Functionality", function() {
       key: "q",
       value: "mimeType='application/vnd.google-apps.spreadsheet'",
     });
+  });
+
+  it("Shows evaluated value pane when url field is focused", function() {
+    cy.NavigateToAPI_Panel();
+    cy.CreateAPI("TestAPI");
+    cy.get(".CodeMirror-placeholder")
+      .first()
+      .click({
+        force: true,
+      });
+    cy.get(commonlocators.evaluatedTypeTitle).should("be.visible");
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiPaneTests/API_Bugs_Spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ApiPaneTests/API_Bugs_Spec.js
@@ -36,7 +36,7 @@ describe("Rest Bugs tests", function() {
     );
     cy.wait(1000);
 
-    cy.contains(commonlocators.entityName, "Page1").click();
+    cy.contains(commonlocators.entityName, "Page1").click({ force: true });
     cy.clickButton("Get Facts!");
     cy.wait(8000); // for all api calls to complete!
 

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -420,6 +420,7 @@ function EmbeddedDatasourcePathField(
     pluginId: string;
     placeholder?: string;
     theme: EditorTheme;
+    dataTreePath: string;
   },
 ) {
   return (

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -49,6 +49,8 @@ import { setDatsourceEditorMode } from "actions/datasourceActions";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
 import { Colors } from "constants/Colors";
 import { Indices } from "constants/Layers";
+import { getExpectedValue } from "utils/validation/common";
+import { ValidationTypes } from "constants/WidgetValidation";
 
 type ReduxStateProps = {
   orgId: string;
@@ -337,6 +339,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
       hinting: [bindingHint, this.handleDatasourceHint()],
       showLightningMenu: false,
       fill: true,
+      expected: getExpectedValue({ type: ValidationTypes.SAFE_URL }),
     };
 
     return (

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -321,7 +321,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
   };
 
   handleEvaluatedValue = () => {
-    const { actionName, dataTree } = this.props;
+    const { actionName, datasource, dataTree } = this.props;
     const entity = dataTree[actionName];
 
     if (!entity) return "";
@@ -335,7 +335,14 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
             `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
         )
         .join("");
-      const evaluatedDatasourceUrl = entity.datasourceUrl;
+
+      // When Api is generated from a datasource,
+      // url is gotten from the datasource's configuration
+
+      const evaluatedDatasourceUrl =
+        "id" in datasource
+          ? datasource.datasourceConfiguration.url
+          : entity.datasourceUrl;
 
       const fullDatasourceUrlPath =
         evaluatedDatasourceUrl + evaluatedPath + evaluatedQueryParameters;

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -51,6 +51,9 @@ import { Colors } from "constants/Colors";
 import { Indices } from "constants/Layers";
 import { getExpectedValue } from "utils/validation/common";
 import { ValidationTypes } from "constants/WidgetValidation";
+import { DataTree, ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
+import { getDataTree } from "selectors/dataTreeSelectors";
+import { KeyValuePair } from "entities/Action";
 
 type ReduxStateProps = {
   orgId: string;
@@ -58,6 +61,8 @@ type ReduxStateProps = {
   datasourceList: Datasource[];
   currentPageId?: string;
   applicationId?: string;
+  dataTree: DataTree;
+  actionName: string;
 };
 
 type ReduxDispatchProps = {
@@ -315,6 +320,31 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
     };
   };
 
+  handleEvaluatedValue = () => {
+    const { actionName, dataTree } = this.props;
+    const entity = dataTree[actionName];
+
+    if (!entity) return "";
+
+    if ("ENTITY_TYPE" in entity && entity.ENTITY_TYPE === ENTITY_TYPE.ACTION) {
+      const evaluatedPath = "path" in entity.config ? entity.config.path : "";
+      const evaluatedQueryParameters = entity.config.queryParameters
+        ?.filter((p: KeyValuePair) => p.key)
+        .map(
+          (p: KeyValuePair, i: number) =>
+            `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
+        )
+        .join("");
+      const evaluatedDatasourceUrl = entity.datasourceUrl;
+
+      const fullDatasourceUrlPath =
+        evaluatedDatasourceUrl + evaluatedPath + evaluatedQueryParameters;
+
+      return fullDatasourceUrlPath;
+    }
+    return "";
+  };
+
   render() {
     const {
       datasource,
@@ -348,6 +378,8 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
           {...props}
           border={CodeEditorBorder.ALL_SIDE}
           className="t--datasource-editor"
+          evaluatedValue={this.handleEvaluatedValue()}
+          height="35px"
         />
         {displayValue && datasource && !("id" in datasource) ? (
           <StoreAsDatasource enable={!!displayValue} />
@@ -377,7 +409,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
 
 const mapStateToProps = (
   state: AppState,
-  ownProps: { pluginId: string },
+  ownProps: { pluginId: string; actionName: string },
 ): ReduxStateProps => {
   const datasourceFromAction = apiFormValueSelector(state, "datasource");
   let datasourceMerged = datasourceFromAction;
@@ -403,6 +435,8 @@ const mapStateToProps = (
     ),
     currentPageId: state.entities.pageList.currentPageId,
     applicationId: getCurrentApplicationId(state),
+    dataTree: getDataTree(state),
+    actionName: ownProps.actionName,
   };
 };
 
@@ -423,7 +457,7 @@ function EmbeddedDatasourcePathField(
     pluginId: string;
     placeholder?: string;
     theme: EditorTheme;
-    dataTreePath: string;
+    actionName: string;
   },
 ) {
   return (

--- a/app/client/src/entities/Action/actionProperties.test.ts
+++ b/app/client/src/entities/Action/actionProperties.test.ts
@@ -28,6 +28,7 @@ describe("getBindingPathsOfAction", () => {
       data: EvaluationSubstitutionType.TEMPLATE,
       isLoading: EvaluationSubstitutionType.TEMPLATE,
       config: EvaluationSubstitutionType.TEMPLATE,
+      datasourceUrl: EvaluationSubstitutionType.TEMPLATE,
     });
   });
 
@@ -76,6 +77,7 @@ describe("getBindingPathsOfAction", () => {
     expect(response).toStrictEqual({
       data: EvaluationSubstitutionType.TEMPLATE,
       isLoading: EvaluationSubstitutionType.TEMPLATE,
+      datasourceUrl: EvaluationSubstitutionType.TEMPLATE,
       "config.body": EvaluationSubstitutionType.TEMPLATE,
       "config.body2": EvaluationSubstitutionType.TEMPLATE,
       "config.field1": EvaluationSubstitutionType.SMART_SUBSTITUTE,
@@ -141,6 +143,7 @@ describe("getBindingPathsOfAction", () => {
     expect(response).toStrictEqual({
       data: EvaluationSubstitutionType.TEMPLATE,
       isLoading: EvaluationSubstitutionType.TEMPLATE,
+      datasourceUrl: EvaluationSubstitutionType.TEMPLATE,
       "config.params[0].key": EvaluationSubstitutionType.TEMPLATE,
       "config.params[0].value": EvaluationSubstitutionType.TEMPLATE,
       "config.params[1].key": EvaluationSubstitutionType.TEMPLATE,
@@ -196,6 +199,7 @@ describe("getBindingPathsOfAction", () => {
     expect(response).toStrictEqual({
       data: EvaluationSubstitutionType.TEMPLATE,
       isLoading: EvaluationSubstitutionType.TEMPLATE,
+      datasourceUrl: EvaluationSubstitutionType.TEMPLATE,
       "config.key": EvaluationSubstitutionType.TEMPLATE,
       "config.value": EvaluationSubstitutionType.TEMPLATE,
     });
@@ -252,6 +256,7 @@ describe("getBindingPathsOfAction", () => {
     expect(response).toStrictEqual({
       data: EvaluationSubstitutionType.TEMPLATE,
       isLoading: EvaluationSubstitutionType.TEMPLATE,
+      datasourceUrl: EvaluationSubstitutionType.TEMPLATE,
       "config.body": EvaluationSubstitutionType.TEMPLATE,
       "config.field1": EvaluationSubstitutionType.SMART_SUBSTITUTE,
     });
@@ -262,6 +267,7 @@ describe("getBindingPathsOfAction", () => {
     expect(response2).toStrictEqual({
       data: EvaluationSubstitutionType.TEMPLATE,
       isLoading: EvaluationSubstitutionType.TEMPLATE,
+      datasourceUrl: EvaluationSubstitutionType.TEMPLATE,
       "config.body": EvaluationSubstitutionType.TEMPLATE,
       "config.body2": EvaluationSubstitutionType.TEMPLATE,
     });

--- a/app/client/src/entities/Action/actionProperties.ts
+++ b/app/client/src/entities/Action/actionProperties.ts
@@ -23,6 +23,7 @@ export const getBindingPathsOfAction = (
   const bindingPaths: Record<string, EvaluationSubstitutionType> = {
     data: EvaluationSubstitutionType.TEMPLATE,
     isLoading: EvaluationSubstitutionType.TEMPLATE,
+    datasourceUrl: EvaluationSubstitutionType.TEMPLATE,
   };
   if (!formConfig) {
     return {

--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -16,11 +16,18 @@ export enum PaginationType {
   URL = "URL",
 }
 
+export interface KeyValuePair {
+  key?: string;
+  value?: unknown;
+}
+
 export interface ActionConfig {
   timeoutInMillisecond?: number;
   paginationType?: PaginationType;
   formData?: Record<string, unknown>;
-  pluginSpecifiedTemplates?: Array<{ key?: string; value?: unknown }>;
+  pluginSpecifiedTemplates?: KeyValuePair[];
+  path?: string;
+  queryParameters?: KeyValuePair[];
 }
 
 export interface ActionProvider {

--- a/app/client/src/entities/DataTree/dataTreeAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeAction.ts
@@ -12,6 +12,8 @@ export const generateDataTreeAction = (
   dependencyConfig: DependencyMap = {},
 ): DataTreeAction => {
   let dynamicBindingPathList: DynamicPath[] = [];
+  let url = "";
+
   // update paths
   if (
     action.config.dynamicBindingPathList &&
@@ -19,9 +21,14 @@ export const generateDataTreeAction = (
   ) {
     dynamicBindingPathList = action.config.dynamicBindingPathList.map((d) => ({
       ...d,
-      key: `config.${d.key}`,
+      key: d.key === "datasourceUrl" ? d.key : `config.${d.key}`,
     }));
   }
+
+  if ("datasourceConfiguration" in action.config.datasource) {
+    url = action.config.datasource.datasourceConfiguration.url;
+  }
+
   const dependencyMap: DependencyMap = {};
   Object.entries(dependencyConfig).forEach(([dependent, dependencies]) => {
     dependencyMap[getDataTreeActionConfigPath(dependent)] = dependencies.map(
@@ -47,5 +54,6 @@ export const generateDataTreeAction = (
     bindingPaths: getBindingPathsOfAction(action.config, editorConfig),
     dependencyMap,
     logBlackList: {},
+    datasourceUrl: url,
   };
 };

--- a/app/client/src/entities/DataTree/dataTreeAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeAction.ts
@@ -5,6 +5,7 @@ import {
   getBindingPathsOfAction,
   getDataTreeActionConfigPath,
 } from "entities/Action/actionProperties";
+import { Property } from "api/ActionAPI";
 
 export const generateDataTreeAction = (
   action: ActionData,
@@ -12,7 +13,7 @@ export const generateDataTreeAction = (
   dependencyConfig: DependencyMap = {},
 ): DataTreeAction => {
   let dynamicBindingPathList: DynamicPath[] = [];
-  let url = "";
+  let datasourceUrl = "";
 
   // update paths
   if (
@@ -25,8 +26,22 @@ export const generateDataTreeAction = (
     }));
   }
 
+  // update datasource url for embedded datasource action
   if ("datasourceConfiguration" in action.config.datasource) {
-    url = action.config.datasource.datasourceConfiguration.url;
+    const path =
+      "path" in action.config.actionConfiguration
+        ? action.config.actionConfiguration.path
+        : "";
+
+    const query = action.config.actionConfiguration.queryParameters
+      .filter((p: Property) => p.key)
+      .map(
+        (p: Property, i: number) => `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
+      )
+      .join("");
+
+    datasourceUrl =
+      action.config.datasource.datasourceConfiguration.url + path + query;
   }
 
   const dependencyMap: DependencyMap = {};
@@ -54,6 +69,6 @@ export const generateDataTreeAction = (
     bindingPaths: getBindingPathsOfAction(action.config, editorConfig),
     dependencyMap,
     logBlackList: {},
-    datasourceUrl: url,
+    datasourceUrl,
   };
 };

--- a/app/client/src/entities/DataTree/dataTreeAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeAction.ts
@@ -25,7 +25,6 @@ export const generateDataTreeAction = (
     }));
   }
 
-  // set datasource url for embedded datasource action
   if ("datasourceConfiguration" in action.config.datasource) {
     datasourceUrl = action.config.datasource.datasourceConfiguration.url;
   }

--- a/app/client/src/entities/DataTree/dataTreeAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeAction.ts
@@ -5,7 +5,6 @@ import {
   getBindingPathsOfAction,
   getDataTreeActionConfigPath,
 } from "entities/Action/actionProperties";
-import { Property } from "api/ActionAPI";
 
 export const generateDataTreeAction = (
   action: ActionData,
@@ -26,22 +25,9 @@ export const generateDataTreeAction = (
     }));
   }
 
-  // update datasource url for embedded datasource action
+  // set datasource url for embedded datasource action
   if ("datasourceConfiguration" in action.config.datasource) {
-    const path =
-      "path" in action.config.actionConfiguration
-        ? action.config.actionConfiguration.path
-        : "";
-
-    const query = action.config.actionConfiguration.queryParameters
-      .filter((p: Property) => p.key)
-      .map(
-        (p: Property, i: number) => `${i === 0 ? "?" : "&"}${p.key}=${p.value}`,
-      )
-      .join("");
-
-    datasourceUrl =
-      action.config.datasource.datasourceConfiguration.url + path + query;
+    datasourceUrl = action.config.datasource.datasourceConfiguration.url;
   }
 
   const dependencyMap: DependencyMap = {};

--- a/app/client/src/entities/DataTree/dataTreeAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeAction.ts
@@ -25,7 +25,10 @@ export const generateDataTreeAction = (
     }));
   }
 
-  if ("datasourceConfiguration" in action.config.datasource) {
+  if (
+    action.config.datasource &&
+    "datasourceConfiguration" in action.config.datasource
+  ) {
     datasourceUrl = action.config.datasource.datasourceConfiguration.url;
   }
 

--- a/app/client/src/entities/DataTree/dataTreeFactory.ts
+++ b/app/client/src/entities/DataTree/dataTreeFactory.ts
@@ -57,6 +57,7 @@ export interface DataTreeAction
   ENTITY_TYPE: ENTITY_TYPE.ACTION;
   dependencyMap: DependencyMap;
   logBlackList: Record<string, true>;
+  datasourceUrl: string;
 }
 
 export interface DataTreeJSAction {

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -617,6 +617,7 @@ function ApiEditorForm(props: Props) {
             </BoundaryContainer>
             <DatasourceWrapper className="t--dataSourceField">
               <EmbeddedDatasourcePathField
+                dataTreePath={`${actionName}.datasourceUrl`}
                 name="actionConfiguration.path"
                 placeholder="https://mock-api.appsmith.com/users"
                 pluginId={pluginId}

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -617,7 +617,7 @@ function ApiEditorForm(props: Props) {
             </BoundaryContainer>
             <DatasourceWrapper className="t--dataSourceField">
               <EmbeddedDatasourcePathField
-                dataTreePath={`${actionName}.datasourceUrl`}
+                actionName={actionName}
                 name="actionConfiguration.path"
                 placeholder="https://mock-api.appsmith.com/users"
                 pluginId={pluginId}

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -397,6 +397,20 @@ export function getDynamicBindingsChangesSaga(
   const bindingField = field.replace("actionConfiguration.", "");
   let dynamicBindings: DynamicPath[] = action.dynamicBindingPathList || [];
 
+  if (
+    "datasourceConfiguration" in action.datasource &&
+    field === "datasource"
+  ) {
+    // only the datasource.datasourceConfiguration.url can be a dynamic field
+    dynamicBindings = dynamicBindings.filter(
+      (binding) => binding.key !== "datasourceUrl",
+    );
+    const datasourceUrl = action.datasource.datasourceConfiguration.url;
+    isDynamicValue(datasourceUrl) &&
+      dynamicBindings.push({ key: "datasourceUrl" });
+    return dynamicBindings;
+  }
+
   // When a key-value pair is added or deleted from a fieldArray
   // Value is an Array representing the new fieldArray.
 

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -449,5 +449,19 @@ export function getDynamicBindingsChangesSaga(
     }
   }
 
+  // For embedded datasource action, full datasource url depends on
+  // url, path and queryParams.
+  // we add the datasourceUrl to the dependencyList if any of these is a dynamic path
+
+  const dynamicBindingListHasFullpathDependencies =
+    !_.some(dynamicBindings, { key: "datasourceUrl" }) &&
+    _.some(dynamicBindings, (dynamicPath) => {
+      return (
+        dynamicPath.key === "path" ||
+        isChildPropertyPath("queryParameters", dynamicPath.key)
+      );
+    });
+  dynamicBindingListHasFullpathDependencies &&
+    dynamicBindings.push({ key: "datasourceUrl" });
   return dynamicBindings;
 }

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -448,20 +448,5 @@ export function getDynamicBindingsChangesSaga(
       dynamicBindings.push({ key: bindingField });
     }
   }
-
-  // For embedded datasource action, full datasource url depends on
-  // url, path and queryParams.
-  // we add the datasourceUrl to the dependencyList if any of these is a dynamic path
-
-  const dynamicBindingListHasFullpathDependencies =
-    !_.some(dynamicBindings, { key: "datasourceUrl" }) &&
-    _.some(dynamicBindings, (dynamicPath) => {
-      return (
-        dynamicPath.key === "path" ||
-        isChildPropertyPath("queryParameters", dynamicPath.key)
-      );
-    });
-  dynamicBindingListHasFullpathDependencies &&
-    dynamicBindings.push({ key: "datasourceUrl" });
   return dynamicBindings;
 }

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -398,6 +398,7 @@ export function getDynamicBindingsChangesSaga(
   let dynamicBindings: DynamicPath[] = action.dynamicBindingPathList || [];
 
   if (
+    action.datasource &&
     "datasourceConfiguration" in action.datasource &&
     field === "datasource"
   ) {


### PR DESCRIPTION
## Description

PR to show evaluated value in datasource URL. 


Fixes #821

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Cypress

- Jest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes












## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feat/show-evaluated-value-in-action-url 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.2 **(-0.02)** | 37.07 **(-0.02)** | 34.06 **(-0.01)** | 55.72 **(-0.02)**
 :red_circle: | app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx | 29.63 **(-1.58)** | 2.06 **(-0.41)** | 3.57 **(-0.43)** | 31.97 **(-1.11)**
 :red_circle: | app/client/src/entities/DataTree/dataTreeAction.ts | 21.05 **(-3.95)** | 0 **(0)** | 0 **(0)** | 21.43 **(-5.84)**
 :red_circle: | app/client/src/utils/DynamicBindingUtils.ts | 83.52 **(-2.28)** | 69.64 **(-0.84)** | 75.86 **(-2.71)** | 82.82 **(-2.53)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>