### PR TITLE
fix: Change delete icon in s3 amazon where clause component

### DIFF
--- a/app/client/src/components/ads/Icon.tsx
+++ b/app/client/src/components/ads/Icon.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, Ref } from "react";
-// import { ReactComponent as DeleteBin } from "assets/icons/ads/delete.svg";
+// import { ReactComponent as DeleteIcon } from "assets/icons/ads/delete.svg";
 import { ReactComponent as BookLineIcon } from "assets/icons/ads/book-open-line.svg";
 import { ReactComponent as BugIcon } from "assets/icons/ads/bug.svg";
 import { ReactComponent as CancelIcon } from "assets/icons/ads/cancel.svg";

--- a/app/client/src/components/formControls/WhereClauseControl.tsx
+++ b/app/client/src/components/formControls/WhereClauseControl.tsx
@@ -170,7 +170,7 @@ function ConditionComponent(props: any, index: number) {
           e.stopPropagation();
           props.onDeletePressed(index);
         }}
-        size={IconSize.LARGE}
+        size={IconSize.XL}
       />
     </ConditionBox>
   );
@@ -258,12 +258,14 @@ function ConditionBlock(props: any) {
                       rerenderOnEveryChange={false}
                     />
                     <CenteredIcon
+                      alignSelf={"center"}
+                      marginBottom={"-5px"}
                       name="trash"
                       onClick={(e) => {
                         e.stopPropagation();
                         onDeletePressed(index);
                       }}
-                      size={IconSize.LARGE}
+                      size={IconSize.XL}
                     />
                   </ConditionBox>
                 );


### PR DESCRIPTION
## Description

Change Icon from cross to delete.

Fixes #9299

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>