### PR TITLE
chore: show only ssh key in the deploy key UI section, rm label

### DIFF
--- a/app/client/src/pages/Editor/gitSync/components/DeployedKeyUI.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/DeployedKeyUI.tsx
@@ -1,7 +1,6 @@
 import { Colors } from "constants/Colors";
 import {
   createMessage,
-  DEPLOY_KEY_TITLE,
   DEPLOY_KEY_USAGE_GUIDE_MESSAGE,
   LEARN_MORE,
 } from "constants/messages";
@@ -66,13 +65,6 @@ const FlexRow = styled.div`
   width: 100%;
 `;
 
-const LabelText = styled.span`
-  margin-left: ${(props) => `${props.theme.spaces[2]}px`};
-  font-size: 14px;
-  color: ${Colors.CODE_GRAY};
-  white-space: nowrap;
-`;
-
 const KeyText = styled.span`
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -119,12 +111,9 @@ function DeployedKeyUI(props: DeployedKeyUIProps) {
           <FlexRow>
             <Key2LineIcon
               color={Colors.DOVE_GRAY2}
-              size={28}
-              style={{ marginTop: -4 }}
+              size={20}
+              style={{ marginTop: -1, marginRight: 4 }}
             />
-            <LabelText>
-              {createMessage(DEPLOY_KEY_TITLE)}&nbsp;:&nbsp;
-            </LabelText>
             <KeyText>{SSHKeyPair}</KeyText>
           </FlexRow>
         </DeployedKeyContainer>


### PR DESCRIPTION
## Description
chore: show only ssh key in the deploy key UI section, rm label

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually, UI change

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>