### PR TITLE
feat: Add keyboard navigation to multiselect dropdown

### DIFF
--- a/app/client/src/components/ads/MultiselectDropdown.test.tsx
+++ b/app/client/src/components/ads/MultiselectDropdown.test.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import { ThemeProvider } from "constants/DefaultTheme";
+import { lightTheme } from "selectors/themeSelectors";
+import userEvent from "@testing-library/user-event";
+import MultiSelectDropdown from "./MultiselectDropdown";
+
+const props = {
+  options: [
+    { label: "Primary", value: "PRIMARY" },
+    { label: "Secondary", value: "SECONDARY" },
+    { label: "Tertiary", value: "TERTIARY" },
+  ],
+  selected: ["PRIMARY"],
+  showLabelOnly: true,
+};
+
+describe("<MultiselectDropdown /> - Keyboard navigation", () => {
+  const getTestComponent = (handleOnSelect: any = undefined) => (
+    <ThemeProvider theme={lightTheme}>
+      <MultiSelectDropdown
+        onSelect={handleOnSelect}
+        options={props.options}
+        selected={props.selected}
+        showLabelOnly={props.showLabelOnly}
+      />
+      ,
+    </ThemeProvider>
+  );
+
+  it("Pressing tab should focus the component", () => {
+    render(getTestComponent());
+    userEvent.tab();
+    expect(screen.getByRole("listbox")).toHaveFocus();
+  });
+
+  // Tests various ways to open dropdown
+  it.each(["{Enter}", " ", "{ArrowDown}", "{ArrowUp}"])(
+    "Once focused, pressing '%s' should open dropdown",
+    async (key) => {
+      render(getTestComponent());
+      expect(screen.queryByRole("option")).toBeNull();
+      userEvent.tab();
+
+      userEvent.keyboard(key);
+      expect(screen.queryAllByRole("option")).toHaveLength(3);
+
+      // Escape to close opened dropdown
+      userEvent.keyboard("{Escape}");
+      await waitForElementToBeRemoved(screen.getAllByRole("option"));
+    },
+  );
+
+  it("Pressing tab once dropdown is opened should close dropdown", async () => {
+    render(getTestComponent());
+    userEvent.tab();
+    userEvent.keyboard("{Enter}");
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+    userEvent.tab();
+    await waitForElementToBeRemoved(screen.getAllByRole("option"));
+  });
+
+  it("{ArrowDown} should select next item", () => {
+    render(getTestComponent());
+    userEvent.tab();
+    userEvent.keyboard("{Enter}");
+
+    // Make sure first item is selected by default
+    expect(screen.getByRole("option", { name: "Primary" })).toHaveClass(
+      "focus",
+    );
+
+    // Press ArrowDown and check results
+    [
+      "Secondary",
+      "Tertiary",
+      // ArrowDown on last item should select first item
+      "Primary",
+    ].forEach((text) => {
+      userEvent.keyboard("{ArrowDown}");
+      expect(screen.getByRole("option", { name: text })).toHaveClass("focus");
+    });
+  });
+
+  it("{ArrowUp} should select previous item", () => {
+    render(getTestComponent());
+    userEvent.tab();
+    userEvent.keyboard("{Enter}");
+
+    // Make sure first item is selected by default
+    expect(screen.getByRole("option", { name: "Primary" })).toHaveClass(
+      "focus",
+    );
+
+    // Press ArrowUp and check results
+    [
+      // ArrowUp on first item should select last item
+      "Tertiary",
+      "Secondary",
+      "Primary",
+    ].forEach((text) => {
+      userEvent.keyboard("{ArrowUp}");
+      expect(screen.getByRole("option", { name: text })).toHaveClass("focus");
+    });
+  });
+
+  it("After selecting an option using arrow, {enter} or ' ' should trigger optionClick", () => {
+    const handleOnSelect = jest.fn();
+    render(getTestComponent(handleOnSelect));
+    userEvent.tab();
+    userEvent.keyboard("{Enter}");
+    userEvent.keyboard("{ArrowDown}");
+    userEvent.keyboard("{Enter}");
+    expect(handleOnSelect).toHaveBeenLastCalledWith([
+      props.options[0].value,
+      props.options[1].value,
+    ]);
+    userEvent.keyboard("{ArrowDown}");
+    userEvent.keyboard(" ");
+    expect(handleOnSelect).toHaveBeenLastCalledWith([
+      props.options[0].value,
+      props.options[2].value,
+    ]);
+  });
+});

