### PR TITLE
fix: fixes inability to rename other widgets, jsactions, pages

### DIFF
--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -507,10 +507,12 @@ export const getExistingActionNames = createSelector(
       );
 
     // if the current action being edited is on the same page, filter the actions on the page and return their names.
+    // or if the there is no current action being edited (this happens when a widget, or any other entity is being edited), return the actions on the page.
     if (
-      editingAction &&
-      editingAction.length > 1 &&
-      editingAction[0].config.pageId === currentPageId
+      (editingAction &&
+        editingAction.length > 1 &&
+        editingAction[0].config.pageId === currentPageId) ||
+      (editingAction && editingAction.length < 1)
     ) {
       return actions.map(
         (actionItem: { config: { name: string; pageId: string } }) => {

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -510,7 +510,7 @@ export const getExistingActionNames = createSelector(
     // or if the there is no current action being edited (this happens when a widget, or any other entity is being edited), return the actions on the page.
     if (
       (editingAction &&
-        editingAction.length > 1 &&
+        editingAction.length > 0 &&
         editingAction[0].config.pageId === currentPageId) ||
       (editingAction && editingAction.length < 1)
     ) {

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -489,7 +489,7 @@ export const getExistingPageNames = createSelector(
 
 export const getExistingWidgetNames = createSelector(
   (state: AppState) => state.entities.canvasWidgets,
-  (widgets) => Object.values(widgets).map((widget) => widget.pageName),
+  (widgets) => Object.values(widgets).map((widget) => widget.widgetName),
 );
 
 export const getExistingActionNames = createSelector(
@@ -507,7 +507,11 @@ export const getExistingActionNames = createSelector(
       );
 
     // if the current action being edited is on the same page, filter the actions on the page and return their names.
-    if (editingAction && editingAction[0].config.pageId === currentPageId) {
+    if (
+      editingAction &&
+      editingAction.length > 1 &&
+      editingAction[0].config.pageId === currentPageId
+    ) {
       return actions.map(
         (actionItem: { config: { name: string; pageId: string } }) => {
           if (actionItem.config.pageId === currentPageId) {


### PR DESCRIPTION
> Pull Request Template
App breaks anytime you try to rename a widget, a page or a jsObject, This PR fixes that

## Description
The bug was as a result of an empty array being passed to one of the if else statements which made the wrong conditional block to run.

Fixes #9843

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-widget-naming-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/selectors/entitiesSelector.ts | 53.52 **(0)** | 13.13 **(0.63)** | 33.07 **(0)** | 50.81 **(0)**</details>