### PR TITLE
test: Support reuse of github actions

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -340,33 +340,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job:
-          [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23,
-          ]
+        job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+        
     # Service containers to run with this job. Required for running tests
     services:
       # Label used to access the service container

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -34,6 +34,28 @@ jobs:
         with:
           ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
 
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "::set-output name=timestamp::$(timestamp +'%Y-%m-%dT%H:%M:%S')"
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-
+
+      # Fetch prior run result
+      - name: Get the previous run result
+        id: run_result
+        run: cat ~/run_result 2>/dev/null || echo 'default'
+
+      # Incase of prior failure run the job
+      - if: steps.run_result.outputs.run_result != 'success'
+        run: echo "I'm alive!" && exit 0
       # Setup Java
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
@@ -42,6 +64,7 @@ jobs:
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/cache@v2
         env:
           cache-name: cache-maven-dependencies
@@ -56,6 +79,7 @@ jobs:
       # Since this is an unreleased build, we get the latest released version number, increment the minor number in it,
       # append a `-SNAPSHOT` at it's end to prepare the snapshot version number. This is used as the project's version.
       - name: Get the version to tag the Docker image
+        if: steps.run_result.outputs.run_result != 'success'
         id: vars
         run: |
           # Since this is an unreleased build, we set the version to incremented version number with a
@@ -69,6 +93,7 @@ jobs:
 
       # Build and test the code
       - name: Build and test
+        if: steps.run_result.outputs.run_result != 'success'
         env:
           APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
           APPSMITH_CLOUD_SERVICES_BASE_URL: "https://release-cs.appsmith.com"
@@ -82,6 +107,16 @@ jobs:
           -DnewVersion=${{ steps.vars.outputs.version }} \
           -DgenerateBackupPoms=false \
           -DprocessAllModules=true
+
+      # Restore the previous built bundle if present. If not push the newly built into the cache
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/server/dist/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
 
         # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle
@@ -110,8 +145,35 @@ jobs:
       - name: Figure out the PR number
         run: echo ${{ github.event.client_payload.pull_request.number }}
 
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "::set-output name=timestamp::$(timestamp +'%Y-%m-%dT%H:%M:%S')"
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-
+
+      # Fetch prior run result
+      - name: Get the previous run result
+        id: run_result
+        run: cat ~/run_result 2>/dev/null || echo 'default'
+
+      # Incase of prior failure run the job
+      - if: steps.run_result.outputs.run_result != 'success'
+        run: echo "I'm alive!" && exit 0
+
+      # Set status = success
+      - run: echo "::set-output name=run_result::success" > ~/run_result
+
       # This step creates a comment on the PR with a link to this workflow run.
       - name: Add a comment on the PR with link to workflow run
+        if: steps.run_result.outputs.run_result != 'success'
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.client_payload.pull_request.number }}
@@ -122,16 +184,19 @@ jobs:
             PR: ${{ github.event.client_payload.pull_request.number }}.
 
       - name: Use Node.js 14.15.4
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-node@v1
         with:
           node-version: "14.15.4"
 
       - name: Get yarn cache directory path
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       # Retrieve npm dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache npm dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache
         uses: actions/cache@v2
         env:
@@ -145,9 +210,11 @@ jobs:
 
       # Install all the dependencies
       - name: Install dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         run: yarn install
 
       - name: Set the build environment based on the branch
+        if: steps.run_result.outputs.run_result != 'success'
         id: vars
         run: |
           echo "::set-output name=REACT_APP_ENVIRONMENT::DEVELOPMENT"
@@ -166,11 +233,13 @@ jobs:
           echo ::set-output name=version::$next_version-SNAPSHOT
 
       - name: Run the jest tests
+        if: steps.run_result.outputs.run_result != 'success'
         run: REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} yarn run test:unit
 
       # We burn React environment & the Segment analytics key into the build itself.
       # This is to ensure that we don't need to configure it in each installation
       - name: Create the bundle
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           REACT_APP_ENVIRONMENT=${{steps.vars.outputs.REACT_APP_ENVIRONMENT}} \
             REACT_APP_FUSIONCHARTS_LICENSE_KEY=${{ secrets.APPSMITH_FUSIONCHARTS_LICENSE_KEY }} \
