### PR TITLE
fix: Hide scrollbar in header and show when user hovers over header in Table Widget

### DIFF
--- a/app/client/src/widgets/TableWidget/component/Table.tsx
+++ b/app/client/src/widgets/TableWidget/component/Table.tsx
@@ -230,9 +230,13 @@ export function Table(props: TableProps) {
           width={props.width}
         >
           <Scrollbars
+            autoHide
             renderThumbHorizontal={ScrollbarHorizontalThumb}
             renderThumbVertical={ScrollbarVerticalThumb}
-            style={{ width: props.width, height: 38 }}
+            style={{
+              width: props.width,
+              height: 38,
+            }}
           >
             <TableHeaderInnerWrapper
               backgroundColor={Colors.WHITE}

--- a/app/client/src/widgets/TableWidget/index.ts
+++ b/app/client/src/widgets/TableWidget/index.ts
@@ -14,7 +14,7 @@ export const CONFIG = {
   needsMeta: true,
   defaults: {
     rows: 7 * GRID_DENSITY_MIGRATION_V1,
-    columns: 7.5 * GRID_DENSITY_MIGRATION_V1,
+    columns: 12.5 * GRID_DENSITY_MIGRATION_V1,
     defaultSelectedRow: "0",
     label: "Data",
     widgetName: "Table",

--- a/app/client/src/widgets/TableWidget/index.ts
+++ b/app/client/src/widgets/TableWidget/index.ts
@@ -14,7 +14,7 @@ export const CONFIG = {
   needsMeta: true,
   defaults: {
     rows: 7 * GRID_DENSITY_MIGRATION_V1,
-    columns: 12.5 * GRID_DENSITY_MIGRATION_V1,
+    columns: 8.5 * GRID_DENSITY_MIGRATION_V1,
     defaultSelectedRow: "0",
     label: "Data",
     widgetName: "Table",


### PR DESCRIPTION
## Description
Hide scrollbar and show only when user hovers over header in Table Widget. Also change default table widget width to hide scrollbars. 

Fixes #9312 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: bug/horizonal-header-scroll 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.03 **(-0.01)** | 36.93 **(-0.01)** | 33.76 **(0)** | 55.51 **(-0.01)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>