### PR TITLE
fix: Where clause UI fixes (10406)

### DIFF
--- a/app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx
+++ b/app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx
@@ -90,7 +90,7 @@ const StyledFormLabel = styled.label<{ config?: ControlProps }>`
     props.config?.controlType === "SWITCH" ||
     props.config?.controlType === "CHECKBOX"
       ? "auto;"
-      : "50vh;"} 
+      : "20vw;"} 
   margin-left: ${(props) =>
     // margin required for CHECKBOX
     props.config?.controlType === "CHECKBOX" ? "0px;" : "16px;"} 

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -85,7 +85,7 @@ function renderDropdown(props: {
       isLoading={props.isLoading}
       isMultiSelect={props?.props?.isMultiSelect}
       onSelect={props.input?.onChange}
-      optionWidth="20vw"
+      optionWidth={props.width}
       options={props.options}
       placeholder={props.props?.placeholderText}
       selected={selectedOption}

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -13,14 +13,18 @@ import { DynamicValues } from "reducers/evaluationReducers/formEvaluationReducer
 
 const DropdownSelect = styled.div`
   font-size: 14px;
-  width: 50vh;
+  width: 20vw;
 `;
 
 class DropDownControl extends BaseControl<DropDownControlProps> {
   render() {
-    let width = "50vh";
-    if (this.props.customStyles && this.props?.customStyles?.width) {
-      width = this.props?.customStyles?.width;
+    let width = "20vw";
+    if (
+      "customStyles" in this.props &&
+      !!this.props.customStyles &&
+      "width" in this.props.customStyles
+    ) {
+      width = this.props.customStyles.width;
     }
 
     // Options will be set dynamically if the config has fetchOptionsConditionally set to true
@@ -54,7 +58,8 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
 function renderDropdown(props: {
   input?: WrappedFieldInputProps;
   meta?: WrappedFieldMetaProps;
-  props: DropDownControlProps & { width?: string };
+  props: DropDownControlProps;
+  width: string;
   formName: string;
   isLoading?: boolean;
   options: DropdownOption[];
@@ -64,6 +69,8 @@ function renderDropdown(props: {
   if (_.isUndefined(props.input?.value)) {
     selectedValue = props?.props?.initialValue;
   }
+
+  console.log("Ayush", props.width);
 
   const selectedOption =
     props.options.find(
@@ -80,12 +87,12 @@ function renderDropdown(props: {
       isLoading={props.isLoading}
       isMultiSelect={props?.props?.isMultiSelect}
       onSelect={props.input?.onChange}
-      optionWidth="50vh"
+      optionWidth="20vw"
       options={props.options}
       placeholder={props.props?.placeholderText}
       selected={selectedOption}
       showLabelOnly
-      width={props?.props?.width ? props?.props?.width : "50vh"}
+      width={props.width}
     />
   );
 }

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -70,8 +70,6 @@ function renderDropdown(props: {
     selectedValue = props?.props?.initialValue;
   }
 
-  console.log("Ayush", props.width);
-
   const selectedOption =
     props.options.find(
       (option: DropdownOption) => option.value === selectedValue,

--- a/app/client/src/components/formControls/DynamicInputTextControl.tsx
+++ b/app/client/src/components/formControls/DynamicInputTextControl.tsx
@@ -57,14 +57,14 @@ export function InputText(props: {
     };
   }
 
-  let customStyle = { width: "50vh", minHeight: "38px" };
+  let customStyle = { width: "20vw", minHeight: "38px" };
   if (!!props.customStyles && _.isEmpty(props.customStyles) === false) {
     customStyle = { ...props.customStyles };
-    if (props.customStyles?.width) {
-      customStyle.width = "50vh";
+    if ("width" in props.customStyles) {
+      customStyle.width = props.customStyles.width;
     }
-    if (props.customStyles?.minHeight) {
-      customStyle.minHeight = "34px";
+    if ("minHeight" in props.customStyles) {
+      customStyle.minHeight = props.customStyles.minHeight;
     }
   }
   return (

--- a/app/client/src/components/formControls/FilePickerControl.tsx
+++ b/app/client/src/components/formControls/FilePickerControl.tsx
@@ -105,7 +105,7 @@ function RenderFilePicker(props: RenderFilePickerProps) {
     <>
       <div
         className={replayHighlightClass}
-        style={{ flexDirection: "row", display: "flex", width: "50vh" }}
+        style={{ flexDirection: "row", display: "flex", width: "20vw" }}
       >
         <StyledDiv>{props?.input?.value?.name}</StyledDiv>
         <SelectButton

--- a/app/client/src/components/formControls/FixedKeyInputControl.tsx
+++ b/app/client/src/components/formControls/FixedKeyInputControl.tsx
@@ -6,7 +6,7 @@ import TextField from "components/editorComponents/form/fields/TextField";
 import styled from "styled-components";
 
 const Wrapper = styled.div`
