### PR TITLE
fix: Google sheets Bulk insert of empty array returns an error

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
@@ -152,13 +152,10 @@ public class BulkAppendMethod implements Method {
                                     }
                                     valueMap.put(header.asText(), value);
                                 }
-                                if (Boolean.TRUE.equals(validValues)) {
-                                    rowObject.setValueMap(valueMap);
-                                } else {
-                                    throw Exceptions.propagate(new AppsmithPluginException(
-                                            AppsmithPluginError.PLUGIN_ERROR,
-                                            "Could not map values to existing data."));
+                                if (Boolean.FALSE.equals(validValues)) {
+                                    valueMap.put("", "");
                                 }
+                                rowObject.setValueMap(valueMap);
                             }
 
                             methodConfig.setBody(finalRowObjectListFromBody);

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
@@ -18,7 +18,6 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,30 +82,16 @@ public class BulkAppendMethod implements Method {
         final GetValuesMethod getValuesMethod = new GetValuesMethod(this.objectMapper);
 
         List<RowObject> rowObjectListFromBody = null;
-        JsonNode body = null;
         try {
-            body = this.objectMapper.readTree(methodConfig.getRowObjects());
+            JsonNode body = this.objectMapper.readTree(methodConfig.getRowObjects());
+
+            if ( body.isEmpty()) {
+                return Mono.empty();
+            }
+
+            rowObjectListFromBody = this.getRowObjectListFromBody(body);
         } catch (JsonProcessingException e) {
             // Should never enter here
-        }
-
-        rowObjectListFromBody = this.getRowObjectListFromBody(body);
-        if (body.isArray()) {
-            boolean fieldsEmpty = true;
-            for (JsonNode jsonNode : body) {
-                String fieldName = "";
-                if(jsonNode.fields().hasNext()) {
-                //    jsonNode.fields().next();
-                    fieldName = jsonNode.fields().next().getKey();
-                    if (fieldName.length() > 0) {
-                        fieldsEmpty = false;
-                        break;
-                    }
-                }
-            }
-            if(fieldsEmpty) {
-                return Mono.just(true);
-            }
         }
 
         assert rowObjectListFromBody != null;
@@ -216,17 +201,6 @@ public class BulkAppendMethod implements Method {
         uriBuilder.queryParam("includeValuesInResponse", Boolean.FALSE);
 
         final List<RowObject> body1 = (List<RowObject>) methodConfig.getBody();
-
-        if(body1==null){
-            final ValueRange valueRange = new ValueRange();
-            valueRange.setMajorDimension("ROWS");
-            valueRange.setRange(range);
-            valueRange.setValues(null);
-            return webClient.method(HttpMethod.POST)
-                    .uri(uriBuilder.build(true).toUri())
-                    .body(BodyInserters.fromValue(valueRange));
-        }
-
         List<List<Object>> collect = body1.stream()
                 .map(row -> row.getAsSheetValues(body1.get(0).getValueMap().keySet().toArray(new String[0])))
                 .collect(Collectors.toList());

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/plugins/GoogleSheetsPlugin.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Extension;
 import org.pf4j.PluginWrapper;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -169,6 +170,7 @@ public class GoogleSheetsPlugin extends BasePlugin {
             // Triggering the actual REST API call
             return method.executePrerequisites(methodConfig, oauth2)
                     // This method call will populate the request with all the configurations it needs for a particular method
+                    .switchIfEmpty( Mono.defer(() -> handleEmptyRowObjects(methodConfig, method, oauth2, client)))
                     .flatMap(res -> {
                         return method.getClient(client, methodConfig)
                                 .headers(headers -> headers.set(
@@ -241,6 +243,29 @@ public class GoogleSheetsPlugin extends BasePlugin {
                                     System.out.println(e.getMessage());
                                     return Mono.just(errorResult);
                                 });
+                    });
+        }
+
+
+        public Mono<ResponseEntity> handleEmptyRowObjects(MethodConfig methodConfig, Method method, OAuth2 oauth2, WebClient client) {
+            return method.getClient(client, methodConfig)
+                    .headers(headers -> headers.set(
+                            "Authorization",
+                            "Bearer " + oauth2.getAuthenticationResponse().getToken()))
+                    .exchange()
+                    .flatMap(clientResponse -> clientResponse.toEntity(byte[].class))
+                    .map(stringResponseEntity -> {
+                        methodConfig.getBody();
+                        JsonNode emptyRowObjects = null;
+                        try {
+                            emptyRowObjects = objectMapper.readTree("{\"message\":\"No rows inserted\"}");
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+
+                        return stringResponseEntity.ok()
+                                .header(stringResponseEntity.getHeaders().toString())
+                                .body(emptyRowObjects);
                     });
         }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
@@ -51,13 +51,6 @@ public class BulkAppendMethodTest {
         List properties = new ArrayList<Property>();
         MethodConfig methodConfig = new MethodConfig(properties);
 
-        methodConfig.setSpreadsheetUrl("https://docs.google.com/spreadsheets/d/test123$$/edit#gid=0");
-        methodConfig.setSpreadsheetId("https://docs.google.com/spreadsheets/d");
-        methodConfig.setTableHeaderIndex("1");
-        methodConfig.setSheetName("Sheet1");
-        methodConfig.setQueryFormat("Rows");
-        methodConfig.setRowOffset("1");
-        methodConfig.setRowLimit("1");
         methodConfig.setRowObjects(rowObject);
 
         return methodConfig;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
@@ -13,15 +13,6 @@ import java.util.List;
 public class BulkAppendMethodTest {
     final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static String accessKey;
-    private static String secretKey;
-
-    @BeforeClass
-    public static void setUp() {
-        accessKey   = "access_key";
-        secretKey   = "secret_key";
-    }
-
     /**
      * To Test if it passes the empty Mono criteria,
      * else it should fail
@@ -40,38 +31,12 @@ public class BulkAppendMethodTest {
         }
     }
 
-    /**
-     * To Test if it passes the Non-empty Mono criteria,
-     * down the line the code may fail which is not the scope of testing
-     * that means, no code changes are done after empty Mono handling condition
-     * for which this test is intended to run.
-     */
-    @Test
-    public void testBulkAppendHandleNonEmptyMonoExecutePrerequisites() {
-        String[] testDataArray = {
-                "[{\"Sl #\":\"100\"}]",
-                "[{}]",
-                "[{\"Sl #\":\"100\"},{\"Sl#\":\"101\"}]",
-                "[{\"Sl #\":\"100\",\"Topic\":\"topic\"}]"};
-
-        for(int i=0; i<testDataArray.length; i++) {
-            MethodConfig methodConfig = getMethodConfigObject(testDataArray[i]);
-            BulkAppendMethod bulkAppend = new BulkAppendMethod(objectMapper);
-            Mono<Object> monoTest = bulkAppend.executePrerequisites(methodConfig, getOAuthObject());
-
-            StepVerifier
-                    .create(monoTest)
-                    .expectErrorMatches(throwable ->  throwable instanceof  java.lang.AssertionError);  }
-    }
-
-    /**
+   /**
      * Simulated oAuth2 object, just to bypass few case.
      * @return
      */
     private OAuth2 getOAuthObject(){
-        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
         OAuth2 oAuth2 = new OAuth2();
-        oAuth2.setAuthenticationResponse(datasourceConfiguration.getAuthentication().getAuthenticationResponse());
         oAuth2.setAuthenticationResponse(new AuthenticationResponse() );
         oAuth2.getAuthenticationResponse().setToken("welcome123");
         return oAuth2;
@@ -96,20 +61,5 @@ public class BulkAppendMethodTest {
         methodConfig.setRowObjects(rowObject);
 
         return methodConfig;
-    }
-
-    /**
-     * DatasourceConfiguration object need for creating OAuth
-     * @return
-     */
-    private DatasourceConfiguration createDatasourceConfiguration() {
-        DBAuth authDTO = new DBAuth();
-        authDTO.setAuthType(DBAuth.Type.USERNAME_PASSWORD);
-        authDTO.setUsername(accessKey);
-        authDTO.setPassword(secretKey);
-
-        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
-        dsConfig.setAuthentication(authDTO);
-        return dsConfig;
     }
 }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/BulkAppendMethodTest.java
@@ -1,0 +1,115 @@
+package com.external.config;
+
+import com.appsmith.external.models.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BulkAppendMethodTest {
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static String accessKey;
+    private static String secretKey;
+
+    @BeforeClass
+    public static void setUp() {
+        accessKey   = "access_key";
+        secretKey   = "secret_key";
+    }
+
+    /**
+     * To Test if it passes the empty Mono criteria,
+     * else it should fail
+     */
+    @Test
+    public void testBulkAppendHandleEmptyMonoExecutePrerequisites() {
+        String[] testDataArray = {"[]", ""};
+
+        for(int i=0; i<testDataArray.length; i++) {
+            BulkAppendMethod bulkAppend = new BulkAppendMethod(objectMapper);
+            Mono<Object> monoTest = bulkAppend.executePrerequisites(getMethodConfigObject(testDataArray[i]), getOAuthObject());
+
+            StepVerifier.create(monoTest)
+                    .expectComplete()
+                    .verify();
+        }
+    }
+
+    /**
+     * To Test if it passes the Non-empty Mono criteria,
+     * down the line the code may fail which is not the scope of testing
+     * that means, no code changes are done after empty Mono handling condition
+     * for which this test is intended to run.
+     */
+    @Test
+    public void testBulkAppendHandleNonEmptyMonoExecutePrerequisites() {
+        String[] testDataArray = {
+                "[{\"Sl #\":\"100\"}]",
+                "[{}]",
+                "[{\"Sl #\":\"100\"},{\"Sl#\":\"101\"}]",
+                "[{\"Sl #\":\"100\",\"Topic\":\"topic\"}]"};
+
+        for(int i=0; i<testDataArray.length; i++) {
+            MethodConfig methodConfig = getMethodConfigObject(testDataArray[i]);
+            BulkAppendMethod bulkAppend = new BulkAppendMethod(objectMapper);
+            Mono<Object> monoTest = bulkAppend.executePrerequisites(methodConfig, getOAuthObject());
+
+            StepVerifier
+                    .create(monoTest)
+                    .expectErrorMatches(throwable ->  throwable instanceof  java.lang.AssertionError);  }
+    }
+
+    /**
+     * Simulated oAuth2 object, just to bypass few case.
+     * @return
+     */
+    private OAuth2 getOAuthObject(){
+        DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
+        OAuth2 oAuth2 = new OAuth2();
+        oAuth2.setAuthenticationResponse(datasourceConfiguration.getAuthentication().getAuthenticationResponse());
+        oAuth2.setAuthenticationResponse(new AuthenticationResponse() );
+        oAuth2.getAuthenticationResponse().setToken("welcome123");
+        return oAuth2;
+    }
+
+    /**
+     * Simulated MethodConfig object with testable data.
+     * @param rowObject
+     * @return
+     */
+    private  MethodConfig getMethodConfigObject(String rowObject){
+        List properties = new ArrayList<Property>();
+        MethodConfig methodConfig = new MethodConfig(properties);
+
+        methodConfig.setSpreadsheetUrl("https://docs.google.com/spreadsheets/d/test123$$/edit#gid=0");
+        methodConfig.setSpreadsheetId("https://docs.google.com/spreadsheets/d");
+        methodConfig.setTableHeaderIndex("1");
+        methodConfig.setSheetName("Sheet1");
+        methodConfig.setQueryFormat("Rows");
+        methodConfig.setRowOffset("1");
+        methodConfig.setRowLimit("1");
+        methodConfig.setRowObjects(rowObject);
+
+        return methodConfig;
+    }
+
+    /**
+     * DatasourceConfiguration object need for creating OAuth
+     * @return
+     */
+    private DatasourceConfiguration createDatasourceConfiguration() {
+        DBAuth authDTO = new DBAuth();
+        authDTO.setAuthType(DBAuth.Type.USERNAME_PASSWORD);
+        authDTO.setUsername(accessKey);
+        authDTO.setPassword(secretKey);
+
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        dsConfig.setAuthentication(authDTO);
+        return dsConfig;
+    }
+}


### PR DESCRIPTION
## Description

> When executing a Google sheets Bulk insert rows query, an error is returned if the data array is empty.

Fixes #8924

## Type of change
- Bug fix (non-breaking change which fixes an issue)   

## How Has This Been Tested?
> Tested manually with different inputs of empty data
> JUnit Test implemented
 
## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
