### PR TITLE
fix: make query params visible in various flows when saved in REST API datasource

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/resources/form.json
@@ -16,6 +16,11 @@
           "controlType": "KEY_VAL_INPUT"
         },
         {
+          "label": "Query Params",
+          "configProperty": "datasourceConfiguration.queryParameters",
+          "controlType": "KEY_VAL_INPUT"
+        },
+        {
           "label": "Send Authentication Information Key (Do not edit)",
           "configProperty": "datasourceConfiguration.properties[0].key",
           "controlType": "INPUT_TEXT",


### PR DESCRIPTION
## Description
- Make query params visible when an API datasource is saved. Currently only header info is shown on the page immediately following the `save` datasource action. 
- Make query params visible on the right hand section when a REST API action is edited. 
- TBD: some FE side changes will be added separately.

Fixes #9930 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
