### PR TITLE
fix:  add pre-filled option on adding an option to a checkbox or radio button

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Checkbox_group_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Checkbox_group_spec.js
@@ -12,8 +12,9 @@ describe("checkboxgroupwidget Widget Functionality", function() {
     cy.get(".t--widget-checkboxgroupwidget").should("exist");
   });
 
-  it("should check that empty value is allowed in options", () => {
+  it("should check that prefilled option is added and empty value is allowed in options", () => {
     cy.openPropertyPane("checkboxgroupwidget");
+    cy.get(".t--property-control-options-add").click({ force: true });
     cy.get(".t--property-control-options")
       .find(".t--js-toggle")
       .click({ force: true });

--- a/app/client/src/components/propertyControls/KeyValueComponent.tsx
+++ b/app/client/src/components/propertyControls/KeyValueComponent.tsx
@@ -169,7 +169,10 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
         "OPTION",
         renderPairs.map((pair: any) => pair.value),
       ),
-      key: generateReactKey(),
+      key: getNextEntityName(
+        "OPTION",
+        renderPairs.map((pair: any) => pair.value),
+      ),
     });
 
     setRenderPairs(updatedRenderPairs);

--- a/app/client/src/components/propertyControls/KeyValueComponent.tsx
+++ b/app/client/src/components/propertyControls/KeyValueComponent.tsx
@@ -14,6 +14,7 @@ import { DropdownOption } from "components/constants";
 import { generateReactKey } from "utils/generators";
 import { Category, Size } from "components/ads/Button";
 import { debounce } from "lodash";
+import { getNextEntityName } from "utils/AppsmithUtils";
 
 function updateOptionLabel<T>(
   options: Array<T>,
@@ -148,9 +149,28 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
   function addPair() {
     let { pairs } = props;
     pairs = Array.isArray(pairs) ? pairs.slice() : [];
-    pairs.push({ label: "", value: "" });
+    pairs.push({
+      label: getNextEntityName(
+        "Option",
+        pairs.map((pair: any) => pair.label),
+      ),
+      value: getNextEntityName(
+        "OPTION",
+        pairs.map((pair: any) => pair.value),
+      ),
+    });
     const updatedRenderPairs = renderPairs.slice();
-    updatedRenderPairs.push({ label: "", value: "", key: generateReactKey() });
+    updatedRenderPairs.push({
+      label: getNextEntityName(
+        "Option",
+        renderPairs.map((pair: any) => pair.label),
+      ),
+      value: getNextEntityName(
+        "OPTION",
+        renderPairs.map((pair: any) => pair.value),
+      ),
+      key: generateReactKey(),
+    });
 
     setRenderPairs(updatedRenderPairs);
     props.updatePairs(pairs);
@@ -203,6 +223,7 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
 
       <StyledPropertyPaneButton
         category={Category.tertiary}
+        className="t--property-control-options-add"
         icon="plus"
         onClick={addPair}
         size={Size.medium}


### PR DESCRIPTION

## Description


Fixes #8503  (issue)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/add-option 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.01 **(0)** | 36.5 **(0)** | 34.72 **(-0.01)** | 55.4 **(-0.01)**
 :green_circle: | app/client/src/components/propertyControls/KeyValueComponent.tsx | 15.79 **(0.08)** | 24 **(0)** | 0 **(0)** | 17.14 **(-0.05)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>