### PR TITLE
fix: button group cursor in case of disable

### DIFF
--- a/app/client/src/widgets/ButtonGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/ButtonGroupWidget/component/index.tsx
@@ -39,6 +39,8 @@ const ButtonGroupWrapper = styled.div<ThemeProp & WrapperStyleProps>`
   justify-content: stretch;
   align-items: stretch;
   overflow: hidden;
+  cursor: not-allowed;
+
   ${(props) =>
     props.isHorizontal ? "flex-direction: row" : "flex-direction: column"};
 
@@ -193,7 +195,6 @@ const StyledButton = styled.button<ThemeProp & ButtonStyleProps>`
     ${isDisabled &&
       `
       & {
-        cursor: not-allowed;
         pointer-events: none;
         border: 1px solid ${Colors.ALTO2} !important;
         background: ${theme.colors.button.disabled.bgColor} !important;


### PR DESCRIPTION
## Description

> add disable mouse pointer when ButtonGroup widget is disabled 

Fixes #9202 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>