@@ -179,6 +248,16 @@ jobs:
             REACT_APP_VERSION_ID=${{ steps.vars.outputs.version }} \
             REACT_APP_VERSION_RELEASE_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ') \
             yarn build
+
+      # Restore the previous built bundle if present. If not push the newly built into the cache
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/client/build/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload react build bundle
@@ -246,6 +325,9 @@ jobs:
             return result;
             }
 
+      # Set status = success
+      - run: echo "::set-output name=run_result::success" > ~/run_result
+
   ui-test:
     needs: [build, server-build]
     # Only run if the build step is successful
@@ -258,7 +340,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+        job:
+          [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+          ]
     # Service containers to run with this job. Required for running tests
     services:
       # Label used to access the service container
@@ -280,17 +388,69 @@ jobs:
         with:
           ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
 
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "::set-output name=timestamp::$(timestamp +'%Y-%m-%dT%H:%M:%S')"
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        uses: martijnhols/actions-cache@v3
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+
+      # Fetch prior run result
+      - name: Get the previous run result
+        id: run_result
+        run: cat ~/run_result 2>/dev/null || echo 'default'
+
+      # In case this is second attempt try restoring failed tests
+      - name: Restore the previous failed combine result
+        if: steps.run_result.outputs.run_result == 'failedtest'
+        uses: martijnhols/actions-cache/restore@v3
+        with:
+          path: |
+            ~/combined_failed_spec
+          key: ${{ github.run_id }}-"ui-test-result"-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
+      # failed_spec_env will contain list of all failed specs
+      # We are using evnironment variable instead of regular to support multiline
+      - name: Get failed_spec
+        if: steps.run_result.outputs.run_result == 'failedtest'
+        run: |
+          failed_spec_env=$(cat ~/combined_failed_spec)
+          echo "failed_spec_env<<EOF" >> $GITHUB_ENV
+          echo "$failed_spec_env" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - if: steps.run_result.outputs.run_result != 'success' && steps.run_result.outputs.run_result != 'failedtest'
+        run: echo "Starting full run" && exit 0
+
+      - if: steps.run_result.outputs.run_result == 'failedtest'
+        run: echo "Rerunning failed tests" && exit 0
+
+      - name: cat run_result
+        run: echo ${{ steps.run_result.outputs.run_result }}
+
       - name: Use Node.js 14.15.4
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-node@v1
         with:
           node-version: "14.15.4"
 
       - name: Get yarn cache directory path
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       # Retrieve npm dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache npm dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache
         uses: actions/cache@v2
         env:
@@ -304,15 +464,18 @@ jobs:
 
       # Install all the dependencies
       - name: Install dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         run: yarn install
 
       - name: Download the react build artifact
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/download-artifact@v2
         with:
           name: build
           path: app/client/build
 
       - name: Download the server build artifact
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/download-artifact@v2
         with:
           name: build
@@ -320,6 +483,7 @@ jobs:
 
       # Start server
       - name: start server
+        if: steps.run_result.outputs.run_result != 'success'
         working-directory: app/server
         env:
           APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
@@ -339,10 +503,12 @@ jobs:
           ./scripts/start-dev-server.sh &> server-logs.log &
 
       - name: Wait for 30 seconds for server to start
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           sleep 30s
 
       - name: Exit if Server hasnt started
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           if [[ `ps -ef | grep "server-1.0-SNAPSHOT" | grep java |wc -l` == 0 ]]; then
              echo "Server Not Started";
@@ -352,11 +518,13 @@ jobs:
            fi
 
       - name: Installing Yarn serve
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           yarn global add serve
           echo "$(yarn global bin)" >> $GITHUB_PATH
 
       - name: Setting up the cypress tests
+        if: steps.run_result.outputs.run_result != 'success'
         shell: bash
         env:
           APPSMITH_SSL_CERTIFICATE: ${{ secrets.APPSMITH_SSL_CERTIFICATE }}
@@ -379,6 +547,7 @@ jobs:
           ./cypress/setup-test.sh
 
       - name: Run the cypress test
