### PR TITLE
feat: Add flow to generate Nginx HTTP only if provision cert fail

### DIFF
--- a/deploy/docker/scripts/init_ssl_cert.sh
+++ b/deploy/docker/scripts/init_ssl_cert.sh
@@ -62,6 +62,12 @@ init_ssl_cert() {
     --agree-tos \
     --force-renewal
 
+  if (($? != 0)); then
+    echo "Stop Nginx due to provisioning fail"
+    nginx -s stop
+    return 1
+  fi
+
   echo "Stop Nginx"
   nginx -s stop
 }

--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -11,6 +11,11 @@ if [[ -n $APPSMITH_CUSTOM_DOMAIN ]]; then
   if ! [[ -e "/etc/letsencrypt/live/$APPSMITH_CUSTOM_DOMAIN" ]]; then
     source "/opt/appsmith/init_ssl_cert.sh"
     init_ssl_cert "$APPSMITH_CUSTOM_DOMAIN"
+    
+    if (($? != 0)); then
+      echo $?
+      APP_TEMPLATE="$TEMPLATE_DIR/nginx-app-http.conf.template.sh"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Description
- Add logic to check exit code of certbot command
- Assign HTTP template if the exit code of certbot command is greater than 0 (provisioning fail) 

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