--- a/app/client/src/components/ads/MultiselectDropdown.tsx
+++ b/app/client/src/components/ads/MultiselectDropdown.tsx
@@ -186,7 +186,7 @@ function MultiSelectDropdown(props: DropdownProps) {
     }
   }, []);
 
-  const [currentItemIndex, setCurrentItemIndex] = useState<number>(-1);
+  const [currentItemIndex, setCurrentItemIndex] = useState<number>(0);
   const btnRef = useRef<HTMLButtonElement>(null);
 
   const optionClickHandler = useCallback(
@@ -245,12 +245,14 @@ function MultiSelectDropdown(props: DropdownProps) {
     (e: React.KeyboardEvent) => {
       switch (e.key) {
         case "Escape":
+        case "Esc":
           if (isOpen) {
             setIsOpen(false);
             e.nativeEvent.stopImmediatePropagation();
           }
           break;
         case " ":
+        case "Spacebar":
         case "Enter":
           if (isOpen) {
             if (props.options[currentItemIndex]?.value) {
@@ -262,6 +264,7 @@ function MultiSelectDropdown(props: DropdownProps) {
           }
           break;
         case "ArrowUp":
+        case "Up":
           e.preventDefault();
           if (isOpen) {
             setCurrentItemIndex((prevIndex) => {
@@ -273,6 +276,7 @@ function MultiSelectDropdown(props: DropdownProps) {
           }
           break;
         case "ArrowDown":
+        case "Down":
           e.preventDefault();
           if (isOpen) {
             setCurrentItemIndex((prevIndex) => {

--- a/app/client/src/components/ads/MultiselectDropdown.tsx
+++ b/app/client/src/components/ads/MultiselectDropdown.tsx
@@ -188,95 +188,106 @@ function MultiSelectDropdown(props: DropdownProps) {
 
   const [currentItemIndex, setCurrentItemIndex] = useState<number>(0);
 
-  const optionClickHandler = (option: string) => {
-    const currentIndex = _.findIndex(props.selected, (value) => {
-      return value === option;
-    });
+  const optionClickHandler = useCallback(
+    (option: string) => {
+      const currentIndex = _.findIndex(props.selected, (value) => {
+        return value === option;
+      });
 
-    let selectedOption = [...props.selected];
+      let selectedOption = [...props.selected];
 
-    if (currentIndex === -1) {
-      selectedOption.push(option);
-    } else {
-      selectedOption.splice(currentIndex, 1);
-    }
+      if (currentIndex === -1) {
+        selectedOption.push(option);
+      } else {
+        selectedOption.splice(currentIndex, 1);
+      }
 
-    if (props.selectAll) {
-      const isAllSelectorPresent = props.selected.includes(
-        props.selectAllQuantifier as string,
-      );
-      const isAllSelectorSelected =
-        props.selectAllQuantifier && option === props.selectAllQuantifier;
+      if (props.selectAll) {
+        const isAllSelectorPresent = props.selected.includes(
+          props.selectAllQuantifier as string,
+        );
+        const isAllSelectorSelected =
+          props.selectAllQuantifier && option === props.selectAllQuantifier;
 
-      if (isAllSelectorSelected) {
-        if (isAllSelectorPresent) {
-          selectedOption = [];
-        } else {
+        if (isAllSelectorSelected) {
+          if (isAllSelectorPresent) {
+            selectedOption = [];
+          } else {
+            selectedOption = _.map(
+              props.options,
+              (item) => item.value,
+            ) as string[];
+          }
+        } else if (isAllSelectorPresent) {
+          selectedOption = selectedOption.filter(
+            (item) => item !== props.selectAllQuantifier,
+          );
+        } else if (
+          !isAllSelectorPresent &&
+          selectedOption.length === props.options.length - 1
+        ) {
           selectedOption = _.map(
             props.options,
             (item) => item.value,
           ) as string[];
         }
-      } else if (isAllSelectorPresent) {
-        selectedOption = selectedOption.filter(
-          (item) => item !== props.selectAllQuantifier,
-        );
-      } else if (
-        !isAllSelectorPresent &&
-        selectedOption.length === props.options.length - 1
-      ) {
-        selectedOption = _.map(props.options, (item) => item.value) as string[];
       }
-    }
 
-    props.onSelect && props.onSelect([...selectedOption]);
-  };
+      props.onSelect && props.onSelect([...selectedOption]);
+    },
+    [props.selected, props.selectAll, props.selectAllQuantifier],
+  );
 
-  const handleKeydown = (e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case "Escape":
-        if (isOpen) {
-          setIsOpen(false);
-          e.nativeEvent.stopImmediatePropagation();
-        }
-        break;
-      case " ":
-      case "Enter":
-        if (isOpen) {
-          if (props.options[currentItemIndex]?.value)
-            optionClickHandler(props.options[currentItemIndex].value as string);
+  const handleKeydown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+          if (isOpen) {
+            setIsOpen(false);
+            e.nativeEvent.stopImmediatePropagation();
+          }
+          break;
+        case " ":
+        case "Enter":
+          if (isOpen) {
+            if (props.options[currentItemIndex]?.value)
+              optionClickHandler(
+                props.options[currentItemIndex].value as string,
+              );
+            e.preventDefault();
+          }
+          break;
+        case "ArrowUp":
           e.preventDefault();
-        }
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        if (isOpen) {
-          setCurrentItemIndex((prevIndex) => {
-            if (prevIndex <= 0) return props.options.length - 1;
-            return prevIndex - 1;
-          });
-        } else {
-          setIsOpen(true);
-        }
-        break;
-      case "ArrowDown":
-        e.preventDefault();
-        if (isOpen) {
-          setCurrentItemIndex((prevIndex) => {
-            if (prevIndex === props.options.length - 1) return 0;
-            return prevIndex + 1;
-          });
-        } else {
-          setIsOpen(true);
-        }
-        break;
-      case "Tab":
-        if (isOpen) {
-          setIsOpen(false);
-        }
-        break;
-    }
-  };
+          if (isOpen) {
+            setCurrentItemIndex((prevIndex) => {
+              if (prevIndex <= 0) return props.options.length - 1;
+              return prevIndex - 1;
+            });
+          } else {
+            setIsOpen(true);
+          }
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          if (isOpen) {
+            setCurrentItemIndex((prevIndex) => {
+              if (prevIndex === props.options.length - 1) return 0;
+              return prevIndex + 1;
+            });
+          } else {
+            setIsOpen(true);
+          }
+          break;
+        case "Tab":
+          if (isOpen) {
+            setIsOpen(false);
+          }
+          break;
+      }
+    },
+    [isOpen, props.options, currentItemIndex],
+  );
 
   const isItemSelected = (item?: string) => {
     if (!item) {

--- a/app/client/src/components/ads/MultiselectDropdown.tsx
+++ b/app/client/src/components/ads/MultiselectDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import Icon, { IconName, IconSize } from "./Icon";
 import { Classes, CommonComponentProps } from "./common";
 import Text, { TextType } from "./Text";
@@ -186,13 +186,16 @@ function MultiSelectDropdown(props: DropdownProps) {
     }
   }, []);
 
-  const [currentItemIndex, setCurrentItemIndex] = useState<number>(0);
+  const [currentItemIndex, setCurrentItemIndex] = useState<number>(-1);
+  const btnRef = useRef<HTMLButtonElement>(null);
 
   const optionClickHandler = useCallback(
     (option: string) => {
       const currentIndex = _.findIndex(props.selected, (value) => {
         return value === option;
       });
+
+      if (btnRef.current) btnRef.current.focus();
 
       let selectedOption = [...props.selected];
 
@@ -250,10 +253,11 @@ function MultiSelectDropdown(props: DropdownProps) {
         case " ":
         case "Enter":
           if (isOpen) {
-            if (props.options[currentItemIndex]?.value)
+            if (props.options[currentItemIndex]?.value) {
               optionClickHandler(
                 props.options[currentItemIndex].value as string,
               );
+            }
             e.preventDefault();
           }
           break;
@@ -315,6 +319,7 @@ function MultiSelectDropdown(props: DropdownProps) {
           isOpen={isOpen}
           onClick={() => setIsOpen(!isOpen)}
           onKeyDown={handleKeydown}
+          ref={btnRef}
           role="listbox"
           tabIndex={0}
         >

--- a/app/client/src/components/ads/MultiselectDropdown.tsx
+++ b/app/client/src/components/ads/MultiselectDropdown.tsx
@@ -294,7 +294,7 @@ function MultiSelectDropdown(props: DropdownProps) {
           break;
       }
     },
-    [isOpen, props.options, currentItemIndex],
+    [isOpen, props.options, props.selected, currentItemIndex],
   );
 
   const isItemSelected = (item?: string) => {

--- a/app/client/src/components/ads/MultiselectDropdown.tsx
+++ b/app/client/src/components/ads/MultiselectDropdown.tsx
@@ -186,7 +186,7 @@ function MultiSelectDropdown(props: DropdownProps) {
     }
   }, []);
 
-  const [currentItemIndex, setCurrentItemIndex] = useState<number>(0);
+  const [currentItemIndex, setCurrentItemIndex] = useState<number>(-1);
   const btnRef = useRef<HTMLButtonElement>(null);
 
   const optionClickHandler = useCallback(
@@ -260,8 +260,11 @@ function MultiSelectDropdown(props: DropdownProps) {
                 props.options[currentItemIndex].value as string,
               );
             }
-            e.preventDefault();
+          } else {
+            setIsOpen(true);
+            setCurrentItemIndex((prev) => (prev < 0 ? 0 : prev));
           }
+          e.preventDefault();
           break;
         case "ArrowUp":
         case "Up":
@@ -272,6 +275,7 @@ function MultiSelectDropdown(props: DropdownProps) {
               return prevIndex - 1;
             });
           } else {
+            setCurrentItemIndex((prev) => (prev < 0 ? 0 : prev));
             setIsOpen(true);
           }
           break;
@@ -284,6 +288,7 @@ function MultiSelectDropdown(props: DropdownProps) {
               return prevIndex + 1;
             });
           } else {
+            setCurrentItemIndex((prev) => (prev < 0 ? 0 : prev));
             setIsOpen(true);
           }
           break;
@@ -321,7 +326,10 @@ function MultiSelectDropdown(props: DropdownProps) {
           className={props.className}
           disabled={props.disabled}
           isOpen={isOpen}
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={() => {
+            setCurrentItemIndex(-1);
+            setIsOpen(!isOpen);
+          }}
           onKeyDown={handleKeydown}
           ref={btnRef}
           role="listbox"
@@ -346,6 +354,7 @@ function MultiSelectDropdown(props: DropdownProps) {
                 key={index}
                 onClick={() => {
                   optionClickHandler(option.value as string);
+                  setCurrentItemIndex(index);
                 }}
                 role="option"
                 selected={isItemSelected(option.value)}

--- a/app/client/src/components/propertyControls/MultiSelectControl.tsx
+++ b/app/client/src/components/propertyControls/MultiSelectControl.tsx
@@ -19,7 +19,7 @@ class MultiSelectControl extends BaseControl<MultiSelectControlProps> {
     return (
       <StyledMultiSelectDropDown
         onSelect={this.onItemSelect}
-        optionWidth="187px"
+        optionWidth="260px"
         options={this.props.options}
         selectAll
         selectAllQuantifier="*"

--- a/app/client/src/components/propertyControls/StyledControls.tsx
+++ b/app/client/src/components/propertyControls/StyledControls.tsx
@@ -107,7 +107,6 @@ export const StyledDropDown = styled(Dropdown)`
 `;
 
 export const StyledMultiSelectDropDown = styled(MultiSelectDropdown)`
-  height: auto;
   background-color: ${(props) => props.theme.colors.propertyPane.buttonText};
 `;
 


### PR DESCRIPTION
## Description

Use `Tab` to focus the dropdown
`Enter` or `Space` to open dropdown
`Arrow Up` and `Arrow Down` keys to focus dropdown menu items
`Space` or `Enter` to select items
`Esc` to close dropdown menu

Fixes #10373 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually tested and Jest tests added

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feat/keyboard-accessible-multiselect-dropdown 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.23 **(0.12)** | 37.06 **(0.19)** | 35.29 **(0.3)** | 55.71 **(0.12)**
 :green_circle: | app/client/src/components/ads/MultiselectDropdown.tsx | 83.87 **(63.62)** | 70.83 **(53.33)** | 85.37 **(85.37)** | 82.14 **(60.52)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>