### PR TITLE
fix: [Fix] Removed sentry reporting when application not found

### DIFF
--- a/app/client/src/sagas/CommentSagas/index.ts
+++ b/app/client/src/sagas/CommentSagas/index.ts
@@ -174,7 +174,7 @@ function* fetchApplicationComments() {
   } catch (error) {
     yield put({
       type: ReduxActionErrorTypes.FETCH_APPLICATION_COMMENTS_ERROR,
-      payload: { error, logToSentry: true },
+      payload: { error, logToSentry: false },
     });
   }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommentServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommentServiceCEImpl.java
@@ -564,7 +564,7 @@ public class CommentServiceCEImpl extends BaseService<CommentRepository, Comment
     public Mono<List<CommentThread>> getThreadsByApplicationId(CommentThreadFilterDTO commentThreadFilterDTO) {
         return applicationService.findById(commentThreadFilterDTO.getApplicationId(), READ_APPLICATIONS)
                 .switchIfEmpty(Mono.error(new AppsmithException(
-                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, FieldName.APPLICATION_ID
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, commentThreadFilterDTO.getApplicationId()
                 )))
                 .zipWith(sessionUserService.getCurrentUser())
                 .flatMap(objects -> {


### PR DESCRIPTION
## Description

Removes sentry reporting when application permission check fails during fetching comment threads.

Fixes #9838


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>