### PR TITLE
fix: remove special character from password reset success message

### DIFF
--- a/app/client/src/pages/UserProfile/General.tsx
+++ b/app/client/src/pages/UserProfile/General.tsx
@@ -9,7 +9,10 @@ import { getCurrentUser } from "selectors/usersSelectors";
 import { forgotPasswordSubmitHandler } from "pages/UserAuth/helpers";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
-import { FORGOT_PASSWORD_SUCCESS_TEXT } from "constants/messages";
+import {
+  createMessage,
+  FORGOT_PASSWORD_SUCCESS_TEXT,
+} from "constants/messages";
 import { logoutUser, updateUserDetails } from "actions/userActions";
 import { AppState } from "reducers";
 import UserProfileImagePicker from "components/ads/UserProfileImagePicker";
@@ -39,7 +42,7 @@ function General() {
     try {
       await forgotPasswordSubmitHandler({ email: user?.email }, dispatch);
       Toaster.show({
-        text: `${FORGOT_PASSWORD_SUCCESS_TEXT} ${user?.email}`,
+        text: `${createMessage(FORGOT_PASSWORD_SUCCESS_TEXT)} ${user?.email}`,
         variant: Variant.success,
       });
       dispatch(logoutUser());


### PR DESCRIPTION
## Description

Upon clicking on the password reset link it shows a special character with the response text.

Fixes #9911 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
