### PR TITLE
fix: fixes duplication of where clause AND-condition fields

### DIFF
--- a/app/client/src/components/formControls/WhereClauseControl.tsx
+++ b/app/client/src/components/formControls/WhereClauseControl.tsx
@@ -4,9 +4,11 @@ import Text, { TextType } from "components/ads/Text";
 import Icon, { IconSize } from "components/ads/Icon";
 import { Classes } from "components/ads/common";
 import styled from "styled-components";
-import { FieldArray } from "redux-form";
+import { FieldArray, getFormValues } from "redux-form";
 import FormLabel from "components/editorComponents/FormLabel";
 import { ControlProps } from "./BaseControl";
+import _ from "lodash";
+import { useSelector } from "react-redux";
 
 // Type of the value for each condition
 export type whereClauseValueType = {
@@ -175,8 +177,22 @@ function ConditionComponent(props: any, index: number) {
 
 // This is the block which contains an operator and multiple conditions/ condition blocks
 function ConditionBlock(props: any) {
+  const formValues: any = useSelector((state) =>
+    getFormValues(props.formName)(state),
+  );
+
+  const onDeletePressed = (index: number) => {
+    props.fields.remove(index);
+  };
+
+  // sometimes, this condition runs before the appropriate formValues has been initialized with the correct query values.
   useEffect(() => {
-    if (props.fields.length < 1) {
+    // so make sure the new formValue has been initialized with the where object,
+    // especially when switching between various queries across the same Query editor form.
+    const whereConfigValue = _.get(formValues, props.configProperty);
+    // if the where object exists then it means the initialization of the form has been completed.
+    // if the where object exists and the length of children field is less than one, add a new field.
+    if (props.fields.length < 1 && !!whereConfigValue) {
       if (props.currentNestingLevel === 0) {
         props.fields.push({
           condition: props.comparisonTypes[0].value,
@@ -186,9 +202,7 @@ function ConditionBlock(props: any) {
       }
     }
   }, [props.fields.length]);
-  const onDeletePressed = (index: number) => {
-    props.fields.remove(index);
-  };
+
   let marginTop = "8px";
   // In case the first component is a complex element, add extra margin
   // because the keys are not visible. Will not affect the outer most

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -737,6 +737,12 @@ export function EditorJSONtoForm(props: Props) {
     props.actionName,
   );
 
+  // when switching between different redux forms, make sure this redux form has been initialized before rendering anything.
+  // the initialized prop below comes from redux-form.
+  if (!props.initialized) {
+    return null;
+  }
+
   return (
     <>
       <CloseEditor />


### PR DESCRIPTION
This resolves the continuous addition of new where clause "AND" fields every time the query is navigated to, from another query or API action.

Fixes #9665.

- Bug fix (non-breaking change which fixes an issue)

Manual Testing employed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/duplicated-and-condition 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.12 **(0)** | 37.03 **(-0.01)** | 34.01 **(-0.01)** | 55.64 **(0)**
 :red_circle: | app/client/src/components/formControls/WhereClauseControl.tsx | 34.92 **(0.44)** | 40 **(-2.42)** | 0 **(0)** | 34.92 **(0.44)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 41.99 **(-0.47)** | 30.97 **(-0.4)** | 0 **(0)** | 43.93 **(-0.51)**</details>