### PR TITLE
fix: issues with key / column ID in QueryEditor

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -13,6 +13,7 @@ import ErrorBoundary from "components/editorComponents/ErrorBoundry";
 import { CellWrapper } from "widgets/TableWidget/component/TableStyledWrappers";
 import AutoToolTipComponent from "widgets/TableWidget/component/AutoToolTipComponent";
 import { Theme } from "constants/DefaultTheme";
+import { uniqueId } from "lodash";
 
 interface TableProps {
   data: Record<string, any>[];
@@ -194,7 +195,19 @@ const renderCell = (props: any) => {
 };
 
 function Table(props: TableProps) {
-  const data = React.useMemo(() => props.data, [props.data]);
+  const data = React.useMemo(() => {
+    const emptyString = "";
+    const keys = Object.keys(props.data[0]);
+    keys.forEach((key) => {
+      if (key === emptyString) {
+        const value = props.data[0][key];
+        delete props.data[0][key];
+        props.data[0][uniqueId()] = value;
+      }
+    });
+
+    return props.data;
+  }, [props.data]);
   const columns = React.useMemo(() => {
     if (data.length) {
       return Object.keys(data[0]).map((key: any) => {

--- a/app/client/src/pages/Editor/__tests__/QueryEditorTable.test.tsx
+++ b/app/client/src/pages/Editor/__tests__/QueryEditorTable.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render, screen } from "test/testUtils";
+import "@testing-library/jest-dom";
+import Table from "../QueryEditor/Table";
+
+describe("Query Editor Table", () => {
+  it("it should render table with missing key", () => {
+    render(<Table data={[{ "": "Jan 1 1970 10:15AM" }]} />);
+    const date = screen.getByText(/Jan 1 1970 10:15AM/i);
+    expect(date).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

return invalid data in query Editor causing table to crash

Fixes #6968 


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix--column-ID-issue-in-Query-Editor 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.77 **(0.14)** | 36.76 **(0.43)** | 33.37 **(0.29)** | 55.3 **(0.15)**
 :green_circle: | app/client/src/pages/Editor/QueryEditor/Table.tsx | 86.15 **(61.59)** | 46.15 **(37.82)** | 100 **(100)** | 85.71 **(59.78)**
 :green_circle: | app/client/src/utils/helpers.tsx | 62.41 **(2.26)** | 31.25 **(0)** | 47.5 **(2.5)** | 60.19 **(2.91)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.26 **(0.22)** | 41.25 **(0.83)** | 34.48 **(0)** | 56.22 **(0.26)**
 :green_circle: | app/client/src/widgets/TableWidget/component/AutoToolTipComponent.tsx | 57.58 **(30.31)** | 39.29 **(25)** | 33.33 **(33.33)** | 58.62 **(27.59)**
 :green_circle: | app/client/src/widgets/TableWidget/component/TableStyledWrappers.tsx | 86.9 **(16.66)** | 54.51 **(33.08)** | 79.63 **(25.93)** | 86.9 **(16.66)**</details>