### PR TITLE
fix: Race condition issue of meta reducer update

### DIFF
--- a/app/client/src/actions/metaActions.ts
+++ b/app/client/src/actions/metaActions.ts
@@ -1,8 +1,7 @@
 import { ReduxActionTypes, ReduxAction } from "constants/ReduxActionConstants";
 import { BatchAction, batchAction } from "actions/batchActions";
-import { MetaState } from "../reducers/entityReducers/metaReducer";
-import set from "lodash/set";
 import { Diff } from "deep-diff";
+import { DataTree } from "entities/DataTree/dataTreeFactory";
 
 export interface UpdateWidgetMetaPropertyPayload {
   widgetId: string;
@@ -46,20 +45,15 @@ export const resetChildrenMetaProperty = (
   };
 };
 
-export const updateMetaState = (updates: Diff<any, any>[]) => {
-  const updatedWidgetMetaState: MetaState = {};
-  if (updates.length) {
-    updates.forEach((update) => {
-      // if meta field is updated in the dataTree then update metaReducer values.
-      if (update.kind === "E" && update.path && update.path?.includes("meta")) {
-        set(updatedWidgetMetaState, update.path, update.rhs);
-      }
-    });
-  }
+export const updateMetaState = (
+  updates: Diff<any, any>[],
+  updatedDataTree: DataTree,
+) => {
   return {
     type: ReduxActionTypes.UPDATE_META_STATE,
     payload: {
-      updatedWidgetMetaState,
+      updates,
+      updatedDataTree,
     },
   };
 };

--- a/app/client/src/actions/metaActions.ts
+++ b/app/client/src/actions/metaActions.ts
@@ -50,7 +50,7 @@ export const updateMetaState = (updates: Diff<any, any>[]) => {
   const updatedWidgetMetaState: MetaState = {};
   if (updates.length) {
     updates.forEach((update) => {
-      // if meta field is updated in old and new dataTree when update metaReducer
+      // if meta field is updated in the dataTree then update metaReducer values.
       if (update.kind === "E" && update.path && update.path?.includes("meta")) {
         set(updatedWidgetMetaState, update.path, update.rhs);
       }

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -140,7 +140,7 @@ function* evaluateTreeSaga(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
 
-  yield put(updateMetaState(dataTree));
+  yield put(updateMetaState(updates));
 
   const updatedDataTree = yield select(getDataTree);
   log.debug({ jsUpdates: jsUpdates });

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -140,7 +140,7 @@ function* evaluateTreeSaga(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
 
-  yield put(updateMetaState(updates));
+  yield put(updateMetaState(updates, dataTree));
 
   const updatedDataTree = yield select(getDataTree);
   log.debug({ jsUpdates: jsUpdates });

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -805,10 +805,11 @@ export const overrideWidgetProperties = (
     const overridingPropertyPaths =
       entity.overridingPropertyPaths[propertyPath];
 
-    overridingPropertyPaths.forEach((overriddenPropertyKey) => {
+    overridingPropertyPaths.forEach((overriddenPropertyPath) => {
+      const overriddenPropertyPathArray = overriddenPropertyPath.split(".");
       _.set(
         currentTree,
-        `${entity.widgetName}.${overriddenPropertyKey}`,
+        [entity.widgetName, ...overriddenPropertyPathArray],
         clonedValue,
       );
     });
@@ -824,9 +825,10 @@ export const overrideWidgetProperties = (
       const defaultValue = entity[propertyOverridingKeyMap.DEFAULT];
       const clonedDefaultValue = cloneDeep(defaultValue);
       if (defaultValue !== undefined) {
+        const propertyPathArray = propertyPath.split(".");
         _.set(
           currentTree,
-          `${entity.widgetName}.${propertyPath}`,
+          [entity.widgetName, ...propertyPathArray],
           clonedDefaultValue,
         );
         return {


### PR DESCRIPTION
## Description

Fixes #10818

Changing the logic to only update metaReducer values when there is a change between previous dataTree and current data tree. 

**Caveat** - This logic assumes that when a widget property's default and meta value both change, it is okay to give preference to the default value and clear the meta.

For meta-evaluation changes refer - https://github.com/appsmithorg/appsmith/pull/10401

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/metaEval-raceCondition 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.94 **(0)** | 36.38 **(-0.01)** | 34.61 **(0)** | 55.35 **(0)**
 :green_circle: | app/client/src/actions/metaActions.ts | 78.57 **(13.57)** | 100 **(100)** | 25 **(5)** | 70 **(13.75)**
 :green_circle: | app/client/src/reducers/entityReducers/metaReducer.ts | 33.33 **(0.83)** | 0 **(0)** | 20 **(0)** | 35 **(0.79)**
 :red_circle: | app/client/src/workers/evaluationUtils.ts | 58.37 **(-0.04)** | 56.61 **(0)** | 64.52 **(0)** | 57.7 **(-0.05)**</details>