-  width: 50vh;
+  width: 20vw;
 `;
 
 class FixKeyInputControl extends BaseControl<FixedKeyInputControlProps> {

--- a/app/client/src/components/formControls/InputTextControl.tsx
+++ b/app/client/src/components/formControls/InputTextControl.tsx
@@ -35,7 +35,7 @@ export function InputText(props: {
   const { dataType, disabled, name, placeholder } = props;
 
   return (
-    <div data-cy={name} style={{ width: "50vh" }}>
+    <div data-cy={name} style={{ width: "20vw" }}>
       <Field
         component={renderComponent}
         datatype={dataType}

--- a/app/client/src/components/formControls/KeyValueArrayControl.tsx
+++ b/app/client/src/components/formControls/KeyValueArrayControl.tsx
@@ -111,7 +111,7 @@ function KeyValueRow(
           >
             <div
               data-replay-id={btoa(keyTextFieldName)}
-              style={{ width: "50vh" }}
+              style={{ width: "20vw" }}
             >
               <Field
                 component={renderTextInput}
@@ -129,7 +129,7 @@ function KeyValueRow(
               />
             </div>
             {!props.actionConfig && (
-              <div style={{ marginLeft: "16px", width: "50vh" }}>
+              <div style={{ marginLeft: "16px", width: "20vw" }}>
                 <div
                   data-replay-id={valueTextFieldName}
                   style={{ display: "flex", flexDirection: "row" }}

--- a/app/client/src/components/formControls/KeyValueInputControl.tsx
+++ b/app/client/src/components/formControls/KeyValueInputControl.tsx
@@ -55,7 +55,7 @@ function KeyValueRow(props: KeyValueRowProps & WrappedFieldArrayProps) {
             <FormRowWithLabel key={index} style={{ marginTop: index ? 13 : 0 }}>
               <div
                 data-replay-id={btoa(`${field}.key`)}
-                style={{ width: "50vh" }}
+                style={{ width: "20vw" }}
               >
                 <TextField name={`${field}.key`} placeholder="Key" />
               </div>
@@ -64,7 +64,7 @@ function KeyValueRow(props: KeyValueRowProps & WrappedFieldArrayProps) {
                 <div style={{ display: "flex", flexDirection: "row" }}>
                   <div
                     data-replay-id={btoa(`${field}.value`)}
-                    style={{ marginRight: 14, width: "50vh" }}
+                    style={{ marginRight: 14, width: "20vw" }}
                   >
                     <TextField name={`${field}.value`} placeholder="Value" />
                   </div>

--- a/app/client/src/components/formControls/PaginationControl.tsx
+++ b/app/client/src/components/formControls/PaginationControl.tsx
@@ -52,7 +52,7 @@ export function Pagination(props: {
   const { configProperty, customStyles, formName, name } = props;
 
   return (
-    <div data-cy={name} style={{ width: "50vh" }}>
+    <div data-cy={name} style={{ width: "20vw" }}>
       {/*  form control for Limit field */}
       <FormControlContainer>
         <FormControl

--- a/app/client/src/components/formControls/WhereClauseControl.tsx
+++ b/app/client/src/components/formControls/WhereClauseControl.tsx
@@ -50,10 +50,14 @@ const logicalFieldConfig: any = {
 };
 
 // Component for the delete Icon
-const CenteredIcon = styled(Icon)`
+const CenteredIcon = styled(Icon)<{
+  alignSelf?: string;
+  marginBottom?: string;
+}>`
   margin-left: 5px;
-  align-self: end;
-  margin-bottom: 10px;
+  align-self: ${(props) => (props.alignSelf ? props.alignSelf : "end")};
+  margin-bottom: ${(props) =>
+    props.marginBottom ? props.marginBottom : "10px"};
   &.hide {
     opacity: 0;
     pointer-events: none;
@@ -254,6 +258,8 @@ function ConditionBlock(props: any) {
                       rerenderOnEveryChange={false}
                     />
                     <CenteredIcon
+                      alignSelf={"center"}
+                      marginBottom={"-5px"}
                       name="cross"
                       onClick={(e) => {
                         e.stopPropagation();

--- a/app/client/src/components/formControls/WhereClauseControl.tsx
+++ b/app/client/src/components/formControls/WhereClauseControl.tsx
@@ -174,7 +174,6 @@ function ConditionComponent(props: any, index: number) {
 
 // This is the block which contains an operator and multiple conditions/ condition blocks
 function ConditionBlock(props: any) {
-  console.log("Ayush Main block", props.currentNestingLevel, props.maxWidth);
   const formValues: any = useSelector((state) =>
     getFormValues(props.formName)(state),
   );

--- a/app/client/src/components/formControls/WhereClauseControl.tsx
+++ b/app/client/src/components/formControls/WhereClauseControl.tsx
@@ -46,7 +46,7 @@ const logicalFieldConfig: any = {
   controlType: "DROP_DOWN",
   initialValue: "EQ",
   options: [],
-  customStyles: { width: "10vh", height: "30px" },
+  customStyles: { width: "5vw" },
 };
 
 // Component for the delete Icon
@@ -112,11 +112,9 @@ const AddMoreAction = styled.div`
 // Component to display single line of condition, includes 2 inputs and 1 dropdown
 function ConditionComponent(props: any, index: number) {
   // Custom styles have to be passed as props, otherwise the UI will be disproportional
-  const customStyles = {
-    // 15 is subtracted because the width of the operator dropdown is 15px
-    width: `${(props.maxWidth - 15) / 3}vh`,
-    height: "30px",
-  };
+
+  // 5 is subtracted because the width of the operator dropdown is 5vw
+  const unitWidth = (props.maxWidth - 5) / 5;
 
   // Labels are only displayed if the condition is the first one
   let keyLabel = "";
@@ -134,7 +132,7 @@ function ConditionComponent(props: any, index: number) {
         config={{
           ...keyFieldConfig,
           label: keyLabel,
-          customStyles,
+          customStyles: { width: `${unitWidth * 2}vw` },
           configProperty: `${props.field}.key`,
         }}
         formName={props.formName}
@@ -144,7 +142,7 @@ function ConditionComponent(props: any, index: number) {
         config={{
           ...conditionFieldConfig,
           label: conditionLabel,
-          customStyles,
+          customStyles: { width: `${unitWidth * 1}vw` },
           configProperty: `${props.field}.condition`,
           options: props.comparisonTypes,
           initialValue: props.comparisonTypes[0].value,
@@ -156,7 +154,7 @@ function ConditionComponent(props: any, index: number) {
         config={{
           ...valueFieldConfig,
           label: valueLabel,
-          customStyles,
+          customStyles: { width: `${unitWidth * 2}vw` },
           configProperty: `${props.field}.value`,
         }}
         formName={props.formName}
@@ -176,6 +174,7 @@ function ConditionComponent(props: any, index: number) {
 
 // This is the block which contains an operator and multiple conditions/ condition blocks
 function ConditionBlock(props: any) {
+  console.log("Ayush Main block", props.currentNestingLevel, props.maxWidth);
   const formValues: any = useSelector((state) =>
     getFormValues(props.formName)(state),
   );
@@ -235,6 +234,7 @@ function ConditionBlock(props: any) {
               const fieldValue: whereClauseValueType = props.fields.get(index);
               if (!!fieldValue && "children" in fieldValue) {
                 // If the value contains children in it, that means it is a ConditionBlock
+                const maxWidth = props.maxWidth - 7.5;
                 return (
                   <ConditionBox>
                     <FieldArray
@@ -242,7 +242,7 @@ function ConditionBlock(props: any) {
                       key={`${field}.children`}
                       name={`${field}.children`}
                       props={{
-                        maxWidth: props.maxWidth - 15,
+                        maxWidth,
                         configProperty: `${field}`,
                         formName: props.formName,
                         logicalTypes: props.logicalTypes,
@@ -322,7 +322,7 @@ export default function WhereClauseControl(props: WhereClauseControlProps) {
   } = props;
 
   // Max width is designed in a way that the proportion stays same even after nesting
-  const maxWidth = 105;
+  const maxWidth = 55;
   return (
     <FieldArray
       component={ConditionBlock}

--- a/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
@@ -29,8 +29,8 @@ const CurlImportFormContainer = styled.div`
 
   .textAreaStyles {
     margin-bottom: 20px;
-    min-height: 50vh;
-    max-height: 50vh;
+    min-height: 20vw;
+    max-height: 20vw;
     padding: 10px;
     min-width: 100%;
     max-width: 100%;

--- a/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
@@ -29,8 +29,8 @@ const CurlImportFormContainer = styled.div`
 
   .textAreaStyles {
     margin-bottom: 20px;
-    min-height: 20vw;
-    max-height: 20vw;
+    min-height: 50vh;
+    max-height: 50vh;
     padding: 10px;
     min-width: 100%;
     max-width: 100%;

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -772,7 +772,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
           )}
         </FormInputContainer>
         <FormInputContainer>
-          <div style={{ width: "50vh" }}>
+          <div style={{ width: "20vw" }}>
             <FormLabel>
               Redirect URL
               <br />


### PR DESCRIPTION
## Description

The ADS changes caused the UI for where clause component to break. The reason was the customStyles option is not getting properly extracted in the control component.

Also replaced `vh` with `vw` for the width of the components as per the guidelines from ADS.

Fixes #10406 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/10406-where-clause-ui-fixes 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.98 **(-0.01)** | 36.72 **(0.04)** | 34.7 **(-0.01)** | 55.49 **(-0.01)**
 :green_circle: | app/client/src/components/formControls/DropDownControl.tsx | 44.83 **(0)** | 3.28 **(1.15)** | 20 **(0)** | 42.86 **(0)**
 :green_circle: | app/client/src/components/formControls/DynamicInputTextControl.tsx | 86.79 **(0)** | 55 **(15.71)** | 83.33 **(0)** | 86.54 **(0)**
 :red_circle: | app/client/src/components/formControls/WhereClauseControl.tsx | 32.81 **(-1.62)** | 35.9 **(-4.1)** | 0 **(0)** | 32.81 **(-1.62)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>