### PR TITLE
fix: Install plugin to existing organizations after approval

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PluginServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PluginServiceCEImpl.java
@@ -200,8 +200,13 @@ public class PluginServiceCEImpl extends BaseService<PluginRepository, Plugin, S
                 .collect(Collectors.toList());
         return organizationService.getAll()
                 .flatMap(organization -> {
-                    organization.getPlugins().addAll(newOrganizationPlugins);
-                    return organizationService.save(organization);
+                    // Only perform a DB op if plugins associated to this org have changed
+                    if (organization.getPlugins().containsAll(newOrganizationPlugins)) {
+                        return Mono.just(organization);
+                    } else {
+                        organization.getPlugins().addAll(newOrganizationPlugins);
+                        return organizationService.save(organization);
+                    }
                 });
     }
 


### PR DESCRIPTION
## Description

We were only installing plugins to all organizations if the plugin was new. But since the testing process allows plugins to be introduced to the cloud db without default install, we would not ever be installing to existing organizations on the cloud.

This fix adds the same logic to the update plugin flow, with an extra check in place to avoid db updated in case the plugins for that organization have not changed.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually tested for local Saas plugin
