### PR TITLE
fix: Fix Appsmith image name in Helm chart values

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -39,7 +39,7 @@ strategyType: RollingUpdate
 ##
 image:
   registry: index.docker.io
-  repository: appsmith/appsmith-editor
+  repository: appsmith/appsmith-ce
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"


### PR DESCRIPTION
In Helm charts' values.yaml file, we are pointing to the slim editor image instead of the fat Appsmith image. This PR fixes this.
