### PR TITLE
fix: Mute action execution errors when error callback is present

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/Error_handling_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/Error_handling_spec.js
@@ -1,0 +1,65 @@
+const commonlocators = require("../../../../locators/commonlocators.json");
+const dsl = require("../../../../fixtures/buttonApiDsl.json");
+const widgetsPage = require("../../../../locators/Widgets.json");
+const publishPage = require("../../../../locators/publishWidgetspage.json");
+
+describe("Test Create Api and Bind to Table widget", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Test_Add users api and execute api", function() {
+    cy.createAndFillApi(this.data.userApi, "/random");
+    cy.RunAPI();
+  });
+
+  it("Call the api without error handling", () => {
+    cy.SearchEntityandOpen("Button1");
+    cy.get(widgetsPage.toggleOnClick)
+      .invoke("attr", "class")
+      .then((classes) => {
+        if (classes.includes("is-active")) {
+          cy.get(widgetsPage.toggleOnClick).click();
+        }
+      });
+    cy.get(widgetsPage.toggleOnClick).click();
+
+    cy.get(".t--property-control-onclick").then(($el) => {
+      cy.updateCodeInput($el, "{{Api1.run()}}");
+    });
+
+    cy.PublishtheApp();
+
+    cy.get(publishPage.buttonWidget).click();
+    cy.wait("@postExecute").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
+
+    cy.get(commonlocators.toastAction)
+      .should("have.length", 1)
+      .should("contain.text", "failed to execute");
+
+    cy.get(publishPage.backToEditor).click({ force: true });
+  });
+
+  it("Call the api with error handling", () => {
+    cy.SearchEntityandOpen("Button1");
+
+    cy.get(".t--property-control-onclick").then(($el) => {
+      cy.updateCodeInput($el, "{{Api1.run(() => {}, () => {})}}");
+    });
+
+    cy.PublishtheApp();
+
+    cy.get(publishPage.buttonWidget).click();
+    cy.wait("@postExecute").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
+
+    cy.get(commonlocators.toastAction).should("not.exist");
+  });
+});

--- a/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
@@ -66,7 +66,6 @@ export function* executeActionTriggers(
         executePluginActionTriggerSaga,
         trigger.payload,
         eventType,
-        triggerMeta,
       );
       break;
     case ActionTriggerType.CLEAR_PLUGIN_ACTION:

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -86,7 +86,6 @@ import { RunPluginActionDescription } from "entities/DataTree/actionTriggers";
 import { APP_MODE } from "entities/App";
 import { FileDataTypes } from "widgets/constants";
 import { hideDebuggerErrors } from "actions/debuggerActions";
-import { TriggerMeta } from "sagas/ActionExecution/ActionExecutionSagas";
 import {
   PluginTriggerFailureError,
   PluginActionExecutionError,
@@ -243,7 +242,6 @@ function* confirmRunActionSaga() {
 export default function* executePluginActionTriggerSaga(
   pluginAction: RunPluginActionDescription["payload"],
   eventType: EventType,
-  triggerMeta: TriggerMeta,
 ) {
   const { actionId, params } = pluginAction;
   PerformanceTracker.startAsyncTracking(
@@ -310,7 +308,6 @@ export default function* executePluginActionTriggerSaga(
     throw new PluginTriggerFailureError(
       createMessage(ERROR_PLUGIN_ACTION_EXECUTE, action.name),
       [payload.body, params],
-      triggerMeta,
     );
   } else {
     AppsmithConsole.info({

--- a/app/client/src/sagas/ActionExecution/errorUtils.ts
+++ b/app/client/src/sagas/ActionExecution/errorUtils.ts
@@ -58,15 +58,11 @@ export const logActionExecutionError = (
   });
 };
 
-export class PluginTriggerFailureError extends TriggerFailureError {
+export class PluginTriggerFailureError extends Error {
   responseData: unknown[] = [];
 
-  constructor(
-    reason: string,
-    responseData: unknown[],
-    triggerMeta: TriggerMeta,
-  ) {
-    super(reason, triggerMeta);
+  constructor(reason: string, responseData: unknown[]) {
+    super(reason);
     this.responseData = responseData;
   }
 }


### PR DESCRIPTION
## Description

Don't show platform Action errors when a error callback is configured


## Type of change

- Bug fix (non-breaking change which fixes an issue)



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/action-error-toasts 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.04 **(0)** | 36.94 **(0.01)** | 33.78 **(0)** | 55.52 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.26 **(0.22)** | 41.25 **(0.83)** | 34.48 **(0)** | 56.22 **(0.26)**</details>