### PR TITLE
feat: added a support for multipart form data content type in execute action request

### DIFF
--- a/app/client/src/api/ActionAPI.tsx
+++ b/app/client/src/api/ActionAPI.tsx
@@ -166,11 +166,15 @@ class ActionAPI extends API {
   }
 
   static executeAction(
-    executeAction: ExecuteActionRequest,
+    executeAction: FormData,
     timeout?: number,
   ): AxiosPromise<ActionExecutionResponse> {
     return API.post(ActionAPI.url + "/execute", executeAction, undefined, {
       timeout: timeout || DEFAULT_EXECUTE_ACTION_TIMEOUT_MS,
+      headers: {
+        accept: "application/json",
+        "Content-Type": "multipart/form-data",
+      },
     });
   }
 


### PR DESCRIPTION
## Description

1. Changed the headers for the Execute Action request for passing data as `multipart/form-data` and receiving data back as `application/json`.
2. Changed the structure of passing the data to the Execute Action request by converting the data to FormData objects rather than key value pairs 

Fixes # (issue)

#9395

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

>  Added actions by creating API's, query and passing different params from widget to perform execute action request.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feat/binary-data-request 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/sagas/ActionExecution/PluginActionSaga.ts | 17.67 **(0.07)** | 2.75 **(0.02)** | 10.53 **(0)** | 20.19 **(0)**</details>