### PR TITLE
Set default APPSMITH_GIT_ROOT value in Docker

### DIFF
--- a/deploy/docker/scripts/run-with-env.sh
+++ b/deploy/docker/scripts/run-with-env.sh
@@ -30,4 +30,9 @@ if [[ -z "${APPSMITH_RECAPTCHA_SITE_KEY}" ]] || [[ -z "${APPSMITH_RECAPTCHA_SECR
   unset APPSMITH_RECAPTCHA_ENABLED
 fi
 
+if [[ -z "${APPSMITH_GIT_ROOT:-}" ]]; then
+  export APPSMITH_GIT_ROOT=/appsmith-stacks/git-storage
+fi
+mkdir -pv "$APPSMITH_GIT_ROOT"
+
 exec "$@"


### PR DESCRIPTION
This sets the default value for the git root where all the git storage is done.
