### PR TITLE
feat: added a keydown listener to focus property pane title on pressing f2

### DIFF
--- a/app/client/src/components/ads/EditableText.test.tsx
+++ b/app/client/src/components/ads/EditableText.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import EditableText from "./EditableText";
+import userEvent from "@testing-library/user-event";
+import { EditInteractionKind, SavingState } from "./EditableTextSubComponent";
+import { ThemeProvider } from "constants/DefaultTheme";
+import { lightTheme } from "selectors/themeSelectors";
+
+describe("<EditableText />", () => {
+  it("should call onBlurEverytime on each and every blur", async () => {
+    const handleBlur = jest.fn();
+    const getTestComponent = () => (
+      <ThemeProvider theme={lightTheme}>
+        <EditableText
+          defaultValue="Test"
+          editInteractionKind={EditInteractionKind.SINGLE}
+          onBlurEverytime={handleBlur}
+          savingState={SavingState.NOT_STARTED}
+        />
+      </ThemeProvider>
+    );
+    const component = getTestComponent();
+    const renderResult = render(component);
+    const EditableTextElement = renderResult.container.firstElementChild;
+    if (EditableTextElement) {
+      userEvent.click(EditableTextElement);
+      userEvent.tab();
+      expect(handleBlur).toHaveBeenCalled();
+    } else {
+      throw new Error("Failed");
+    }
+  });
+});

--- a/app/client/src/components/ads/EditableText.tsx
+++ b/app/client/src/components/ads/EditableText.tsx
@@ -16,7 +16,8 @@ export type EditableTextProps = CommonComponentProps & {
   placeholder?: string;
   editInteractionKind: EditInteractionKind;
   savingState: SavingState;
-  onBlur?: (value: string) => void;
+  onBlur?: (value: string) => void; // This `Blur` will be called only when there is a change in the value after we unfocus from the input field
+  onBlurEverytime?: (value: string) => void; // This `Blur` will be called everytime we unfocus from the input field
   onTextChanged?: (value: string) => void;
   valueTransform?: (value: string) => string;
   isEditingDefault?: boolean;

--- a/app/client/src/components/ads/EditableTextSubComponent.tsx
+++ b/app/client/src/components/ads/EditableTextSubComponent.tsx
@@ -38,7 +38,8 @@ export type EditableTextSubComponentProps = CommonComponentProps & {
   defaultSavingState: SavingState;
   savingState: SavingState;
   setSavingState: typeof noop;
-  onBlur?: (value: string) => void;
+  onBlur?: (value: string) => void; // This `Blur` will be called only when there is a change in the value after we unfocus from the input field
+  onBlurEverytime?: (value: string) => void; // This `Blur` will be called everytime we unfocus from the input field
   onTextChanged?: (value: string) => void;
   valueTransform?: (value: string) => string;
   isEditingDefault?: boolean;
@@ -159,6 +160,7 @@ export function EditableTextSubComponent(props: EditableTextSubComponentProps) {
     isError,
     isInvalid,
     onBlur,
+    onBlurEverytime,
     onTextChanged,
     savingState,
     setIsEditing,
@@ -204,6 +206,7 @@ export function EditableTextSubComponent(props: EditableTextSubComponentProps) {
   const onConfirm = useCallback(
     (_value: string) => {
       const finalVal: string = _value.trim();
+      onBlurEverytime && onBlurEverytime(finalVal);
       if (savingState === SavingState.ERROR || isInvalid || finalVal === "") {
         setValue(lastValidValue);
         onBlur && onBlur(lastValidValue);

--- a/app/client/src/pages/Editor/PropertyPaneTitle.test.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import PropertyPaneTitle from "./PropertyPaneTitle";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "constants/DefaultTheme";
+import { lightTheme } from "selectors/themeSelectors";
+import { Provider } from "react-redux";
+import store from "../../store";
+
+describe("<PropertyPaneTitle />", () => {
+  it("should focus when f2 is pressed", async () => {
+    const getTestComponent = () => (
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <PropertyPaneTitle
+            actions={[]}
+            isPanelTitle
+            // title="test"
+            widgetId="1"
+          />
+        </ThemeProvider>
+      </Provider>
+    );
+    const component = getTestComponent();
+    const renderResult = render(component);
+    await userEvent.keyboard("{F2}");
+    expect(renderResult.container.querySelector("input")).toBeVisible();
+  });
+});

--- a/app/client/src/pages/Editor/PropertyPaneTitle.tsx
+++ b/app/client/src/pages/Editor/PropertyPaneTitle.tsx
@@ -95,6 +95,27 @@ const PropertyPaneTitle = memo(function PropertyPaneTitle(
     setName(props.title);
   }, [props.title]);
 
+  // Focus title on F2
+
+  const [isEditingDefault, setIsEditingDefault] = useState(
+    !props.isPanelTitle ? isNew : undefined,
+  );
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === "F2") {
+      setIsEditingDefault(true);
+    }
+  }
+
+  function handleOnBlurEverytime() {
+    setIsEditingDefault(false);
+  }
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  });
+
   return props.widgetId || props.isPanelTitle ? (
     <div className="flex items-center w-full px-3 space-x-1 z-3">
       {/* BACK BUTTON */}
@@ -114,8 +135,9 @@ const PropertyPaneTitle = memo(function PropertyPaneTitle(
           editInteractionKind={EditInteractionKind.SINGLE}
           fill
           hideEditIcon
-          isEditingDefault={!props.isPanelTitle ? isNew : undefined}
+          isEditingDefault={isEditingDefault}
           onBlur={!props.isPanelTitle ? updateTitle : undefined}
+          onBlurEverytime={handleOnBlurEverytime}
           onTextChanged={!props.isPanelTitle ? undefined : updateNewTitle}
           placeholder={props.title}
           savingState={updating ? SavingState.STARTED : SavingState.NOT_STARTED}


### PR DESCRIPTION
## Description

- Added a key-down listener as an effect in PropertyPaneTitle to listen to F2 key and trigger isEditing to true.
- Added a new onBlurEverytime callback prop to EditableTextSubComponent to call it every time the user unfocus from the input, the existing onBlur calls only if there is a change in the value in the input field.
- Since EditableText is a wrapper component around EditableTextSubComponent added onBlurEverytime there also.
- Using this new onBlurEverytime in PropertyPaneTitle we will set isEditing to false.


Fixes #9413

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual UI Testing
- Added jest tests for PropertyPaneTitle and EditableText.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: enhancement/focus-widget-title-on-f2 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.04 **(0.04)** | 36.67 **(0.11)** | 34.99 **(0.06)** | 55.45 **(0.05)**
 :green_circle: | app/client/src/components/ads/EditableText.tsx | 97.06 **(17.65)** | 68.75 **(37.5)** | 100 **(25)** | 96.3 **(22.23)**
 :green_circle: | app/client/src/components/ads/EditableTextSubComponent.tsx | 75.82 **(10.26)** | 63.33 **(19.01)** | 84 **(12)** | 75 **(11.14)**
 :green_circle: | app/client/src/components/ads/Icon.tsx | 52.59 **(0.94)** | 36.63 **(2.33)** | 100 **(0)** | 52.48 **(0.94)**
 :green_circle: | app/client/src/pages/Editor/PropertyPaneTitle.tsx | 73.68 **(3.47)** | 35 **(13.95)** | 72.73 **(1.3)** | 70.59 **(2.41)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>