### PR TITLE
chore: beta tags for git sync

### DIFF
--- a/app/client/src/constants/Colors.tsx
+++ b/app/client/src/constants/Colors.tsx
@@ -164,5 +164,7 @@ export const Colors = {
 
   GRAY_900: "#101828",
   SCORPION: "#575757",
+
+  COD_GRAY: "#191919",
 };
 export type Color = typeof Colors[keyof typeof Colors];

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -583,6 +583,7 @@ export const IS_MERGING = () => "MERGING CHANGES...";
 export const MERGE_CHANGES = () => "Merge changes";
 export const SELECT_BRANCH_TO_MERGE = () => "Select branch to merge";
 export const CONNECT_GIT = () => "Connect Git";
+export const CONNECT_GIT_BETA = () => "Connect Git (Beta)";
 export const RETRY = () => "RETRY";
 export const CREATE_NEW_BRANCH = () => "CREATE NEW BRANCH";
 export const ERROR_WHILE_PULLING_CHANGES = () => "ERROR WHILE PULLING CHANGES";

--- a/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
+++ b/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
@@ -17,6 +17,7 @@ import {
   DURING_ONBOARDING_TOUR,
   createMessage,
   GIT_SETTINGS,
+  CONNECT_GIT_BETA,
 } from "constants/messages";
 
 import Tooltip from "components/ads/Tooltip";
@@ -256,7 +257,7 @@ function ConnectGitPlaceholder() {
                 dispatch(showConnectGitModal());
               }}
               size={Size.small}
-              text={createMessage(CONNECT_GIT)}
+              text={createMessage(CONNECT_GIT_BETA)}
             />
           ) : (
             <PlaceholderButton>{createMessage(CONNECT_GIT)}</PlaceholderButton>

--- a/app/client/src/pages/Editor/gitSync/components/BetaTag.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BetaTag.tsx
@@ -1,0 +1,21 @@
+import { Colors } from "constants/Colors";
+import { getTypographyByKey } from "constants/DefaultTheme";
+import React from "react";
+import styled from "styled-components";
+
+const StyledTag = styled.div`
+  height: 16px;
+  width: 48px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  ${(props) => getTypographyByKey(props, "btnSmall")};
+  border: 1px solid ${Colors.COD_GRAY};
+  color: ${Colors.COD_GRAY};
+`;
+
+function BetaTag() {
+  return <StyledTag>BETA</StyledTag>;
+}
+
+export default BetaTag;

--- a/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
@@ -44,6 +44,7 @@ import { isEllipsisActive } from "utils/helpers";
 import { getIsStartingWithRemoteBranches } from "pages/Editor/gitSync/utils";
 
 import SegmentHeader from "components/ads/ListSegmentHeader";
+import BetaTag from "./BetaTag";
 
 const ListContainer = styled.div`
   flex: 1;
@@ -360,6 +361,9 @@ function Header({
             />
           </Tooltip>
         </span>
+        <div style={{ marginLeft: 6 }}>
+          <BetaTag />
+        </div>
       </div>
       <Icon
         fillColor={get(theme, "colors.gitSyncModal.closeIcon")}

--- a/app/client/src/pages/Editor/gitSync/components/TabItem.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/TabItem.tsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import { getTypographyByKey, Theme } from "constants/DefaultTheme";
 import { TabProp } from "components/ads/Tabs";
 import { Colors } from "constants/Colors";
+import { MENU_ITEM } from "../constants";
+import BetaTag from "./BetaTag";
 
 type WrapperProps = {
   selected: boolean;
@@ -34,6 +36,8 @@ const Wrapper = styled.div<WrapperProps>`
   padding: ${(props) => `${props.theme.spaces[5]}px 0px`};
 
   width: 100%;
+
+  align-items: center;
 `;
 
 export default function TabItem(props: {
@@ -45,6 +49,11 @@ export default function TabItem(props: {
   return (
     <Wrapper key={tab.title} selected={selected} vertical={vertical}>
       {tab.title}
+      {tab.key === MENU_ITEM.GIT_CONNECTION && (
+        <div style={{ marginLeft: 6 }}>
+          <BetaTag />
+        </div>
+      )}
     </Wrapper>
   );
 }


### PR DESCRIPTION
## Description
chore: beta tags for git sync

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: git-sync-beta-tags 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.02 **(0.01)** | 36.51 **(0.01)** | 34.72 **(-0.01)** | 55.42 **(0.01)**
 :red_circle: | app/client/src/constants/messages.ts | 74.83 **(-0.02)** | 100 **(0)** | 25.41 **(-0.04)** | 80.31 **(0.02)**
 :sparkles: :new: | **app/client/src/pages/Editor/gitSync/components/BetaTag.tsx** | **75** | **100** | **0** | **75**
 :green_circle: | app/client/src/pages/Editor/gitSync/components/BranchList.tsx | 23.78 **(0.47)** | 10.13 **(0)** | 2.5 **(0)** | 25.85 **(0.51)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>