### PR TITLE
fix: Widget pane not closing when switching from canvas

### DIFF
--- a/app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { useSelector } from "react-redux";
 import {
   getCurrentPageId,
@@ -15,6 +15,8 @@ import { Spinner } from "@blueprintjs/core";
 import Canvas from "../Canvas";
 import { useParams } from "react-router";
 import classNames from "classnames";
+import { forceOpenWidgetPanel } from "actions/widgetSidebarActions";
+import { useDispatch } from "react-redux";
 
 const Container = styled.section`
   width: 100%;
@@ -39,6 +41,13 @@ function CanvasContainer() {
   const isPreviewMode = useSelector(previewModeSelector);
   const params = useParams<{ applicationId: string; pageId: string }>();
   const shouldHaveTopMargin = !isPreviewMode || pages.length > 1;
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    return () => {
+      dispatch(forceOpenWidgetPanel(false));
+    };
+  }, []);
 
   const pageLoading = (
     <Centered>


### PR DESCRIPTION
## Description

 Fixed issue in widget pane, was not closing when navigate to Datasource page via omnibar.

Fixes #9194 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested navigation from omnibar
- Tested navigation from run query in property pane.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/9194-widget-pane-switching-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.07 **(0.01)** | 36.57 **(0.01)** | 34.52 **(0.01)** | 55.58 **(0.01)**
 :green_circle: | app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx | 96.77 **(0.77)** | 66.67 **(0)** | 100 **(0)** | 96.77 **(0.77)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**</details>