### PR TITLE
fix: fix margin top issues with checkbox form controls

### DIFF
--- a/app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx
+++ b/app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx
@@ -32,7 +32,7 @@ font-size: 12px;
 `;
 
 //Styled help text, intended to be used with Form Fields
-const FormInputHelperText = styled.p`
+const FormInputHelperText = styled.p<{ addMarginTop?: string }>`
   color: #858282;
   font-style: normal;
   font-weight: normal;
@@ -40,6 +40,12 @@ const FormInputHelperText = styled.p`
   line-height: 16px;
   letter-spacing: -0.221538px;
   margin: 0px;
+
+  ${(props) =>
+    props.addMarginTop &&
+    `
+    margin-top: ${props.addMarginTop};
+  `}
 `;
 
 //Styled error text, intended to be used with Form Fields

--- a/app/client/src/pages/Editor/FormControl.tsx
+++ b/app/client/src/pages/Editor/FormControl.tsx
@@ -186,10 +186,16 @@ function renderFormConfigBottom(props: {
   config: ControlProps;
   configErrors?: EvaluationError[];
 }) {
-  const { info } = { ...props.config };
+  const { controlType, info } = { ...props.config };
   return (
     <>
-      {info && <FormInputHelperText>{info}</FormInputHelperText>}
+      {info && (
+        <FormInputHelperText
+          addMarginTop={controlType === "CHECKBOX" ? "8px" : "2px"} // checkboxes need a higher margin top than others form control types
+        >
+          {info}
+        </FormInputHelperText>
+      )}
       {props.configErrors &&
         props.configErrors.length > 0 &&
         props.configErrors


### PR DESCRIPTION
This PR fixes the margin top property for info texts beneath Checkboxes and other form controls.

Fixes #10783 


- Bug fix (non-breaking change which fixes an issue)

Manual tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-checkbox-info-text 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.98 **(-0.01)** | 36.32 **(0)** | 34.67 **(-0.01)** | 55.37 **(0)**
 :red_circle: | app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx | 65.38 **(-2.62)** | 15.56 **(-0.35)** | 0 **(0)** | 65.38 **(-2.62)**
 :red_circle: | app/client/src/pages/Editor/FormControl.tsx | 24.44 **(-1.14)** | 0 **(0)** | 0 **(0)** | 26.83 **(0)**</details>