### PR TITLE
fix: passing params from JS to API/SQL query

### DIFF
--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -118,7 +118,7 @@ export interface ExecuteErrorPayload extends ErrorActionPayload {
 export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/[\s\S]*?)?(\?(?![^{]*})[\s\S]*)?$/;
 
 export const EXECUTION_PARAM_KEY = "executionParams";
-export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params/g;
+export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params|this\?.params/g;
 export const THIS_DOT_PARAMS_KEY = "params";
 
 export const RESP_HEADER_DATATYPE = "X-APPSMITH-DATATYPE";

--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -118,6 +118,7 @@ export interface ExecuteErrorPayload extends ErrorActionPayload {
 export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/[\s\S]*?)?(\?(?![^{]*})[\s\S]*)?$/;
 
 export const EXECUTION_PARAM_KEY = "executionParams";
+export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params/g;
 export const THIS_DOT_PARAMS_KEY = "params";
 
 export const RESP_HEADER_DATATYPE = "X-APPSMITH-DATATYPE";

--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -118,7 +118,7 @@ export interface ExecuteErrorPayload extends ErrorActionPayload {
 export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/[\s\S]*?)?(\?(?![^{]*})[\s\S]*)?$/;
 
 export const EXECUTION_PARAM_KEY = "executionParams";
