### PR TITLE
fix: flattenObject handles circular objects

### DIFF
--- a/app/client/src/utils/helpers.test.ts
+++ b/app/client/src/utils/helpers.test.ts
@@ -6,6 +6,45 @@ import {
 } from "./helpers";
 
 describe("flattenObject test", () => {
+  it("Check if recursively referenced object is returend correctly", () => {
+    type InputType = {
+      s: string;
+      n: number;
+      b: boolean;
+      o1: { s: string };
+      o2: InputType;
+      a1: number[];
+      a2: InputType[];
+    };
+    const input: InputType = {
+      s: "string",
+      n: 1,
+      b: true,
+      o1: { s: "str" },
+      o2: {} as InputType,
+      a1: [1, 2, 3],
+      a2: [] as InputType[],
+    };
+
+    input.o2 = input;
+    input.a2[0] = input;
+    input.a2[1] = input;
+
+    const output = {
+      s: "string",
+      n: 1,
+      b: true,
+      "o1.s": "str",
+      o2: input,
+      "a1[0]": 1,
+      "a1[1]": 2,
+      "a1[2]": 3,
+      "a2[0]": input,
+      "a2[1]": input,
+    };
+
+    expect(flattenObject(input)).toStrictEqual(output);
+  });
   it("Check if non nested object is returned correctly", () => {
     const testObject = {
       isVisible: true,

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -428,6 +428,7 @@ export const scrollbarWidth = () => {
 // To { isValid: false, settings.color: false}
 export const flattenObject = (data: Record<string, any>) => {
   const result: Record<string, any> = {};
+  const seen = [] as any[];
   function recurse(cur: any, prop: any) {
     if (Object(cur) !== cur) {
       result[prop] = cur;
@@ -436,6 +437,11 @@ export const flattenObject = (data: Record<string, any>) => {
         recurse(cur[i], prop + "[" + i + "]");
       if (cur.length == 0) result[prop] = [];
     } else {
+      if (seen.some((s) => s === cur)) {
+        result[prop] = cur;
+        return;
+      }
+      seen.push(cur);
       let isEmpty = true;
       for (const p in cur) {
         isEmpty = false;


### PR DESCRIPTION
## Description

`app/client/src/utils/helpers.tsx` has a function `flattenObject` which is used to (well) flatten an object. This function however didn't handle any recursive/self-referential objects. This might crash the program.

Fixes # (issue)

#10557 10557

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added a test in `app/client/src/utils/helpers.test.ts`

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
