### PR TITLE
fix: Google Sheet plugin error on empty row for bulk Insert

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
@@ -1,0 +1,100 @@
+package com.external.config;
+
+import com.appsmith.external.models.Property;
+import com.external.domains.RowObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+
+public class BulkAppendMethodTest {
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testBulkAppendExecutePrerequisites() {
+
+        Property testProp = null;
+        List<Property> properties = null;
+
+        //Test data Expected output type vs inputs
+        Map<String, String> testDataMap = new HashMap<String, String>();
+        testDataMap.put("emptyArray",           "[{}]");
+        testDataMap.put("arrayWithData",        "[{\"Sl#\":\"100\"}]");
+        testDataMap.put("arrayWithData",        "[{\"Sl#\":\"100\",\"Topic\":\"topic\"}]");
+        testDataMap.put("arrayWithData",        "[{\"Sl#\":\"100\"},{\"Sl#\":\"101\"}]");
+        testDataMap.put("notAnArray",           "[]");
+        testDataMap.put("notAnArray",           "");
+
+
+            for (Map.Entry<String, String> testData : testDataMap.entrySet()) {
+
+
+                properties = new ArrayList<Property>();
+                testProp = new Property("rowObjects", testData.getValue());
+                properties.add(testProp);
+                MethodConfig methodConfig = new MethodConfig(properties);
+
+                List<RowObject> rowObjectListFromBody = null;
+                JsonNode body = null;
+                try {
+                    body = objectMapper.readTree(methodConfig.getRowObjects());
+                } catch (JsonProcessingException e) {
+                    // Should never enter here
+                }
+
+                MethodConfig returnMethodConfig = null;
+                rowObjectListFromBody = this.getRowObjectListFromBody(body);
+
+                if(rowObjectListFromBody != null ) {
+                    boolean fieldsEmpty = true;
+
+                    for (RowObject rowObject : rowObjectListFromBody) {
+                        if (rowObject.getValueMap().size() == 0) continue;
+                        fieldsEmpty = false;
+                    }
+
+                    if (fieldsEmpty) {
+                        //Mono.just(methodConfig);
+                        returnMethodConfig = new MethodConfig(new ArrayList<Property>());  //In new implementation, we are returning Mono earlier to GoogleSheetPlugin
+                    } else {
+                        returnMethodConfig = methodConfig;  // Proceed with existing implementation
+                    }
+                }
+
+           switch (testData.getKey()) {
+                case "emptyArray":
+                    Assert.assertEquals(returnMethodConfig.getRowObjects(), new MethodConfig(new ArrayList<Property>()).getRowObjects());
+                    break;
+                case "arrayWithData":
+                    Assert.assertEquals(returnMethodConfig.getRowObjects(), methodConfig.getRowObjects());
+                    break;
+                case "notAnArray":
+                    Assert.assertEquals(rowObjectListFromBody, null);
+                    break;
+            }
+        }
+    }
+
+    private List<RowObject> getRowObjectListFromBody(JsonNode body) {
+        if (!body.isArray() || body.isEmpty()) {
+            return null;
+        }
+        return StreamSupport
+                .stream(body.spliterator(), false)
+                .map(rowJson -> new RowObject(
+                        objectMapper.convertValue(
+                                rowJson,
+                                TypeFactory
+                                        .defaultInstance()
+                                        .constructMapType(LinkedHashMap.class, String.class, String.class))))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Description

> When executing a Google sheets Bulk insert rows query, an error is returned if the data array is empty.

Fixes #8924

## Type of change
- Bug fix (non-breaking change which fixes an issue)   

## How Has This Been Tested?
> Tested manually with different inputs of empty data
> JUnit Test implemented
 
## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
