### PR TITLE
fix: broken list widget

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -131,6 +131,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       props,
       PATH_TO_ALL_WIDGETS_IN_LIST_WIDGET,
     );
+    if (!listWidgetChildren) return;
     listWidgetChildren.map((child) => {
       privateWidgets[child.widgetName] = true;
     });


### PR DESCRIPTION
## Description

When the List Widget's height is less than the height of the template container height, the path to the list of its children becomes "not defined".

<img width="315" alt="Screenshot 2022-01-27 at 07 02 24" src="https://user-images.githubusercontent.com/46670083/151302073-6f2b133c-0fe0-4a6d-9dc7-2c911688b16f.png">


Fixes #10668


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/broken-list-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.05 **(0)** | 36.66 **(-0.01)** | 34.98 **(0)** | 55.45 **(0)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/widgets/ListWidget/widget/index.tsx | 63.34 **(-0.09)** | 27.36 **(0.22)** | 58.49 **(0)** | 62.54 **(0.13)**</details>