### PR TITLE
fix: Show correct toast type options in debugger

### DIFF
--- a/app/client/src/components/ads/Toast.tsx
+++ b/app/client/src/components/ads/Toast.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { CommonComponentProps, Classes, Variant } from "./common";
+import {
+  CommonComponentProps,
+  Classes,
+  Variant,
+  ToastTypeOptions,
+} from "./common";
 import styled from "styled-components";
 import Icon, { IconSize } from "./Icon";
 import Text, { TextType } from "./Text";
@@ -207,7 +212,8 @@ export const Toaster = {
     }
     if (config.variant && !Object.values(Variant).includes(config.variant)) {
       log.error(
-        "Toast type needs to be a one of " + Object.values(Variant).join(", "),
+        "Toast type needs to be a one of " +
+          Object.values(ToastTypeOptions).join(", "),
       );
       return;
     }

--- a/app/client/src/components/ads/common.tsx
+++ b/app/client/src/components/ads/common.tsx
@@ -1,7 +1,7 @@
 import { Theme } from "constants/DefaultTheme";
 import tinycolor from "tinycolor2";
 import styled from "styled-components";
-import { toast } from "react-toastify";
+import { toast, TypeOptions } from "react-toastify";
 
 export interface CommonComponentProps {
   isLoading?: boolean; //default false
@@ -73,6 +73,13 @@ export enum Variant {
   info = "info",
   warning = "warning",
   danger = "danger",
+}
+
+export enum ToastTypeOptions {
+  success = "success",
+  info = "info",
+  warning = "warning",
+  error = "error",
 }
 
 export const ToastVariant = (type: any) => {

--- a/app/client/src/components/ads/common.tsx
+++ b/app/client/src/components/ads/common.tsx
@@ -1,7 +1,7 @@
 import { Theme } from "constants/DefaultTheme";
 import tinycolor from "tinycolor2";
 import styled from "styled-components";
-import { toast, TypeOptions } from "react-toastify";
+import { toast } from "react-toastify";
 
 export interface CommonComponentProps {
   isLoading?: boolean; //default false

--- a/app/client/src/sagas/ActionExecution/ShowAlertActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/ShowAlertActionSaga.ts
@@ -1,4 +1,4 @@
-import { Variant } from "components/ads/common";
+import { ToastTypeOptions, Variant } from "components/ads/common";
 import { Toaster } from "components/ads/Toast";
 import AppsmithConsole from "utils/AppsmithConsole";
 import { ShowAlertActionDescription } from "entities/DataTree/actionTriggers";
@@ -32,7 +32,9 @@ export default function* showAlertSaga(
   }
   if (payload.style && !variant) {
     throw new TriggerFailureError(
-      `Toast type needs to be a one of ${Object.values(Variant).join(", ")}`,
+      `Toast type needs to be a one of ${Object.values(ToastTypeOptions).join(
+        ", ",
+      )}`,
       triggerMeta,
     );
   }


### PR DESCRIPTION
## Description

- This PR makes a change to the list of acceptable styles for alert messages shown to the user when a wrong alert message style is entered.

Fixes #9384 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/incorrect-toast-type-options 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.1 **(0.01)** | 37.02 **(0)** | 33.86 **(0)** | 55.58 **(0)**
 :green_circle: | app/client/src/components/ads/common.tsx | 72.55 **(2.98)** | 60 **(6.15)** | 62.5 **(5.36)** | 69.57 **(3.72)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.04 **(-0.22)** | 40.42 **(-0.83)** | 34.48 **(0)** | 55.96 **(-0.26)**</details>