### PR TITLE
fix: Allow empty value in select type widgets options property

### DIFF
--- a/app/client/cypress/fixtures/emptyDSL.json
+++ b/app/client/cypress/fixtures/emptyDSL.json
@@ -1,0 +1,1 @@
+{"widgetName":"MainContainer","backgroundColor":"none","rightColumn":1296,"snapColumns":64,"detachFromLayout":true,"widgetId":"0","topRow":0,"bottomRow":440,"containerStyle":"none","snapRows":125,"parentRowSpace":1,"type":"CANVAS_WIDGET","canExtend":true,"version":47,"minHeight":420,"parentColumnSpace":1,"dynamicBindingPathList":[],"leftColumn":0,"children":[]}

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Checkbox_group_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Checkbox_group_spec.js
@@ -1,0 +1,65 @@
+const dsl = require("../../../../fixtures/emptyDSL.json");
+const explorer = require("../../../../locators/explorerlocators.json");
+
+describe("checkboxgroupwidget Widget Functionality", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Add new widget", () => {
+    cy.get(explorer.addWidget).click();
+    cy.dragAndDropToCanvas("checkboxgroupwidget", { x: 300, y: 300 });
+    cy.get(".t--widget-checkboxgroupwidget").should("exist");
+  });
+
+  it("should check that empty value is allowed in options", () => {
+    cy.openPropertyPane("checkboxgroupwidget");
+    cy.get(".t--property-control-options")
+      .find(".t--js-toggle")
+      .click({ force: true });
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": "GREEN"
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "not.exist",
+    );
+  });
+
+  it("should check that more thatn empty value is not allowed in options", () => {
+    cy.openPropertyPane("checkboxgroupwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": ""
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "exist",
+    );
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Dropdown_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Dropdown_spec.js
@@ -1,0 +1,62 @@
+const dsl = require("../../../../fixtures/emptyDSL.json");
+const explorer = require("../../../../locators/explorerlocators.json");
+
+describe("Dropdown Widget Functionality", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Add new dropdown widget", () => {
+    cy.get(explorer.addWidget).click();
+    cy.dragAndDropToCanvas("dropdownwidget", { x: 300, y: 300 });
+    cy.get(".t--widget-dropdownwidget").should("exist");
+  });
+
+  it("should check that empty value is allowed in options", () => {
+    cy.openPropertyPane("dropdownwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": "GREEN"
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "not.exist",
+    );
+  });
+
+  it("should check that more thatn empty value is not allowed in options", () => {
+    cy.openPropertyPane("dropdownwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": ""
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "exist",
+    );
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiSelect_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiSelect_spec.js
@@ -1,0 +1,62 @@
+const dsl = require("../../../../fixtures/emptyDSL.json");
+const explorer = require("../../../../locators/explorerlocators.json");
+
+describe("MultiSelect Widget Functionality", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Add new dropdown widget", () => {
+    cy.get(explorer.addWidget).click();
+    cy.dragAndDropToCanvas("multiselectwidget", { x: 300, y: 300 });
+    cy.get(".t--widget-multiselectwidget").should("exist");
+  });
+
+  it("should check that empty value is allowed in options", () => {
+    cy.openPropertyPane("multiselectwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": "GREEN"
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "not.exist",
+    );
+  });
+
+  it("should check that more thatn empty value is not allowed in options", () => {
+    cy.openPropertyPane("multiselectwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": ""
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "exist",
+    );
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiTreeSelect_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiTreeSelect_spec.js
@@ -1,28 +1,19 @@
 const dsl = require("../../../../fixtures/emptyDSL.json");
 const explorer = require("../../../../locators/explorerlocators.json");
 
-describe("Tree Select Widget", function() {
+describe("Multi Tree Select Widget", function() {
   before(() => {
     cy.addDsl(dsl);
   });
 
-  // it("Open Existing MultiSelectTree from created Widgets list", () => {
-  //   cy.get(".widgets").click();
-  //   cy.get(".t--entity-name:contains(MultiSelectTree1)").click();
-  // });
-  // it("Open Existing SingleSelectTree from created Widgets list", () => {
-  //   cy.get(".widgets").click();
-  //   cy.get(".t--entity-name:contains(SingleSelectTree1)").click();
-  // });
-
   it("Add new widget", () => {
     cy.get(explorer.addWidget).click();
-    cy.dragAndDropToCanvas("singleselecttreewidget", { x: 300, y: 300 });
-    cy.get(".t--widget-singleselecttreewidget").should("exist");
+    cy.dragAndDropToCanvas("multiselecttreewidget", { x: 300, y: 300 });
+    cy.get(".t--widget-multiselecttreewidget").should("exist");
   });
 
   it("should check that empty value is allowed in options", () => {
-    cy.openPropertyPane("singleselecttreewidget");
+    cy.openPropertyPane("multiselecttreewidget");
     cy.updateCodeInput(
       ".t--property-control-options",
       `[
@@ -56,7 +47,7 @@ describe("Tree Select Widget", function() {
   });
 
   it("should check that more thatn empty value is not allowed in options", () => {
-    cy.openPropertyPane("singleselecttreewidget");
+    cy.openPropertyPane("multiselecttreewidget");
     cy.updateCodeInput(
       ".t--property-control-options",
       `[

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/RadioGroup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/RadioGroup_spec.js
@@ -1,0 +1,57 @@
+const dsl = require("../../../../fixtures/emptyDSL.json");
+const explorer = require("../../../../locators/explorerlocators.json");
+
+describe("Radiogroup Widget Functionality", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Add new widget", () => {
+    cy.get(explorer.addWidget).click();
+    cy.dragAndDropToCanvas("radiogroupwidget", { x: 300, y: 300 });
+    cy.get(".t--widget-radiogroupwidget").should("exist");
+  });
+
+  it("should check that empty value is allowed in options", () => {
+    cy.openPropertyPane("radiogroupwidget");
+    cy.get(".t--property-control-options")
+      .find(".t--js-toggle")
+      .click({ force: true });
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+          {
+            "label": "Yes",
+            "value": "Y"
+          },
+          {
+            "label": "No",
+            "value": ""
+          }
+        ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "not.exist",
+    );
+  });
+
+  it("should check that more thatn empty value is not allowed in options", () => {
+    cy.openPropertyPane("radiogroupwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+          {
+            "label": "Yes",
+            "value": ""
+          },
+          {
+            "label": "No",
+            "value": ""
+          }
+        ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "exist",
+    );
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Switchgroup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Switchgroup_spec.js
@@ -1,0 +1,62 @@
+const dsl = require("../../../../fixtures/emptyDSL.json");
+const explorer = require("../../../../locators/explorerlocators.json");
+
+describe("Switchgroup Widget Functionality", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("Add new widget", () => {
+    cy.get(explorer.addWidget).click();
+    cy.dragAndDropToCanvas("switchgroupwidget", { x: 300, y: 300 });
+    cy.get(".t--widget-switchgroupwidget").should("exist");
+  });
+
+  it("should check that empty value is allowed in options", () => {
+    cy.openPropertyPane("switchgroupwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": "GREEN"
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "not.exist",
+    );
+  });
+
+  it("should check that more thatn empty value is not allowed in options", () => {
+    cy.openPropertyPane("switchgroupwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": ""
+        },
+        {
+          "label": "Green",
+          "value": ""
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "exist",
+    );
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Tree_Select_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Tree_Select_spec.js
@@ -6,15 +6,6 @@ describe("Tree Select Widget", function() {
     cy.addDsl(dsl);
   });
 
-  // it("Open Existing MultiSelectTree from created Widgets list", () => {
-  //   cy.get(".widgets").click();
-  //   cy.get(".t--entity-name:contains(MultiSelectTree1)").click();
-  // });
-  // it("Open Existing SingleSelectTree from created Widgets list", () => {
-  //   cy.get(".widgets").click();
-  //   cy.get(".t--entity-name:contains(SingleSelectTree1)").click();
-  // });
-
   it("Add new widget", () => {
     cy.get(explorer.addWidget).click();
     cy.dragAndDropToCanvas("singleselecttreewidget", { x: 300, y: 300 });

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -85,7 +85,6 @@ class CheckboxGroupWidget extends BaseWidget<
                         type: ValidationTypes.TEXT,
                         params: {
                           default: "",
-                          required: true,
                         },
                       },
                     ],

--- a/app/client/src/widgets/DropdownWidget/widget/index.tsx
+++ b/app/client/src/widgets/DropdownWidget/widget/index.tsx
@@ -61,7 +61,6 @@ class DropdownWidget extends BaseWidget<DropdownWidgetProps, WidgetState> {
                         type: ValidationTypes.TEXT,
                         params: {
                           default: "",
-                          required: true,
                         },
                       },
                     ],

--- a/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
@@ -102,7 +102,6 @@ class MultiSelectTreeWidget extends BaseWidget<
                         type: ValidationTypes.TEXT,
                         params: {
                           default: "",
-                          required: true,
                         },
                       },
                       {
@@ -127,7 +126,6 @@ class MultiSelectTreeWidget extends BaseWidget<
                                   type: ValidationTypes.TEXT,
                                   params: {
                                     default: "",
-                                    required: true,
                                   },
                                 },
                               ],

--- a/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidget/widget/index.tsx
@@ -81,7 +81,6 @@ class MultiSelectWidget extends BaseWidget<
                         type: ValidationTypes.TEXT,
                         params: {
                           default: "",
-                          required: true,
                         },
                       },
                     ],

--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -24,7 +24,6 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
             isTriggerProperty: false,
             validation: {
               type: ValidationTypes.ARRAY,
-              unique: ["value"],
               params: {
                 unique: ["value"],
                 default: [],

--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -45,7 +45,6 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
                         type: ValidationTypes.TEXT,
                         params: {
                           default: "",
-                          required: true,
                         },
                       },
                     ],

--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -26,6 +26,7 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
               type: ValidationTypes.ARRAY,
               unique: ["value"],
               params: {
+                unique: ["value"],
                 default: [],
                 children: {
                   type: ValidationTypes.OBJECT,

--- a/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
@@ -66,7 +66,6 @@ class SingleSelectTreeWidget extends BaseWidget<
                         type: ValidationTypes.TEXT,
                         params: {
                           default: "",
-                          required: true,
                         },
                       },
                       {
@@ -91,7 +90,6 @@ class SingleSelectTreeWidget extends BaseWidget<
                                   type: ValidationTypes.TEXT,
                                   params: {
                                     default: "",
-                                    required: true,
                                   },
                                 },
                               ],

--- a/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
@@ -48,7 +48,6 @@ class SwitchGroupWidget extends BaseWidget<
                         type: ValidationTypes.TEXT,
                         params: {
                           default: "",
-                          required: true,
                           unique: true,
                         },
                       },


### PR DESCRIPTION
Fixes #10007 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/select-widget-empty-value 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.09 **(0.01)** | 36.53 **(0.01)** | 34.48 **(0)** | 55.61 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**</details>