### PR TITLE
fix: Incorrect member list sorting on user roles

### DIFF
--- a/app/client/src/components/ads/TableDropdown.tsx
+++ b/app/client/src/components/ads/TableDropdown.tsx
@@ -3,7 +3,7 @@ import {
   Popover,
   PopoverInteractionKind,
 } from "@blueprintjs/core/lib/esm/components/popover/popover";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { Classes, CommonComponentProps } from "./common";
 import Icon, { IconSize } from "./Icon";
@@ -88,6 +88,13 @@ function TableDropdown(props: DropdownProps) {
   const [selectedOption, setSelectedOption] = useState(
     props.options[props.selectedIndex] || {},
   );
+
+  useEffect(() => {
+    if (props.selectedIndex !== selectedIndex) {
+      setSelectedIndex(props.selectedIndex);
+      setSelectedOption(props.options[props.selectedIndex]);
+    }
+  }, [props.selectedIndex]);
 
   const optionSelector = (index: number) => {
     setSelectedIndex(index);


### PR DESCRIPTION
## Description

> Members list of any selected organization wasn't getting sorted correctly based on **Role** column. Fixed this issue.

Fixes #10447

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Select an organization
- Click 3 dots on the right-hand side of the organization card.
- Click Members from the list.
- Invite multiple users with different roles assigned to them.
- Now, try sorting the members based on the Role column.
- Each user should have the correct role next to their name (unlike before).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>