### PR TITLE
fix: Ignore form data elements with null keys

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/FieldName.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/FieldName.java
@@ -12,4 +12,6 @@ public class FieldName {
     public static final String KEY = "key";
     public static final String CONDITION = "condition";
     public static final String VALUE = "value";
+
+    public static final String FILE_TYPE = "FILE";
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/DataUtils.java
@@ -109,7 +109,9 @@ public class DataUtils {
         }
 
         return bodyFormData
+                // Disregard keys that are null
                 .stream()
+                .filter(property -> property.getKey() != null)
                 .map(property -> {
                     String key = property.getKey();
                     String value = (String) property.getValue();
@@ -139,6 +141,10 @@ public class DataUtils {
 
                     for (Property property : bodyFormData) {
                         final String key = property.getKey();
+
+                        if (property.getKey() == null) {
+                            continue;
+                        }
 
                         // This condition is for the current scenario, while we wait for client changes to come in
                         // before the migration can be introduced

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
@@ -119,18 +119,26 @@ public class RequestCaptureFilter implements ExchangeFilterFunction {
         if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(reqContentType.get())) {
             final List<Property> bodyFormData = actionConfiguration.getBodyFormData();
             Map<String, Object> bodyDataMap = new HashMap<>();
-            bodyFormData.forEach(property -> bodyDataMap.put(property.getKey(), property.getValue()));
+            bodyFormData
+                    // Disregard keys that are null
+                    .stream()
+                    .filter(property -> property.getKey() != null)
+                    .forEach(property -> bodyDataMap.put(property.getKey(), property.getValue()));
             actionExecutionRequest.setBody(bodyDataMap);
         } else if (MediaType.MULTIPART_FORM_DATA_VALUE.equals(reqContentType.get())) {
             final List<Property> bodyFormData = actionConfiguration.getBodyFormData();
             Map<String, Object> bodyDataMap = new HashMap<>();
-            bodyFormData.forEach(property -> {
-                if ("FILE".equalsIgnoreCase(property.getType())) {
-                    bodyDataMap.put(property.getKey(), "<file>");
-                } else {
-                    bodyDataMap.put(property.getKey(), property.getValue());
-                }
-            });
+            bodyFormData
+                    // Disregard keys that are null
+                    .stream()
+                    .filter(property -> property.getKey() != null)
+                    .forEach(property -> {
+                        if ("FILE".equalsIgnoreCase(property.getType())) {
+                            bodyDataMap.put(property.getKey(), "<file>");
+                        } else {
+                            bodyDataMap.put(property.getKey(), property.getValue());
+                        }
+                    });
             actionExecutionRequest.setBody(bodyDataMap);
         }
 

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.appsmith.external.constants.FieldName.FILE_TYPE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 /**
@@ -133,7 +134,7 @@ public class RequestCaptureFilter implements ExchangeFilterFunction {
                     .stream()
                     .filter(property -> property.getKey() != null)
                     .forEach(property -> {
-                        if ("FILE".equalsIgnoreCase(property.getType())) {
+                        if (FILE_TYPE.equalsIgnoreCase(property.getType())) {
                             bodyDataMap.put(property.getKey(), "<file>");
                         } else {
                             bodyDataMap.put(property.getKey(), property.getValue());

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -121,7 +121,11 @@ public class RestApiPluginTest {
         ActionConfiguration actionConfig = new ActionConfiguration();
         actionConfig.setHeaders(List.of(new Property("content-type", "application/x-www-form-urlencoded")));
         actionConfig.setHttpMethod(HttpMethod.POST);
-        actionConfig.setBodyFormData(List.of(new Property("key", "value"), new Property("key1", "value1")));
+        actionConfig.setBodyFormData(List.of(
+                new Property("key", "value"),
+                new Property("key1", "value1"),
+                new Property(null, "irrelevantValue")
+        ));
         Mono<ActionExecutionResult> resultMono = pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);
 
         StepVerifier.create(resultMono)
@@ -443,9 +447,10 @@ public class RestApiPluginTest {
         final Property key1 = new Property("key1", "onlyValue");
         final Property key2 = new Property("key2", "{\"name\":\"fileName\", \"type\":\"application/json\", \"data\":{\"key\":\"value\"}}");
         final Property key3 = new Property("key3", "[{\"name\":\"fileName2\", \"type\":\"application/json\", \"data\":{\"key2\":\"value2\"}}]");
+        final Property key4 = new Property(null, "irrelevantValue");
         key2.setType("FILE");
         key3.setType("FILE");
-        List<Property> formData = List.of(key1, key2, key3);
+        List<Property> formData = List.of(key1, key2, key3, key4);
         actionConfig.setBodyFormData(formData);
 
         Mono<ActionExecutionResult> resultMono = pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);

--- a/app/server/appsmith-plugins/saasPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
+++ b/app/server/appsmith-plugins/saasPlugin/src/main/java/com/external/helpers/RequestCaptureFilter.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.appsmith.external.constants.FieldName.FILE_TYPE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 /**
@@ -125,7 +126,7 @@ public class RequestCaptureFilter implements ExchangeFilterFunction {
             final List<Property> bodyFormData = actionConfiguration.getBodyFormData();
             Map<String, Object> bodyDataMap = new HashMap<>();
             bodyFormData.forEach(property -> {
-                if ("FILE".equalsIgnoreCase(property.getType())) {
+                if (FILE_TYPE.equalsIgnoreCase(property.getType())) {
                     bodyDataMap.put(property.getKey(), "<file>");
                 } else {
                     bodyDataMap.put(property.getKey(), property.getValue());


### PR DESCRIPTION
This issue was being caused by the form data request body parser trying to create a map out of the input data. However, when the input data contains null keys (as part of the `Property` type), the map creation step was failing.

While adding safe handling, I have also removed the processing of k-v pairs where the key is null. Effectively the APIs will not be using such values at all.

Fixes #9362 