+        if: steps.run_result.outputs.run_result != 'success'  && steps.run_result.outputs.run_result != 'failedtest'
         uses: cypress-io/github-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -410,6 +579,97 @@ jobs:
           tag: ${{ github.event_name }}
           env: "NODE_ENV=development"
 
+      # Incase of second attemtp only run failed specs
+      - name: Run the cypress test with failed tests
+        if: steps.run_result.outputs.run_result == 'failedtest'
+        uses: cypress-io/github-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+          CYPRESS_USERNAME: ${{ secrets.CYPRESS_USERNAME }}
+          CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
+          CYPRESS_TESTUSERNAME1: ${{ secrets.CYPRESS_TESTUSERNAME1 }}
+          CYPRESS_TESTPASSWORD1: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
+          CYPRESS_TESTUSERNAME2: ${{ secrets.CYPRESS_TESTUSERNAME2 }}
+          CYPRESS_TESTPASSWORD2: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
+          CYPRESS_S3_ACCESS_KEY: ${{ secrets.CYPRESS_S3_ACCESS_KEY }}
+          CYPRESS_S3_SECRET_KEY: ${{ secrets.CYPRESS_S3_SECRET_KEY }}
+          APPSMITH_DISABLE_TELEMETRY: true
+          APPSMITH_GOOGLE_MAPS_API_KEY: ${{ secrets.APPSMITH_GOOGLE_MAPS_API_KEY }}
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+        with:
+          browser: chrome
+          headless: true
+          record: true
+          install: false
+          parallel: true
+          group: "Electrons on Github Action"
+          spec: ${{ env.failed_spec_env }}
+          working-directory: app/client
+          # tag will be either "push" or "pull_request"
+          tag: ${{ github.event_name }}
+          env: "NODE_ENV=development"
+
+      # Set status = failedtest
+      - name: Set fail if there are test failures
+        if: failure()
+        run: echo "::set-output name=run_result::failedtest" > ~/run_result
+
+      # Create a directory ~/failed_spec and add a dummy file
+      # This will ensure upload and download steps are successfull
+      - name: Create direcotrs for failed tests
+        if: always()
+        run: |
+          mkdir -p  ~/failed_spec
+          echo  "empty" >> ~/failed_spec/dummy-${{ matrix.job }}
+
+      # add list failed tests to a file
+      - name: Incase of test failures copy them to a file
+        if: failure()
+        run: |
+          cd /home/runner/work/appsmith/appsmith/app/client/cypress/
+          find screenshots -type d|grep spec |sed 's/screenshots/cypress\/integration/g' > ~/failed_spec/failed_spec-${{ matrix.job }}
+
+      # Upload failed test list using common path for all matrix job
+      - name: Upload failed test list artifact
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: failed-spec
+          path: ~/failed_spec
+
+      # Force store previous run result to cache
+      - name: Store the previous run result
+        if: failure()
+        uses: martijnhols/actions-cache/save@v3
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+
+      # Force store previous failed test list to cache
+      - name: Store the previous failed test result
+        if: failure()
+        uses: martijnhols/actions-cache/save@v3
+        with:
+          path: |
+            ~/failed_spec
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/client/cypress/snapshots/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+
       # Upload the screenshots as artifacts if there's a failure
       - uses: actions/upload-artifact@v1
         if: failure()
@@ -438,6 +698,39 @@ jobs:
         env:
           PAYLOAD_CONTEXT: ${{ toJson(github.event.client_payload) }}
         run: echo "$PAYLOAD_CONTEXT"
+
+      # Download failed_spec list for all jobs
+      - uses: actions/download-artifact@v2
+        if: needs.ui-test.result
+        id: download
+        with:
+          name: failed-spec
+          path: ~/failed_spec
+
+      # Incase for any uti-test job failure, create combined failed spec
+      - name: "combine all specs"
+        if: needs.ui-test.result != 'success'
+        run: cat ~/failed_spec/failed_spec* >> ~/combined_failed_spec
+
+      # Force save the failed spec list into a cache
+      - name: Store the combined run result
+        if: needs.ui-test.result
+        uses: martijnhols/actions-cache/save@v3
+        with:
+          path: |
+            ~/combined_failed_spec
+          key: ${{ github.run_id }}-"ui-test-result"-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
+      # Upload combined failed spec list to a file
+      # This is done for debugging.
+      - name: upload combined failed spec
+        if: needs.ui-test.result
+        uses: actions/upload-artifact@v2
+        with:
+          name: combined_failed_spec
+          path: ~/combined_failed_spec
 
       # Update check run called "ui-test-result"
       - name: Mark ui-test-result job as complete
