### PR TITLE
fix: updated condition select widget

### DIFF
--- a/app/client/src/sagas/WidgetSelectionSagas.ts
+++ b/app/client/src/sagas/WidgetSelectionSagas.ts
@@ -133,7 +133,7 @@ function* getAllSelectableChildren() {
   const canvasId: string = yield call(getLastSelectedCanvas);
   let allChildren: string[] = [];
   const selectGrandChildren: boolean = lastSelectedWidget
-    ? widgetLastSelected.type === WidgetTypes.LIST_WIDGET
+    ? widgetLastSelected && widgetLastSelected.type === WidgetTypes.LIST_WIDGET
     : false;
   if (selectGrandChildren) {
     allChildren = yield call(


### PR DESCRIPTION

## Description

> fixed cannot read properties of undefined (reading 'type') error occurs when the user groups widget as container and pressing cmd+A 

Fixes #8959

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: bug/fixed-widget-selection 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.63 **(0)** | 36.35 **(-0.01)** | 33.09 **(0)** | 55.15 **(-0.01)**
 :red_circle: | app/client/src/sagas/WidgetSelectionSagas.ts | 90.6 **(-0.68)** | 88.42 **(0.25)** | 100 **(0)** | 89.84 **(-0.79)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.04 **(-0.22)** | 40.42 **(-0.83)** | 34.48 **(0)** | 55.96 **(-0.26)**</details>