### PR TITLE
fix: Fix NPE during import when page ids are missing for published action and actionCollection 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -792,18 +792,11 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 }
 
                                 // If pageId is missing in the actionDTO create a fallback pageId
-                                final String parentPageId = !StringUtils.isEmpty(unpublishedAction.getPageId())
-                                        ? unpublishedAction.getPageId()
-                                        : publishedAction != null && !StringUtils.isEmpty(publishedAction.getPageId())
-                                            ? publishedAction.getPageId()
-                                            : pageNameMap.keySet().stream().findAny().orElse(null);
+                                final String fallbackParentPageId = unpublishedAction.getPageId();
 
                                 // pageNameMap.get(action.getPageId())
                                 if (unpublishedAction.getName() != null) {
                                     unpublishedAction.setId(newAction.getId());
-                                    if (StringUtils.isEmpty(unpublishedAction.getPageId())) {
-                                        unpublishedAction.setPageId(parentPageId);
-                                    }
                                     parentPage = updatePageInAction(unpublishedAction, pageNameMap, actionIdMap);
                                     sanitizeDatasourceInActionDTO(unpublishedAction, datasourceMap, pluginMap, organizationId, false);
                                 }
@@ -811,7 +804,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 if (publishedAction != null && publishedAction.getName() != null) {
                                     publishedAction.setId(newAction.getId());
                                     if (StringUtils.isEmpty(publishedAction.getPageId())) {
-                                        publishedAction.setPageId(parentPageId);
+                                        publishedAction.setPageId(fallbackParentPageId);
                                     }
                                     NewPage publishedActionPage = updatePageInAction(publishedAction, pageNameMap, actionIdMap);
                                     parentPage = parentPage == null ? publishedActionPage : parentPage;
@@ -920,18 +913,11 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 final ActionCollectionDTO publishedCollection = actionCollection.getPublishedCollection();
 
                                 // If pageId is missing in the actionDTO create a fallback pageId
-                                final String parentPageId = !StringUtils.isEmpty(unpublishedCollection.getPageId())
-                                        ? unpublishedCollection.getPageId()
-                                        : publishedCollection != null && !StringUtils.isEmpty(publishedCollection.getPageId())
-                                        ? publishedCollection.getPageId()
-                                        : pageNameMap.keySet().stream().findAny().orElse(null);
+                                final String fallbackParentPageId = unpublishedCollection.getPageId();
 
                                 if (unpublishedCollection.getName() != null) {
                                     unpublishedCollection.setDefaultToBranchedActionIdsMap(unpublishedActionCollectionIdMap.get(importedActionCollectionId));
                                     unpublishedCollection.setPluginId(pluginMap.get(unpublishedCollection.getPluginId()));
-                                    if (StringUtils.isEmpty(unpublishedCollection.getPageId())) {
-                                        unpublishedCollection.setPageId(parentPageId);
-                                    }
                                     parentPage = updatePageInActionCollection(unpublishedCollection, pageNameMap);
                                 }
 
@@ -939,7 +925,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                     publishedCollection.setDefaultToBranchedActionIdsMap(publishedActionCollectionIdMap.get(importedActionCollectionId));
                                     publishedCollection.setPluginId(pluginMap.get(publishedCollection.getPluginId()));
                                     if (StringUtils.isEmpty(publishedCollection.getPageId())) {
-                                        publishedCollection.setPageId(parentPageId);
+                                        publishedCollection.setPageId(fallbackParentPageId);
                                     }
                                     NewPage publishedCollectionPage = updatePageInActionCollection(publishedCollection, pageNameMap);
                                     parentPage = parentPage == null ? publishedCollectionPage : parentPage;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -744,6 +744,14 @@ public class ImportExportApplicationServiceTests {
                 actionList.forEach(newAction -> {
                     ActionDTO actionDTO = newAction.getUnpublishedAction();
                     assertThat(actionDTO.getPageId()).isNotEqualTo(pageList.get(0).getName());
+                    if (StringUtils.equals(actionDTO.getName(), "api_wo_auth")) {
+                        ActionDTO publishedAction = newAction.getPublishedAction();
+                        assertThat(publishedAction).isNotNull();
+                        assertThat(publishedAction.getActionConfiguration()).isNotNull();
+                        // Test the fallback page ID from the unpublishedAction is copied to published version when
+                        // published version does not have pageId
+                        assertThat(actionDTO.getPageId()).isEqualTo(publishedAction.getPageId());
+                    }
                     if (!StringUtils.isEmpty(actionDTO.getCollectionId())) {
                         collectionIdInAction.add(actionDTO.getCollectionId());
                     }

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
@@ -517,11 +517,42 @@
         "userPermissions": []
       },
       "publishedAction": {
+        "name": "api_wo_auth",
         "datasource": {
+          "id": "api_ds_wo_auth",
           "userPermissions": [],
           "isValid": true,
-          "new": true
+          "new": false
         },
+        "actionConfiguration": {
+          "timeoutInMillisecond": 10000,
+          "paginationType": "NONE",
+          "path": "/params",
+          "headers": [
+            {
+              "key": "",
+              "value": ""
+            },
+            {
+              "key": "",
+              "value": ""
+            }
+          ],
+          "encodeParamsToggle": true,
+          "queryParameters": [],
+          "body": "",
+          "httpMethod": "GET",
+          "pluginSpecifiedTemplates": [
+            {
+              "value": false
+            }
+          ]
+        },
+        "executeOnLoad": true,
+        "dynamicBindingPathList": [],
+        "isValid": true,
+        "invalids": [],
+        "jsonPathKeys": [],
         "confirmBeforeExecute": false,
         "userPermissions": []
       },


### PR DESCRIPTION
## Description

> When the application is imported from the JSON file with null pageId for action and actionCollection, internal server error is thrown. This PR will use the unpublished resource pageId as a fallback when the published one don't have one for actions and/or action collection and then import the application.
 
Fixes https://github.com/appsmithorg/appsmith/issues/10857

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Junit TC
> Manual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
