### PR TITLE
fix: Fix npe while importing application when JSObject contains only variables and no action

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DefaultResourcesUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DefaultResourcesUtils.java
@@ -49,7 +49,7 @@ public class DefaultResourcesUtils {
                         }
                     });
 
-            if (!CollectionUtils.isNullOrEmpty(page.getPublishedPage().getLayouts())) {
+            if (page.getPublishedPage() != null && !CollectionUtils.isNullOrEmpty(page.getPublishedPage().getLayouts())) {
                 page.getPublishedPage()
                         .getLayouts()
                         .forEach(layout -> {
@@ -78,10 +78,12 @@ public class DefaultResourcesUtils {
             collectionDTO.setDefaultResources(defaultResources);
 
             Map<String, String> updatedActionIds = new HashMap<>();
-            collectionDTO.getDefaultToBranchedActionIdsMap()
-                    .values()
-                    .forEach(val -> updatedActionIds.put(val, val));
-            collectionDTO.setDefaultToBranchedActionIdsMap(updatedActionIds);
+            if (!CollectionUtils.isNullOrEmpty(collectionDTO.getDefaultToBranchedActionIdsMap())) {
+                collectionDTO.getDefaultToBranchedActionIdsMap()
+                        .values()
+                        .forEach(val -> updatedActionIds.put(val, val));
+                collectionDTO.setDefaultToBranchedActionIdsMap(updatedActionIds);
+            }
         }
         return resource;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ActionCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ActionCollectionServiceCEImpl.java
@@ -211,10 +211,16 @@ public class ActionCollectionServiceCEImpl extends BaseService<ActionCollectionR
                                     // Default pageId will be taken from publishedCollection.defaultResources
                                     DefaultResources defaults = actionCollection.getDefaultResources();
                                     // Consider a situation when collection is not published but user is viewing in deployed mode
-                                    if (publishedCollection.getDefaultResources() != null) {
+                                    if (publishedCollection.getDefaultResources() != null && defaults != null) {
                                         defaults.setPageId(publishedCollection.getDefaultResources().getPageId());
                                     } else {
-                                        defaults.setPageId(null);
+                                        log.debug("Unreachable state, unable to find default ids for actionCollection: {}", actionCollection.getId());
+                                        if (defaults == null) {
+                                            defaults = new DefaultResources();
+                                            defaults.setApplicationId(actionCollection.getApplicationId());
+                                            defaults.setCollectionId(actionCollection.getId());
+                                        }
+                                        defaults.setPageId(actionCollection.getPublishedCollection().getPageId());
                                     }
                                     actionCollectionViewDTO.setDefaultResources(defaults);
                                     return Flux.fromIterable(publishedCollection.getDefaultToBranchedActionIdsMap().values())

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -45,6 +45,7 @@ import com.appsmith.server.services.UserService;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -634,14 +635,14 @@ public class ImportExportApplicationServiceTests {
                 .flatMap(application -> Mono.zip(
                         Mono.just(application),
                         datasourceService.findAllByOrganizationId(application.getOrganizationId(), MANAGE_DATASOURCES).collectList(),
-                        getActionsInApplication(application).collectList(),
+                        newActionService.findAllByApplicationIdAndViewMode(application.getId(), false, READ_ACTIONS, null).collectList(),
                         newPageService.findByApplicationId(application.getId(), MANAGE_PAGES, false).collectList(),
                         actionCollectionService.findAllByApplicationIdAndViewMode(application.getId(), false, MANAGE_ACTIONS, null).collectList()
                 )))
             .assertNext(tuple -> {
                 final Application application = tuple.getT1();
                 final List<Datasource> datasourceList = tuple.getT2();
-                final List<ActionDTO> actionDTOS = tuple.getT3();
+                final List<NewAction> actionList = tuple.getT3();
                 final List<PageDTO> pageList = tuple.getT4();
                 final List<ActionCollection> actionCollectionList = tuple.getT5();
 
@@ -668,15 +669,25 @@ public class ImportExportApplicationServiceTests {
                     }
                 });
 
-                assertThat(actionDTOS).isNotEmpty();
-                actionDTOS.forEach(actionDTO -> {
+                List<String> collectionIdInAction = new ArrayList<>();
+                assertThat(actionList).isNotEmpty();
+                actionList.forEach(newAction -> {
+                    ActionDTO actionDTO = newAction.getUnpublishedAction();
                     assertThat(actionDTO.getPageId()).isNotEqualTo(pageList.get(0).getName());
-
+                    if (!StringUtils.isEmpty(actionDTO.getCollectionId())) {
+                        collectionIdInAction.add(actionDTO.getCollectionId());
+                    }
                 });
 
                 assertThat(actionCollectionList).isNotEmpty();
                 actionCollectionList.forEach(actionCollection -> {
                     assertThat(actionCollection.getUnpublishedCollection().getPageId()).isNotEqualTo(pageList.get(0).getName());
+                    if (StringUtils.equals(actionCollection.getUnpublishedCollection().getName(), "JSObject2")) {
+                        // Check if this action collection is not attached to any action
+                        assertThat(collectionIdInAction).doesNotContain(actionCollection.getId());
+                    } else {
+                        assertThat(collectionIdInAction).contains(actionCollection.getId());
+                    }
                 });
 
                 assertThat(pageList).hasSize(2);

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
@@ -603,6 +603,30 @@
         ]
       },
       "new": false
+    },
+    {
+      "id": "collection_wo_action",
+      "userPermissions": [
+        "read:actions",
+        "execute:actions",
+        "manage:actions"
+      ],
+      "unpublishedCollection": {
+        "name": "JSObject2",
+        "pageId": "Page1",
+        "pluginId": "js-plugin",
+        "pluginType": "JS",
+        "actions": [],
+        "archivedActions": [],
+        "body": "export default {results: []}",
+        "variables": [
+          {
+            "name": "results",
+            "value": []
+          }
+        ]
+      },
+      "new": false
     }
   ],
   "decryptedFields": {


### PR DESCRIPTION
## Description

> When the JSObject only contains the variables with no action reference we were getting npe as `actionCollectionDTO.getDefaultToBranchedActionIdsMap()` was null. Also as the imported application is ina bad state with no defaultResource ids set this was throwing the exception while fetching the `actionCollection` as well

Fixes #10002

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

> JUnit TC
> Manual Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
