### PR TITLE
fix: filter menu not opening in snippet search

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GlobalSearch/GlobalSearch_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GlobalSearch/GlobalSearch_spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 const commonlocators = require("../../../../locators/commonlocators.json");
 const dsl = require("../../../../fixtures/MultipleWidgetDsl.json");
+const globalSearchLocators = require("../../../../locators/GlobalSearch.json");
 
 describe("GlobalSearch", function() {
   before(() => {
@@ -9,6 +10,14 @@ describe("GlobalSearch", function() {
 
   beforeEach(() => {
     cy.startRoutesForDatasource();
+  });
+
+  it("Clicking on filter should show the filter menu", () => {
+    cy.get(commonlocators.globalSearchTrigger).click({ force: true });
+    cy.contains(globalSearchLocators.docHint, "Snippets").click();
+    cy.get(globalSearchLocators.filterButton).click();
+    cy.contains("Reset Filter").should("be.visible");
+    cy.get("body").type("{esc}");
   });
 
   it("1. showsAndHidesUsingKeyboardShortcuts", () => {

--- a/app/client/cypress/locators/GlobalSearch.json
+++ b/app/client/cypress/locators/GlobalSearch.json
@@ -1,0 +1,4 @@
+{
+    "docHint": ".t--docHit",
+    "filterButton": ".t--filter-button"
+}

--- a/app/client/src/components/editorComponents/GlobalSearch/SnippetsFilter.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/SnippetsFilter.tsx
@@ -133,7 +133,8 @@ function SnippetsFilter({ refinements, snippetsEmpty }: any) {
   const ref = useRef<HTMLDivElement>(null);
   const handleOutsideClick = useCallback(
     (e: MouseEvent) => {
-      if (ref && !ref.current?.contains(e?.target as Node))
+      // Check if the clicked element has the `ref` element in the path(i.e parent list).
+      if (ref && !e.composedPath().includes(ref?.current as EventTarget))
         toggleSnippetFilter(false);
     },
     [showSnippetFilter],
@@ -161,7 +162,7 @@ function SnippetsFilter({ refinements, snippetsEmpty }: any) {
       snippetsEmpty={snippetsEmpty}
     >
       <button
-        className="flex items-center justify-center space-x-1"
+        className="flex items-center justify-center space-x-1 t--filter-button"
         onClick={() => toggleSnippetFilter(!showSnippetFilter)}
       >
         {!showSnippetFilter && <FilterIcon />}
@@ -175,7 +176,7 @@ function SnippetsFilter({ refinements, snippetsEmpty }: any) {
         {!showSnippetFilter && <span> Filter</span>}
         {showSnippetFilter && <CloseFilterIcon />}
       </button>
-      <div className="filter-list">
+      <div className="filter-list t--filter-list">
         <div
           className="container"
           onClick={(e: React.MouseEvent) => {


### PR DESCRIPTION
## Description

Clicking on the `filter` text wasn't opening the filter menu. The check to see when the element contains in the parent wrapper was returning false for unknown reason. Using composedPath which has the path of an elements parent's instead to fix this.

Fixes #9427 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/filter-dropdown 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.04 **(0)** | 36.57 **(0.01)** | 34.49 **(0)** | 55.56 **(0)**
 :green_circle: | app/client/src/components/editorComponents/GlobalSearch/SnippetsFilter.tsx | 19.23 **(0)** | 4.08 **(0.31)** | 0 **(0)** | 21.28 **(0)**</details>