-export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params/g;
+export const THIS_DOT_PARAMS_KEY = "params";
 
 export const RESP_HEADER_DATATYPE = "X-APPSMITH-DATATYPE";
 export const API_REQUEST_HEADERS: APIHeaders = {

--- a/app/client/src/workers/DataTreeEvaluator.test.ts
+++ b/app/client/src/workers/DataTreeEvaluator.test.ts
@@ -1,0 +1,79 @@
+import DataTreeEvaluator from "./DataTreeEvaluator";
+
+describe("DataTreeEvaluator", () => {
+  let dataTreeEvaluator: DataTreeEvaluator;
+  beforeAll(() => {
+    dataTreeEvaluator = new DataTreeEvaluator({});
+  });
+  describe("evaluateActionBindings", () => {
+    it("handles this.params.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(function() { return this.params.property })()",
+          "(() => { return this.params.property })()",
+          'this.params.property || "1=1"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+    });
+
+    it("handles this?.params.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(() => { return this?.params.property })()",
+          "(function() { return this?.params.property })()",
+          'this?.params.property || "1=1"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+    });
+
+    it("handles this?.params?.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(() => { return this?.params?.property })()",
+          "(function() { return this?.params?.property })()",
+          'this?.params?.property || "1=1"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+    });
+
+    it("handles executionParams.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(function() { return executionParams.property })()",
+          "(() => { return executionParams.property })()",
+          'executionParams.property || "1=1"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+    });
+
+    it("handles executionParams?.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(function() { return executionParams?.property })()",
+          "(() => { return executionParams?.property })()",
+          'executionParams?.property || "1=1"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+    });
+  });
+});

--- a/app/client/src/workers/DataTreeEvaluator.test.ts
+++ b/app/client/src/workers/DataTreeEvaluator.test.ts
@@ -11,13 +11,19 @@ describe("DataTreeEvaluator", () => {
         [
           "(function() { return this.params.property })()",
           "(() => { return this.params.property })()",
-          'this.params.property || "1=1"',
+          'this.params.property || "default value"',
+          'this.params.property1 || "default value"',
         ],
         {
           property: "my value",
         },
       );
-      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
     });
 
     it("handles this?.params.property", () => {
@@ -25,13 +31,19 @@ describe("DataTreeEvaluator", () => {
         [
           "(() => { return this?.params.property })()",
           "(function() { return this?.params.property })()",
-          'this?.params.property || "1=1"',
+          'this?.params.property || "default value"',
+          'this?.params.property1 || "default value"',
         ],
         {
           property: "my value",
         },
       );
-      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
     });
 
     it("handles this?.params?.property", () => {
@@ -39,13 +51,19 @@ describe("DataTreeEvaluator", () => {
         [
           "(() => { return this?.params?.property })()",
           "(function() { return this?.params?.property })()",
-          'this?.params?.property || "1=1"',
+          'this?.params?.property || "default value"',
+          'this?.params?.property1 || "default value"',
         ],
         {
           property: "my value",
         },
       );
-      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
     });
 
     it("handles executionParams.property", () => {
@@ -53,13 +71,19 @@ describe("DataTreeEvaluator", () => {
         [
           "(function() { return executionParams.property })()",
           "(() => { return executionParams.property })()",
-          'executionParams.property || "1=1"',
+          'executionParams.property || "default value"',
+          'executionParams.property1 || "default value"',
         ],
         {
           property: "my value",
         },
       );
-      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
     });
 
     it("handles executionParams?.property", () => {
@@ -67,13 +91,19 @@ describe("DataTreeEvaluator", () => {
         [
           "(function() { return executionParams?.property })()",
           "(() => { return executionParams?.property })()",
-          'executionParams?.property || "1=1"',
+          'executionParams?.property || "default value"',
+          'executionParams?.property1 || "default value"',
         ],
         {
           property: "my value",
         },
       );
-      expect(result).toStrictEqual(["my value", "my value", "my value"]);
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
     });
   });
 });

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -1580,7 +1580,7 @@ export default class DataTreeEvaluator {
     return bindings.map((binding) => {
       // Replace any reference of 'this.params' to 'executionParams' (backwards compatibility)
       // also helps with dealing with IIFE which are normal functions (not arrow)
-      // because normal functions won't retain 'this' context (when execute elsewhere)
+      // because normal functions won't retain 'this' context (when executed elsewhere)
       const replacedBinding = binding.replace(
         EXECUTION_PARAM_REFERENCE_REGEX,
         EXECUTION_PARAM_KEY,

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -1573,10 +1573,6 @@ export default class DataTreeEvaluator {
       );
     }
 
-    const dataTreeWithExecutionParams = Object.assign({}, this.evalTree, {
-      [EXECUTION_PARAM_KEY]: evaluatedExecutionParams,
-    });
-
     return bindings.map((binding) => {
       // Replace any reference of 'this.params' to 'executionParams' (backwards compatibility)
       // also helps with dealing with IIFE which are normal functions (not arrow)
@@ -1587,7 +1583,7 @@ export default class DataTreeEvaluator {
       );
       return this.getDynamicValue(
         `{{${replacedBinding}}}`,
-        dataTreeWithExecutionParams,
+        this.evalTree,
         this.resolvedFunctions,
         EvaluationSubstitutionType.TEMPLATE,
         // params can be accessed via "this.params" or "executionParams"

--- a/app/client/src/workers/evaluate.test.ts
+++ b/app/client/src/workers/evaluate.test.ts
@@ -75,7 +75,7 @@ describe("evaluateSync", () => {
     const result = wrongJS
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "wrongJS",
@@ -89,7 +89,7 @@ describe("evaluateSync", () => {
     const result = wrongJS
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "wrongJS",
@@ -108,7 +108,7 @@ describe("evaluateSync", () => {
     const result = {}.map()
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "{}.map()",
@@ -135,7 +135,7 @@ describe("evaluateSync", () => {
     const result = setTimeout(() => {}, 100)
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
           severity: "error",
           originalBinding: "setTimeout(() => {}, 100)",
@@ -151,7 +151,7 @@ describe("evaluateSync", () => {
   it("evaluates functions with callback data", () => {
     const js = "(arg1, arg2) => arg1.value + arg2";
     const callbackData = [{ value: "test" }, "1"];
-    const response = evaluate(js, dataTree, {}, callbackData);
+    const response = evaluate(js, dataTree, {}, {}, callbackData);
     expect(response.result).toBe("test1");
   });
   it("handles EXPRESSIONS with new lines", () => {
@@ -165,21 +165,37 @@ describe("evaluateSync", () => {
   });
   it("handles TRIGGERS with new lines", () => {
     let js = "\n";
-    let response = evaluate(js, dataTree, {}, undefined);
+    let response = evaluate(js, dataTree, {}, undefined, undefined);
     expect(response.errors.length).toBe(0);
 
     js = "\n\n\n";
-    response = evaluate(js, dataTree, {}, undefined);
+    response = evaluate(js, dataTree, {}, undefined, undefined);
     expect(response.errors.length).toBe(0);
   });
   it("handles ANONYMOUS_FUNCTION with new lines", () => {
     let js = "\n";
-    let response = evaluate(js, dataTree, {}, undefined);
+    let response = evaluate(js, dataTree, {}, undefined, undefined);
     expect(response.errors.length).toBe(0);
 
     js = "\n\n\n";
-    response = evaluate(js, dataTree, {}, undefined);
+    response = evaluate(js, dataTree, {}, undefined, undefined);
     expect(response.errors.length).toBe(0);
+  });
+  it("has access to this context", () => {
+    const js = "this.contextVariable";
+    const thisContext = { contextVariable: "test" };
+    const response = evaluate(js, dataTree, {}, { thisContext });
+    expect(response.result).toBe("test");
+    // there should not be any error when accessing "this" variables
+    expect(response.errors).toHaveLength(0);
+  });
+
+  it("has access to additional global context", () => {
+    const js = "contextVariable";
+    const globalContext = { contextVariable: "test" };
+    const response = evaluate(js, dataTree, {}, { globalContext });
+    expect(response.result).toBe("test");
+    expect(response.errors).toHaveLength(0);
   });
 });
 

--- a/app/client/src/workers/evaluate.test.ts
+++ b/app/client/src/workers/evaluate.test.ts
@@ -30,6 +30,9 @@ describe("evaluateSync", () => {
     triggerPaths: {},
     validationPaths: {},
     logBlackList: {},
+    overridingPropertyPaths: {},
+    privateWidgets: {},
+    propertyOverrideDependency: {},
   };
   const dataTree: DataTree = {
     Input1: widget,
@@ -272,7 +275,7 @@ describe("isFunctionAsync", () => {
       if (typeof testFunc === "string") {
         testFunc = eval(testFunc);
       }
-      const actual = isFunctionAsync(testFunc, {});
+      const actual = isFunctionAsync(testFunc, {}, {});
       expect(actual).toBe(testCase.expected);
     }
   });

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -34,12 +34,12 @@ export const EvaluationScripts: Record<EvaluationScriptType, string> = {
     const result = ${ScriptTemplate}
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
   [EvaluationScriptType.ANONYMOUS_FUNCTION]: `
   function callback (script) {
     const userFunction = script;
-    const result = userFunction?.apply(self, ARGUMENTS);
+    const result = userFunction?.apply(THIS_CONTEXT, ARGUMENTS);
     return result;
   }
   callback(${ScriptTemplate})
@@ -49,7 +49,7 @@ export const EvaluationScripts: Record<EvaluationScriptType, string> = {
     const result = await ${ScriptTemplate};
     return result;
   }
-  closedFunction();
+  closedFunction.call(THIS_CONTEXT);
   `,
 };
 
@@ -102,6 +102,18 @@ export const createGlobalData = (
   const GLOBAL_DATA: Record<string, any> = {};
   ///// Adding callback data
   GLOBAL_DATA.ARGUMENTS = evalArguments;
+  //// Adding contextual data not part of data tree
+  GLOBAL_DATA.THIS_CONTEXT = {};
+  if (context) {
+    if (context.thisContext) {
+      GLOBAL_DATA.THIS_CONTEXT = context.thisContext;
+    }
+    if (context.globalContext) {
+      Object.entries(context.globalContext).forEach(([key, value]) => {
+        GLOBAL_DATA[key] = value;
+      });
+    }
+  }
   //// Add internal functions to dataTree;
   const dataTreeWithFunctions = enhanceDataTreeWithFunctions(
     dataTree,
@@ -134,9 +146,12 @@ export function sanitizeScript(js: string) {
 }
 
 /** Define a context just for this script
- * requestId is used for completing promises
+ * thisContext will define it on the `this`
+ * globalContext will define it globally
  */
 export type EvaluateContext = {
+  thisContext?: Record<string, any>;
+  globalContext?: Record<string, any>;
   requestId?: string;
 };
 
@@ -172,6 +187,7 @@ export default function evaluateSync(
   userScript: string,
   dataTree: DataTree,
   resolvedFunctions: Record<string, any>,
+  context?: EvaluateContext,
   evalArguments?: Array<any>,
 ): EvalResult {
   return (function() {
@@ -181,7 +197,7 @@ export default function evaluateSync(
     const GLOBAL_DATA: Record<string, any> = createGlobalData(
       dataTree,
       resolvedFunctions,
-      undefined,
+      context,
       evalArguments,
     );
     GLOBAL_DATA.ALLOW_ASYNC = false;

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -148,6 +148,7 @@ export function sanitizeScript(js: string) {
 /** Define a context just for this script
  * thisContext will define it on the `this`
  * globalContext will define it globally
+ * requestId is used for completing promises
  */
 export type EvaluateContext = {
   thisContext?: Record<string, any>;

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -803,7 +803,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     };
     if (config.params?.fnString && isString(config.params?.fnString)) {
       try {
-        const { result } = evaluate(config.params.fnString, {}, {}, [
+        const { result } = evaluate(config.params.fnString, {}, {}, undefined, [
           value,
           props,
           _,


### PR DESCRIPTION
Description:
Bringing back #9651 with some changes. (Which was reverted here #10322).

- Will support `this.params` in normal function IIFE's. (replacing `this.params` with `executionparams`)
- Will fix #10784

---

List of covered scenarios:

no optional chaining `this.params`:
- `{{ (function() { return this.params.condition })() }}`
- `{{ (() => { return this.params.condition })() }}`
- `{{ this.params.condition }}`

with optional chaining `this?.params`:
- `{{ (function() { return this?.params.condition })() }}`
- `{{ (() => { return this?.params.condition })() }}`
- `{{ this?.params.condition }}`

with optional chaining `this?.params?`:
- `{{ (function() { return this?.params?.condition })() }}`
- `{{ (() => { return this?.params?.condition })() }}`
- `{{ this?.params?.condition }}`







## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/this-params 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.97 **(0.03)** | 36.42 **(0.03)** | 34.63 **(0.02)** | 55.38 **(0.03)**
 :green_circle: | app/client/src/workers/DataTreeEvaluator.ts | 77.22 **(1.49)** | 57.93 **(1.68)** | 75.29 **(3.2)** | 76.98 **(1.42)**
 :green_circle: | app/client/src/workers/evaluate.ts | 90.15 **(0.81)** | 76.19 **(3.97)** | 83.33 **(0.72)** | 89.43 **(0.64)**</details>