### PR TITLE
fix: Send unsupported message when trying to test SaaS integrations

### DIFF
--- a/app/server/appsmith-plugins/saasPlugin/src/main/java/com/external/plugins/SaasPlugin.java
+++ b/app/server/appsmith-plugins/saasPlugin/src/main/java/com/external/plugins/SaasPlugin.java
@@ -213,7 +213,7 @@ public class SaasPlugin extends BasePlugin {
 
         @Override
         public Mono<DatasourceTestResult> testDatasource(DatasourceConfiguration datasourceConfiguration) {
-            return Mono.empty();
+            return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, "Unsupported Operation"));
         }
     }
 }


### PR DESCRIPTION
Show the message "Unsupported operation" when trying to test SaaS integrations.