### PR TITLE
fix: Google Sheet Plugin Numeric inputs Whitespace issue.

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
@@ -58,25 +58,25 @@ public class MethodConfig {
                         }
                         break;
                     case "range":
-                        this.spreadsheetRange = propertyValue;
+                        this.spreadsheetRange = propertyValue.trim();
                         break;
                     case "spreadsheetName":
                         this.spreadsheetName = propertyValue;
                         break;
                     case "tableHeaderIndex":
-                        this.tableHeaderIndex = propertyValue;
+                        this.tableHeaderIndex = propertyValue.trim();
                         break;
                     case "queryFormat":
                         this.queryFormat = propertyValue;
                         break;
                     case "rowLimit":
-                        this.rowLimit = propertyValue;
+                        this.rowLimit = propertyValue.trim();
                         break;
                     case "rowOffset":
-                        this.rowOffset = propertyValue;
+                        this.rowOffset = propertyValue.trim();
                         break;
                     case "rowIndex":
-                        this.rowIndex = propertyValue;
+                        this.rowIndex = propertyValue.trim();
                         break;
                     case "sheetName":
                         this.sheetName = propertyValue;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
@@ -44,7 +44,7 @@ public class MethodConfig {
         propertyList.stream().parallel().forEach(property -> {
             Object value = property.getValue();
             if (value != null) {
-                String propertyValue = String.valueOf(value);
+                String propertyValue = String.valueOf(value).trim();
                 switch (property.getKey()) {
                     case "sheetUrl":
                         this.spreadsheetUrl = propertyValue;
@@ -58,25 +58,25 @@ public class MethodConfig {
                         }
                         break;
                     case "range":
-                        this.spreadsheetRange = propertyValue.trim();
+                        this.spreadsheetRange = propertyValue;
                         break;
                     case "spreadsheetName":
                         this.spreadsheetName = propertyValue;
                         break;
                     case "tableHeaderIndex":
-                        this.tableHeaderIndex = propertyValue.trim();
+                        this.tableHeaderIndex = propertyValue;
                         break;
                     case "queryFormat":
                         this.queryFormat = propertyValue;
                         break;
                     case "rowLimit":
-                        this.rowLimit = propertyValue.trim();
+                        this.rowLimit = propertyValue;
                         break;
                     case "rowOffset":
-                        this.rowOffset = propertyValue.trim();
+                        this.rowOffset = propertyValue;
                         break;
                     case "rowIndex":
-                        this.rowIndex = propertyValue.trim();
+                        this.rowIndex = propertyValue;
                         break;
                     case "sheetName":
                         this.sheetName = propertyValue;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/MethodConfigTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/MethodConfigTest.java
@@ -1,4 +1,4 @@
-package com.external.plugins;
+package com.external.config;
 
 
 import com.appsmith.external.models.Property;
@@ -7,7 +7,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import java.util.*;
 
-public class GoogleSheetsPluginTest {
+public class MethodConfigTest {
 
     @Test
     public void testWhiteSpaceRemovalForIntegerParsingErrors() throws Exception {

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/plugins/GoogleSheetsPluginTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/plugins/GoogleSheetsPluginTest.java
@@ -1,0 +1,64 @@
+package com.external.plugins;
+
+
+import com.appsmith.external.models.Property;
+import com.external.config.MethodConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.*;
+
+public class GoogleSheetsPluginTest {
+
+    @Test
+    public void testWhiteSpaceRemovalForIntegerParsingErrors() throws Exception {
+        Property testProp = null;
+        MethodConfig methodConfig =null;
+        List<Property> properties = null;
+        final String[] testPropKeys = { "range","tableHeaderIndex","rowLimit","rowOffset","rowIndex"};
+
+        //Test data Expected output vs inputs
+        Map<String, String>  testDataMap = new HashMap<String, String>();
+        testDataMap.put("2",       "2 ");
+        testDataMap.put("22",      " 22 ");
+        testDataMap.put("200",     "  200");
+        testDataMap.put("2",       "  \t 2  ");
+        testDataMap.put("7",       "7 \n");
+        testDataMap.put("72",      " \n\n 72 \n\n");
+        testDataMap.put("24",      "\t\n 24 ");
+        testDataMap.put("444",     "\t\n 444 \t\n");
+        testDataMap.put("7878",    "\n\n\n\n 7878 ");
+        testDataMap.put("7",       "7 \n\n\n\n\n");
+        testDataMap.put("1",       "\n\n\n 1 \n\n\n\n ");
+
+        for(int i=0; i< testPropKeys.length; i++) {
+
+            for (Map.Entry<String, String> e : testDataMap.entrySet()){
+                properties = new ArrayList<Property>();
+                testProp = new Property(testPropKeys[i],e.getValue());
+                properties.add(testProp);
+
+                methodConfig = new MethodConfig(properties); // We are testing this Class with test data
+
+                switch (testPropKeys[i]){
+                    case "range":
+                        Assert.assertEquals(methodConfig.getSpreadsheetRange(), e.getKey());
+                        break;
+                    case "tableHeaderIndex":
+                        Assert.assertEquals(methodConfig.getTableHeaderIndex(), e.getKey());
+                        break;
+                    case "rowLimit":
+                        Assert.assertEquals(methodConfig.getRowLimit(), e.getKey());
+                        break;
+                    case "rowOffset":
+                        Assert.assertEquals(methodConfig.getRowOffset(), e.getKey());
+                        break;
+                    case "rowIndex":
+                        Assert.assertEquals(methodConfig.getRowIndex(), e.getKey());
+                        break;
+                }
+
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Description
> Google sheets plugin: Row limit does not parse properly
>When We give a space or enter in the input where an Integer is expected, it is throwing error. 

Fixes #8196
> By adding a trim() where an integer value is expected, this error is handle
>This fix resolves 5 input fields, and also handles enter keys before and after values

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Unit Test has been added for this issue

## How Has This Been Tested?
Use google sheet get query
-While defining the row limit add an additional new line after input value - Error was found and fixed now
-While defining the row limit add an additional new line before input value- Error was found and fixed now
-While defining the row limit add a space before input value- Error was found and fixed now
-While defining the row limit add a space before input value- Error was found and fixed now

Tested for the following input fields
(1) Table Heading Row Index - Error was found and fixed now
(2) Row Offset - Error was found and fixed now
(3) Row Limit - Error was found and fixed now
(4) Cell Range - Error was found and fixed now

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
