### PR TITLE
fix: downloaded file gets corrupted when base64 string is used in download action

### DIFF
--- a/app/client/src/sagas/ActionExecution/DownloadActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/DownloadActionSaga.ts
@@ -1,4 +1,4 @@
-import { getType, isURL, Types } from "utils/TypeHelpers";
+import { getType, Types } from "utils/TypeHelpers";
 import downloadjs from "downloadjs";
 import AppsmithConsole from "utils/AppsmithConsole";
 import Axios from "axios";
@@ -7,6 +7,7 @@ import {
   DownloadActionDescription,
 } from "entities/DataTree/actionTriggers";
 import { ActionValidationError } from "sagas/ActionExecution/errorUtils";
+import { isBase64String, isUrlString } from "./downloadActionUtils";
 
 export default async function downloadSaga(
   action: DownloadActionDescription["payload"],
@@ -27,10 +28,19 @@ export default async function downloadSaga(
     AppsmithConsole.info({
       text: `download('${jsonString}', '${name}', '${type}') was triggered`,
     });
-  } else if (dataType === Types.STRING && isURL(data)) {
+  } else if (isUrlString(data)) {
     // In the event that a url string is supplied, we need to fetch the image with the response type arraybuffer.
     // This also covers the case where the file to be downloaded is Binary.
     Axios.get(data, { responseType: "arraybuffer" }).then((res) => {
+      downloadjs(res.data, name, type);
+      AppsmithConsole.info({
+        text: `download('${data}', '${name}', '${type}') was triggered`,
+      });
+    });
+  } else if (isBase64String(data)) {
+    Axios.get(`data:${type};base64,${data}`, {
+      responseType: "arraybuffer",
+    }).then((res) => {
       downloadjs(res.data, name, type);
       AppsmithConsole.info({
         text: `download('${data}', '${name}', '${type}') was triggered`,

--- a/app/client/src/sagas/ActionExecution/downloadActionUtils.ts
+++ b/app/client/src/sagas/ActionExecution/downloadActionUtils.ts
@@ -1,0 +1,11 @@
+import { getType, isURL, Types } from "utils/TypeHelpers";
+
+const BASE64_STRING_REGEX = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/;
+
+export const isBase64String = (data: any) => {
+  return getType(data) === Types.STRING && BASE64_STRING_REGEX.test(data);
+};
+
+export const isUrlString = (data: any) => {
+  return getType(data) === Types.STRING && isURL(data);
+};


### PR DESCRIPTION
## Description

This PR prevents corruption of downloaded file when base64 string is supplied to download action

Fixes #3559

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/handle-base64-encoded-strings-in-download-action 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.06 **(-0.01)** | 36.56 **(-0.01)** | 34.49 **(-0.01)** | 55.58 **(0)**
 :red_circle: | app/client/src/sagas/ActionExecution/DownloadActionSaga.ts | 30.77 **(-2.56)** | 0 **(0)** | 0 **(0)** | 30.77 **(-2.56)**
 :sparkles: :new: | **app/client/src/sagas/ActionExecution/downloadActionUtils.ts** | **75** | **0** | **0** | **66.67**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>