### PR TITLE
fix: check if smartlook, sentry and analytics are inited before the init call

### DIFF
--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -60,7 +60,7 @@ export const initializeAnalyticsAndTrackers = () => {
   try {
     const appsmithConfigs = getAppsmithConfigs();
 
-    if (appsmithConfigs.sentry.enabled) {
+    if (appsmithConfigs.sentry.enabled && !window.Sentry) {
       window.Sentry = Sentry;
       Sentry.init({
         ...appsmithConfigs.sentry,
@@ -92,7 +92,7 @@ export const initializeAnalyticsAndTrackers = () => {
       AnalyticsUtil.initializeSmartLook(id);
     }
 
-    if (appsmithConfigs.segment.enabled) {
+    if (appsmithConfigs.segment.enabled && !(window as any).analytics) {
       if (appsmithConfigs.segment.apiKey) {
         // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
         AnalyticsUtil.initializeSegment(appsmithConfigs.segment.apiKey);

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -57,45 +57,53 @@ export const appInitializer = () => {
 };
 
 export const initializeAnalyticsAndTrackers = () => {
-  const appsmithConfigs = getAppsmithConfigs();
+  try {
+    const appsmithConfigs = getAppsmithConfigs();
 
-  if (appsmithConfigs.sentry.enabled) {
-    window.Sentry = Sentry;
-    Sentry.init({
-      ...appsmithConfigs.sentry,
-      beforeBreadcrumb(breadcrumb) {
-        if (breadcrumb.category === "console" && breadcrumb.level !== "error") {
-          return null;
-        }
-        if (breadcrumb.category === "sentry.transaction") {
-          return null;
-        }
-        if (breadcrumb.category === "redux.action") {
+    if (appsmithConfigs.sentry.enabled) {
+      window.Sentry = Sentry;
+      Sentry.init({
+        ...appsmithConfigs.sentry,
+        beforeBreadcrumb(breadcrumb) {
           if (
-            breadcrumb.data &&
-            breadcrumb.data.type === "SET_EVALUATED_TREE"
+            breadcrumb.category === "console" &&
+            breadcrumb.level !== "error"
           ) {
-            breadcrumb.data = undefined;
+            return null;
           }
-        }
-        return breadcrumb;
-      },
-    });
-  }
-
-  if (appsmithConfigs.smartLook.enabled) {
-    const { id } = appsmithConfigs.smartLook;
-    AnalyticsUtil.initializeSmartLook(id);
-  }
-
-  if (appsmithConfigs.segment.enabled) {
-    if (appsmithConfigs.segment.apiKey) {
-      // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
-      AnalyticsUtil.initializeSegment(appsmithConfigs.segment.apiKey);
-    } else if (appsmithConfigs.segment.ceKey) {
-      // This value is set in self-hosted environments. But if the analytics are disabled, it's never used.
-      AnalyticsUtil.initializeSegment(appsmithConfigs.segment.ceKey);
+          if (breadcrumb.category === "sentry.transaction") {
+            return null;
+          }
+          if (breadcrumb.category === "redux.action") {
+            if (
+              breadcrumb.data &&
+              breadcrumb.data.type === "SET_EVALUATED_TREE"
+            ) {
+              breadcrumb.data = undefined;
+            }
+          }
+          return breadcrumb;
+        },
+      });
     }
+
+    if (appsmithConfigs.smartLook.enabled && !(window as any).smartlook) {
+      const { id } = appsmithConfigs.smartLook;
+      AnalyticsUtil.initializeSmartLook(id);
+    }
+
+    if (appsmithConfigs.segment.enabled) {
+      if (appsmithConfigs.segment.apiKey) {
+        // This value is only enabled for Appsmith's cloud hosted version. It is not set in self-hosted environments
+        AnalyticsUtil.initializeSegment(appsmithConfigs.segment.apiKey);
+      } else if (appsmithConfigs.segment.ceKey) {
+        // This value is set in self-hosted environments. But if the analytics are disabled, it's never used.
+        AnalyticsUtil.initializeSegment(appsmithConfigs.segment.ceKey);
+      }
+    }
+  } catch (e) {
+    Sentry.captureException(e);
+    log.error(e);
   }
 };
 

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -102,7 +102,12 @@ export const initializeAnalyticsAndTrackers = () => {
       }
     }
   } catch (e) {
-    Sentry.captureException(e);
+    // In case the error is due to sentry itself
+    try {
+      Sentry.captureException(e);
+    } catch (e) {
+      log.error(e);
+    }
     log.error(e);
   }
 };


### PR DESCRIPTION
## Description
Checks if smartlook, sentry and analytics exist on the `window` object before initing
Fixes #9575

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually: this would need smartlook enabled to verify 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: reinit-smartlook-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.13 **(-0.01)** | 37.16 **(-0.02)** | 33.97 **(0)** | 55.63 **(-0.02)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :red_circle: | app/client/src/utils/AppsmithUtils.tsx | 55.19 **(-1.33)** | 28.85 **(-1.76)** | 33.33 **(0)** | 50 **(-1.41)**</details>