### PR TITLE
fix: S3: update dynamic binding path list for published actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3912,11 +3912,10 @@ public class DatabaseChangelog {
                 Plugin.class
         );
 
-        // Query to find all S3 Actions where `publishedAction` attribute exists and is non-null.
+        // Query to find all S3 Actions where `publishedAction` attribute exists.
         Query queryToFindAllS3ActionsWithPublishedActionField = query(
                 where("pluginId").is(s3Plugin.getId())
                         .and("publishedAction").exists(true)
-                        .and("publishedAction").ne(null)
         );
 
         // Fetch all S3 Actions where `publishedAction` attribute exists and is non-null.
@@ -3925,6 +3924,7 @@ public class DatabaseChangelog {
 
         // Migrate the dynamic binding path list for published action
         s3Actions.stream()
+                .filter(action -> action.getPublishedAction() != null)
                 .forEach(action -> {
                     ActionDTO publishedAction = action.getPublishedAction();
                     List<Property> dynamicBindingPathList = publishedAction.getDynamicBindingPathList();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3549,7 +3549,7 @@ public class DatabaseChangelog {
     }
 
     private List<Property> getUpdatedDynamicBindingPathList(List<Property> dynamicBindingPathList,
-                                                            ObjectMapper objectMapper, NewAction s3Action) {
+                                                            ObjectMapper objectMapper, NewAction action) {
         // Return if empty.
         if (CollectionUtils.isEmpty(dynamicBindingPathList)) {
             return dynamicBindingPathList;
@@ -3583,7 +3583,7 @@ public class DatabaseChangelog {
                     .map(property -> property.getKey())
                     .collect(Collectors.toList());
 
-            Set<String> pathsToRemove = getInvalidDynamicBindingPathsInAction(objectMapper, s3Action, dynamicBindingPathNames);
+            Set<String> pathsToRemove = getInvalidDynamicBindingPathsInAction(objectMapper, action, dynamicBindingPathNames);
 
             // We have found atleast 1 invalid dynamic binding path.
             if (!pathsToRemove.isEmpty()) {
@@ -3889,7 +3889,7 @@ public class DatabaseChangelog {
     /**
      * One of the previous migrations updated the `dynamicBindingPathList` for unpublished actions of S3 plugin as part
      * of porting S3 plugin to UQI model. However, the `dynamicBindingPathList` update for published actions got
-     * skipped somehow. This fix takes care of the skip.
+     * skipped somehow. This fix updates the `dynamicBindingPathList` for published actions of S3 plugin.
      * @param mongockTemplate
      */
     @ChangeSet(order = "098", id = "fix-s3-dynamic-binding-path-list-migration", author = "")

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3534,7 +3534,7 @@ public class DatabaseChangelog {
             // Migrate the dynamic binding path list for unpublished action
             List<Property> dynamicBindingPathList = unpublishedAction.getDynamicBindingPathList();
             List<Property> newDynamicBindingPathList = getUpdatedDynamicBindingPathList(dynamicBindingPathList,
-                    objectMapper, s3Action);
+                    objectMapper, s3Action, s3MigrationMap);
             unpublishedAction.setDynamicBindingPathList(newDynamicBindingPathList);
 
             actionsToSave.add(s3Action);
@@ -3548,8 +3548,19 @@ public class DatabaseChangelog {
         mongockTemplate.save(s3Plugin);
     }
 
+    /**
+     * Method to port `dynamicBindingPathList` to UQI model.
+     *
+     * @param dynamicBindingPathList : old dynamicBindingPathList
+     * @param objectMapper
+     * @param action
+     * @param migrationMap : A mapping from `pluginSpecifiedTemplates` index to attribute path in UQI model. For
+     *                     reference, please check out the `s3MigrationMap` defined above.
+     * @return : updated dynamicBindingPathList - ported to UQI model.
+     */
     private List<Property> getUpdatedDynamicBindingPathList(List<Property> dynamicBindingPathList,
-                                                            ObjectMapper objectMapper, NewAction action) {
+                                                            ObjectMapper objectMapper, NewAction action,
+                                                            Map<Integer, List<String>> migrationMap) {
         // Return if empty.
         if (CollectionUtils.isEmpty(dynamicBindingPathList)) {
             return dynamicBindingPathList;
@@ -3566,7 +3577,7 @@ public class DatabaseChangelog {
 
                 while (matcher.find()) {
                     int index = Integer.parseInt(matcher.group());
-                    List<String> partialPaths = s3MigrationMap.get(index);
+                    List<String> partialPaths = migrationMap.get(index);
                     for (String partialPath : partialPaths) {
                         Property dynamicBindingPath = new Property("formData." + partialPath, null);
                         newDynamicBindingPathList.add(dynamicBindingPath);
@@ -3918,7 +3929,7 @@ public class DatabaseChangelog {
                     ActionDTO publishedAction = action.getPublishedAction();
                     List<Property> dynamicBindingPathList = publishedAction.getDynamicBindingPathList();
                     List<Property> newDynamicBindingPathList = getUpdatedDynamicBindingPathList(dynamicBindingPathList,
-                            objectMapper, action);
+                            objectMapper, action, s3MigrationMap);
                     publishedAction.setDynamicBindingPathList(newDynamicBindingPathList);
                 });
 


### PR DESCRIPTION
## Description
- One of the previous migrations updated the `dynamicBindingPathList` for unpublished actions of S3 plugin as part of porting S3 plugin to UQI model. However, the `dynamicBindingPathList` update for published actions got skipped somehow. This fix updates the `dynamicBindingPathList` for published actions of S3 plugin.
- Minor refactor.

Fixes #9380 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
