### PR TITLE
fix: Consistent rename behaviour for datasources

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
@@ -95,6 +95,11 @@ const ExplorerDatasourceEntity = React.memo(
       [datasourceStructure, props.datasource.id, dispatch],
     );
 
+    const nameTransformFn = useCallback(
+      (input: string) => input.slice(0, 30),
+      [],
+    );
+
     let isDefaultExpanded = false;
     if (expandDatasourceId === props.datasource.id) {
       isDefaultExpanded = true;
@@ -119,6 +124,7 @@ const ExplorerDatasourceEntity = React.memo(
         isDefaultExpanded={isDefaultExpanded}
         key={props.datasource.id}
         name={props.datasource.name}
+        onNameEdit={nameTransformFn}
         onToggle={getDatasourceStructure}
         searchKeyword={props.searchKeyword}
         step={props.step}


### PR DESCRIPTION
## Description
Fixes the rename behavior of datasources in explorer. It will not have the names transformed with underscore anymore and would have a length limit of 30 (just like how it works in the datasources page header).

Fixes #4904 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/4904-datasource-rename-explorer 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.02 **(0.01)** | 36.51 **(0.01)** | 34.73 **(0)** | 55.41 **(0)**
 :red_circle: | app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx | 37.5 **(-1.63)** | 0 **(0)** | 0 **(0)** | 37.5 **(-1.63)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**</details>