### PR TITLE
fix: added sentry exception for invalid DynamicBindingListPath

### DIFF
--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -53,7 +53,7 @@ import {
 } from "redux-saga/effects";
 import history from "utils/history";
 import { BUILDER_PAGE_URL } from "constants/routes";
-import { isInvalidDynamicBindingPath, isNameValid } from "utils/helpers";
+import { captureInvalidDynamicBindingPath, isNameValid } from "utils/helpers";
 import { extractCurrentDSL } from "utils/WidgetPropsUtils";
 import { checkIfMigrationIsNeeded } from "utils/DSLMigrations";
 import {
@@ -378,7 +378,7 @@ function* savePageSaga(action: ReduxAction<{ isRetry?: boolean }>) {
       payload: savePageRequest.dsl,
     });
 
-    isInvalidDynamicBindingPath(
+    captureInvalidDynamicBindingPath(
       CanvasWidgetsNormalizer.denormalize("0", {
         canvasWidgets: widgets,
       }),

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -53,7 +53,7 @@ import {
 } from "redux-saga/effects";
 import history from "utils/history";
 import { BUILDER_PAGE_URL } from "constants/routes";
-import { isNameValid } from "utils/helpers";
+import { isInvalidDynamicBindingPath, isNameValid } from "utils/helpers";
 import { extractCurrentDSL } from "utils/WidgetPropsUtils";
 import { checkIfMigrationIsNeeded } from "utils/DSLMigrations";
 import {
@@ -377,6 +377,12 @@ function* savePageSaga(action: ReduxAction<{ isRetry?: boolean }>) {
       type: ReduxActionTypes.UPDATE_CANVAS_STRUCTURE,
       payload: savePageRequest.dsl,
     });
+
+    isInvalidDynamicBindingPath(
+      CanvasWidgetsNormalizer.denormalize("0", {
+        canvasWidgets: widgets,
+      }),
+    );
 
     const savePageResponse: SavePageResponse = yield call(
       PageApi.savePage,

--- a/app/client/src/utils/helpers.test.ts
+++ b/app/client/src/utils/helpers.test.ts
@@ -6,7 +6,7 @@ import {
   flattenObject,
   getLocale,
   getSubstringBetweenTwoWords,
-  isInvalidDynamicBindingPath,
+  captureInvalidDynamicBindingPath,
   mergeWidgetConfig,
 } from "./helpers";
 import WidgetFactory from "./WidgetFactory";
@@ -195,8 +195,8 @@ describe("#getLocale", () => {
   });
 });
 
-describe("#isInvalidDynamicBindingPath", () => {
-  it("DSL should not alter", () => {
+describe("#captureInvalidDynamicBindingPath", () => {
+  it("DSL should not be altered", () => {
     const baseDSL = {
       widgetName: "RadioGroup1",
       dynamicPropertyPathList: [],
@@ -364,7 +364,7 @@ describe("#isInvalidDynamicBindingPath", () => {
         id: "b2k5a0t632",
       },
     ]);
-    const newDsl = isInvalidDynamicBindingPath(baseDSL);
+    const newDsl = captureInvalidDynamicBindingPath(baseDSL);
     expect(baseDSL).toEqual(newDsl);
   });
 
@@ -538,7 +538,7 @@ describe("#isInvalidDynamicBindingPath", () => {
 
     const sentrySpy = jest.spyOn(Sentry, "captureException");
 
-    isInvalidDynamicBindingPath(baseDSL);
+    captureInvalidDynamicBindingPath(baseDSL);
     expect(sentrySpy).toHaveBeenCalledWith(
       new Error(
         `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: RadioGroup1.options`,

--- a/app/client/src/utils/helpers.test.ts
+++ b/app/client/src/utils/helpers.test.ts
@@ -1,9 +1,16 @@
+import { RenderModes } from "constants/WidgetConstants";
+import { ValidationTypes } from "constants/WidgetValidation";
+import { EvaluationSubstitutionType } from "entities/DataTree/dataTreeFactory";
+import { AutocompleteDataType } from "./autocomplete/TernServer";
 import {
   flattenObject,
   getLocale,
   getSubstringBetweenTwoWords,
+  isInvalidDynamicBindingPath,
   mergeWidgetConfig,
 } from "./helpers";
+import WidgetFactory from "./WidgetFactory";
+import * as Sentry from "@sentry/react";
 
 describe("flattenObject test", () => {
   it("Check if non nested object is returned correctly", () => {
@@ -185,5 +192,357 @@ describe("#mergeWidgetConfig", () => {
 describe("#getLocale", () => {
   it("should test that getLocale is returning navigator.languages[0]", () => {
     expect(getLocale()).toBe(navigator.languages[0]);
+  });
+});
+
+describe("#isInvalidDynamicBindingPath", () => {
+  it("DSL should not alter", () => {
+    const baseDSL = {
+      widgetName: "RadioGroup1",
+      dynamicPropertyPathList: [],
+      displayName: "Radio Group",
+      iconSVG: "/static/media/icon.ba2b2ee0.svg",
+      topRow: 57,
+      bottomRow: 65,
+      parentRowSpace: 10,
+      type: "RADIO_GROUP_WIDGET",
+      hideCard: false,
+      defaultOptionValue: "{{1}}",
+      animateLoading: true,
+      parentColumnSpace: 33.375,
+      dynamicTriggerPathList: [],
+      leftColumn: 42,
+      dynamicBindingPathList: [
+        {
+          key: "defaultOptionValue",
+        },
+        {
+          key: "options",
+        },
+      ],
+      options:
+        '[\n  {\n    "label": "Yes",\n    "value": {{1 > 0 ? 1 : 0}}\n  },\n  {\n    "label": "No",\n    "value": 2\n  }\n]',
+      isDisabled: false,
+      key: "opzs6suotf",
+      isRequired: false,
+      rightColumn: 62,
+      widgetId: "s195otz2jm",
+      isVisible: true,
+      label: "",
+      version: 1,
+      parentId: "0",
+      renderMode: RenderModes.CANVAS,
+      isLoading: false,
+    };
+
+    const getPropertyConfig = jest.spyOn(
+      WidgetFactory,
+      "getWidgetPropertyPaneConfig",
+    );
+    getPropertyConfig.mockReturnValueOnce([
+      {
+        sectionName: "General",
+        children: [
+          {
+            helpText: "Displays a list of unique options",
+            propertyName: "options",
+            label: "Options",
+            controlType: "OPTION_INPUT",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.FUNCTION,
+              params: {
+                expected: {
+                  type:
+                    'Array<{ "label": "string", "value": "string" | number}>',
+                  example: '[{"label": "abc", "value": "abc" | 1}]',
+                  autocompleteDataType: AutocompleteDataType.STRING,
+                },
+                fnString:
+                  'function optionsCustomValidation(options, props, _) {\n  var validationUtil = (options, _) => {\n    var _isValid = true;\n    var message = "";\n    var valueType = "";\n    var uniqueLabels = {};\n\n    for (var i = 0; i < options.length; i++) {\n      var _options$i = options[i],\n          label = _options$i.label,\n          value = _options$i.value;\n\n      if (!valueType) {\n        valueType = typeof value;\n      } //Checks the uniqueness all the values in the options\n\n\n      if (!uniqueLabels.hasOwnProperty(value)) {\n        uniqueLabels[value] = "";\n      } else {\n        _isValid = false;\n        message = "path:value must be unique. Duplicate values found";\n        break;\n      } //Check if the required field "label" is present:\n\n\n      if (!label) {\n        _isValid = false;\n        message = "Invalid entry at index: " + i + ". Missing required key: label";\n        break;\n      } //Validation checks for the the label.\n\n\n      if (_.isNil(label) || label === "" || typeof label !== "string" && typeof label !== "number") {\n        _isValid = false;\n        message = "Invalid entry at index: " + i + ". Value of key: label is invalid: This value does not evaluate to type string";\n        break;\n      } //Check if all the data types for the value prop is the same.\n\n\n      if (typeof value !== valueType) {\n        _isValid = false;\n        message = "All value properties in options must have the same type";\n        break;\n      } //Check if the each object has value property.\n\n\n      if (_.isNil(value)) {\n        _isValid = false;\n        message = \'This value does not evaluate to type Array<{ "label": "string", "value": "string" | number }>\';\n        break;\n      }\n    }\n\n    return {\n      isValid: _isValid,\n      parsed: _isValid ? options : [],\n      messages: [message]\n    };\n  };\n\n  var invalidResponse = {\n    isValid: false,\n    parsed: [],\n    messages: [\'This value does not evaluate to type Array<{ "label": "string", "value": "string" | number }>\']\n  };\n\n  try {\n    if (_.isString(options)) {\n      options = JSON.parse(options);\n    }\n\n    if (Array.isArray(options)) {\n      return validationUtil(options, _);\n    } else {\n      return invalidResponse;\n    }\n  } catch (e) {\n    return invalidResponse;\n  }\n}',
+              },
+            },
+            evaluationSubstitutionType:
+              EvaluationSubstitutionType.SMART_SUBSTITUTE,
+            id: "6su4u0bwoe",
+          },
+          {
+            helpText: "Sets a default selected option",
+            propertyName: "defaultOptionValue",
+            label: "Default Selected Value",
+            // placeholderText: "Y",
+            controlType: "INPUT_TEXT",
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.FUNCTION,
+              params: {
+                expected: {
+                  type: "string |\nnumber (only works in mustache syntax)",
+                  example: "abc | {{1}}",
+                  autocompleteDataType: AutocompleteDataType.STRING,
+                },
+                fnString:
+                  'function defaultOptionValidation(value, props, _) {\n  //Checks if the value is not of object type in {{}}\n  if (_.isObject(value)) {\n    return {\n      isValid: false,\n      parsed: JSON.stringify(value, null, 2),\n      messages: ["This value does not evaluate to type: string or number"]\n    };\n  } //Checks if the value is not of boolean type in {{}}\n\n\n  if (_.isBoolean(value)) {\n    return {\n      isValid: false,\n      parsed: value,\n      messages: ["This value does not evaluate to type: string or number"]\n    };\n  }\n\n  return {\n    isValid: true,\n    parsed: value\n  };\n}',
+              },
+            },
+            id: "8wpzo6szbl",
+          },
+          {
+            propertyName: "isRequired",
+            label: "Required",
+            helpText: "Makes input to the widget mandatory",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "60kc73ivwp",
+          },
+          {
+            helpText: "Controls the visibility of the widget",
+            propertyName: "isVisible",
+            label: "Visible",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "w4591dtf5l",
+          },
+          {
+            propertyName: "isDisabled",
+            label: "Disabled",
+            helpText: "Disables input to this widget",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "6p7181ccec",
+          },
+          {
+            propertyName: "animateLoading",
+            label: "Animate Loading",
+            controlType: "SWITCH",
+            helpText: "Controls the loading of the widget",
+            // defaultValue: true,
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "y2gw796t2z",
+          },
+        ],
+        id: "jfh7ud39r4",
+      },
+      {
+        sectionName: "Events",
+        children: [
+          {
+            helpText:
+              "Triggers an action when a user changes the selected option",
+            propertyName: "onSelectionChange",
+            label: "onSelectionChange",
+            controlType: "ACTION_SELECTOR",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: true,
+            id: "wqgudnqu5n",
+          },
+        ],
+        id: "b2k5a0t632",
+      },
+    ]);
+    const newDsl = isInvalidDynamicBindingPath(baseDSL);
+    expect(baseDSL).toEqual(newDsl);
+  });
+
+  it("Checks if dynamicBindingPathList contains a property path that doesn't have a binding", () => {
+    const baseDSL = {
+      widgetName: "RadioGroup1",
+      dynamicPropertyPathList: [],
+      displayName: "Radio Group",
+      iconSVG: "/static/media/icon.ba2b2ee0.svg",
+      topRow: 57,
+      bottomRow: 65,
+      parentRowSpace: 10,
+      type: "RADIO_GROUP_WIDGET",
+      hideCard: false,
+      defaultOptionValue: "{{1}}",
+      animateLoading: true,
+      parentColumnSpace: 33.375,
+      dynamicTriggerPathList: [],
+      leftColumn: 42,
+      dynamicBindingPathList: [
+        {
+          key: "defaultOptionValue",
+        },
+        {
+          key: "options",
+        },
+      ],
+      options: [],
+      isDisabled: false,
+      key: "opzs6suotf",
+      isRequired: false,
+      rightColumn: 62,
+      widgetId: "s195otz2jm",
+      isVisible: true,
+      label: "",
+      version: 1,
+      parentId: "0",
+      renderMode: RenderModes.CANVAS,
+      isLoading: false,
+    };
+
+    const getPropertyConfig = jest.spyOn(
+      WidgetFactory,
+      "getWidgetPropertyPaneConfig",
+    );
+    getPropertyConfig.mockReturnValueOnce([
+      {
+        sectionName: "General",
+        children: [
+          {
+            helpText: "Displays a list of unique options",
+            propertyName: "options",
+            label: "Options",
+            controlType: "OPTION_INPUT",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.FUNCTION,
+              params: {
+                expected: {
+                  type:
+                    'Array<{ "label": "string", "value": "string" | number}>',
+                  example: '[{"label": "abc", "value": "abc" | 1}]',
+                  autocompleteDataType: AutocompleteDataType.STRING,
+                },
+                fnString:
+                  'function optionsCustomValidation(options, props, _) {\n  var validationUtil = (options, _) => {\n    var _isValid = true;\n    var message = "";\n    var valueType = "";\n    var uniqueLabels = {};\n\n    for (var i = 0; i < options.length; i++) {\n      var _options$i = options[i],\n          label = _options$i.label,\n          value = _options$i.value;\n\n      if (!valueType) {\n        valueType = typeof value;\n      } //Checks the uniqueness all the values in the options\n\n\n      if (!uniqueLabels.hasOwnProperty(value)) {\n        uniqueLabels[value] = "";\n      } else {\n        _isValid = false;\n        message = "path:value must be unique. Duplicate values found";\n        break;\n      } //Check if the required field "label" is present:\n\n\n      if (!label) {\n        _isValid = false;\n        message = "Invalid entry at index: " + i + ". Missing required key: label";\n        break;\n      } //Validation checks for the the label.\n\n\n      if (_.isNil(label) || label === "" || typeof label !== "string" && typeof label !== "number") {\n        _isValid = false;\n        message = "Invalid entry at index: " + i + ". Value of key: label is invalid: This value does not evaluate to type string";\n        break;\n      } //Check if all the data types for the value prop is the same.\n\n\n      if (typeof value !== valueType) {\n        _isValid = false;\n        message = "All value properties in options must have the same type";\n        break;\n      } //Check if the each object has value property.\n\n\n      if (_.isNil(value)) {\n        _isValid = false;\n        message = \'This value does not evaluate to type Array<{ "label": "string", "value": "string" | number }>\';\n        break;\n      }\n    }\n\n    return {\n      isValid: _isValid,\n      parsed: _isValid ? options : [],\n      messages: [message]\n    };\n  };\n\n  var invalidResponse = {\n    isValid: false,\n    parsed: [],\n    messages: [\'This value does not evaluate to type Array<{ "label": "string", "value": "string" | number }>\']\n  };\n\n  try {\n    if (_.isString(options)) {\n      options = JSON.parse(options);\n    }\n\n    if (Array.isArray(options)) {\n      return validationUtil(options, _);\n    } else {\n      return invalidResponse;\n    }\n  } catch (e) {\n    return invalidResponse;\n  }\n}',
+              },
+            },
+            evaluationSubstitutionType:
+              EvaluationSubstitutionType.SMART_SUBSTITUTE,
+            id: "6su4u0bwoe",
+          },
+          {
+            helpText: "Sets a default selected option",
+            propertyName: "defaultOptionValue",
+            label: "Default Selected Value",
+            // placeholderText: "Y",
+            controlType: "INPUT_TEXT",
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.FUNCTION,
+              params: {
+                expected: {
+                  type: "string |\nnumber (only works in mustache syntax)",
+                  example: "abc | {{1}}",
+                  autocompleteDataType: AutocompleteDataType.STRING,
+                },
+                fnString:
+                  'function defaultOptionValidation(value, props, _) {\n  //Checks if the value is not of object type in {{}}\n  if (_.isObject(value)) {\n    return {\n      isValid: false,\n      parsed: JSON.stringify(value, null, 2),\n      messages: ["This value does not evaluate to type: string or number"]\n    };\n  } //Checks if the value is not of boolean type in {{}}\n\n\n  if (_.isBoolean(value)) {\n    return {\n      isValid: false,\n      parsed: value,\n      messages: ["This value does not evaluate to type: string or number"]\n    };\n  }\n\n  return {\n    isValid: true,\n    parsed: value\n  };\n}',
+              },
+            },
+            id: "8wpzo6szbl",
+          },
+          {
+            propertyName: "isRequired",
+            label: "Required",
+            helpText: "Makes input to the widget mandatory",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "60kc73ivwp",
+          },
+          {
+            helpText: "Controls the visibility of the widget",
+            propertyName: "isVisible",
+            label: "Visible",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "w4591dtf5l",
+          },
+          {
+            propertyName: "isDisabled",
+            label: "Disabled",
+            helpText: "Disables input to this widget",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "6p7181ccec",
+          },
+          {
+            propertyName: "animateLoading",
+            label: "Animate Loading",
+            controlType: "SWITCH",
+            helpText: "Controls the loading of the widget",
+            // defaultValue: true,
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: {
+              type: ValidationTypes.BOOLEAN,
+            },
+            id: "y2gw796t2z",
+          },
+        ],
+        id: "jfh7ud39r4",
+      },
+      {
+        sectionName: "Events",
+        children: [
+          {
+            helpText:
+              "Triggers an action when a user changes the selected option",
+            propertyName: "onSelectionChange",
+            label: "onSelectionChange",
+            controlType: "ACTION_SELECTOR",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: true,
+            id: "wqgudnqu5n",
+          },
+        ],
+        id: "b2k5a0t632",
+      },
+    ]);
+
+    const sentrySpy = jest.spyOn(Sentry, "captureException");
+
+    isInvalidDynamicBindingPath(baseDSL);
+    expect(sentrySpy).toHaveBeenCalledWith(
+      new Error(
+        `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: RadioGroup1.options`,
+      ),
+    );
   });
 });

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -700,8 +700,9 @@ export const isInvalidDynamicBindingPath = (
       !!find(dynamicBindingPathList, { key: bindingPath })
     ) {
       Sentry.captureException(
-        new Error(`INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list. 
-          ${bindingPath} still present in the dynamicBindingPathList even if ${bindingPath} does not contain any bindings.`),
+        new Error(
+          `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: ${currentDSL.widgetName}.${bindingPath}`,
+        ),
       );
       return;
     }

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -25,8 +25,6 @@ import log from "loglevel";
 import { extraLibrariesNames, isDynamicValue } from "./DynamicBindingUtils";
 import { ApiResponse } from "api/ApiResponses";
 import { DSLWidget } from "widgets/constants";
-import WidgetFactory from "./WidgetFactory";
-import { getAllPathsFromPropertyConfig } from "entities/Widget/utils";
 import * as Sentry from "@sentry/react";
 
 const { cloudHosting, intercomAppID } = getAppsmithConfigs();
@@ -675,30 +673,14 @@ export const getLocale = () => {
 export const captureInvalidDynamicBindingPath = (
   currentDSL: Readonly<DSLWidget>,
 ) => {
-  //Get the propertyPaneConfig for the current DSL Type
-  const propertyPaneConfig = WidgetFactory.getWidgetPropertyPaneConfig(
-    currentDSL.type,
-  );
-
-  //Get the bindingPaths from the dsl and propertyPaneConfig
-  const { bindingPaths } = getAllPathsFromPropertyConfig(
-    currentDSL,
-    propertyPaneConfig,
-    {},
-  );
-
   //Get the dynamicBindingPathList of the current DSL
   const dynamicBindingPathList = get(currentDSL, "dynamicBindingPathList");
   dynamicBindingPathList?.forEach((dBindingPath) => {
     const pathValue = get(currentDSL, dBindingPath.key); //Gets the value for the given dynamic binding path
-
     /**
      * Checks if dynamicBindingPathList contains a property path that doesn't have a binding
      */
-    if (
-      !isDynamicValue(pathValue) &&
-      bindingPaths.hasOwnProperty(dBindingPath.key)
-    ) {
+    if (!isDynamicValue(pathValue)) {
       Sentry.captureException(
         new Error(
           `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: ${currentDSL.widgetName}.${dBindingPath.key}`,

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -11,7 +11,7 @@ import {
   WINDOW_OBJECT_PROPERTIES,
 } from "constants/WidgetValidation";
 import { GLOBAL_FUNCTIONS } from "./autocomplete/EntityDefinitions";
-import { get, set, find } from "lodash";
+import { get, set } from "lodash";
 import { Org } from "constants/orgConstants";
 import {
   isPermitted,
@@ -672,7 +672,7 @@ export const getLocale = () => {
  * @param currentDSL
  * @returns
  */
-export const isInvalidDynamicBindingPath = (
+export const captureInvalidDynamicBindingPath = (
   currentDSL: Readonly<DSLWidget>,
 ) => {
   //Get the propertyPaneConfig for the current DSL Type
@@ -689,19 +689,19 @@ export const isInvalidDynamicBindingPath = (
 
   //Get the dynamicBindingPathList of the current DSL
   const dynamicBindingPathList = get(currentDSL, "dynamicBindingPathList");
-  Object.keys(bindingPaths).forEach((bindingPath) => {
-    const pathValue = get(currentDSL, bindingPath); //Gets the value for the given binding path
+  dynamicBindingPathList?.forEach((dBindingPath) => {
+    const pathValue = get(currentDSL, dBindingPath.key); //Gets the value for the given dynamic binding path
 
     /**
      * Checks if dynamicBindingPathList contains a property path that doesn't have a binding
      */
     if (
       !isDynamicValue(pathValue) &&
-      !!find(dynamicBindingPathList, { key: bindingPath })
+      bindingPaths.hasOwnProperty(dBindingPath.key)
     ) {
       Sentry.captureException(
         new Error(
-          `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: ${currentDSL.widgetName}.${bindingPath}`,
+          `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: ${currentDSL.widgetName}.${dBindingPath.key}`,
         ),
       );
       return;
@@ -709,7 +709,7 @@ export const isInvalidDynamicBindingPath = (
   });
 
   if (currentDSL.children) {
-    currentDSL.children.map(isInvalidDynamicBindingPath);
+    currentDSL.children.map(captureInvalidDynamicBindingPath);
   }
   return currentDSL;
 };


### PR DESCRIPTION
## Description
**Summary of changes**

- Added a function called `isInvalidDynamicBindingPath` in the PageSagas.tsx

**Motivation**

- This function will log error into the sentry whenever the property value is not Dynamic and the bindingPath is still present in the `dynamicBindingPathList`
- Thus the function - Checks if dynamicBindingPathList contains a property path that doesn't have a binding

Fixes #10712

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have update the unit test file: `helpers.test.ts` 
The test case checks the following:

- Check if the DSL is not altered
- Checks if dynamicBindingPathList contains a property path that doesn't have a binding

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-log_sentry_error_dynamic_binding_path 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.06 **(0)** | 36.62 **(0)** | 34.79 **(0.01)** | 55.46 **(0)**
 :green_circle: | app/client/src/sagas/PageSagas.tsx | 24.42 **(0.22)** | 5.88 **(0)** | 14.71 **(0)** | 26.19 **(0.25)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :green_circle: | app/client/src/utils/helpers.tsx | 67.09 **(1.31)** | 34.57 **(2.35)** | 60.38 **(1.56)** | 65.31 **(1.63)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>