### PR TITLE
fix: Regex to detect function args

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/Fields.test.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.test.ts
@@ -1,0 +1,80 @@
+jest.mock("sagas/ActionExecution/NavigateActionSaga", () => ({
+  __esModule: true,
+  default: "",
+  NavigationTargetType: { SAME_WINDOW: "" },
+}));
+
+import { argsStringToArray } from "./Fields";
+
+describe("Test argStringToArray", () => {
+  const cases = [
+    { index: 0, input: "", expected: [""] },
+    { index: 1, input: "'a'", expected: ["'a'"] },
+    { index: 2, input: "a", expected: ["a"] },
+    { index: 3, input: "'a,b,c'", expected: ["'a,b,c'"] },
+    { index: 4, input: "a,b,c", expected: ["a", "b", "c"] },
+    { index: 5, input: "a, b, c", expected: ["a", " b", " c"] },
+    { index: 6, input: "a , b , c", expected: ["a ", " b ", " c"] },
+    { index: 7, input: "a\n,\nb,\nc", expected: ["a\n", "\nb", "\nc"] },
+    { index: 8, input: "[a,b,c]", expected: ["[a,b,c]"] },
+    { index: 9, input: "[a, b, c]", expected: ["[a, b, c]"] },
+    {
+      index: 10,
+      input: "[\n\ta,\n\tb,\n\tc\n]",
+      expected: ["[\n\ta,\n\tb,\n\tc\n]"],
+    },
+    { index: 11, input: "{a:1,b:2,c:3}", expected: ["{a:1,b:2,c:3}"] },
+    {
+      index: 12,
+      input: '{"a":1,"b":2,"c":3}',
+      expected: ['{"a":1,"b":2,"c":3}'],
+    },
+    {
+      index: 13,
+      input: "{\n\ta:1,\n\tb:2,\n\tc:3}",
+      expected: ["{\n\ta:1,\n\tb:2,\n\tc:3}"],
+    },
+    {
+      index: 14,
+      input: "()=>{}",
+      expected: ["()=>{}"],
+    },
+    {
+      index: 15,
+      input: "(a, b)=>{return a+b}",
+      expected: ["(a, b)=>{return a+b}"],
+    },
+    {
+      index: 16,
+      input: "(a, b)=>{\n\treturn a+b;\n\t}",
+      expected: ["(a, b)=>{\n\treturn a+b;\n\t}"],
+    },
+    {
+      index: 17,
+      input: "(\n\ta,\n\tb\n)=>{\n\treturn a+b;\n\t}",
+      expected: ["(\n\ta,\n\tb\n)=>{\n\treturn a+b;\n\t}"],
+    },
+    {
+      index: 18,
+      input: `() => {return 5}`,
+      expected: ["() => {return 5}"],
+    },
+    {
+      index: 19,
+      input: `(a) => {return a + 1}`,
+      expected: ["(a) => {return a + 1}"],
+    },
+    {
+      index: 20,
+      input: `(a, b) => {return a + b}`,
+      expected: ["(a, b) => {return a + b}"],
+    },
+  ];
+  test.each(cases.map((x) => [x.index, x.input, x.expected]))(
+    "test case %d",
+    (_, input, expected) => {
+      const result = argsStringToArray(input as string);
+      expect(result).toStrictEqual(expected);
+    },
+  );
+});

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -78,7 +78,6 @@ export const ACTION_TRIGGER_REGEX = /^{{([\s\S]*?)\(([\s\S]*?)\)}}$/g;
 //Old Regex:: /\(\) => ([\s\S]*?)(\([\s\S]*?\))/g;
 export const ACTION_ANONYMOUS_FUNC_REGEX = /\(\) => (({[\s\S]*?})|([\s\S]*?)(\([\s\S]*?\)))/g;
 export const IS_URL_OR_MODAL = /^'.*'$/;
-// A useless comment which I've to remove before merging the PR. Doing this to satisfy CI
 const modalSetter = (changeValue: any, currentValue: string) => {
   const matches = [...currentValue.matchAll(ACTION_TRIGGER_REGEX)];
   let args: string[] = [];

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -73,7 +73,7 @@ const NAVIGATION_TARGET_FIELD_OPTIONS = [
   },
 ];
 
