### PR TITLE
feat: Mongo plugin: add `limit` field to `aggregate` command to allow users to define `batchSize` 

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Aggregate.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Aggregate.java
@@ -16,14 +16,17 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromFormData;
+import static com.external.plugins.constants.FieldName.AGGREGATE_LIMIT;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafely;
 import static com.appsmith.external.helpers.PluginUtils.validConfigurationPresentInFormData;
 import static com.external.plugins.constants.FieldName.AGGREGATE_PIPELINE;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Getter
 @Setter
 public class Aggregate extends MongoCommand {
     String pipeline;
+    String limit;
 
     public Aggregate(ActionConfiguration actionConfiguration) {
         super(actionConfiguration);
@@ -32,6 +35,10 @@ public class Aggregate extends MongoCommand {
 
         if (validConfigurationPresentInFormData(formData, AGGREGATE_PIPELINE)) {
             this.pipeline = (String) getValueSafelyFromFormData(formData, AGGREGATE_PIPELINE);
+        }
+
+        if (validConfigurationPresentInFormData(formData, AGGREGATE_LIMIT)) {
+            this.limit = (String) getValueSafelyFromFormData(formData, AGGREGATE_LIMIT);
         }
     }
 
@@ -75,8 +82,12 @@ public class Aggregate extends MongoCommand {
             commandDocument.put("pipeline", documentArrayList);
         }
 
-        // Add default cursor
-        commandDocument.put("cursor", parseSafely("cursor", "{}"));
+        // Default to returning 10 documents if not mentioned
+        int limit = 10;
+        if (!isBlank(this.limit)) {
+            limit = Integer.parseInt(this.limit);
+        }
+        commandDocument.put("cursor", parseSafely("cursor", "{batchSize: " + limit + "}"));
 
         return commandDocument;
     }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/constants/FieldName.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/constants/FieldName.java
@@ -25,6 +25,7 @@ public class FieldName {
     public static final String DOCUMENTS = "documents";
 
     public static final String AGGREGATE_PIPELINE = AGGREGATE + "." + "arrayPipelines";
+    public static final String AGGREGATE_LIMIT = AGGREGATE + "." + LIMIT;
     public static final String COUNT_QUERY = COUNT + "." + QUERY;
     public static final String DELETE_QUERY = DELETE + "." + QUERY;
     public static final String DELETE_LIMIT = DELETE + "." + LIMIT;

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/aggregate.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/aggregate.json
@@ -31,6 +31,13 @@
           "placeholderText" : "[{ $project: { tags: 1 } }, { $unwind: \"$tags\" }, { $group: { _id: \"$tags\", count: { $sum : 1 } } }  ]"
         }
       ]
+    },
+    {
+      "label": "Limit",
+      "configProperty": "actionConfiguration.formData.aggregate.limit",
+      "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+      "evaluationSubstitutionType": "TEMPLATE",
+      "initialValue": "10"
     }
   ]
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -4813,10 +4813,11 @@ public class DatabaseChangelog {
     }
 
     /**
-     * This migration adds a new field to Mongo aggregate command: formData.aggregate.limit. This field is set by
-     * this migration to 101 for all existing actions since this is the default batchSize used by Mongo database -
-     * this is the same value that would have been applied to the aggregate cmd so far by the database.  However, for
-     * any new action, this field's initial value is 10.
+     * This migration adds a new field to Mongo aggregate command to set batchSize: formData.aggregate.limit. Its value
+     * is set by this migration to 101 for all existing actions since this is the default `batchSize` used by
+     * Mongo database - this is the same value that would have been applied to the aggregate cmd so far by the
+     * database. However, for any new action, this field's initial value is 10.
+     * Ref: https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/ 
      * @param mongockTemplate
      */
     @ChangeSet(order = "109", id = "add-limit-field-data-to-mongo-aggregate-cmd", author = "")

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -4770,16 +4770,24 @@ public class DatabaseChangelog {
         );
     }
 
