### PR TITLE
fix: radio group widget crash when one of options becomes null

### DIFF
--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -6,7 +6,7 @@ import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { RadioOption } from "../constants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
-import { isArray } from "lodash";
+import { compact, isArray } from "lodash";
 
 class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
   static getPropertyPaneConfig() {
@@ -144,7 +144,7 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
         key={this.props.widgetId}
         label={`${this.props.label}`}
         onRadioSelectionChange={this.onRadioSelectionChange}
-        options={isArray(this.props.options) ? this.props.options : []}
+        options={isArray(this.props.options) ? compact(this.props.options) : []}
         selectedOptionValue={this.props.selectedOptionValue}
         widgetId={this.props.widgetId}
       />


### PR DESCRIPTION
## Description

Fixes #9289 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Refer [this comment](https://github.com/appsmithorg/appsmith/issues/9289#issuecomment-976417079) to reproduce the issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>