### PR TITLE
fix: handle empty column name in UQI sort component

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -310,12 +310,19 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
      * @throws AppsmithPluginException
      */
     private void addSortCondition(StringBuilder sb, List<Map<String, String>> sortBy) throws AppsmithPluginException {
-        if (CollectionUtils.isEmpty(sortBy)) {
+
+        /**
+         * Checks if:
+         *  o `sortBy` condition list is null or empty
+         *  o all column names in the sortBy list are empty
+         */
+        if (isSortConditionEmpty(sortBy)) {
             return;
         }
 
         sb.append(" ORDER BY");
         sortBy.stream()
+                .filter(sortCondition -> !isBlank(sortCondition.get(SORT_BY_COLUMN_NAME_KEY)))
                 .forEachOrdered(sortCondition -> {
                     String columnName = sortCondition.get(SORT_BY_COLUMN_NAME_KEY);
                     SortType sortType;
@@ -330,6 +337,20 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 });
 
         sb.setLength(sb.length() - 1);
+    }
+
+    /**
+     * Checks if:
+     *  o `sortBy` condition list is null or empty
+     *  o all column names in the sortBy list are empty
+     */
+    private boolean isSortConditionEmpty(List<Map<String, String>> sortBy) {
+        if (CollectionUtils.isEmpty(sortBy)) {
+            return true;
+        }
+
+        return sortBy.stream()
+                .allMatch(sortCondition -> isBlank(sortCondition.get(SORT_BY_COLUMN_NAME_KEY)));
     }
 
 

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -1538,10 +1538,14 @@ public class FilterDataServiceTest {
             Condition condition = parseWhereClause(unparsedWhereClause);
 
             List<Map<String, String>> sortBy = new ArrayList<>();
-            Map<String, String> sortCondition = new HashMap<>();
-            sortCondition.put(SORT_BY_COLUMN_NAME_KEY, "orderAmount");
-            sortCondition.put(SORT_BY_TYPE_KEY, VALUE_DESCENDING);
-            sortBy.add(sortCondition);
+            Map<String, String> sortCondition1 = new HashMap<>();
+            sortCondition1.put(SORT_BY_COLUMN_NAME_KEY, "orderAmount");
+            sortCondition1.put(SORT_BY_TYPE_KEY, VALUE_DESCENDING);
+            sortBy.add(sortCondition1);
+            Map<String, String> sortCondition2 = new HashMap<>();
+            sortCondition2.put(SORT_BY_COLUMN_NAME_KEY, ""); // column name empty
+            sortCondition2.put(SORT_BY_TYPE_KEY, VALUE_DESCENDING);
+            sortBy.add(sortCondition2);
 
             ArrayNode filteredData = filterDataService.filterDataNew(items, new UQIDataFilterParams(condition, null,
                     sortBy, null));
@@ -1697,6 +1701,77 @@ public class FilterDataServiceTest {
             String expectedOrderAmount = "9.99";
             String returnedOrderAmount = filteredData.get(0).get("orderAmount").asText();
             assertEquals(expectedOrderAmount, returnedOrderAmount);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSortByWithEmptyColumnNameOnly() {
+        String data = "[\n" +
+                "  {\n" +
+                "    \"id\": 2381224,\n" +
+                "    \"email\": \"michael.lawson@reqres.in\",\n" +
+                "    \"userName\": \"Michael Lawson\",\n" +
+                "    \"productName\": \"Chicken Sandwich\",\n" +
+                "    \"orderAmount\": 4.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 2736212,\n" +
+                "    \"email\": \"lindsay.ferguson@reqres.in\",\n" +
+                "    \"userName\": \"Lindsay Ferguson\",\n" +
+                "    \"productName\": \"Tuna Salad\",\n" +
+                "    \"orderAmount\": 9.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 6788734,\n" +
+                "    \"email\": \"tobias.funke@reqres.in\",\n" +
+                "    \"userName\": \"Tobias Funke\",\n" +
+                "    \"productName\": \"Beef steak\",\n" +
+                "    \"orderAmount\": 19.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  }\n" +
+                "]";
+
+        String whereJson = "{\n" +
+                "  \"where\": {\n" +
+                "    \"children\": [\n" +
+                "      {\n" +
+                "        \"key\": \"orderAmount\",\n" +
+                "        \"condition\": \"LT\",\n" +
+                "        \"value\": \"15\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"condition\": \"AND\"\n" +
+                "  }\n" +
+                "}";
+
+        try {
+            ArrayNode items = (ArrayNode) objectMapper.readTree(data);
+
+            Map<String, Object> whereClause = objectMapper.readValue(whereJson, HashMap.class);
+            Map<String, Object> unparsedWhereClause = (Map<String, Object>) whereClause.get("where");
+            Condition condition = parseWhereClause(unparsedWhereClause);
+
+            List<Map<String, String>> sortBy = new ArrayList<>();
+            Map<String, String> sortCondition1 = new HashMap<>();
+            sortCondition1.put(SORT_BY_COLUMN_NAME_KEY, "");
+            sortCondition1.put(SORT_BY_TYPE_KEY, VALUE_DESCENDING);
+            sortBy.add(sortCondition1);
+
+            ArrayNode filteredData = filterDataService.filterDataNew(items, new UQIDataFilterParams(condition, null,
+                    sortBy, null));
+
+            assertEquals(filteredData.size(), 2);
+
+            List<String> expectedOrder = List.of("4.99", "9.99");
+            List<String> returnedOrder = new ArrayList<>();
+            returnedOrder.add(filteredData.get(0).get("orderAmount").asText());
+            returnedOrder.add(filteredData.get(1).get("orderAmount").asText());
+            assertEquals(expectedOrder, returnedOrder);
         } catch (IOException e) {
             e.printStackTrace();
             Assert.fail(e.getMessage());


### PR DESCRIPTION
## Description
- The sort component introduced as part of UQI currently fails if any of the column names are empty. This is a problem because if a sort component is added to a query editor form then at least one sort component with an empty column gets added by default, which can make the query fail.
- This PR adds changes to ignore all the empty column names (or ignore the sort conditon if all column names are empty). 

Fixes #10896

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