-export const FUNC_ARGS_REGEX = /((["][^"]*["])|([\[].*[\]])|([\{].*[\}])|(['][^']*['])|([\(].*[\)[=][>][{].*[}])|([^'",][^,"+]*[^'",]*))*/gi;
+export const FUNC_ARGS_REGEX = /((["][^"]*["])|([\[][\s\S]*[\]])|([\{][\s\S]*[\}])|(['][^']*['])|([\(][\s\S]*[\)[=][>][{][\s\S]*[}])|([^'",][^,"+]*[^'",]*))*/gi;
 export const ACTION_TRIGGER_REGEX = /^{{([\s\S]*?)\(([\s\S]*?)\)}}$/g;
 //Old Regex:: /\(\) => ([\s\S]*?)(\([\s\S]*?\))/g;
 export const ACTION_ANONYMOUS_FUNC_REGEX = /\(\) => (({[\s\S]*?})|([\s\S]*?)(\([\s\S]*?\)))/g;

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -73,7 +73,7 @@ const NAVIGATION_TARGET_FIELD_OPTIONS = [
   },
 ];
 
-export const FUNC_ARGS_REGEX = /((["][^"]*["])|([\[][\s\S]*[\]])|([\{][\s\S]*[\}])|(['][^']*['])|([\(][\s\S]*[\)[=][>][{][\s\S]*[}])|([^'",][^,"+]*[^'",]*))*/gi;
+export const FUNC_ARGS_REGEX = /((["][^"]*["])|([\[][\s\S]*[\]])|([\{][\s\S]*[\}])|(['][^']*['])|([\(][\s\S]*[\)][\s\S]*=>[\s\S]*[{][\s\S]*[}])|([^'",][^,"+]*[^'",]*))*/gi;
 export const ACTION_TRIGGER_REGEX = /^{{([\s\S]*?)\(([\s\S]*?)\)}}$/g;
 //Old Regex:: /\(\) => ([\s\S]*?)(\([\s\S]*?\))/g;
 export const ACTION_ANONYMOUS_FUNC_REGEX = /\(\) => (({[\s\S]*?})|([\s\S]*?)(\([\s\S]*?\)))/g;

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -78,6 +78,7 @@ export const ACTION_TRIGGER_REGEX = /^{{([\s\S]*?)\(([\s\S]*?)\)}}$/g;
 //Old Regex:: /\(\) => ([\s\S]*?)(\([\s\S]*?\))/g;
 export const ACTION_ANONYMOUS_FUNC_REGEX = /\(\) => (({[\s\S]*?})|([\s\S]*?)(\([\s\S]*?\)))/g;
 export const IS_URL_OR_MODAL = /^'.*'$/;
+// A useless comment which I've to remove before merging the PR. Doing this to satisfy CI
 const modalSetter = (changeValue: any, currentValue: string) => {
   const matches = [...currentValue.matchAll(ACTION_TRIGGER_REGEX)];
   let args: string[] = [];

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -134,7 +134,7 @@ export const JSToString = (js: string): string => {
     .join("");
 };
 
-const argsStringToArray = (funcArgs: string): string[] => {
+export const argsStringToArray = (funcArgs: string): string[] => {
   const argsplitMatches = [...funcArgs.matchAll(FUNC_ARGS_REGEX)];
   const arr: string[] = [];
   let isPrevUndefined = true;

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -73,7 +73,7 @@ const NAVIGATION_TARGET_FIELD_OPTIONS = [
   },
 ];
 
-export const FUNC_ARGS_REGEX = /((["][^"]*["])|([\[][\s\S]*[\]])|([\{][\s\S]*[\}])|(['][^']*['])|([\(][\s\S]*[\)][\s\S]*=>[\s\S]*[{][\s\S]*[}])|([^'",][^,"+]*[^'",]*))*/gi;
+export const FUNC_ARGS_REGEX = /((["][^"]*["])|([\[][\s\S]*[\]])|([\{][\s\S]*[\}])|(['][^']*['])|([\(][\s\S]*[\)][ ]*=>[ ]*[{][\s\S]*[}])|([^'",][^,"+]*[^'",]*))*/gi;
 export const ACTION_TRIGGER_REGEX = /^{{([\s\S]*?)\(([\s\S]*?)\)}}$/g;
 //Old Regex:: /\(\) => ([\s\S]*?)(\([\s\S]*?\))/g;
 export const ACTION_ANONYMOUS_FUNC_REGEX = /\(\) => (({[\s\S]*?})|([\s\S]*?)(\([\s\S]*?\)))/g;


### PR DESCRIPTION
## Description

Regex was not working with whitespace characters since we are using `.*`
Replaced it with `[\s\S]*` to include whitespace characters.
Arrow function was not matching when space is there between arrow (`()  =>  {}`) that is also fixed.

Fixes #8169

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested this manually by providing whitespace characters into the argument fields of action selectors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes








## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/action-selector-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.15 **(0.02)** | 37.06 **(0.01)** | 34.04 **(0.02)** | 55.67 **(0.02)**
 :green_circle: | app/client/src/components/editorComponents/ActionCreator/Fields.tsx | 35.52 **(3.78)** | 25.42 **(3.39)** | 10.39 **(2.6)** | 34.86 **(3.67)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>