### PR TITLE
fix: remove duplicate query params in evaluated value

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Edit_spec.js
@@ -1,8 +1,12 @@
 const testdata = require("../../../../fixtures/testdata.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
+const dsl = require("../../../../fixtures/uiBindDsl.json");
 
 describe("API Panel Test Functionality", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
   it("Test Search API fetaure", function() {
     cy.log("Login Successful");
     cy.NavigateToAPI_Panel();
@@ -78,11 +82,18 @@ describe("API Panel Test Functionality", function() {
   it("Shows evaluated value pane when url field is focused", function() {
     cy.NavigateToAPI_Panel();
     cy.CreateAPI("TestAPI");
-    cy.get(".CodeMirror-placeholder")
+    cy.get(".CodeMirror textarea")
       .first()
       .click({
         force: true,
-      });
-    cy.get(commonlocators.evaluatedTypeTitle).should("be.visible");
+      })
+      .type(
+        "https://www.facebook.com/users/{{Button2.text}}?key=test&val={{Button2.text}}",
+        { force: true, parseSpecialCharSequences: false },
+      )
+      .wait(1000)
+      .type("{enter}", { parseSpecialCharSequences: true });
+
+    cy.contains("https://www.facebook.com/users/Cancel?key=test&val=Cancel");
   });
 });

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -327,7 +327,11 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
     if (!entity) return "";
 
     if ("ENTITY_TYPE" in entity && entity.ENTITY_TYPE === ENTITY_TYPE.ACTION) {
-      const evaluatedPath = "path" in entity.config ? entity.config.path : "";
+      let evaluatedPath = "path" in entity.config ? entity.config.path : "";
+
+      if (evaluatedPath && evaluatedPath.indexOf("?") > -1) {
+        evaluatedPath = evaluatedPath.slice(0, evaluatedPath.indexOf("?"));
+      }
       const evaluatedQueryParameters = entity.config.queryParameters
         ?.filter((p: KeyValuePair) => p.key)
         .map(

--- a/app/client/src/transformers/RestActionTransformer.ts
+++ b/app/client/src/transformers/RestActionTransformer.ts
@@ -21,7 +21,7 @@ export const transformRestAction = (data: ApiAction): ApiAction => {
         ...action,
         actionConfiguration: {
           ...action.actionConfiguration,
-          path: path.substr(0, path.indexOf("?")),
+          path: path.slice(0, path.indexOf("?")),
         },
       };
     }


### PR DESCRIPTION
## Description

- Duplicate query params are removed from the evaluated value in API url
- String.substr method is replaced, as it is deprecated.

Fixes #821

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/duplicate-query-params-in-evaluated-value 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.13 **(0)** | 36.63 **(-0.01)** | 34.56 **(0)** | 55.66 **(0)**
 :red_circle: | app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx | 29.27 **(-0.36)** | 1.98 **(-0.08)** | 3.57 **(0)** | 31.54 **(-0.43)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>