### PR TITLE
fix: added condition for where clause evaluated value binding path

### DIFF
--- a/app/client/src/entities/Action/actionProperties.ts
+++ b/app/client/src/entities/Action/actionProperties.ts
@@ -42,8 +42,7 @@ export const getBindingPathsOfAction = (
             formConfig.evaluationSubstitutionType,
           );
         }
-      }
-      if (formConfig.controlType === "ARRAY_FIELD") {
+      } else if (formConfig.controlType === "ARRAY_FIELD") {
         let actionValue = _.get(action, formConfig.configProperty);
         if (Array.isArray(actionValue)) {
           actionValue = actionValue.filter((val) => val);
@@ -62,6 +61,54 @@ export const getBindingPathsOfAction = (
               }
             });
           }
+        }
+      } else if (formConfig.controlType === "WHERE_CLAUSE") {
+        const recursiveFindBindingPathsForWhereClause = (
+          newConfigPath: string,
+          actionValue: any,
+        ) => {
+          if (
+            actionValue &&
+            actionValue.hasOwnProperty("children") &&
+            Array.isArray(actionValue.children)
+          ) {
+            actionValue.children.forEach((value: any, index: number) => {
+              recursiveFindBindingPathsForWhereClause(
+                `${newConfigPath}.children[${index}]`,
+                value,
+              );
+            });
+          } else {
+            if (actionValue.hasOwnProperty("key")) {
+              bindingPaths[
+                `${newConfigPath}.key`
+              ] = getCorrectEvaluationSubstitutionType(
+                formConfig.evaluationSubstitutionType,
+              );
+            }
+
+            if (actionValue.hasOwnProperty("value")) {
+              bindingPaths[
+                `${newConfigPath}.value`
+              ] = getCorrectEvaluationSubstitutionType(
+                formConfig.evaluationSubstitutionType,
+              );
+            }
+          }
+        };
+
+        const actionValue = _.get(action, formConfig.configProperty);
+        if (
+          actionValue &&
+          actionValue.hasOwnProperty("children") &&
+          Array.isArray(actionValue.children)
+        ) {
+          actionValue.children.forEach((value: any, index: number) => {
+            recursiveFindBindingPathsForWhereClause(
+              `${configPath}.children[${index}]`,
+              value,
+            );
+          });
         }
       }
     }


### PR DESCRIPTION
## Description

There was a condition missing for initialising the binding paths for the evaluated values. This PR adds a fix for the same issue. 

Fixes # (issue)

#9301 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Add a where clause to the S3 plugin query.
2. Update the key and value or where clause.
3. When the values are updated the evaluated values are updated in the popup which was previously undefined for any value.
4. Add more conditions and check for the same.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
