### PR TITLE
chore - Fix typo in integration-tests-command workflow

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -581,7 +581,7 @@ jobs:
         shell: bash
     strategy:
       fail-fast: false
-      matrix: job:[0]
+
 
     # Service containers to run with this job. Required for running tests
     services:

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -582,7 +582,6 @@ jobs:
     strategy:
       fail-fast: false
 
-
     # Service containers to run with this job. Required for running tests
     services:
       # Label used to access the service container


### PR DESCRIPTION
Fix a typo in the integration-tests-command workflow

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
