### PR TITLE
feat: added datasource icon on left of entity name, revamped name editor

### DIFF
--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -1,25 +1,21 @@
-import React, { useEffect, useState, useCallback } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React, { memo } from "react";
+import { useSelector } from "react-redux";
 
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import EditableText, {
   EditInteractionKind,
 } from "components/editorComponents/EditableText";
-import { removeSpecialChars, isNameValid } from "utils/helpers";
+import { removeSpecialChars } from "utils/helpers";
 import { AppState } from "reducers";
 import { Action } from "entities/Action";
-import { JSCollection } from "entities/JSCollection";
-import { getDataTree } from "selectors/dataTreeSelectors";
-import { getExistingPageNames } from "sagas/selectors";
 
 import { saveActionName } from "actions/pluginActionActions";
 import { Spinner } from "@blueprintjs/core";
 import { Classes } from "@blueprintjs/core";
-import log from "loglevel";
-import { JSCollectionData } from "reducers/entityReducers/jsActionsReducer";
-import { inGuidedTour } from "selectors/onboardingSelectors";
-import { toggleShowDeviationDialog } from "actions/onboardingActions";
+import { getAction, getPlugin } from "selectors/entitiesSelector";
+import { Plugin } from "api/PluginApi";
+import NameEditorComponent from "components/utils/NameEditorComponent";
 
 const ApiNameWrapper = styled.div<{ page?: string }>`
   min-width: 50%;
@@ -45,6 +41,13 @@ const ApiNameWrapper = styled.div<{ page?: string }>`
       : null}
 `;
 
+const ApiIconWrapper = styled.img`
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+  align-self: center;
+`;
+
 type ActionNameEditorProps = {
   /*
     This prop checks if page is API Pane or Query Pane or Curl Pane
@@ -55,131 +58,70 @@ type ActionNameEditorProps = {
   page?: string;
 };
 
-export function ActionNameEditor(props: ActionNameEditorProps) {
+function ActionNameEditor(props: ActionNameEditorProps) {
   const params = useParams<{ apiId?: string; queryId?: string }>();
-  const isNew =
-    new URLSearchParams(window.location.search).get("editName") === "true";
-  const [forceUpdate, setForceUpdate] = useState(false);
-  const dispatch = useDispatch();
-  if (!params.apiId && !params.queryId) {
-    log.error("No API id or Query id found in the url.");
-  }
-  const guidedTourEnabled = useSelector(inGuidedTour);
-  const actions: Action[] = useSelector((state: AppState) =>
-    state.entities.actions.map((action) => action.config),
+
+  const currentActionConfig:
+    | Action
+    | undefined = useSelector((state: AppState) =>
+    getAction(state, params.apiId || params.queryId || ""),
   );
 
-  const jsActions: JSCollection[] = useSelector((state: AppState) =>
-    state.entities.jsActions.map((action: JSCollectionData) => action.config),
+  const currentPlugin: Plugin | undefined = useSelector((state: AppState) =>
+    getPlugin(state, currentActionConfig?.pluginId || ""),
   );
-
-  const currentActionConfig: Action | undefined = actions.find(
-    (action) => action.id === params.apiId || action.id === params.queryId,
-  );
-
-  const existingWidgetNames: string[] = useSelector((state: AppState) =>
-    Object.values(state.entities.canvasWidgets).map(
-      (widget) => widget.widgetName,
-    ),
-  );
-
-  const evalTree = useSelector(getDataTree);
-  const existingPageNames = useSelector(getExistingPageNames);
-
-  const saveStatus: {
-    isSaving: boolean;
-    error: boolean;
-  } = useSelector((state: AppState) => {
-    const id = currentActionConfig ? currentActionConfig.id : "";
-    return {
-      isSaving: state.ui.apiName.isSaving[id],
-      error: state.ui.apiName.errors[id],
-    };
-  });
-
-  const hasActionNameConflict = useCallback(
-    (name: string) => !isNameValid(name, { ...existingPageNames, ...evalTree }),
-    [existingPageNames, actions, existingWidgetNames, jsActions],
-  );
-
-  const isInvalidActionName = useCallback(
-    (name: string): string | boolean => {
-      if (!name || name.trim().length === 0) {
-        return "Please enter a valid name";
-      } else if (
-        name !== currentActionConfig?.name &&
-        hasActionNameConflict(name)
-      ) {
-        return `${name} is already being used or is a restricted keyword.`;
-      }
-      return false;
-    },
-    [currentActionConfig, hasActionNameConflict],
-  );
-
-  const handleAPINameChange = useCallback(
-    (name: string) => {
-      if (
-        currentActionConfig &&
-        name !== currentActionConfig?.name &&
-        !isInvalidActionName(name)
-      ) {
-        if (guidedTourEnabled) {
-          dispatch(toggleShowDeviationDialog(true));
-          return;
-        }
-        dispatch(saveActionName({ id: currentActionConfig.id, name }));
-      }
-    },
-    [dispatch, isInvalidActionName, currentActionConfig, guidedTourEnabled],
-  );
-
-  useEffect(() => {
-    if (saveStatus.isSaving === false && saveStatus.error === true) {
-      setForceUpdate(true);
-    } else if (saveStatus.isSaving === true) {
-      setForceUpdate(false);
-    } else if (saveStatus.isSaving === false && saveStatus.error === false) {
-      // Construct URLSearchParams object instance from current URL querystring.
-      const queryParams = new URLSearchParams(window.location.search);
-
-      if (
-        queryParams.has("editName") &&
-        queryParams.get("editName") === "true"
-      ) {
-        // Set new or modify existing parameter value.
-        queryParams.set("editName", "false");
-        // Replace current querystring with the new one.
-        history.replaceState({}, "", "?" + queryParams.toString());
-      }
-    }
-  }, [saveStatus.isSaving, saveStatus.error]);
 
   return (
-    <ApiNameWrapper page={props.page}>
-      <div
-        style={{
-          display: "flex",
-        }}
-      >
-        <EditableText
-          className="t--action-name-edit-field"
-          defaultValue={currentActionConfig ? currentActionConfig.name : ""}
-          editInteractionKind={EditInteractionKind.SINGLE}
-          errorTooltipClass="t--action-name-edit-error"
-          forceDefault={forceUpdate}
-          isEditingDefault={isNew}
-          isInvalid={isInvalidActionName}
-          onTextChanged={handleAPINameChange}
-          placeholder="Name of the API in camelCase"
-          type="text"
-          updating={saveStatus.isSaving}
-          valueTransform={removeSpecialChars}
-        />
-        {saveStatus.isSaving && <Spinner size={16} />}
-      </div>
-    </ApiNameWrapper>
+    <NameEditorComponent
+      checkForGuidedTour
+      currentActionConfig={currentActionConfig}
+      dispatchAction={saveActionName}
+    >
+      {({
+        forceUpdate,
+        handleNameChange,
+        isInvalidNameForEntity,
+        isNew,
+        saveStatus,
+      }: {
+        forceUpdate: boolean;
+        handleNameChange: (value: string) => void;
+        isInvalidNameForEntity: (value: string) => string | boolean;
+        isNew: boolean;
+        saveStatus: any;
+      }) => (
+        <ApiNameWrapper page={props.page}>
+          <div
+            style={{
+              display: "flex",
+            }}
+          >
+            {currentPlugin && (
+              <ApiIconWrapper
+                alt={currentPlugin.name}
+                src={currentPlugin.iconLocation}
+              />
+            )}
+            <EditableText
+              className="t--action-name-edit-field"
+              defaultValue={currentActionConfig ? currentActionConfig.name : ""}
+              editInteractionKind={EditInteractionKind.SINGLE}
+              errorTooltipClass="t--action-name-edit-error"
+              forceDefault={forceUpdate}
+              isEditingDefault={isNew}
+              isInvalid={isInvalidNameForEntity}
+              onTextChanged={handleNameChange}
+              placeholder="Name of the API in camelCase"
+              type="text"
+              updating={saveStatus.isSaving}
+              valueTransform={removeSpecialChars}
+            />
+            {saveStatus.isSaving && <Spinner size={16} />}
+          </div>
+        </ApiNameWrapper>
+      )}
+    </NameEditorComponent>
   );
 }
 
-export default ActionNameEditor;
+export default memo(ActionNameEditor);

--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -16,6 +16,7 @@ import { Classes } from "@blueprintjs/core";
 import { getAction, getPlugin } from "selectors/entitiesSelector";
 import { Plugin } from "api/PluginApi";
 import NameEditorComponent from "components/utils/NameEditorComponent";
+import { ACTION_NAME_PLACEHOLDER, createMessage } from "constants/messages";
 
 const ApiNameWrapper = styled.div<{ page?: string }>`
   min-width: 50%;
