### PR TITLE
fix: added focus styling for switches in property pane

### DIFF
--- a/app/client/src/components/ads/Switch.tsx
+++ b/app/client/src/components/ads/Switch.tsx
@@ -8,6 +8,10 @@ const StyledSwitch = styled(Switch)`
   &&&&& input:checked ~ span {
     background: ${Colors.GREY_10};
   }
+
+  & input:focus + .bp3-control-indicator {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.2) !important;
+  }
 `;
 
 export default function AdsSwitch(props: ISwitchProps) {


### PR DESCRIPTION
## Description

> Added box shadow for switches on focus state in the property pane.

Fix #10032

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Manually


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/property-pane-switch-focus 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.03 **(0)** | 36.46 **(0.01)** | 34.44 **(0)** | 55.56 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>