### PR TITLE
fix: alignment issues in dropdown component of ads

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -256,6 +256,11 @@ export const DropdownContainer = styled.div<{ width: string; height?: string }>`
   position: relative;
   span.bp3-popover-target {
     display: inline-block;
+    width: 100%;
+  }
+
+  span.bp3-popover-wrapper {
+    width: 100%;
   }
 
   &:focus-visible ${Selected} {
@@ -432,6 +437,7 @@ const SelectedDropDownHolder = styled.div`
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
+  width: 100%;
 
   & ${Text} {
     max-width: 100%;

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
@@ -615,7 +615,7 @@ function GeneratePageForm() {
         </DescWrapper>
       </Wrapper>
       <FormWrapper>
-        <SelectWrapper className="space-y-3" width={DROPDOWN_DIMENSION.WIDTH}>
+        <SelectWrapper className="space-y-2" width={DROPDOWN_DIMENSION.WIDTH}>
           <Label>{createMessage(GEN_CRUD_DATASOURCE_DROPDOWN_LABEL)}</Label>
           <Dropdown
             cypressSelector="t--datasource-dropdown"
@@ -641,7 +641,7 @@ function GeneratePageForm() {
           />
         </SelectWrapper>
         {selectedDatasource.value ? (
-          <SelectWrapper className="space-y-3" width={DROPDOWN_DIMENSION.WIDTH}>
+          <SelectWrapper className="space-y-2" width={DROPDOWN_DIMENSION.WIDTH}>
             <Label>
               Select {pluginField.TABLE} from{" "}
               <Bold>{selectedDatasource.label}</Bold>
@@ -674,7 +674,7 @@ function GeneratePageForm() {
           <>
             {showSearchableColumn && (
               <SelectWrapper
-                className="space-y-3"
+                className="space-y-2"
                 width={DROPDOWN_DIMENSION.WIDTH}
               >
                 <Row>

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
@@ -289,7 +289,7 @@ function GoogleSheetForm(props: Props) {
   return (
     <>
       {selectedSpreadsheet.value ? (
-        <SelectWrapper width={DROPDOWN_DIMENSION.WIDTH}>
+        <SelectWrapper className="space-y-2" width={DROPDOWN_DIMENSION.WIDTH}>
           <Label>
             Select sheet from <Bold>{selectedSpreadsheet.label}</Bold>
           </Label>
@@ -310,7 +310,7 @@ function GoogleSheetForm(props: Props) {
 
       {selectedSheet.value ? (
         <>
-          <SelectWrapper width={DROPDOWN_DIMENSION.WIDTH}>
+          <SelectWrapper className="space-y-2" width={DROPDOWN_DIMENSION.WIDTH}>
             <Row>
               <RowHeading>
                 {createMessage(GEN_CRUD_TABLE_HEADER_LABEL)}


### PR DESCRIPTION
There were few alignments happening in the crud app builder. Specifically in the dropdown component.

Fixes #9037
Fixes #9428
Fixes #10194

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change
- Bug fix 

## How Has This Been Tested?
- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/alignment-issues 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.07 **(0.01)** | 36.57 **(0.01)** | 34.49 **(0)** | 55.58 **(0)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>