### PR TITLE
feat: Connect drop down to redux state to fetch options dynamically

### DIFF
--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -6,11 +6,14 @@ import { ControlType } from "constants/PropertyControlConstants";
 import _ from "lodash";
 import {
   Field,
+  getFormValues,
   WrappedFieldInputProps,
   WrappedFieldMetaProps,
 } from "redux-form";
 import { connect } from "react-redux";
 import { AppState } from "reducers";
+import { QUERY_EDITOR_FORM_NAME } from "constants/forms";
+import { QueryAction } from "entities/Action";
 
 const DropdownSelect = styled.div`
   font-size: 14px;
@@ -46,25 +49,18 @@ function renderDropdown(props: {
   input?: WrappedFieldInputProps;
   meta?: WrappedFieldMetaProps;
   props: DropDownControlProps & { width?: string };
-  options: DropdownOption[];
   fetchOptionsCondtionally: boolean;
   formName: string;
-  dynamicFormData: DropdownOption[];
+  dropDownOptions: DropdownOption[];
 }): JSX.Element {
-  let options = [];
-  if ("fetchOptionsCondtionally" in props && props.fetchOptionsCondtionally) {
-    options = props.dynamicFormData;
-  } else {
-    options = props.options;
-  }
-
   let selectedValue = props.input?.value;
   if (_.isUndefined(props.input?.value)) {
     selectedValue = props?.props?.initialValue;
   }
   const selectedOption =
-    options.find((option: DropdownOption) => option.value === selectedValue) ||
-    {};
+    props.dropDownOptions.find(
+      (option: DropdownOption) => option.value === selectedValue,
+    ) || {};
   return (
     <Dropdown
       boundary="window"
@@ -75,7 +71,7 @@ function renderDropdown(props: {
       isMultiSelect={props?.props?.isMultiSelect}
       onSelect={props.input?.onChange}
       optionWidth="50vh"
-      options={options}
+      options={props.dropDownOptions}
       placeholder={props.props?.placeholderText}
       selected={selectedOption}
       showLabelOnly
@@ -95,19 +91,21 @@ export interface DropDownControlProps extends ControlProps {
   fetchOptionsCondtionally?: boolean;
 }
 const mapStateToProps = (state: AppState, ownProps: DropDownControlProps) => {
-  let dynamicFormData: DropdownOption[] = [];
+  let dropDownOptions: DropdownOption[] = [];
 
   // if the component has an option enabled to fetch the options dynamically,
   if (ownProps.fetchOptionsCondtionally) {
     // TODO: this is just a test, will be updated once the fetchDynamicFormData is implemented
-    dynamicFormData = [
+    dropDownOptions = [
       { label: "Test1", value: "SINGLE" },
       { label: "Test2", value: "ALL" },
     ];
+  } else {
+    dropDownOptions = ownProps.options;
   }
 
   return {
-    dynamicFormData,
+    dropDownOptions,
   };
 };
 

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -6,14 +6,11 @@ import { ControlType } from "constants/PropertyControlConstants";
 import _ from "lodash";
 import {
   Field,
-  getFormValues,
   WrappedFieldInputProps,
   WrappedFieldMetaProps,
 } from "redux-form";
 import { connect } from "react-redux";
 import { AppState } from "reducers";
-import { QUERY_EDITOR_FORM_NAME } from "constants/forms";
-import { QueryAction } from "entities/Action";
 
 const DropdownSelect = styled.div`
   font-size: 14px;

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -9,6 +9,8 @@ import {
   WrappedFieldInputProps,
   WrappedFieldMetaProps,
 } from "redux-form";
+import { connect } from "react-redux";
+import { AppState } from "reducers";
 
 const DropdownSelect = styled.div`
   font-size: 14px;
@@ -44,16 +46,25 @@ function renderDropdown(props: {
   input?: WrappedFieldInputProps;
   meta?: WrappedFieldMetaProps;
   props: DropDownControlProps & { width?: string };
-  options: { label: string; value: string }[];
+  options: DropdownOption[];
+  fetchOptionsCondtionally: boolean;
+  formName: string;
+  dynamicFormData: DropdownOption[];
 }): JSX.Element {
+  let options = [];
+  if ("fetchOptionsCondtionally" in props && props.fetchOptionsCondtionally) {
+    options = props.dynamicFormData;
+  } else {
+    options = props.options;
+  }
+
   let selectedValue = props.input?.value;
   if (_.isUndefined(props.input?.value)) {
     selectedValue = props?.props?.initialValue;
   }
   const selectedOption =
-    props?.options.find(
-      (option: DropdownOption) => option.value === selectedValue,
-    ) || {};
+    options.find((option: DropdownOption) => option.value === selectedValue) ||
+    {};
   return (
     <Dropdown
       boundary="window"
@@ -64,7 +75,7 @@ function renderDropdown(props: {
       isMultiSelect={props?.props?.isMultiSelect}
       onSelect={props.input?.onChange}
       optionWidth="50vh"
-      options={props.options}
+      options={options}
       placeholder={props.props?.placeholderText}
       selected={selectedOption}
       showLabelOnly
@@ -81,6 +92,23 @@ export interface DropDownControlProps extends ControlProps {
   isMultiSelect?: boolean;
   isDisabled?: boolean;
   isSearchable?: boolean;
+  fetchOptionsCondtionally?: boolean;
 }
+const mapStateToProps = (state: AppState, ownProps: DropDownControlProps) => {
+  let dynamicFormData: DropdownOption[] = [];
 
-export default DropDownControl;
+  // if the component has an option enabled to fetch the options dynamically,
+  if (ownProps.fetchOptionsCondtionally) {
+    // TODO: this is just a test, will be updated once the fetchDynamicFormData is implemented
+    dynamicFormData = [
+      { label: "Test1", value: "SINGLE" },
+      { label: "Test2", value: "ALL" },
+    ];
+  }
+
+  return {
+    dynamicFormData,
+  };
+};
+
+export default connect(mapStateToProps)(DropDownControl);


### PR DESCRIPTION

## Description
This PR enables the dropdown component to fetch its options dynamically from the redux state. It will allow for further enhancements to the component like hooking the options to response of an API call or any other variable. This is part of the UQI project and the change is completely backwards compatible.

Fixes #10191 

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feat/10191-drop-down-allow-dynamic-options 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.12 **(0)** | 36.65 **(0)** | 34.54 **(0)** | 55.64 **(-0.01)**
 :red_circle: | app/client/src/components/formControls/DropDownControl.tsx | 48.39 **(-5.78)** | 2.17 **(0.04)** | 16.67 **(-3.33)** | 46.67 **(-5.5)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**</details>