### PR TITLE
fix: Gracefully handle defaultResourceIds exception

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ActionViewDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ActionViewDTO.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.dtos;
 
 import com.appsmith.external.models.DefaultResources;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -21,6 +22,7 @@ public class ActionViewDTO {
     Integer timeoutInMillisecond;
     Boolean confirmBeforeExecute;
     Set<String> jsonPathKeys;
+    @JsonIgnore
     DefaultResources defaultResources;
 
     // Overriding the getter to ensure that for actions missing action configuration, the timeout is

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/GlobalExceptionHandler.java
@@ -10,7 +10,6 @@ import io.sentry.SentryLevel;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,14 +33,13 @@ import java.util.Map;
 @Slf4j
 public class GlobalExceptionHandler {
 
-    public void doLog(Throwable error, String source) {
+    private void doLog(Throwable error) {
         log.error("", error);
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter printWriter = new PrintWriter(stringWriter);
         error.printStackTrace(printWriter);
         String stringStackTrace = stringWriter.toString();
-        String src = StringUtils.hasLength(source) ? source : "appsmith-internal-server";
 
         Sentry.configureScope(
                 scope -> {
@@ -51,7 +49,7 @@ public class GlobalExceptionHandler {
                      * */
                     scope.setExtra("Stack Trace", stringStackTrace);
                     scope.setLevel(SentryLevel.ERROR);
-                    scope.setTag("source", src);
+                    scope.setTag("source", "appsmith-internal-server");
                 }
         );
 
@@ -62,10 +60,6 @@ public class GlobalExceptionHandler {
         } else {
             Sentry.captureException(error);
         }
-    }
-
-    private void doLog(Throwable error) {
-        this.doLog(error, null);
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
@@ -71,7 +71,7 @@ public class ResponseUtils {
                 || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
                 || StringUtils.isEmpty(defaultResourceIds.getPageId())
         ) {
-            log.debug("Unable to find default ids for page: {}", newPage.getId());
+            log.error("Unable to find default ids for page: {}", newPage.getId());
             globalExceptionHandler
                     .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "page", newPage.getId()), "defaultResourceIds");
 
@@ -100,7 +100,7 @@ public class ResponseUtils {
         List<PageNameIdDTO> pageNameIdList = applicationPages.getPages();
         for (PageNameIdDTO page : pageNameIdList) {
             if (StringUtils.isEmpty(page.getDefaultPageId())) {
-                log.debug("Unable to find default pageId for applicationPage: {}", page.getId());
+                log.error("Unable to find default pageId for applicationPage: {}", page.getId());
                 globalExceptionHandler
                         .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "applicationPage", page.getId()), "defaultResourcesIds");
                 continue;
@@ -194,7 +194,7 @@ public class ResponseUtils {
         if (defaultResourceIds == null
                 || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
                 || StringUtils.isEmpty(defaultResourceIds.getActionId())) {
-            log.debug("Unable to find default ids for newAction: {}", newAction.getId());
+            log.error("Unable to find default ids for newAction: {}", newAction.getId());
 
             globalExceptionHandler
                     .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "newAction", newAction.getId()), "defaultResourcesIds");
@@ -225,7 +225,7 @@ public class ResponseUtils {
         if (defaultResourceIds == null
                 || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
                 || StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
-            log.debug("Unable to find default ids for actionCollection: {}", actionCollection.getId());
+            log.error("Unable to find default ids for actionCollection: {}", actionCollection.getId());
 
             globalExceptionHandler
                     .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionCollection", actionCollection.getId()), "defaultResourcesIds");

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
@@ -17,7 +17,6 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.PageNameIdDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
-import com.appsmith.server.exceptions.GlobalExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -30,8 +29,6 @@ import java.util.List;
 @Slf4j
 @Component
 public class ResponseUtils {
-
-    private final GlobalExceptionHandler globalExceptionHandler;
 
     public PageDTO updatePageDTOWithDefaultResources(PageDTO page) {
         DefaultResources defaultResourceIds = page.getDefaultResources();
@@ -71,9 +68,11 @@ public class ResponseUtils {
                 || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
                 || StringUtils.isEmpty(defaultResourceIds.getPageId())
         ) {
-            log.error("Unable to find default ids for page: {}", newPage.getId());
-            globalExceptionHandler
-                    .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "page", newPage.getId()), "defaultResourceIds");
+            log.error(
+                    "Unable to find default ids for page: {}",
+                    newPage.getId(),
+                    new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "page", newPage.getId())
+            );
 
             if (defaultResourceIds == null) {
                 return newPage;
@@ -100,9 +99,11 @@ public class ResponseUtils {
         List<PageNameIdDTO> pageNameIdList = applicationPages.getPages();
         for (PageNameIdDTO page : pageNameIdList) {
             if (StringUtils.isEmpty(page.getDefaultPageId())) {
-                log.error("Unable to find default pageId for applicationPage: {}", page.getId());
-                globalExceptionHandler
-                        .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "applicationPage", page.getId()), "defaultResourcesIds");
+                log.error(
+                        "Unable to find default pageId for applicationPage: {}",
+                        page.getId(),
+                        new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "applicationPage", page.getId())
+                );
                 continue;
             }
             page.setId(page.getDefaultPageId());
@@ -194,10 +195,12 @@ public class ResponseUtils {
         if (defaultResourceIds == null
                 || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
                 || StringUtils.isEmpty(defaultResourceIds.getActionId())) {
-            log.error("Unable to find default ids for newAction: {}", newAction.getId());
+            log.error(
+                    "Unable to find default ids for newAction: {}",
+                    newAction.getId(),
+                    new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "newAction", newAction.getId())
+            );
 
-            globalExceptionHandler
-                    .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "newAction", newAction.getId()), "defaultResourcesIds");
             if (defaultResourceIds == null) {
                 return newAction;
             }
@@ -225,10 +228,12 @@ public class ResponseUtils {
         if (defaultResourceIds == null
                 || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
                 || StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
-            log.error("Unable to find default ids for actionCollection: {}", actionCollection.getId());
+            log.error(
+                    "Unable to find default ids for actionCollection: {}",
+                    actionCollection.getId(),
+                    new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionCollection", actionCollection.getId())
+            );
 
-            globalExceptionHandler
-                    .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionCollection", actionCollection.getId()), "defaultResourcesIds");
             if (defaultResourceIds == null) {
                 return actionCollection;
             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
@@ -17,11 +17,12 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.dtos.PageNameIdDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.exceptions.GlobalExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -30,36 +31,62 @@ import java.util.List;
 @Component
 public class ResponseUtils {
 
-    public PageDTO updatePageDTOWithDefaultResources(PageDTO page) {
-        DefaultResources defaults = page.getDefaultResources();
-        if (defaults == null
-                || StringUtils.isEmpty(defaults.getApplicationId())
-                || StringUtils.isEmpty(defaults.getPageId())) {
+    private final GlobalExceptionHandler globalExceptionHandler;
 
-            log.debug("Unable to find default ids for page: {}", page.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "page", page.getId());
+    public PageDTO updatePageDTOWithDefaultResources(PageDTO page) {
+        DefaultResources defaultResourceIds = page.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
+                || StringUtils.isEmpty(defaultResourceIds.getPageId())) {
+
+            if (defaultResourceIds == null) {
+                return page;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getApplicationId())) {
+                defaultResourceIds.setApplicationId(page.getApplicationId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getPageId())) {
+                defaultResourceIds.setPageId(page.getId());
+            }
         }
-        page.setApplicationId(defaults.getApplicationId());
-        page.setId(defaults.getPageId());
+        page.setApplicationId(defaultResourceIds.getApplicationId());
+        page.setId(defaultResourceIds.getPageId());
 
         page.getLayouts()
                 .stream().filter(layout -> !CollectionUtils.isEmpty(layout.getLayoutOnLoadActions()))
                 .forEach(layout -> layout.getLayoutOnLoadActions()
                         .forEach(dslActionDTOS -> dslActionDTOS
-                                .forEach(actionDTO -> actionDTO.setId(actionDTO.getDefaultActionId())))
+                                .forEach(actionDTO -> {
+                                    if (!StringUtils.isEmpty(actionDTO.getDefaultActionId())) {
+                                        actionDTO.setId(actionDTO.getDefaultActionId());
+                                    }
+                                }))
                 );
-
         return page;
     }
 
     public NewPage updateNewPageWithDefaultResources(NewPage newPage) {
-        DefaultResources defaultResources = newPage.getDefaultResources();
-        if (defaultResources == null) {
+        DefaultResources defaultResourceIds = newPage.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
+                || StringUtils.isEmpty(defaultResourceIds.getPageId())
+        ) {
             log.debug("Unable to find default ids for page: {}", newPage.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "page", newPage.getId());
+            globalExceptionHandler
+                    .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "page", newPage.getId()), "defaultResourceIds");
+
+            if (defaultResourceIds == null) {
+                return newPage;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getApplicationId())) {
+                defaultResourceIds.setApplicationId(newPage.getApplicationId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getPageId())) {
+                defaultResourceIds.setPageId(newPage.getId());
+            }
         }
-        newPage.setId(defaultResources.getPageId());
-        newPage.setApplicationId(defaultResources.getApplicationId());
+        newPage.setId(defaultResourceIds.getPageId());
+        newPage.setApplicationId(defaultResourceIds.getApplicationId());
         if (newPage.getUnpublishedPage() != null) {
             newPage.setUnpublishedPage(this.updatePageDTOWithDefaultResources(newPage.getUnpublishedPage()));
         }
@@ -71,29 +98,44 @@ public class ResponseUtils {
 
     public ApplicationPagesDTO updateApplicationPagesDTOWithDefaultResources(ApplicationPagesDTO applicationPages) {
         List<PageNameIdDTO> pageNameIdList = applicationPages.getPages();
-        pageNameIdList.forEach(page -> {
+        for (PageNameIdDTO page : pageNameIdList) {
             if (StringUtils.isEmpty(page.getDefaultPageId())) {
                 log.debug("Unable to find default pageId for applicationPage: {}", page.getId());
-                throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "applicationPage", page.getId());
+                globalExceptionHandler
+                        .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "applicationPage", page.getId()), "defaultResourcesIds");
+                continue;
             }
             page.setId(page.getDefaultPageId());
-        });
+        }
         return applicationPages;
     }
 
     public ActionDTO updateActionDTOWithDefaultResources(ActionDTO action) {
-        DefaultResources defaults = action.getDefaultResources();
-        if (defaults == null
-                || StringUtils.isEmpty(defaults.getApplicationId())
-                || StringUtils.isEmpty(defaults.getPageId())
-                || StringUtils.isEmpty(defaults.getActionId())) {
-            log.debug("Unable to find default ids for action: {}", action.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "action", action.getId());
+        DefaultResources defaultResourceIds = action.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
+                || StringUtils.isEmpty(defaultResourceIds.getPageId())
+                || StringUtils.isEmpty(defaultResourceIds.getActionId())) {
+
+            if (defaultResourceIds == null) {
+                return action;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getApplicationId())) {
+                defaultResourceIds.setApplicationId(action.getApplicationId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getPageId())) {
+                defaultResourceIds.setPageId(action.getPageId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getActionId())) {
+                defaultResourceIds.setActionId(action.getId());
+            }
         }
-        action.setApplicationId(defaults.getApplicationId());
-        action.setPageId(defaults.getPageId());
-        action.setId(defaults.getActionId());
-        action.setCollectionId(defaults.getCollectionId());
+        action.setApplicationId(defaultResourceIds.getApplicationId());
+        action.setPageId(defaultResourceIds.getPageId());
+        action.setId(defaultResourceIds.getActionId());
+        if (!StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
+            action.setCollectionId(defaultResourceIds.getCollectionId());
+        }
         return action;
     }
 
@@ -104,7 +146,12 @@ public class ResponseUtils {
         }
         if (!CollectionUtils.isEmpty(layout.getLayoutOnLoadActions())) {
             layout.getLayoutOnLoadActions().forEach(layoutOnLoadAction ->
-                    layoutOnLoadAction.forEach(onLoadAction -> onLoadAction.setId(onLoadAction.getDefaultActionId())));
+                    layoutOnLoadAction.forEach(onLoadAction -> {
+                        if (!StringUtils.isEmpty(onLoadAction.getDefaultActionId())) {
+                            onLoadAction.setId(onLoadAction.getDefaultActionId());
+                        }
+                    })
+            );
         }
         return layout;
     }
@@ -112,31 +159,58 @@ public class ResponseUtils {
     public Layout updateLayoutWithDefaultResources(Layout layout) {
         if (!CollectionUtils.isEmpty(layout.getLayoutOnLoadActions())) {
             layout.getLayoutOnLoadActions().forEach(layoutOnLoadAction ->
-                    layoutOnLoadAction.forEach(onLoadAction -> onLoadAction.setId(onLoadAction.getDefaultActionId())));
+                    layoutOnLoadAction.forEach(onLoadAction -> {
+                        if (!StringUtils.isEmpty(onLoadAction.getDefaultActionId())) {
+                            onLoadAction.setId(onLoadAction.getDefaultActionId());
+                        }
+                    }));
         }
         return layout;
     }
 
     public ActionViewDTO updateActionViewDTOWithDefaultResources(ActionViewDTO viewDTO) {
-        DefaultResources defaults = viewDTO.getDefaultResources();
-        if (defaults == null
-                || StringUtils.isEmpty(defaults.getActionId())) {
-            log.debug("Unable to find default ids for actionViewDTO: {}", viewDTO.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionView", viewDTO.getId());
+        DefaultResources defaultResourceIds = viewDTO.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getPageId())
+                || StringUtils.isEmpty(defaultResourceIds.getActionId())) {
+
+            if (defaultResourceIds == null) {
+                return viewDTO;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getPageId())) {
+                defaultResourceIds.setPageId(viewDTO.getPageId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getActionId())) {
+                defaultResourceIds.setActionId(viewDTO.getId());
+            }
         }
-        viewDTO.setId(defaults.getActionId());
-        viewDTO.setPageId(defaults.getPageId());
+        viewDTO.setId(defaultResourceIds.getActionId());
+        viewDTO.setPageId(defaultResourceIds.getPageId());
         return viewDTO;
     }
 
     public NewAction updateNewActionWithDefaultResources(NewAction newAction) {
-        DefaultResources defaultResources = newAction.getDefaultResources();
-        if (defaultResources == null) {
+        DefaultResources defaultResourceIds = newAction.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
+                || StringUtils.isEmpty(defaultResourceIds.getActionId())) {
             log.debug("Unable to find default ids for newAction: {}", newAction.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "action", newAction.getId());
+
+            globalExceptionHandler
+                    .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "newAction", newAction.getId()), "defaultResourcesIds");
+            if (defaultResourceIds == null) {
+                return newAction;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getApplicationId())) {
+                defaultResourceIds.setApplicationId(newAction.getApplicationId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getActionId())) {
+                defaultResourceIds.setActionId(newAction.getId());
+            }
         }
