### PR TITLE
feat: Admin settings page to tinker with env variables

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/AdminSettings/Admin_settings_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/AdminSettings/Admin_settings_spec.js
@@ -1,0 +1,128 @@
+const AdminsSettingsLocators = require("../../../../locators/AdminsSettingsLocators.json");
+
+describe("Admin settings page", function() {
+  it("should test that settings page is accessible to super user", () => {
+    cy.LogOut();
+    cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+    cy.visit("/applications");
+    cy.get(".t--profile-menu-icon").should("be.visible");
+    cy.get(".t--profile-menu-icon").click();
+    cy.get(".t--admin-settings-menu").should("be.visible");
+    cy.get(".t--admin-settings-menu").click();
+    cy.url().should("contain", "/settings/general");
+    cy.wait("@getEnvVariables");
+    cy.LogOut();
+  });
+
+  it("should test that settings page is not accessible to normal users", () => {
+    cy.wait(2000);
+    cy.LoginFromAPI(Cypress.env("TESTUSERNAME1"), Cypress.env("TESTPASSWORD1"));
+    cy.visit("/applications");
+    cy.get(".t--profile-menu-icon").should("be.visible");
+    cy.get(".t--profile-menu-icon").click();
+    cy.get(".t--admin-settings-menu").should("not.exist");
+    cy.visit("/settings/general");
+    // non super users are redirected to home page
+    cy.url().should("contain", "/applications");
+    cy.LogOut();
+  });
+
+  it("should test that settings page is redirected to default tab", () => {
+    cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+    cy.visit("/settings");
+    cy.url().should("contain", "/settings/general");
+  });
+
+  it("should test that settings page tab redirects", () => {
+    cy.get(AdminsSettingsLocators.generalTab).click();
+    cy.url().should("contain", "/settings/general");
+    cy.get(AdminsSettingsLocators.advancedTab).click();
+    cy.url().should("contain", "/settings/advanced");
+    cy.get(AdminsSettingsLocators.authenticationTab).click();
+    cy.url().should("contain", "/settings/authentication");
+    cy.get(AdminsSettingsLocators.emailTab).click();
+    cy.url().should("contain", "/settings/email");
+    cy.get(AdminsSettingsLocators.googleMapsTab).click();
+    cy.url().should("contain", "/settings/google-maps");
+    cy.get(AdminsSettingsLocators.versionTab).click();
+    cy.url().should("contain", "/settings/version");
+  });
+
+  it("should test that setting page back button redirects to home page", () => {
+    cy.get(AdminsSettingsLocators.backButton).should("be.visible");
+    cy.get(AdminsSettingsLocators.backButton).click();
+    cy.url().should("contain", "/applications");
+  });
+
+  it("should test save and clear buttons disabled state", () => {
+    cy.visit("/settings/general");
+    const assertVisibilityAndDisabledState = () => {
+      cy.get(AdminsSettingsLocators.saveButton).should("be.visible");
+      cy.get(AdminsSettingsLocators.saveButton).should("be.disabled");
+      cy.get(AdminsSettingsLocators.resetButton).should("be.visible");
+      cy.get(AdminsSettingsLocators.resetButton).should("be.disabled");
+    };
+    assertVisibilityAndDisabledState();
+    cy.get(AdminsSettingsLocators.instanceName).should("be.visible");
+    cy.get(AdminsSettingsLocators.instanceName)
+      .clear()
+      .type("AppsmithInstance");
+    cy.get(AdminsSettingsLocators.saveButton).should("be.visible");
+    cy.get(AdminsSettingsLocators.saveButton).should("not.be.disabled");
+    cy.get(AdminsSettingsLocators.resetButton).should("be.visible");
+    cy.get(AdminsSettingsLocators.resetButton).should("not.be.disabled");
+    cy.get(AdminsSettingsLocators.resetButton).click();
+    assertVisibilityAndDisabledState();
+  });
+
+  it("should test saving a setting value", () => {
+    cy.visit("/settings/general");
+    cy.get(AdminsSettingsLocators.restartNotice).should("not.exist");
+    cy.get(AdminsSettingsLocators.instanceName).should("be.visible");
+    cy.generateUUID().then((uuid) => {
+      cy.get(AdminsSettingsLocators.instanceName)
+        .clear()
+        .type(uuid);
+    });
+    cy.get(AdminsSettingsLocators.saveButton).should("be.visible");
+    cy.get(AdminsSettingsLocators.saveButton).should("not.be.disabled");
+    cy.intercept("POST", "/api/v1/admin/restart", {
+      body: { responseMeta: { status: 200, success: true }, data: true },
+    });
+    cy.get(AdminsSettingsLocators.saveButton).click();
+    cy.get(AdminsSettingsLocators.restartNotice).should("be.visible");
+    cy.wait(3000);
+    cy.get(AdminsSettingsLocators.restartNotice).should("not.exist");
+    cy.wait(3000);
+  });
+
+  it("should test saving settings value from different tabs", () => {
+    cy.visit("/settings/general");
+    cy.get(AdminsSettingsLocators.restartNotice).should("not.exist");
+    cy.get(AdminsSettingsLocators.instanceName).should("be.visible");
+    cy.generateUUID().then((uuid) => {
+      cy.get(AdminsSettingsLocators.instanceName)
+        .clear()
+        .type(uuid);
+    });
+    cy.get(AdminsSettingsLocators.saveButton).should("be.visible");
+    cy.get(AdminsSettingsLocators.saveButton).should("not.be.disabled");
+    cy.get(AdminsSettingsLocators.emailTab).click();
+    cy.get(AdminsSettingsLocators.saveButton).should("be.visible");
+    cy.get(AdminsSettingsLocators.saveButton).should("not.be.disabled");
+    cy.get(AdminsSettingsLocators.fromAddress).should("be.visible");
+    cy.generateUUID().then((uuid) => {
+      cy.get(AdminsSettingsLocators.fromAddress)
+        .clear()
+        .type(`${uuid}@appsmith.com`);
+    });
+    cy.intercept("POST", "/api/v1/admin/restart", {
+      body: { responseMeta: { status: 200, success: true }, data: true },
+    });
+    cy.get(AdminsSettingsLocators.saveButton).click();
+    cy.get(AdminsSettingsLocators.restartNotice).should("be.visible");
+    cy.wait(3000);
+    cy.get(AdminsSettingsLocators.restartNotice).should("not.exist");
+    cy.wait(3000);
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/AdminSettings/Admin_settings_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/AdminSettings/Admin_settings_spec.js
@@ -29,11 +29,14 @@ describe("Admin settings page", function() {
 
   it("should test that settings page is redirected to default tab", () => {
     cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+    cy.wait(3000);
     cy.visit("/settings");
     cy.url().should("contain", "/settings/general");
   });
 
   it("should test that settings page tab redirects", () => {
+    cy.visit("/settings");
+    cy.wait(3000);
     cy.get(AdminsSettingsLocators.generalTab).click();
     cy.url().should("contain", "/settings/general");
     cy.get(AdminsSettingsLocators.advancedTab).click();

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/AdminSettings/Admin_settings_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/AdminSettings/Admin_settings_spec.js
@@ -29,14 +29,17 @@ describe("Admin settings page", function() {
 
   it("should test that settings page is redirected to default tab", () => {
     cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+    cy.visit("/applications");
     cy.wait(3000);
     cy.visit("/settings");
     cy.url().should("contain", "/settings/general");
   });
 
   it("should test that settings page tab redirects", () => {
-    cy.visit("/settings");
+    cy.visit("/applications");
     cy.wait(3000);
+    cy.get(".t--profile-menu-icon").click();
+    cy.get(".t--admin-settings-menu").click();
     cy.get(AdminsSettingsLocators.generalTab).click();
     cy.url().should("contain", "/settings/general");
     cy.get(AdminsSettingsLocators.advancedTab).click();

--- a/app/client/cypress/locators/AdminsSettingsLocators.json
+++ b/app/client/cypress/locators/AdminsSettingsLocators.json
@@ -1,0 +1,16 @@
+{
+  "Tabs": ".t--settings-category-list",
+  "generalTab": ".t--settings-category-general",
+  "advancedTab": ".t--settings-category-advanced",
+  "authenticationTab": ".t--settings-category-authentication",
+  "emailTab": ".t--settings-category-email",
+  "googleMapsTab": ".t--settings-category-google-maps",
+  "versionTab": ".t--settings-category-version",
+  "backButton": ".t--admin-settings-back-button",
+  "saveButton": ".t--admin-settings-save-button",
+  "resetButton": ".t--admin-settings-reset-button",
+  "textInput": ".t--admin-settings-text-input input",
+  "instanceName": ".t--admin-settings-APPSMITH_INSTANCE_NAME input",
+  "fromAddress": ".t--admin-settings-APPSMITH_MAIL_FROM input",
+  "restartNotice": ".t--admin-settings-restart-notice"
+}

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -2917,6 +2917,7 @@ Cypress.Commands.add("startServerAndRoutes", () => {
 
   cy.intercept("POST", "/api/v1/users/super").as("createSuperUser");
   cy.intercept("POST", "/api/v1/actions/execute").as("postExecute");
+  cy.intercept("GET", "/api/v1/admin/env").as("getEnvVariables");
 });
 
 Cypress.Commands.add("startErrorRoutes", () => {

--- a/app/client/src/entities/FeatureFlag.ts
+++ b/app/client/src/entities/FeatureFlag.ts
@@ -3,7 +3,6 @@ type FeatureFlag = {
   MULTIPLAYER: boolean;
   SNIPPET: boolean;
   GIT: boolean;
-  ADMIN_SETTINGS: boolean;
   GIT_IMPORT: boolean;
 };
 

--- a/app/client/src/pages/Settings/LeftPane.tsx
+++ b/app/client/src/pages/Settings/LeftPane.tsx
@@ -75,11 +75,12 @@ export default function LeftPane() {
       <HeaderContainer>
         <StyledHeader>Appsmith Admin</StyledHeader>
       </HeaderContainer>
-      <CategoryList>
+      <CategoryList className="t--settings-category-list">
         {categories.map((config) => (
           <Category key={config.slug}>
             <StyledLink
               $active={category == config.slug}
+              className={`t--settings-category-${config.slug}`}
               to={getAdminSettingsCategoryUrl(config.slug)}
             >
               {config.label}

--- a/app/client/src/pages/Settings/Main.tsx
+++ b/app/client/src/pages/Settings/Main.tsx
@@ -153,7 +153,7 @@ export function Main(
 
   return (
     <Wrapper>
-      <BackButton onClick={onBack}>
+      <BackButton className="t--admin-settings-back-button" onClick={onBack}>
         <Icon icon="chevron-left" iconSize={16} />
         <BackButtonText>&nbsp;Back</BackButtonText>
       </BackButton>
@@ -164,6 +164,7 @@ export function Main(
           <SettingsButtonWrapper>
             <StyledSaveButton
               category={Category.primary}
+              className="t--admin-settings-save-button"
               disabled={Object.keys(props.settings).length == 0 || !props.valid}
               isLoading={props.isSaving}
               onClick={onSave}
@@ -172,6 +173,7 @@ export function Main(
             />
             <StyledClearButton
               category={Category.tertiary}
+              className="t--admin-settings-reset-button"
               disabled={Object.keys(props.settings).length == 0}
               onClick={onClear}
               tag="button"

--- a/app/client/src/pages/Settings/Main/Button.test.tsx
+++ b/app/client/src/pages/Settings/Main/Button.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "test/testUtils";
+import React from "react";
+import { SettingTypes } from "../SettingsConfig";
+import ButtonComponent from "./Button";
+
+let container: any = null;
+const buttonClickHandler = jest.fn();
+const setting = {
+  text: "download",
+  action: buttonClickHandler,
+  category: "test",
+  controlType: SettingTypes.BUTTON,
+};
+const dispatch = jest.fn();
+jest.mock("react-redux", () => {
+  const originalModule = jest.requireActual("react-redux");
+  return {
+    ...originalModule,
+    useDispatch: () => dispatch,
+  };
+});
+
+function renderComponent() {
+  render(<ButtonComponent setting={setting} />, container);
+}
+
+describe("Button", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("is rendered", () => {
+    renderComponent();
+    const button = screen.queryAllByTestId("admin-settings-button");
+    expect(button).toHaveLength(1);
+  });
+
+  it("is rendered with proper text", () => {
+    renderComponent();
+    const button = screen.queryAllByTestId("admin-settings-button");
+    expect(button).toHaveLength(1);
+    expect(button[0].textContent).toBe(setting.text);
+  });
+
+  it("is executing action of setting on click", () => {
+    renderComponent();
+    const button = screen.queryAllByTestId("admin-settings-button");
+    expect(buttonClickHandler).not.toHaveBeenCalled();
+    button[0].click();
+    expect(buttonClickHandler).toHaveBeenCalledWith(dispatch);
+  });
+});

--- a/app/client/src/pages/Settings/Main/Button.test.tsx
+++ b/app/client/src/pages/Settings/Main/Button.test.tsx
@@ -5,11 +5,13 @@ import ButtonComponent from "./Button";
 
 let container: any = null;
 const buttonClickHandler = jest.fn();
+const buttonIsDisabled = jest.fn();
 const setting = {
   text: "download",
   action: buttonClickHandler,
   category: "test",
   controlType: SettingTypes.BUTTON,
+  isDisabled: buttonIsDisabled,
 };
 const dispatch = jest.fn();
 jest.mock("react-redux", () => {
@@ -17,6 +19,15 @@ jest.mock("react-redux", () => {
   return {
     ...originalModule,
     useDispatch: () => dispatch,
+  };
+});
+
+const settings = {};
+jest.mock("store", () => {
+  const store = jest.requireActual("store").default;
+  return {
+    ...store,
+    useSelector: () => settings,
   };
 });
 
@@ -43,11 +54,27 @@ describe("Button", () => {
     expect(button[0].textContent).toBe(setting.text);
   });
 
+  it("is disabled when isDisabled is returning true", () => {
+    buttonIsDisabled.mockReturnValue(true);
+    renderComponent();
+    const button = screen.queryAllByTestId("admin-settings-button");
+    expect(buttonIsDisabled).toHaveBeenCalledWith(settings);
+    expect((button[0] as any).disabled).toBeTruthy();
+  });
+
+  it("is not disabled when isDisabled is returning false", () => {
+    buttonIsDisabled.mockReturnValue(false);
+    renderComponent();
+    const button = screen.queryAllByTestId("admin-settings-button");
+    expect(buttonIsDisabled).toHaveBeenCalledWith(settings);
+    expect((button[0] as any).disabled).toBeFalsy();
+  });
+
   it("is executing action of setting on click", () => {
     renderComponent();
     const button = screen.queryAllByTestId("admin-settings-button");
     expect(buttonClickHandler).not.toHaveBeenCalled();
     button[0].click();
-    expect(buttonClickHandler).toHaveBeenCalled();
+    expect(buttonClickHandler).toHaveBeenCalledWith(dispatch, settings);
   });
 });

--- a/app/client/src/pages/Settings/Main/Button.test.tsx
+++ b/app/client/src/pages/Settings/Main/Button.test.tsx
@@ -48,6 +48,6 @@ describe("Button", () => {
     const button = screen.queryAllByTestId("admin-settings-button");
     expect(buttonClickHandler).not.toHaveBeenCalled();
     button[0].click();
-    expect(buttonClickHandler).toHaveBeenCalledWith(dispatch);
+    expect(buttonClickHandler).toHaveBeenCalled();
   });
 });

--- a/app/client/src/pages/Settings/Main/Button.tsx
+++ b/app/client/src/pages/Settings/Main/Button.tsx
@@ -29,6 +29,7 @@ export default function ButtonComponent({ setting }: SettingComponentProps) {
       <ButtonWrapper>
         <StyledButton
           category={Category.tertiary}
+          data-testid="admin-settings-button"
           disabled={setting.isDisabled && setting.isDisabled(settings)}
           onClick={() => {
             if (setting.action) {

--- a/app/client/src/pages/Settings/Main/Common.tsx
+++ b/app/client/src/pages/Settings/Main/Common.tsx
@@ -10,6 +10,7 @@ import { Colors } from "constants/Colors";
 type FieldHelperProps = {
   setting: Setting;
   children: React.ReactNode;
+  className?: string;
 };
 
 const StyledIcon = styled(Icon)`
@@ -50,18 +51,28 @@ export const StyledSubtext = styled.p`
   color: ${Colors.GRAY};
 `;
 
-export function FormGroup({ children, setting }: FieldHelperProps) {
+export function FormGroup({ children, className, setting }: FieldHelperProps) {
   return (
-    <StyledFormGroup>
-      <StyledLabel>{createMessage(() => setting.label || "")}</StyledLabel>
+    <StyledFormGroup
+      className={className}
+      data-testid="admin-settings-form-group"
+    >
+      <StyledLabel data-testid="admin-settings-form-group-label">
+        {createMessage(() => setting.label || "")}
+      </StyledLabel>
       {setting.helpText && (
         <Tooltip content={createMessage(() => setting.helpText || "")}>
-          <StyledIcon fillColor="#fff" name="help" size={IconSize.XXS} />
+          <StyledIcon
+            data-testid="admin-settings-form-group-helptext"
+            fillColor="#fff"
+            name="help"
+            size={IconSize.XXS}
+          />
         </Tooltip>
       )}
       {children}
       {setting.subText && (
-        <StyledSubtext>
+        <StyledSubtext data-testid="admin-settings-form-group-subtext">
           * {createMessage(() => setting.subText || "")}
         </StyledSubtext>
       )}

--- a/app/client/src/pages/Settings/Main/Group.text.tsx
+++ b/app/client/src/pages/Settings/Main/Group.text.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "test/testUtils";
+import React from "react";
+import { SettingTypes } from "../SettingsConfig";
+import Group from "./group";
+import { SETTINGS_FORM_NAME } from "constants/forms";
+import { reduxForm } from "redux-form";
+
+let container: any = null;
+const settings = [
+  {
+    name: "test",
+    label: "formGroup",
+    helpText: "",
+    subText: "",
+    category: "test",
+    controlType: SettingTypes.BUTTON,
+  },
+];
+
+function renderComponent() {
+  function GroupComponent() {
+    return <Group name="test" settings={settings} />;
+  }
+  const Parent = reduxForm<any, any>({
+    validate: () => {
+      return {};
+    },
+    form: SETTINGS_FORM_NAME,
+    touchOnBlur: true,
+  })(GroupComponent);
+
+  render(<Parent />);
+}
+
+function getElements() {
+  const textInput = screen.queryAllByTestId("admin-settings-group-text-input");
+  const toggle = screen.queryAllByTestId("admin-settings-group-toggle");
+  const link = screen.queryAllByTestId("admin-settings-group-link");
+  const text = screen.queryAllByTestId("admin-settings-group-text");
+  const button = screen.queryAllByTestId("admin-settings-group-button");
+  const group = screen.queryAllByTestId("admin-settings-group");
+
+  return { textInput, toggle, link, text, button, group };
+}
+
+describe("Group", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("is rendered", () => {
+    renderComponent();
+    const group = screen.queryAllByTestId("admin-settings-group-wrapper");
+    expect(group).toHaveLength(1);
+  });
+
+  it("is rendered for text input", () => {
+    settings[0].controlType = SettingTypes.TEXTINPUT;
+    renderComponent();
+    const { button, group, link, text, textInput, toggle } = getElements();
+    expect(textInput).toHaveLength(1);
+    expect(toggle).toHaveLength(0);
+    expect(link).toHaveLength(0);
+    expect(text).toHaveLength(0);
+    expect(button).toHaveLength(0);
+    expect(group).toHaveLength(0);
+  });
+
+  it("is rendered for toggle", () => {
+    settings[0].controlType = SettingTypes.TOGGLE;
+    renderComponent();
+    const { button, group, link, text, textInput, toggle } = getElements();
+    expect(textInput).toHaveLength(0);
+    expect(toggle).toHaveLength(1);
+    expect(link).toHaveLength(0);
+    expect(text).toHaveLength(0);
+    expect(button).toHaveLength(0);
+    expect(group).toHaveLength(0);
+  });
+
+  it("is rendered for link", () => {
+    settings[0].controlType = SettingTypes.LINK;
+    renderComponent();
+    const { button, group, link, text, textInput, toggle } = getElements();
+    expect(textInput).toHaveLength(0);
+    expect(toggle).toHaveLength(0);
+    expect(link).toHaveLength(1);
+    expect(text).toHaveLength(0);
+    expect(button).toHaveLength(0);
+    expect(group).toHaveLength(0);
+  });
+
+  it("is rendered for text", () => {
+    settings[0].controlType = SettingTypes.TEXT;
+    renderComponent();
+    const { button, group, link, text, textInput, toggle } = getElements();
+    expect(textInput).toHaveLength(0);
+    expect(toggle).toHaveLength(0);
+    expect(link).toHaveLength(0);
+    expect(text).toHaveLength(1);
+    expect(button).toHaveLength(0);
+    expect(group).toHaveLength(0);
+  });
+
+  it("is rendered for button", () => {
+    settings[0].controlType = SettingTypes.BUTTON;
+    renderComponent();
+    const { button, group, link, text, textInput, toggle } = getElements();
+    expect(textInput).toHaveLength(0);
+    expect(toggle).toHaveLength(0);
+    expect(link).toHaveLength(0);
+    expect(text).toHaveLength(0);
+    expect(button).toHaveLength(1);
+    expect(group).toHaveLength(0);
+  });
+
+  it("is rendered for group", () => {
+    settings[0].controlType = SettingTypes.GROUP;
+    renderComponent();
+    const { button, group, link, text, textInput, toggle } = getElements();
+    expect(textInput).toHaveLength(0);
+    expect(toggle).toHaveLength(0);
+    expect(link).toHaveLength(0);
+    expect(text).toHaveLength(0);
+    expect(button).toHaveLength(0);
+    expect(group).toHaveLength(1);
+  });
+});

--- a/app/client/src/pages/Settings/Main/Link.test.tsx
+++ b/app/client/src/pages/Settings/Main/Link.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "test/testUtils";
+import React from "react";
+import { SettingTypes } from "../SettingsConfig";
+import Link from "./Link";
+
+let container: any = null;
+const linkClickHandler = jest.fn();
+const setting = {
+  isHidden: false,
+  label: "setting label",
+  action: linkClickHandler,
+  category: "test",
+  controlType: SettingTypes.LINK,
+  url: "",
+};
+const dispatch = jest.fn();
+jest.mock("react-redux", () => {
+  const originalModule = jest.requireActual("react-redux");
+  return {
+    ...originalModule,
+    useDispatch: () => dispatch,
+  };
+});
+
+function renderComponent() {
+  render(<Link setting={setting} />);
+}
+
+describe("Link", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("is rendered", () => {
+    renderComponent();
+    const link = screen.queryAllByTestId("admin-settings-link");
+    expect(link).toHaveLength(1);
+  });
+
+  it("is rendered with label", () => {
+    renderComponent();
+    const linkLabel = screen.queryAllByTestId("admin-settings-link-label");
+    expect(linkLabel).toHaveLength(1);
+    expect(linkLabel[0].textContent).toBe(setting.label);
+  });
+
+  it("is rendered with click handler", () => {
+    renderComponent();
+    const linkAnchor = screen.queryAllByTestId("admin-settings-link-anchor");
+    expect(linkAnchor).toHaveLength(1);
+    expect(linkClickHandler).not.toHaveBeenCalled();
+    linkAnchor[0].click();
+    expect(linkClickHandler).toHaveBeenCalledWith(dispatch);
+  });
+
+  it("is rendered with href", () => {
+    const url = "http://test.appsmith.com";
+    setting.url = url;
+    renderComponent();
+    const linkAnchor = screen.queryAllByTestId("admin-settings-link-anchor");
+    expect(linkAnchor).toHaveLength(1);
+    expect(linkAnchor[0].getAttribute("href")).toBe(url);
+    expect(linkAnchor[0].getAttribute("target")).toBe("_blank");
+  });
+});

--- a/app/client/src/pages/Settings/Main/Link.tsx
+++ b/app/client/src/pages/Settings/Main/Link.tsx
@@ -60,9 +60,14 @@ export default function Link({ setting }: SettingComponentProps) {
     };
   }
   return (
-    <LinkWrapper className={setting.isHidden ? "hide" : ""}>
-      <StyledLink {...linkProps}>
-        <LinkLabel>{createMessage(() => setting.label || "")}</LinkLabel>
+    <LinkWrapper
+      className={setting.isHidden ? "hide" : ""}
+      data-testid="admin-settings-link"
+    >
+      <StyledLink data-testid="admin-settings-link-anchor" {...linkProps}>
+        <LinkLabel data-testid="admin-settings-link-label">
+          {createMessage(() => setting.label || "")}
+        </LinkLabel>
         &nbsp;
         <StyledText type={TextType.P1}>READ MORE</StyledText>
         &nbsp;

--- a/app/client/src/pages/Settings/Main/Text.test.tsx
+++ b/app/client/src/pages/Settings/Main/Text.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "test/testUtils";
+import React from "react";
+import { SettingTypes } from "../SettingsConfig";
+import TextComponent from "./Text";
+
+let container: any = null;
+const buttonClickHandler = jest.fn();
+const setting = {
+  name: "textType",
+  text: "download",
+  action: buttonClickHandler,
+  category: "test",
+  controlType: SettingTypes.TEXT,
+};
+
+const useSelector = jest.fn();
+const settingsConfig = {
+  textType: "some text value",
+};
+useSelector.mockReturnValue(settingsConfig);
+
+function renderComponent() {
+  render(<TextComponent setting={setting} />, {
+    initialState: {
+      settings: {
+        isLoading: false,
+        isSaving: false,
+        isRestarting: false,
+        showReleaseNotes: false,
+        isRestartFailed: false,
+        config: settingsConfig,
+      },
+    },
+  });
+}
+
+describe("Text", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("is rendered", () => {
+    renderComponent();
+    const text = screen.queryAllByTestId("admin-settings-text");
+    expect(text).toHaveLength(1);
+    expect(text[0].textContent).toBe(settingsConfig.textType);
+  });
+});

--- a/app/client/src/pages/Settings/Main/Text.tsx
+++ b/app/client/src/pages/Settings/Main/Text.tsx
@@ -13,13 +13,15 @@ const StyledText = styled(Text)`
   color: ${(props) => props.theme.colors.settings.link};
 `;
 
-export default function Link({ setting }: SettingComponentProps) {
+export default function TextComponent({ setting }: SettingComponentProps) {
   const settingsConfig = useSelector(getSettings);
   const value = setting.name && settingsConfig && settingsConfig[setting.name];
   return (
     <FormGroup setting={setting}>
       <TextWrapper>
-        <StyledText type={TextType.P1}>{value}</StyledText>
+        <StyledText data-testid="admin-settings-text" type={TextType.P1}>
+          {value}
+        </StyledText>
       </TextWrapper>
     </FormGroup>
   );

--- a/app/client/src/pages/Settings/Main/TextInput.tsx
+++ b/app/client/src/pages/Settings/Main/TextInput.tsx
@@ -5,7 +5,10 @@ import { FormGroup, SettingComponentProps } from "./Common";
 
 export default function TextInput({ setting }: SettingComponentProps) {
   return (
-    <FormGroup setting={setting}>
+    <FormGroup
+      className={`t--admin-settings-text-input t--admin-settings-${setting.name}`}
+      setting={setting}
+    >
       <FormTextField
         name={setting.name || ""}
         placeholder={createMessage(() => setting.placeholder || "")}

--- a/app/client/src/pages/Settings/Main/common.test.tsx
+++ b/app/client/src/pages/Settings/Main/common.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "test/testUtils";
+import React from "react";
+import { SettingTypes } from "../SettingsConfig";
+import { FormGroup } from "./Common";
+
+let container: any = null;
+const setting = {
+  label: "formGroup",
+  helpText: "",
+  subText: "",
+  category: "test",
+  controlType: SettingTypes.BUTTON,
+};
+const CLASSNAME = "form-group";
+
+function renderComponent() {
+  render(
+    <FormGroup className={CLASSNAME} setting={setting}>
+      <div data-testid="admin-settings-form-group-child" />
+    </FormGroup>,
+    container,
+  );
+}
+
+describe("FormGroup", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("is rendered", () => {
+    renderComponent();
+    const formGroup = screen.queryAllByTestId("admin-settings-form-group");
+    expect(formGroup).toHaveLength(1);
+    expect(formGroup[0].className).toContain(CLASSNAME);
+    const formGroupLabel = screen.queryAllByTestId(
+      "admin-settings-form-group-label",
+    );
+    expect(formGroupLabel).toHaveLength(1);
+    expect(formGroupLabel[0].textContent).toBe(setting.label);
+    const formGroupHelpText = screen.queryAllByTestId(
+      "admin-settings-form-group-helptext",
+    );
+    expect(formGroupHelpText).toHaveLength(0);
+    const formGroupSubtext = screen.queryAllByTestId(
+      "admin-settings-form-group-subtext",
+    );
+    expect(formGroupSubtext).toHaveLength(0);
+  });
+
+  it("is rendered with helpText", () => {
+    setting.helpText = "some help text";
+    renderComponent();
+    const formGroupHelpText = screen.queryAllByTestId(
+      "admin-settings-form-group-helptext",
+    );
+    expect(formGroupHelpText).toHaveLength(1);
+  });
+
+  it("is rendered with subText", () => {
+    setting.subText = "some sub text";
+    renderComponent();
+    const formGroupSubtext = screen.queryAllByTestId(
+      "admin-settings-form-group-subtext",
+    );
+    expect(formGroupSubtext).toHaveLength(1);
+    expect(formGroupSubtext[0].textContent).toBe(`* ${setting.subText}`);
+  });
+
+  it("is rendered with children", () => {
+    renderComponent();
+    const formGroupChild = screen.queryAllByTestId(
+      "admin-settings-form-group-child",
+    );
+    expect(formGroupChild).toHaveLength(1);
+  });
+});

--- a/app/client/src/pages/Settings/Main/group.tsx
+++ b/app/client/src/pages/Settings/Main/group.tsx
@@ -44,7 +44,7 @@ const formValuesSelector = getFormValues(SETTINGS_FORM_NAME);
 export default function Group({ name, settings }: GroupProps) {
   const state = useSelector((state) => state);
   return (
-    <GroupWrapper>
+    <GroupWrapper data-testid="admin-settings-group-wrapper">
       <GroupHeader>{createMessage(() => name || "")}</GroupHeader>
       <GroupBody>
         {settings &&
@@ -60,6 +60,7 @@ export default function Group({ name, settings }: GroupProps) {
                 return (
                   <div
                     className={setting.isHidden ? "hide" : ""}
+                    data-testid="admin-settings-group-text-input"
                     key={setting.name}
                   >
                     <TextInput setting={setting} />
@@ -69,6 +70,7 @@ export default function Group({ name, settings }: GroupProps) {
                 return (
                   <div
                     className={setting.isHidden ? "hide" : ""}
+                    data-testid="admin-settings-group-toggle"
                     key={setting.name}
                   >
                     <Toggle setting={setting} />
@@ -78,6 +80,7 @@ export default function Group({ name, settings }: GroupProps) {
                 return (
                   <div
                     className={setting.isHidden ? "hide" : ""}
+                    data-testid="admin-settings-group-link"
                     key={setting.name}
                   >
                     <Link setting={setting} />
@@ -87,6 +90,7 @@ export default function Group({ name, settings }: GroupProps) {
                 return (
                   <div
                     className={setting.isHidden ? "hide" : ""}
+                    data-testid="admin-settings-group-text"
                     key={setting.name}
                   >
                     <Text setting={setting} />
@@ -96,6 +100,7 @@ export default function Group({ name, settings }: GroupProps) {
                 return (
                   <div
                     className={setting.isHidden ? "hide" : ""}
+                    data-testid="admin-settings-group-button"
                     key={setting.name}
                   >
                     <Button setting={setting} />
@@ -105,6 +110,7 @@ export default function Group({ name, settings }: GroupProps) {
                 return (
                   <div
                     className={setting.isHidden ? "hide" : ""}
+                    data-testid="admin-settings-group"
                     key={setting.name}
                   >
                     <Group name={setting.name} settings={setting.children} />

--- a/app/client/src/pages/Settings/RestartBanner.tsx
+++ b/app/client/src/pages/Settings/RestartBanner.tsx
@@ -69,6 +69,7 @@ export default function RestartBanner() {
     <Dialog
       canEscapeKeyClose={false}
       canOutsideClickClose={false}
+      className="t--admin-settings-restart-notice"
       getHeader={() => <Header />}
       isOpen
       showHeaderUnderline

--- a/app/client/src/pages/Settings/index.tsx
+++ b/app/client/src/pages/Settings/index.tsx
@@ -1,14 +1,11 @@
 import { Spinner } from "@blueprintjs/core";
 import { ReduxActionTypes } from "constants/ReduxActionConstants";
-import { APPLICATIONS_URL } from "constants/routes";
 import PageWrapper from "pages/common/PageWrapper";
 import React from "react";
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Redirect } from "react-router";
 import { getSettingsLoadingState } from "selectors/settingsSelectors";
 import styled from "styled-components";
-import getFeatureFlags from "utils/featureFlags";
 import LeftPane from "./LeftPane";
 import Main from "./Main";
 import WithSuperUserHOC from "./WithSuperUserHoc";
@@ -27,7 +24,6 @@ const LoaderContainer = styled.div`
 function Settings() {
   const dispatch = useDispatch();
   const isLoading = useSelector(getSettingsLoadingState);
-  const isAdminSettingsEnabled = getFeatureFlags().ADMIN_SETTINGS;
   useEffect(() => {
     dispatch({
       type: ReduxActionTypes.FETCH_ADMIN_SETTINGS,
@@ -36,9 +32,6 @@ function Settings() {
       type: ReduxActionTypes.FETCH_RELEASES,
     });
   }, []);
-  if (!isAdminSettingsEnabled) {
-    return <Redirect to={APPLICATIONS_URL} />;
-  }
 
   return (
     <PageWrapper>

--- a/app/client/src/pages/common/ProfileDropdown.tsx
+++ b/app/client/src/pages/common/ProfileDropdown.tsx
@@ -24,7 +24,6 @@ import {
 import { TOOLTIP_HOVER_ON_DELAY } from "constants/AppConstants";
 import { useSelector } from "react-redux";
 import { getCurrentUser } from "selectors/usersSelectors";
-import getFeatureFlags from "utils/featureFlags";
 
 type TagProps = CommonComponentProps & {
   onClick?: (text: string) => void;
@@ -105,7 +104,6 @@ export default function ProfileDropdown(props: TagProps) {
       />
     </TooltipComponent>
   );
-  const isAdminSettingsEnabled = getFeatureFlags().ADMIN_SETTINGS;
 
   return (
     <Menu
@@ -141,7 +139,7 @@ export default function ProfileDropdown(props: TagProps) {
         }}
         text="Edit Profile"
       />
-      {user?.isSuperUser && user?.isConfigurable && isAdminSettingsEnabled && (
+      {user?.isSuperUser && user?.isConfigurable && (
         <StyledMenuItem
           className={`t--settings ${BlueprintClasses.POPOVER_DISMISS}`}
           icon="setting"

--- a/app/client/src/pages/common/ProfileDropdown.tsx
+++ b/app/client/src/pages/common/ProfileDropdown.tsx
@@ -141,7 +141,7 @@ export default function ProfileDropdown(props: TagProps) {
       />
       {user?.isSuperUser && user?.isConfigurable && (
         <StyledMenuItem
-          className={`t--settings ${BlueprintClasses.POPOVER_DISMISS}`}
+          className={`t--admin-settings-menu ${BlueprintClasses.POPOVER_DISMISS}`}
           icon="setting"
           onSelect={() => {
             getOnSelectAction(DropdownOnSelectActions.REDIRECT, {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/featureflags/FeatureFlagEnum.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/featureflags/FeatureFlagEnum.java
@@ -28,6 +28,5 @@ public enum FeatureFlagEnum {
     LINTING,
     MULTIPLAYER,
     GIT,
-    ADMIN_SETTINGS,
     GIT_IMPORT;
 }

--- a/app/server/appsmith-server/src/main/resources/features/init-flags.yml
+++ b/app/server/appsmith-server/src/main/resources/features/init-flags.yml
@@ -44,15 +44,6 @@ ff4j:
           - name: emailDomains
             value: appsmith.com
 
-    - uid: ADMIN_SETTINGS
-      enable: true
-      description: Enable admin settings for apps
-      flipstrategy:
-        class: com.appsmith.server.featureflags.strategies.EmailBasedRolloutStrategy
-        param:
-          - name: emailDomains
-            value: appsmith.com
-    
     - uid: GIT_IMPORT
       enable: true
       description: Enable git import for apps


### PR DESCRIPTION
## Description

Moving Admin settings page out of feature flag.

Fixes #9686

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feat/admin-settings-inauguration 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.25 **(0.12)** | 37.13 **(0.08)** | 34.15 **(0.13)** | 55.77 **(0.12)**
 :green_circle: | app/client/src/components/ads/Icon.tsx | 52.9 **(0.51)** | 36.2 **(0.62)** | 100 **(0)** | 52.78 **(0.51)**
 :sparkles: :new: | **app/client/src/pages/Settings/SettingsConfig.ts** | **68.37** | **25** | **21.05** | **69.47**
 :sparkles: :new: | **app/client/src/pages/Settings/Main/Button.tsx** | **100** | **87.5** | **100** | **100**
 :sparkles: :new: | **app/client/src/pages/Settings/Main/Common.tsx** | **100** | **88.89** | **100** | **100**
 :sparkles: :new: | **app/client/src/pages/Settings/Main/Link.tsx** | **100** | **80** | **100** | **100**
 :sparkles: :new: | **app/client/src/pages/Settings/Main/Text.tsx** | **100** | **100** | **100** | **100**
 :green_circle: | app/client/src/pages/common/ProfileDropdown.tsx | 68.75 **(1.1)** | 28.57 **(1.3)** | 0 **(0)** | 68.75 **(1.1)**
 :sparkles: :new: | **app/client/src/selectors/settingsSelectors.tsx** | **72.22** | **100** | **16.67** | **54.55**</details>