### PR TITLE
fix: marking old async functions as async in the backed for settings

### DIFF
--- a/app/client/src/actions/evaluationActions.ts
+++ b/app/client/src/actions/evaluationActions.ts
@@ -17,7 +17,8 @@ export const FIRST_EVAL_REDUX_ACTIONS = [
 export const EVALUATE_REDUX_ACTIONS = [
   ...FIRST_EVAL_REDUX_ACTIONS,
   // Actions
-  ReduxActionTypes.FETCH_ACTIONS_SUCCESS,
+  //ReduxActionTypes.FETCH_ACTIONS_SUCCESS,
+  ReduxActionTypes.FETCH_ALL_ACTIONS_SUCCESS,
   ReduxActionTypes.FETCH_PLUGIN_FORM_CONFIGS_SUCCESS,
   ReduxActionTypes.FETCH_ACTIONS_VIEW_MODE_SUCCESS,
   ReduxActionErrorTypes.FETCH_ACTIONS_ERROR,
@@ -35,7 +36,7 @@ export const EVALUATE_REDUX_ACTIONS = [
   ReduxActionErrorTypes.EXECUTE_PLUGIN_ACTION_ERROR,
   ReduxActionTypes.CLEAR_ACTION_RESPONSE,
   // JS Actions
-  ReduxActionTypes.FETCH_JS_ACTIONS_SUCCESS,
+  //ReduxActionTypes.FETCH_JS_ACTIONS_SUCCESS,
   ReduxActionTypes.CREATE_JS_ACTION_SUCCESS,
   ReduxActionErrorTypes.FETCH_JS_ACTIONS_ERROR,
   ReduxActionTypes.DELETE_JS_ACTION_SUCCESS,

--- a/app/client/src/constants/ReduxActionConstants.tsx
+++ b/app/client/src/constants/ReduxActionConstants.tsx
@@ -640,6 +640,7 @@ export const ReduxActionTypes = {
   /* This action constants is for identifying the status of the updates of the entities */
   ENTITY_UPDATE_STARTED: "ENTITY_UPDATE_STARTED",
   ENTITY_UPDATE_SUCCESS: "ENTITY_UPDATE_SUCCESS",
+  FETCH_ALL_ACTIONS_SUCCESS: "FETCH_ALL_ACTIONS_SUCCESS",
 };
 
 export type ReduxActionType = typeof ReduxActionTypes[keyof typeof ReduxActionTypes];

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -126,7 +126,6 @@ function* initializeEditorSaga(
       }),
       fetchPageList({ applicationId }, APP_MODE.EDIT),
     ];
-
     const successEffects = [
       ReduxActionTypes.FETCH_APPLICATION_SUCCESS,
       ReduxActionTypes.FETCH_PAGE_LIST_SUCCESS,
@@ -136,12 +135,12 @@ function* initializeEditorSaga(
       ReduxActionErrorTypes.FETCH_APPLICATION_ERROR,
       ReduxActionErrorTypes.FETCH_PAGE_LIST_ERROR,
     ];
-    const jsActionsCall = yield failFastApiCalls(
-      [fetchJSCollections({ applicationId })],
-      [ReduxActionTypes.FETCH_JS_ACTIONS_SUCCESS],
-      [ReduxActionErrorTypes.FETCH_JS_ACTIONS_ERROR],
-    );
-    if (!jsActionsCall) return;
+    // const jsActionsCall = yield failFastApiCalls(
+    //   [fetchJSCollections({ applicationId })],
+    //   [ReduxActionTypes.FETCH_JS_ACTIONS_SUCCESS],
+    //   [ReduxActionErrorTypes.FETCH_JS_ACTIONS_ERROR],
+    // );
+    // if (!jsActionsCall) return;
     if (pageId) {
       initCalls.push(fetchPage(pageId, true) as any);
       successEffects.push(ReduxActionTypes.FETCH_PAGE_SUCCESS);
@@ -155,6 +154,34 @@ function* initializeEditorSaga(
     );
 
     if (!applicationAndLayoutCalls) return;
+
+    const initActionsCalls = [
+      fetchActions({ applicationId }, []),
+      fetchJSCollections({ applicationId }),
+    ];
+
+    const successActionEffects = [
+      ReduxActionTypes.FETCH_JS_ACTIONS_SUCCESS,
+      ReduxActionTypes.FETCH_ACTIONS_SUCCESS,
+    ];
+    const failureActionEffects = [
+      ReduxActionErrorTypes.FETCH_JS_ACTIONS_ERROR,
+      ReduxActionErrorTypes.FETCH_ACTIONS_ERROR,
+    ];
+    const allActionCalls = yield failFastApiCalls(
+      initActionsCalls,
+      successActionEffects,
+      failureActionEffects,
+    );
+
+    if (!allActionCalls) {
+      return;
+    } else {
+      yield put({
+        type: ReduxActionTypes.FETCH_ALL_ACTIONS_SUCCESS,
+      });
+      yield put(executePageLoadActions());
+    }
 
     let fetchPageCallResult;
     const defaultPageId = yield select(getDefaultPageId);
@@ -193,12 +220,12 @@ function* initializeEditorSaga(
     );
     if (!pluginFormCall) return;
 
-    const actionsCall = yield failFastApiCalls(
-      [fetchActions({ applicationId }, [executePageLoadActions()])],
-      [ReduxActionTypes.FETCH_ACTIONS_SUCCESS],
-      [ReduxActionErrorTypes.FETCH_ACTIONS_ERROR],
-    );
-    if (!actionsCall) return;
+    // const actionsCall = yield failFastApiCalls(
+    //   [fetchActions({ applicationId }, [executePageLoadActions()])],
+    //   [ReduxActionTypes.FETCH_ACTIONS_SUCCESS],
+    //   [ReduxActionErrorTypes.FETCH_ACTIONS_ERROR],
+    // );
+    // if (!actionsCall) return;
 
     const currentApplication = yield select(getCurrentApplication);
     const appName = currentApplication ? currentApplication.name : "";

--- a/app/client/src/utils/JSPaneUtils.tsx
+++ b/app/client/src/utils/JSPaneUtils.tsx
@@ -37,7 +37,10 @@ export const getDifferenceInJSCollection = (
       const action = parsedBody.actions[i];
       const preExisted = jsAction.actions.find((js) => js.name === action.name);
       if (preExisted) {
-        if (preExisted.actionConfiguration.body !== action.body) {
+        if (
+          preExisted.actionConfiguration.body !== action.body ||
+          preExisted.actionConfiguration.isAsync !== action.isAsync
+        ) {
           toBeUpdatedActions.push({
             ...preExisted,
             actionConfiguration: {


### PR DESCRIPTION
## Description
1. we have seen multiple reference errors for APIs when mentioned in js functions
2. We are making this change to mark old async functions in the backend

Fixes #10237

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
