### PR TITLE
feat: on pressing f2 widget title is focused

### DIFF
--- a/app/client/src/actions/propertyPaneActions.ts
+++ b/app/client/src/actions/propertyPaneActions.ts
@@ -24,3 +24,8 @@ export const setSnipingMode = (payload: boolean) => ({
 export const resetSnipingMode = () => ({
   type: ReduxActionTypes.RESET_SNIPING_MODE,
 });
+
+export const focusWidgetTitle = (payload: boolean) => ({
+  type: ReduxActionTypes.FOCUS_WIDGET_TITLE,
+  payload,
+});

--- a/app/client/src/components/ads/EditableText.tsx
+++ b/app/client/src/components/ads/EditableText.tsx
@@ -8,6 +8,9 @@ import EditableTextSubComponent, {
   EditInteractionKind,
   SavingState,
 } from "./EditableTextSubComponent";
+import { useDispatch, useSelector } from "react-redux";
+import { AppState } from "reducers";
+import { focusWidgetTitle } from "actions/propertyPaneActions";
 
 export { EditInteractionKind, SavingState };
 
@@ -50,6 +53,21 @@ export const EditableTextWrapper = styled.div<{
   }
 `;
 
+function useIsEditing(
+  defaultValue: boolean,
+): [boolean, (value: boolean) => void] {
+  const isEditing = useSelector(
+    (state: AppState) => state.ui.propertyPane.isWidgetTitleEditing,
+  );
+
+  const dispatch = useDispatch();
+  const setIsEditing = useCallback((value: boolean) => {
+    dispatch(focusWidgetTitle(value));
+  }, []);
+
+  return [isEditing, setIsEditing];
+}
+
 export function EditableText(props: EditableTextProps) {
   const {
     defaultValue,
@@ -58,7 +76,7 @@ export function EditableText(props: EditableTextProps) {
     savingState: defaultSavingState,
     ...others
   } = props;
-  const [isEditing, setIsEditing] = useState(!!isEditingDefault);
+  const [isEditing, setIsEditing] = useIsEditing(!!isEditingDefault);
   const [isInvalid, setIsInvalid] = useState<string | boolean>(false);
   const [savingState, setSavingState] = useState<SavingState>(
     SavingState.NOT_STARTED,

--- a/app/client/src/components/ads/EditableText.tsx
+++ b/app/client/src/components/ads/EditableText.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 
 import styled from "styled-components";
 import { noop } from "lodash";
@@ -63,6 +63,12 @@ function useIsEditing(
   const dispatch = useDispatch();
   const setIsEditing = useCallback((value: boolean) => {
     dispatch(focusWidgetTitle(value));
+  }, []);
+
+  useEffect(() => {
+    if (isEditing !== defaultValue) {
+      setIsEditing(defaultValue);
+    }
   }, []);
 
   return [isEditing, setIsEditing];

--- a/app/client/src/constants/ReduxActionConstants.tsx
+++ b/app/client/src/constants/ReduxActionConstants.tsx
@@ -649,6 +649,7 @@ export const ReduxActionTypes = {
   /* This action constants is for identifying the status of the updates of the entities */
   ENTITY_UPDATE_STARTED: "ENTITY_UPDATE_STARTED",
   ENTITY_UPDATE_SUCCESS: "ENTITY_UPDATE_SUCCESS",
+  FOCUS_WIDGET_TITLE: "FOCUS_WIDGET_TITLE",
 };
 
 export type ReduxActionType = typeof ReduxActionTypes[keyof typeof ReduxActionTypes];

--- a/app/client/src/pages/Editor/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.tsx
@@ -23,7 +23,10 @@ import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { getSelectedText } from "utils/helpers";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { WIDGETS_SEARCH_ID } from "constants/Explorer";
-import { resetSnipingMode as resetSnipingModeAction } from "actions/propertyPaneActions";
+import {
+  resetSnipingMode as resetSnipingModeAction,
+  focusWidgetTitle as focusWidgetTitleAction,
+} from "actions/propertyPaneActions";
 import { showDebugger } from "actions/debuggerActions";
 
 import { setCommentModeInUrl } from "pages/Editor/ToggleModeButton";
@@ -76,6 +79,7 @@ type Props = {
   isExplorerPinned: boolean;
   setExplorerPinnedAction: (shouldPinned: boolean) => void;
   showCommitModal: () => void;
+  focusWidgetTitle: () => void;
 };
 
 @HotkeysTarget
@@ -380,6 +384,14 @@ class GlobalHotKeys extends React.Component<Props> {
             this.props.showCommitModal();
           }}
         />
+        <Hotkey
+          combo="f2"
+          global
+          label="Focus widget title"
+          onKeyDown={() => {
+            this.props.focusWidgetTitle();
+          }}
+        />
       </Hotkeys>
     );
   }
@@ -425,6 +437,7 @@ const mapDispatchToProps = (dispatch: any) => {
       dispatch(
         setIsGitSyncModalOpen({ isOpen: true, tab: GitSyncModalTab.DEPLOY }),
       ),
+    focusWidgetTitle: () => dispatch(focusWidgetTitleAction(true)),
   };
 };
 

--- a/app/client/src/reducers/uiReducers/propertyPaneReducer.tsx
+++ b/app/client/src/reducers/uiReducers/propertyPaneReducer.tsx
@@ -10,6 +10,7 @@ const initialState: PropertyPaneReduxState = {
   widgetId: undefined,
   lastWidgetId: undefined,
   isNew: false,
+  isWidgetTitleEditing: false,
 };
 
 const propertyPaneReducer = createReducer(initialState, {
@@ -67,6 +68,12 @@ const propertyPaneReducer = createReducer(initialState, {
       return { ...state, isNew: action.payload.enable };
     return state;
   },
+  [ReduxActionTypes.FOCUS_WIDGET_TITLE]: (
+    state: PropertyPaneReduxState,
+    action: ReduxAction<boolean>,
+  ) => {
+    return { ...state, isWidgetTitleEditing: action.payload };
+  },
 });
 
 export interface PropertyPaneReduxState {
@@ -77,6 +84,7 @@ export interface PropertyPaneReduxState {
   isNew: boolean;
   propertyControlId?: string;
   widgetChildProperty?: string;
+  isWidgetTitleEditing: boolean;
 }
 
 export default propertyPaneReducer;


### PR DESCRIPTION
## Description

> Added a new property to store to manage whether Property Pane Widget Title is in editing state or not.

Enhancement #9413


## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/focus-widget-title-on-f2 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.15 **(0.01)** | 36.64 **(0)** | 34.6 **(0.03)** | 55.68 **(0.01)**
 :green_circle: | app/client/src/actions/propertyPaneActions.ts | 87.5 **(2.88)** | 100 **(0)** | 60 **(10)** | 75 **(3.57)**
 :green_circle: | app/client/src/components/ads/EditableText.tsx | 82.22 **(2.81)** | 33.33 **(2.08)** | 83.33 **(8.33)** | 78.95 **(4.88)**
 :red_circle: | app/client/src/pages/Editor/GlobalHotKeys.tsx | 60.94 **(-0.96)** | 28.57 **(0)** | 48.94 **(-2.17)** | 60.16 **(-1)**
 :green_circle: | app/client/src/reducers/uiReducers/propertyPaneReducer.tsx | 28 **(3)** | 0 **(0)** | 50 **(16.67)** | 30.43 **(3.16)**</details>