### PR TITLE
feat: Add code hints for JS promises in JS Object editor

### DIFF
--- a/app/client/src/utils/JSPaneUtils.tsx
+++ b/app/client/src/utils/JSPaneUtils.tsx
@@ -182,7 +182,7 @@ export const createDummyJSCollectionActions = (
   organizationId: string,
 ) => {
   const body =
-    "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: () => {\n\t\t//write code here\n\t}\n}";
+    "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//do async stuff here or use JS promises\n\t}\n}";
 
   const actions = [
     {


### PR DESCRIPTION

## Description

This change adds hints to the JS Objects editor to let devs know that they can now use JS promises or async/await on appsmith. This change makes the JS promise feature more discoverable. See myFunc2 in the below screenshot

<img width="582" alt="Screenshot 2022-01-23 at 4 04 06 PM" src="https://user-images.githubusercontent.com/17744578/150684886-c8f6cbef-875f-40ab-953b-82d31f7db0fb.png">


## Type of change

- New feature

## How Has This Been Tested?

Tested on my locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