@@ -728,7 +1021,6 @@ jobs:
           name: performance-summaries
           path: app/client/perf/traces
 
-  
       - name: Read summary file
         id: read_summary
         uses: andstor/file-reader-action@v1
@@ -743,5 +1035,3 @@ jobs:
             UI Performance test run logs and artifacts: <https://github.com/appsmithorg/appsmith/actions/runs/${{ github.run_id }}>.
             Commit: `${{ github.event.client_payload.slash_command.sha }}`.
             Results: ${{ steps.read_summary.outputs.contents }}
-        
-

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -52,17 +52,49 @@ jobs:
       - name: Figure out the PR number
         run: echo ${{ github.event.pull_request.number }}
 
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "::set-output name=timestamp::$(timestamp +'%Y-%m-%dT%H:%M:%S')"
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-
+
+      # Fetch prior run result
+      - name: Get the previous run result
+        id: run_result
+        run: cat ~/run_result 2>/dev/null || echo 'default'
+
+      #- uses: actions/checkout@v2
+      #  if: steps.run_result.outputs.run_result != 'success'
+
+      # Incase of prior failure run the job
+      - if: steps.run_result.outputs.run_result != 'success'
+        run: echo "I'm alive!" && exit 0
+
+      # Set status = success
+      - run: echo "::set-output name=run_result::success" > ~/run_result
+
       - name: Use Node.js 14.15.4
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-node@v1
         with:
           node-version: "14.15.4"
 
       - name: Get yarn cache directory path
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       # Retrieve npm dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache npm dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache
         uses: actions/cache@v2
         env:
@@ -76,9 +108,11 @@ jobs:
 
       # Install all the dependencies
       - name: Install dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         run: yarn install
 
       - name: Set the build environment based on the branch
+        if: steps.run_result.outputs.run_result != 'success'
         id: vars
         run: |
           echo "::set-output name=REACT_APP_ENVIRONMENT::DEVELOPMENT"
@@ -99,6 +133,7 @@ jobs:
       # We burn React environment & the Segment analytics key into the build itself.
       # This is to ensure that we don't need to configure it in each installation
       - name: Create the bundle
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           if [[ $GITHUB_REF == "refs/heads/release" ]]; then
             REACT_APP_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}
@@ -116,12 +151,25 @@ jobs:
             yarn build
           ls -l build
 
+      # Restore the previous built bundle if present. If not push the newly built into the cache
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/client/build/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload react build bundle
         uses: actions/upload-artifact@v2
         with:
           name: client-build
           path: app/client/build/
+
+      # Set status = success
+      - run: echo "::set-output name=run_result::success" > ~/run_result
 
   buildServer:
     defaults:
@@ -156,14 +204,39 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "::set-output name=timestamp::$(timestamp +'%Y-%m-%dT%H:%M:%S')"
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-
+
+      # Fetch prior run result
+      - name: Get the previous run result
+        id: run_result
+        run: cat ~/run_result 2>/dev/null || echo 'default'
+
+      # Incase of prior failure run the job
+      - if: steps.run_result.outputs.run_result != 'success'
+        run: echo "I'm alive!" && exit 0
+
       # Setup Java
       - name: Set up JDK 1.11
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-java@v1
         with:
           java-version: "11.0.10"
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/cache@v2
         env:
           cache-name: cache-maven-dependencies
@@ -178,6 +251,7 @@ jobs:
       # Since this is an unreleased build, we get the latest released version number, increment the minor number in it,
       # append a `-SNAPSHOT` at it's end to prepare the snapshot version number. This is used as the project's version.
       - name: Get the version to tag the Docker image
