### PR TITLE
fix: reset meta keys instead of deleting it

### DIFF
--- a/app/client/src/reducers/entityReducers/metaReducer.ts
+++ b/app/client/src/reducers/entityReducers/metaReducer.ts
@@ -90,7 +90,7 @@ export const metaReducer = createReducer(initialState, {
         ...state[widgetId],
       };
       Object.keys(resetData).forEach((key: string) => {
-        delete resetData[key];
+        resetData[key] = undefined;
       });
       return { ...state, [widgetId]: { ...resetData } };
     }


### PR DESCRIPTION

## Description

>  default property and metaProperty value was different in props so the condition was not executed properly that's why 
> updated data was not reached to file widget

Fixes #6492

## Type of change

- Bugfix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/reset-filepicker 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.94 **(0)** | 36.38 **(-0.01)** | 34.61 **(0)** | 55.35 **(0)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>