### PR TITLE
fix: Second time file upload is failing in S3 crud page

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/derived.js
+++ b/app/client/src/widgets/ListWidget/widget/derived.js
@@ -100,10 +100,12 @@ export default {
           }
         });
 
-        currentItem[currentWidgetName] = _.pick(
-          currentWidget,
-          props.childrenEntityDefinitions[currentWidget.type],
-        );
+        if (props.childrenEntityDefinitions) {
+          currentItem[currentWidgetName] = _.pick(
+            currentWidget,
+            props.childrenEntityDefinitions[currentWidget.type],
+          );
+        }
       }
 
       updatedItems[itemIndex] = currentItem;


### PR DESCRIPTION
Fixes the failing of s3 crud app on second time on uploading the file

Fixes #9201 

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change
- Bug fix 

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/list-widget-s3-crud-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.63 **(0)** | 36.35 **(0.01)** | 33.09 **(0)** | 55.15 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.26 **(0.22)** | 41.25 **(0.83)** | 34.48 **(0)** | 56.22 **(0.26)**
 :green_circle: | app/client/src/widgets/ListWidget/widget/derived.js | 68.18 **(0.49)** | 37.5 **(0.83)** | 54.55 **(0)** | 66.13 **(0.56)**</details>