### PR TITLE
fix: added all js object functions as part of global data while checking isAsync

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -991,12 +991,6 @@ export default class DataTreeEvaluator {
             if (typeof unEvalValue === "function") {
               const params = getParams(unEvalValue);
               const functionString = unEvalValue.toString();
-              actions.push({
-                name: unEvalFunc,
-                body: functionString,
-                arguments: params,
-                isAsync: isFunctionAsync(unEvalValue, unEvalDataTree),
-              });
               _.set(
                 this.resolvedFunctions,
                 `${entityName}.${unEvalFunc}`,
@@ -1007,6 +1001,12 @@ export default class DataTreeEvaluator {
                 `${entityName}.${unEvalFunc}`,
                 functionString,
               );
+              actions.push({
+                name: unEvalFunc,
+                body: functionString,
+                arguments: params,
+                value: unEvalValue,
+              });
             } else {
               variables.push({
                 name: unEvalFunc,
@@ -1019,7 +1019,25 @@ export default class DataTreeEvaluator {
               );
             }
           });
-          const parsedBody = { body: entity.body, actions, variables };
+
+          const modifiedActions = actions.map((action: any) => {
+            return {
+              name: action.name,
+              body: action.body,
+              arguments: action.arguments,
+              isAsync: isFunctionAsync(
+                action.value,
+                unEvalDataTree,
+                this.resolvedFunctions,
+              ),
+            };
+          });
+
+          const parsedBody = {
+            body: entity.body,
+            actions: modifiedActions,
+            variables,
+          };
           _.set(jsUpdates, `${entityName}`, {
             parsedBody,
             id: entity.actionId,

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -310,7 +310,11 @@ export async function evaluateAsync(
   })();
 }
 
-export function isFunctionAsync(userFunction: unknown, dataTree: DataTree) {
+export function isFunctionAsync(
+  userFunction: unknown,
+  dataTree: DataTree,
+  resolvedFunctions: Record<string, any>,
+) {
   return (function() {
     /**** Setting the eval context ****/
     const GLOBAL_DATA: Record<string, any> = {
@@ -323,6 +327,17 @@ export function isFunctionAsync(userFunction: unknown, dataTree: DataTree) {
     Object.keys(dataTreeWithFunctions).forEach((datum) => {
       GLOBAL_DATA[datum] = dataTreeWithFunctions[datum];
     });
+    if (!isEmpty(resolvedFunctions)) {
+      Object.keys(resolvedFunctions).forEach((datum: any) => {
+        const resolvedObject = resolvedFunctions[datum];
+        Object.keys(resolvedObject).forEach((key: any) => {
+          const dataTreeKey = GLOBAL_DATA[datum];
+          if (dataTreeKey) {
+            dataTreeKey[key] = resolvedObject[key];
+          }
+        });
+      });
+    }
     // Set it to self so that the eval function can have access to it
     // as global data. This is what enables access all appsmith
     // entity properties from the global context
@@ -331,6 +346,7 @@ export function isFunctionAsync(userFunction: unknown, dataTree: DataTree) {
       // @ts-ignore: No types available
       self[key] = GLOBAL_DATA[key];
     });
+
     try {
       if (typeof userFunction === "function") {
         const returnValue = userFunction();

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -6248,6 +6248,11 @@ cypress-real-events@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.5.1.tgz#5eeb86d2a7aad9aa6d5271e288a23e46373915cd"
 
+cypress-wait-until@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
+  integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
+
 cypress-xpath@^1.4.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/cypress-xpath/-/cypress-xpath-1.6.0.tgz"


### PR DESCRIPTION
## Description
When any js object function was referred to in any other js object function. it was throwing an error that `function does not exist`
The problem was while checking is a function asych, we were not adding existing functions which are stored as part of resolvedFunctions hence it was not getting the reference. I have added all resolvedFunctions as part of global data to avoid reference errors

Fixes #10150 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: critical-10150 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.96 **(-0.01)** | 36.64 **(-0.01)** | 34.67 **(-0.01)** | 55.47 **(-0.01)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 77.58 **(-0.25)** | 61.15 **(0)** | 75 **(-0.86)** | 77.32 **(-0.27)**
 :red_circle: | app/client/src/workers/evaluate.ts | 89.34 **(-4.57)** | 72.22 **(-5.91)** | 82.61 **(-7.87)** | 88.79 **(-4.79)**</details>