### PR TITLE
fix: show lint when unused variable is present in code

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/constants.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/constants.ts
@@ -1,0 +1,6 @@
+// For these error types, we want to show a warning
+// All messages can be found here => https://github.com/jshint/jshint/blob/2.9.5/src/messages.js
+
+export const WARNING_LINT_ERRORS = {
+  W098: "'{a}' is defined but never used.",
+};

--- a/app/client/src/components/editorComponents/CodeEditor/constants.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/constants.ts
@@ -1,5 +1,6 @@
 // For these error types, we want to show a warning
 // All messages can be found here => https://github.com/jshint/jshint/blob/2.9.5/src/messages.js
+
 export const WARNING_LINT_ERRORS = {
   W098: "'{a}' is defined but never used.",
 };

--- a/app/client/src/components/editorComponents/CodeEditor/constants.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/constants.ts
@@ -1,6 +1,5 @@
 // For these error types, we want to show a warning
 // All messages can be found here => https://github.com/jshint/jshint/blob/2.9.5/src/messages.js
-
 export const WARNING_LINT_ERRORS = {
   W098: "'{a}' is defined but never used.",
 };

--- a/app/client/src/components/editorComponents/CodeEditor/lintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/lintHelpers.ts
@@ -4,6 +4,7 @@ import {
   EvaluationError,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
+import { Severity } from "entities/AppsmithConsole";
 
 export const getIndexOfRegex = (
   str: string,
@@ -124,4 +125,26 @@ export const getLintAnnotations = (
     }
   });
   return annotations;
+};
+
+// For these error types, we want to show a warning
+// All messages can be found here => https://github.com/jshint/jshint/blob/2.9.5/src/messages.js
+const WARNING_LINT_ERRORS = [
+  {
+    code: "W098",
+    message: "'{a}' is defined but never used.",
+  },
+];
+
+export const getLintSeverity = (
+  code: string,
+): Severity.WARNING | Severity.ERROR => {
+  let severity = Severity.ERROR;
+
+  WARNING_LINT_ERRORS.forEach((warningError) => {
+    if (warningError.code === code) {
+      severity = Severity.WARNING;
+    }
+  });
+  return severity;
 };

--- a/app/client/src/components/editorComponents/CodeEditor/lintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/lintHelpers.ts
@@ -5,6 +5,7 @@ import {
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
 import { Severity } from "entities/AppsmithConsole";
+import { WARNING_LINT_ERRORS } from "./constants";
 
 export const getIndexOfRegex = (
   str: string,
@@ -127,24 +128,10 @@ export const getLintAnnotations = (
   return annotations;
 };
 
-// For these error types, we want to show a warning
-// All messages can be found here => https://github.com/jshint/jshint/blob/2.9.5/src/messages.js
-const WARNING_LINT_ERRORS = [
-  {
-    code: "W098",
-    message: "'{a}' is defined but never used.",
-  },
-];
-
 export const getLintSeverity = (
   code: string,
 ): Severity.WARNING | Severity.ERROR => {
-  let severity = Severity.ERROR;
-
-  WARNING_LINT_ERRORS.forEach((warningError) => {
-    if (warningError.code === code) {
-      severity = Severity.WARNING;
-    }
-  });
+  const severity =
+    code in WARNING_LINT_ERRORS ? Severity.WARNING : Severity.ERROR;
   return severity;
 };

--- a/app/client/src/globalStyles/CodemirrorHintStyles.ts
+++ b/app/client/src/globalStyles/CodemirrorHintStyles.ts
@@ -271,6 +271,6 @@ export const CodemirrorHintStyles = createGlobalStyle<{
     color: #4B4848;
   }
   .CodeMirror-lint-mark-warning{
-    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAADCAYAAAC09K7GAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9sJDw4cOCW1/KIAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAAHElEQVQI12NggIL/DAz/GdA5/xkY/qPKMDAwAADLZwf5rvm+LQAAAABJRU5ErkJggg==")
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAADCAYAAAC09K7GAAAAAXNSR0IArs4c6QAAAB1JREFUGFdjZICC/3sY/jO6MDAygvgwDpiGcWAqASvpC745SEL8AAAAAElFTkSuQmCC");
   }
 `;

--- a/app/client/src/workers/lint.ts
+++ b/app/client/src/workers/lint.ts
@@ -69,7 +69,7 @@ export const getLintingErrors = (
     forin: false, // Doesn't require filtering for..in loops with obj.hasOwnProperty()
     noempty: false, // Empty blocks are allowed
     strict: false, // We won't force strict mode
-    unused: false, // Unused variables are allowed
+    unused: "strict", // Unused variables are not allowed
     asi: true, // Tolerate Automatic Semicolon Insertion (no semicolons)
     boss: true, // Tolerate assignments where comparisons would be expected
     evil: false, // Use of eval not allowed

--- a/app/client/src/workers/lint.ts
+++ b/app/client/src/workers/lint.ts
@@ -4,7 +4,7 @@ import {
   extraLibraries,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
-import { JSHINT as jshint, LintError } from "jshint";
+import { JSHINT as jshint } from "jshint";
 import { isEmpty, keys, last } from "lodash";
 import {
   EvaluationScripts,

--- a/app/client/src/workers/lint.ts
+++ b/app/client/src/workers/lint.ts
@@ -4,8 +4,7 @@ import {
   extraLibraries,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
-import { JSHINT as jshint } from "jshint";
-import { Severity } from "entities/AppsmithConsole";
+import { JSHINT as jshint, LintError } from "jshint";
 import { isEmpty, keys, last } from "lodash";
 import {
   EvaluationScripts,
@@ -13,6 +12,7 @@ import {
   ScriptTemplate,
 } from "workers/evaluate";
 import { ECMA_VERSION } from "workers/constants";
+import { getLintSeverity } from "components/editorComponents/CodeEditor/lintHelpers";
 
 export const getPositionInEvaluationScript = (
   type: EvaluationScriptType,
@@ -90,8 +90,7 @@ export const getLintingErrors = (
     return {
       errorType: PropertyEvaluationErrorType.LINT,
       raw: script,
-      // We are forcing warnings to errors and removing unwanted JSHint checks
-      severity: Severity.ERROR,
+      severity: getLintSeverity(lintError.code),
       errorMessage: lintError.reason,
       errorSegment: lintError.evidence,
       originalBinding,


### PR DESCRIPTION
## Description
This PR introduces warnings in linting. Users get warned when an unused variable is present in the code.

<img width="243" alt="Screenshot 2022-01-27 at 22 03 12" src="https://user-images.githubusercontent.com/46670083/151457909-256d92b9-f6d4-4d63-82bc-2a0cf27ef91d.png">




Fixes #10589 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/show-lint-error-for-unused-variables 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.01 **(0.01)** | 36.57 **(0.01)** | 34.93 **(0)** | 55.41 **(0.01)**
 :sparkles: :new: | **app/client/src/components/editorComponents/CodeEditor/constants.ts** | **100** | **100** | **100** | **100**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/lintHelpers.ts | 97.33 **(0.23)** | 77.78 **(1.31)** | 100 **(0)** | 96.67 **(0.31)**</details>