### PR TITLE
chore: releaseBlockerFixes-v1.6.9

### DIFF
--- a/app/client/src/actions/metaActions.ts
+++ b/app/client/src/actions/metaActions.ts
@@ -1,9 +1,7 @@
 import { ReduxActionTypes, ReduxAction } from "constants/ReduxActionConstants";
 import { BatchAction, batchAction } from "actions/batchActions";
+import { Diff } from "deep-diff";
 import { DataTree } from "entities/DataTree/dataTreeFactory";
-import { isWidget } from "../workers/evaluationUtils";
-import { MetaState } from "../reducers/entityReducers/metaReducer";
-import isEmpty from "lodash/isEmpty";
 
 export interface UpdateWidgetMetaPropertyPayload {
   widgetId: string;
@@ -47,18 +45,15 @@ export const resetChildrenMetaProperty = (
   };
 };
 
-export const updateMetaState = (evaluatedDataTree: DataTree) => {
-  const updatedWidgetMetaState: MetaState = {};
-  Object.values(evaluatedDataTree).forEach((entity) => {
-    if (isWidget(entity) && entity.widgetId && !isEmpty(entity.meta)) {
-      updatedWidgetMetaState[entity.widgetId] = entity.meta;
-    }
-  });
-
+export const updateMetaState = (
+  updates: Diff<any, any>[],
+  updatedDataTree: DataTree,
+) => {
   return {
     type: ReduxActionTypes.UPDATE_META_STATE,
     payload: {
-      updatedWidgetMetaState,
+      updates,
+      updatedDataTree,
     },
   };
 };

--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -118,7 +118,8 @@ export interface ExecuteErrorPayload extends ErrorActionPayload {
 export const urlGroupsRegexExp = /^(https?:\/{2}\S+?)(\/[\s\S]*?)?(\?(?![^{]*})[\s\S]*)?$/;
 
 export const EXECUTION_PARAM_KEY = "executionParams";
-export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params/g;
+export const EXECUTION_PARAM_REFERENCE_REGEX = /this.params|this\?.params/g;
+export const THIS_DOT_PARAMS_KEY = "params";
 
 export const RESP_HEADER_DATATYPE = "X-APPSMITH-DATATYPE";
 export const API_REQUEST_HEADERS: APIHeaders = {

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -140,7 +140,7 @@ function* evaluateTreeSaga(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
 
-  yield put(updateMetaState(dataTree));
+  yield put(updateMetaState(updates, dataTree));
 
   const updatedDataTree = yield select(getDataTree);
   log.debug({ jsUpdates: jsUpdates });

--- a/app/client/src/utils/DSLMigrations.ts
+++ b/app/client/src/utils/DSLMigrations.ts
@@ -25,7 +25,6 @@ import {
   migrateTableSanitizeColumnKeys,
   isSortableMigration,
   migrateTableWidgetIconButtonVariant,
-  migrateTableWidgetNumericColumnName,
 } from "./migrations/TableWidget";
 import { migrateTextStyleFromTextWidget } from "./migrations/TextWidgetReplaceTextStyle";
 import { DATA_BIND_REGEX_GLOBAL } from "constants/BindingsConstants";
@@ -1039,7 +1038,10 @@ export const transformDSL = (
   }
 
   if (currentDSL.version === 50) {
-    currentDSL = migrateTableWidgetNumericColumnName(currentDSL);
+    /*
+     * We're skipping this to fix a bad table migration - migrateTableWidgetNumericColumnName
+     * it overwrites the computedValue of the table columns
+     */
     currentDSL.version = LATEST_PAGE_VERSION;
   }
 

--- a/app/client/src/utils/migrations/TableWidget.ts
+++ b/app/client/src/utils/migrations/TableWidget.ts
@@ -490,6 +490,9 @@ export const migrateTableWidgetIconButtonVariant = (currentDSL: DSLWidget) => {
   return currentDSL;
 };
 
+/*
+ * DO NOT USE THIS. it overwrites conputedValues of the Table Columns
+ */
 export const migrateTableWidgetNumericColumnName = (currentDSL: DSLWidget) => {
   currentDSL.children = currentDSL.children?.map((child: WidgetProps) => {
     if (child.type === "TABLE_WIDGET") {

--- a/app/client/src/workers/DataTreeEvaluator.test.ts
+++ b/app/client/src/workers/DataTreeEvaluator.test.ts
@@ -1,0 +1,109 @@
+import DataTreeEvaluator from "./DataTreeEvaluator";
+
+describe("DataTreeEvaluator", () => {
+  let dataTreeEvaluator: DataTreeEvaluator;
+  beforeAll(() => {
+    dataTreeEvaluator = new DataTreeEvaluator({});
+  });
+  describe("evaluateActionBindings", () => {
+    it("handles this.params.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(function() { return this.params.property })()",
+          "(() => { return this.params.property })()",
+          'this.params.property || "default value"',
+          'this.params.property1 || "default value"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
+    });
+
+    it("handles this?.params.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(() => { return this?.params.property })()",
+          "(function() { return this?.params.property })()",
+          'this?.params.property || "default value"',
+          'this?.params.property1 || "default value"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
+    });
+
+    it("handles this?.params?.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(() => { return this?.params?.property })()",
+          "(function() { return this?.params?.property })()",
+          'this?.params?.property || "default value"',
+          'this?.params?.property1 || "default value"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
+    });
+
+    it("handles executionParams.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(function() { return executionParams.property })()",
+          "(() => { return executionParams.property })()",
+          'executionParams.property || "default value"',
+          'executionParams.property1 || "default value"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
+    });
+
+    it("handles executionParams?.property", () => {
+      const result = dataTreeEvaluator.evaluateActionBindings(
+        [
+          "(function() { return executionParams?.property })()",
+          "(() => { return executionParams?.property })()",
+          'executionParams?.property || "default value"',
+          'executionParams?.property1 || "default value"',
+        ],
+        {
+          property: "my value",
+        },
+      );
+      expect(result).toStrictEqual([
+        "my value",
+        "my value",
+        "my value",
+        "default value",
+      ]);
+    });
+  });
+});

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -55,11 +55,13 @@ import toposort from "toposort";
 import {
   EXECUTION_PARAM_KEY,
   EXECUTION_PARAM_REFERENCE_REGEX,
+  THIS_DOT_PARAMS_KEY,
 } from "constants/AppsmithActionConstants/ActionConstants";
 import { DATA_BIND_REGEX } from "constants/BindingsConstants";
 import evaluateSync, {
   createGlobalData,
   EvalResult,
+  EvaluateContext,
   EvaluationScriptType,
   getScriptToEval,
   evaluateAsync,
@@ -609,12 +611,19 @@ export default class DataTreeEvaluator {
               entity.bindingPaths[propertyPath] ||
               EvaluationSubstitutionType.TEMPLATE;
 
+            const contextData: EvaluateContext = {};
+            if (isAction(entity)) {
+              contextData.thisContext = {
+                params: {},
+              };
+            }
             try {
               evalPropertyValue = this.getDynamicValue(
                 unEvalPropertyValue,
                 currentTree,
                 resolvedFunctions,
                 evaluationSubstitutionType,
+                contextData,
                 undefined,
                 fullPropertyPath,
               );
@@ -764,6 +773,7 @@ export default class DataTreeEvaluator {
     data: DataTree,
     resolvedFunctions: Record<string, any>,
     evaluationSubstitutionType: EvaluationSubstitutionType,
+    contextData?: EvaluateContext,
     callBackData?: Array<any>,
     fullPropertyPath?: string,
   ) {
@@ -792,6 +802,7 @@ export default class DataTreeEvaluator {
             toBeSentForEval,
             data,
             resolvedFunctions,
+            contextData,
             callBackData,
           );
           if (fullPropertyPath && result.errors.length) {
@@ -864,10 +875,17 @@ export default class DataTreeEvaluator {
     js: string,
     data: DataTree,
     resolvedFunctions: Record<string, any>,
+    contextData?: EvaluateContext,
     callbackData?: Array<any>,
   ): EvalResult {
     try {
-      return evaluateSync(js, data, resolvedFunctions, callbackData);
+      return evaluateSync(
+        js,
+        data,
+        resolvedFunctions,
+        contextData,
+        callbackData,
+      );
     } catch (e) {
       return {
         result: undefined,
@@ -1555,24 +1573,26 @@ export default class DataTreeEvaluator {
       );
     }
 
-    // Replace any reference of 'this.params' to 'executionParams' (backwards compatibility)
-    const bindingsForExecutionParams: string[] = bindings.map(
-      (binding: string) =>
-        binding.replace(EXECUTION_PARAM_REFERENCE_REGEX, EXECUTION_PARAM_KEY),
-    );
-
-    const dataTreeWithExecutionParams = Object.assign({}, this.evalTree, {
-      [EXECUTION_PARAM_KEY]: evaluatedExecutionParams,
-    });
-
-    return bindingsForExecutionParams.map((binding) =>
-      this.getDynamicValue(
-        `{{${binding}}}`,
-        dataTreeWithExecutionParams,
+    return bindings.map((binding) => {
+      // Replace any reference of 'this.params' to 'executionParams' (backwards compatibility)
+      // also helps with dealing with IIFE which are normal functions (not arrow)
+      // because normal functions won't retain 'this' context (when executed elsewhere)
+      const replacedBinding = binding.replace(
+        EXECUTION_PARAM_REFERENCE_REGEX,
+        EXECUTION_PARAM_KEY,
+      );
+      return this.getDynamicValue(
+        `{{${replacedBinding}}}`,
+        this.evalTree,
         this.resolvedFunctions,
         EvaluationSubstitutionType.TEMPLATE,
-      ),
-    );
+        // params can be accessed via "this.params" or "executionParams"
+        {
+          thisContext: { [THIS_DOT_PARAMS_KEY]: evaluatedExecutionParams },
+          globalContext: { [EXECUTION_PARAM_KEY]: evaluatedExecutionParams },
+        },
+      );
+    });
   }
 
   clearErrors() {

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -34,12 +34,12 @@ export const EvaluationScripts: Record<EvaluationScriptType, string> = {
     const result = ${ScriptTemplate}
     return result;
   }
-  closedFunction()
+  closedFunction.call(THIS_CONTEXT)
   `,
   [EvaluationScriptType.ANONYMOUS_FUNCTION]: `
   function callback (script) {
     const userFunction = script;
-    const result = userFunction?.apply(self, ARGUMENTS);
+    const result = userFunction?.apply(THIS_CONTEXT, ARGUMENTS);
     return result;
   }
   callback(${ScriptTemplate})
@@ -49,7 +49,7 @@ export const EvaluationScripts: Record<EvaluationScriptType, string> = {
     const result = await ${ScriptTemplate};
     return result;
   }
-  closedFunction();
+  closedFunction.call(THIS_CONTEXT);
   `,
 };
 
@@ -102,6 +102,18 @@ export const createGlobalData = (
   const GLOBAL_DATA: Record<string, any> = {};
   ///// Adding callback data
   GLOBAL_DATA.ARGUMENTS = evalArguments;
+  //// Adding contextual data not part of data tree
+  GLOBAL_DATA.THIS_CONTEXT = {};
+  if (context) {
+    if (context.thisContext) {
+      GLOBAL_DATA.THIS_CONTEXT = context.thisContext;
+    }
+    if (context.globalContext) {
+      Object.entries(context.globalContext).forEach(([key, value]) => {
+        GLOBAL_DATA[key] = value;
+      });
+    }
+  }
   //// Add internal functions to dataTree;
   const dataTreeWithFunctions = enhanceDataTreeWithFunctions(
     dataTree,
@@ -134,9 +146,13 @@ export function sanitizeScript(js: string) {
 }
 
 /** Define a context just for this script
+ * thisContext will define it on the `this`
+ * globalContext will define it globally
  * requestId is used for completing promises
  */
 export type EvaluateContext = {
+  thisContext?: Record<string, any>;
+  globalContext?: Record<string, any>;
   requestId?: string;
 };
 
@@ -172,6 +188,7 @@ export default function evaluateSync(
   userScript: string,
   dataTree: DataTree,
   resolvedFunctions: Record<string, any>,
+  context?: EvaluateContext,
   evalArguments?: Array<any>,
 ): EvalResult {
   return (function() {
@@ -181,7 +198,7 @@ export default function evaluateSync(
     const GLOBAL_DATA: Record<string, any> = createGlobalData(
       dataTree,
       resolvedFunctions,
-      undefined,
+      context,
       evalArguments,
     );
     GLOBAL_DATA.ALLOW_ASYNC = false;

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -805,10 +805,11 @@ export const overrideWidgetProperties = (
     const overridingPropertyPaths =
       entity.overridingPropertyPaths[propertyPath];
 
-    overridingPropertyPaths.forEach((overriddenPropertyKey) => {
+    overridingPropertyPaths.forEach((overriddenPropertyPath) => {
+      const overriddenPropertyPathArray = overriddenPropertyPath.split(".");
       _.set(
         currentTree,
-        `${entity.widgetName}.${overriddenPropertyKey}`,
+        [entity.widgetName, ...overriddenPropertyPathArray],
         clonedValue,
       );
     });
@@ -824,9 +825,10 @@ export const overrideWidgetProperties = (
       const defaultValue = entity[propertyOverridingKeyMap.DEFAULT];
       const clonedDefaultValue = cloneDeep(defaultValue);
       if (defaultValue !== undefined) {
+        const propertyPathArray = propertyPath.split(".");
         _.set(
           currentTree,
-          `${entity.widgetName}.${propertyPath}`,
+          [entity.widgetName, ...propertyPathArray],
           clonedDefaultValue,
         );
         return {

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -803,7 +803,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     };
     if (config.params?.fnString && isString(config.params?.fnString)) {
       try {
-        const { result } = evaluate(config.params.fnString, {}, {}, [
+        const { result } = evaluate(config.params.fnString, {}, {}, undefined, [
           value,
           props,
           _,


### PR DESCRIPTION
## Description

Merged
• [#10826](https://github.com/appsmithorg/appsmith/pull/10826)
• [#10837](https://github.com/appsmithorg/appsmith/pull/10837)
• [#10897](https://github.com/appsmithorg/appsmith/pull/10897)

Fixes # (issue)


## Type of change

Merging release blocker fixes

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: chore/releaseBlockerFixes-v1.6.9 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.03 **(0.04)** | 36.49 **(0.18)** | 34.74 **(0.06)** | 55.43 **(0.06)**
 :green_circle: | app/client/src/components/ads/DraggableList.tsx | 44.26 **(8.39)** | 33.33 **(14.69)** | 21.43 **(-5.24)** | 51.02 **(12.27)**
 :green_circle: | app/client/src/components/ads/DraggableListComponent.tsx | 42.42 **(1.39)** | 50 **(31.82)** | 37.5 **(4.17)** | 44.44 **(2.02)**
 :red_circle: | app/client/src/components/ads/EditableText.tsx | 79.41 **(-17.65)** | 31.25 **(-37.5)** | 75 **(-25)** | 74.07 **(-22.23)**
 :red_circle: | app/client/src/components/ads/EditableTextSubComponent.tsx | 65.56 **(-10.26)** | 44.32 **(-19.01)** | 72 **(-12)** | 63.86 **(-11.14)**
 :red_circle: | app/client/src/components/ads/Icon.tsx | 51.65 **(-0.94)** | 34.3 **(-2.33)** | 100 **(0)** | 51.54 **(-0.94)**
 :green_circle: | app/client/src/components/editorComponents/ApiResponseView.tsx | 58.67 **(2.26)** | 43.48 **(5.02)** | 0 **(0)** | 58.67 **(2.26)**
 :red_circle: | app/client/src/components/propertyControls/ButtonListControl.tsx | 24.72 **(-6.79)** | 25 **(-2.27)** | 9.09 **(-2.02)** | 26.92 **(-4.07)**
 :red_circle: | app/client/src/components/propertyControls/KeyValueComponent.tsx | 15.71 **(-0.08)** | 24 **(0)** | 0 **(0)** | 17.19 **(0.05)**
 :red_circle: | app/client/src/components/propertyControls/MenuItemsControl.tsx | 22.99 **(-6.59)** | 22.22 **(1.53)** | 9.09 **(-2.02)** | 25 **(-3.99)**
 :red_circle: | app/client/src/components/propertyControls/PrimaryColumnsControl.tsx | 30.56 **(-5.44)** | 11.11 **(-1.2)** | 14.71 **(-4.52)** | 30.54 **(-4.43)**
 :red_circle: | app/client/src/components/propertyControls/TabControl.tsx | 41.49 **(-11.01)** | 35.71 **(-3.18)** | 26.09 **(-8.91)** | 44.05 **(-7.85)**
 :green_circle: | app/client/src/constants/messages.ts | 74.85 **(0.02)** | 100 **(0)** | 25.45 **(0.04)** | 80.29 **(-0.02)**
 :green_circle: | app/client/src/icons/WidgetIcons.tsx | 60.23 **(0.89)** | 100 **(0)** | 16.67 **(0.76)** | 60.23 **(0.89)**
 :red_circle: | app/client/src/pages/Editor/PropertyPaneTitle.tsx | 70.21 **(-3.47)** | 21.05 **(-13.95)** | 71.43 **(-1.3)** | 68.18 **(-2.41)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx | 39.13 **(1.63)** | 0 **(0)** | 0 **(0)** | 39.13 **(1.63)**
 :red_circle: | app/client/src/pages/Editor/gitSync/components/BranchList.tsx | 23.31 **(-0.47)** | 10.13 **(0)** | 2.5 **(0)** | 25.34 **(-0.51)**
 :green_circle: | app/client/src/sagas/DatasourcesSagas.ts | 13.51 **(0)** | 2.4 **(0.14)** | 8.7 **(0)** | 16.12 **(0)**
 :red_circle: | app/client/src/sagas/PageSagas.tsx | 24.2 **(-0.22)** | 5.88 **(0)** | 14.71 **(0)** | 25.94 **(-0.25)**
 :green_circle: | app/client/src/sagas/SnipingModeSagas.ts | 20.59 **(0.59)** | 3.23 **(0.1)** | 40 **(0)** | 21.43 **(0.64)**
 :green_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 51.54 **(0)** | 39.02 **(0.29)** | 52.08 **(0)** | 52.79 **(0)**
 :red_circle: | app/client/src/sagas/WidgetOperationUtils.ts | 60.78 **(-1.08)** | 41.94 **(-2.06)** | 57.14 **(-2.48)** | 60 **(-1.26)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/selectors/gitSyncSelectors.tsx | 70.86 **(-0.28)** | 10.48 **(-1.1)** | 14 **(-0.29)** | 62.37 **(0)**
 :green_circle: | app/client/src/utils/DSLMigrations.ts | 73.26 **(0.14)** | 69.56 **(0.17)** | 71.13 **(0)** | 73.07 **(0.15)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/helpers.tsx | 65.78 **(-1.31)** | 32.22 **(-2.35)** | 58.82 **(-1.56)** | 63.68 **(-1.63)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/widgets/SwitchWidget/component/index.tsx | 93.33 **(-0.42)** | 62.5 **(0)** | 50 **(0)** | 93.33 **(-0.42)**
 :red_circle: | app/client/src/workers/validations.ts | 76.79 **(0)** | 69.37 **(-0.12)** | 67.65 **(0)** | 78.59 **(0)**
 :x: | ~~app/client/src/components/ads/DraggableListCard.tsx~~ | ~~14.29~~ | ~~3.45~~ | ~~0~~ | ~~16.67~~
 :x: | ~~app/client/src/pages/Editor/gitSync/components/BetaTag.tsx~~ | ~~75~~ | ~~100~~ | ~~0~~ | ~~75~~
 :x: | ~~app/client/src/widgets/MultiSelectWidgetV2/index.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/widgets/MultiSelectWidgetV2/component/index.styled.tsx~~ | ~~45~~ | ~~28.13~~ | ~~0~~ | ~~51.52~~
 :x: | ~~app/client/src/widgets/MultiSelectWidgetV2/component/index.tsx~~ | ~~12.77~~ | ~~0~~ | ~~0~~ | ~~14.46~~
 :x: | ~~app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx~~ | ~~66.67~~ | ~~0~~ | ~~60~~ | ~~67.65~~
 :x: | ~~app/client/src/widgets/SelectWidget/index.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/widgets/SelectWidget/component/index.styled.tsx~~ | ~~43.75~~ | ~~21.88~~ | ~~0~~ | ~~48.28~~
 :x: | ~~app/client/src/widgets/SelectWidget/component/index.tsx~~ | ~~25~~ | ~~0~~ | ~~7.14~~ | ~~25.4~~
 :x: | ~~app/client/src/widgets/SelectWidget/widget/index.tsx~~ | ~~49.02~~ | ~~0~~ | ~~46.15~~ | ~~51.06~~</details>