+        if: steps.run_result.outputs.run_result != 'success'
         id: vars
         run: |
           # Since this is an unreleased build, we set the version to incremented version number with a
@@ -190,6 +264,7 @@ jobs:
           echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
 
       - name: Test and Build package
+        if: steps.run_result.outputs.run_result != 'success'
         env:
           APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
           APPSMITH_REDIS_URL: "redis://127.0.0.1:6379"
@@ -206,12 +281,24 @@ jobs:
           ./build.sh -DskipTests
           ls -l dist
 
+      # Restore the previous built bundle if present. If not push the newly built into the cache
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/server/dist/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle
         uses: actions/upload-artifact@v2
         with:
           name: server-build
           path: app/server/dist/
+
+      - run: echo "::set-output name=run_result::success" > ~/run_result
 
   buildRts:
     defaults:
@@ -232,7 +319,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "::set-output name=timestamp::$(timestamp +'%Y-%m-%dT%H:%M:%S')"
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-
+
+      # Fetch prior run result
+      - name: Get the previous run result
+        id: run_result
+        run: cat ~/run_result 2>/dev/null || echo 'default'
+
+      # Incase of prior failure run the job
+      - if: steps.run_result.outputs.run_result != 'success'
+        run: echo "I'm alive!" && exit 0
+
       - name: Use Node.js 14.15.4
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-node@v1
         with:
           node-version: "14.15.4"
@@ -242,6 +353,7 @@ jobs:
       # Since this is an unreleased build, we get the latest released version number, increment the minor number in it,
       # append a `-SNAPSHOT` at it's end to prepare the snapshot version number. This is used as the project's version.
       - name: Get the version to tag the Docker image
+        if: steps.run_result.outputs.run_result != 'success'
         id: vars
         run: |
           # Since this is an unreleased build, we set the version to incremented version number with a
@@ -254,10 +366,31 @@ jobs:
           echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
 
       - name: Build
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           echo 'export const VERSION = "${{ steps.vars.outputs.version }}"' > src/version.js
           ./build.sh
           ls -l dist
+
+      # Restore the previous built bundle if present. If not push the newly built into the cache
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/rts/dist/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
+      # Restore the previous built bundle if present. If not push the newly built into the cache
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/rts/node_modules/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle
@@ -292,7 +425,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+        job:
+          [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+          ]
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -320,13 +479,64 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v2
 
+      # Timestamp will be used to create cache key
+      - id: timestamp
+        run: echo "::set-output name=timestamp::$(timestamp +'%Y-%m-%dT%H:%M:%S')"
+
+      # In case this is second attempt try restoring status of the prior attempt from cache
+      - name: Restore the previous run result
+        uses: martijnhols/actions-cache@v3
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+
+      # Fetch prior run result
+      - name: Get the previous run result
+        id: run_result
+        run: cat ~/run_result 2>/dev/null || echo 'default'
+
+      # In case this is second attempt try restoring failed tests
+      - name: Restore the previous failed combine result
+        if: steps.run_result.outputs.run_result == 'failedtest'
+        uses: martijnhols/actions-cache/restore@v3
+        with:
+          path: |
+            ~/combined_failed_spec
+          key: ${{ github.run_id }}-"ui-test-result"-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
+      # failed_spec_env will contain list of all failed specs
+      # We are using evnironment variable instead of regular to support multiline
+      - name: Get failed_spec
+        if: steps.run_result.outputs.run_result == 'failedtest'
+        run: |
+          failed_spec_env=$(cat ~/combined_failed_spec)
+          echo "failed_spec_env<<EOF" >> $GITHUB_ENV
+          echo "$failed_spec_env" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - if: steps.run_result.outputs.run_result != 'success' && steps.run_result.outputs.run_result != 'failedtest'
+        run: echo "Starting full run" && exit 0
+
+      - if: steps.run_result.outputs.run_result == 'failedtest'
+        run: echo "Rerunning failed tests" && exit 0
+
+      - name: cat run_result
+        run: echo ${{ steps.run_result.outputs.run_result }}
+
       # Setup Java
       - name: Set up JDK 1.11
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-java@v1
         with:
           java-version: "11.0.10"
 
       - name: Download the server build artifact
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/download-artifact@v2
         with:
           name: server-build
