### PR TITLE
fix: Missing acme route in NGINX HTTPS config

### DIFF
--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -45,6 +45,10 @@ server {
   root /opt/appsmith/editor;
   index index.html index.htm;
 
+  location /.well-known/acme-challenge/ {
+    root /appsmith-stacks/data/certificate/certbot;
+  }
+
   proxy_set_header X-Forwarded-Proto \$origin_scheme;
   proxy_set_header X-Forwarded-Host \$host;
 


### PR DESCRIPTION
Because this route definition is missing, cert renewal doesn't work, since when cert is up for renewal, it means HTTPS is already active with the old certificate, which means the HTTPS NGINX config is active, and this config is missing the acme routes needed for domain validation.