### PR TITLE
fix(promise-errors): Correcting the throwing error to logging error for promisified triggers

### DIFF
--- a/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PromiseActionSaga.ts
@@ -8,8 +8,8 @@ import { all, call } from "redux-saga/effects";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import log from "loglevel";
 import {
+  logActionExecutionError,
   PluginTriggerFailureError,
-  UncaughtAppsmithPromiseError,
   UserCancelledActionExecutionError,
 } from "sagas/ActionExecution/errorUtils";
 
@@ -65,7 +65,12 @@ export default function* executePromiseSaga(
       });
     } else {
       log.error(e);
-      throw new UncaughtAppsmithPromiseError(e.message, triggerMeta, e);
+      /* Logging the error instead of throwing an error as it was making the ui to go into a loading states */
+      logActionExecutionError(
+        e.message,
+        triggerMeta.source,
+        triggerMeta.triggerPropertyName,
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Added a logging action for a promisified trigger instead of throwing an error. 

Fixes #9258 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Steps To Reproduce
1. Create a Text Field and a button.
2. Call multiple API actions using JS on Click functionality on the button. Make sure one of them throws an error.
3. Add the response data of each API actions to the Text Field.
4. Notice when the button is clicked, now the text field does not go into infinite loading state when one of the API throws an error which was used to be the previous thing.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/promise-errors 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.08 **(0)** | 37.02 **(0)** | 33.83 **(0)** | 55.57 **(0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**</details>