### PR TITLE
fix: Do not return JS actions when fetching page actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -1202,6 +1202,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                     .flatMap(this::setTransientFieldsInUnpublishedAction);
         }
         return repository.findAllActionsByNameAndPageIdsAndViewMode(name, pageIds, false, READ_ACTIONS, sort)
+                .filter(newAction -> !PluginType.JS.equals(newAction.getPluginType()))
                 .flatMap(this::setTransientFieldsInUnpublishedAction);
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesOrganizationClonerTests.java
@@ -764,15 +764,15 @@ public class ExamplesOrganizationClonerTests {
                             "datasource 2"
                     );
 
-                    assertThat(data.actions).hasSize(4);
+                    assertThat(data.actions).hasSize(3);
                     assertThat(getUnpublishedActionName(data.actions)).containsExactlyInAnyOrder(
                             "newPageAction",
                             "action1",
-                            "action3",
-                            "run"
+                            "action3"
                     );
                     assertThat(data.actionCollections).hasSize(1);
                     assertThat(data.actionCollections.get(0).getDefaultToBranchedActionIdsMap()).hasSize(1);
+                    assertThat(data.actionCollections.get(0).getActions()).hasSize(1);
                 })
                 .verifyComplete();
 
@@ -1033,7 +1033,7 @@ public class ExamplesOrganizationClonerTests {
                 .findByOrganizationId(organization.getId(), READ_APPLICATIONS)
                 // fetch the unpublished pages
                 .flatMap(application -> newPageService.findByApplicationId(application.getId(), READ_PAGES, false))
-                .flatMap(page -> actionCollectionService.getActionCollectionsByViewMode(new LinkedMultiValueMap<>(
+                .flatMap(page -> actionCollectionService.getPopulatedActionCollectionsByViewMode(new LinkedMultiValueMap<>(
                         Map.of(FieldName.PAGE_ID, Collections.singletonList(page.getId()))), false));
     }
 }


### PR DESCRIPTION
This change filters out JS actions when fetching actions by page.