-        newAction.setId(defaultResources.getActionId());
-        newAction.setApplicationId(defaultResources.getApplicationId());
+
+        newAction.setId(defaultResourceIds.getActionId());
+        newAction.setApplicationId(defaultResourceIds.getApplicationId());
         if (newAction.getUnpublishedAction() != null) {
             newAction.setUnpublishedAction(this.updateActionDTOWithDefaultResources(newAction.getUnpublishedAction()));
         }
@@ -147,13 +221,26 @@ public class ResponseUtils {
     }
 
     public ActionCollection updateActionCollectionWithDefaultResources(ActionCollection actionCollection) {
-        DefaultResources defaultResources = actionCollection.getDefaultResources();
-        if (defaultResources == null) {
+        DefaultResources defaultResourceIds = actionCollection.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
+                || StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
             log.debug("Unable to find default ids for actionCollection: {}", actionCollection.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionCollection", actionCollection.getId());
+
+            globalExceptionHandler
+                    .doLog(new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionCollection", actionCollection.getId()), "defaultResourcesIds");
+            if (defaultResourceIds == null) {
+                return actionCollection;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getApplicationId())) {
+                defaultResourceIds.setApplicationId(actionCollection.getApplicationId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
+                defaultResourceIds.setCollectionId(actionCollection.getId());
+            }
         }
-        actionCollection.setId(defaultResources.getCollectionId());
-        actionCollection.setApplicationId(defaultResources.getApplicationId());
+        actionCollection.setId(defaultResourceIds.getCollectionId());
+        actionCollection.setApplicationId(defaultResourceIds.getApplicationId());
         if (actionCollection.getUnpublishedCollection() != null) {
             actionCollection.setUnpublishedCollection(this.updateCollectionDTOWithDefaultResources(actionCollection.getUnpublishedCollection()));
         }
@@ -164,17 +251,28 @@ public class ResponseUtils {
     }
 
     public ActionCollectionDTO updateCollectionDTOWithDefaultResources(ActionCollectionDTO collection) {
-        DefaultResources defaults = collection.getDefaultResources();
-        if (defaults == null
-                || StringUtils.isEmpty(defaults.getApplicationId())
-                || StringUtils.isEmpty(defaults.getPageId())
-                || StringUtils.isEmpty(defaults.getCollectionId())) {
-            log.debug("Unable to find default ids for actionCollection: {}", collection.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionCollection", collection.getId());
+        DefaultResources defaultResourceIds = collection.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
+                || StringUtils.isEmpty(defaultResourceIds.getPageId())
+                || StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
+
+            if (defaultResourceIds == null) {
+                return collection;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getApplicationId())) {
+                defaultResourceIds.setApplicationId(collection.getApplicationId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getPageId())) {
+                defaultResourceIds.setPageId(collection.getPageId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
+                defaultResourceIds.setCollectionId(collection.getId());
+            }
         }
-        collection.setApplicationId(defaults.getApplicationId());
-        collection.setPageId(defaults.getPageId());
-        collection.setId(defaults.getCollectionId());
+        collection.setApplicationId(defaultResourceIds.getApplicationId());
+        collection.setPageId(defaultResourceIds.getPageId());
+        collection.setId(defaultResourceIds.getCollectionId());
 
         // Update actions within the collection
         collection.getActions().forEach(this::updateActionDTOWithDefaultResources);
@@ -184,15 +282,28 @@ public class ResponseUtils {
     }
 
     public ActionCollectionViewDTO updateActionCollectionViewDTOWithDefaultResources(ActionCollectionViewDTO viewDTO) {
-        DefaultResources defaults = viewDTO.getDefaultResources();
-        if (defaults == null
-                || StringUtils.isEmpty(defaults.getCollectionId())) {
-            log.debug("Unable to find default ids for actionCollectionViewDTO: {}", viewDTO.getId());
-            throw new AppsmithException(AppsmithError.DEFAULT_RESOURCES_UNAVAILABLE, "actionCollectionView", viewDTO.getId());
+        DefaultResources defaultResourceIds = viewDTO.getDefaultResources();
+        if (defaultResourceIds == null
+                || StringUtils.isEmpty(defaultResourceIds.getPageId())
+                || StringUtils.isEmpty(defaultResourceIds.getApplicationId())
+                || StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
+
+            if (defaultResourceIds == null) {
+                return viewDTO;
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getApplicationId())) {
+                defaultResourceIds.setApplicationId(viewDTO.getApplicationId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getPageId())) {
+                defaultResourceIds.setPageId(viewDTO.getPageId());
+            }
+            if (StringUtils.isEmpty(defaultResourceIds.getCollectionId())) {
+                defaultResourceIds.setCollectionId(viewDTO.getId());
+            }
         }
-        viewDTO.setId(defaults.getCollectionId());
-        viewDTO.setApplicationId(defaults.getApplicationId());
-        viewDTO.setPageId(defaults.getPageId());
+        viewDTO.setId(defaultResourceIds.getCollectionId());
+        viewDTO.setApplicationId(defaultResourceIds.getApplicationId());
+        viewDTO.setPageId(defaultResourceIds.getPageId());
         viewDTO.getActions().forEach(this::updateActionDTOWithDefaultResources);
         return viewDTO;
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ResponseUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ResponseUtilsTest.java
@@ -1,0 +1,106 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.external.helpers.BeanCopyUtils;
+import com.appsmith.server.domains.ActionCollection;
+import com.appsmith.server.domains.NewAction;
+import com.appsmith.server.domains.NewPage;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import lombok.SneakyThrows;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.File;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@DirtiesContext
+public class ResponseUtilsTest {
+
+    @Autowired
+    ResponseUtils responseUtils;
+
+    private static final File mockObjects = new File("src/test/resources/test_assets/ResponseUtilsTest/mockObjects.json");
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static JsonNode jsonNode;
+    Gson gson = new Gson();
+
+    @SneakyThrows
+    @Before
+    public void setup() {
+        jsonNode = objectMapper.readValue(mockObjects, JsonNode.class);
+    }
+
+    @Test
+    public void getPage_whenDefaultIdsNull_returnsSamePage() {
+        final NewPage newPage = objectMapper.convertValue(jsonNode.get("newPage"), NewPage.class);
+        newPage.setDefaultResources(null);
+        Assert.assertEquals(newPage, responseUtils.updateNewPageWithDefaultResources(newPage));
+    }
+
+    @Test
+    public void getPage_withDefaultIdsPresent_returnsUpdatedPage() {
+        NewPage newPage = gson.fromJson(String.valueOf(jsonNode.get("newPage")), NewPage.class);
+
+        final NewPage newPageCopy = new NewPage();
+        BeanCopyUtils.copyNestedNonNullProperties(newPage, newPageCopy);
+        responseUtils.updateNewPageWithDefaultResources(newPage);
+        Assert.assertNotEquals(newPageCopy, newPage);
+        Assert.assertEquals(newPageCopy.getDefaultResources().getPageId(), newPage.getId());
+        Assert.assertEquals(newPageCopy.getDefaultResources().getApplicationId(), newPage.getApplicationId());
+    }
+
+    @Test
+    public void getAction_whenDefaultIdsNull_returnsSameAction() {
+        final NewAction newAction = objectMapper.convertValue(jsonNode.get("newAction"), NewAction.class);
+        newAction.setDefaultResources(null);
+        Assert.assertEquals(newAction, responseUtils.updateNewActionWithDefaultResources(newAction));
+    }
+
+    @Test
+    public void getAction_withDefaultIdsPresent_returnsUpdatedAction() {
+        NewAction newAction = gson.fromJson(String.valueOf(jsonNode.get("newAction")), NewAction.class);
+
+        final NewAction newActionCopy = new NewAction();
+        BeanCopyUtils.copyNestedNonNullProperties(newAction, newActionCopy);
+        responseUtils.updateNewActionWithDefaultResources(newAction);
+        Assert.assertNotEquals(newActionCopy, newAction);
+        Assert.assertEquals(newActionCopy.getDefaultResources().getActionId(), newAction.getId());
+        Assert.assertEquals(newActionCopy.getDefaultResources().getApplicationId(), newAction.getApplicationId());
+
+        Assert.assertEquals(newActionCopy.getUnpublishedAction().getDefaultResources().getPageId(), newAction.getUnpublishedAction().getPageId());
+        Assert.assertEquals(newActionCopy.getUnpublishedAction().getDefaultResources().getCollectionId(), newAction.getUnpublishedAction().getCollectionId());
+
+        Assert.assertEquals(newActionCopy.getPublishedAction().getDefaultResources().getPageId(), newAction.getPublishedAction().getPageId());
+        Assert.assertEquals(newActionCopy.getPublishedAction().getDefaultResources().getCollectionId(), newAction.getPublishedAction().getCollectionId());
+    }
+
+    @Test
+    public void getActionCollection_whenDefaultIdsNull_returnsSameActionCollection() {
+        final ActionCollection actionCollection = objectMapper.convertValue(jsonNode.get("actionCollection"), ActionCollection.class);
+        actionCollection.setDefaultResources(null);
+        Assert.assertEquals(actionCollection, responseUtils.updateActionCollectionWithDefaultResources(actionCollection));
+    }
+
+    @Test
+    public void getActionCollection_withDefaultIdsPresent_returnsUpdatedActionCollection() {
+        ActionCollection actionCollection = gson.fromJson(String.valueOf(jsonNode.get("actionCollection")), ActionCollection.class);
+
+        final ActionCollection actionCollectionCopy = new ActionCollection();
+        BeanCopyUtils.copyNestedNonNullProperties(actionCollection, actionCollectionCopy);
+        responseUtils.updateActionCollectionWithDefaultResources(actionCollection);
+        Assert.assertNotEquals(actionCollectionCopy, actionCollection);
+        Assert.assertEquals(actionCollectionCopy.getDefaultResources().getCollectionId(), actionCollection.getId());
+        Assert.assertEquals(actionCollectionCopy.getDefaultResources().getApplicationId(), actionCollection.getApplicationId());
+
+        Assert.assertEquals(actionCollectionCopy.getUnpublishedCollection().getDefaultResources().getPageId(), actionCollection.getUnpublishedCollection().getPageId());
+        Assert.assertEquals(actionCollectionCopy.getPublishedCollection().getDefaultResources().getPageId(), actionCollection.getPublishedCollection().getPageId());
+    }
+}

--- a/app/server/appsmith-server/src/test/resources/test_assets/ResponseUtilsTest/mockObjects.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ResponseUtilsTest/mockObjects.json
@@ -1,0 +1,55 @@
+{
+  "newPage": {
+    "id": "testPageId",
+    "applicationId": "testApplicationId",
+    "defaultResources": {
+      "pageId" : "defaultTestPageId",
+      "applicationId": "defaultApplicationId"
+    }
+  },
+  "newAction": {
+    "id": "testActionId",
+    "applicationId": "testApplicationId",
+    "unpublishedAction": {
+      "pageId": "testPageId",
+      "collectionId": "testCollectionId",
+      "defaultResources": {
+        "pageId": "defaultTestPageIdUnpublished",
+        "collectionId": "defaultTestCollectionIdUnpublished"
+      }
+    },
+    "publishedAction": {
+      "pageId": "testPageId",
+      "collectionId": "testCollectionId",
+      "defaultResources": {
+        "pageId": "defaultTestPageIdPublished",
+        "collectionId": "defaultTestCollectionIdPublished"
+      }
+    },
+    "defaultResources": {
+      "actionId": "defaultTestActionId",
+      "applicationId": "defaultApplicationId"
+    }
+  },
+  "actionCollection": {
+    "id": "testCollectionId",
+    "applicationId": "testApplicationId",
+    "organizationId": "testOrganizationId",
+    "unpublishedCollection": {
+      "pageId": "testPageIdUnpublished",
+      "defaultResources": {
+        "pageId": "defaultTestPageIdUnpublished"
+      }
+    },
+    "publishedCollection": {
+      "pageId": "testPageIdPublished",
+      "defaultResources": {
+        "pageId": "defaultTestPageIdPublished"
+      }
+    },
+    "defaultResources": {
+      "collectionId": "defaultTestCollectionId",
+      "applicationId": "defaultApplicationId"
+    }
+  }
+}


### PR DESCRIPTION
Keeping this in a draft state as TCs are still pending 
## Description

> When the resources attached to the application like page, action and actionCollection don't get saved in a sane state because of NPE or some other issues like subscription is closed from client side defaultResourceIds gets saved as a null object. This is throwing the exception today. This PR will henceforth just logs such scenarios but will send the valid response to client   

Fixes #10451 #10084

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
