### PR TITLE
fix: 10502-Space in Google Sheet name

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/AppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/AppendMethod.java
@@ -18,6 +18,8 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -185,8 +187,8 @@ public class AppendMethod implements Method {
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
                 methodConfig.getSpreadsheetId() /* spreadsheet Id */
                         + "/values/"
-                        + range
-                        + ":append");
+                        + URLEncoder.encode(range, StandardCharsets.UTF_8)
+                        + ":append", true);
 
         uriBuilder.queryParam("valueInputOption", "USER_ENTERED");
         uriBuilder.queryParam("includeValuesInResponse", Boolean.FALSE);
@@ -206,7 +208,7 @@ public class AppendMethod implements Method {
         valueRange.setRange(range);
         valueRange.setValues(collect);
         return webClient.method(HttpMethod.POST)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.fromValue(valueRange));
     }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkAppendMethod.java
@@ -18,6 +18,8 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -206,8 +208,9 @@ public class BulkAppendMethod implements Method {
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
                 methodConfig.getSpreadsheetId() /* spreadsheet Id */
                         + "/values/"
-                        + range
-                        + ":append");
+                        + URLEncoder.encode(range, StandardCharsets.UTF_8)
+                        + ":append",
+                true);
 
         uriBuilder.queryParam("valueInputOption", "USER_ENTERED");
         uriBuilder.queryParam("includeValuesInResponse", Boolean.FALSE);
@@ -223,7 +226,7 @@ public class BulkAppendMethod implements Method {
         valueRange.setRange(range);
         valueRange.setValues(collect);
         return webClient.method(HttpMethod.POST)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.fromValue(valueRange));
     }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkUpdateMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/BulkUpdateMethod.java
@@ -16,6 +16,8 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -199,7 +201,8 @@ public class BulkUpdateMethod implements Method {
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
                 methodConfig.getSpreadsheetId() /* spreadsheet Id */
                         + "/values/"
-                        + methodConfig.getSpreadsheetRange() /* spreadsheet Range */
+                        + URLEncoder.encode(methodConfig.getSpreadsheetRange(), StandardCharsets.UTF_8),
+                true
         );
 
         uriBuilder.queryParam("valueInputOption", "USER_ENTERED");
@@ -211,7 +214,7 @@ public class BulkUpdateMethod implements Method {
                 .collect(Collectors.toList());
 
         return webClient.method(HttpMethod.PUT)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.fromValue(Map.of(
                         "range", methodConfig.getSpreadsheetRange(),
                         "majorDimension", "ROWS",

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/ClearMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/ClearMethod.java
@@ -8,6 +8,9 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 /**
  * API reference: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/clear
  */
@@ -38,12 +41,13 @@ public class ClearMethod implements Method {
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
                 methodConfig.getSpreadsheetId() /* spreadsheet Id */
                         + "/values/"
-                        + methodConfig.getSpreadsheetRange() /* spreadsheet Range */
-                        + ":clear"
+                        + URLEncoder.encode(methodConfig.getSpreadsheetRange(), StandardCharsets.UTF_8) /* spreadsheet Range */
+                        + ":clear",
+                true
         );
 
         return webClient.method(HttpMethod.POST)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.empty());
     }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/CopyMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/CopyMethod.java
@@ -37,11 +37,12 @@ public class CopyMethod implements Method {
                 methodConfig.getSpreadsheetId() /* spreadsheet Id */
                         + "/sheets/"
                         + methodConfig.getSheetId() /* sheet Id*/
-                        + ":copyTo"
+                        + ":copyTo",
+                true
         );
 
         return webClient.method(HttpMethod.POST)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.fromObject(methodConfig.getRowObjects()));
     }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/CreateMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/CreateMethod.java
@@ -145,10 +145,10 @@ public class CreateMethod implements Method {
             }
         }
 
-        UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL, "");
+        UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL, "", true);
 
         return webClient.method(HttpMethod.POST)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.fromValue(spreadsheet));
     }
 }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/DeleteRowMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/DeleteRowMethod.java
@@ -123,12 +123,13 @@ public class DeleteRowMethod implements Method {
 
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
                 methodConfig.getSpreadsheetId() /* spreadsheet Id */
-                        + ":batchUpdate");
+                        + ":batchUpdate",
+                true);
 
         final int rowIndex = Integer.parseInt(methodConfig.getTableHeaderIndex()) +
                 Integer.parseInt(methodConfig.getRowIndex());
         return webClient.method(HttpMethod.POST)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.fromValue(
                         Map.of(
                                 "requests", List.of(

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/DeleteSheetMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/DeleteSheetMethod.java
@@ -108,18 +108,19 @@ public class DeleteSheetMethod implements Method {
 
         if (GoogleSheets.SPREADSHEET.equalsIgnoreCase(methodConfig.getDeleteFormat())) {
             UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_DRIVE_API_URL,
-                    methodConfig.getSpreadsheetId() /* spreadsheet Id */
+                    methodConfig.getSpreadsheetId(), /* spreadsheet Id */
+                    true
             );
 
             return webClient.method(HttpMethod.DELETE)
-                    .uri(uriBuilder.build(false).toUri());
+                    .uri(uriBuilder.build(true).toUri());
         } else {
             UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
                     methodConfig.getSpreadsheetId() /* spreadsheet Id */
-                            + ":batchUpdate");
+                            + ":batchUpdate", true);
 
             return webClient.method(HttpMethod.POST)
-                    .uri(uriBuilder.build(false).toUri())
+                    .uri(uriBuilder.build(true).toUri())
                     .body(BodyInserters.fromValue(
                             Map.of(
                                     "requests", List.of(

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/UpdateMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/UpdateMethod.java
@@ -16,6 +16,8 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -175,7 +177,8 @@ public class UpdateMethod implements Method {
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
                 methodConfig.getSpreadsheetId() /* spreadsheet Id */
                         + "/values/"
-                        + methodConfig.getSpreadsheetRange() /* spreadsheet Range */
+                        + URLEncoder.encode(methodConfig.getSpreadsheetRange(), StandardCharsets.UTF_8),  /* spreadsheet Range */
+                true
         );
 
         uriBuilder.queryParam("valueInputOption", "USER_ENTERED");
@@ -184,7 +187,7 @@ public class UpdateMethod implements Method {
         final List<String> objects = new ArrayList<>(rowObject.getValueMap().values());
 
         return webClient.method(HttpMethod.PUT)
-                .uri(uriBuilder.build(false).toUri())
+                .uri(uriBuilder.build(true).toUri())
                 .body(BodyInserters.fromValue(Map.of(
                         "range", methodConfig.getSpreadsheetRange(),
                         "majorDimension", "ROWS",


### PR DESCRIPTION
## Fix for Space in Google Sheet name

> Fixed the error when google sheet name contains space 
> Verified error is not thrown for sheet name containing special chars.

Fixes #10502
 

## Type of change

- Bug fix (non-breaking change which fixes an issue) 
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Manual testing


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
