### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -24,7 +24,7 @@
         <project.version>1.0-SNAPSHOT</project.version>
         <!-- By default skip the dockerization step. Only activate if necessary -->
         <skipDockerBuild>true</skipDockerBuild>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
     </properties>
 
     <build>


### PR DESCRIPTION
From https://logging.apache.org/log4j/2.x/security.html,
log4j version 2.17.1 is the current recommended version.
