### PR TITLE
feat: Add page slug in the get pages API

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageNameIdDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageNameIdDTO.java
@@ -11,6 +11,8 @@ public class PageNameIdDTO {
 
     String name;
 
+    String slug;
+
     Boolean isDefault;
 
     Boolean isHidden;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
@@ -298,19 +298,20 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
                             return Mono.error(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "page", pageFromDb.getId()));
                         }
                         pageNameIdDTO.setDefaultPageId(pageFromDb.getDefaultResources().getPageId());
-
+                        PageDTO pageDTO;
                         if (Boolean.TRUE.equals(view)) {
                             if (pageFromDb.getPublishedPage() == null) {
                                 // We are trying to fetch published page but it doesnt exist because the page hasn't been published yet
                                 return Mono.error(new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND,
                                         FieldName.PAGE, pageFromDb.getId()));
                             }
-                            pageNameIdDTO.setName(pageFromDb.getPublishedPage().getName());
-                            pageNameIdDTO.setIsHidden(pageFromDb.getPublishedPage().getIsHidden());
+                            pageDTO = pageFromDb.getPublishedPage();
                         } else {
-                            pageNameIdDTO.setName(pageFromDb.getUnpublishedPage().getName());
-                            pageNameIdDTO.setIsHidden(pageFromDb.getUnpublishedPage().getIsHidden());
+                            pageDTO = pageFromDb.getUnpublishedPage();
                         }
+                        pageNameIdDTO.setName(pageDTO.getName());
+                        pageNameIdDTO.setIsHidden(pageDTO.getIsHidden());
+                        pageNameIdDTO.setSlug(pageDTO.getSlug());
 
                         if (pageNameIdDTO.getId().equals(defaultPageId)) {
                             pageNameIdDTO.setIsDefault(true);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -1906,7 +1906,9 @@ public class ApplicationServiceTest {
                 .assertNext(applicationPagesDTO -> {
                     assertThat(applicationPagesDTO.getPages().size()).isEqualTo(4);
                     List<String> pageNames = applicationPagesDTO.getPages().stream().map(pageNameIdDTO -> pageNameIdDTO.getName()).collect(Collectors.toList());
+                    List<String> slugNames = applicationPagesDTO.getPages().stream().map(pageNameIdDTO -> pageNameIdDTO.getSlug()).collect(Collectors.toList());
                     assertThat(pageNames).containsExactly("Page1", "Page2", "Page3", "Page4");
+                    assertThat(slugNames).containsExactly("page1", "page2", "page3", "page4");
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
We've added slug for pages. Each page has a slug which is generated from name automatically. In our get pages API `/api/v1/pages/application/<app_id>`, the slug names were not included in the Page DTO. This PR adds slug name in this API response.

Fixes #10271 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- JUnit test
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
