### PR TITLE
chore: Making smtp default install true for new all organizations

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -3940,7 +3940,7 @@ public class DatabaseChangelog {
         plugin.setResponseType(Plugin.ResponseType.JSON);
         plugin.setIconLocation("https://assets.appsmith.com/smtp-icon.svg");
         plugin.setDocumentationLink("https://docs.appsmith.com/datasource-reference/querying-smtp-plugin");
-        plugin.setDefaultInstall(false);
+        plugin.setDefaultInstall(true);
         try {
             mongoTemplate.insert(plugin);
         } catch (DuplicateKeyException e) {


### PR DESCRIPTION
Fixing the DB migration to set default install true for SMTP plugin

Fixes: #9653 