### PR TITLE
fix: Update replaceAll function for browser support

### DIFF
--- a/app/client/src/entities/DataTree/dataTreeJSAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeJSAction.ts
@@ -20,6 +20,7 @@ export const generateDataTreeJSAction = (
   const reg = /this\./g;
   const removeThisReference = js.config.body.replace(reg, `${js.config.name}.`);
   bindingPaths["body"] = EvaluationSubstitutionType.SMART_SUBSTITUTE;
+
   if (variables) {
     for (let i = 0; i < variables.length; i++) {
       const variable = variables[i];

--- a/app/client/src/entities/DataTree/dataTreeJSAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeJSAction.ts
@@ -18,10 +18,7 @@ export const generateDataTreeJSAction = (
   const listVariables: Array<string> = [];
   dynamicBindingPathList.push({ key: "body" });
   const reg = /this\./g;
-  const removeThisReference = js.config.body.replaceAll(
-    reg,
-    `${js.config.name}.`,
-  );
+  const removeThisReference = js.config.body.replace(reg, `${js.config.name}.`);
   bindingPaths["body"] = EvaluationSubstitutionType.SMART_SUBSTITUTE;
   if (variables) {
     for (let i = 0; i < variables.length; i++) {


### PR DESCRIPTION
## Description

The replaceAll function was added in ES12, in older browser versions `TypeError: replaceAll is not a function` exception occurs. With the / /g global flag set in the regex, the replace function is does that same thing but with better browser support.

Fixes #9762 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/replace-all-browser-compatibility 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.14 **(0)** | 37.07 **(-0.01)** | 33.96 **(0)** | 55.64 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>