### PR TITLE
fix: handle no color as transperant

### DIFF
--- a/app/client/src/widgets/DividerWidget/component/index.tsx
+++ b/app/client/src/widgets/DividerWidget/component/index.tsx
@@ -35,14 +35,14 @@ const HorizontalDivider = styled.div<Partial<DividerComponentProps>>`
   width: 100%;
   border-top: ${(props) =>
     `${props.thickness || 1}px ${props.strokeStyle ||
-      "solid"} ${props.dividerColor || "black"};`};
+      "solid"} ${props.dividerColor || "transparent"};`};
 `;
 const VerticalDivider = styled.div<Partial<DividerComponentProps>>`
   width: 0px;
   height: 100%;
   border-right: ${(props) =>
     `${props.thickness || 1}px ${props.strokeStyle ||
-      "solid"} ${props.dividerColor || "black"};`};
+      "solid"} ${props.dividerColor || "transparent"};`};
 `;
 
 const CapWrapper = styled.div<{
@@ -156,7 +156,7 @@ class DividerComponent extends React.Component<DividerComponentProps> {
             <circle
               cx={halfCapSize}
               cy={halfCapSize}
-              fill={dividerColor}
+              fill={dividerColor || "none"}
               r={halfCapSize}
             />
           </svg>
@@ -165,7 +165,7 @@ class DividerComponent extends React.Component<DividerComponentProps> {
             <path
               d="M7 13L1 7L7 1"
               fill="none"
-              stroke={dividerColor}
+              stroke={dividerColor || "transparent"}
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth="2"


### PR DESCRIPTION

## Description


> In Divider Widget cap in added transparent color in case of no color selected

Fixes #10335

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: bug/divider-no-color-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/widgets/DividerWidget/component/index.tsx | 64.58 **(0)** | 40 **(-2.25)** | 41.67 **(0)** | 69.05 **(0)**</details>