### PR TITLE
fix: remove allowed filetype restriction in filepickerwidget

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/filepicker_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/filepicker_spec.js
@@ -1,0 +1,32 @@
+const explorer = require("../../../../locators/explorerlocators.json");
+
+describe("FilePicker Widget Functionality", function() {
+  before(() => {
+    cy.visit("/applications");
+    cy.get(".t--new-button")
+      .first()
+      .click();
+    cy.get(".t--BuildFromScratch").click();
+    cy.get(explorer.addWidget).click();
+    cy.dragAndDropToCanvas("filepickerwidgetv2", { x: 200, y: 600 });
+  });
+
+  it("should test allowed values", () => {
+    cy.openPropertyPane("filepickerwidgetv2");
+    cy.get(".t--property-control-allowedfiletypes .t--js-toggle").click({
+      force: true,
+    });
+    cy.testJsontext("allowedfiletypes", "['.csv']");
+    cy.get(
+      ".t--property-control-allowedfiletypes .t--codemirror-has-error",
+    ).should("not.exist");
+    cy.testJsontext("allowedfiletypes", ".csv");
+    cy.get(
+      ".t--property-control-allowedfiletypes .t--codemirror-has-error",
+    ).should("exist");
+    cy.testJsontext("allowedfiletypes", "['.csv', '.doc']");
+    cy.get(
+      ".t--property-control-allowedfiletypes .t--codemirror-has-error",
+    ).should("not.exist");
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/filepicker_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/filepicker_spec.js
@@ -16,7 +16,7 @@ describe("FilePicker Widget Functionality", function() {
     cy.get(".t--property-control-allowedfiletypes .t--js-toggle").click({
       force: true,
     });
-    cy.testJsontext("allowedfiletypes", "['.csv']");
+    cy.testJsontext("allowedfiletypes", `[".csv"]`);
     cy.get(
       ".t--property-control-allowedfiletypes .t--codemirror-has-error",
     ).should("not.exist");
@@ -24,7 +24,7 @@ describe("FilePicker Widget Functionality", function() {
     cy.get(
       ".t--property-control-allowedfiletypes .t--codemirror-has-error",
     ).should("exist");
-    cy.testJsontext("allowedfiletypes", "['.csv', '.doc']");
+    cy.testJsontext("allowedfiletypes", `[".csv", ".doc"]`);
     cy.get(
       ".t--property-control-allowedfiletypes .t--codemirror-has-error",
     ).should("not.exist");

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -646,7 +646,9 @@ class CodeEditor extends Component<Props, State> {
           <EditorWrapper
             border={border}
             borderLess={borderLess}
-            className={`${className} ${replayHighlightClass}`}
+            className={`${className} ${replayHighlightClass} ${
+              isInvalid ? "t--codemirror-has-error" : ""
+            }`}
             disabled={disabled}
             editorTheme={this.props.theme}
             fill={fill}

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -117,16 +117,10 @@ class FilePickerWidget extends BaseWidget<
             validation: {
               type: ValidationTypes.ARRAY,
               params: {
-                allowedValues: [
-                  "*",
-                  "image/*",
-                  "video/*",
-                  "audio/*",
-                  "text/*",
-                  ".doc",
-                  "image/jpeg",
-                  ".png",
-                ],
+                unique: true,
+                children: {
+                  type: ValidationTypes.TEXT,
+                },
               },
             },
             evaluationSubstitutionType:


### PR DESCRIPTION
Fixes #9907

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/filepicker-allowed-files 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 67.13 **(0)** | 40.36 **(0.12)** | 51.28 **(0)** | 67.05 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>