### PR TITLE
test: Autocomplete not working for Appsmith specific JS APIs

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Autocomplete_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Autocomplete_spec.js
@@ -116,4 +116,77 @@ describe("Autocomplete using slash command and mustache tests", function() {
           .should("have.text", "Button1.text");
       });
   });
+
+  it("Bug 9003: Autocomplete not working for Appsmith specific JS APIs", function() {
+    cy.openPropertyPane("buttonwidget");
+    cy.get(".t--property-control-onclick")
+      .find(".t--js-toggle")
+      .click({ force: true });
+    cy.get(".CodeMirror textarea")
+      .last()
+      .focus()
+      .clear()
+      .type("{{re")
+      .then(() => {
+        cy.get(dynamicInputLocators.hints).should("exist");
+        // validates autocomplete suggestion for resetWidget() in onClick field
+        cy.get(`${dynamicInputLocators.hints} li`)
+          .eq(0)
+          .should("have.text", "resetWidget()");
+      });
+    cy.get(".CodeMirror textarea")
+      .last()
+      .focus()
+      // clearing the onClick field
+      .type("{ctrl}{shift}{uparrow}", { parseSpecialCharSequences: true })
+      .type("{backspace}", { parseSpecialCharSequences: true })
+      .type("{rightarrow}{rightarrow}", { parseSpecialCharSequences: true })
+      .type("{ctrl}{shift}{uparrow}", { parseSpecialCharSequences: true })
+      .type("{backspace}", { parseSpecialCharSequences: true })
+      .type("{{s")
+      .then(() => {
+        cy.get(dynamicInputLocators.hints).should("exist");
+        // validates autocomplete function suggestions on entering '{{s' in onClick field
+        cy.get(`${dynamicInputLocators.hints} li`)
+          .should("contain.text", "storeValue()")
+          .and("contain.text", "showModal()")
+          .and("contain.text", "setInterval()")
+          .and("contain.text", "showAlert()");
+      });
+    cy.get(".CodeMirror textarea")
+      .last()
+      .focus()
+      // clearing the onClick field
+      .type("{ctrl}{shift}{uparrow}", { parseSpecialCharSequences: true })
+      .type("{backspace}", { parseSpecialCharSequences: true })
+      .type("{rightarrow}{rightarrow}", { parseSpecialCharSequences: true })
+      .type("{ctrl}{shift}{uparrow}", { parseSpecialCharSequences: true })
+      .type("{backspace}", { parseSpecialCharSequences: true })
+      .type("{{c")
+      .then(() => {
+        cy.get(dynamicInputLocators.hints).should("exist");
+        // validates autocomplete function suggestions on entering '{{c' in onClick field
+        cy.get(`${dynamicInputLocators.hints} li`)
+          .should("contain.text", "closeModal()")
+          .and("contain.text", "copyToClipboard()")
+          .and("contain.text", "clearInterval()");
+      });
+    cy.get(".CodeMirror textarea")
+      .last()
+      .focus()
+      .type("{ctrl}{shift}{uparrow}", { parseSpecialCharSequences: true })
+      .type("{backspace}", { parseSpecialCharSequences: true })
+      .type("{rightarrow}{rightarrow}", { parseSpecialCharSequences: true })
+      .type("{ctrl}{shift}{uparrow}", { parseSpecialCharSequences: true })
+      .type("{backspace}", { parseSpecialCharSequences: true })
+      .type("{{n")
+      .then(() => {
+        cy.get(dynamicInputLocators.hints).should("exist");
+        // validates autocomplete suggestions on entering '{{n' in onClick field
+        cy.get(`${dynamicInputLocators.hints} li`).should(
+          "contain.text",
+          "navigateTo()",
+        );
+      });
+  });
 });


### PR DESCRIPTION

## Description

This PR contains cypress test for Bug #9003

Fixes #9490

> if no issue exists, please create an issue and ask the maintainers about this first

## How Has This Been Tested?

locally

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: AutocompleteBugTests 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.06 **(0)** | 36.57 **(0.01)** | 34.49 **(0)** | 55.58 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>