### PR TITLE
fix: Fixed issue with H2 where PS parameters were getting merged if the keys were the same

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/PreparedStatementValueDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/PreparedStatementValueDTO.java
@@ -1,0 +1,18 @@
+package com.appsmith.external.dtos;
+
+import com.appsmith.external.constants.DataType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreparedStatementValueDTO {
+
+    String value;
+
+    DataType dataType;
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -3,6 +3,7 @@ package com.appsmith.external.services.ce;
 import com.appsmith.external.constants.ConditionalOperator;
 import com.appsmith.external.constants.DataType;
 import com.appsmith.external.constants.SortType;
+import com.appsmith.external.dtos.PreparedStatementValueDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
@@ -25,10 +26,10 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -176,7 +177,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
          * actually required {"John" -> DataType.String, "John" -> DataType.String} - one for each condition in the
          * where clause. JUnit TC `testProjectionSortingAndPaginationTogether` takes care of this case as well.
          */
-        List<Map<String, Object>> values = new ArrayList<>();
+        List<PreparedStatementValueDTO> values = new ArrayList<>();
 
         if (condition != null) {
             ConditionalOperator operator = condition.getOperator();
@@ -205,11 +206,11 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
         try {
             PreparedStatement preparedStatement = conn.prepareStatement(selectQuery);
-            Iterator<Map<String, Object>> iterator = values.iterator();
+            Iterator<PreparedStatementValueDTO> iterator = values.iterator();
             for (int i = 0; iterator.hasNext(); i++) {
-                Map<String, Object> dataInfo = iterator.next();
-                String value = (String) dataInfo.get("value");
-                DataType dataType = (DataType) dataInfo.get("type");
+                PreparedStatementValueDTO dataInfo = iterator.next();
+                String value = dataInfo.getValue();
+                DataType dataType = dataInfo.getDataType();
                 setValueInStatement(preparedStatement, i + 1, value, dataType);
             }
 
@@ -243,12 +244,12 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
     /**
      * This method adds the following clause to the SQL query: `LIMIT <num> OFFSET <num>`
      *
-     * @param sb - SQL query builder
+     * @param sb         - SQL query builder
      * @param paginateBy - values for limit and offset
-     * @param values - list to hold values to be substituted in prepared statement
+     * @param values     - list to hold values to be substituted in prepared statement
      */
     private void addPaginationCondition(StringBuilder sb, Map<String, String> paginateBy,
-                                        List<Map<String, Object>> values) {
+                                        List<PreparedStatementValueDTO> values) {
         if (CollectionUtils.isEmpty(paginateBy)) {
             return;
         }
@@ -257,17 +258,11 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
         // Set limit value and data type for prepared statement substitution
         String limit = paginateBy.get(PAGINATE_LIMIT_KEY);
-        Map limitDataInfo = new HashMap();
-        limitDataInfo.put(DATA_INFO_VALUE_KEY, limit);
-        limitDataInfo.put(DATA_INFO_TYPE_KEY, DataType.INTEGER);
-        values.add(limitDataInfo);
+        values.add(new PreparedStatementValueDTO(limit, DataType.INTEGER));
 
         // Set offset value and data type for prepared statement substitution
         String offset = paginateBy.get(PAGINATE_OFFSET_KEY);
-        Map offsetDataInfo = new HashMap();
-        offsetDataInfo.put(DATA_INFO_VALUE_KEY, offset);
-        offsetDataInfo.put(DATA_INFO_TYPE_KEY, DataType.INTEGER);
-        values.add(offsetDataInfo);
+        values.add(new PreparedStatementValueDTO(offset, DataType.INTEGER));
     }
 
     /**
@@ -334,7 +329,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
         StringBuilder sb = new StringBuilder("SELECT * FROM " + tableName);
 
-        LinkedHashMap<String, DataType> values = new LinkedHashMap<>();
+        LinkedList<PreparedStatementValueDTO> values = new LinkedList<>();
 
         String whereClause = generateWhereClauseOldFormat(conditions, values, schema);
 
@@ -349,12 +344,11 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
         try {
             PreparedStatement preparedStatement = conn.prepareStatement(selectQuery);
-            Set<Map.Entry<String, DataType>> valueEntries = values.entrySet();
-            Iterator<Map.Entry<String, DataType>> iterator = valueEntries.iterator();
+            Iterator<PreparedStatementValueDTO> iterator = values.iterator();
             for (int i = 0; iterator.hasNext(); i++) {
-                Map.Entry<String, DataType> valueEntry = iterator.next();
-                String value = valueEntry.getKey();
-                DataType dataType = valueEntry.getValue();
+                PreparedStatementValueDTO valueEntry = iterator.next();
+                String value = valueEntry.getValue();
+                DataType dataType = valueEntry.getDataType();
                 setValueInStatement(preparedStatement, i + 1, value, dataType);
             }
 
@@ -385,7 +379,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
         return rowsList;
     }
 
-    private String generateWhereClauseOldFormat(List<Condition> conditions, LinkedHashMap<String, DataType> values, Map<String, DataType> schema) {
+    private String generateWhereClauseOldFormat(List<Condition> conditions, LinkedList<PreparedStatementValueDTO> values, Map<String, DataType> schema) {
 
         StringBuilder sb = new StringBuilder();
 
@@ -426,7 +420,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                     List<String> updatedStringValues = arrayValues
                             .stream()
                             .map(fieldValue -> {
-                                values.put(String.valueOf(fieldValue), schema.get(path));
+                                values.add(new PreparedStatementValueDTO(String.valueOf(fieldValue), schema.get(path)));
                                 return "?";
                             })
                             .collect(Collectors.toList());
@@ -444,7 +438,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
             } else {
                 // Not an array. Simply add a placeholder
                 sb.append("?");
-                values.put(value, schema.get(path));
+                values.add(new PreparedStatementValueDTO(value, schema.get(path)));
             }
         }
         return sb.toString();
@@ -805,7 +799,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
         return true;
     }
 
-    public String generateLogicalExpression(List<Condition> conditions, List<Map<String, Object>> values,
+    public String generateLogicalExpression(List<Condition> conditions, List<PreparedStatementValueDTO> values,
                                             Map<String, DataType> schema, ConditionalOperator logicOp) {
 
         StringBuilder sb = new StringBuilder();
@@ -854,10 +848,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                             List<String> updatedStringValues = arrayValues
                                     .stream()
                                     .map(fieldValue -> {
-                                        Map dataInfo = new HashMap();
-                                        dataInfo.put(DATA_INFO_VALUE_KEY, String.valueOf(fieldValue));
-                                        dataInfo.put(DATA_INFO_TYPE_KEY, schema.get(path));
-                                        values.add(dataInfo);
+                                        values.add(new PreparedStatementValueDTO(String.valueOf(fieldValue), schema.get(path)));
                                         return "?";
                                     })
                                     .collect(Collectors.toList());
@@ -875,10 +866,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                     } else {
                         // Not an array. Simply add a placeholder
                         sb.append("?");
-                        Map dataInfo = new HashMap();
-                        dataInfo.put(DATA_INFO_VALUE_KEY, value);
-                        dataInfo.put(DATA_INFO_TYPE_KEY, schema.get(path));
-                        values.add(dataInfo);
+                        values.add(new PreparedStatementValueDTO(value, schema.get(path)));
                     }
 
                     sb.append(" ) ");

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/IFilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/IFilterDataServiceCE.java
@@ -2,11 +2,11 @@ package com.appsmith.external.services.ce;
 
 import com.appsmith.external.constants.ConditionalOperator;
 import com.appsmith.external.constants.DataType;
+import com.appsmith.external.dtos.PreparedStatementValueDTO;
 import com.appsmith.external.models.Condition;
 import com.appsmith.external.models.UQIDataFilterParams;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +30,7 @@ public interface IFilterDataServiceCE {
 
     boolean validConditionList(List<Condition> conditionList, Map<String, DataType> schema);
 
-    String generateLogicalExpression(List<Condition> conditions, List<Map<String, Object>> values,
+    String generateLogicalExpression(List<Condition> conditions, List<PreparedStatementValueDTO> values,
                                      Map<String, DataType> schema, ConditionalOperator logicOp);
 
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -7,6 +7,7 @@ import com.appsmith.external.models.Condition;
 import com.appsmith.external.models.UQIDataFilterParams;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -85,6 +86,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -97,6 +99,7 @@ public class FilterDataServiceTest {
                 "    \"userName\": \"Michael Lawson\",\n" +
                 "    \"productName\": \"Chicken Sandwich\",\n" +
                 "    \"orderAmount\": 4.99,\n" +
+                "    \"anotherKey\": 20,\n" +
                 "    \"orderStatus\": \"READY\"\n" +
                 "  },\n" +
                 "  {\n" +
@@ -105,6 +108,7 @@ public class FilterDataServiceTest {
                 "    \"userName\": \"Lindsay Ferguson\",\n" +
                 "    \"productName\": \"Tuna Salad\",\n" +
                 "    \"orderAmount\": 9.99,\n" +
+                "    \"anotherKey\": 12,\n" +
                 "    \"orderStatus\": \"NOT READY\"\n" +
                 "  },\n" +
                 "  {\n" +
@@ -113,6 +117,7 @@ public class FilterDataServiceTest {
                 "    \"userName\": \"Tobias Funke\",\n" +
                 "    \"productName\": \"Beef steak\",\n" +
                 "    \"orderAmount\": 19.99,\n" +
+                "    \"anotherKey\": 20,\n" +
                 "    \"orderStatus\": \"READY\"\n" +
                 "  }\n" +
                 "]";
@@ -125,8 +130,12 @@ public class FilterDataServiceTest {
             Condition condition = new Condition("orderAmount", "LT", "15");
             conditionList.add(condition);
 
-            Condition condition1 = new Condition("orderStatus", "EQ", "READY");
+            Condition condition1 = new Condition("anotherKey", "GT", "15");
             conditionList.add(condition1);
+
+
+            Condition condition2 = new Condition("orderStatus", "EQ", "READY");
+            conditionList.add(condition2);
 
             ArrayNode filteredData = filterDataService.filterData(items, conditionList);
 
@@ -135,6 +144,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -185,6 +195,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -235,6 +246,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -285,6 +297,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -341,6 +354,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -388,6 +402,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -435,6 +450,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -485,6 +501,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -578,6 +595,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -637,6 +655,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -649,6 +668,7 @@ public class FilterDataServiceTest {
                 "    \"userName\": \"Michael Lawson\",\n" +
                 "    \"productName\": \"Chicken Sandwich\",\n" +
                 "    \"orderAmount\": 4.99,\n" +
+                "    \"anotherKey\": 20,\n" +
                 "    \"orderStatus\": \"READY\"\n" +
                 "  },\n" +
                 "  {\n" +
@@ -657,6 +677,7 @@ public class FilterDataServiceTest {
                 "    \"userName\": \"Lindsay Ferguson\",\n" +
                 "    \"productName\": \"Tuna Salad\",\n" +
                 "    \"orderAmount\": 9.99,\n" +
+                "    \"anotherKey\": 12,\n" +
                 "    \"orderStatus\": \"NOT READY\"\n" +
                 "  },\n" +
                 "  {\n" +
@@ -665,6 +686,7 @@ public class FilterDataServiceTest {
                 "    \"userName\": \"Tobias Funke\",\n" +
                 "    \"productName\": \"Beef steak\",\n" +
                 "    \"orderAmount\": 19.99,\n" +
+                "    \"anotherKey\": 20,\n" +
                 "    \"orderStatus\": \"READY\"\n" +
                 "  }\n" +
                 "]";
@@ -675,6 +697,11 @@ public class FilterDataServiceTest {
                 "      {\n" +
                 "        \"key\": \"orderAmount\",\n" +
                 "        \"condition\": \"LT\",\n" +
+                "        \"value\": \"15\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"key\": \"anotherKey\",\n" +
+                "        \"condition\": \"GT\",\n" +
                 "        \"value\": \"15\"\n" +
                 "      },\n" +
                 "      {\n" +
@@ -702,6 +729,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -767,6 +795,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -831,6 +860,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -965,6 +995,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1025,6 +1056,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1088,6 +1120,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1146,6 +1179,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1199,6 +1233,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1259,6 +1294,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1318,6 +1354,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1377,6 +1414,7 @@ public class FilterDataServiceTest {
 
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1440,6 +1478,7 @@ public class FilterDataServiceTest {
             assertEquals(expectedColumns, returnedColumns);
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1510,6 +1549,7 @@ public class FilterDataServiceTest {
             assertEquals(expectedOrder, returnedOrder);
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1578,6 +1618,7 @@ public class FilterDataServiceTest {
             assertEquals(expectedOrderAmountValues, returnedOrderAmountValues);
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 
@@ -1652,6 +1693,7 @@ public class FilterDataServiceTest {
             assertEquals(expectedOrderAmount, returnedOrderAmount);
         } catch (IOException e) {
             e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Fixes #10798

When the where clause params have a repeated key, they're getting merged since we're using a map to store these parameters. We end up having a lesser key count for params and hence see this error. Fix was to convert the map into a list to parse through irrespective of repetition. Also introduced a DTO instead of using a map to allow consistent and cleaner consumption.
