### PR TITLE
fix: Fix for on page load action in forked application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ExamplesOrganizationClonerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ExamplesOrganizationClonerCEImpl.java
@@ -385,7 +385,9 @@ public class ExamplesOrganizationClonerCEImpl implements ExamplesOrganizationClo
         for (final Set<DslActionDTO> actionSet : layout.getLayoutOnLoadActions()) {
             for (final DslActionDTO actionDTO : actionSet) {
                 if (actionIdsMap.containsKey(actionDTO.getId())) {
-                    actionDTO.setId(actionIdsMap.get(actionDTO.getId()));
+                    final String srcActionId = actionDTO.getId();
+                    actionDTO.setId(actionIdsMap.get(srcActionId));
+                    actionDTO.setDefaultActionId(actionIdsMap.get(srcActionId));
                     shouldSave = true;
                 } else {
                     log.error(


### PR DESCRIPTION
## Description

> Because of the default actionId was missing in layoutOnLoad action inside page layout for the forked application, forked application on page action was not getting executed. This PR assigns the newly created action id as the defaultActionId. 

Fixes #9945 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Junit TC
> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
