### PR TITLE
fix: fixes uqi component issues

### DIFF
--- a/app/client/src/components/formControls/BaseControl.tsx
+++ b/app/client/src/components/formControls/BaseControl.tsx
@@ -41,6 +41,7 @@ export interface ControlProps extends ControlData, ControlFunctions {
   key?: string;
   extraData?: ControlData[];
   formName: string;
+  nestedFormControl?: boolean;
 }
 
 export interface ControlData {
@@ -55,7 +56,7 @@ export interface ControlData {
   validationMessage?: string;
   validationRegex?: string;
   dataType?: InputType;
-  initialValue?: string | boolean | number;
+  initialValue?: string | boolean | number | Record<string, string>;
   info?: string; //helper text
   isRequired?: boolean;
   conditionals?: ConditonalObject; // Object that contains the conditionals config

--- a/app/client/src/components/formControls/PaginationControl.tsx
+++ b/app/client/src/components/formControls/PaginationControl.tsx
@@ -17,7 +17,8 @@ export const StyledFormLabel = styled(FormLabel)`
 export const FormControlContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-bottom: 10px;
+  width: 20vw;
+  margin-right: 1rem;
 `;
 
 // using query dynamic input text for both so user can dynamically change these values.
@@ -48,11 +49,17 @@ export function Pagination(props: {
   customStyles?: any;
   configProperty: string;
   formName: string;
+  initialValue?: Record<string, string>;
 }) {
-  const { configProperty, customStyles, formName, name } = props;
+  const { configProperty, customStyles, formName, initialValue, name } = props;
 
   return (
-    <div data-cy={name} style={{ width: "20vw" }}>
+    <div
+      data-cy={name}
+      style={{
+        display: "flex",
+      }}
+    >
       {/*  form control for Limit field */}
       <FormControlContainer>
         <FormControl
@@ -61,6 +68,8 @@ export function Pagination(props: {
             label: "Limit",
             customStyles,
             configProperty: `${configProperty}.limit`,
+            initialValue:
+              typeof initialValue === "object" ? initialValue.limit : null,
           }}
           formName={formName}
         />
@@ -75,6 +84,8 @@ export function Pagination(props: {
             label: "Offset",
             customStyles,
             configProperty: `${configProperty}.offset`,
+            initialValue:
+              typeof initialValue === "object" ? initialValue.offset : null,
           }}
           formName={formName}
         />

--- a/app/client/src/components/formControls/SortingControl.tsx
+++ b/app/client/src/components/formControls/SortingControl.tsx
@@ -56,6 +56,7 @@ const SortingDropdownContainer = styled.div`
   flex-direction: row;
   width: min-content;
   justify-content: space-between;
+  margin-bottom: 10px;
 `;
 
 // container for the column dropdown section
@@ -101,7 +102,6 @@ const StyledBottomLabelContainer = styled.div`
 `;
 
 export const StyledBottomLabel = styled(FormLabel)`
-  margin-top: 5px;
   margin-left: 5px;
   font-weight: 400;
   font-size: 12px;
@@ -110,8 +110,13 @@ export const StyledBottomLabel = styled(FormLabel)`
 `;
 
 function SortingComponent(props: any) {
-  const customStyles = {
-    width: `100%`,
+  const columnCustomStyles = {
+    width: "100%",
+    height: "30px",
+  };
+
+  const orderCustomStyles = {
+    width: "15vw",
     height: "30px",
   };
 
@@ -140,7 +145,7 @@ function SortingComponent(props: any) {
               <FormControl
                 config={{
                   ...columnFieldConfig,
-                  customStyles,
+                  customStyles: columnCustomStyles,
                   configProperty: `${field}.column`,
                   nestedFormControl: true,
                 }}
@@ -151,7 +156,7 @@ function SortingComponent(props: any) {
               <FormControl
                 config={{
                   ...orderFieldConfig,
-                  customStyles,
+                  customStyles: orderCustomStyles,
                   configProperty: `${field}.order`,
                   nestedFormControl: true,
                 }}

--- a/app/client/src/components/formControls/SortingControl.tsx
+++ b/app/client/src/components/formControls/SortingControl.tsx
@@ -140,9 +140,9 @@ function SortingComponent(props: any) {
               <FormControl
                 config={{
                   ...columnFieldConfig,
-                  label: "",
                   customStyles,
                   configProperty: `${field}.column`,
+                  nestedFormControl: true,
                 }}
                 formName={props.formName}
               />
@@ -151,9 +151,9 @@ function SortingComponent(props: any) {
               <FormControl
                 config={{
                   ...orderFieldConfig,
-                  label: "",
                   customStyles,
                   configProperty: `${field}.order`,
+                  nestedFormControl: true,
                 }}
                 formName={props.formName}
               />

--- a/app/client/src/pages/Editor/FormControl.tsx
+++ b/app/client/src/pages/Editor/FormControl.tsx
@@ -140,6 +140,7 @@ function renderFormConfigTop(props: { config: ControlProps }) {
     encrypted,
     isRequired,
     label,
+    nestedFormControl,
     subtitle,
     tooltipText = "",
     url,
@@ -147,27 +148,29 @@ function renderFormConfigTop(props: { config: ControlProps }) {
   } = { ...props.config };
   return (
     <React.Fragment key={props.config.label}>
-      <FormLabel config={props.config}>
-        <p className="label-icon-wrapper">
-          {label} {isRequired && "*"}{" "}
-          {encrypted && (
-            <>
-              <FormIcons.LOCK_ICON height={12} keepColors width={12} />
-              <FormSubtitleText config={props.config}>
-                Encrypted
-              </FormSubtitleText>
-            </>
+      {!nestedFormControl && ( // if the form control is a nested form control hide its label
+        <FormLabel config={props.config}>
+          <p className="label-icon-wrapper">
+            {label} {isRequired && "*"}{" "}
+            {encrypted && (
+              <>
+                <FormIcons.LOCK_ICON height={12} keepColors width={12} />
+                <FormSubtitleText config={props.config}>
+                  Encrypted
+                </FormSubtitleText>
+              </>
+            )}
+            {tooltipText && (
+              <Tooltip content={tooltipText} hoverOpenDelay={1000}>
+                <FormIcons.HELP_ICON height={16} width={16} />
+              </Tooltip>
+            )}
+          </p>
+          {subtitle && (
+            <FormInfoText config={props.config}>{subtitle}</FormInfoText>
           )}
-          {tooltipText && (
-            <Tooltip content={tooltipText} hoverOpenDelay={1000}>
-              <FormIcons.HELP_ICON height={16} width={16} />
-            </Tooltip>
-          )}
-        </p>
-        {subtitle && (
-          <FormInfoText config={props.config}>{subtitle}</FormInfoText>
-        )}
-      </FormLabel>
+        </FormLabel>
+      )}
       {urlText && (
         <FormInputAnchor href={url} target="_blank">
           {urlText}


### PR DESCRIPTION
This PR addresses the following issues:

- Pagination fields should be in single row
- Too much gap between label and first input field in Sort component
- Need a way to assign initial value to Pagination component.

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

Manual Tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-uqi-components 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.98 **(-0.01)** | 36.31 **(-0.01)** | 34.68 **(0)** | 55.37 **(0)**
 :red_circle: | app/client/src/components/formControls/PaginationControl.tsx | 60 **(0)** | 50 **(-50)** | 25 **(0)** | 58.62 **(0)**
 :red_circle: | app/client/src/components/formControls/SortingControl.tsx | 55.56 **(-1.58)** | 59.26 **(0)** | 11.11 **(0)** | 55.56 **(-1.58)**
 :red_circle: | app/client/src/pages/Editor/FormControl.tsx | 25 **(-0.58)** | 0 **(0)** | 0 **(0)** | 26.19 **(-0.64)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>