### PR TITLE
fix: Update ApplicationPageId with defaultPageId while fetching applications for homepage 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Organization.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Organization.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import javax.validation.constraints.NotBlank;
@@ -54,8 +53,5 @@ public class Organization extends BaseDomain {
     public String getLogoUrl() {
         return Url.ASSET_URL + "/" + logoAssetId;
     }
-
-    @Transient
-    private long gitConnectedApplications;
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ResponseUtils.java
@@ -327,6 +327,15 @@ public class ResponseUtils {
                         }
                     });
         }
+        if (!CollectionUtils.isEmpty(application.getPublishedPages())) {
+            application
+                    .getPublishedPages()
+                    .forEach(page -> {
+                        if (!StringUtils.isEmpty(page.getDefaultPageId())) {
+                            page.setId(page.getDefaultPageId());
+                        }
+                    });
+        }
         return application;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationFetcherImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ApplicationFetcherImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.solutions;
 
+import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.services.OrganizationService;
 import com.appsmith.server.services.SessionUserService;
@@ -17,9 +18,10 @@ public class ApplicationFetcherImpl extends ApplicationFetcherCEImpl implements 
                                   UserDataService userDataService,
                                   OrganizationService organizationService,
                                   ApplicationRepository applicationRepository,
-                                  ReleaseNotesService releaseNotesService) {
+                                  ReleaseNotesService releaseNotesService,
+                                  ResponseUtils responseUtils) {
 
         super(sessionUserService, userService, userDataService, organizationService, applicationRepository,
-                releaseNotesService);
+                releaseNotesService, responseUtils);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ResponseUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ResponseUtilsTest.java
@@ -2,6 +2,8 @@ package com.appsmith.server.helpers;
 
 import com.appsmith.external.helpers.BeanCopyUtils;
 import com.appsmith.server.domains.ActionCollection;
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.domains.ApplicationPage;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -102,5 +104,30 @@ public class ResponseUtilsTest {
 
         Assert.assertEquals(actionCollectionCopy.getUnpublishedCollection().getDefaultResources().getPageId(), actionCollection.getUnpublishedCollection().getPageId());
         Assert.assertEquals(actionCollectionCopy.getPublishedCollection().getDefaultResources().getPageId(), actionCollection.getPublishedCollection().getPageId());
+    }
+
+    @Test
+    public void getApplication_withDefaultIdsPresent_returnsUpdatedApplication() {
+        Application application = gson.fromJson(String.valueOf(jsonNode.get("application")), Application.class);
+
+        final Application applicationCopy = new Application();
+        BeanCopyUtils.copyNestedNonNullProperties(application, applicationCopy);
+
+        // Check if the id and defaultPage ids for pages are not same before we update the application using responseUtils
+        for (ApplicationPage applicationPage : application.getPages()) {
+            Assert.assertNotEquals(applicationPage.getId(), applicationPage.getDefaultPageId());
+        }
+        for (ApplicationPage applicationPage : application.getPublishedPages()) {
+            Assert.assertNotEquals(applicationPage.getId(), applicationPage.getDefaultPageId());
+        }
+        responseUtils.updateApplicationWithDefaultResources(application);
+        Assert.assertNotEquals(applicationCopy, application);
+        // Check if the id and defaultPage ids for pages are same after we update the application from responseUtils
+        for (ApplicationPage applicationPage : application.getPages()) {
+            Assert.assertEquals(applicationPage.getId(), applicationPage.getDefaultPageId());
+        }
+        for (ApplicationPage applicationPage : application.getPublishedPages()) {
+            Assert.assertEquals(applicationPage.getId(), applicationPage.getDefaultPageId());
+        }
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationFetcherUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationFetcherUnitTest.java
@@ -5,6 +5,7 @@ import com.appsmith.server.domains.Organization;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserData;
 import com.appsmith.server.dtos.OrganizationApplicationsDTO;
+import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.services.OrganizationService;
 import com.appsmith.server.services.SessionUserService;
@@ -49,6 +50,9 @@ public class ApplicationFetcherUnitTest {
     @MockBean
     ReleaseNotesService releaseNotesService;
 
+    @MockBean
+    ResponseUtils responseUtils;
+
     ApplicationFetcher applicationFetcher;
 
     User testUser;
@@ -61,7 +65,8 @@ public class ApplicationFetcherUnitTest {
                 userDataService,
                 organizationService,
                 applicationRepository,
-                releaseNotesService);
+                releaseNotesService,
+                responseUtils);
     }
 
     private List<Application> createDummyApplications(int orgCount, int appCount) {

--- a/app/server/appsmith-server/src/test/resources/test_assets/ResponseUtilsTest/mockObjects.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ResponseUtilsTest/mockObjects.json
@@ -51,5 +51,32 @@
       "collectionId": "defaultTestCollectionId",
       "applicationId": "defaultApplicationId"
     }
+  },
+  "application": {
+    "id": "testApplicationId",
+    "pages": [
+      {
+        "id" : "testPageId1",
+        "isDefault": true,
+        "defaultPageId": "defaultTestPageId1"
+      },
+      {
+        "id" : "testPageId2",
+        "isDefault": false,
+        "defaultPageId": "defaultTestPageId2"
+      }
+    ],
+    "publishedPages": [
+      {
+        "id" : "testPageId1",
+        "isDefault": false,
+        "defaultPageId": "defaultTestPageId1"
+      },
+      {
+        "id" : "testPageId2",
+        "isDefault": true,
+        "defaultPageId": "defaultTestPageId2"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description

> While fetching the applications for the homepage using all the orgs we were not updating the applicationPageIds which was resulting in the unexpected state as the client always expects the default ids for all the resources. 

Fixes #10793

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> JUnit test
> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
