### PR TITLE
fix: remove unnecessary spaces from the active datasource page for consistent page scroll

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx
@@ -69,8 +69,7 @@ const MainTabsContainer = styled.div`
 const SectionGrid = styled.div`
   margin-top: 16px;
   display: grid;
-  grid-template-columns: 1fr 180px;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-columns: 1fr;
   gap: 10px 16px;
   flex: 1;
   min-height: 0;

--- a/app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx
@@ -66,10 +66,11 @@ const MainTabsContainer = styled.div`
   height: 100%;
 `;
 
-const SectionGrid = styled.div`
+const SectionGrid = styled.div<{ isActiveTab?: boolean }>`
   margin-top: 16px;
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 1fr ${({ isActiveTab }) => isActiveTab && "180px"};
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 10px 16px;
   flex: 1;
   min-height: 0;
@@ -486,7 +487,11 @@ class IntegrationsHomeScreen extends React.Component<
           <HeaderFlex>
             <p className="sectionHeadings">Datasources</p>
           </HeaderFlex>
-          <SectionGrid>
+          <SectionGrid
+            isActiveTab={
+              this.state.activePrimaryMenuId !== PRIMARY_MENU_IDS.ACTIVE
+            }
+          >
             <MainTabsContainer>
               {showTabs && (
                 <TabComponent


### PR DESCRIPTION
## Description

Removes unnecessary spaces from the active data source page for consistent page scroll

Fixes #8592 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/active-datasources-page-scroll 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.11 **(-0.01)** | 36.61 **(0)** | 34.54 **(0)** | 55.64 **(0)**
 :red_circle: | app/client/src/pages/Editor/IntegrationEditor/IntegrationsHomeScreen.tsx | 27.81 **(-0.38)** | 11.63 **(-0.27)** | 4.55 **(-0.21)** | 32.54 **(-0.26)**</details>