### PR TITLE
fix: props is now required in type Validator

### DIFF
--- a/app/client/src/constants/WidgetValidation.ts
+++ b/app/client/src/constants/WidgetValidation.ts
@@ -28,7 +28,7 @@ export type ValidationResponse = {
 export type Validator = (
   config: ValidationConfig,
   value: unknown,
-  props?: Record<string, unknown>,
+  props: Record<string, unknown>,
 ) => ValidationResponse;
 
 export const ISO_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ss.sssZ";

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -361,7 +361,7 @@ export function validateActionProperty(
       parsed: value,
     };
   }
-  return validate(config, value, undefined);
+  return validate(config, value, {});
 }
 
 export function getValidatedTree(tree: DataTree) {

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -630,11 +630,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
       try {
         const _value = JSON.parse(value);
         if (Array.isArray(_value)) {
-          const result = validateArray(
-            config,
-            _value,
-            props as Record<string, unknown>,
-          );
+          const result = validateArray(config, _value, props);
           return result;
         }
       } catch (e) {
@@ -643,7 +639,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     }
 
     if (Array.isArray(value)) {
-      return validateArray(config, value, props as Record<string, unknown>);
+      return validateArray(config, value, props);
     }
 
     return invalidResponse;

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -53,7 +53,7 @@ function getPropertyEntry(
 function validatePlainObject(
   config: ValidationConfig,
   value: Record<string, unknown>,
-  props?: Record<string, unknown>,
+  props: Record<string, unknown>,
 ) {
   if (config.params?.allowedKeys) {
     let _valid = true;
@@ -216,7 +216,7 @@ function validateArray(
 export const validate = (
   config: ValidationConfig,
   value: unknown,
-  props: undefined | Record<string, unknown>,
+  props: Record<string, unknown>,
 ): ValidationResponse => {
   const _result = VALIDATORS[config.type as ValidationTypes](
     config,
@@ -300,7 +300,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.TEXT]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     if (value === undefined || value === null || value === "") {
       if (config.params && config.params.required) {
@@ -377,7 +377,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.REGEX]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     const { isValid, messages, parsed } = VALIDATORS[ValidationTypes.TEXT](
       config,
@@ -400,7 +400,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.NUMBER]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     if (value === undefined || value === null || value === "") {
       if (config.params?.required) {
@@ -490,7 +490,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.BOOLEAN]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     if (value === undefined || value === null || value === "") {
       if (config.params && config.params.required) {
@@ -534,7 +534,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.OBJECT]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     if (
       value === undefined ||
@@ -589,7 +589,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.ARRAY]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     const invalidResponse = {
       isValid: false,
@@ -651,7 +651,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.OBJECT_ARRAY]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     const invalidResponse = {
       isValid: false,
@@ -712,7 +712,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.NESTED_OBJECT_ARRAY]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     let response: ValidationResponse = {
       isValid: false,
@@ -749,7 +749,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.DATE_ISO_STRING]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     const invalidResponse = {
       isValid: false,
@@ -794,7 +794,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.FUNCTION]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     const invalidResponse = {
       isValid: false,
@@ -819,7 +819,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.IMAGE_URL]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     const invalidResponse = {
       isValid: false,
@@ -884,7 +884,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
   [ValidationTypes.TABLE_PROPERTY]: (
     config: ValidationConfig,
     value: unknown,
-    props?: Record<string, unknown>,
+    props: Record<string, unknown>,
   ): ValidationResponse => {
     if (!config.params?.type)
       return {


### PR DESCRIPTION
## Description
This PR updates typescript interface `Validator`, makes `props` required from optional. We are doing so in order ensure that props is passed for `ValidationTypes.FUNCTION`. 

Fixes #10850 

## How Has This Been Tested?

Not required.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/10850-make-props-required 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 54.95 **(0.01)** | 36.4 **(0.01)** | 34.61 **(0)** | 55.36 **(0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**</details>