### PR TITLE
fix: onOptionChange on TreeSelects and fix Switch Toggle

### DIFF
--- a/app/client/cypress.env.json
+++ b/app/client/cypress.env.json
@@ -1,6 +1,4 @@
 {
   "MySQL":1,
-  "Mongo":1,
-  "USERNAME": "tol@gmail.com",
-  "PASSWORD": "password"
+  "Mongo":1
  }

--- a/app/client/cypress.env.json
+++ b/app/client/cypress.env.json
@@ -1,4 +1,6 @@
 {
   "MySQL":1,
-  "Mongo":1
+  "Mongo":1,
+  "USERNAME": "tol@gmail.com",
+  "PASSWORD": "password"
  }

--- a/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
@@ -404,15 +404,8 @@ class MultiSelectTreeWidget extends BaseWidget<
   }
 
   onOptionChange = (value?: DefaultValueType, labelList?: ReactNode[]) => {
+    this.props.updateWidgetMetaProperty("selectedOptionValueArr", value);
     this.props.updateWidgetMetaProperty("selectedLabel", labelList, {
-      triggerPropertyName: "onOptionChange",
-      dynamicString: this.props.onOptionChange,
-      event: {
-        type: EventType.ON_OPTION_CHANGE,
-      },
-    });
-
-    this.props.updateWidgetMetaProperty("selectedOptionValueArr", value, {
       triggerPropertyName: "onOptionChange",
       dynamicString: this.props.onOptionChange,
       event: {

--- a/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
@@ -367,15 +367,8 @@ class SingleSelectTreeWidget extends BaseWidget<
   }
 
   onOptionChange = (value?: DefaultValueType, labelList?: ReactNode[]) => {
+    this.props.updateWidgetMetaProperty("selectedOption", value);
     this.props.updateWidgetMetaProperty("selectedLabel", labelList, {
-      triggerPropertyName: "onOptionChange",
-      dynamicString: this.props.onOptionChange,
-      event: {
-        type: EventType.ON_OPTION_CHANGE,
-      },
-    });
-
-    this.props.updateWidgetMetaProperty("selectedOption", value, {
       triggerPropertyName: "onOptionChange",
       dynamicString: this.props.onOptionChange,
       event: {

--- a/app/client/src/widgets/SwitchWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/component/index.tsx
@@ -1,4 +1,5 @@
 import { Alignment, Classes, Switch } from "@blueprintjs/core";
+import { Colors } from "constants/Colors";
 import { BlueprintControlTransform } from "constants/DefaultTheme";
 import React from "react";
 import styled from "styled-components";
@@ -19,6 +20,10 @@ const SwitchComponentContainer = styled.div`
   align-items: center;
   .${Classes.CONTROL} {
     margin: 0;
+    input:checked ~ .${Classes.CONTROL_INDICATOR} {
+      background: ${Colors.GREEN} !important;
+      border: 1px solid ${Colors.GREEN} !important;
+    }
   }
   &.${Alignment.RIGHT} {
     justify-content: flex-end;

--- a/app/client/src/widgets/SwitchWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/component/index.tsx
@@ -18,11 +18,11 @@ const SwitchComponentContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  .${Classes.CONTROL} {
+  &&& .${Classes.CONTROL} {
     margin: 0;
     input:checked ~ .${Classes.CONTROL_INDICATOR} {
-      background: ${Colors.GREEN} !important;
-      border: 1px solid ${Colors.GREEN} !important;
+      background: ${Colors.GREEN};
+      border: 1px solid ${Colors.GREEN};
     }
   }
   &.${Alignment.RIGHT} {


### PR DESCRIPTION
## Description
 FIxes onOptionChange for TreeSelect and Multiselect

Fixes #9078
Fixes #9598

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/OnOptionChange-called-twice-in-Tree-select 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/widgets/SwitchWidget/component/index.tsx | 93.75 **(0.42)** | 62.5 **(0)** | 50 **(0)** | 93.75 **(0.42)**</details>