### PR TITLE
fix: Excess bottom rows not lost post dragging or resizing widgets.

### DIFF
--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -122,7 +122,7 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
       rowRef.current = snapRows;
       updateHeight();
     }
-  }, [isDragging]);
+  }, [isDragging, isResizing]);
 
   const updateHeight = () => {
     if (dropTargetRef.current) {

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -114,7 +114,7 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     }
   }, [props.bottomRow, props.canExtend]);
   useEffect(() => {
-    if (!isDragging || !isResizing) {
+    if (!isDragging && !isResizing) {
       // bottom row of canvas can increase by any number as user moves/resizes any widget towards the bottom of the canvas
       // but canvas height is not lost when user moves/resizes back top.
       // it is done that way to have a pleasant building experience.

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -100,6 +100,8 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
   const showPropertyPane = useShowPropertyPane();
   const { deselectAll, focusWidget } = useWidgetSelection();
   const updateCanvasSnapRows = useCanvasSnapRowsUpdateHook();
+  const showDragLayer =
+    (isDragging && draggedOn === props.widgetId) || isResizing;
 
   useEffect(() => {
     const snapRows = getCanvasSnapRows(props.bottomRow, props.canExtend);
@@ -111,6 +113,16 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
       }
     }
   }, [props.bottomRow, props.canExtend]);
+  useEffect(() => {
+    if (!isDragging || !isResizing) {
+      // bottom row of canvas can increase by any number as user moves/resizes any widget towards the bottom of the canvas
+      // but canvas height is not lost when user moves/resizes back top.
+      // it is done that way to have a pleasant building experience.
+      // post drop the bottom most row is used to appropriately calculate the canvas height and lose unwanted height.
+      rowRef.current = snapRows;
+      updateHeight();
+    }
+  }, [isDragging]);
 
   const updateHeight = () => {
     if (dropTargetRef.current) {
@@ -181,7 +193,7 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
         {!(childWidgets && childWidgets.length) &&
           !isDragging &&
           !props.parentId && <Onboarding />}
-        {((isDragging && draggedOn === props.widgetId) || isResizing) && (
+        {showDragLayer && (
           <DragLayerComponent
             noPad={props.noPad || false}
             parentColumnWidth={props.snapColumnSpace}


### PR DESCRIPTION
> Pull Request Template
>
> Use this template to quickly create a well written pull request. Delete all quotes before creating the pull request.

## Description

> Please include a summary of the changes and which issue has been fixed. Please also include relevant motivation
> and context. List any dependencies that are required for this change.

Fixes # (issue)

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/canvas-bottom-row 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.29 **(0)** | 37.14 **(0.01)** | 34.33 **(0)** | 55.81 **(0.01)**
 :green_circle: | app/client/src/components/editorComponents/DropTargetComponent.tsx | 89.19 **(0.78)** | 71.15 **(5.19)** | 90.91 **(0.91)** | 88.89 **(0.83)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>