@@ -334,6 +544,7 @@ jobs:
 
       # Retrieve maven dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache maven dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/cache@v2
         env:
           cache-name: cache-maven-dependencies
@@ -348,6 +559,7 @@ jobs:
       # Since this is an unreleased build, we get the latest released version number, increment the minor number in it,
       # append a `-SNAPSHOT` at it's end to prepare the snapshot version number. This is used as the project's version.
       - name: Get the version to tag the Docker image
+        if: steps.run_result.outputs.run_result != 'success'
         id: vars
         run: |
           # Since this is an unreleased build, we set the version to incremented version number with a
@@ -361,6 +573,7 @@ jobs:
 
       # Start server
       - name: Start server
+        if: steps.run_result.outputs.run_result != 'success'
         working-directory: app/server
         env:
           APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
@@ -380,6 +593,7 @@ jobs:
           ./scripts/start-dev-server.sh &> server-logs.log &
 
       - name: Wait for 30s and check if server is running
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           sleep 30s
           if lsof -i :8080; then
@@ -391,16 +605,19 @@ jobs:
           fi
 
       - name: Use Node.js 14.15.4
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/setup-node@v1
         with:
           node-version: "14.15.4"
 
       - name: Get yarn cache directory path
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       # Retrieve npm dependencies from cache. After a successful run, these dependencies are cached again
       - name: Cache npm dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         id: yarn-dep-cache
         uses: actions/cache@v2
         env:
@@ -414,20 +631,24 @@ jobs:
 
       # Install all the dependencies
       - name: Install dependencies
+        if: steps.run_result.outputs.run_result != 'success'
         run: yarn install
 
       - name: Download the react build artifact
+        if: steps.run_result.outputs.run_result != 'success'
         uses: actions/download-artifact@v2
         with:
           name: client-build
           path: app/client/build
 
       - name: Installing Yarn serve
+        if: steps.run_result.outputs.run_result != 'success'
         run: |
           yarn global add serve
           echo "$(yarn global bin)" >> $GITHUB_PATH
 
       - name: Setting up the cypress tests
+        if: steps.run_result.outputs.run_result != 'success'
         shell: bash
         env:
           APPSMITH_SSL_CERTIFICATE: ${{ secrets.APPSMITH_SSL_CERTIFICATE }}
@@ -448,6 +669,7 @@ jobs:
           ./cypress/setup-test.sh
 
       - name: Run the cypress test
+        if: steps.run_result.outputs.run_result != 'success' && steps.run_result.outputs.run_result != 'failedtest'
         uses: cypress-io/github-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -477,12 +699,103 @@ jobs:
           tag: ${{ github.event_name }}
           env: "NODE_ENV=development"
 
