### PR TITLE
fix: Fix 10463 js object cloning issue

### DIFF
--- a/app/client/src/actions/jsActionActions.ts
+++ b/app/client/src/actions/jsActionActions.ts
@@ -69,6 +69,7 @@ export const copyJSCollectionError = (payload: {
 export const moveJSCollectionRequest = (payload: {
   id: string;
   destinationPageId: string;
+  name: string;
 }) => {
   return {
     type: ReduxActionTypes.MOVE_JS_ACTION_INIT,

--- a/app/client/src/api/JSActionAPI.tsx
+++ b/app/client/src/api/JSActionAPI.tsx
@@ -10,6 +10,7 @@ export interface JSCollectionCreateUpdateResponse extends ApiResponse {
 export interface MoveJSCollectionRequest {
   collectionId: string;
   destinationPageId: string;
+  name: string;
 }
 export interface UpdateJSObjectNameRequest {
   pageId: string;

--- a/app/client/src/pages/Editor/Explorer/JSActions/JSActionContextMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSActions/JSActionContextMenu.tsx
@@ -40,6 +40,7 @@ export function JSCollectionEntityContextMenu(props: EntityContextMenuProps) {
         moveJSCollectionRequest({
           id: actionId,
           destinationPageId,
+          name: nextEntityName(actionName, destinationPageId, false),
         }),
       ),
     [dispatch, nextEntityName, props.pageId],

--- a/app/client/src/pages/Editor/Explorer/JSActions/MoreJSActionsMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSActions/MoreJSActionsMenu.tsx
@@ -82,6 +82,7 @@ export function MoreJSCollectionsMenu(props: EntityContextMenuProps) {
         moveJSCollectionRequest({
           id: actionId,
           destinationPageId,
+          name: nextEntityName(actionName, destinationPageId, false),
         }),
       ),
     [dispatch, nextEntityName, props.pageId],

--- a/app/client/src/sagas/JSActionSagas.ts
+++ b/app/client/src/sagas/JSActionSagas.ts
@@ -180,6 +180,7 @@ function* moveJSCollectionSaga(
   action: ReduxAction<{
     id: string;
     destinationPageId: string;
+    name: string;
   }>,
 ) {
   const actionObject: JSCollection = yield select(
@@ -190,6 +191,7 @@ function* moveJSCollectionSaga(
     const response = yield JSActionAPI.moveJSCollection({
       collectionId: actionObject.id,
       destinationPageId: action.payload.destinationPageId,
+      name: action.payload.name,
     });
 
     const isValidResponse = yield validateResponse(response);

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
@@ -211,6 +211,7 @@ public class BulkAppendMethod implements Method {
 
         uriBuilder.queryParam("valueInputOption", "USER_ENTERED");
         uriBuilder.queryParam("includeValuesInResponse", Boolean.FALSE);
+        uriBuilder.queryParam("insertDataOption", "INSERT_ROWS");
 
         final List<RowObject> body1 = (List<RowObject>) methodConfig.getBody();
         List<List<Object>> collect = body1.stream()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ActionCollectionMoveDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/ActionCollectionMoveDTO.java
@@ -10,6 +10,9 @@ import javax.validation.constraints.NotNull;
 public class ActionCollectionMoveDTO {
 
     @NotNull
+    String name;
+
+    @NotNull
     String collectionId;
 
     @NotNull

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -355,6 +355,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
                     final String oldPageId = actionCollectionDTO.getPageId();
                     actionCollectionDTO.setPageId(destinationPageId);
                     actionCollectionDTO.getDefaultResources().setPageId(destinationPage.getDefaultResources().getPageId());
+                    actionCollectionDTO.setName(actionCollectionMoveDTO.getName());
 
                     return actionUpdatesFlux
                             .collectList()


### PR DESCRIPTION
## Cloning JS Objects Not getting renamed
- The issue is when moving a JavaScript objects in between pages they are not getting renamed
- Made server side changes thereby sending back the renamed object and got it resolved

Fixes #10492

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually



## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-10463-JSObject_Cloning_issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.11 **(0)** | 36.87 **(0)** | 34.99 **(0)** | 55.6 **(0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>