### PR TITLE
test: Add quiet for cypress warnings

### DIFF
--- a/app/client/cypress.json
+++ b/app/client/cypress.json
@@ -10,7 +10,8 @@
     "reportDir": "results",
     "overwrite": false,
     "html": true,
-    "json": false
+    "json": false,
+    "quiet": true
   },
    "ignoreTestFiles": [
     "**/Smoke_TestSuite/Application/PgAdmin_spec*.js",


### PR DESCRIPTION
## Description

Add quiet for cypress warnings

Fixes #  

Add quiet for cypress warnings
## Type of change


- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Tested locally

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>