### PR TITLE
feat: Add support to send arbitrary form values to oAuth server during Datasource authentication

### DIFF
--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -52,6 +52,7 @@ export interface Oauth2Common {
 
 export interface ClientCredentials extends Oauth2Common {
   grantType: GrantType.ClientCredentials;
+  customTokenParameters: Property[];
 }
 
 export interface AuthorizationCode extends Oauth2Common {

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -693,7 +693,14 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
   renderOauth2CommonAdvanced = () => {
     return (
       <>
-        <FormInputContainer data-replay-id={btoa("authentication.audience")}>
+        <FormInputContainer>
+          <KeyValueInputControl
+            {...COMMON_INPUT_PROPS}
+            configProperty="authentication.customTokenParameters"
+            label="Custom Client Credentials"
+          />
+        </FormInputContainer>
+        <FormInputContainer>
           <InputTextControl
             {...COMMON_INPUT_PROPS}
             configProperty="authentication.audience"

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -697,7 +697,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
           <KeyValueInputControl
             {...COMMON_INPUT_PROPS}
             configProperty="authentication.customTokenParameters"
-            label="Custom Client Credentials"
+            label="Custom Token Parameters"
           />
         </FormInputContainer>
         <FormInputContainer>

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -93,6 +93,9 @@ const formToDatasourceAuthentication = (
       return {
         ...oAuth2Common,
         grantType: GrantType.ClientCredentials,
+        customTokenParameters: cleanupProperties(
+          authentication.customTokenParameters,
+        ),
       };
     }
     if (isAuthorizationCode(authType, authentication)) {
@@ -174,6 +177,9 @@ const datasourceToFormAuthentication = (
       return {
         ...oAuth2Common,
         grantType: GrantType.ClientCredentials,
+        customTokenParameters: cleanupProperties(
+          authentication.customTokenParameters,
+        ),
       };
     }
     if (isAuthorizationCode(authType, authentication)) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -29,6 +29,7 @@ public class Authentication {
     public static final String RESPONSE_TYPE = "response_type";
     public static final String AUDIENCE = "audience";
     public static final String RESOURCE = "resource";
+    public static final String CUSTOM_TOKEN_PARAMETER = "custom_token_parameter";
 
     // Request parameter values
     public static final String AUTHORIZATION_CODE = "authorization_code";

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/Authentication.java
@@ -29,7 +29,6 @@ public class Authentication {
     public static final String RESPONSE_TYPE = "response_type";
     public static final String AUDIENCE = "audience";
     public static final String RESOURCE = "resource";
-    public static final String CUSTOM_TOKEN_PARAMETER = "custom_token_parameter";
 
     // Request parameter values
     public static final String AUTHORIZATION_CODE = "authorization_code";

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -2,7 +2,10 @@ package com.external.connections;
 
 import com.appsmith.external.constants.Authentication;
 import com.appsmith.external.exceptions.pluginExceptions.StaleConnectionException;
-import com.appsmith.external.models.*;
+import com.appsmith.external.models.AuthenticationDTO;
+import com.appsmith.external.models.AuthenticationResponse;
+import com.appsmith.external.models.OAuth2;
+import com.appsmith.external.models.UpdatableConnection;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,9 +29,7 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 @Setter
 @Getter

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -178,7 +178,10 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
         }
         //Custom Token Parameters
         if (oAuth2.getCustomTokenParameters() != null) {
-            body.with(Authentication.CUSTOM_TOKEN_PARAMETER, StringUtils.collectionToDelimitedString(oAuth2.getCustomTokenParameters(),""));
+
+             oAuth2.getCustomTokenParameters().forEach(params ->
+               body.with(params.getKey(), params.getValue().toString())
+                    );
         }
         return body;
     }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -2,10 +2,7 @@ package com.external.connections;
 
 import com.appsmith.external.constants.Authentication;
 import com.appsmith.external.exceptions.pluginExceptions.StaleConnectionException;
-import com.appsmith.external.models.AuthenticationDTO;
-import com.appsmith.external.models.AuthenticationResponse;
-import com.appsmith.external.models.OAuth2;
-import com.appsmith.external.models.UpdatableConnection;
+import com.appsmith.external.models.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +26,9 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 @Setter
 @Getter
@@ -176,6 +175,14 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
         // Optionally add scope, if applicable
         if (!CollectionUtils.isEmpty(oAuth2.getScope())) {
             body.with(Authentication.SCOPE, StringUtils.collectionToDelimitedString(oAuth2.getScope(), " "));
+        }
+        //Custom Client Credentials
+        if (oAuth2.getCustomTokenParameters() != null) {
+            Set<Property> customProps= new HashSet();
+            oAuth2.getCustomTokenParameters().forEach(x ->
+                customProps.add(new Property(x.getKey(), x.getValue()))
+                    );
+            body.with(Authentication.CUSTOM_TOKEN_PARAMETER, StringUtils.collectionToDelimitedString(customProps,""));
         }
         return body;
     }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -176,13 +176,9 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
         if (!CollectionUtils.isEmpty(oAuth2.getScope())) {
             body.with(Authentication.SCOPE, StringUtils.collectionToDelimitedString(oAuth2.getScope(), " "));
         }
-        //Custom Client Credentials
+        //Custom Token Parameters
         if (oAuth2.getCustomTokenParameters() != null) {
-            Set<Property> customProps= new HashSet();
-            oAuth2.getCustomTokenParameters().forEach(x ->
-                customProps.add(new Property(x.getKey(), x.getValue()))
-                    );
-            body.with(Authentication.CUSTOM_TOKEN_PARAMETER, StringUtils.collectionToDelimitedString(customProps,""));
+            body.with(Authentication.CUSTOM_TOKEN_PARAMETER, StringUtils.collectionToDelimitedString(oAuth2.getCustomTokenParameters(),""));
         }
         return body;
     }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -179,7 +179,6 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
         }
         //Custom Token Parameters
         if (oAuth2.getCustomTokenParameters() != null) {
-
              oAuth2.getCustomTokenParameters().forEach(params ->
                body.with(params.getKey(), params.getValue().toString())
                     );


### PR DESCRIPTION
## Description

> Add support to send arbitrary form values to oAuth server during Datasource authentication.

Fixes #9389

## Type of change

> New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Debugged during development and ensured that the Custom Client Parameters are sent to the back-end and is available as a property known as customTokenParameters of oAuth object 
- Also added those value as a property to the bodyInserters for the next level of processing.
- No unit tests implemented at this time
- To be tested with the specific client requirement which requested this feature that is not available at the time of this implementation.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>