### PR TITLE
revert: "fix: Added iFrame to load Base64 PDF data in document viewer widget"

### DIFF
--- a/app/client/src/widgets/DocumentViewerWidget/component/index.test.tsx
+++ b/app/client/src/widgets/DocumentViewerWidget/component/index.test.tsx
@@ -36,7 +36,7 @@ describe("validate document viewer url", () => {
       {
         url:
           "https://roteemealplancover.s3.ap-south-1.amazonaws.com/sample/Project+proposal.pdf",
-        viewer: "pdf",
+        viewer: "url",
         errorMessage: "",
         renderer: Renderers.DOCUMENT_VIEWER,
       },

--- a/app/client/src/widgets/DocumentViewerWidget/component/index.tsx
+++ b/app/client/src/widgets/DocumentViewerWidget/component/index.tsx
@@ -131,8 +131,6 @@ export const getDocViewerConfigs = (docUrl: string): ConfigResponse => {
           renderer = Renderers.DOCX_VIEWER;
         } else if (extension === "xlsx") {
           renderer = Renderers.XLSX_VIEWER;
-        } else if (extension === "pdf") {
-          viewer = "pdf";
         }
       } else {
         errorMessage = "invalid base64 data";
@@ -174,20 +172,9 @@ export const getDocViewerConfigs = (docUrl: string): ConfigResponse => {
   const { extension, hasExtension, validExtension } = checkUrlExtension(url);
   if (hasExtension) {
     if (validExtension) {
-      renderer = Renderers.DOCUMENT_VIEWER;
-      switch (extension) {
-        case "pdf": {
-          viewer = "pdf";
-          break;
-        }
-        case "txt": {
-          viewer = "url";
-          break;
-        }
-        default: {
-          viewer = "office";
-          break;
-        }
+      if (!(extension === "txt" || extension === "pdf")) {
+        viewer = "office";
+        renderer = Renderers.DOCUMENT_VIEWER;
       }
     } else {
       errorMessage = "Current file type is not supported";
@@ -219,20 +206,7 @@ function DocumentViewerComponent(props: DocumentViewerComponentProps) {
         </Suspense>
       );
     case Renderers.DOCUMENT_VIEWER:
-      if (viewer === "pdf") {
-        return (
-          <iframe
-            frameBorder="0"
-            height="100%"
-            id="pdfiframe"
-            src={url}
-            title="pdfiframe"
-            width="100%"
-          />
-        );
-      } else {
-        return <DocumentViewer url={url} viewer={viewer} />;
-      }
+      return <DocumentViewer url={url} viewer={viewer} />;
 
     default:
       return null;


### PR DESCRIPTION
Reverts appsmithorg/appsmith#10770
## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: revert-10770-fix/pdf-document-viewer 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55 **(0)** | 36.48 **(-0.01)** | 34.71 **(0)** | 55.4 **(0)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/widgets/DocumentViewerWidget/component/index.tsx | 40.37 **(-1.16)** | 45.65 **(4.83)** | 16.67 **(0)** | 42.11 **(-1.16)**</details>