### PR TITLE
fix: action.run signature check

### DIFF
--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -120,34 +120,37 @@ const DATA_TREE_FUNCTIONS: Record<
         onError?: () => unknown,
         params = {},
       ): ActionDescriptionWithExecutionType {
-        const isOldSignature =
-          typeof onSuccessOrParams === "function" ||
-          typeof onError === "function";
+        const noArguments =
+          !onSuccessOrParams && !onError && isTrueObject(params);
+        const isNewSignature = noArguments || isTrueObject(onSuccessOrParams);
 
-        if (isOldSignature) {
-          // Backwards compatibility
+        const actionParams = isTrueObject(onSuccessOrParams)
+          ? onSuccessOrParams
+          : params;
+
+        if (isNewSignature) {
           return {
             type: ActionTriggerType.RUN_PLUGIN_ACTION,
             payload: {
               actionId: isAction(entity) ? entity.actionId : "",
-              onSuccess: onSuccessOrParams
-                ? onSuccessOrParams.toString()
-                : undefined,
-              onError: onError ? onError.toString() : undefined,
-              params,
-            },
-            executionType: ExecutionType.TRIGGER,
-          };
-        } else {
-          return {
-            type: ActionTriggerType.RUN_PLUGIN_ACTION,
-            payload: {
-              actionId: isAction(entity) ? entity.actionId : "",
-              params: isTrueObject(onSuccessOrParams) ? onSuccessOrParams : {},
+              params: actionParams,
             },
             executionType: ExecutionType.PROMISE,
           };
         }
+        // Backwards compatibility
+        return {
+          type: ActionTriggerType.RUN_PLUGIN_ACTION,
+          payload: {
+            actionId: isAction(entity) ? entity.actionId : "",
+            onSuccess: onSuccessOrParams
+              ? onSuccessOrParams.toString()
+              : undefined,
+            onError: onError ? onError.toString() : undefined,
+            params: actionParams,
+          },
+          executionType: ExecutionType.TRIGGER,
+        };
       },
   },
   clear: {


### PR DESCRIPTION
## Description

Fix not getting the params properly when old signature is used with no function passed in callbacks


Fixes #10211 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Updated jest tests with new cases


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/passig-params-correctly 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.1 **(0)** | 36.63 **(0.01)** | 34.52 **(0)** | 55.63 **(0.01)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :green_circle: | app/client/src/workers/Actions.ts | 91.55 **(0.25)** | 68.85 **(5.06)** | 80 **(0)** | 90.48 **(0.32)**</details>