### PR TITLE
fix: [Rest API Plugin] Only do generic mustache replacement if smart substitution is turned off

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -174,9 +174,9 @@ public class RestApiPlugin extends BasePlugin {
 
                     actionConfiguration.setBody(updatedBody);
                 }
+            } else {
+                prepareConfigurationsForExecution(executeActionDTO, actionConfiguration, datasourceConfiguration);
             }
-
-            prepareConfigurationsForExecution(executeActionDTO, actionConfiguration, datasourceConfiguration);
 
             // If the action is paginated, update the configurations to update the correct URL.
             if (actionConfiguration.getPaginationType() != null &&


### PR DESCRIPTION
Fixes #10489 

Today, if smart substitution is turned on, mustache replacement happens twice. First, as per required for smart substitution, and then the generic mustache replacement which is meant to get hit when smart substitution is turned off. This leads to mustache substitution twice in case of smart substitution turned on. This wouldnt have been a problem because in usual circumstances because all the mustaches get replaced in the first round with nothing happening in the second round. In this particular instance, the evaluated value contains mustaches which when going through the erroneous second replacement leads to incorrect request body being sent out.