### PR TITLE
fix: fix firestore pagination cyclic dependency error

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/getCollection.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/getCollection.json
@@ -24,7 +24,7 @@
     },
     {
       "label": "Start After",
-      "configProperty": "actionConfiguration.formData.startAfter",
+      "configProperty": "actionConfiguration.next",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "isRequired": true,
@@ -32,7 +32,7 @@
     },
     {
       "label": "End Before",
-      "configProperty": "actionConfiguration.formData.endBefore",
+      "configProperty": "actionConfiguration.prev",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
       "isRequired": true,

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -481,8 +481,8 @@ public class FirestorePluginTest {
 
         if (first != null && last != null) {
             try {
-                setValueSafelyInFormData(configMap, START_AFTER, objectMapper.writeValueAsString(last));
-                setValueSafelyInFormData(configMap, END_BEFORE, objectMapper.writeValueAsString(first));
+                actionConfiguration.setNext(objectMapper.writeValueAsString(last));
+                actionConfiguration.setPrev(objectMapper.writeValueAsString(first));
             } catch (JsonProcessingException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
## Description
- fix cyclic dependency error caused by using Firestore query data in the same query's pagination fields. 
- fix bad migration for firestore UQI. 

Fixes #9871 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
