### PR TITLE
fix: add work around to handle bad data in Firestore UQI migration

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -4710,10 +4710,12 @@ public class DatabaseChangelog {
      */
     @ChangeSet(order = "107", id = "migrate-firestore-to-uqi-3", author = "")
     public void migrateFirestorePluginToUqi3(MongockTemplate mongockTemplate) {
+        // Update Firestore plugin to indicate use of UQI schema
         Plugin firestorePlugin = mongockTemplate.findOne(
                 query(where("packageName").is("firestore-plugin")),
                 Plugin.class
         );
+        firestorePlugin.setUiComponent("UQIDbEditorForm");
 
         // Find all Firestore actions
         final Query firestoreActionQuery = query(
@@ -4728,6 +4730,8 @@ public class DatabaseChangelog {
         );
 
         migrateFirestoreToUQI(mongockTemplate, firestoreActions);
-    }
 
+        // Update plugin data.
+        mongockTemplate.save(firestorePlugin);
+    }
 }


### PR DESCRIPTION
## Description
- add another migration for those Firestore actions that could not be migrated. 
- handle ClassCastException via try catch and assigning default empty value. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
