### PR TITLE
chore: Send telemetry option in user profile to client

### DIFF
--- a/app/client/cypress/fixtures/user.json
+++ b/app/client/cypress/fixtures/user.json
@@ -1,0 +1,15 @@
+{
+  "accountNonExpired": true,
+  "accountNonLocked": true,
+  "credentialsNonExpired": true,
+  "email": "test@appsmith.com",
+  "emptyInstance": false,
+  "enableTelemetry": false,
+  "isAnonymous": false,
+  "isConfigurable": true,
+  "isEnabled": true,
+  "isSuperUser": true,
+  "name": "test",
+  "organizationIds": ["61a8a112ccc8b629d92a1aad"],
+  "username": "test@appsmith.com"
+}

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Auth/Analytics_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Auth/Analytics_spec.js
@@ -1,0 +1,77 @@
+import User from "../../../../fixtures/user.json";
+
+function mockSegmentKey() {
+  cy.window().then((window) => {
+    if (!window.APPSMITH_FEATURE_CONFIGS.segment) {
+      window.APPSMITH_FEATURE_CONFIGS.segment = {
+        apiKey: "test",
+        ceKey: "test",
+      };
+    }
+  });
+}
+
+let appId;
+
+describe("Checks for analytics initialization", function() {
+  it("Should check analytics is not initialised when enableTelemtry is false", function() {
+    cy.intercept("GET", "/api/v1/users/me", {
+      body: { responseMeta: { status: 200, success: true }, data: User },
+    }).as("getUsersWithoutTelemetry");
+    cy.visit("/applications");
+    cy.reload();
+    mockSegmentKey();
+    cy.wait("@getUsersWithoutTelemetry");
+    cy.window().then((window) => {
+      expect(window.analytics).to.be.equal(undefined);
+    });
+    let interceptFlag = false;
+    cy.intercept("POST", "https://api.segment.io/**", (req) => {
+      interceptFlag = true;
+      req.continue();
+    });
+    cy.generateUUID().then((id) => {
+      appId = id;
+      cy.CreateAppInFirstListedOrg(id);
+      localStorage.setItem("AppName", appId);
+    });
+    cy.wait(3000);
+    cy.window().then(() => {
+      cy.wrap(interceptFlag).should("eq", false);
+    });
+  });
+  it("Should check analytics is initialised when enableTelemtry is true", function() {
+    cy.intercept("GET", "/api/v1/users/me", {
+      body: {
+        responseMeta: { status: 200, success: true },
+        data: {
+          ...User,
+          enableTelemetry: true,
+        },
+      },
+    }).as("getUsersWithoutTelemetry");
+    cy.visit("/applications");
+    cy.reload();
+    mockSegmentKey();
+    cy.wait("@getUsersWithoutTelemetry");
+    cy.wait(5000);
+    cy.window().then((window) => {
+      expect(window.analytics).not.to.be.undefined;
+    });
+    cy.wait(3000);
+    let interceptFlag = false;
+    cy.intercept("POST", "https://api.segment.io/**", (req) => {
+      interceptFlag = true;
+      req.continue();
+    }).as("segment");
+    cy.generateUUID().then((id) => {
+      appId = id;
+      cy.CreateAppInFirstListedOrg(id);
+      localStorage.setItem("AppName", appId);
+    });
+    cy.wait("@segment");
+    cy.window().then(() => {
+      cy.wrap(interceptFlag).should("eq", true);
+    });
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Auth/Analytics_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Auth/Analytics_spec.js
@@ -1,30 +1,5 @@
 import User from "../../../../fixtures/user.json";
 
-function mockAnalyticsAndTrackersKey() {
-  cy.window().then((window) => {
-    if (!window.APPSMITH_FEATURE_CONFIGS.segment) {
-      window.APPSMITH_FEATURE_CONFIGS.segment = {
-        apiKey: "test",
-        ceKey: "test",
-      };
-    }
-
-    if (!window.APPSMITH_FEATURE_CONFIGS.smartLook) {
-      window.APPSMITH_FEATURE_CONFIGS.smartLook = {
-        id: "test",
-      };
-    }
-
-    if (!window.APPSMITH_FEATURE_CONFIGS.sentry) {
-      window.APPSMITH_FEATURE_CONFIGS.sentry = {
-        dsn: "test",
-        release: "test",
-        environment: "test",
-      };
-    }
-  });
-}
-
 let appId;
 
 describe("Checks for analytics initialization", function() {
@@ -34,7 +9,6 @@ describe("Checks for analytics initialization", function() {
     }).as("getUsersWithoutTelemetry");
     cy.visit("/applications");
     cy.reload();
-    mockAnalyticsAndTrackersKey();
     cy.wait("@getUsersWithoutTelemetry");
     cy.window().then((window) => {
       expect(window.analytics).to.be.equal(undefined);
@@ -66,7 +40,6 @@ describe("Checks for analytics initialization", function() {
     }).as("getUsersWithTelemetry");
     cy.visit("/applications");
     cy.reload();
-    mockAnalyticsAndTrackersKey();
     cy.wait("@getUsersWithTelemetry");
     cy.wait(5000);
     cy.window().then((window) => {
@@ -95,29 +68,23 @@ describe("Checks for analytics initialization", function() {
     }).as("getUsersWithoutTelemetry");
     cy.visit("/applications");
     cy.reload();
-    mockAnalyticsAndTrackersKey();
     cy.wait("@getUsersWithoutTelemetry");
     cy.window().then((window) => {
       expect(window.smartlook).to.be.equal(undefined);
     });
-  });
-  it("Should check smartlook is initialised when enableTelemtry is true", function() {
-    cy.intercept("GET", "/api/v1/users/me", {
-      body: {
-        responseMeta: { status: 200, success: true },
-        data: {
-          ...User,
-          enableTelemetry: true,
-        },
-      },
-    }).as("getUsersWithTelemetry");
-    cy.visit("/applications");
-    cy.reload();
-    mockAnalyticsAndTrackersKey();
-    cy.wait("@getUsersWithTelemetry");
-    cy.wait(5000);
-    cy.window().then((window) => {
-      expect(window.smartlook).not.to.be.undefined;
+    let interceptFlag = false;
+    cy.intercept("POST", "https://**.smartlook.**", (req) => {
+      interceptFlag = true;
+      req.continue();
+    });
+    cy.generateUUID().then((id) => {
+      appId = id;
+      cy.CreateAppInFirstListedOrg(id);
+      localStorage.setItem("AppName", appId);
+    });
+    cy.wait(3000);
+    cy.window().then(() => {
+      cy.wrap(interceptFlag).should("eq", false);
     });
   });
 
@@ -127,29 +94,23 @@ describe("Checks for analytics initialization", function() {
     }).as("getUsersWithoutTelemetry");
     cy.visit("/applications");
     cy.reload();
-    mockAnalyticsAndTrackersKey();
     cy.wait("@getUsersWithoutTelemetry");
     cy.window().then((window) => {
       expect(window.Sentry).to.be.equal(undefined);
     });
-  });
-  it("Should check Sentry is initialised when enableTelemtry is true", function() {
-    cy.intercept("GET", "/api/v1/users/me", {
-      body: {
-        responseMeta: { status: 200, success: true },
-        data: {
-          ...User,
-          enableTelemetry: true,
-        },
-      },
-    }).as("getUsersWithTelemetry");
-    cy.visit("/applications");
-    cy.reload();
-    mockAnalyticsAndTrackersKey();
-    cy.wait("@getUsersWithTelemetry");
-    cy.wait(5000);
-    cy.window().then((window) => {
-      expect(window.Sentry).not.to.be.undefined;
+    let interceptFlag = false;
+    cy.intercept("POST", "https://**.sentry.io/**", (req) => {
+      interceptFlag = true;
+      req.continue();
+    });
+    cy.generateUUID().then((id) => {
+      appId = id;
+      cy.CreateAppInFirstListedOrg(id);
+      localStorage.setItem("AppName", appId);
+    });
+    cy.wait(3000);
+    cy.window().then(() => {
+      cy.wrap(interceptFlag).should("eq", false);
     });
   });
 });

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -170,7 +170,6 @@
     const CONFIG_LOG_LEVEL_INDEX = LOG_LEVELS.indexOf(parseConfig("__APPSMITH_CLIENT_LOG_LEVEL__"));
 
     const INTERCOM_APP_ID = parseConfig("%REACT_APP_INTERCOM_APP_ID%") || parseConfig("__APPSMITH_INTERCOM_APP_ID__");
-    const DISABLE_TELEMETRY = parseConfig("__APPSMITH_DISABLE_TELEMETRY__");
     const DISABLE_INTERCOM = parseConfig("__APPSMITH_DISABLE_INTERCOM__");
 
     // Initialize the Intercom library
@@ -215,7 +214,6 @@
       },
       intercomAppID: INTERCOM_APP_ID,
       mailEnabled: parseConfig("__APPSMITH_MAIL_ENABLED__"),
-      disableTelemetry: DISABLE_TELEMETRY === "" || DISABLE_TELEMETRY,
       cloudServicesBaseUrl: parseConfig("__APPSMITH_CLOUD_SERVICES_BASE_URL__") || "https://cs.appsmith.com",
       googleRecaptchaSiteKey: parseConfig("__APPSMITH_RECAPTCHA_SITE_KEY__"),
     };

--- a/app/client/src/configs/index.ts
+++ b/app/client/src/configs/index.ts
@@ -244,7 +244,6 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
       id: smartLook.value,
     },
     segment: {
-      enabled: segment.enabled,
       apiKey: segment.value,
       ceKey: segmentCEKey.value,
     },

--- a/app/client/src/configs/index.ts
+++ b/app/client/src/configs/index.ts
@@ -42,7 +42,6 @@ export type INJECTED_CONFIGS = {
   };
   intercomAppID: string;
   mailEnabled: boolean;
-  disableTelemetry: boolean;
   cloudServicesBaseUrl: string;
   googleRecaptchaSiteKey: string;
   supportEmail: string;
@@ -120,7 +119,6 @@ const getConfigsFromEnvVars = (): INJECTED_CONFIGS => {
     mailEnabled: process.env.REACT_APP_MAIL_ENABLED
       ? process.env.REACT_APP_MAIL_ENABLED.length > 0
       : false,
-    disableTelemetry: true,
     cloudServicesBaseUrl: process.env.REACT_APP_CLOUD_SERVICES_BASE_URL || "",
     googleRecaptchaSiteKey:
       process.env.REACT_APP_GOOGLE_RECAPTCHA_SITE_KEY || "",
@@ -212,21 +210,9 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
   // We enable segment tracking if either the Cloud API key is set or the self-hosted CE key is set
   segment.enabled = segment.enabled || segmentCEKey.enabled;
 
-  let sentryTelemetry = true;
-  // Turn off all analytics if telemetry is disabled
-  if (APPSMITH_FEATURE_CONFIGS.disableTelemetry) {
-    smartLook.enabled = false;
-    segment.enabled = false;
-    sentryTelemetry = false;
-  }
-
   return {
     sentry: {
-      enabled:
-        sentryDSN.enabled &&
-        sentryRelease.enabled &&
-        sentryENV.enabled &&
-        sentryTelemetry,
+      enabled: sentryDSN.enabled && sentryRelease.enabled && sentryENV.enabled,
       dsn: sentryDSN.value,
       release: sentryRelease.value,
       environment: sentryENV.value,
@@ -244,6 +230,7 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
       id: smartLook.value,
     },
     segment: {
+      enabled: segment.enabled,
       apiKey: segment.value,
       ceKey: segmentCEKey.value,
     },
@@ -287,7 +274,6 @@ export const getAppsmithConfigs = (): AppsmithUIConfigs => {
     intercomAppID:
       ENV_CONFIG.intercomAppID || APPSMITH_FEATURE_CONFIGS.intercomAppID,
     mailEnabled: ENV_CONFIG.mailEnabled || APPSMITH_FEATURE_CONFIGS.mailEnabled,
-    disableTelemetry: APPSMITH_FEATURE_CONFIGS.disableTelemetry,
     commentsTestModeEnabled: false,
     cloudServicesBaseUrl:
       ENV_CONFIG.cloudServicesBaseUrl ||

--- a/app/client/src/configs/types.ts
+++ b/app/client/src/configs/types.ts
@@ -31,6 +31,7 @@ export type AppsmithUIConfigs = {
     id: string;
   };
   segment: {
+    enabled: boolean;
     apiKey: string;
     ceKey: string;
   };
@@ -67,8 +68,6 @@ export type AppsmithUIConfigs = {
   };
   intercomAppID: string;
   mailEnabled: boolean;
-
-  disableTelemetry: boolean;
   commentsTestModeEnabled: boolean;
 
   cloudServicesBaseUrl: string;

--- a/app/client/src/configs/types.ts
+++ b/app/client/src/configs/types.ts
@@ -31,7 +31,6 @@ export type AppsmithUIConfigs = {
     id: string;
   };
   segment: {
-    enabled: boolean;
     apiKey: string;
     ceKey: string;
   };

--- a/app/client/src/constants/userConstants.ts
+++ b/app/client/src/constants/userConstants.ts
@@ -20,6 +20,7 @@ export type User = {
   role?: string;
   useCase?: string;
   isConfigurable: boolean;
+  enableTelemetry: boolean;
 };
 
 export interface UserApplication {
@@ -39,6 +40,7 @@ export const DefaultCurrentUserDetails: User = {
   gender: "MALE",
   isSuperUser: false,
   isConfigurable: false,
+  enableTelemetry: false,
 };
 
 // TODO keeping it here instead of the USER_API since it leads to cyclic deps errors during tests

--- a/app/client/src/sagas/userSagas.tsx
+++ b/app/client/src/sagas/userSagas.tsx
@@ -65,7 +65,7 @@ import {
   getFirstTimeUserOnboardingApplicationId,
   getFirstTimeUserOnboardingIntroModalVisibility,
 } from "utils/storage";
-import { analyticsInitializer } from "utils/AppsmithUtils";
+import { initializeAnalyticsAndTrackers } from "utils/AppsmithUtils";
 
 export function* createUserSaga(
   action: ReduxActionWithPromise<CreateUserRequest>,
@@ -116,7 +116,7 @@ export function* getCurrentUserSaga() {
     if (isValidResponse) {
       const { enableTelemetry } = response.data;
       if (enableTelemetry) {
-        analyticsInitializer();
+        initializeAnalyticsAndTrackers();
       }
       yield put(initAppLevelSocketConnection());
       yield put(initPageLevelSocketConnection());

--- a/app/client/src/sagas/userSagas.tsx
+++ b/app/client/src/sagas/userSagas.tsx
@@ -65,6 +65,7 @@ import {
   getFirstTimeUserOnboardingApplicationId,
   getFirstTimeUserOnboardingIntroModalVisibility,
 } from "utils/storage";
+import { analyticsInitializer } from "utils/AppsmithUtils";
 
 export function* createUserSaga(
   action: ReduxActionWithPromise<CreateUserRequest>,
@@ -113,6 +114,10 @@ export function* getCurrentUserSaga() {
 
     const isValidResponse = yield validateResponse(response);
     if (isValidResponse) {
+      const { enableTelemetry } = response.data;
+      if (enableTelemetry) {
+        analyticsInitializer();
+      }
       yield put(initAppLevelSocketConnection());
       yield put(initPageLevelSocketConnection());
       if (

--- a/app/client/src/sagas/userSagas.tsx
+++ b/app/client/src/sagas/userSagas.tsx
@@ -124,7 +124,7 @@ export function* getCurrentUserSaga() {
         !response.data.isAnonymous &&
         response.data.username !== ANONYMOUS_USERNAME
       ) {
-        AnalyticsUtil.identifyUser(response.data);
+        enableTelemetry && AnalyticsUtil.identifyUser(response.data);
         // make fetch feature call only if logged in
         yield put(fetchFeatureFlagsInit());
       } else {

--- a/app/client/src/utils/AnalyticsUtil.tsx
+++ b/app/client/src/utils/AnalyticsUtil.tsx
@@ -267,7 +267,7 @@ class AnalyticsUtil {
     if (userData) {
       const { segment } = getAppsmithConfigs();
       let user: any = {};
-      if (segment.enabled && segment.apiKey) {
+      if (userData.enableTelemetry && segment.apiKey) {
         user = {
           userId: userData.username,
           email: userData.email,
@@ -291,7 +291,7 @@ class AnalyticsUtil {
       };
     }
 
-    if (windowDoc.analytics) {
+    if (userData?.enableTelemetry && windowDoc.analytics) {
       log.debug("Event fired", eventName, finalEventData);
       windowDoc.analytics.track(eventName, finalEventData);
     } else {

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -83,17 +83,19 @@ export const appInitializer = () => {
     AnalyticsUtil.initializeSmartLook(id);
   }
 
-  if (appsmithConfigs.segment.enabled) {
-    if (appsmithConfigs.segment.apiKey) {
-      // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
-      AnalyticsUtil.initializeSegment(appsmithConfigs.segment.apiKey);
-    } else if (appsmithConfigs.segment.ceKey) {
-      // This value is set in self-hosted environments. But if the analytics are disabled, it's never used.
-      AnalyticsUtil.initializeSegment(appsmithConfigs.segment.ceKey);
-    }
-  }
-
   log.setLevel(getEnvLogLevel(appsmithConfigs.logLevel));
+};
+
+export const analyticsInitializer = () => {
+  const { segment } = getAppsmithConfigs();
+
+  if (segment.apiKey) {
+    // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
+    AnalyticsUtil.initializeSegment(segment.apiKey);
+  } else if (segment.ceKey) {
+    // This value is set in self-hosted environments. But if the analytics are disabled, it's never used.
+    AnalyticsUtil.initializeSegment(segment.ceKey);
+  }
 };
 
 export const mapToPropList = (map: Record<string, string>): Property[] => {

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -53,6 +53,11 @@ export const createImmerReducer = (
 export const appInitializer = () => {
   FormControlRegistry.registerFormControlBuilders();
   const appsmithConfigs = getAppsmithConfigs();
+  log.setLevel(getEnvLogLevel(appsmithConfigs.logLevel));
+};
+
+export const initializeAnalyticsAndTrackers = () => {
+  const appsmithConfigs = getAppsmithConfigs();
 
   if (appsmithConfigs.sentry.enabled) {
     window.Sentry = Sentry;
@@ -83,18 +88,14 @@ export const appInitializer = () => {
     AnalyticsUtil.initializeSmartLook(id);
   }
 
-  log.setLevel(getEnvLogLevel(appsmithConfigs.logLevel));
-};
-
-export const analyticsInitializer = () => {
-  const { segment } = getAppsmithConfigs();
-
-  if (segment.apiKey) {
-    // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
-    AnalyticsUtil.initializeSegment(segment.apiKey);
-  } else if (segment.ceKey) {
-    // This value is set in self-hosted environments. But if the analytics are disabled, it's never used.
-    AnalyticsUtil.initializeSegment(segment.ceKey);
+  if (appsmithConfigs.segment.enabled) {
+    if (appsmithConfigs.segment.apiKey) {
+      // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
+      AnalyticsUtil.initializeSegment(appsmithConfigs.segment.apiKey);
+    } else if (appsmithConfigs.segment.ceKey) {
+      // This value is set in self-hosted environments. But if the analytics are disabled, it's never used.
+      AnalyticsUtil.initializeSegment(appsmithConfigs.segment.ceKey);
+    }
   }
 };
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
@@ -41,7 +41,7 @@ public class UserProfileDTO {
 
     String useCase;
 
-    boolean disableTelemetry = true;
+    boolean enableTelemetry = false;
 
     public boolean isAccountNonExpired() {
         return this.isEnabled;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
@@ -41,6 +41,8 @@ public class UserProfileDTO {
 
     String useCase;
 
+    boolean disableTelemetry = true;
+
     public boolean isAccountNonExpired() {
         return this.isEnabled;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -912,7 +912,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                     profile.setRole(userData.getRole());
                     profile.setUseCase(userData.getUseCase());
                     profile.setPhotoId(userData.getProfilePhotoAssetId());
-                    profile.setDisableTelemetry(commonConfig.isTelemetryDisabled());
+                    profile.setEnableTelemetry(!commonConfig.isTelemetryDisabled());
 
                     profile.setSuperUser(policyUtils.isPermissionPresentForUser(
                             userFromDb.getPolicies(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UserServiceImpl.java
@@ -912,6 +912,7 @@ public class UserServiceImpl extends BaseService<UserRepository, User, String> i
                     profile.setRole(userData.getRole());
                     profile.setUseCase(userData.getUseCase());
                     profile.setPhotoId(userData.getProfilePhotoAssetId());
+                    profile.setDisableTelemetry(commonConfig.isTelemetryDisabled());
 
                     profile.setSuperUser(policyUtils.isPermissionPresentForUser(
                             userFromDb.getPolicies(),


### PR DESCRIPTION




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/telemetry-from-welcome-page 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.15 **(-0.01)** | 37.19 **(0)** | 33.99 **(0)** | 55.66 **(-0.01)**
 :green_circle: | app/client/src/configs/index.ts | 95.12 **(-0.53)** | 86.14 **(1.52)** | 100 **(0)** | 97.3 **(-0.32)**
 :green_circle: | app/client/src/sagas/userSagas.tsx | 16.17 **(0.15)** | 1.23 **(-0.07)** | 5 **(0)** | 19.39 **(0.12)**
 :green_circle: | app/client/src/utils/AnalyticsUtil.tsx | 29.17 **(0)** | 19.05 **(7.94)** | 30.77 **(0)** | 29.35 **(0)**
 :red_circle: | app/client/src/utils/AppsmithUtils.tsx | 56.52 **(0.15)** | 30.61 **(0)** | 33.33 **(-0.76)** | 51.41 **(-0.02)**</details>