### PR TITLE
fix: run button loading infinitely due to entity update start action

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -405,8 +405,13 @@ class CodeEditor extends Component<Props, State> {
   startChange = (instance?: any, changeObj?: any) => {
     /* This action updates the status of the savingEntity to true so that any
       shortcut commands do not execute before updating the entity in the store */
-    const entity = this.getEntityInformation();
-    if (entity.entityId) {
+    const value = this.editor.getValue() || "";
+    const inputValue = this.props.input.value || "";
+    if (
+      this.props.input.onChange &&
+      value !== inputValue &&
+      this.state.isFocused
+    ) {
       this.props.startingEntityUpdation();
     }
     this.handleDebouncedChange(instance, changeObj);


### PR DESCRIPTION
## Description

Added a fix to update entity start action only when the input is focused and there is a change in the input values.

This bug occurred because the query being switched from the left navigation pane was re-rendering the code editor and the onChange for the data was getting fired which was updating the status of the entity being updated to true but the success event was not getting triggered due to the check of focused input for redux store update. So the loading state was always true when the query was switched, I avoided that status update with the same check as for the redux store update.

Fixes # (issue)

#10124 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Either of the below method can be used to test the bug fix.

> Type in the query in the query editor of the datasource and then while typing the query continuously press CMD+ENTER to execute the query. After the fix the query should execute with the latest value in the editor after updating the values in the redux store as well.

> Add two queries (eg. postgres queries). Update either of the two, execute the same query. Switch to another query from the left side panel. Click on run query. Earlier the run button was going into infinite loading state. After this it will be fixed as the action update is blocked only when there is a change in the input value and it is focused.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/run-button-infinite-loading 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 67.46 **(0.11)** | 41.14 **(0.66)** | 51.22 **(0)** | 67.4 **(0.12)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>