### PR TITLE
fix: fixes apiEditor url overflow, indicates active datasource in datasour…

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -139,6 +139,7 @@ export type EditorProps = EditorStyleProps &
     errors?: any;
     isInvalid?: boolean;
     isEditorHidden?: boolean;
+    codeEditorVisibleOverflow?: boolean; // flag for determining the input overflow type for the code editor
   };
 
 type Props = ReduxStateProps &
@@ -595,6 +596,7 @@ class CodeEditor extends Component<Props, State> {
       border,
       borderLess,
       className,
+      codeEditorVisibleOverflow,
       dataTreePath,
       disabled,
       dynamicData,
@@ -679,6 +681,7 @@ class CodeEditor extends Component<Props, State> {
             className={`${className} ${replayHighlightClass} ${
               isInvalid ? "t--codemirror-has-error" : ""
             }`}
+            codeEditorVisibleOverflow={codeEditorVisibleOverflow}
             disabled={disabled}
             editorTheme={this.props.theme}
             fill={fill}

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -50,6 +50,7 @@ export const EditorWrapper = styled.div<{
   hoverInteraction?: boolean;
   fill?: boolean;
   className?: string;
+  codeEditorVisibleOverflow?: boolean;
 }>`
   width: 100%;
   ${(props) =>
@@ -265,6 +266,18 @@ export const EditorWrapper = styled.div<{
       return `height: ${height}`;
     }}
   }
+
+  ${(props) =>
+    props.codeEditorVisibleOverflow &&
+    `
+    & .CodeMirror-scroll {
+      overflow: visible !important;
+    }
+   
+    & .CodeEditorTarget {
+      height: ${props.isFocused ? "auto" : "35px"};
+    }
+  `}
 `;
 
 export const IconContainer = styled.div`

--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -75,6 +75,7 @@ type Props = EditorProps &
   ReduxDispatchProps & {
     input: Partial<WrappedFieldInputProps>;
     pluginId: string;
+    codeEditorVisibleOverflow: boolean; // this variable adds a custom style to the codeEditor when focused.
   };
 
 const DatasourceContainer = styled.div`
@@ -358,6 +359,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
 
   render() {
     const {
+      codeEditorVisibleOverflow,
       datasource,
       input: { value },
     } = this.props;
@@ -381,6 +383,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
       showLightningMenu: false,
       fill: true,
       expected: getExpectedValue({ type: ValidationTypes.SAFE_URL }),
+      codeEditorVisibleOverflow,
     };
 
     return (
@@ -390,7 +393,6 @@ class EmbeddedDatasourcePathComponent extends React.Component<Props> {
           border={CodeEditorBorder.ALL_SIDE}
           className="t--datasource-editor"
           evaluatedValue={this.handleEvaluatedValue()}
-          height="35px"
         />
         {displayValue && datasource && !("id" in datasource) ? (
           <StoreAsDatasource enable={!!displayValue} />
@@ -469,6 +471,7 @@ function EmbeddedDatasourcePathField(
     placeholder?: string;
     theme: EditorTheme;
     actionName: string;
+    codeEditorVisibleOverflow?: boolean;
   },
 ) {
   return (

--- a/app/client/src/constants/Colors.tsx
+++ b/app/client/src/constants/Colors.tsx
@@ -42,6 +42,7 @@ export const Colors = {
 
   FOAM: "#D9FDED",
   GREEN: "#03B365",
+  LIGHT_GREEN_CYAN: "#e5f6ec",
   JUNGLE_GREEN: "#24BA91",
   JUNGLE_GREEN_DARKER: "#30A481",
   FERN_GREEN: "#50AF6C",

--- a/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import styled from "styled-components";
 import Icon, { IconSize } from "components/ads/Icon";
 import { StyledSeparator } from "pages/Applications/ProductUpdatesModal/ReleaseComponent";
@@ -13,9 +13,10 @@ import ActionRightPane, {
   useEntityDependencies,
 } from "components/editorComponents/ActionRightPane";
 import { useSelector } from "react-redux";
-
 import { Classes } from "components/ads/common";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
+import { Colors } from "constants/Colors";
+import { sortedDatasourcesHandler } from "./helpers";
 
 const EmptyDatasourceContainer = styled.div`
   display: flex;
@@ -117,6 +118,32 @@ const DataSourceNameContainer = styled.div`
   }
 `;
 
+const IconContainer = styled.div`
+  display: inherit;
+`;
+
+const SelectedDatasourceInfoContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 2px 8px;
+  background-color: ${Colors.LIGHT_GREEN_CYAN};
+  margin-right: 5px;
+  text-transform: uppercase;
+  & p {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 8px;
+    line-height: 10px;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    color: ${Colors.GREEN};
+  }
+`;
+
 const SomeWrapper = styled.div`
   border-left: 2px solid ${(props) => props.theme.colors.apiPane.dividerBg};
   height: 100%;
@@ -157,7 +184,7 @@ export const getDatasourceInfo = (datasource: any): string => {
   return info.join(" | ");
 };
 
-export default function ApiRightPane(props: any) {
+function ApiRightPane(props: any) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { entityDependencies, hasDependencies } = useEntityDependencies(
     props.actionName,
@@ -167,6 +194,16 @@ export default function ApiRightPane(props: any) {
   }, [props.hasResponse]);
 
   const applicationId = useSelector(getCurrentApplicationId);
+
+  // array of datasources with the current action's datasource first, followed by the rest.
+  const sortedDatasources = useMemo(
+    () =>
+      sortedDatasourcesHandler(
+        props.datasources,
+        props.currentActionDatasourceId,
+      ),
+    [props.datasources, props.currentActionDatasourceId],
+  );
 
   return (
     <DatasourceContainer>
@@ -183,7 +220,7 @@ export default function ApiRightPane(props: any) {
                   <DataSourceListWrapper
                     className={selectedIndex === 0 ? "show" : ""}
                   >
-                    {(props.datasources || []).map((d: any, idx: number) => {
+                    {(sortedDatasources || []).map((d: any, idx: number) => {
                       const dataSourceInfo: string = getDatasourceInfo(d);
                       return (
                         <DatasourceCard
@@ -194,21 +231,28 @@ export default function ApiRightPane(props: any) {
                             <Text type={TextType.H5} weight={FontWeight.BOLD}>
                               {d.name}
                             </Text>
-                            <Icon
-                              name="edit"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                history.push(
-                                  DATA_SOURCES_EDITOR_ID_URL(
-                                    applicationId,
-                                    props.currentPageId,
-                                    d.id,
-                                    getQueryParams(),
-                                  ),
-                                );
-                              }}
-                              size={IconSize.LARGE}
-                            />
+                            <IconContainer>
+                              {d?.id === props.currentActionDatasourceId && (
+                                <SelectedDatasourceInfoContainer>
+                                  <p>In use</p>
+                                </SelectedDatasourceInfoContainer>
+                              )}
+                              <Icon
+                                name="edit"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  history.push(
+                                    DATA_SOURCES_EDITOR_ID_URL(
+                                      applicationId,
+                                      props.currentPageId,
+                                      d.id,
+                                      getQueryParams(),
+                                    ),
+                                  );
+                                }}
+                                size={IconSize.LARGE}
+                              />
+                            </IconContainer>
                           </DataSourceNameContainer>
                           <DatasourceURL>
                             {d.datasourceConfiguration.url}
@@ -267,3 +311,5 @@ export default function ApiRightPane(props: any) {
     </DatasourceContainer>
   );
 }
+
+export default React.memo(ApiRightPane);

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -257,6 +257,7 @@ interface APIFormProps {
   hasResponse: boolean;
   suggestedWidgets?: SuggestedWidget[];
   updateDatasource: (datasource: Datasource) => void;
+  currentActionDatasourceId: string;
 }
 
 type Props = APIFormProps & InjectedFormProps<Action, APIFormProps>;
@@ -535,6 +536,7 @@ function ApiEditorForm(props: Props) {
     actionConfigurationHeaders,
     actionConfigurationParams,
     actionName,
+    currentActionDatasourceId,
     handleSubmit,
     headersCount,
     hintMessages,
@@ -618,6 +620,7 @@ function ApiEditorForm(props: Props) {
             <DatasourceWrapper className="t--dataSourceField">
               <EmbeddedDatasourcePathField
                 actionName={actionName}
+                codeEditorVisibleOverflow
                 name="actionConfiguration.path"
                 placeholder="https://mock-api.appsmith.com/users"
                 pluginId={pluginId}
@@ -752,6 +755,7 @@ function ApiEditorForm(props: Props) {
           <DataSourceList
             actionName={actionName}
             applicationId={props.applicationId}
+            currentActionDatasourceId={currentActionDatasourceId}
             currentPageId={props.currentPageId}
             datasources={props.datasources}
             hasResponse={props.hasResponse}
@@ -800,6 +804,8 @@ export default connect((state: AppState, props: { pluginId: string }) => {
     get(datasourceFromAction, "datasourceConfiguration.queryParameters") || [];
 
   const apiId = selector(state, "id");
+  const currentActionDatasourceId = selector(state, "datasource.id");
+
   const actionName = getApiName(state, apiId) || "";
   const headers = selector(state, "actionConfiguration.headers");
   let headersCount = 0;
@@ -849,6 +855,7 @@ export default connect((state: AppState, props: { pluginId: string }) => {
     httpMethodFromForm,
     actionConfigurationHeaders,
     actionConfigurationParams,
+    currentActionDatasourceId,
     datasourceHeaders,
     datasourceParams,
     headersCount,

--- a/app/client/src/pages/Editor/APIEditor/helpers.ts
+++ b/app/client/src/pages/Editor/APIEditor/helpers.ts
@@ -12,3 +12,22 @@ export const curlImportSubmitHandler = (
 ) => {
   dispatch(submitCurlImportForm(values));
 };
+
+export const sortedDatasourcesHandler = (
+  datasources: Record<string, any>,
+  currentDatasourceId: string,
+) => {
+  // this function sorts the datasources list, with the current action's datasource first, followed by others.
+  let sortedArr = [];
+
+  sortedArr = datasources.filter(
+    (d: { id: string }) => d?.id === currentDatasourceId,
+  );
+
+  sortedArr = [
+    ...sortedArr,
+    ...datasources.filter((d: { id: string }) => d?.id !== currentDatasourceId),
+  ];
+
+  return sortedArr;
+};


### PR DESCRIPTION
Prior to this PR:

1. The Api Editor's url input introduces a scroll inside the input field when the text overflows to the next line causing the first line to be unreadable.
2. It was difficult to identify the datasource of the action being used in the Api Editor.

This PR addresses the issues by

1. Increasing the size of the focused input field when the text goes to the next line.
2. Sorts the Datasources list such that the current action's datasource is displayed first and a "In use" tag is attached to it.

Fixes #6215 

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

Manual tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
