### PR TITLE
test: Adding fix for Chart_Widget_Loading_spec

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
@@ -36,6 +36,7 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
      */
 
     //Step1
+    cy.wait(2000);
     cy.NavigateToDatasourceEditor();
 
     //Step2
@@ -45,7 +46,7 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
     cy.get(`${datasource.datasourceCard}`)
       .contains("Users")
       .get(`${datasource.createQuerty}`)
-      .first()
+      .last()
       .click({ force: true });
 
     //Step5.1: Click the editing field
@@ -96,7 +97,7 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
     cy.get(".t--widget-chartwidget div[class*='bp3-skeleton']").should("exist");
 
     //Step13:
-    cy.openPropertyPane("chartwidget");
+    /* cy.openPropertyPane("chartwidget");
     cy.updateCodeInput(".t--property-control-chart-series-data-control", "");
     cy.openPropertyPane("buttonwidget");
     cy.get(".t--property-control-onclick .t--js-toggle").click({ force: true });
@@ -118,13 +119,9 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
       .click();
     cy.get(pages.integrationActiveTab).click({ force: true });
     cy.get("span[name*='comment-context-menu']")
-      .first()
+      .last()
       .click({ force: true });
     cy.wait(150);
-    cy.get(".t--datasource-option-delete").click({ force: true });
-  });
-
-  afterEach(() => {
-    cy.goToEditFromPublish();
+    cy.get(".t--datasource-option-delete").click({ force: true }); */
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
@@ -98,7 +98,7 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
     cy.get(".t--widget-chartwidget div[class*='bp3-skeleton']").should("exist");
 
     //Step13:
-    cy.openPropertyPane("chartwidget");
+    /*cy.openPropertyPane("chartwidget");
     cy.updateCodeInput(".t--property-control-chart-series-data-control", "");
     cy.openPropertyPane("buttonwidget");
     cy.get(".t--property-control-onclick .t--js-toggle").click({ force: true });
@@ -123,6 +123,6 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
       .last()
       .click({ force: true });
     cy.wait(150);
-    cy.get(".t--datasource-option-delete").click({ force: true });
+    cy.get(".t--datasource-option-delete").click({ force: true }); */
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
@@ -13,10 +13,6 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
     cy.addDsl(dsl);
   });
 
-  beforeEach(() => {
-    cy.openPropertyPane("chartwidget");
-  });
-
   it("Test case while reloading and on submission", function() {
     /**
      * Use case:

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Chart_Widget_Loading_spec.js
@@ -94,10 +94,11 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
     cy.reload();
 
     //Step12:
+    cy.wait(2000);
     cy.get(".t--widget-chartwidget div[class*='bp3-skeleton']").should("exist");
 
     //Step13:
-    /* cy.openPropertyPane("chartwidget");
+    cy.openPropertyPane("chartwidget");
     cy.updateCodeInput(".t--property-control-chart-series-data-control", "");
     cy.openPropertyPane("buttonwidget");
     cy.get(".t--property-control-onclick .t--js-toggle").click({ force: true });
@@ -122,6 +123,6 @@ describe("Chart Widget Skeleton Loading Functionality", function() {
       .last()
       .click({ force: true });
     cy.wait(150);
-    cy.get(".t--datasource-option-delete").click({ force: true }); */
+    cy.get(".t--datasource-option-delete").click({ force: true });
   });
 });


### PR DESCRIPTION

## Description

This PR contains fix for Chart_Widget_Loading_spec's test.

## How Has This Been Tested?

locally 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: FlakyTestsFix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.99 **(-0.02)** | 36.6 **(-0.01)** | 34.82 **(0)** | 55.47 **(-0.02)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :x: | ~~app/client/src/widgets/CircularProgressWidget/constants.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/widgets/CircularProgressWidget/index.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/widgets/CircularProgressWidget/component/index.tsx~~ | ~~37.04~~ | ~~40~~ | ~~0~~ | ~~41.67~~
 :x: | ~~app/client/src/widgets/CircularProgressWidget/widget/index.tsx~~ | ~~94.12~~ | ~~100~~ | ~~75~~ | ~~93.75~~</details>