### PR TITLE
fix: Map pin does not center when location is changed and centering option is turned on

### DIFF
--- a/app/client/src/widgets/MapWidget/widget/index.tsx
+++ b/app/client/src/widgets/MapWidget/widget/index.tsx
@@ -325,7 +325,10 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
       this.props.markers.length > 0 &&
       JSON.stringify(prevProps.markers) !== JSON.stringify(this.props.markers)
     ) {
-      this.props.updateWidgetMetaProperty("center", this.props.markers[0]);
+      this.props.updateWidgetMetaProperty(
+        "center",
+        this.props.markers[this.props.markers.length - 1],
+      );
     }
   }
 

--- a/app/client/src/widgets/MapWidget/widget/index.tsx
+++ b/app/client/src/widgets/MapWidget/widget/index.tsx
@@ -309,6 +309,24 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
     ) {
       this.unselectMarker();
     }
+
+    // If initial location was changed
+    if (
+      JSON.stringify(prevProps.mapCenter) !==
+      JSON.stringify(this.props.mapCenter)
+    ) {
+      this.props.updateWidgetMetaProperty("center", this.props.mapCenter);
+      return;
+    }
+
+    // If markers were changed
+    if (
+      this.props.markers &&
+      this.props.markers.length > 0 &&
+      JSON.stringify(prevProps.markers) !== JSON.stringify(this.props.markers)
+    ) {
+      this.props.updateWidgetMetaProperty("center", this.props.markers[0]);
+    }
   }
 
   enableDrag = () => {


### PR DESCRIPTION

## Description

- Pinned location should move when location changes on the map when Map & marker centering is turned on. Currently, the pin moves as location changes but manual intervention is needed to center or even bring the pin into view since it does not auto-adjust.
- Update center meta property accordingly when defaultMarkers or mapCenter properties were changed

Fixes #9844 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/9844-map-pin-center 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.06 **(-0.01)** | 36.56 **(-0.01)** | 34.49 **(0)** | 55.57 **(-0.01)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :red_circle: | app/client/src/widgets/MapWidget/widget/index.tsx | 44.78 **(-3.61)** | 6.9 **(-2.19)** | 33.33 **(0)** | 44.62 **(-3.71)**</details>