### PR TITLE
fix: skip bad table migration thats breaking computed columns we di…

### DIFF
--- a/app/client/src/utils/DSLMigrations.ts
+++ b/app/client/src/utils/DSLMigrations.ts
@@ -25,7 +25,6 @@ import {
   migrateTableSanitizeColumnKeys,
   isSortableMigration,
   migrateTableWidgetIconButtonVariant,
-  migrateTableWidgetNumericColumnName,
 } from "./migrations/TableWidget";
 import { migrateTextStyleFromTextWidget } from "./migrations/TextWidgetReplaceTextStyle";
 import { DATA_BIND_REGEX_GLOBAL } from "constants/BindingsConstants";
@@ -1039,7 +1038,10 @@ export const transformDSL = (
   }
 
   if (currentDSL.version === 50) {
-    // We're skipping this to fix a bad table migration.
+    /*
+     * We're skipping this to fix a bad table migration - migrateTableWidgetNumericColumnName
+     * it overwrites the computedValue of the table columns
+     */
     currentDSL.version = LATEST_PAGE_VERSION;
   }
 

--- a/app/client/src/utils/DSLMigrations.ts
+++ b/app/client/src/utils/DSLMigrations.ts
@@ -1039,7 +1039,7 @@ export const transformDSL = (
   }
 
   if (currentDSL.version === 50) {
-    currentDSL = migrateTableWidgetNumericColumnName(currentDSL);
+    // We're skipping this to fix a bad table migration.
     currentDSL.version = LATEST_PAGE_VERSION;
   }
 

--- a/app/client/src/utils/migrations/TableWidget.ts
+++ b/app/client/src/utils/migrations/TableWidget.ts
@@ -490,6 +490,9 @@ export const migrateTableWidgetIconButtonVariant = (currentDSL: DSLWidget) => {
   return currentDSL;
 };
 
+/*
+ * DO NOT USE THIS. it overwrites conputedValues of the Table Columns
+ */
 export const migrateTableWidgetNumericColumnName = (currentDSL: DSLWidget) => {
   currentDSL.children = currentDSL.children?.map((child: WidgetProps) => {
     if (child.type === "TABLE_WIDGET") {


### PR DESCRIPTION
…d in https://github.com/appsmithorg/appsmith/pull/10383



## Description
skips table migration that got introduced here - https://github.com/appsmithorg/appsmith/pull/10383

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/revert-bad-table-migration 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.99 **(0)** | 36.32 **(-0.02)** | 34.68 **(0)** | 55.37 **(-0.01)**
 :red_circle: | app/client/src/utils/DSLMigrations.ts | 73.12 **(-0.04)** | 69.39 **(0)** | 71.13 **(0)** | 72.92 **(-0.04)**
 :red_circle: | app/client/src/utils/migrations/TableWidget.ts | 84.91 **(-0.75)** | 73.04 **(-2.18)** | 91.18 **(0)** | 86.38 **(-0.85)**</details>