### PR TITLE
chore: Entity Name re-render fix

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
@@ -18,6 +18,7 @@ import { Classes, Position } from "@blueprintjs/core";
 import { AppState } from "reducers";
 import {
   getExistingActionNames,
+  getExistingJSCollectionNames,
   getExistingPageNames,
   getExistingWidgetNames,
 } from "selectors/entitiesSelector";
@@ -150,10 +151,8 @@ export const EntityName = forwardRef(
 
     const existingActionNames: string[] = useSelector(getExistingActionNames);
 
-    const existingJSCollectionNames: string[] = useSelector((state: AppState) =>
-      state.entities.jsActions.map(
-        (action: { config: { name: string } }) => action.config.name,
-      ),
+    const existingJSCollectionNames: string[] = useSelector(
+      getExistingJSCollectionNames,
     );
 
     const hasNameConflict = useCallback(

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -498,6 +498,12 @@ export const getExistingActionNames = createSelector(
     actions.map((action: { config: { name: string } }) => action.config.name),
 );
 
+export const getExistingJSCollectionNames = createSelector(
+  getJSCollections,
+  (jsActions) =>
+    jsActions.map((action: { config: { name: string } }) => action.config.name),
+);
+
 export const getAppMode = (state: AppState) => state.entities.app.mode;
 
 export const widgetsMapWithParentModalId = (state: AppState) => {


### PR DESCRIPTION
## Description

Moving selector logic away from the component to a separate Selector to prevent re-render of 
https://github.com/appsmithorg/appsmith/blob/release/app/client/src/pages/Editor/Explorer/Entity/Name.tsx Component

Fixes #9702 

## Type of change
Performance fix

## How Has This Been Tested?
React profiler and performance profiler

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: entity-name-rerender-fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.12 **(0)** | 37.05 **(0.01)** | 34.02 **(0)** | 55.65 **(0.01)**
 :red_circle: | app/client/src/pages/Editor/Explorer/Entity/Name.tsx | 62.35 **(0.28)** | 34.04 **(0)** | 38.46 **(-1.54)** | 61.73 **(0.28)**
 :green_circle: | app/client/src/selectors/entitiesSelector.ts | 54.26 **(0.12)** | 10.47 **(0)** | 33.06 **(0.27)** | 51.91 **(0.41)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>