### PR TITLE
fix: The date data in ISO 8601 format is throwing Invalid date on table widget

### DIFF
--- a/app/client/src/widgets/TableWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/TableWidget/widget/propertyConfig.ts
@@ -265,7 +265,7 @@ export default [
                     },
                     {
                       label: "ISO 8601",
-                      value: "YYYY-MM-DDTHH:mm:ss.sssZ",
+                      value: "YYYY-MM-DDTHH:mm:ss.SSSZ",
                     },
                     {
                       label: "YYYY-MM-DDTHH:mm:ss",
@@ -374,7 +374,7 @@ export default [
                     },
                     {
                       label: "ISO 8601",
-                      value: "YYYY-MM-DDTHH:mm:ss.sssZ",
+                      value: "YYYY-MM-DDTHH:mm:ss.SSSZ",
                     },
                     {
                       label: "YYYY-MM-DDTHH:mm:ss",


### PR DESCRIPTION

## Description

-- Fix on wrong ISO8601 format token

Fixes #9494 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>