### PR TITLE
fix: Incorrect error handling when incorrect sheet name is used in Google Sheets query

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/AppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/AppendMethod.java
@@ -104,6 +104,11 @@ public class AppendMethod implements Method {
                     // Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
+                    if (responseBody == null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Expected to receive a response body."));
+                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody;
                     try {
@@ -121,12 +126,12 @@ public class AppendMethod implements Method {
                                 "Expected to receive a response of existing headers."));
                     }
 
-                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
-                    }
+                    if (response.getStatusCode() != null && !response.getStatusCode().is2xxSuccessful()) {
+                        if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") != null) {
+                            throw Exceptions.propagate(new AppsmithPluginException(
+                                    AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                        }
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
                         throw Exceptions.propagate(new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_ERROR,
                                 "Could not map request back to existing data"));

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/AppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/AppendMethod.java
@@ -104,11 +104,6 @@ public class AppendMethod implements Method {
                     // Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,
-                                "Could not map request back to existing data"));
-                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody;
                     try {
@@ -124,6 +119,17 @@ public class AppendMethod implements Method {
                         throw Exceptions.propagate(new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_ERROR,
                                 "Expected to receive a response of existing headers."));
+                    }
+
+                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                    }
+
+                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Could not map request back to existing data"));
                     }
 
                     ArrayNode valueRanges = (ArrayNode) jsonNodeBody.get("valueRanges");

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
@@ -112,6 +112,11 @@ public class BulkAppendMethod implements Method {
                 .map(response -> {// Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
+                    if (responseBody == null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Expected to receive a response body."));
+                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody;
                     try {
@@ -124,12 +129,12 @@ public class BulkAppendMethod implements Method {
                         ));
                     }
 
-                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
-                    }
+                    if (response.getStatusCode() != null && !response.getStatusCode().is2xxSuccessful()) {
+                        if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
+                            throw Exceptions.propagate(new AppsmithPluginException(
+                                    AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                        }
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
                         throw Exceptions.propagate(new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_ERROR,
                                 "Could not map request back to existing data"));

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
@@ -112,11 +112,6 @@ public class BulkAppendMethod implements Method {
                 .map(response -> {// Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,
-                                "Could not map request back to existing data"));
-                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody;
                     try {
@@ -128,6 +123,18 @@ public class BulkAppendMethod implements Method {
                                 e.getMessage()
                         ));
                     }
+
+                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                    }
+
+                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Could not map request back to existing data"));
+                    }
+
                     if (jsonNodeBody == null) {
                         throw Exceptions.propagate(new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_ERROR,

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkUpdateMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkUpdateMethod.java
@@ -108,11 +108,6 @@ public class BulkUpdateMethod implements Method {
                     // Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,
-                                "Could not map request back to existing data"));
-                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody;
                     try {
@@ -123,6 +118,17 @@ public class BulkUpdateMethod implements Method {
                                 new String(responseBody),
                                 e.getMessage()
                         ));
+                    }
+
+                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                    }
+
+                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Could not map request back to existing data"));
                     }
 
                     // This is the object with the original values in the referred row

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkUpdateMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkUpdateMethod.java
@@ -108,6 +108,11 @@ public class BulkUpdateMethod implements Method {
                     // Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
+                    if (responseBody == null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Expected to receive a response body."));
+                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody;
                     try {
@@ -120,12 +125,13 @@ public class BulkUpdateMethod implements Method {
                         ));
                     }
 
-                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
-                    }
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
+                    if (response.getStatusCode() != null && !response.getStatusCode().is2xxSuccessful()) {
+                        if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
+                            throw Exceptions.propagate(new AppsmithPluginException(
+                                    AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                        }
+
                         throw Exceptions.propagate(new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_ERROR,
                                 "Could not map request back to existing data"));

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/UpdateMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/UpdateMethod.java
@@ -99,11 +99,6 @@ public class UpdateMethod implements Method {
                 .map(response -> {// Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,
-                                "Could not map request back to existing data"));
-                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody = null;
                     try {
@@ -114,6 +109,16 @@ public class UpdateMethod implements Method {
                                 new String(responseBody),
                                 e.getMessage()
                         ));
+                    }
+                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                    }
+
+                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Could not map request back to existing data"));
                     }
 
                     // This is the object with the original values in the referred row

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/UpdateMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/UpdateMethod.java
@@ -99,6 +99,11 @@ public class UpdateMethod implements Method {
                 .map(response -> {// Choose body depending on response status
                     byte[] responseBody = response.getBody();
 
+                    if (responseBody == null) {
+                        throw Exceptions.propagate(new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Expected to receive a response body."));
+                    }
                     String jsonBody = new String(responseBody);
                     JsonNode jsonNodeBody = null;
                     try {
@@ -110,15 +115,15 @@ public class UpdateMethod implements Method {
                                 e.getMessage()
                         ));
                     }
-                    if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") !=null) {
-                        throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
-                    }
+                    if (response.getStatusCode() != null && !response.getStatusCode().is2xxSuccessful()) {
+                        if (jsonNodeBody.get("error") != null && jsonNodeBody.get("error").get("message") != null) {
+                            throw Exceptions.propagate(new AppsmithPluginException(
+                                    AppsmithPluginError.PLUGIN_ERROR,   jsonNodeBody.get("error").get("message").toString()));
+                        }
 
-                    if (responseBody == null || !response.getStatusCode().is2xxSuccessful()) {
                         throw Exceptions.propagate(new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,
-                                "Could not map request back to existing data"));
+                            AppsmithPluginError.PLUGIN_ERROR,
+                            "Could not map request back to existing data"));
                     }
 
                     // This is the object with the original values in the referred row


### PR DESCRIPTION
## Description

> Incorrect error handling when incorrect sheet name is used in Google Sheets query

Fixes #9463

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> The already generated error from Response is parsed and displayed.
> Earlier as soon as an error is identified generic error message are thrown.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
