### PR TITLE
fix: Revert "fix: Select widget Value"

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Widgets_Default_data_validation_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Widgets_Default_data_validation_spec.js
@@ -2,7 +2,6 @@ const commonlocators = require("../../../../locators/commonlocators.json");
 const formWidgetsPage = require("../../../../locators/FormWidgets.json");
 const dsl = require("../../../../fixtures/MultipleWidgetDsl.json");
 const pages = require("../../../../locators/Pages.json");
-const widgetLocators = require("../../../../locators/Widgets.json");
 const widgetsPage = require("../../../../locators/Widgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const testdata = require("../../../../fixtures/testdata.json");
@@ -13,7 +12,6 @@ describe("Binding the multiple widgets and validating default data", function() 
   });
 
   it("Input widget test with default value from table widget", function() {
-    cy.wait(3000);
     cy.openPropertyPane("inputwidget");
     cy.testJsontext("defaulttext", testdata.defaultInputWidget + "}}");
 
@@ -26,31 +24,21 @@ describe("Binding the multiple widgets and validating default data", function() 
 
   //To be enabled once the single select multi select issues are resolved
   it("Dropdown widget test with default value from table widget", function() {
-    cy.isSelectRow(1);
     cy.openPropertyPane("dropdownwidget");
     cy.testJsontext("options", JSON.stringify(testdata.deafultDropDownWidget));
+
     cy.wait("@updateLayout").should(
       "have.nested.property",
       "response.body.responseMeta.status",
       200,
     );
-    cy.get(formWidgetsPage.dropdownWidget)
-      .find(widgetLocators.dropdownSingleSelect)
-      .click({ force: true });
-    cy.get(commonlocators.singleSelectMenuItem)
-      .contains("lindsay.ferguson@reqres.in")
-      .click({ force: true });
-    // Verify the selected value
-    cy.get(formWidgetsPage.dropdownWidget)
-      .find(widgetLocators.defaultSingleSelectValue)
-      .should("have.text", "lindsay.ferguson@reqres.in");
   });
 
   it("validation of default data displayed in all widgets based on row selected", function() {
-    cy.isSelectRow(2);
-    cy.readTabledataPublish("2", "0").then((tabData) => {
+    cy.isSelectRow(1);
+    cy.readTabledataPublish("1", "0").then((tabData) => {
       const tabValue = tabData;
-      expect(tabValue).to.be.equal("6788734");
+      expect(tabValue).to.be.equal("2736212");
       cy.log("the value is" + tabValue);
 
       cy.get(publish.inputWidget + " " + "input")
@@ -59,9 +47,9 @@ describe("Binding the multiple widgets and validating default data", function() 
         .should("contain", tabValue);
     });
 
-    cy.readTabledataPublish("2", "1").then((tabData) => {
+    cy.readTabledataPublish("1", "1").then((tabData) => {
       const tabValue = tabData;
-      expect(tabValue).to.be.equal("tobias.funke@reqres.in");
+      expect(tabValue).to.be.equal("lindsay.ferguson@reqres.in");
       cy.log("the value is" + tabValue);
       cy.get(widgetsPage.defaultSingleSelectValue)
         .first()

--- a/app/client/src/widgets/DropdownWidget/widget/index.test.tsx
+++ b/app/client/src/widgets/DropdownWidget/widget/index.test.tsx
@@ -74,7 +74,6 @@ describe("<DropdownWidget />", () => {
       selectedOptionLabel: "mock-label-1",
       serverSideFiltering: false,
       onFilterUpdate: "mock-update",
-      updateWidgetMetaProperty: jest.fn(),
     };
     renderDropdownWidget(mockDataWithEmptyOptions);
 

--- a/app/client/src/widgets/DropdownWidget/widget/index.tsx
+++ b/app/client/src/widgets/DropdownWidget/widget/index.tsx
@@ -269,7 +269,12 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
 
   static getDerivedPropertiesMap() {
     return {
-      isValid: `{{this.isRequired  ? !!this.selectedOptionValue : true}}`,
+      isValid: `{{this.isRequired  ? !!this.selectedOption : true}}`,
+      selectedOption: `{{  _.find(this.options, { value:  this.defaultValue }) }}`,
+      selectedIndex: `{{ _.findIndex(this.options, { value: this.selectedOption.value } ) }}`,
+      value: `{{  this.defaultValue }}`,
+      selectedOptionLabel: `{{(()=>{const index = _.findIndex(this.options, { value: this.defaultValue }); return this.options[index]?.label; })()}}`,
+      selectedOptionValue: `{{(()=>{const index = _.findIndex(this.options, { value: this.defaultValue }); return this.options[index]?.value; })()}}`,
     };
   }
 
@@ -282,22 +287,7 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
   static getMetaPropertiesMap(): Record<string, any> {
     return {
       defaultValue: undefined,
-      selectedOptionValue: undefined,
-      selectedOptionLabel: undefined,
     };
-  }
-
-  componentDidMount() {
-    this.changeSelectedOption();
-  }
-  componentDidUpdate(prevProps: DropdownWidgetProps): void {
-    // removing selectedOptionValue if defaultValueChanges
-    if (
-      prevProps.defaultOptionValue !== this.props.defaultOptionValue ||
-      prevProps.option !== this.props.option
-    ) {
-      this.changeSelectedOption();
-    }
   }
 
   getPageView() {
@@ -305,7 +295,7 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
     const dropDownWidth = MinimumPopupRows * this.props.parentColumnSpace;
 
     const selectedIndex = _.findIndex(this.props.options, {
-      value: this.props.selectedOptionValue,
+      value: this.props.defaultValue,
     });
     console.log("dropDownWidth Select", dropDownWidth);
 
@@ -349,32 +339,20 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
     if (this.props.selectedOptionValue) {
       isChanged = !(this.props.selectedOptionValue === selectedOption.value);
     }
+
     if (isChanged) {
       this.props.updateWidgetMetaProperty(
-        "selectedOptionValue",
+        "defaultValue",
         selectedOption.value,
         {
           triggerPropertyName: "onOptionChange",
-          dynamicString: this.props.onOptionChange as string,
+          dynamicString: this.props.onOptionChange,
           event: {
             type: EventType.ON_OPTION_CHANGE,
           },
         },
       );
-      this.props.updateWidgetMetaProperty(
-        "selectedOptionLabel",
-        selectedOption.label,
-      );
     }
-  };
-  changeSelectedOption = () => {
-    const index = _.findIndex(this.props.options, {
-      value: this.props.defaultOptionValue,
-    });
-    const value = this.props.options?.[index]?.value;
-    const label = this.props.options?.[index]?.label;
-    this.props.updateWidgetMetaProperty("selectedOptionValue", value);
-    this.props.updateWidgetMetaProperty("selectedOptionLabel", label);
   };
 
   onFilterChange = (value: string) => {
@@ -401,7 +379,7 @@ export interface DropdownWidgetProps extends WidgetProps {
   selectedOption: DropdownOption;
   options?: DropdownOption[];
   onOptionChange?: string;
-  defaultOptionValue?: string;
+  defaultOptionValue?: string | string[];
   isRequired: boolean;
   isFilterable: boolean;
   defaultValue: string;


### PR DESCRIPTION
Reverts appsmithorg/appsmith#9444
## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: revert-9444-fix/selectedOptionValue-from-Select-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.12 **(0)** | 37.03 **(-0.01)** | 34.01 **(-0.01)** | 55.64 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/widgets/DropdownWidget/widget/index.tsx | 72.92 **(-0.41)** | 23.53 **(-19.71)** | 63.64 **(-0.65)** | 72.09 **(-0.64)**</details>