### PR TITLE
fix: Use the authorName as committer to avoid the inconsistency with name 

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
@@ -103,6 +103,7 @@ public class GitExecutorImpl implements GitExecutor {
                         // Only make a commit if there are any updates
                         .setAllowEmpty(false)
                         .setAuthor(finalAuthorName, finalAuthorEmail)
+                        .setCommitter(finalAuthorName, finalAuthorEmail)
                         .call();
                 return "Committed successfully!";
             }


### PR DESCRIPTION
## Description

> Inconsistency in git clients in commit history with root is being used as committer. JGit picks up the global config for committer name and if that is not set then root is used. So if the authorName set by user is different from the global git config then we will see different name in git client as commiter and authorName are different.
Ideally the authorNames are configured by git clients but since we act as a proxy between the users git repo we see the `root` because the git server is not able to find this user(the one user has set in the profile/config section)

As fix we are explicitly setting the committer info while committing to avoid this issue. 

Fixes #10517 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
