### PR TITLE
fix: Use port from mock db details when creating mock datasource

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/MockDataServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/MockDataServiceImpl.java
@@ -182,8 +182,8 @@ public class MockDataServiceImpl implements MockDataService {
         connection.setSsl(sslDetails);
         connection.setMode(Connection.Mode.READ_WRITE);
         endpoint.setHost(credentials.getHost());
+        endpoint.setPort(Long.valueOf(credentials.getPort()));
         endpointList.add(endpoint);
-
 
         auth.setDatabaseName(credentials.getDbname());
         auth.setPassword(credentials.getPassword());


### PR DESCRIPTION
The port information from cloud services is not being used when creating a new mock datasource. This isn't a problem today since all mock datasources use the default ports. Fixing this now so it doesn't become a headache later.

Marking it as draft since we want this merged _after_ a release made after 5-Dec-2021.
