### PR TITLE
fix: App crashes when a modal has a filepicker?

### DIFF
--- a/app/client/src/widgets/FilepickerWidget/widget/index.tsx
+++ b/app/client/src/widgets/FilepickerWidget/widget/index.tsx
@@ -14,6 +14,7 @@ import Dashboard from "@uppy/dashboard";
 import shallowequal from "shallowequal";
 import _ from "lodash";
 import FileDataTypes from "./FileDataTypes";
+import log from "loglevel";
 import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
 
 class FilePickerWidget extends BaseWidget<
@@ -328,14 +329,17 @@ class FilePickerWidget extends BaseWidget<
       .use(Url, { companionUrl: "https://companion.uppy.io" })
       .use(OneDrive, {
         companionUrl: "https://companion.uppy.io/",
-      })
-      .use(Webcam, {
+      });
+
+    if (location.protocol === "https:") {
+      this.state.uppy.use(Webcam, {
         onBeforeSnapshot: () => Promise.resolve(),
         countdown: false,
         mirror: true,
         facingMode: "user",
         locale: {},
       });
+    }
 
     this.state.uppy.on("file-removed", (file: any) => {
       const updatedFiles = this.props.selectedFiles
@@ -440,7 +444,11 @@ class FilePickerWidget extends BaseWidget<
   }
 
   componentDidMount() {
-    this.initializeUppyEventListeners();
+    try {
+      this.initializeUppyEventListeners();
+    } catch (e) {
+      log.debug("Error in initializing uppy");
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## Description
- Due to our recent changes, filepicker started crashing on the self-hosted instances that don't have an SSL certificate. The filepicker was making a call to a function (due to webam plugin of @uppy) `enumerateDevice` that is only available on websites that has an SSL certificate. 
- This PR adds a try-catch and only adds the webcam plugin of @uppy only when the site is loaded over https.

Fixes #10283 

## Type of change
- Bug fix 

## How Has This Been Tested?
- Manully tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/http-issue-with-filepicker-v1 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/widgets/FilepickerWidget/widget/index.tsx | 37.36 **(-1.01)** | 0 **(0)** | 21.43 **(0)** | 36.67 **(-0.98)**</details>