### PR TITLE
fix: Signposting intro modal UI issue

### DIFF
--- a/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
+++ b/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
@@ -55,7 +55,7 @@ const StyledImgWrapper = styled.div`
   text-align: center;
 `;
 
-const StyledImg = styled.img`
+const StyledImg = styled.img<{ width: number }>`
   width: ${(props) => props.width}px;
   vertical-align: middle;
 `;
@@ -129,15 +129,15 @@ export default function IntroductionModal({ close }: IntroductionModalProps) {
           <ModalBody>
             <ModalImgWrapper>
               <StyledImgWrapper className="flex">
-                <StyledImg src={getConnectDataImg()} />
-                <StyledImg src={getArrowImg()} />
+                <StyledImg src={getConnectDataImg()} width={135} />
+                <StyledImg src={getArrowImg()} width={42} />
               </StyledImgWrapper>
               <StyledImgWrapper className="flex flex-grow px-5">
-                <StyledImg src={getQueryDataImg()} />
+                <StyledImg src={getQueryDataImg()} width={330} />
               </StyledImgWrapper>
               <StyledImgWrapper className="flex pr-12">
-                <StyledImg src={getArrowImg()} />
-                <StyledImg src={getPublishAppsImg()} />
+                <StyledImg src={getArrowImg()} width={42} />
+                <StyledImg src={getPublishAppsImg()} width={92} />
               </StyledImgWrapper>
             </ModalImgWrapper>
             <ModalContentWrapper className="flex">


### PR DESCRIPTION
## Description

The signposting intro modal has images overflowing the width. Adding back image widths which where removed in https://github.com/appsmithorg/appsmith/commit/8395f5e18f9cb55ae3f8672d32cae8171854f784#diff-bc602b2a6716d7e958e76414c31fce543a15919b02a26a222805ccd7e2508786L161

Currently on release
<img width="1108" alt="current" src="https://user-images.githubusercontent.com/67054171/149452633-b82ef69c-0965-45b0-b6b5-fbdef6e8cb0b.png">

After fix
<img width="961" alt="post-fix" src="https://user-images.githubusercontent.com/67054171/149452701-2ae4b5f4-892e-4fbc-970f-5f48ce08c92c.png">


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/first-time-onboarding-image 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>