### PR TITLE
fix: enable response tab in js editor even if it has warnings

### DIFF
--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -214,7 +214,7 @@ function JSResponseView(props: Props) {
               ""
             )}
           </HelpSection>
-          <ResponseTabWrapper className={errors.length ? "disable" : ""}>
+          <ResponseTabWrapper className={errorsList.length ? "disable" : ""}>
             {sortedActionList && !sortedActionList?.length ? (
               <NoResponseContainer className="flex items-center">
                 {createMessage(EMPTY_JS_OBJECT)}


### PR DESCRIPTION
## Description

The response tab was disabled if the code has lint warnings. We want to disable it only on errors.

Fixes #10824 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: 10824-fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>