+      # Incase of second attemtp only run failed specs
+      - name: Run the cypress test with failed tests
+        if: steps.run_result.outputs.run_result == 'failedtest'
+        uses: cypress-io/github-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+          CYPRESS_USERNAME: ${{ secrets.CYPRESS_USERNAME }}
+          CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
+          CYPRESS_TESTUSERNAME1: ${{ secrets.CYPRESS_TESTUSERNAME1 }}
+          CYPRESS_TESTPASSWORD1: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
+          CYPRESS_TESTUSERNAME2: ${{ secrets.CYPRESS_TESTUSERNAME2 }}
+          CYPRESS_TESTPASSWORD2: ${{ secrets.CYPRESS_TESTPASSWORD1 }}
+          CYPRESS_S3_ACCESS_KEY: ${{ secrets.CYPRESS_S3_ACCESS_KEY }}
+          CYPRESS_S3_SECRET_KEY: ${{ secrets.CYPRESS_S3_SECRET_KEY }}
+          APPSMITH_DISABLE_TELEMETRY: true
+          APPSMITH_GOOGLE_MAPS_API_KEY: ${{ secrets.APPSMITH_GOOGLE_MAPS_API_KEY }}
+          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+        with:
+          browser: chrome
+          headless: true
+          record: true
+          install: false
+          parallel: true
+          group: "Electrons on Github Action"
+          spec: ${{ env.failed_spec_env }}
+          working-directory: app/client
+          # tag will be either "push" or "pull_request"
+          tag: ${{ github.event_name }}
+          env: "NODE_ENV=development"
+
+      # Set status = failedtest
+      - name: Set fail if there are test failures
+        if: failure()
+        run: echo "::set-output name=run_result::failedtest" > ~/run_result
+
+      # Create a directory ~/failed_spec and add a dummy file
+      # This will ensure upload and download steps are successfull
+      - name: Create direcotrs for failed tests
+        if: always()
+        run: |
+          mkdir -p  ~/failed_spec
+          echo  "empty" >> ~/failed_spec/dummy-${{ matrix.job }}
+
+      # add list failed tests to a file
+      - name: Incase of test failures copy them to a file
+        if: failure()
+        run: |
+          cd /home/runner/work/appsmith/appsmith/app/client/cypress/
+          find screenshots -type d|grep spec |sed 's/screenshots/cypress\/integration/g' > ~/failed_spec/failed_spec-${{ matrix.job }}
+
+      # Upload failed test list using common path for all matrix job
+      - name: Upload failed test list artifact
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: failed-spec
+          path: ~/failed_spec
+
+      # Force store previous run result to cache
+      - name: Store the previous run result
+        if: failure()
+        uses: martijnhols/actions-cache/save@v3
+        with:
+          path: |
+            ~/run_result
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+
+      # Force store previous failed test list to cache
+      - name: Store the previous failed test result
+        if: failure()
+        uses: martijnhols/actions-cache/save@v3
+        with:
+          path: |
+            ~/failed_spec
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
+
       # Upload the screenshots as artifacts if there's a failure
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: cypress-screenshots-${{ matrix.job }}
           path: app/client/cypress/screenshots/
+
+      - name: Restore the previous bundle
+        uses: actions/cache@v2
+        with:
+          path: |
+            app/client/cypress/snapshots/
+          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}-${{ matrix.job }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}-${{ matrix.job }}
 
       # Upload the snapshots as artifacts for layout validation
       - uses: actions/upload-artifact@v1
@@ -498,6 +811,9 @@ jobs:
           name: server-logs-${{ matrix.job }}
           path: app/server/server-logs.log
 
+      # Set status = success
+      - run: echo "::set-output name=run_result::success" > ~/run_result
+
   ui-test-result:
     needs: ui-test
     if: always() &&
@@ -512,6 +828,39 @@ jobs:
         shell: bash
     steps:
       - run: echo "All ui-test matrices completed"
+
+      # Download failed_spec list for all jobs
+      - uses: actions/download-artifact@v2
+        if: needs.ui-test.result
+        id: download
+        with:
+          name: failed-spec
+          path: ~/failed_spec
+
+      # Incase for any uti-test job failure, create combined failed spec
+      - name: "combine all specs"
+        if: needs.ui-test.result != 'success'
+        run: cat ~/failed_spec/failed_spec* >> ~/combined_failed_spec
+
+      # Force save the failed spec list into a cache
+      - name: Store the combined run result
+        if: needs.ui-test.result
+        uses: martijnhols/actions-cache/save@v3
+        with:
+          path: |
+            ~/combined_failed_spec
+          key: ${{ github.run_id }}-"ui-test-result"-${{ steps.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+
+      # Upload combined failed spec list to a file
+      # This is done for debugging.
+      - name: upload combined failed spec
+        if: needs.ui-test.result
+        uses: actions/upload-artifact@v2
+        with:
+          name: combined_failed_spec
+          path: ~/combined_failed_spec
 
       - name: Return status for ui-matrix
         run: |

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -425,33 +425,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job:
-          [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23,
-          ]
+        job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
 
     # Service containers to run with this job. Required for running tests
     services:


### PR DESCRIPTION
Support reuse of github actions

## Description

Using github cache we avoid rerunning successful jobs 
Fixes # 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested push workflow in my own fork.
ok-to-test flow is not tested.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
