### PR TITLE
chore: Make sure to keep forked application in valid state even if client exits the flow before server responds 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ApplicationForkingServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ApplicationForkingServiceCEImpl.java
@@ -44,7 +44,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
 
         Mono<User> userMono = sessionUserService.getCurrentUser();
 
-        return Mono.zip(sourceApplicationMono, targetOrganizationMono, userMono)
+        Mono<Application> forkApplicationMono = Mono.zip(sourceApplicationMono, targetOrganizationMono, userMono)
                 .flatMap(tuple -> {
                     final Application application = tuple.getT1();
                     final Organization targetOrganization = tuple.getT2();
@@ -75,6 +75,17 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
                             .flatMap(application ->
                                     sendForkApplicationAnalyticsEvent(srcApplicationId, targetOrganizationId, application));
                 });
+
+        // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
+        // copy all the actions and collections. This process may take time and the client may cancel the request.
+        // This leads to the flow getting stopped mid way producing corrupted DB objects. The following ensures that even
+        // though the client may have cancelled the flow, the forking of the application should proceed uninterrupted
+        // and whenever the user refreshes the page, the sane forked application is available.
+        // To achieve this, we use a synchronous sink which does not take subscription cancellations into account. This
+        // means that even if the subscriber has cancelled its subscription, the create method still generates its event.
+        return Mono.create(sink -> forkApplicationMono
+                .subscribe(sink::success, sink::error, null, sink.currentContext())
+        );
     }
 
     public Mono<Application> forkApplicationToOrganization(String srcApplicationId,


### PR DESCRIPTION
## Description

Fork application is currently a slow API because it needs to create an application, fork all the pages, and then copy all the actions and collections. This process may take time and the client may cancel the request. This leads to the flow getting stopped midway producing corrupted DB objects. The PR ensures that even though the client may have cancelled the flow, the forking of the application should proceed uninterrupted and whenever the user refreshes the page, the sane forked application is available.

Fixes #10184 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> JUnit TC
> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
