### PR TITLE
fix: Added iFrame to load Base64 PDF data in document viewer widget

### DIFF
--- a/app/client/src/widgets/DocumentViewerWidget/component/index.test.tsx
+++ b/app/client/src/widgets/DocumentViewerWidget/component/index.test.tsx
@@ -36,7 +36,7 @@ describe("validate document viewer url", () => {
       {
         url:
           "https://roteemealplancover.s3.ap-south-1.amazonaws.com/sample/Project+proposal.pdf",
-        viewer: "url",
+        viewer: "pdf",
         errorMessage: "",
         renderer: Renderers.DOCUMENT_VIEWER,
       },

--- a/app/client/src/widgets/DocumentViewerWidget/component/index.tsx
+++ b/app/client/src/widgets/DocumentViewerWidget/component/index.tsx
@@ -174,15 +174,20 @@ export const getDocViewerConfigs = (docUrl: string): ConfigResponse => {
   const { extension, hasExtension, validExtension } = checkUrlExtension(url);
   if (hasExtension) {
     if (validExtension) {
-      if (extension === "pdf") {
-        viewer = "pdf";
-        renderer = Renderers.DOCUMENT_VIEWER;
-      } else if (extension === "txt") {
-        viewer = "url";
-        renderer = Renderers.DOCUMENT_VIEWER;
-      } else {
-        viewer = "office";
-        renderer = Renderers.DOCUMENT_VIEWER;
+      renderer = Renderers.DOCUMENT_VIEWER;
+      switch (extension) {
+        case "pdf": {
+          viewer = "pdf";
+          break;
+        }
+        case "txt": {
+          viewer = "url";
+          break;
+        }
+        default: {
+          viewer = "office";
+          break;
+        }
       }
     } else {
       errorMessage = "Current file type is not supported";
@@ -225,8 +230,9 @@ function DocumentViewerComponent(props: DocumentViewerComponentProps) {
             width="100%"
           />
         );
+      } else {
+        return <DocumentViewer url={url} viewer={viewer} />;
       }
-      return <DocumentViewer url={url} viewer={viewer} />;
 
     default:
       return null;

--- a/app/client/src/widgets/DocumentViewerWidget/component/index.tsx
+++ b/app/client/src/widgets/DocumentViewerWidget/component/index.tsx
@@ -131,6 +131,8 @@ export const getDocViewerConfigs = (docUrl: string): ConfigResponse => {
           renderer = Renderers.DOCX_VIEWER;
         } else if (extension === "xlsx") {
           renderer = Renderers.XLSX_VIEWER;
+        } else if (extension === "pdf") {
+          viewer = "pdf";
         }
       } else {
         errorMessage = "invalid base64 data";
@@ -172,7 +174,13 @@ export const getDocViewerConfigs = (docUrl: string): ConfigResponse => {
   const { extension, hasExtension, validExtension } = checkUrlExtension(url);
   if (hasExtension) {
     if (validExtension) {
-      if (!(extension === "txt" || extension === "pdf")) {
+      if (extension === "pdf") {
+        viewer = "pdf";
+        renderer = Renderers.DOCUMENT_VIEWER;
+      } else if (extension === "txt") {
+        viewer = "url";
+        renderer = Renderers.DOCUMENT_VIEWER;
+      } else {
         viewer = "office";
         renderer = Renderers.DOCUMENT_VIEWER;
       }
@@ -206,6 +214,18 @@ function DocumentViewerComponent(props: DocumentViewerComponentProps) {
         </Suspense>
       );
     case Renderers.DOCUMENT_VIEWER:
+      if (viewer === "pdf") {
+        return (
+          <iframe
+            frameBorder="0"
+            height="100%"
+            id="pdfiframe"
+            src={url}
+            title="pdfiframe"
+            width="100%"
+          />
+        );
+      }
       return <DocumentViewer url={url} viewer={viewer} />;
 
     default:


### PR DESCRIPTION
## Description

Added Iframe for load Base64 PDF in document viewer widget

Fixes #10756 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/pdf-document-viewer 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55 **(0)** | 36.49 **(0.01)** | 34.71 **(0)** | 55.4 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/widgets/DocumentViewerWidget/component/index.tsx | 41.53 **(1.16)** | 40.82 **(-4.83)** | 16.67 **(0)** | 43.27 **(1.16)**</details>