### PR TITLE
feat: focus widget title in property pane on pressing F2

### DIFF
--- a/app/client/src/components/ads/EditableText.tsx
+++ b/app/client/src/components/ads/EditableText.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect, useContext } from "react";
 
 import styled from "styled-components";
 import { noop } from "lodash";
@@ -8,6 +8,7 @@ import EditableTextSubComponent, {
   EditInteractionKind,
   SavingState,
 } from "./EditableTextSubComponent";
+import { KeyboardContext, KeyboardKeyType } from "pages/Editor/GlobalHotKeys";
 
 export { EditInteractionKind, SavingState };
 
@@ -27,6 +28,7 @@ export type EditableTextProps = CommonComponentProps & {
   fill?: boolean;
   underline?: boolean;
   isError?: boolean;
+  shouldFocusOnF2?: boolean;
 };
 
 // Width of the component when the `filled` prop is false
@@ -56,6 +58,7 @@ export function EditableText(props: EditableTextProps) {
     isEditingDefault,
     isInvalid: inputValidation,
     savingState: defaultSavingState,
+    shouldFocusOnF2,
     ...others
   } = props;
   const [isEditing, setIsEditing] = useState(!!isEditingDefault);
@@ -80,6 +83,20 @@ export function EditableText(props: EditableTextProps) {
       setSavingState(SavingState.NOT_STARTED);
     }
   };
+
+  const { registerKeyDownHandler, unregisterKeyDownHandler } = useContext(
+    KeyboardContext,
+  );
+
+  useEffect(() => {
+    if (shouldFocusOnF2) {
+      registerKeyDownHandler(KeyboardKeyType.F2, () => {
+        setIsEditing(true);
+      });
+
+      return () => unregisterKeyDownHandler(KeyboardKeyType.F2);
+    }
+  }, []);
 
   return (
     <EditableTextWrapper

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -119,6 +119,7 @@ const PropertyPaneTitle = memo(function PropertyPaneTitle(
           onTextChanged={!props.isPanelTitle ? undefined : updateNewTitle}
           placeholder={props.title}
           savingState={updating ? SavingState.STARTED : SavingState.NOT_STARTED}
+          shouldFocusOnF2
           underline
           valueTransform={!props.isPanelTitle ? removeSpecialChars : undefined}
         />


### PR DESCRIPTION
## Description

- There is no way to access the binding of the keyboard to custom handlers from anywhere in the tree but in GlobalHotKeys. So made GlobalHotKeys a context provider to register and unregister custom handlers from anywhere in the tree below GlobalHotkeys.
- This is done to focus the property pane title on pressing the `F2` key.
- Added a boolean prop `shouldFocusOnF2` in EditableText which is used in many places like PropertyPaneTitle and JSEditorTitle.
- Whenever that prop is set to true, EditableText will run an effect that will register a key-down handler for key F2 and focus its input and deregister on unmount.
- This is prop is set to true only in PropertyPaneTitle.

Fixes #9413

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Manually, will add tests later after confirmation on the changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feat/focus-property-pane-title-f2 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.08 **(0.01)** | 36.57 **(0)** | 34.52 **(0.03)** | 55.59 **(0.01)**
 :green_circle: | app/client/src/components/ads/EditableText.tsx | 81.82 **(2.41)** | 33.33 **(2.08)** | 72.73 **(-2.27)** | 76.47 **(2.4)**
 :green_circle: | app/client/src/pages/Editor/GlobalHotKeys.tsx | 63.38 **(1.48)** | 36.96 **(8.39)** | 53.06 **(1.95)** | 62.5 **(1.34)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>