### PR TITLE
fix: Added null check on eval output and started using standard call for pluginId

### DIFF
--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -66,14 +66,10 @@ function* changeQuerySaga(actionPayload: ReduxAction<{ id: string }>) {
     return;
   }
 
-  const currentEditorConfig: any[] = yield select(
-    getEditorConfig,
-    action.datasource.pluginId,
-  );
-  const currentSettingConfig: any[] = yield select(
-    getSettingConfig,
-    action.datasource.pluginId,
-  );
+  // fetching pluginId and the consequent configs from the action
+  const pluginId = action.pluginId;
+  const currentEditorConfig: any[] = yield select(getEditorConfig, pluginId);
+  const currentSettingConfig: any[] = yield select(getSettingConfig, pluginId);
 
   // Update the evaluations when the queryID is changed by changing the
   // URL or selecting new query from the query pane

--- a/app/client/src/workers/formEval.ts
+++ b/app/client/src/workers/formEval.ts
@@ -6,6 +6,7 @@ import { ReduxActionTypes } from "constants/ReduxActionConstants";
 import { ActionConfig } from "entities/Action";
 import { FormEvalActionPayload } from "sagas/FormEvaluationSaga";
 import { FormConfig } from "components/formControls/BaseControl";
+import { isEmpty } from "lodash";
 
 export enum ConditionType {
   HIDE = "hide", // When set, the component will be shown until condition is true
@@ -144,6 +145,11 @@ export function setFormEvaluationSaga(
       payload.settingConfig.forEach((config: FormConfig) => {
         generateInitialEvalState(config);
       });
+    }
+
+    // if the evaluations are empty, then the form is not valid, don't mutate the state
+    if (isEmpty(finalEvalObj)) {
+      return currentEvalState;
     }
 
     // This is the initial evaluation state, evaluations can now be run on top of this


### PR DESCRIPTION
## Description

We were using 2 different paths for fetching pluginID (`action.pluginId` and `action.datasource.pluginId`) for fetching the query forms. While the first one is a standard call, we used the second one in some places causing issues. While most of the plugins had both of the values set, in some cases the second one was not set. This was causing the evaluations to not run and hence leading to an infinite loading state since the form was waiting on evaluation output. This PR fixes the same. Also, added a null check on the output of the evaluation output to prevent setting the whole state as null.

Fixes #10286 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
