### PR TITLE
fix: S3 - Unable to Search from 2nd Uploaded file onwards

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -105,12 +105,10 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       });
     }
 
-    if (this.props.updateWidgetMetaProperty) {
-      this.props.updateWidgetMetaProperty(
-        "childrenEntityDefinitions",
-        childrenEntityDefinitions,
-      );
-    }
+    super.updateWidgetProperty(
+      "childrenEntityDefinitions",
+      childrenEntityDefinitions,
+    );
   }
 
   generateChildrenDefaultPropertiesMap = (
@@ -137,8 +135,8 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       });
     }
 
-    if (this.props.updateWidgetProperty) {
-      this.props.updateWidgetProperty(
+    if (this.props.updateWidgetMetaProperty) {
+      this.props.updateWidgetMetaProperty(
         "childrenDefaultPropertiesMap",
         childrenDefaultPropertiesMap,
       );

--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -137,8 +137,8 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       });
     }
 
-    if (this.props.updateWidgetMetaProperty) {
-      this.props.updateWidgetMetaProperty(
+    if (this.props.updateWidgetProperty) {
+      this.props.updateWidgetProperty(
         "childrenDefaultPropertiesMap",
         childrenDefaultPropertiesMap,
       );


### PR DESCRIPTION
Fixes #9922 

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/s3-2nd-upload-list-widget-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.95 **(0.02)** | 36.34 **(0.03)** | 34.25 **(0.02)** | 55.48 **(0.02)**
 :green_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 54.23 **(0.24)** | 43.24 **(0.54)** | 53.19 **(0)** | 55.59 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 78.86 **(4.88)** | 44.44 **(8.88)** | 75 **(6.25)** | 77.97 **(5.09)**
 :red_circle: | app/client/src/widgets/ListWidget/widget/index.tsx | 61.82 **(-0.13)** | 26.15 **(0.26)** | 56.86 **(0)** | 60.65 **(-0.14)**</details>