### PR TITLE
fix: Remove private widgets from autocompletion

### DIFF
--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -3,6 +3,7 @@ import { DataTree } from "entities/DataTree/dataTreeFactory";
 import {
   DataTreeDiff,
   DataTreeDiffEvent,
+  getAllPrivateWidgetsInDataTree,
   getEntityNameAndPropertyPath,
   isAction,
   isJSAction,
@@ -16,7 +17,7 @@ import {
   getEvalValuePath,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
-import { find, get, some } from "lodash";
+import { find, get, some, omit } from "lodash";
 import LOG_TYPE from "../entities/AppsmithConsole/logtype";
 import { put, select } from "redux-saga/effects";
 import {
@@ -367,7 +368,13 @@ export function* updateTernDefinitions(
   }
   if (shouldUpdate) {
     const start = performance.now();
-    const { def, entityInfo } = dataTreeTypeDefCreator(dataTree);
+    // remove private widgets from dataTree used for autocompletion
+    const privateWidgets = getAllPrivateWidgetsInDataTree(dataTree);
+    const privateWidgetNames = Object.keys(privateWidgets);
+    const treeWithoutPrivateWidgets = omit(dataTree, privateWidgetNames);
+    const { def, entityInfo } = dataTreeTypeDefCreator(
+      treeWithoutPrivateWidgets,
+    );
     TernServer.updateDef("DATA_TREE", def, entityInfo);
     const end = performance.now();
     log.debug("Tern", { updates });

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -3,7 +3,7 @@ import { DataTree } from "entities/DataTree/dataTreeFactory";
 import {
   DataTreeDiff,
   DataTreeDiffEvent,
-  getAllPrivateWidgetsInDataTree,
+  getDataTreeWithoutPrivateWidgets,
   getEntityNameAndPropertyPath,
   isAction,
   isJSAction,
@@ -17,7 +17,7 @@ import {
   getEvalValuePath,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
-import { find, get, some, omit } from "lodash";
+import { find, get, some } from "lodash";
 import LOG_TYPE from "../entities/AppsmithConsole/logtype";
 import { put, select } from "redux-saga/effects";
 import {
@@ -369,9 +369,9 @@ export function* updateTernDefinitions(
   if (shouldUpdate) {
     const start = performance.now();
     // remove private widgets from dataTree used for autocompletion
-    const privateWidgets = getAllPrivateWidgetsInDataTree(dataTree);
-    const privateWidgetNames = Object.keys(privateWidgets);
-    const treeWithoutPrivateWidgets = omit(dataTree, privateWidgetNames);
+    const treeWithoutPrivateWidgets = getDataTreeWithoutPrivateWidgets(
+      dataTree,
+    );
     const { def, entityInfo } = dataTreeTypeDefCreator(
       treeWithoutPrivateWidgets,
     );

--- a/app/client/src/selectors/dataTreeSelectors.ts
+++ b/app/client/src/selectors/dataTreeSelectors.ts
@@ -12,6 +12,8 @@ import { getWidgets, getWidgetsMeta } from "sagas/selectors";
 import "url-search-params-polyfill";
 import { getPageList } from "./appViewSelectors";
 import { AppState } from "reducers";
+import { getAllPrivateWidgetsInDataTree } from "workers/evaluationUtils";
+import _ from "lodash";
 
 export const getUnevaluatedDataTree = createSelector(
   getActionsForCurrentPage,

--- a/app/client/src/selectors/dataTreeSelectors.ts
+++ b/app/client/src/selectors/dataTreeSelectors.ts
@@ -12,8 +12,6 @@ import { getWidgets, getWidgetsMeta } from "sagas/selectors";
 import "url-search-params-polyfill";
 import { getPageList } from "./appViewSelectors";
 import { AppState } from "reducers";
-import { getAllPrivateWidgetsInDataTree } from "workers/evaluationUtils";
-import _ from "lodash";
 
 export const getUnevaluatedDataTree = createSelector(
   getActionsForCurrentPage,

--- a/app/client/src/workers/evaluation.test.ts
+++ b/app/client/src/workers/evaluation.test.ts
@@ -225,6 +225,7 @@ const BASE_WIDGET: DataTreeWidget = {
   triggerPaths: {},
   validationPaths: {},
   ENTITY_TYPE: ENTITY_TYPE.WIDGET,
+  privateWidgets: {},
 };
 
 const BASE_ACTION: DataTreeAction = {
@@ -247,6 +248,7 @@ const BASE_ACTION: DataTreeAction = {
     data: EvaluationSubstitutionType.TEMPLATE,
   },
   dependencyMap: {},
+  datasourceUrl: "",
 };
 
 describe("DataTreeEvaluator", () => {

--- a/app/client/src/workers/evaluationUtils.test.ts
+++ b/app/client/src/workers/evaluationUtils.test.ts
@@ -1,5 +1,106 @@
-import { PrivateWidgets } from "entities/DataTree/dataTreeFactory";
-import { getAllPaths, isPrivateEntityPath } from "./evaluationUtils";
+import { RenderModes } from "constants/WidgetConstants";
+import { ValidationTypes } from "constants/WidgetValidation";
+import {
+  DataTreeWidget,
+  ENTITY_TYPE,
+  EvaluationSubstitutionType,
+  PrivateWidgets,
+} from "entities/DataTree/dataTreeFactory";
+import {
+  getAllPaths,
+  getAllPrivateWidgetsInDataTree,
+  getDataTreeWithoutPrivateWidgets,
+  isPrivateEntityPath,
+} from "./evaluationUtils";
+
+const BASE_WIDGET: DataTreeWidget = {
+  logBlackList: {},
+  widgetId: "randomID",
+  widgetName: "randomWidgetName",
+  bottomRow: 0,
+  isLoading: false,
+  leftColumn: 0,
+  parentColumnSpace: 0,
+  parentRowSpace: 0,
+  renderMode: RenderModes.CANVAS,
+  rightColumn: 0,
+  topRow: 0,
+  type: "SKELETON_WIDGET",
+  parentId: "0",
+  version: 1,
+  bindingPaths: {},
+  triggerPaths: {},
+  validationPaths: {},
+  ENTITY_TYPE: ENTITY_TYPE.WIDGET,
+  privateWidgets: {},
+};
+
+const testDataTree: Record<string, DataTreeWidget> = {
+  Text1: {
+    ...BASE_WIDGET,
+    widgetName: "Text1",
+    text: "Label",
+    type: "TEXT_WIDGET",
+    bindingPaths: {
+      text: EvaluationSubstitutionType.TEMPLATE,
+    },
+    validationPaths: {
+      text: { type: ValidationTypes.TEXT },
+    },
+  },
+  Text2: {
+    ...BASE_WIDGET,
+    widgetName: "Text2",
+    text: "{{Text1.text}}",
+    dynamicBindingPathList: [{ key: "text" }],
+    type: "TEXT_WIDGET",
+    bindingPaths: {
+      text: EvaluationSubstitutionType.TEMPLATE,
+    },
+    validationPaths: {
+      text: { type: ValidationTypes.TEXT },
+    },
+  },
+  Text3: {
+    ...BASE_WIDGET,
+    widgetName: "Text3",
+    text: "{{Text1.text}}",
+    dynamicBindingPathList: [{ key: "text" }],
+    type: "TEXT_WIDGET",
+    bindingPaths: {
+      text: EvaluationSubstitutionType.TEMPLATE,
+    },
+    validationPaths: {
+      text: { type: ValidationTypes.TEXT },
+    },
+  },
+  Text4: {
+    ...BASE_WIDGET,
+    widgetName: "Text4",
+    text: "{{Text1.text}}",
+    dynamicBindingPathList: [{ key: "text" }],
+    type: "TEXT_WIDGET",
+    bindingPaths: {
+      text: EvaluationSubstitutionType.TEMPLATE,
+    },
+    validationPaths: {
+      text: { type: ValidationTypes.TEXT },
+    },
+  },
+
+  List1: {
+    ...BASE_WIDGET,
+    privateWidgets: {
+      Text2: true,
+    },
+  },
+  List2: {
+    ...BASE_WIDGET,
+    privateWidgets: {
+      Text3: true,
+    },
+  },
+};
 
 describe("Correctly handle paths", () => {
   it("getsAllPaths", () => {
@@ -39,7 +140,9 @@ describe("Correctly handle paths", () => {
     const actual = getAllPaths(myTree);
     expect(actual).toStrictEqual(result);
   });
+});
 
+describe("privateWidgets", () => {
   it("correctly checks if path is a PrivateEntityPath", () => {
     const privateWidgets: PrivateWidgets = {
       Button1: true,
@@ -56,5 +159,73 @@ describe("Correctly handle paths", () => {
       isPrivateEntityPath(privateWidgets, "List2.template.Image2.data"),
     ).toBeFalsy();
     expect(isPrivateEntityPath(privateWidgets, "Image2.data")).toBeTruthy();
+  });
+
+  it("Returns list of all privateWidgets", () => {
+    const expectedPrivateWidgetsList = {
+      Text2: true,
+      Text3: true,
+    };
+
+    const actualPrivateWidgetsList = getAllPrivateWidgetsInDataTree(
+      testDataTree,
+    );
+
+    expect(expectedPrivateWidgetsList).toStrictEqual(actualPrivateWidgetsList);
+  });
+
+  it("Returns data tree without privateWidgets", () => {
+    const expectedDataTreeWithoutPrivateWidgets: Record<
+      string,
+      DataTreeWidget
+    > = {
+      Text1: {
+        ...BASE_WIDGET,
+        widgetName: "Text1",
+        text: "Label",
+        type: "TEXT_WIDGET",
+        bindingPaths: {
+          text: EvaluationSubstitutionType.TEMPLATE,
+        },
+        validationPaths: {
+          text: { type: ValidationTypes.TEXT },
+        },
+      },
+
+      Text4: {
+        ...BASE_WIDGET,
+        widgetName: "Text4",
+        text: "{{Text1.text}}",
+        dynamicBindingPathList: [{ key: "text" }],
+        type: "TEXT_WIDGET",
+        bindingPaths: {
+          text: EvaluationSubstitutionType.TEMPLATE,
+        },
+        validationPaths: {
+          text: { type: ValidationTypes.TEXT },
+        },
+      },
+
+      List1: {
+        ...BASE_WIDGET,
+        privateWidgets: {
+          Text2: true,
+        },
+      },
+      List2: {
+        ...BASE_WIDGET,
+        privateWidgets: {
+          Text3: true,
+        },
+      },
+    };
+
+    const actualDataTreeWithoutPrivateWidgets = getDataTreeWithoutPrivateWidgets(
+      testDataTree,
+    );
+
+    expect(expectedDataTreeWithoutPrivateWidgets).toStrictEqual(
+      actualDataTreeWithoutPrivateWidgets,
+    );
   });
 });

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -722,3 +722,18 @@ export const isPrivateEntityPath = (
   }
   return false;
 };
+
+export const getAllPrivateWidgetsInDataTree = (
+  dataTree: DataTree,
+): PrivateWidgets => {
+  let privateWidgets: PrivateWidgets = {};
+
+  Object.keys(dataTree).forEach((entityName) => {
+    const entity = dataTree[entityName];
+    if (isWidget(entity) && !_.isEmpty(entity.privateWidgets)) {
+      privateWidgets = { ...privateWidgets, ...entity.privateWidgets };
+    }
+  });
+
+  return privateWidgets;
+};

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -737,3 +737,12 @@ export const getAllPrivateWidgetsInDataTree = (
 
   return privateWidgets;
 };
+
+export const getDataTreeWithoutPrivateWidgets = (
+  dataTree: DataTree,
+): DataTree => {
+  const privateWidgets = getAllPrivateWidgetsInDataTree(dataTree);
+  const privateWidgetNames = Object.keys(privateWidgets);
+  const treeWithoutPrivateWidgets = _.omit(dataTree, privateWidgetNames);
+  return treeWithoutPrivateWidgets;
+};


### PR DESCRIPTION
## Description

This PR removes private widgets from autocomplete hints

Fixes #10534 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

- Jest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/remove-private-widgets-from-autocomplete 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.12 **(0.01)** | 36.88 **(0.01)** | 35.01 **(0.02)** | 55.6 **(0.01)**
 :red_circle: | app/client/src/sagas/PostEvaluationSagas.ts | 16.44 **(-0.11)** | 0 **(0)** | 0 **(0)** | 20 **(-0.17)**
 :green_circle: | app/client/src/workers/evaluationUtils.ts | 59.69 **(1.54)** | 55.56 **(1.07)** | 64.91 **(1.95)** | 57.54 **(1.63)**</details>