### PR TITLE
fix: prevent lint tooltips from getting clipped ✂️ 

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/constants.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/constants.ts
@@ -4,3 +4,13 @@
 export const WARNING_LINT_ERRORS = {
   W098: "'{a}' is defined but never used.",
 };
+
+export const LINT_TOOLTIP_CLASS = "CodeMirror-lint-tooltip";
+
+export const LINT_TOOLTIP_JUSTIFIFIED_LEFT_CLASS =
+  "CodeMirror-lint-tooltip-left";
+
+export enum LintTooltipDirection {
+  left = "left",
+  right = "right",
+}

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -80,12 +80,17 @@ import { ExpectedValueExample } from "utils/validation/common";
 import { getRecentEntityIds } from "selectors/globalSearchSelectors";
 import { AutocompleteDataType } from "utils/autocomplete/TernServer";
 import { Placement } from "@blueprintjs/popover2";
-import { getLintAnnotations } from "./lintHelpers";
+import { getLintAnnotations, getLintTooltipDirection } from "./lintHelpers";
 import { executeCommandAction } from "actions/apiPaneActions";
 import { startingEntityUpdation } from "actions/editorActions";
 import { SlashCommandPayload } from "entities/Action";
 import { Indices } from "constants/Layers";
 import { replayHighlightClass } from "globalStyles/portals";
+import {
+  LintTooltipDirection,
+  LINT_TOOLTIP_CLASS,
+  LINT_TOOLTIP_JUSTIFIFIED_LEFT_CLASS,
+} from "./constants";
 
 interface ReduxStateProps {
   dynamicData: DataTree;
@@ -152,6 +157,8 @@ type State = {
   hinterOpen: boolean;
   // Flag for determining whether the entity change has been started or not so that even if the initial and final value remains the same, the status should be changed to not loading
   changeStarted: boolean;
+  // state of lint errors in editor
+  hasLintError: boolean;
 };
 
 class CodeEditor extends Component<Props, State> {
@@ -174,6 +181,7 @@ class CodeEditor extends Component<Props, State> {
       autoCompleteVisible: false,
       hinterOpen: false,
       changeStarted: false,
+      hasLintError: false,
     };
     this.updatePropertyValue = this.updatePropertyValue.bind(this);
   }
@@ -385,6 +393,21 @@ class CodeEditor extends Component<Props, State> {
     }
   };
 
+  handleLintTooltip = () => {
+    // return if there is no lint error in editor instance
+    if (!this.state.hasLintError) return;
+    const lintTooltipList = document.getElementsByClassName(LINT_TOOLTIP_CLASS);
+    if (!lintTooltipList) return;
+    for (const tooltip of lintTooltipList) {
+      if (
+        tooltip &&
+        getLintTooltipDirection(tooltip) === LintTooltipDirection.left
+      ) {
+        tooltip.classList.add(LINT_TOOLTIP_JUSTIFIFIED_LEFT_CLASS);
+      }
+    }
+  };
+
   handleChange = (instance?: any, changeObj?: any) => {
     const value = this.editor.getValue() || "";
     if (changeObj && changeObj.origin === "complete") {
@@ -581,6 +604,16 @@ class CodeEditor extends Component<Props, State> {
       (error) => error.errorType !== PropertyEvaluationErrorType.LINT,
     );
 
+    const lintErrors = errors.filter(
+      (error) => error.errorType === PropertyEvaluationErrorType.LINT,
+    );
+
+    if (!_.isEmpty(lintErrors)) {
+      !this.state.hasLintError && this.setState({ hasLintError: true });
+    } else {
+      this.state.hasLintError && this.setState({ hasLintError: false });
+    }
+
     const pathEvaluatedValue = _.get(dataTree, getEvalValuePath(dataTreePath));
 
     return {
@@ -687,6 +720,7 @@ class CodeEditor extends Component<Props, State> {
             hoverInteraction={hoverInteraction}
             isFocused={this.state.isFocused}
             isNotHover={this.state.isFocused || this.state.isOpened}
+            onMouseMove={this.handleLintTooltip}
             ref={this.editorWrapperRef}
             size={size}
           >

--- a/app/client/src/components/editorComponents/CodeEditor/lintHelpers.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/lintHelpers.ts
@@ -5,7 +5,7 @@ import {
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
 import { Severity } from "entities/AppsmithConsole";
-import { WARNING_LINT_ERRORS } from "./constants";
+import { LintTooltipDirection, WARNING_LINT_ERRORS } from "./constants";
 
 export const getIndexOfRegex = (
   str: string,
@@ -134,4 +134,20 @@ export const getLintSeverity = (
   const severity =
     code in WARNING_LINT_ERRORS ? Severity.WARNING : Severity.ERROR;
   return severity;
+};
+
+/* By default, lint tooltips are rendered to the right of the cursor
+if the tooltip overflows out of the page, we want to render it to the left of the cursor
+*/
+export const getLintTooltipDirection = (
+  tooltip: Element,
+): LintTooltipDirection => {
+  if (
+    tooltip.getBoundingClientRect().right >
+    (window.innerWidth || document.documentElement.clientWidth)
+  ) {
+    return LintTooltipDirection.left;
+  } else {
+    return LintTooltipDirection.right;
+  }
 };

--- a/app/client/src/globalStyles/CodemirrorHintStyles.ts
+++ b/app/client/src/globalStyles/CodemirrorHintStyles.ts
@@ -1,6 +1,7 @@
 import { createGlobalStyle } from "styled-components";
 import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
 import { getTypographyByKey, Theme } from "constants/DefaultTheme";
+import { LINT_TOOLTIP_JUSTIFIFIED_LEFT_CLASS } from "components/editorComponents/CodeEditor/constants";
 
 export const CodemirrorHintStyles = createGlobalStyle<{
   editorTheme: EditorTheme;
@@ -257,6 +258,11 @@ export const CodemirrorHintStyles = createGlobalStyle<{
     box-shadow: 0px 12px 28px -6px rgba(0, 0, 0, 0.32);
     padding: 7px 12px;
     border-radius: 0;
+    
+    &.${LINT_TOOLTIP_JUSTIFIFIED_LEFT_CLASS}{
+    transform: translate(-100%);
+  }
+  
   }
   .CodeMirror-lint-message {
     margin-top: 5px;


### PR DESCRIPTION
## Description

- Cause of the issue 

Lint tooltips get clipped when they extend beyond the width of the page. This is inevitable since Codemirror's lint addon always renders tooltip to the right. An issue has already been raised, however, [from this comment by the maintainer](https://github.com/codemirror/CodeMirror/issues/6745#issuecomment-883326686), it's not going to be fixed anytime soon. 

- Solution Approach

Tooltip gets rendered to the left if it will overflow when rendered to the right

Fixes #9765 
Fixes #8943

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
