### PR TITLE
fix: limit validation errors in debugger

### DIFF
--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -1001,3 +1001,12 @@ export const CONTEXT_MOVE = () => "Move to page";
 export const CONTEXT_COPY = () => "Copy to page";
 export const CONTEXT_DELETE = () => "Delete";
 export const CONTEXT_NO_PAGE = () => "No pages";
+
+// Validations
+export const VALIDATION_ARRAY_UNIQUE = () =>
+  "Array must be unique. Duplicate values found";
+export const VALIDATION_ARRAY_DUPLICATE_PROPERTY_VALUES = () =>
+  "Duplicate values found for the following properties, in the array entries, that must be unique --";
+export const VALIDATION_ARRAY_DISALLOWED_VALUE = () =>
+  "Value is not allowed in this array";
+export const VALIDATION_ARRAY_INVALID_ENTRY = () => "Invalid entry at index:";

--- a/app/client/src/workers/helpers.test.ts
+++ b/app/client/src/workers/helpers.test.ts
@@ -1,0 +1,49 @@
+import { findDuplicateIndex } from "./helpers";
+
+describe("Worker Helper functions test", () => {
+  it("Correctly finds the duplicate index in an array of strings", () => {
+    const input = ["a", "b", "c", "d", "e", "a", "b"];
+    const expected = 5;
+    const result = findDuplicateIndex(input);
+    expect(result).toStrictEqual(expected);
+  });
+  it("Correctly finds the duplicate index in an array of objects and strings", () => {
+    const input = [
+      "a",
+      "b",
+      { a: 1, b: 2 },
+      { a: 2, b: 3 },
+      "e",
+      { a: 1, b: 2 },
+      "b",
+    ];
+    const expected = 5;
+    const result = findDuplicateIndex(input);
+    expect(result).toStrictEqual(expected);
+  });
+
+  /* TODO(abhinav): These kinds of issues creep up when dealing with JSON.stringify to make
+                    things simple. So, the ideal solution here is to prevent the
+                    usage of this function for array of objects
+                    */
+  it("Correctly ignores the duplicate index in an array of objects and strings, when properties are not ordered", () => {
+    const input = [
+      "a",
+      "b",
+      { a: 1, b: 2 },
+      { a: 2, b: 3 },
+      "e",
+      { b: 2, a: 1 },
+      "b",
+    ];
+    const expected = 6;
+    const result = findDuplicateIndex(input);
+    expect(result).toStrictEqual(expected);
+  });
+  it("Correctly returns -1 if no duplicates are found", () => {
+    const input = ["a", "b", "c", "d", "e", "f", "g"];
+    const expected = -1;
+    const result = findDuplicateIndex(input);
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/app/client/src/workers/helpers.ts
+++ b/app/client/src/workers/helpers.ts
@@ -1,0 +1,17 @@
+// Finds the first index which is a duplicate value
+// Returns -1 if there are no duplicates
+// Returns the index of the first duplicate entry it finds
+
+// Note: This "can" fail if the object entries don't have their properties in the
+// same order.
+export const findDuplicateIndex = (arr: Array<unknown>) => {
+  const _uniqSet = new Set();
+  let currSetSize = 0;
+  for (let i = 0; i < arr.length; i++) {
+    // JSON.stringify because value can be objects
+    _uniqSet.add(JSON.stringify(arr[i]));
+    if (_uniqSet.size > currSetSize) currSetSize = _uniqSet.size;
+    else return i;
+  }
+  return -1;
+};

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -1273,6 +1273,53 @@ describe("Validate Validators", () => {
     });
   });
 
+  it("correctly validates uniqueness of keys in array objects", () => {
+    const config = {
+      type: ValidationTypes.ARRAY,
+      params: {
+        children: {
+          type: ValidationTypes.OBJECT,
+          params: {
+            allowedKeys: [
+              {
+                name: "label",
+                type: ValidationTypes.TEXT,
+                params: {
+                  default: "",
+                  required: true,
+                  unique: true,
+                },
+              },
+              {
+                name: "value",
+                type: ValidationTypes.TEXT,
+                params: {
+                  default: "",
+                  unique: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const input = [
+      { label: "Blue", value: "" },
+      { label: "Green", value: "" },
+      { label: "Red", value: "red" },
+    ];
+    const expected = {
+      isValid: false,
+      parsed: [],
+      messages: [
+        "Duplicate values found for the following properties, in the array entries, that must be unique -- label,value.",
+      ],
+    };
+
+    const result = validate(config, input, DUMMY_WIDGET);
+    expect(result).toStrictEqual(expected);
+  });
+
   it("correctly validates TableProperty", () => {
     const inputs = [
       "a",

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -575,12 +575,15 @@ describe("Validate Validators", () => {
       {
         isValid: false,
         parsed: [],
-        messages: ["Disallowed value: q"],
+        messages: ["Value is not allowed in this array: q"],
       },
       {
         isValid: false,
         parsed: [],
-        messages: ["Disallowed value: q"],
+        messages: [
+          "Value is not allowed in this array: q",
+          "Value is not allowed in this array: s",
+        ],
       },
       {
         isValid: true,
@@ -631,12 +634,15 @@ describe("Validate Validators", () => {
       {
         isValid: false,
         parsed: ["a"],
-        messages: ["Disallowed value: q"],
+        messages: ["Value is not allowed in this array: q"],
       },
       {
         isValid: false,
         parsed: ["a"],
-        messages: ["Disallowed value: q"],
+        messages: [
+          "Value is not allowed in this array: q",
+          "Value is not allowed in this array: s",
+        ],
       },
       {
         isValid: true,
@@ -655,6 +661,58 @@ describe("Validate Validators", () => {
       const result = validate(config, input, DUMMY_WIDGET);
       expect(result).toStrictEqual(expected[index]);
     });
+  });
+
+  it("correctly limits the number of validation errors in array validation", () => {
+    const input = [
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "k",
+      "l",
+      "m",
+      "n",
+      "o",
+      "p",
+    ];
+    const config = {
+      type: ValidationTypes.ARRAY,
+      params: {
+        children: {
+          type: ValidationTypes.NUMBER,
+          params: {
+            required: true,
+            allowedValues: [1, 2, 3, 4],
+          },
+        },
+      },
+    };
+    const expected = {
+      isValid: false,
+      parsed: [],
+      messages: [
+        "Invalid entry at index: 0. This value does not evaluate to type number Required",
+        "Invalid entry at index: 1. This value does not evaluate to type number Required",
+        "Invalid entry at index: 2. This value does not evaluate to type number Required",
+        "Invalid entry at index: 3. This value does not evaluate to type number Required",
+        "Invalid entry at index: 4. This value does not evaluate to type number Required",
+        "Invalid entry at index: 5. This value does not evaluate to type number Required",
+        "Invalid entry at index: 6. This value does not evaluate to type number Required",
+        "Invalid entry at index: 7. This value does not evaluate to type number Required",
+        "Invalid entry at index: 8. This value does not evaluate to type number Required",
+        "Invalid entry at index: 9. This value does not evaluate to type number Required",
+      ],
+    };
+
+    const result = validate(config, input, DUMMY_WIDGET);
+    expect(result).toStrictEqual(expected);
   });
 
   it("correctly validates array when required is true", () => {

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -809,7 +809,7 @@ describe("Validate Validators", () => {
       {
         isValid: false,
         parsed: [],
-        messages: ["Array must be unique. Duplicate values found"],
+        messages: ["Array must be unique. Duplicate values found at index: 2"],
       },
       {
         isValid: false,

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -184,12 +184,12 @@ function validateArray(
   if (shouldArrayValuesHaveUniqueValuesForKeys) {
     // Loop
     // Get only unique entries from the value array
-    const uniqueEntries = _.uniqBy(
+    const uniqueEntries = _.uniqWith(
       value as Array<Record<string, unknown>>,
-      (entry: Record<string, unknown>) =>
-        // create a simple string using the values of the entry which must be checked for uniqueness
-        // This will be used to verify if two values are different in the _.uniqBy function
-        uniqueKeys.reduce((prev, next) => `${prev}${entry[next]}`, ""),
+      (a: Record<string, unknown>, b: Record<string, unknown>) => {
+        // If any of the keys are the same, we fail the uniqueness test
+        return uniqueKeys.some((key) => a[key] === b[key]);
+      },
     );
 
     if (uniqueEntries.length !== value.length) {

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -31,6 +31,7 @@ import {
   VALIDATION_ARRAY_INVALID_ENTRY,
   VALIDATION_ARRAY_UNIQUE,
 } from "constants/messages";
+import { findDuplicateIndex } from "./helpers";
 export const UNDEFINED_VALIDATION = "UNDEFINED_VALIDATION";
 export const VALIDATION_ERROR_COUNT_THRESHOLD = 10;
 
@@ -167,17 +168,15 @@ function validateArray(
 
   // Verify if all values are unique
   if (shouldArrayHaveUniqueEntries) {
-    // Converting to a Set will remove all duplicate values
-    // Optimization credits to: @aswathkk and @SatishGandham on Github
-    const _value = new Set(value);
-    // Loop
-    if (_value.size !== value.length) {
+    // Find the index of a duplicate value in array
+    const duplicateIndex = findDuplicateIndex(value);
+    if (duplicateIndex !== -1) {
       // Bail out early
       // Because, we don't want to re-iterate, if this validation fails
       return {
         isValid: false,
         parsed: config.params?.default || [],
-        messages: [VALIDATION_ARRAY_UNIQUE()],
+        messages: [`${VALIDATION_ARRAY_UNIQUE()} at index: ${duplicateIndex}`],
       };
     }
   }

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -6,6 +6,7 @@ import {
   Validator,
 } from "../constants/WidgetValidation";
 import _, {
+  compact,
   get,
   isArray,
   isObject,
@@ -25,6 +26,7 @@ import getIsSafeURL from "utils/validation/getIsSafeURL";
 import * as log from "loglevel";
 import { QueryActionConfig } from "entities/Action";
 export const UNDEFINED_VALIDATION = "UNDEFINED_VALIDATION";
+export const VALIDATION_ERROR_COUNT_THRESHOLD = 10;
 
 const flat = (array: Record<string, any>[], uniqueParam: string) => {
   let result: { value: string }[] = [];
@@ -106,105 +108,133 @@ function validateArray(
   value: unknown[],
   props: Record<string, unknown>,
 ) {
-  let _isValid = true;
-  const _messages: string[] = [];
-  const whiteList = config.params?.allowedValues;
-  if (whiteList) {
-    for (const entry of value) {
-      if (!whiteList.includes(entry)) {
-        return {
-          isValid: false,
-          parsed: config.params?.default || [],
-          messages: [`Disallowed value: ${entry}`],
-        };
-      }
-    }
-  }
-  // Check uniqueness of object elements in an array
+  let _isValid = true; // Let's first assume that this is valid
+  const _messages: string[] = []; // Initialise messages array
+
+  // Values allowed in the array
+  const allowedValues = config.params?.allowedValues;
+
+  // Keys whose values are supposed to be unique across all values in all objects in the array
+  let uniqueKeys: Array<string> = [];
+  const allowedKeyConfigs = config.params?.children?.params?.allowedKeys;
   if (
     config.params?.children?.type === ValidationTypes.OBJECT &&
-    (config.params.children.params?.allowedKeys || []).length > 0
+    Array.isArray(allowedKeyConfigs) &&
+    allowedKeyConfigs.length
   ) {
-    const allowedKeysCofigArray =
-      config.params.children.params?.allowedKeys || [];
+    uniqueKeys = compact(
+      allowedKeyConfigs.map((allowedKeyConfig) => {
+        // TODO(abhinav): This is concerning, we now have two ways,
+        // in which we can define unique keys in an array of objects
+        // We need to disable one option.
 
-    const allowedKeys = (config.params.children.params?.allowedKeys || []).map(
-      (key) => key.name,
+        // If this key is supposed to be unique across all objects in the value array
+        // We include it in the uniqueKeys list
+        if (allowedKeyConfig.params?.unique) return allowedKeyConfig.name;
+      }),
     );
-    type ObjectKeys = typeof allowedKeys[number];
-    type ItemType = {
-      [key in ObjectKeys]: string;
-    };
-
-    const valueWithType = value as ItemType[];
-    allowedKeysCofigArray.forEach((allowedKeyConfig) => {
-      if (allowedKeyConfig.params?.unique) {
-        const allowedKeyValues = valueWithType.map(
-          (item) => item[allowedKeyConfig.name],
-        );
-        const normalizedValues = valueWithType.map((item) =>
-          item[allowedKeyConfig.name].toLowerCase(),
-        );
-        // Check if value is duplicated
-        _messages.push(
-          ...allowedKeyValues.reduce(
-            (acc: string[], currentValue, currentIndex) => {
-              if (
-                normalizedValues.indexOf(currentValue.toLowerCase()) !==
-                currentIndex
-              ) {
-                acc.push(
-                  `Duplicated entry at index: ${currentIndex + 1}, key: ${
-                    allowedKeyConfig.name
-                  }, value: ${currentValue}`,
-                );
-              }
-              return acc;
-            },
-            [],
-          ),
-        );
-        if (_messages.length > 0) {
-          _isValid = false;
-        }
-      }
-    });
   }
 
-  const children = config.params?.children;
+  // Concatenate unique keys from config.params?.unique
+  uniqueKeys = Array.isArray(config.params?.unique)
+    ? uniqueKeys.concat(config.params?.unique as Array<string>)
+    : uniqueKeys;
 
-  if (children) {
-    value.forEach((entry, index) => {
-      const validation = validate(children, entry, props);
-      if (!validation.isValid) {
+  // Validation configuration for children
+  const childrenValidationConfig = config.params?.children;
+
+  // Should we validate against disallowed values in the value array?
+  const shouldVerifyAllowedValues =
+    Array.isArray(allowedValues) && allowedValues.length;
+
+  // Do we have validation config for array children?
+  const shouldValidateChildren = !!childrenValidationConfig;
+
+  // Should array values be unique? This should applies only to primitive values in array children
+  // If we have to validate children with their own validation config, this should be false (Needs verification)
+  // If this option is true, shouldArrayValuesHaveUniqueValuesForKeys will become false
+  const shouldArrayHaveUniqueEntries =
+    config.params?.unique === true && !shouldValidateChildren;
+
+  // Should we validate for unique values for properties in the array entries?
+  const shouldArrayValuesHaveUniqueValuesForKeys =
+    !!uniqueKeys.length && !shouldArrayHaveUniqueEntries;
+
+  // Verify if all values are unique
+  if (shouldArrayHaveUniqueEntries) {
+    // Loop
+    if (
+      uniq(value.map((entry) => JSON.stringify(entry))).length !== value.length
+    ) {
+      // Bail out early
+      // Because, we don't want to re-iterate, if this validation fails
+      return {
+        isValid: false,
+        parsed: config.params?.default || [],
+        messages: [`Array must be unique. Duplicate values found`],
+      };
+    }
+  }
+
+  if (shouldArrayValuesHaveUniqueValuesForKeys) {
+    // Loop
+    // Get only unique entries from the value array
+    const uniqueEntries = _.uniqBy(
+      value as Array<Record<string, unknown>>,
+      (entry: Record<string, unknown>) =>
+        // create a simple string using the values of the entry which must be checked for uniqueness
+        // This will be used to verify if two values are different in the _.uniqBy function
+        uniqueKeys.reduce((prev, next) => `${prev}${entry[next]}`, ""),
+    );
+
+    if (uniqueEntries.length !== value.length) {
+      // Bail out early
+      // Because, we don't want to re-iterate, if this validation fails
+      return {
+        isValid: false,
+        parsed: config.params?.default || [],
+        messages: [
+          `Duplicate values found for the following properties, in the array entries, that must be unique -- ${uniqueKeys.join(
+            ",",
+          )}.`,
+        ],
+      };
+    }
+  }
+
+  // Loop
+  value.every((entry, index) => {
+    // Validate for allowed values
+    if (shouldVerifyAllowedValues && !(allowedValues || []).includes(entry)) {
+      _messages.push(`Disallowed value: ${entry}`);
+      _isValid = false;
+    }
+
+    // validate using validation config
+    if (shouldValidateChildren && childrenValidationConfig) {
+      // Validate this entry
+      const childValidationResult = validate(
+        childrenValidationConfig,
+        entry,
+        props,
+      );
+
+      // If invalid, append to messages
+      if (!childValidationResult.isValid) {
         _isValid = false;
-        validation.messages?.map((message) =>
+        childValidationResult.messages?.map((message) =>
           _messages.push(`Invalid entry at index: ${index}. ${message}`),
         );
       }
-    });
-  }
-  if (config.params?.unique) {
-    if (isArray(config.params?.unique)) {
-      for (const param of config.params?.unique) {
-        const shouldBeUnique = value.map((entry) =>
-          get(entry, param as string, ""),
-        );
-        if (uniq(shouldBeUnique).length !== value.length) {
-          _isValid = false;
-          _messages.push(
-            `path:${param} must be unique. Duplicate values found`,
-          );
-          break;
-        }
-      }
-    } else if (
-      uniq(value.map((entry) => JSON.stringify(entry))).length !== value.length
-    ) {
-      _isValid = false;
-      _messages.push(`Array must be unique. Duplicate values found`);
     }
-  }
+
+    // Bail out, if the error count threshold has been overcome
+    // This way, debugger will not have to render too many errors
+    if (_messages.length > VALIDATION_ERROR_COUNT_THRESHOLD && !_isValid) {
+      return false;
+    }
+    return true;
+  });
 
   return {
     isValid: _isValid,
@@ -218,11 +248,13 @@ export const validate = (
   value: unknown,
   props: Record<string, unknown>,
 ): ValidationResponse => {
+  const start = performance.now();
   const _result = VALIDATORS[config.type as ValidationTypes](
     config,
     value,
     props,
   );
+
   return _result;
 };
 


### PR DESCRIPTION
## Description

When we have large, improperly formatted, data being validated; large number of error messages are rendered in the debugger.
For example, if we're trying to bind an array with 20000 entries (objects) in a chart widget, and these entries do not have `x` and `y` properties, validations return 20000 error messages (one for each entry). When the debugger tries to render these many messages, the application freezes for a few seconds. 

The solution here, is to bail out of validations early **_IF_** we have already encountered a fixed number (in this case 10) of validation errors and show these messages in the debugger.

Does it negatively effect DX?
Fixing the issues shown so far will trigger another validation. As a result,
- If there are more validation errors, they will be displayed. 
- If there aren't any more validation errors, the fix added earlier has fixed all validation errors.

Also, this only effects individual property validations. Each property with errors in validation, will have their errors displayed nevertheless.

There will not be any lack of relevant information displayed to an Appsmith developer. 
Hence, there shouldn't be any negative effects to the DX.

Fixes #10938

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests added and some updated

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/limit-validation-errors 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.03 **(0.04)** | 36.36 **(0.04)** | 34.72 **(0.04)** | 55.41 **(0.04)**
 :green_circle: | app/client/src/constants/messages.ts | 75 **(0.17)** | 100 **(0)** | 25.9 **(0.49)** | 80.47 **(0.16)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 68.63 **(-3.92)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :sparkles: :new: | **app/client/src/workers/helpers.ts** | **100** | **100** | **100** | **100**
 :green_circle: | app/client/src/workers/validations.ts | 82.01 **(5.22)** | 71.23 **(1.74)** | 76.67 **(9.02)** | 83.44 **(4.85)**</details>