### PR TITLE
fix: Fix custom domain's env variable name

### DIFF
--- a/deploy/docker/scripts/renew-certificate.sh
+++ b/deploy/docker/scripts/renew-certificate.sh
@@ -10,10 +10,9 @@ if [[ -f /appsmith-stacks/configuration/docker.env ]]; then
 fi
 
 if [[ -n $APPSMITH_CUSTOM_DOMAIN ]]; then
-	#then run script
-	local data_path="/appsmith-stacks/data/certificate"
+	data_path="/appsmith-stacks/data/certificate"
 	domain="$APPSMITH_CUSTOM_DOMAIN"
-	local rsa_key_size=4096
+	rsa_key_size=4096
 
 	certbot certonly --webroot --webroot-path="$data_path/certbot" \
 		--register-unsafely-without-email \

--- a/deploy/docker/scripts/renew-certificate.sh
+++ b/deploy/docker/scripts/renew-certificate.sh
@@ -9,10 +9,10 @@ if [[ -f /appsmith-stacks/configuration/docker.env ]]; then
 	set +o allexport
 fi
 
-if [[ -n $CUSTOM_DOMAIN ]]; then
+if [[ -n $APPSMITH_CUSTOM_DOMAIN ]]; then
 	#then run script
 	local data_path="/appsmith-stacks/data/certificate"
-	domain="$CUSTOM_DOMAIN"
+	domain="$APPSMITH_CUSTOM_DOMAIN"
 	local rsa_key_size=4096
 
 	certbot certonly --webroot --webroot-path="$data_path/certbot" \


### PR DESCRIPTION
The cert renewal script fails to renew the SSL certificate because it is checking the wrong env variable for the domain name.
