### PR TITLE
fix: google sheets plugin input fields for numbers parse issue

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
@@ -58,25 +58,25 @@ public class MethodConfig {
                         }
                         break;
                     case "range":
-                        this.spreadsheetRange = propertyValue;
+                        this.spreadsheetRange = propertyValue.trim();
                         break;
                     case "spreadsheetName":
                         this.spreadsheetName = propertyValue;
                         break;
                     case "tableHeaderIndex":
-                        this.tableHeaderIndex = propertyValue;
+                        this.tableHeaderIndex = propertyValue.trim();
                         break;
                     case "queryFormat":
                         this.queryFormat = propertyValue;
                         break;
                     case "rowLimit":
-                        this.rowLimit = propertyValue;
+                        this.rowLimit = propertyValue.trim();
                         break;
                     case "rowOffset":
-                        this.rowOffset = propertyValue;
+                        this.rowOffset = propertyValue.trim();
                         break;
                     case "rowIndex":
-                        this.rowIndex = propertyValue;
+                        this.rowIndex = propertyValue.trim();
                         break;
                     case "sheetName":
                         this.sheetName = propertyValue;


### PR DESCRIPTION
## Description

> Google sheets plugin: Row limit does not parse properly
> When We give a space or enter in the input where an Integer is expected, it is throwing error.

Fixes #8196

>By adding a trim() where an integer value is expected, this error is handled
>This fix resolved in 5 input fields, and also handles enter keys before and after values

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

>Use google sheet get query
-While defining the row limit add an additional new line after input value - Error was found and fixed now
-While defining the row limit add an additional new line before input value- Error was found and fixed now
-While defining the row limit add a space before input value- Error was found and fixed now
-While defining the row limit add a space before input value- Error was found and fixed now
 
>Tested for the following input fields
(1) Table Heading Row Index   - Error was found and fixed now
(2) Row Offset   - Error was found and fixed now
(3) Row Limit   - Error was found and fixed now
(4) Cell Range   - Error was found and fixed now


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
