### PR TITLE
fix: Execute query overflow scroll issue

### DIFF
--- a/app/client/src/components/ads/TreeDropdown.tsx
+++ b/app/client/src/components/ads/TreeDropdown.tsx
@@ -60,6 +60,8 @@ const StyledMenu = styled(Menu)`
     border-radius: 0px;
     background-color: ${(props) =>
       props.theme.colors.treeDropdown.menuBg.normal};
+    max-height: 90vh;
+    overflow-y: scroll;
   }
   .${Classes.MENU_ITEM} {
     border-radius: 0px;


### PR DESCRIPTION
## Description

This PR has the fix the overflow not scrolling when the list of queries are more than the screen height in Execute query section.

Fixes #10835


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally by adding more than 20 queries.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: bug-fix/10835-execute-query-overflow-scroll 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.93 **(0)** | 36.39 **(0.01)** | 34.6 **(0)** | 55.34 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>