### PR TITLE
feat: Add support for custom 'this' and 'global' variables during evaluation

### DIFF
--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -112,7 +112,7 @@ export interface ExecuteErrorPayload extends ErrorActionPayload {
 export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/[\s\S]*?)(\?(?![^{]*})[\s\S]*)?$/;
 
 export const EXECUTION_PARAM_KEY = "executionParams";
-export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params/g;
+export const THIS_DOT_PARAMS_KEY = "params";
 
 export const RESP_HEADER_DATATYPE = "X-APPSMITH-DATATYPE";
 export const API_REQUEST_HEADERS: APIHeaders = {

--- a/app/client/src/workers/evaluate.test.ts
+++ b/app/client/src/workers/evaluate.test.ts
@@ -72,7 +72,7 @@ describe("evaluate", () => {
     const result = wrongJS
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "wrongJS",
@@ -86,7 +86,7 @@ describe("evaluate", () => {
     const result = wrongJS
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "wrongJS",
@@ -106,7 +106,7 @@ describe("evaluate", () => {
     const result = {}.map()
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "{}.map()",
@@ -121,7 +121,7 @@ describe("evaluate", () => {
   });
   it("gets triggers from a function", () => {
     const js = "showAlert('message', 'info')";
-    const response = evaluate(js, dataTree, {}, undefined, true);
+    const response = evaluate(js, dataTree, {}, undefined, undefined, true);
     //this will be changed again in new implemenation for promises
     const data = {
       action: {
@@ -172,7 +172,7 @@ describe("evaluate", () => {
     const result = setTimeout(() => {}, 100)
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "setTimeout(() => {}, 100)",
@@ -188,7 +188,23 @@ describe("evaluate", () => {
   it("evaluates functions with callback data", () => {
     const js = "(arg1, arg2) => arg1.value + arg2";
     const callbackData = [{ value: "test" }, "1"];
-    const response = evaluate(js, dataTree, {}, callbackData);
+    const response = evaluate(js, dataTree, {}, {}, callbackData);
     expect(response.result).toBe("test1");
+  });
+  it("has access to this context", () => {
+    const js = "this.contextVariable";
+    const thisContext = { contextVariable: "test" };
+    const response = evaluate(js, dataTree, {}, { thisContext });
+    expect(response.result).toBe("test");
+    // there should not be any error when accessing "this" variables
+    expect(response.errors).toHaveLength(0);
+  });
+
+  it("has access to additional global context", () => {
+    const js = "contextVariable";
+    const globalContext = { contextVariable: "test" };
+    const response = evaluate(js, dataTree, {}, { globalContext });
+    expect(response.result).toBe("test");
+    expect(response.errors).toHaveLength(0);
   });
 });

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -32,12 +32,12 @@ export const EvaluationScripts: Record<EvaluationScriptType, string> = {
     const result = ${ScriptTemplate}
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
   [EvaluationScriptType.ANONYMOUS_FUNCTION]: `
   function callback (script) {
     const userFunction = script;
-    const result = userFunction.apply(self, ARGUMENTS);
+    const result = userFunction.apply(THIS_CONTEXT, ARGUMENTS);
     return result;
   }
   callback(${ScriptTemplate})
@@ -47,7 +47,7 @@ export const EvaluationScripts: Record<EvaluationScriptType, string> = {
     const result = ${ScriptTemplate}
     return result
   }
-  closedFunction();
+  closedFunction.call(THIS_CONTEXT);
   `,
 };
 
@@ -95,11 +95,24 @@ export const createGlobalData = (
   dataTree: DataTree,
   resolvedFunctions: Record<string, any>,
   isTriggerBased: boolean,
+  context?: EvaluateContext,
   evalArguments?: Array<any>,
 ) => {
   const GLOBAL_DATA: Record<string, any> = {};
   ///// Adding callback data
   GLOBAL_DATA.ARGUMENTS = evalArguments;
+  //// Adding contextual data not part of data tree
+  GLOBAL_DATA.THIS_CONTEXT = {};
+  if (context) {
+    if (context.thisContext) {
+      GLOBAL_DATA.THIS_CONTEXT = context.thisContext;
+    }
+    if (context.globalContext) {
+      Object.entries(context.globalContext).forEach(([key, value]) => {
+        GLOBAL_DATA[key] = value;
+      });
+    }
+  }
   ///// Mocking Promise class
   GLOBAL_DATA.Promise = AppsmithPromise;
   if (isTriggerBased) {
@@ -128,26 +141,34 @@ export const createGlobalData = (
   return GLOBAL_DATA;
 };
 
-export function unEscapeScript(js: string) {
+export function sanitizeScript(js: string) {
   // We remove any line breaks from the beginning of the script because that
   // makes the final function invalid. We also unescape any escaped characters
   // so that eval can happen
   const trimmedJS = js.replace(beginsWithLineBreakRegex, "");
-  const unescapedJS =
-    self.evaluationVersion > 1 ? trimmedJS : unescapeJS(trimmedJS);
-  return unescapedJS;
+  return self.evaluationVersion > 1 ? trimmedJS : unescapeJS(trimmedJS);
 }
+
+/** Define a context just for this script
+ * thisContext will define it on the `this`
+ * globalContext will define it globally
+ */
+export type EvaluateContext = {
+  thisContext?: Record<string, any>;
+  globalContext?: Record<string, any>;
+};
 
 export default function evaluate(
   js: string,
   data: DataTree,
   resolvedFunctions: Record<string, any>,
+  context?: EvaluateContext,
   evalArguments?: Array<any>,
   isTriggerBased = false,
 ): EvalResult {
-  const unescapedJS = unEscapeScript(js);
+  const sanitizedScript = sanitizeScript(js);
   const scriptType = getScriptType(evalArguments, isTriggerBased);
-  const script = getScriptToEval(unescapedJS, scriptType);
+  const script = getScriptToEval(sanitizedScript, scriptType);
   // We are linting original js binding,
   // This will make sure that the character count is not messed up when we do unescapejs
   const scriptToLint = getScriptToEval(js, scriptType);
@@ -160,6 +181,7 @@ export default function evaluate(
       data,
       resolvedFunctions,
       isTriggerBased,
+      context,
       evalArguments,
     );
 

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -193,6 +193,7 @@ ctx.addEventListener(
           resolvedFunctions,
           EvaluationSubstitutionType.TEMPLATE,
           true,
+          undefined,
           callbackData,
           fullPropertyPath,
         );

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -265,6 +265,7 @@ ctx.addEventListener(
           evalTree,
           resolvedFunctions,
           undefined,
+          undefined,
           true,
         );
         return result;
@@ -274,7 +275,7 @@ ctx.addEventListener(
         const evalTree = dataTreeEvaluator?.evalTree;
         if (!evalTree) return {};
         return isTrigger
-          ? evaluate(expression, evalTree, {}, [], true)
+          ? evaluate(expression, evalTree, {}, undefined, [], true)
           : evaluate(expression, evalTree, {});
       case EVAL_WORKER_ACTIONS.UPDATE_REPLAY_OBJECT:
         const { entity, entityId, entityType } = requestData;

--- a/app/client/src/workers/lint.ts
+++ b/app/client/src/workers/lint.ts
@@ -6,7 +6,7 @@ import {
 } from "utils/DynamicBindingUtils";
 import { JSHINT as jshint } from "jshint";
 import { Severity } from "entities/AppsmithConsole";
-import { last, keys, isEmpty } from "lodash";
+import { isEmpty, keys, last } from "lodash";
 import {
   EvaluationScripts,
   EvaluationScriptType,
@@ -27,21 +27,20 @@ export const getPositionInEvaluationScript = (
   return { line: lines.length, ch: lastLine.length };
 };
 
-const EvalutionScriptPositions: Record<string, Position> = {};
+const EvaluationScriptPositions: Record<string, Position> = {};
 
 function getEvaluationScriptPosition(scriptType: EvaluationScriptType) {
-  if (isEmpty(EvalutionScriptPositions)) {
+  if (isEmpty(EvaluationScriptPositions)) {
     // We are computing position of <<script>> in our templates.
     // This will be used to get the exact location of error in linting
     keys(EvaluationScripts).forEach((type) => {
-      const location = getPositionInEvaluationScript(
+      EvaluationScriptPositions[type] = getPositionInEvaluationScript(
         type as EvaluationScriptType,
       );
-      EvalutionScriptPositions[type] = location;
     });
   }
 
-  return EvalutionScriptPositions[scriptType];
+  return EvaluationScriptPositions[scriptType];
 }
 
 export const getLintingErrors = (

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -795,7 +795,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     };
     if (config.params?.fnString && isString(config.params?.fnString)) {
       try {
-        const { result } = evaluate(config.params.fnString, {}, {}, [
+        const { result } = evaluate(config.params.fnString, {}, {}, undefined, [
           value,
           props,
           _,


### PR DESCRIPTION
## Description

Adds a feature in evaluate to allow defining custom "this" and "global" variables that are not part of the data tree. It can help in defining field / entity level properties that we would not want to exist in the data tree during evaluation

Fixes #6732

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Jest
Test that these variables are available and evaluated
Test that errors are not raised

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/this.params-reference-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.14 **(0.01)** | 37.07 **(0.02)** | 34.03 **(0.01)** | 55.66 **(0.01)**
 :green_circle: | app/client/src/workers/DataTreeEvaluator.ts | 77.64 **(0.48)** | 61.97 **(0.27)** | 76.74 **(0.88)** | 77.38 **(0.51)**
 :green_circle: | app/client/src/workers/evaluate.ts | 87.91 **(1.32)** | 76.67 **(5.84)** | 77.78 **(1.31)** | 87.21 **(0.96)**</details>