### PR TITLE
fix: fixes JS object cloning issue

### DIFF
--- a/app/client/src/actions/jsActionActions.ts
+++ b/app/client/src/actions/jsActionActions.ts
@@ -69,6 +69,7 @@ export const copyJSCollectionError = (payload: {
 export const moveJSCollectionRequest = (payload: {
   id: string;
   destinationPageId: string;
+  name: string;
 }) => {
   return {
     type: ReduxActionTypes.MOVE_JS_ACTION_INIT,

--- a/app/client/src/api/JSActionAPI.tsx
+++ b/app/client/src/api/JSActionAPI.tsx
@@ -10,6 +10,7 @@ export interface JSCollectionCreateUpdateResponse extends ApiResponse {
 export interface MoveJSCollectionRequest {
   collectionId: string;
   destinationPageId: string;
+  name: string;
 }
 export interface UpdateJSObjectNameRequest {
   pageId: string;

--- a/app/client/src/pages/Editor/Explorer/JSActions/JSActionContextMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSActions/JSActionContextMenu.tsx
@@ -40,6 +40,7 @@ export function JSCollectionEntityContextMenu(props: EntityContextMenuProps) {
         moveJSCollectionRequest({
           id: actionId,
           destinationPageId,
+          name: nextEntityName(actionName, destinationPageId, false),
         }),
       ),
     [dispatch, nextEntityName, props.pageId],

--- a/app/client/src/pages/Editor/Explorer/JSActions/MoreJSActionsMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSActions/MoreJSActionsMenu.tsx
@@ -82,6 +82,7 @@ export function MoreJSCollectionsMenu(props: EntityContextMenuProps) {
         moveJSCollectionRequest({
           id: actionId,
           destinationPageId,
+          name: nextEntityName(actionName, destinationPageId, false),
         }),
       ),
     [dispatch, nextEntityName, props.pageId],

--- a/app/client/src/sagas/JSActionSagas.ts
+++ b/app/client/src/sagas/JSActionSagas.ts
@@ -180,6 +180,7 @@ function* moveJSCollectionSaga(
   action: ReduxAction<{
     id: string;
     destinationPageId: string;
+    name: string;
   }>,
 ) {
   const actionObject: JSCollection = yield select(
@@ -190,6 +191,7 @@ function* moveJSCollectionSaga(
     const response = yield JSActionAPI.moveJSCollection({
       collectionId: actionObject.id,
       destinationPageId: action.payload.destinationPageId,
+      name: action.payload.name,
     });
 
     const isValidResponse = yield validateResponse(response);

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -2764,11 +2764,6 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
-
 "@tinymce/tinymce-react@^3.13.0":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@tinymce/tinymce-react/-/tinymce-react-3.13.0.tgz#51ae6dbaa4076efde3389229d61c38e4533bc5ee"
@@ -2776,6 +2771,11 @@
   dependencies:
     prop-types "^15.6.2"
     tinymce "^5.5.1"
+
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@transloadit/prettier-bytes@0.0.7":
   version "0.0.7"
@@ -4159,10 +4159,6 @@ app-path@^3.2.0:
   integrity sha512-EAgEXkdcxH1cgEePOSsmUtw9ItPl0KTxnh/pj9ZbhvbKbij9x0oX6PWpGnorDr0DS5AosLgoa5n3T/hZmKQpYA==
   dependencies:
     execa "^1.0.0"
-
-aproba@^1.0.3, aproba@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz"
 
 "aproba@^1.0.3 || ^2.0.0":
   version "2.0.0"
@@ -11668,6 +11664,11 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-forge@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This PR addresses a bug that arises as a result of moving a JsObject from one Page to another, Currently moving a Js object to a page which already has another Js Object with similar Name is possible, which is a bug, This PR fixes that.

Fixes #10492 

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual Tests employed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-js-object-clone-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.99 **(-0.02)** | 36.61 **(0.01)** | 34.82 **(0)** | 55.48 **(-0.01)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :x: | ~~app/client/src/widgets/CircularProgressWidget/constants.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/widgets/CircularProgressWidget/index.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/widgets/CircularProgressWidget/component/index.tsx~~ | ~~37.04~~ | ~~40~~ | ~~0~~ | ~~41.67~~
 :x: | ~~app/client/src/widgets/CircularProgressWidget/widget/index.tsx~~ | ~~94.12~~ | ~~100~~ | ~~75~~ | ~~93.75~~</details>