### PR TITLE
fix: changed conditions for variables as variables were undefined

### DIFF
--- a/app/client/src/utils/JSPaneUtils.tsx
+++ b/app/client/src/utils/JSPaneUtils.tsx
@@ -133,7 +133,12 @@ export const getDifferenceInJSCollection = (
       const existedVar = varList.find((item) => item.name === newVar.name);
       if (!!existedVar) {
         const existedValue = existedVar.value;
-        if (existedValue.toString() !== newVar.value.toString()) {
+        if (
+          (!!existedValue &&
+            existedValue.toString() !==
+              (newVar.value && newVar.value.toString())) ||
+          (!existedValue && !!newVar.value)
+        ) {
           changedVariables.push(newVar);
         }
       } else {

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -629,7 +629,11 @@ export const updateJSCollectionInDataTree = (
       const existedVar = varList.indexOf(newVar.name);
       if (existedVar > -1) {
         const existedVarVal = jsCollection[newVar.name];
-        if (existedVarVal.toString() !== newVar.value.toString()) {
+        if (
+          (!!existedVarVal && existedVarVal.toString()) !==
+            (newVar.value && newVar.value.toString()) ||
+          (!existedVarVal && !!newVar)
+        ) {
           _.set(
             modifiedDataTree,
             `${jsCollection.name}.${newVar.name}`,


### PR DESCRIPTION

## Description
After parsing, while updating data tree variables were undefined and to update we compare values by turning it into string. that was failing

Fixes #9730 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: Critical-9730-fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.12 **(0)** | 37.01 **(-0.01)** | 34.01 **(0)** | 55.64 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/workers/evaluationUtils.ts | 57.46 **(0)** | 53.94 **(-2.39)** | 62.26 **(0)** | 55.19 **(0)**</details>