### PR TITLE
fix: run button loading infinitely due to query update when final and initial value remains same

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -150,6 +150,8 @@ type State = {
   isOpened: boolean;
   autoCompleteVisible: boolean;
   hinterOpen: boolean;
+  // Flag for determining whether the entity change has been started or not so that even if the initial and final value remains the same, the status should be changed to not loading
+  changeStarted: boolean;
 };
 
 class CodeEditor extends Component<Props, State> {
@@ -171,6 +173,7 @@ class CodeEditor extends Component<Props, State> {
       isOpened: false,
       autoCompleteVisible: false,
       hinterOpen: false,
+      changeStarted: false,
     };
     this.updatePropertyValue = this.updatePropertyValue.bind(this);
   }
@@ -392,9 +395,12 @@ class CodeEditor extends Component<Props, State> {
     const inputValue = this.props.input.value || "";
     if (
       this.props.input.onChange &&
-      value !== inputValue &&
-      this.state.isFocused
+      ((value !== inputValue && this.state.isFocused) ||
+        this.state.changeStarted)
     ) {
+      this.setState({
+        changeStarted: false,
+      });
       this.props.input.onChange(value);
     }
     CodeEditor.updateMarkings(this.editor, this.props.marking);
@@ -410,8 +416,12 @@ class CodeEditor extends Component<Props, State> {
     if (
       this.props.input.onChange &&
       value !== inputValue &&
-      this.state.isFocused
+      this.state.isFocused &&
+      !this.state.changeStarted
     ) {
+      this.setState({
+        changeStarted: true,
+      });
       this.props.startingEntityUpdation();
     }
     this.handleDebouncedChange(instance, changeObj);


### PR DESCRIPTION
## Description

When we update the query `very fast` but the previous value and ending value remains same eg. `ABCD` we remove `D` and then add `D` so the ending data remains `ABCD`  and we hit `CMD+ENTER` or click on `RUN` for running the query. Then the loading state remains in the infinite loading state. 

Fixes #10124 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Type in the query in the query editor of the datasource and then while typing the query continuously press CMD+ENTER to execute the query. After the fix the query should execute with the latest value in the editor after updating the values in the redux store as well.`

> Add two queries (eg. postgres queries). Update either of the two, execute the same query. Switch to another query from the left side panel. Click on run query. Earlier the run button was going into infinite loading state. After this it will be fixed as the action update is blocked only when there is a change in the input value and it is focused.

> Similar way of the description


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/run-loading-button 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 67 **(-0.46)** | 40.68 **(-0.46)** | 51.22 **(0)** | 66.91 **(-0.49)**</details>