@@ -111,7 +112,7 @@ function ActionNameEditor(props: ActionNameEditorProps) {
               isEditingDefault={isNew}
               isInvalid={isInvalidNameForEntity}
               onTextChanged={handleNameChange}
-              placeholder="Name of the API in camelCase"
+              placeholder={createMessage(ACTION_NAME_PLACEHOLDER, "Api")}
               type="text"
               updating={saveStatus.isSaving}
               valueTransform={removeSpecialChars}

--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -89,7 +89,7 @@ function ActionNameEditor(props: ActionNameEditorProps) {
         handleNameChange: (value: string) => void;
         isInvalidNameForEntity: (value: string) => string | boolean;
         isNew: boolean;
-        saveStatus: any;
+        saveStatus: { isSaving: boolean; error: boolean };
       }) => (
         <ApiNameWrapper page={props.page}>
           <div

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -20,7 +20,7 @@ import {
 type NameEditorProps = {
   checkForGuidedTour?: boolean;
   children: (params: any) => JSX.Element;
-  currentActionConfig: any;
+  currentActionConfig: { id: string; name: string } | undefined;
   dispatchAction: (a: any) => any;
   suffixErrorMessage?: (params?: any) => string;
 };
@@ -43,7 +43,7 @@ function NameEditor(props: NameEditorProps) {
     new URLSearchParams(window.location.search).get("editName") === "true";
   const [forceUpdate, setForceUpdate] = useState(false);
   const dispatch = useDispatch();
-  if (!currentActionConfig.id) {
+  if (!currentActionConfig?.id) {
     log.error("No correct API id or Query id found in the url.");
   }
   const guidedTourEnabled = useSelector(inGuidedTour);
@@ -56,7 +56,8 @@ function NameEditor(props: NameEditorProps) {
   );
 
   const conflictingNames = useSelector(
-    (state: AppState) => getUsedActionNames(state, currentActionConfig.id),
+    (state: AppState) =>
+      getUsedActionNames(state, currentActionConfig?.id || ""),
     shallowEqual,
   );
 
@@ -84,7 +85,7 @@ function NameEditor(props: NameEditorProps) {
     (name: string) => {
       if (
         currentActionConfig &&
-        name !== currentActionConfig?.name &&
+        name !== currentActionConfig.name &&
         !isInvalidNameForEntity(name)
       ) {
         if (checkForGuidedTour && guidedTourEnabled) {

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState, useCallback, memo } from "react";
+import { useSelector, useDispatch, shallowEqual } from "react-redux";
+
+import { isNameValid } from "utils/helpers";
+import { AppState } from "reducers";
+
+import log from "loglevel";
+import { inGuidedTour } from "selectors/onboardingSelectors";
+import { toggleShowDeviationDialog } from "actions/onboardingActions";
+import {
+  getUsedActionNames,
+  getSavingStatusForActionName,
+} from "selectors/actionSelectors";
+
+type NameEditorProps = {
+  checkForGuidedTour?: boolean;
+  children: (params: any) => JSX.Element;
+  currentActionConfig: any;
+  dispatchAction: (a: any) => any;
+  suffixErrorMessage?: string;
+};
+
+/**
+ * It is wrapper component using render props method.
+ * This Component is used to make a common function for changing the names of the entities, page, widget, js objects etc with the single point of logic.
+ * This code is memoized for usage to optimise the application.
+ * This passes down different properties as well as functions to the wrapped component (a function which is present inside the children property of props).
+ */
+
+function NameEditor(props: NameEditorProps) {
+  const {
+    checkForGuidedTour,
+    currentActionConfig,
+    dispatchAction,
+    suffixErrorMessage = "is already being used or is a restricted keyword.",
+  } = props;
+  const isNew =
+    new URLSearchParams(window.location.search).get("editName") === "true";
+  const [forceUpdate, setForceUpdate] = useState(false);
+  const dispatch = useDispatch();
+  if (!currentActionConfig.id) {
+    log.error("No correct API id or Query id found in the url.");
+  }
+  const guidedTourEnabled = useSelector(inGuidedTour);
+
+  const saveStatus: {
+    isSaving: boolean;
+    error: boolean;
+  } = useSelector((state: AppState) =>
+    getSavingStatusForActionName(state, currentActionConfig?.id || ""),
+  );
+
+  const conflictingNames = useSelector(
+    (state: AppState) => getUsedActionNames(state, currentActionConfig.id),
+    shallowEqual,
+  );
+
+  const hasActionNameConflict = useCallback(
+    (name: string) => !isNameValid(name, conflictingNames),
+    [conflictingNames],
+  );
+
+  const isInvalidNameForEntity = useCallback(
+    (name: string): string | boolean => {
+      if (!name || name.trim().length === 0) {
+        return "Please enter a valid name";
+      } else if (
+        name !== currentActionConfig?.name &&
+        hasActionNameConflict(name)
+      ) {
+        return `${name} ${suffixErrorMessage}`;
+      }
+      return false;
+    },
+    [currentActionConfig, hasActionNameConflict],
+  );
+
+  const handleNameChange = useCallback(
+    (name: string) => {
+      if (
+        currentActionConfig &&
+        name !== currentActionConfig?.name &&
+        !isInvalidNameForEntity(name)
+      ) {
+        if (checkForGuidedTour && guidedTourEnabled) {
+          dispatch(toggleShowDeviationDialog(true));
+          return;
+        }
+
+        dispatch(dispatchAction({ id: currentActionConfig.id, name }));
+      }
+    },
+    [dispatch, isInvalidNameForEntity, currentActionConfig, guidedTourEnabled],
+  );
+
+  useEffect(() => {
+    if (saveStatus.isSaving === false && saveStatus.error === true) {
+      setForceUpdate(true);
+    } else if (saveStatus.isSaving === true) {
+      setForceUpdate(false);
+    } else if (saveStatus.isSaving === false && saveStatus.error === false) {
+      // Construct URLSearchParams object instance from current URL querystring.
+      const queryParams = new URLSearchParams(window.location.search);
+
+      if (
+        queryParams.has("editName") &&
+        queryParams.get("editName") === "true"
+      ) {
+        // Set new or modify existing parameter value.
+        queryParams.set("editName", "false");
+        // Replace current querystring with the new one.
+        history.replaceState({}, "", "?" + queryParams.toString());
+      }
+    }
+  }, [saveStatus.isSaving, saveStatus.error]);
+
+  return props.children({
+    forceUpdate,
+    isNew,
+    isInvalidNameForEntity,
+    handleNameChange,
+    saveStatus,
+  });
+}
+
+export default memo(NameEditor);

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -11,13 +11,18 @@ import {
   getUsedActionNames,
   getSavingStatusForActionName,
 } from "selectors/actionSelectors";
+import {
+  ACTION_INVALID_NAME_ERROR,
+  ACTION_NAME_CONFLICT_ERROR,
+  createMessage,
+} from "constants/messages";
 
 type NameEditorProps = {
   checkForGuidedTour?: boolean;
   children: (params: any) => JSX.Element;
   currentActionConfig: any;
   dispatchAction: (a: any) => any;
-  suffixErrorMessage?: string;
+  suffixErrorMessage?: (params?: any) => string;
 };
 
 /**
@@ -32,7 +37,7 @@ function NameEditor(props: NameEditorProps) {
     checkForGuidedTour,
     currentActionConfig,
     dispatchAction,
-    suffixErrorMessage = "is already being used or is a restricted keyword.",
+    suffixErrorMessage = ACTION_NAME_CONFLICT_ERROR,
   } = props;
   const isNew =
     new URLSearchParams(window.location.search).get("editName") === "true";
@@ -63,12 +68,12 @@ function NameEditor(props: NameEditorProps) {
   const isInvalidNameForEntity = useCallback(
     (name: string): string | boolean => {
       if (!name || name.trim().length === 0) {
-        return "Please enter a valid name";
+        return createMessage(ACTION_INVALID_NAME_ERROR);
       } else if (
         name !== currentActionConfig?.name &&
         hasActionNameConflict(name)
       ) {
-        return `${name} ${suffixErrorMessage}`;
+        return createMessage(suffixErrorMessage, name);
       }
       return false;
     },

--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -244,6 +244,15 @@ export const ERROR_ACTION_COPY_FAIL = (actionName: string) =>
 export const ERROR_ACTION_RENAME_FAIL = (actionName: string) =>
   `Unable to update action name to ${actionName}`;
 
+// Action Names Messages
+export const ACTION_NAME_PLACEHOLDER = (type: string) =>
+  `Name of the ${type} in camelCase`;
+export const ACTION_INVALID_NAME_ERROR = () => "Please enter a valid name";
+export const ACTION_NAME_CONFLICT_ERROR = (name: string) =>
+  `${name} is already being used or is a restricted keyword.`;
+export const ENTITY_EXPLORER_ACTION_NAME_CONFLICT_ERROR = (name: string) =>
+  `${name} is already being used.`;
+
 export const DATASOURCE_CREATE = (dsName: string) =>
   `${dsName} datasource created`;
 export const DATASOURCE_DELETE = (dsName: string) =>

--- a/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
@@ -12,6 +12,7 @@ import { isEllipsisActive, removeSpecialChars } from "utils/helpers";
 import { TOOLTIP_HOVER_ON_DELAY } from "constants/AppConstants";
 import { ReactComponent as BetaIcon } from "assets/icons/menu/beta.svg";
 import NameEditorComponent from "components/utils/NameEditorComponent";
+import { ENTITY_EXPLORER_ACTION_NAME_CONFLICT_ERROR } from "constants/messages";
 
 export const searchHighlightSpanClassName = "token";
 export const searchTokenizationDelimiter = "!!";
@@ -155,7 +156,7 @@ export const EntityName = React.memo(
       <NameEditorComponent
         currentActionConfig={{ id: props.entityId, name: updatedName }}
         dispatchAction={handleUpdateName}
-        suffixErrorMessage="is already being used."
+        suffixErrorMessage={ENTITY_EXPLORER_ACTION_NAME_CONFLICT_ERROR}
       >
         {({
           handleNameChange,

--- a/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/Name.tsx
@@ -3,28 +3,15 @@ import EditableText, {
 } from "components/editorComponents/EditableText";
 import TooltipComponent from "components/ads/Tooltip";
 import { Colors } from "constants/Colors";
-import get from "lodash/get";
 
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useRef,
-} from "react";
-import { useDispatch, useSelector, useStore } from "react-redux";
+import React, { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 import { Classes, Position } from "@blueprintjs/core";
-import { AppState } from "reducers";
 import styled from "styled-components";
 import { isEllipsisActive, removeSpecialChars } from "utils/helpers";
 
-import WidgetFactory from "utils/WidgetFactory";
 import { TOOLTIP_HOVER_ON_DELAY } from "constants/AppConstants";
 import { ReactComponent as BetaIcon } from "assets/icons/menu/beta.svg";
-import { getCurrentPageId } from "selectors/editorSelectors";
-
-const WidgetTypes = WidgetFactory.widgetTypes;
+import NameEditorComponent from "components/utils/NameEditorComponent";
 
 export const searchHighlightSpanClassName = "token";
 export const searchTokenizationDelimiter = "!!";
@@ -108,105 +95,16 @@ export interface EntityNameProps {
 export const EntityName = React.memo(
   forwardRef((props: EntityNameProps, ref: React.Ref<HTMLDivElement>) => {
     const { name, searchKeyword, updateEntityName } = props;
-    const currentPageId = useSelector(getCurrentPageId);
-    const tabs:
-      | Array<{ id: string; widgetId: string; label: string }>
-      | undefined = useSelector((state: AppState) => {
-      if (state.entities.canvasWidgets.hasOwnProperty(props.entityId)) {
-        const widget = state.entities.canvasWidgets[props.entityId];
-        if (
-          widget.parentId &&
-          state.entities.canvasWidgets.hasOwnProperty(widget.parentId)
-        ) {
-          const parent = state.entities.canvasWidgets[widget.parentId];
-          // Todo(abhinav): abstraction leak
-          if (parent.type === WidgetTypes.TABS_WIDGET) {
-            return Object.values(parent.tabsObj);
-          }
-        }
-      }
-      return;
-    });
+    const [updatedName, setUpdatedName] = useState(name);
 
-    const nameUpdateError = useSelector((state: AppState) => {
-      return (
-        get(state, "ui.explorer.entity.updateEntityError") === props.entityId
-      );
-    });
     const targetRef = useRef<HTMLDivElement | null>(null);
 
-    const [updatedName, setUpdatedName] = useState(name);
+    const handleUpdateName = ({ name }: { name: string }) =>
+      updateEntityName(name);
 
     useEffect(() => {
       setUpdatedName(name);
-    }, [name, nameUpdateError]);
-
-    const dispatch = useDispatch();
-
-    const store = useStore();
-
-    const hasNameConflict = useCallback(
-      (
-        newName: string,
-        tabs?: Array<{ id: string; widgetId: string; label: string }>,
-      ) => {
-        if (tabs === undefined) {
-          const state: AppState = store.getState();
-          const existingPageNames = state.entities.pageList.pages.map(
-            (page) => page.pageName,
-          );
-          const existingActionNames = state.entities.actions
-            .filter(
-              (action) =>
-                action.config.id !== props.entityId &&
-                action.config.pageId === currentPageId,
-            )
-            .map((action) => action.config.name);
-          const existingJSCollectionNames = state.entities.jsActions
-            .filter((jsAction) => {
-              return (
-                jsAction.config.id !== props.entityId &&
-                jsAction.config.pageId === currentPageId
-              );
-            })
-            .map((jsAction) => jsAction.config.name);
-          const existingWidgetNames = Object.values(
-            state.entities.canvasWidgets,
-          ).map((widget) => widget.widgetName);
-          return !(
-            existingPageNames.indexOf(newName) === -1 &&
-            existingActionNames.indexOf(newName) === -1 &&
-            existingWidgetNames.indexOf(newName) === -1 &&
-            existingJSCollectionNames.indexOf(newName)
-          );
-        } else {
-          return tabs.findIndex((tab) => tab.label === newName) > -1;
-        }
-      },
-      [],
-    );
-
-    const isInvalidName = useCallback(
-      (newName: string): string | boolean => {
-        if (!newName || newName.trim().length === 0) {
-          return "Please enter a name";
-        } else if (newName !== name && hasNameConflict(newName, tabs)) {
-          return `${newName} is already being used.`;
-        }
-        return false;
-      },
-      [name, hasNameConflict],
-    );
-
-    const handleAPINameChange = useCallback(
-      (newName: string) => {
-        if (name && newName !== name && !isInvalidName(newName)) {
-          setUpdatedName(newName);
-          dispatch(updateEntityName(newName));
-        }
-      },
-      [dispatch, isInvalidName, name, updateEntityName],
-    );
+    }, [name, setUpdatedName]);
 
     const searchHighlightedName = useMemo(() => {
       if (searchKeyword) {
@@ -252,22 +150,37 @@ export const EntityName = React.memo(
           </TooltipComponent>
         </Container>
       );
+
     return (
-      <EditableWrapper>
-        <EditableText
-          className={`${props.className} editing`}
-          defaultValue={updatedName}
-          editInteractionKind={EditInteractionKind.SINGLE}
-          isEditingDefault
-          isInvalid={isInvalidName}
-          minimal
-          onBlur={props.exitEditMode}
-          onTextChanged={handleAPINameChange}
-          placeholder="Name"
-          type="text"
-          valueTransform={props.nameTransformFn || removeSpecialChars}
-        />
-      </EditableWrapper>
+      <NameEditorComponent
+        currentActionConfig={{ id: props.entityId, name: updatedName }}
+        dispatchAction={handleUpdateName}
+        suffixErrorMessage="is already being used."
+      >
+        {({
+          handleNameChange,
+          isInvalidNameForEntity,
+        }: {
+          handleNameChange: (value: string) => void;
+          isInvalidNameForEntity: (value: string) => string | boolean;
+        }) => (
+          <EditableWrapper>
+            <EditableText
+              className={`${props.className} editing`}
+              defaultValue={updatedName}
+              editInteractionKind={EditInteractionKind.SINGLE}
+              isEditingDefault
+              isInvalid={isInvalidNameForEntity}
+              minimal
+              onBlur={props.exitEditMode}
+              onTextChanged={handleNameChange}
+              placeholder="Name"
+              type="text"
+              valueTransform={props.nameTransformFn || removeSpecialChars}
+            />
+          </EditableWrapper>
+        )}
+      </NameEditorComponent>
     );
   }),
 );

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -15,6 +15,7 @@ import { Classes } from "@blueprintjs/core";
 import { saveJSObjectName } from "actions/jsActionActions";
 import { getJSCollection } from "selectors/entitiesSelector";
 import NameEditorComponent from "components/utils/NameEditorComponent";
+import { ACTION_NAME_PLACEHOLDER, createMessage } from "constants/messages";
 
 const JSObjectNameWrapper = styled.div<{ page?: string }>`
   min-width: 50%;
@@ -90,7 +91,7 @@ export function JSObjectNameEditor(props: ActionNameEditorProps) {
             isEditingDefault={isNew}
             isInvalid={isInvalidNameForEntity}
             onBlur={handleNameChange}
-            placeholder="Name of the object in camelCase"
+            placeholder={createMessage(ACTION_NAME_PLACEHOLDER, "object")}
             savingState={
               saveStatus.isSaving
                 ? SavingState.STARTED

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -76,7 +76,7 @@ export function JSObjectNameEditor(props: ActionNameEditorProps) {
         handleNameChange: (value: string) => void;
         isInvalidNameForEntity: (value: string) => string | boolean;
         isNew: boolean;
-        saveStatus: any;
+        saveStatus: { isSaving: boolean; error: boolean };
       }) => (
         <JSObjectNameWrapper page={props.page}>
           <NewEditableText

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState, useCallback } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React from "react";
+import { useSelector } from "react-redux";
 
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
@@ -8,15 +8,13 @@ import {
   EditInteractionKind as NewEditInteractionKind,
   SavingState,
 } from "components/ads/EditableText";
-import { removeSpecialChars, isNameValid } from "utils/helpers";
+import { removeSpecialChars } from "utils/helpers";
 import { AppState } from "reducers";
 import { JSCollection } from "entities/JSCollection";
-import { getDataTree } from "selectors/dataTreeSelectors";
-import { getExistingPageNames } from "sagas/selectors";
 import { Classes } from "@blueprintjs/core";
-import log from "loglevel";
-import { Action } from "entities/Action";
 import { saveJSObjectName } from "actions/jsActionActions";
+import { getJSCollection } from "selectors/entitiesSelector";
+import NameEditorComponent from "components/utils/NameEditorComponent";
 
 const JSObjectNameWrapper = styled.div<{ page?: string }>`
   min-width: 50%;
@@ -54,120 +52,56 @@ type ActionNameEditorProps = {
 
 export function JSObjectNameEditor(props: ActionNameEditorProps) {
   const params = useParams<{ collectionId?: string; queryId?: string }>();
-  const isNew =
-    new URLSearchParams(window.location.search).get("editName") === "true";
-  const [forceUpdate, setForceUpdate] = useState(false);
-  if (!params.collectionId) {
-    log.error("No API id or Query id found in the url.");
-  }
-  const dispatch = useDispatch();
 
-  const jsActions: JSCollection[] = useSelector((state: AppState) =>
-    state.entities.jsActions.map((action) => action.config),
+  const currentJSObjectConfig:
+    | JSCollection
+    | undefined = useSelector((state: AppState) =>
+    getJSCollection(state, params.collectionId || ""),
   );
-
-  const currentJSObjectConfig: JSCollection | undefined = jsActions.find(
-    (action) => action.id === params.collectionId,
-  );
-
-  const existingWidgetNames: string[] = useSelector((state: AppState) =>
-    Object.values(state.entities.canvasWidgets).map(
-      (widget) => widget.widgetName,
-    ),
-  );
-
-  const actions: Action[] = useSelector((state: AppState) =>
-    state.entities.actions.map((action) => action.config),
-  );
-
-  const evalTree = useSelector(getDataTree);
-  const existingPageNames = useSelector(getExistingPageNames);
-
-  const saveStatus: {
-    isSaving: boolean;
-    error: boolean;
-  } = useSelector((state: AppState) => {
-    const id = currentJSObjectConfig ? currentJSObjectConfig.id : "";
-    return {
-      isSaving: state.ui.apiName.isSaving[id],
-      error: state.ui.apiName.errors[id],
-    };
-  });
-
-  const hasNameConflict = useCallback(
-    (name: string) => !isNameValid(name, { ...existingPageNames, ...evalTree }),
-    [existingPageNames, jsActions, existingWidgetNames, actions],
-  );
-
-  const isInvalidJSObjectName = useCallback(
-    (name: string): string | boolean => {
-      if (!name || name.trim().length === 0) {
-        return "Please enter a valid name";
-      } else if (
-        name !== currentJSObjectConfig?.name &&
-        hasNameConflict(name)
-      ) {
-        return `${name} is already being used or is a restricted keyword.`;
-      }
-      return false;
-    },
-    [currentJSObjectConfig, hasNameConflict],
-  );
-
-  const handleJSObjectNameChange = useCallback(
-    (name: string) => {
-      if (
-        currentJSObjectConfig &&
-        name !== currentJSObjectConfig?.name &&
-        !isInvalidJSObjectName(name)
-      ) {
-        dispatch(saveJSObjectName({ id: currentJSObjectConfig.id, name }));
-      }
-    },
-    [dispatch, isInvalidJSObjectName, currentJSObjectConfig],
-  );
-
-  useEffect(() => {
-    if (saveStatus.isSaving === false && saveStatus.error === true) {
-      setForceUpdate(true);
-    } else if (saveStatus.isSaving === true) {
-      setForceUpdate(false);
-    } else if (saveStatus.isSaving === false && saveStatus.error === false) {
-      // Construct URLSearchParams object instance from current URL querystring.
-      const queryParams = new URLSearchParams(window.location.search);
-
-      if (
-        queryParams.has("editName") &&
-        queryParams.get("editName") === "true"
-      ) {
-        // Set new or modify existing parameter value.
-        queryParams.set("editName", "false");
-        // Replace current querystring with the new one.
-        history.replaceState({}, "", "?" + queryParams.toString());
-      }
-    }
-  }, [saveStatus.isSaving, saveStatus.error]);
 
   return (
-    <JSObjectNameWrapper page={props.page}>
-      <NewEditableText
-        className="t--js-action-name-edit-field"
-        defaultValue={currentJSObjectConfig ? currentJSObjectConfig.name : ""}
-        editInteractionKind={NewEditInteractionKind.SINGLE}
-        fill
-        forceDefault={forceUpdate}
-        hideEditIcon
-        isEditingDefault={isNew}
-        isInvalid={isInvalidJSObjectName}
-        onBlur={handleJSObjectNameChange}
-        placeholder="Name of the object in camelCase"
-        savingState={
-          saveStatus.isSaving ? SavingState.STARTED : SavingState.NOT_STARTED
-        }
-        underline
-        valueTransform={removeSpecialChars}
-      />
-    </JSObjectNameWrapper>
+    <NameEditorComponent
+      currentActionConfig={currentJSObjectConfig}
+      dispatchAction={saveJSObjectName}
+    >
+      {({
+        forceUpdate,
+        handleNameChange,
+        isInvalidNameForEntity,
+        isNew,
+        saveStatus,
+      }: {
+        forceUpdate: boolean;
+        handleNameChange: (value: string) => void;
+        isInvalidNameForEntity: (value: string) => string | boolean;
+        isNew: boolean;
+        saveStatus: any;
+      }) => (
+        <JSObjectNameWrapper page={props.page}>
+          <NewEditableText
+            className="t--js-action-name-edit-field"
+            defaultValue={
+              currentJSObjectConfig ? currentJSObjectConfig.name : ""
+            }
+            editInteractionKind={NewEditInteractionKind.SINGLE}
+            fill
+            forceDefault={forceUpdate}
+            hideEditIcon
+            isEditingDefault={isNew}
+            isInvalid={isInvalidNameForEntity}
+            onBlur={handleNameChange}
+            placeholder="Name of the object in camelCase"
+            savingState={
+              saveStatus.isSaving
+                ? SavingState.STARTED
+                : SavingState.NOT_STARTED
+            }
+            underline
+            valueTransform={removeSpecialChars}
+          />
+        </JSObjectNameWrapper>
+      )}
+    </NameEditorComponent>
   );
 }
 

--- a/app/client/src/selectors/actionSelectors.tsx
+++ b/app/client/src/selectors/actionSelectors.tsx
@@ -1,0 +1,52 @@
+import { DataTree } from "entities/DataTree/dataTreeFactory";
+import { createSelector } from "reselect";
+import WidgetFactory from "utils/WidgetFactory";
+import { FlattenedWidgetProps } from "widgets/constants";
+import { getDataTree } from "./dataTreeSelectors";
+import { getExistingPageNames } from "./entitiesSelector";
+import { getErrorForApiName, getIsSavingForApiName } from "./ui";
+import { getParentWidget } from "./widgetSelectors";
+
+/**
+ * Selector to return names that are already taken by other api, js objects, pagenames etc.
+ */
+export const getUsedActionNames = createSelector(
+  getExistingPageNames,
+  getDataTree,
+  getParentWidget,
+  (
+    pageNames: Record<string, any>,
+    dataTree: DataTree,
+    parentWidget: FlattenedWidgetProps | undefined,
+  ) => {
+    const map: Record<string, boolean> = {};
+    // The logic has been copied from Explorer/Entity/Name.tsx Component.
+    // Todo(abhinav): abstraction leak
+    if (
+      parentWidget &&
+      parentWidget.type === WidgetFactory.widgetTypes.TABS_WIDGET
+    ) {
+      Object.values(parentWidget.tabsObj).forEach((tab: any) => {
+        map[tab.label] = true;
+      });
+    } else {
+      pageNames.forEach((pageName: string) => {
+        map[pageName] = true;
+      });
+      Object.keys(dataTree).forEach((treeItem: string) => {
+        map[treeItem] = true;
+      });
+    }
+
+    return map;
+  },
+);
+
+export const getSavingStatusForActionName = createSelector(
+  getIsSavingForApiName,
+  getErrorForApiName,
+  (isSaving: boolean, error: boolean) => ({
+    isSaving,
+    error,
+  }),
+);

--- a/app/client/src/selectors/ui.tsx
+++ b/app/client/src/selectors/ui.tsx
@@ -5,3 +5,15 @@ export const getSelectedWidget = (state: AppState) =>
 
 export const getSelectedWidgets = (state: AppState) =>
   state.ui.widgetDragResize.selectedWidgets;
+
+/**
+ * Selector to use id and provide the status of saving an API.
+ */
+export const getIsSavingForApiName = (state: AppState, id: string) =>
+  state.ui.apiName.isSaving[id];
+
+/**
+ * Selector to use id and provide the status of error in an API.
+ */
+export const getErrorForApiName = (state: AppState, id: string) =>
+  state.ui.apiName.errors[id];

--- a/app/client/src/selectors/widgetSelectors.ts
+++ b/app/client/src/selectors/widgetSelectors.ts
@@ -31,3 +31,21 @@ export const getNextModalName = createSelector(
     return getNextEntityName(prefix, names);
   },
 );
+
+/**
+ * Selector to get the parent widget of a particaular widget with id as a prop
+ */
+export const getParentWidget = createSelector(
+  getCanvasWidgets,
+  (state: AppState, widgetId: string) => widgetId,
+  (canvasWidgets, widgetId: string): FlattenedWidgetProps | undefined => {
+    if (canvasWidgets.hasOwnProperty(widgetId)) {
+      const widget = canvasWidgets[widgetId];
+      if (widget.parentId && canvasWidgets.hasOwnProperty(widget.parentId)) {
+        const parent = canvasWidgets[widget.parentId];
+        return parent;
+      }
+    }
+    return;
+  },
+);


### PR DESCRIPTION
## Description

1. Added Datasource Icon on the left of the query name on the Query Editor page to signify the type of editing datasource query
2. There were multiple components with similar logic to identify the conflicting names when editing names of JSObject, Query Name, PageName, Names in the Entity Explorer Menu. Revamped and added a new wrapper component for Multiple Components so that logic for name editing remains at one point.

Fixes #10542 

## Type of change

> Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Changing Name from the Query Editor page and see if it reflects on the entity explorer as well.
2. Changing Name from the Page Editor page and see if it reflects on the entity explorer as well.
3. Changing Name from JS Object Editor page and see if it reflects on the entity explorer as well.
4. Check if typing Conflicting Names, it shows an error or not.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feat/datasource-icon 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.05 **(0.04)** | 36.36 **(0.02)** | 34.7 **(0.01)** | 55.43 **(0.04)**
 :green_circle: | app/client/src/components/editorComponents/ActionNameEditor.tsx | 50 **(25.71)** | 19.05 **(15.28)** | 0 **(0)** | 50 **(24.24)**
 :sparkles: :new: | **app/client/src/components/utils/NameEditorComponent.tsx** | **18.75** | **0** | **0** | **19.57**
 :red_circle: | app/client/src/constants/messages.ts | 74.78 **(-0.05)** | 100 **(0)** | 25.24 **(-0.17)** | 80.12 **(-0.19)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Entity/Name.tsx | 58.62 **(4.36)** | 45.45 **(13.37)** | 33.33 **(7.01)** | 57.41 **(4.08)**
 :green_circle: | app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx | 51.85 **(29.63)** | 20 **(15.74)** | 0 **(0)** | 51.85 **(28.12)**
 :sparkles: :new: | **app/client/src/selectors/actionSelectors.tsx** | **44.44** | **0** | **0** | **44.44**
 :red_circle: | app/client/src/selectors/ui.tsx | 83.33 **(-16.67)** | 100 **(0)** | 50 **(-50)** | 75 **(-25)**
 :red_circle: | app/client/src/selectors/widgetSelectors.ts | 62.5 **(-25)** | 35.71 **(-26.79)** | 57.14 **(-22.86)** | 61.9 **(-30.41)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>