### PR TITLE
fix: App crashes when a modal has a filepicker?

### DIFF
--- a/app/client/src/widgets/CameraWidget/component/index.tsx
+++ b/app/client/src/widgets/CameraWidget/component/index.tsx
@@ -9,6 +9,7 @@ import {
   FullScreenHandle,
   useFullScreenHandle,
 } from "react-full-screen";
+import log from "loglevel";
 
 import { ThemeProp } from "components/ads/common";
 import {
@@ -898,7 +899,9 @@ function CameraComponent(props: CameraComponentProps) {
         .catch((err) => {
           setError(err.message);
         });
-    } catch (e) {}
+    } catch (e) {
+      log.debug("Error in calling enumerateDevices");
+    }
   }, []);
 
   useEffect(() => {

--- a/app/client/src/widgets/CameraWidget/component/index.tsx
+++ b/app/client/src/widgets/CameraWidget/component/index.tsx
@@ -891,12 +891,14 @@ function CameraComponent(props: CameraComponentProps) {
   const fullScreenHandle = useFullScreenHandle();
 
   useEffect(() => {
-    navigator.mediaDevices
-      .enumerateDevices()
-      .then(handleDeviceInputs)
-      .catch((err) => {
-        setError(err.message);
-      });
+    try {
+      navigator.mediaDevices
+        .enumerateDevices()
+        .then(handleDeviceInputs)
+        .catch((err) => {
+          setError(err.message);
+        });
+    } catch (e) {}
   }, []);
 
   useEffect(() => {

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -16,6 +16,7 @@ import _, { findIndex } from "lodash";
 import FileDataTypes from "../constants";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 import { createBlobUrl, isBlobUrl } from "utils/AppsmithUtils";
+import log from "loglevel";
 
 class FilePickerWidget extends BaseWidget<
   FilePickerWidgetProps,
@@ -456,7 +457,9 @@ class FilePickerWidget extends BaseWidget<
 
     try {
       this.initializeUppyEventListeners();
-    } catch (e) {}
+    } catch (e) {
+      log.debug("Error in initializing uppy");
+    }
   }
 
   componentWillUnmount() {

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -323,14 +323,17 @@ class FilePickerWidget extends BaseWidget<
       .use(Url, { companionUrl: "https://companion.uppy.io" })
       .use(OneDrive, {
         companionUrl: "https://companion.uppy.io/",
-      })
-      .use(Webcam, {
+      });
+
+    if (location.protocol === "https:") {
+      this.state.uppy.use(Webcam, {
         onBeforeSnapshot: () => Promise.resolve(),
         countdown: false,
         mirror: true,
         facingMode: "user",
         locale: {},
       });
+    }
 
     this.state.uppy.on("file-removed", (file: any) => {
       const updatedFiles = this.props.selectedFiles
@@ -451,7 +454,9 @@ class FilePickerWidget extends BaseWidget<
   componentDidMount() {
     super.componentDidMount();
 
-    this.initializeUppyEventListeners();
+    try {
+      this.initializeUppyEventListeners();
+    } catch (e) {}
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fixes #10283

## Type of change

- Bug fix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/http-issue-with-filepicker 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.07 **(0)** | 36.59 **(0)** | 34.54 **(0)** | 55.56 **(-0.01)**
 :red_circle: | app/client/src/widgets/CameraWidget/component/index.tsx | 10.53 **(-0.03)** | 14.72 **(0)** | 0 **(0)** | 12.41 **(-0.04)**
 :red_circle: | app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx | 32.41 **(-0.92)** | 0 **(0)** | 20.69 **(0)** | 33.33 **(-1.01)**</details>