### PR TITLE
feat: adds Headers tab to the Api response view

### DIFF
--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -199,6 +199,7 @@ const ResponseDataContainer = styled.div`
   flex: 1;
   overflow: auto;
   display: flex;
+  margin-bottom: 10px;
   flex-direction: column;
   & .CodeEditorTarget {
     overflow: hidden;
@@ -238,11 +239,19 @@ function ApiResponseView(props: Props) {
   };
 
   const messages = response?.messages;
+  let responseHeaders;
+
+  // if no headers are present in the response, use the default body text.
+  if (response.headers) {
+    responseHeaders = response.headers;
+  } else {
+    responseHeaders = response.body;
+  }
 
   const tabs = [
     {
       key: "body",
-      title: "Response Body",
+      title: "Body",
       panelComponent: (
         <ResponseTabWrapper>
           {Array.isArray(messages) && messages.length > 0 && (
@@ -291,6 +300,58 @@ function ApiResponseView(props: Props) {
                 input={{
                   value: response.body
                     ? JSON.stringify(response.body, null, 2)
+                    : "",
+                }}
+              />
+            )}
+          </ResponseDataContainer>
+        </ResponseTabWrapper>
+      ),
+    },
+    {
+      key: "headers",
+      title: "Headers",
+      panelComponent: (
+        <ResponseTabWrapper>
+          {hasFailed && !isRunning && (
+            <StyledCallout
+              fill
+              label={
+                <FailedMessage>
+                  <DebugButton
+                    className="api-debugcta"
+                    onClick={onDebugClick}
+                  />
+                </FailedMessage>
+              }
+              text={createMessage(CHECK_REQUEST_BODY)}
+              variant={Variant.danger}
+            />
+          )}
+          <ResponseDataContainer>
+            {_.isEmpty(response.statusCode) ? (
+              <NoResponseContainer>
+                <Icon name="no-response" />
+                <Text type={TextType.P1}>
+                  {EMPTY_RESPONSE_FIRST_HALF()}
+                  <InlineButton
+                    isLoading={isRunning}
+                    onClick={onRunClick}
+                    size={Size.medium}
+                    tag="button"
+                    text="Run"
+                    type="button"
+                  />
+                  {EMPTY_RESPONSE_LAST_HALF()}
+                </Text>
+              </NoResponseContainer>
+            ) : (
+              <ReadOnlyEditor
+                folding
+                height={"100%"}
+                input={{
+                  value: response.body
+                    ? JSON.stringify(responseHeaders, null, 2)
                     : "",
                 }}
               />

--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -245,7 +245,7 @@ function ApiResponseView(props: Props) {
   if (response.headers) {
     responseHeaders = response.headers;
   } else {
-    responseHeaders = response.body;
+    responseHeaders = {}; // if the response headers is empty show an empty object.
   }
 
   const tabs = [


### PR DESCRIPTION
This PR introduces an Headers tab to the API pane response view, thus giving users the ability to see the headers attached to the responses of their queries.

<img width="1440" alt="Screen Shot 2022-02-01 at 6 45 58 PM" src="https://user-images.githubusercontent.com/37867493/152022251-c4b0c254-72ed-4993-9987-8dba007cdf01.png">

Fixes #9766

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

Manual Tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feat/show-response-header 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.94 **(0)** | 36.39 **(-0.01)** | 34.61 **(0)** | 55.34 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/ApiResponseView.tsx | 56.41 **(-2.26)** | 38.46 **(-5.02)** | 0 **(0)** | 56.41 **(-2.26)**</details>