### PR TITLE
chore: Update docker compose file to have update schedule to 1 hour

### DIFF
--- a/deploy/aws_ami/docker-compose.yml
+++ b/deploy/aws_ami/docker-compose.yml
@@ -19,5 +19,5 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check interval in seconds.
-    command: --interval 300 --label-enable --cleanup
+    command: --schedule "0 0 * ? * *" --label-enable --cleanup
     restart: unless-stopped

--- a/deploy/aws_ami/docker-compose.yml
+++ b/deploy/aws_ami/docker-compose.yml
@@ -18,6 +18,6 @@ services:
     image: containrrr/watchtower:latest-dev
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    # Update check interval in seconds.
+    # Update check every hour.
     command: --schedule "0 0 * ? * *" --label-enable --cleanup
     restart: unless-stopped

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -56,7 +56,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check interval in seconds.
-    command: --interval 300 --label-enable --cleanup
+    command: --schedule "0 0 * ? * *" --label-enable --cleanup
 ```
 
 After saving this file, `cd` to the folder that contains this file and run the following command to start Appsmith:

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -55,7 +55,7 @@ services:
     image: containrrr/watchtower:latest-dev
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    # Update check interval in seconds.
+    # Update check every hour.
     command: --schedule "0 0 * ? * *" --label-enable --cleanup
 ```
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -18,4 +18,4 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check interval in seconds.
-    command: --interval 300 --label-enable --cleanup
+    command: --schedule "0 0 * ? * *" --label-enable --cleanup

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -17,5 +17,5 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    # Update check interval in hour.
+    # Update check every hour.
     command: --schedule "0 0 * ? * *" --label-enable --cleanup

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -17,5 +17,5 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    # Update check interval in seconds.
+    # Update check interval in hour.
     command: --schedule "0 0 * ? * *" --label-enable --cleanup

--- a/deploy/template/docker-compose.yml.sh
+++ b/deploy/template/docker-compose.yml.sh
@@ -83,7 +83,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check interval in seconds.
-    command: --interval 300 --label-enable --cleanup
+    command: --schedule "0 0 * ? * *" --label-enable --cleanup
     networks:
       - appsmith
     restart: always

--- a/deploy/template/docker-compose.yml.sh
+++ b/deploy/template/docker-compose.yml.sh
@@ -82,7 +82,7 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    # Update check interval in seconds.
+    # Update check every hour.
     command: --schedule "0 0 * ? * *" --label-enable --cleanup
     networks:
       - appsmith


### PR DESCRIPTION

## Description

> Updated the docker-compose value to check for updates every hour
was 
command: --interval 300 --label-enable --cleanup
changed to 
command: --schedule "0 0 * ? * *” --label-enable --cleanup

Fixes # (issue)

>Update interval changed to hourly



## How Has This Been Tested?

Updated the changes and tested in an ec2 instance

- Test A
- Test B

## Checklist:

- [✓ My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [ ✓ I have commented my code, particularly in hard-to-understand areas
- [ ✓ I have made corresponding changes to the documentation
- [ ✓ My changes generate no new warnings
- [ ✓ I have added tests that prove my fix is effective or that my feature works
- [ ✓ New and existing unit tests pass locally with my changes
