### PR TITLE
fix(query-keys-map): Adding empty array check for mapping keys

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -197,6 +197,7 @@ const renderCell = (props: any) => {
 function Table(props: TableProps) {
   const data = React.useMemo(() => {
     const emptyString = "";
+    /* Check for length greater than 0 of rows returned from the query for mappings keys */
     if (props.data?.length > 0) {
       const keys = Object.keys(props.data[0]);
       keys.forEach((key) => {

--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -197,16 +197,20 @@ const renderCell = (props: any) => {
 function Table(props: TableProps) {
   const data = React.useMemo(() => {
     const emptyString = "";
-    const keys = Object.keys(props.data[0]);
-    keys.forEach((key) => {
-      if (key === emptyString) {
-        const value = props.data[0][key];
-        delete props.data[0][key];
-        props.data[0][uniqueId()] = value;
-      }
-    });
+    if (props.data?.length > 0) {
+      const keys = Object.keys(props.data[0]);
+      keys.forEach((key) => {
+        if (key === emptyString) {
+          const value = props.data[0][key];
+          delete props.data[0][key];
+          props.data[0][uniqueId()] = value;
+        }
+      });
 
-    return props.data;
+      return props.data;
+    }
+
+    return [];
   }, [props.data]);
   const columns = React.useMemo(() => {
     if (data.length) {


### PR DESCRIPTION
## Description

Adding an empty array check before mapping for keys for the query data. An array of keys is being created by looping the data there was no check added if there was empty data being returned for the query.

Fixes #9425 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Steps to reproduce :

1. Go to datasource
2.  Add a Select Query in Postgres Database
3.  Add A query as SELECT * FROM Company WHERE NAME LIKE 'Sh%';
4.  Run the query Or Copy the query from other Datasource and forget to change the Table name Run the query the application breaks
5. Previously it was breaking the application.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/query-keys-map 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/pages/Editor/QueryEditor/Table.tsx | 85.07 **(-1.08)** | 50 **(3.85)** | 100 **(0)** | 84.62 **(-1.09)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.04 **(-0.22)** | 40.42 **(-0.83)** | 34.48 **(0)** | 55.96 **(-0.26)**</details>