### PR TITLE
chore: Add env variable for git filesystem in CI

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -76,6 +76,7 @@ jobs:
           APPSMITH_ENCRYPTION_PASSWORD: "password"
           APPSMITH_ENCRYPTION_SALT: "salt"
           APPSMITH_IS_SELF_HOSTED: false
+          APPSMITH_GIT_ROOT: "./container-volumes/git-storage"
         run: |
           ./build.sh versions:set \
           -DnewVersion=${{ steps.vars.outputs.version }} \
@@ -329,6 +330,7 @@ jobs:
           APPSMITH_CLOUD_SERVICES_BASE_URL: https://release-cs.appsmith.com
           APPSMITH_CLOUD_SERVICES_USERNAME: ""
           APPSMITH_CLOUD_SERVICES_PASSWORD: ""
+          APPSMITH_GIT_ROOT: "./container-volumes/git-storage"
         run: |
           ls -l
           ls -l scripts/
@@ -653,6 +655,7 @@ jobs:
           APPSMITH_CLOUD_SERVICES_BASE_URL: https://release-cs.appsmith.com
           APPSMITH_CLOUD_SERVICES_USERNAME: ""
           APPSMITH_CLOUD_SERVICES_PASSWORD: ""
+          APPSMITH_GIT_ROOT: "./container-volumes/git-storage"
         run: |
           ls -l
           ls -l scripts/

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -196,6 +196,7 @@ jobs:
           APPSMITH_ENCRYPTION_PASSWORD: "password"
           APPSMITH_ENCRYPTION_SALT: "salt"
           APPSMITH_IS_SELF_HOSTED: false
+          APPSMITH_GIT_ROOT: "./container-volumes/git-storage"
         working-directory: app/server
         run: |
           mvn --batch-mode versions:set \
@@ -370,6 +371,7 @@ jobs:
           APPSMITH_CLOUD_SERVICES_BASE_URL: "https://release-cs.appsmith.com"
           APPSMITH_CLOUD_SERVICES_USERNAME: ""
           APPSMITH_CLOUD_SERVICES_PASSWORD: ""
+          APPSMITH_GIT_ROOT: "./container-volumes/git-storage"
         run: |
           ls -l
           ls -l scripts/


### PR DESCRIPTION
## Description

> Set a file path for the git to store files during the CI runs. As this was not set earlier TCs were failing with the error `Creating a directory failed`   

## Type of change

- Bug fix (non-breaking change which fixes an issue)