### PR TITLE
fix: Purge orphaned paths from dynamic path lists in widgets

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -489,10 +489,7 @@ export function* getPropertiesUpdatedWidget(
 // Purge all paths in a provided widgets' dynamicTriggerPathList, which don't exist in the widget
 function purgeOrphanedDynamicTriggerPaths(widget: WidgetProps) {
   // Attempt to purge only if there are dynamicTriggerPaths in this widget
-  if (
-    widget.dynamicTriggerPathList &&
-    widget.dynamicTriggerPathList.length > 0
-  ) {
+  if (widget.dynamicTriggerPathList && widget.dynamicTriggerPathList.length) {
     // Filter out all the paths from the dynamicTriggerPathList which don't exist in the widget
     widget.dynamicTriggerPathList = widget.dynamicTriggerPathList.filter(
       (path: DynamicPath) => {

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -94,6 +94,7 @@ import {
   getNextWidgetName,
   getParentWidgetIdForGrouping,
   isCopiedModalWidget,
+  purgeOrphanedDynamicPaths,
 } from "./WidgetOperationUtils";
 import { getSelectedWidgets } from "selectors/ui";
 import { widgetSelectionSagas } from "./WidgetSelectionSagas";
@@ -480,25 +481,10 @@ export function* getPropertiesUpdatedWidget(
   }
 
   // Note: This may not be the best place to do this.
-  // If there exists another spot in this workflow, where we are iterating over the dynamicTriggerPathList, after
+  // If there exists another spot in this workflow, where we are iterating over the dynamicTriggerPathList and dynamicBindingPathList, after
   // performing all updates to the widget, we can piggy back on that iteration to purge orphaned paths
   // I couldn't find it, so here it is.
-  return purgeOrphanedDynamicTriggerPaths(widget);
-}
-
-// Purge all paths in a provided widgets' dynamicTriggerPathList, which don't exist in the widget
-function purgeOrphanedDynamicTriggerPaths(widget: WidgetProps) {
-  // Attempt to purge only if there are dynamicTriggerPaths in this widget
-  if (widget.dynamicTriggerPathList && widget.dynamicTriggerPathList.length) {
-    // Filter out all the paths from the dynamicTriggerPathList which don't exist in the widget
-    widget.dynamicTriggerPathList = widget.dynamicTriggerPathList.filter(
-      (path: DynamicPath) => {
-        // Use lodash _.has to check if the path exists in the widget
-        return _.has(widget, path.key);
-      },
-    );
-  }
-  return widget;
+  return purgeOrphanedDynamicPaths(widget);
 }
 
 function* batchUpdateWidgetPropertySaga(

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -478,6 +478,29 @@ export function* getPropertiesUpdatedWidget(
   if (Array.isArray(remove) && remove.length > 0) {
     widget = yield removeWidgetProperties(widget, remove);
   }
+
+  // Note: This may not be the best place to do this.
+  // If there exists another spot in this workflow, where we are iterating over the dynamicTriggerPathList, after
+  // performing all updates to the widget, we can piggy back on that iteration to purge orphaned paths
+  // I couldn't find it, so here it is.
+  return purgeOrphanedDynamicTriggerPaths(widget);
+}
+
+// Purge all paths in a provided widgets' dynamicTriggerPathList, which don't exist in the widget
+function purgeOrphanedDynamicTriggerPaths(widget: WidgetProps) {
+  // Attempt to purge only if there are dynamicTriggerPaths in this widget
+  if (
+    widget.dynamicTriggerPathList &&
+    widget.dynamicTriggerPathList.length > 0
+  ) {
+    // Filter out all the paths from the dynamicTriggerPathList which don't exist in the widget
+    widget.dynamicTriggerPathList = widget.dynamicTriggerPathList.filter(
+      (path: DynamicPath) => {
+        // Use lodash _.has to check if the path exists in the widget
+        return _.has(widget, path.key);
+      },
+    );
+  }
   return widget;
 }
 

--- a/app/client/src/sagas/WidgetOperationUtils.test.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.test.ts
@@ -1,10 +1,12 @@
 import { get } from "lodash";
+import { WidgetProps } from "widgets/BaseWidget";
 import {
   handleIfParentIsListWidgetWhilePasting,
   handleSpecificCasesWhilePasting,
   doesTriggerPathsContainPropertyPath,
   checkIfPastingIntoListWidget,
   updateListWidgetPropertiesOnChildDelete,
+  purgeOrphanedDynamicPaths,
 } from "./WidgetOperationUtils";
 
 describe("WidgetOperationSaga", () => {
@@ -579,6 +581,45 @@ describe("WidgetOperationSaga", () => {
       "ButtonWidget1",
     );
 
+    expect(result).toStrictEqual(expected);
+  });
+
+  it("should purge orphaned dynamicTriggerPaths and dynamicBindingPaths from widget", () => {
+    const input = {
+      dynamicBindingPathList: [
+        { key: "primaryColumns.name.computedValue" },
+        { key: "primaryColumns.name.fontStyle" },
+        { key: "primaryColumns.name.nonExistentPath" },
+        { key: "nonExistentKey}" },
+      ],
+      dynamicTriggerPathList: [
+        { key: "primaryColumns.name.onClick" },
+        { key: "primaryColumns.name.nonExistentPath" },
+        { key: "nonExistentKey}" },
+      ],
+      primaryColumns: {
+        name: {
+          computedValue: "{{currentRow.something}}",
+          fontStyle: "bold",
+          onClick: "{{showAlert('message', 'error')}}",
+        },
+      },
+    };
+    const expected = {
+      dynamicBindingPathList: [
+        { key: "primaryColumns.name.computedValue" },
+        { key: "primaryColumns.name.fontStyle" },
+      ],
+      dynamicTriggerPathList: [{ key: "primaryColumns.name.onClick" }],
+      primaryColumns: {
+        name: {
+          computedValue: "{{currentRow.something}}",
+          fontStyle: "bold",
+          onClick: "{{showAlert('message', 'error')}}",
+        },
+      },
+    };
+    const result = purgeOrphanedDynamicPaths((input as any) as WidgetProps);
     expect(result).toStrictEqual(expected);
   });
 });

--- a/app/client/src/sagas/WidgetOperationUtils.test.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.test.ts
@@ -590,12 +590,12 @@ describe("WidgetOperationSaga", () => {
         { key: "primaryColumns.name.computedValue" },
         { key: "primaryColumns.name.fontStyle" },
         { key: "primaryColumns.name.nonExistentPath" },
-        { key: "nonExistentKey}" },
+        { key: "nonExistentKey" },
       ],
       dynamicTriggerPathList: [
         { key: "primaryColumns.name.onClick" },
         { key: "primaryColumns.name.nonExistentPath" },
-        { key: "nonExistentKey}" },
+        { key: "nonExistentKey" },
       ],
       primaryColumns: {
         name: {

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -26,6 +26,7 @@ import { getDataTree } from "selectors/dataTreeSelectors";
 import {
   getDynamicBindings,
   combineDynamicBindings,
+  DynamicPath,
 } from "utils/DynamicBindingUtils";
 import { getNextEntityName } from "utils/AppsmithUtils";
 import WidgetFactory from "utils/WidgetFactory";
@@ -859,4 +860,37 @@ export function updateListWidgetPropertiesOnChildDelete(
   }
 
   return clone;
+}
+
+/**
+ * Purge all paths in a provided widgets' dynamicTriggerPathList and dynamicBindingPathList, which no longer exist in the widget
+ * I call these paths orphaned dynamic paths
+ *
+ * @param widget : WidgetProps
+ *
+ * returns the updated widget
+ */
+
+// Purge all paths in a provided widgets' dynamicTriggerPathList, which don't exist in the widget
+export function purgeOrphanedDynamicPaths(widget: WidgetProps) {
+  // Attempt to purge only if there are dynamicTriggerPaths in this widget
+  if (widget.dynamicTriggerPathList && widget.dynamicTriggerPathList.length) {
+    // Filter out all the paths from the dynamicTriggerPathList which don't exist in the widget
+    widget.dynamicTriggerPathList = widget.dynamicTriggerPathList.filter(
+      (path: DynamicPath) => {
+        // Use lodash _.has to check if the path exists in the widget
+        return _.has(widget, path.key);
+      },
+    );
+  }
+  if (widget.dynamicBindingPathList && widget.dynamicBindingPathList.length) {
+    // Filter out all the paths from the dynamicBindingPaths which don't exist in the widget
+    widget.dynamicBindingPathList = widget.dynamicBindingPathList.filter(
+      (path: DynamicPath) => {
+        // Use lodash _.has to check if the path exists in the widget
+        return _.has(widget, path.key);
+      },
+    );
+  }
+  return widget;
 }


### PR DESCRIPTION
## Description

On certain occasions, we find that paths which are defined in a widget's `dynamicTriggerPathList` and `dynamicBindingPathList` don't really exist in the widget. This has been observed in the [MenuButton widget](https://github.com/appsmithorg/appsmith/issues/10768)

This results in issues in subsequent evaluations. The details with respect to the exact issue in the evaluations are unclear -- nevertheless, having orphaned paths is akin to having a bad DSL. This fix purges then during property update.

Fixes #10791
Fixes #10768 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Jest test added for the purging function. 
Tested manually using the steps shown in #10768 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/purge-orphaned-triggerpaths 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.05 **(0)** | 36.62 **(0.01)** | 34.79 **(0.02)** | 55.45 **(0)**
 :red_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 51.54 **(0)** | 38.73 **(-0.29)** | 52.08 **(0)** | 52.79 **(0)**
 :green_circle: | app/client/src/sagas/WidgetOperationUtils.ts | 61.86 **(1.08)** | 44 **(2.06)** | 59.62 **(2.48)** | 61.26 **(1.26)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>