### PR TITLE
fix: undo meta reducer update on eval

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -85,7 +85,7 @@ import { Channel } from "redux-saga";
 import { ActionDescription } from "entities/DataTree/actionTriggers";
 import { FormEvaluationState } from "reducers/evaluationReducers/formEvaluationReducer";
 import { FormEvalActionPayload } from "./FormEvaluationSaga";
-import { updateMetaState } from "../actions/metaActions";
+// import { updateMetaState } from "../actions/metaActions";
 import { getAllActionValidationConfig } from "selectors/entitiesSelector";
 
 let widgetTypeConfigMap: WidgetTypeConfigMap;

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -140,7 +140,7 @@ function* evaluateTreeSaga(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
 
-  yield put(updateMetaState(dataTree));
+  // yield put(updateMetaState(dataTree));
 
   const updatedDataTree = yield select(getDataTree);
   log.debug({ jsUpdates: jsUpdates });


### PR DESCRIPTION
- This will re-open #10026

## Description


Fixes #10818

This issue occurs because as per new changes, defaultValue on eval updates meta value inside the data tree, and we update these meta values directly in meta reducer, to keep meta values in sync.

- 1st Eval cycle -   text = {{defaultText}} = 10000 
 
- In PhoneInputWidget's `ComponentDidMount` we have  `updateWidgetMetaProperty` changing text in metaReducer to `10,000`

- But as we have evaluation running, it was noticed that before `10,000` value from metaReducer went to worked via unEvalTree, we updated the metaReducer with old metaValue. Earsing the update done by widget.

## Type of change

- hot fix

## How Has This Been Tested?


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: hotfix/metaEval 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/sagas/EvaluationsSaga.ts | 19.82 **(-0.27)** | 2.13 **(0)** | 8 **(0)** | 22.75 **(-0.29)**</details>