### PR TITLE
fix: Add default props dependency in dependency map

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -93,6 +93,7 @@ export default class DataTreeEvaluator {
   }
 
   createFirstTree(unEvalTree: DataTree) {
+    debugger;
     const totalStart = performance.now();
     let localUnEvalTree = JSON.parse(JSON.stringify(unEvalTree));
     let jsUpdates: Record<string, JSUpdate> = {};
@@ -1541,6 +1542,7 @@ const extractReferencesFromBinding = (
   const identifiers = dependentPath.match(/[a-zA-Z_$][a-zA-Z_$0-9.\[\]]*/g) || [
     dependentPath,
   ];
+  debugger;
   identifiers.forEach((identifier: string) => {
     // If the identifier exists directly, add it and return
     if (all.hasOwnProperty(identifier)) {
@@ -1555,8 +1557,13 @@ const extractReferencesFromBinding = (
     // we can remove the length requirement and it will still work
     while (subpaths.length > 1) {
       current = convertPathToString(subpaths);
+      const defaultPropsPath = convertPathToString([
+        subpaths[0],
+        "defaultProps",
+        ...subpaths.slice(1),
+      ]);
       // We've found the dep, add it and return
-      if (all.hasOwnProperty(current)) {
+      if (all.hasOwnProperty(current) || all.hasOwnProperty(defaultPropsPath)) {
         subDeps.push(current);
         return;
       }

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -93,7 +93,6 @@ export default class DataTreeEvaluator {
   }
 
   createFirstTree(unEvalTree: DataTree) {
-    debugger;
     const totalStart = performance.now();
     let localUnEvalTree = JSON.parse(JSON.stringify(unEvalTree));
     let jsUpdates: Record<string, JSUpdate> = {};
@@ -1542,7 +1541,7 @@ const extractReferencesFromBinding = (
   const identifiers = dependentPath.match(/[a-zA-Z_$][a-zA-Z_$0-9.\[\]]*/g) || [
     dependentPath,
   ];
-  debugger;
+
   identifiers.forEach((identifier: string) => {
     // If the identifier exists directly, add it and return
     if (all.hasOwnProperty(identifier)) {

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -94,7 +94,7 @@ export default class DataTreeEvaluator {
 
   createFirstTree(unEvalTree: DataTree) {
     const totalStart = performance.now();
-    let localUnEvalTree = JSON.parse(JSON.stringify(unEvalTree));
+    let localUnEvalTree = _.cloneDeep(unEvalTree);
     let jsUpdates: Record<string, JSUpdate> = {};
     //parse js collection to get functions
     //save current state of js collection action and variables to be added to uneval tree
@@ -1541,7 +1541,6 @@ const extractReferencesFromBinding = (
   const identifiers = dependentPath.match(/[a-zA-Z_$][a-zA-Z_$0-9.\[\]]*/g) || [
     dependentPath,
   ];
-
   identifiers.forEach((identifier: string) => {
     // If the identifier exists directly, add it and return
     if (all.hasOwnProperty(identifier)) {
@@ -1556,13 +1555,8 @@ const extractReferencesFromBinding = (
     // we can remove the length requirement and it will still work
     while (subpaths.length > 1) {
       current = convertPathToString(subpaths);
-      const defaultPropsPath = convertPathToString([
-        subpaths[0],
-        "defaultProps",
-        ...subpaths.slice(1),
-      ]);
       // We've found the dep, add it and return
-      if (all.hasOwnProperty(current) || all.hasOwnProperty(defaultPropsPath)) {
+      if (all.hasOwnProperty(current)) {
         subDeps.push(current);
         return;
       }

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -92,8 +92,20 @@ export default class DataTreeEvaluator {
     this.widgetConfigMap = widgetConfigMap;
   }
 
+  /**
+   * This method takes unEvalTree as input and does following
+   * 1. parseJSActions and updates JS
+   * 2. Creates dependencyMap, sorted dependencyMap
+   * 3. Generates inverseDependencyTree
+   * 4. Finally, evaluates the unEvalTree and returns that with JSUpdates
+   *
+   * @param {DataTree} unEvalTree
+   * @return {*}
+   * @memberof DataTreeEvaluator
+   */
   createFirstTree(unEvalTree: DataTree) {
     const totalStart = performance.now();
+    // cloneDeep will make sure not to omit key which has value as undefined.
     let localUnEvalTree = _.cloneDeep(unEvalTree);
     let jsUpdates: Record<string, JSUpdate> = {};
     //parse js collection to get functions
@@ -129,7 +141,7 @@ export default class DataTreeEvaluator {
     this.evalTree = getValidatedTree(evaluatedTree);
     const validateEnd = performance.now();
 
-    this.oldUnEvalTree = JSON.parse(JSON.stringify(localUnEvalTree));
+    this.oldUnEvalTree = _.cloneDeep(localUnEvalTree);
     const totalEnd = performance.now();
     const timeTakenForFirstTree = {
       total: (totalEnd - totalStart).toFixed(2),


### PR DESCRIPTION
Fixes #9334 #9096 

## Description

### Problem

When we have a SelectWidget named `Select1` on canvas and `createFirstTree` runs, it was noticed that `Select1.defaultValue` is getting evaluated after `Select1.selectedOptionValue` 

This is due to an incorrect sorted dependency map.
Logically, `Select1.selectedOptionValue` is dependent on `defaultValue` but in dependencyMap current there is no such relation.
 ```
 selectedOptionValue: `{{(()=>{const index = _.findIndex(this.options, { value: this.defaultValue }); return this.options[index]?.value; })()}}`
 ```
 
But when we see the actual dependencyMap, there is no relation between `selectedOptionValue` and `defaultValue`.

<img width="685" alt="Screenshot 2021-11-29 at 12 12 33 AM" src="https://user-images.githubusercontent.com/23132741/143786264-bf02949a-5611-4c1b-82a2-fc9e09cc440f.png">

### Remarks - 
#### Why does this doesn't happen `onPageLoad` when it happens `onPageSwitch` if it is a depenedencyMap issue?
This doesn’t happen onPageLoad because there we also run updateDataTree,
1. In createDataTree’s evaluation itself defaultValue is evaluated and stored in dataTree 
2. hence. when executing updateDataTree and evaluating `Select1.selectedOptionValue`  before `Select1.defaultValue`  doesn’t seem a problem as `Select1.defaultValue` got defined.

Though, logically it is an issue because we need to always evaluate `Select1.defaultValue` before `Select1.selectedOptionValue`.


## Solution

Make sure property with `undefined` value doesn't get omitted.

When forming a dependency map, getAllKeys will have defaultValue as key and this will result `Select1.selectedOptionValue` to depend on `Select1.defaultValue`.

This will fix the sortedDependencyMap and also the evaluation sequence.


## Type of change

- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>