### PR TITLE
chore: Removing trailing slash from application API endpoint.

### DIFF
--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -2903,7 +2903,7 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("POST", "/api/v1/datasources").as("createDatasource");
   cy.route("DELETE", "/api/v1/datasources/*").as("deleteDatasource");
   cy.route("DELETE", "/api/v1/applications/*").as("deleteApplication");
-  cy.route("POST", "/api/v1/applications/?orgId=*").as("createNewApplication");
+  cy.route("POST", "/api/v1/applications?orgId=*").as("createNewApplication");
   cy.route("PUT", "/api/v1/applications/*").as("updateApplication");
   cy.route("PUT", "/api/v1/actions/*").as("saveAction");
   cy.route("PUT", "/api/v1/actions/move").as("moveAction");

--- a/app/client/src/api/ApplicationApi.tsx
+++ b/app/client/src/api/ApplicationApi.tsx
@@ -149,7 +149,7 @@ class ApplicationApi extends Api {
     `/publish/${applicationId}`;
   static createApplicationPath = (orgId: string) => `?orgId=${orgId}`;
   static changeAppViewAccessPath = (applicationId: string) =>
-    `${applicationId}/changeAccess`;
+    `/${applicationId}/changeAccess`;
   static setDefaultPagePath = (request: SetDefaultPageRequest) =>
     `${ApplicationApi.baseURL}/${request.applicationId}/page/${request.id}/makeDefault`;
   static publishApplication(

--- a/app/client/src/api/ApplicationApi.tsx
+++ b/app/client/src/api/ApplicationApi.tsx
@@ -144,13 +144,14 @@ export interface ImportApplicationRequest {
 }
 
 class ApplicationApi extends Api {
-  static baseURL = "v1/applications/";
-  static publishURLPath = (applicationId: string) => `publish/${applicationId}`;
+  static baseURL = "v1/applications";
+  static publishURLPath = (applicationId: string) =>
+    `/publish/${applicationId}`;
   static createApplicationPath = (orgId: string) => `?orgId=${orgId}`;
   static changeAppViewAccessPath = (applicationId: string) =>
     `${applicationId}/changeAccess`;
   static setDefaultPagePath = (request: SetDefaultPageRequest) =>
-    `${ApplicationApi.baseURL}${request.applicationId}/page/${request.id}/makeDefault`;
+    `${ApplicationApi.baseURL}/${request.applicationId}/page/${request.id}/makeDefault`;
   static publishApplication(
     publishApplicationRequest: PublishApplicationRequest,
   ): AxiosPromise<PublishApplicationResponse> {
@@ -166,19 +167,19 @@ class ApplicationApi extends Api {
   }
 
   static getAllApplication(): AxiosPromise<GetAllApplicationResponse> {
-    return Api.get(ApplicationApi.baseURL + "new");
+    return Api.get(ApplicationApi.baseURL + "/new");
   }
 
   static fetchApplication(
     applicationId: string,
   ): AxiosPromise<FetchApplicationResponse> {
-    return Api.get(ApplicationApi.baseURL + applicationId);
+    return Api.get(ApplicationApi.baseURL + "/" + applicationId);
   }
 
   static fetchApplicationForViewMode(
     applicationId: string,
   ): AxiosPromise<FetchApplicationResponse> {
-    return Api.get(ApplicationApi.baseURL + `view/${applicationId}`);
+    return Api.get(ApplicationApi.baseURL + `/view/${applicationId}`);
   }
 
   static createApplication(
@@ -211,26 +212,27 @@ class ApplicationApi extends Api {
     request: UpdateApplicationRequest,
   ): AxiosPromise<ApiResponse> {
     const { id, ...rest } = request;
-    return Api.put(ApplicationApi.baseURL + id, rest);
+    return Api.put(ApplicationApi.baseURL + "/" + id, rest);
   }
 
   static deleteApplication(
     request: DeleteApplicationRequest,
   ): AxiosPromise<ApiResponse> {
-    return Api.delete(ApplicationApi.baseURL + request.applicationId);
+    return Api.delete(ApplicationApi.baseURL + "/" + request.applicationId);
   }
 
   static duplicateApplication(
     request: DuplicateApplicationRequest,
   ): AxiosPromise<ApiResponse> {
-    return Api.post(ApplicationApi.baseURL + "clone/" + request.applicationId);
+    return Api.post(ApplicationApi.baseURL + "/clone/" + request.applicationId);
   }
 
   static forkApplication(
     request: ForkApplicationRequest,
   ): AxiosPromise<ApiResponse> {
     return Api.post(
-      "v1/applications/" +
+      ApplicationApi.baseURL +
+        "/" +
         request.applicationId +
         "/fork/" +
         request.organizationId,
@@ -244,20 +246,25 @@ class ApplicationApi extends Api {
     if (request.applicationFile) {
       formData.append("file", request.applicationFile);
     }
-    return Api.post("v1/applications/import/" + request.orgId, formData, null, {
-      headers: {
-        "Content-Type": "multipart/form-data",
+    return Api.post(
+      ApplicationApi.baseURL + "/import/" + request.orgId,
+      formData,
+      null,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+        onUploadProgress: request.progress,
       },
-      onUploadProgress: request.progress,
-    });
+    );
   }
 
   static getSSHKeyPair(applicationId: string): AxiosPromise<ApiResponse> {
-    return Api.get(ApplicationApi.baseURL + "ssh-keypair/" + applicationId);
+    return Api.get(ApplicationApi.baseURL + "/ssh-keypair/" + applicationId);
   }
 
   static generateSSHKeyPair(applicationId: string): AxiosPromise<ApiResponse> {
-    return Api.post(ApplicationApi.baseURL + "ssh-keypair/" + applicationId);
+    return Api.post(ApplicationApi.baseURL + "/ssh-keypair/" + applicationId);
   }
 }
 


### PR DESCRIPTION
## Description

The trailing slash causes issues in Vercel's deploy preview when creating an app. The server ends up responding with 405 Method Not Allowed error. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: create-app-405 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.01 **(0)** | 36.71 **(-0.01)** | 34.7 **(0)** | 55.51 **(0)**
 :red_circle: | app/client/src/api/ApplicationApi.tsx | 51.02 **(0)** | 0 **(0)** | 5 **(0)** | 52.17 **(-1.16)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>