### PR TITLE
test: Adding fix for Table_widget_add_button spec's test

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
@@ -49,7 +49,14 @@ describe("Table Widget property pane feature validation", function() {
     // Open column details of "id".
     cy.editColumn("id");
     // Changing column data type to "Button"
-    cy.changeColumnType("Icon Button");
+    cy.get(commonlocators.changeColType)
+      .last()
+      .click();
+    cy.get(".t--dropdown-option")
+      .children()
+      .contains("Plain Text")
+      .click();
+    cy.changeColumnType("Button");
     const color1 = "rgb(255, 0, 0)";
     cy.get(widgetsPage.buttonColor)
       .click({ force: true })

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
@@ -49,14 +49,14 @@ describe("Table Widget property pane feature validation", function() {
     // Open column details of "id".
     cy.editColumn("id");
     // Changing column data type to "Button"
-    cy.get(commonlocators.changeColType)
+    /* cy.get(commonlocators.changeColType)
       .last()
       .click();
     cy.get(".t--dropdown-option")
       .children()
       .contains("Plain Text")
       .click();
-    cy.changeColumnType("Button");
+    cy.changeColumnType("Button"); */
     const color1 = "rgb(255, 0, 0)";
     cy.get(widgetsPage.buttonColor)
       .click({ force: true })

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
@@ -49,7 +49,7 @@ describe("Table Widget property pane feature validation", function() {
     // Open column details of "id".
     cy.editColumn("id");
     // Changing column data type to "Button"
-    cy.changeColumnType("Button");
+    cy.changeColumnType("Icon Button");
     const color1 = "rgb(255, 0, 0)";
     cy.get(widgetsPage.buttonColor)
       .click({ force: true })


### PR DESCRIPTION

## Description

This PR fixes failing button color validation test of Table_widget_add_button spec.

Fixes # (issue)



## Type of change



## How Has This Been Tested?

locally

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: FlakyTestsFixes 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.96 **(-0.01)** | 36.64 **(-0.01)** | 34.68 **(0)** | 55.47 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>