+    /**
+     * This method sets the key formData.aggregate.limit to 101 for all Mongo plugin actions.
+     * It iterates over each action id one by one to avoid out of memory error.
+     * @param mongoActions
+     * @param mongockTemplate
+     */
     private void updateLimitFieldForEachAction(List<NewAction> mongoActions, MongockTemplate mongockTemplate) {
         mongoActions.stream()
-                .map(NewAction::getId)
-                .map(actionId -> fetchActionUsingId(actionId, mongockTemplate))
+                .map(NewAction::getId) // iterate over one action id at a time
+                .map(actionId -> fetchActionUsingId(actionId, mongockTemplate)) // fetch action using id
                 .filter(this::hasUnpublishedActionConfiguration)
                 .forEachOrdered(mongoAction -> {
+                    /* set key for unpublished action */
                     Map<String, Object> unpublishedFormData =
                             mongoAction.getUnpublishedAction().getActionConfiguration().getFormData();
                     setValueSafelyInFormData(unpublishedFormData, AGGREGATE_LIMIT, DEFAULT_BATCH_SIZE);
 
+                    /* set key for published action */
                     if (hasPublishedActionConfiguration(mongoAction)) {
                         Map<String, Object> publishedFormData =
                                 mongoAction.getPublishedAction().getActionConfiguration().getFormData();
@@ -4790,6 +4798,27 @@ public class DatabaseChangelog {
                 });
     }
 
+    /**
+     * Returns true only if the action has non-null published actionConfiguration.
+     * @param action
+     * @return true / false
+     */
+    private boolean hasPublishedActionConfiguration(NewAction action) {
+        ActionDTO publishedAction = action.getPublishedAction();
+        if (publishedAction == null || publishedAction.getActionConfiguration() == null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * This migration adds a new field to Mongo aggregate command: formData.aggregate.limit. This field is set by
+     * this migration to 101 for all existing actions since this is the default batchSize used by Mongo database -
+     * this is the same value that would have been applied to the aggregate cmd so far by the database.  However, for
+     * any new action, this field's initial value is 10.
+     * @param mongockTemplate
+     */
     @ChangeSet(order = "109", id = "add-limit-field-data-to-mongo-aggregate-cmd", author = "")
     public void addLimitFieldDataToMongoAggregateCommand(MongockTemplate mongockTemplate) {
         Plugin mongoPlugin = mongockTemplate.findOne(query(where("packageName").is("mongo-plugin")), Plugin.class);
@@ -4803,18 +4832,15 @@ public class DatabaseChangelog {
         /* Fetch Mongo actions using the previous query */
         List<NewAction> mongoActions = mongockTemplate.find(queryToGetActions, NewAction.class);
 
+        /* insert key formData.aggregate.limit */
         updateLimitFieldForEachAction(mongoActions, mongockTemplate);
     }
 
-    private boolean hasPublishedActionConfiguration(NewAction action) {
-        ActionDTO publishedAction = action.getPublishedAction();
-        if (publishedAction == null || publishedAction.getActionConfiguration() == null) {
-            return false;
-        }
-
-        return true;
-    }
-
+    /**
+     * Returns true only if the action has non-null un-published actionConfiguration.
+     * @param action
+     * @return true / false
+     */
     private boolean hasUnpublishedActionConfiguration(NewAction action) {
         ActionDTO unpublishedAction = action.getUnpublishedAction();
         if (unpublishedAction == null || unpublishedAction.getActionConfiguration() == null) {
@@ -4824,12 +4850,23 @@ public class DatabaseChangelog {
         return true;
     }
 
+    /**
+     * Fetch an action using id.
+     * @param actionId
+     * @param mongockTemplate
+     * @return action
+     */
     private NewAction fetchActionUsingId(String actionId, MongockTemplate mongockTemplate) {
         final NewAction action =
                 mongockTemplate.findOne(query(where(fieldName(QNewAction.newAction.id)).is(actionId)), NewAction.class);
         return action;
     }
 
+    /**
+     * Generate query to fetch all non-deleted actions defined for a given plugin.
+     * @param plugin
+     * @return query
+     */
     private Query getQueryToFetchAllPluginActionsWhichAreNotDeleted(Plugin plugin) {
         Criteria pluginIdIsMongoPluginId = where("pluginId").is(plugin.getId());
         Criteria isNotDeleted = where("deleted").ne(true);


### PR DESCRIPTION
## Description
- This PR adds a `limit` field which sets the `batchSize` for `aggregate` command. This way the user can set the number of documents they want in their Mongo query result. 
- `limit` is set to `10` initially. However, for pre-existing Mongo actions, migration has been added to set this field to `101` - which is the default value that has been used by Mongodb in the absence of any user set value.  Ref: https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/

Fixes #2290

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
