### PR TITLE
fix: Sort unordered set elements before committing to git repo so as to have same serialised output string for identical set of elements

### DIFF
--- a/app/server/appsmith-git/pom.xml
+++ b/app/server/appsmith-git/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/converters/GsonDoubleToLongConverter.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/converters/GsonDoubleToLongConverter.java
@@ -1,0 +1,18 @@
+package com.appsmith.git.converters;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+public class GsonDoubleToLongConverter implements JsonSerializer<Double> {
+        @Override
+        public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
+            if(src == src.longValue()) {
+                return new JsonPrimitive(src.longValue());
+            }
+            return new JsonPrimitive(src);
+        }
+}

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/converters/GsonUnorderedToOrderedSetConverter.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/converters/GsonUnorderedToOrderedSetConverter.java
@@ -1,0 +1,37 @@
+package com.appsmith.git.converters;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import org.springframework.util.CollectionUtils;
+
+import javax.lang.model.type.PrimitiveType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class GsonUnorderedToOrderedSetConverter implements JsonSerializer<Set> {
+    @Override
+    public JsonArray serialize(Set src, Type typeOfSrc, JsonSerializationContext context) {
+        // Sort the set so that same elements will not end up in merge conflicts
+        return (JsonArray) new Gson().toJsonTree(getOrderedResource(src));
+    }
+
+    /**
+     * Sort the primitive datatype objects and string so that we will have predictable output
+     * @param objects set of objects which needs to be sorted before serialisation
+     * @param <T>
+     * @return sorted collection
+     */
+    private <T> Collection<T> getOrderedResource(Set<T> objects) {
+        if (!CollectionUtils.isEmpty(objects)) {
+            T element = objects.iterator().next();
+            if (element instanceof String || element instanceof PrimitiveType) {
+                return objects.stream().sorted().collect(Collectors.toList());
+            }
+        }
+        return objects;
+    }
+}

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/converters/GsonUnorderedToOrderedSetConverter.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/converters/GsonUnorderedToOrderedSetConverter.java
@@ -20,7 +20,10 @@ public class GsonUnorderedToOrderedSetConverter implements JsonSerializer<Set> {
     }
 
     /**
-     * Sort the primitive datatype objects and string so that we will have predictable output
+     * Sort the primitive datatype objects and string so that we will have predictable sorted output
+     * e.g. Input => ["abcd", "abc", "abcd1", "1abcd","xyz", "1xyz", "0xyz"]
+     * Output => ["0xyz","1abcd","1xyz","abc","abcd","abcd1","xyz"]
+     *
      * @param objects set of objects which needs to be sorted before serialisation
      * @param <T>
      * @return sorted collection

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.external.git.GitExecutor;
 import com.appsmith.external.models.ApplicationGitReference;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.git.configurations.GitServiceConfig;
+import com.appsmith.git.converters.GsonUnorderedToOrderedSetConverter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -93,7 +94,6 @@ public class FileUtilsImpl implements FileInterface {
                     // convert to Double
                     Gson gson = new GsonBuilder()
                             .registerTypeAdapter(Double.class,  new JsonSerializer<Double>() {
-
                                 @Override
                                 public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
                                     if(src == src.longValue())
@@ -101,6 +101,7 @@ public class FileUtilsImpl implements FileInterface {
                                     return new JsonPrimitive(src);
                                 }
                             })
+                            .registerTypeAdapter(Set.class, new GsonUnorderedToOrderedSetConverter())
                             .disableHtmlEscaping()
                             .setPrettyPrinting()
                             .create();

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
@@ -5,13 +5,10 @@ import com.appsmith.external.git.GitExecutor;
 import com.appsmith.external.models.ApplicationGitReference;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.git.configurations.GitServiceConfig;
+import com.appsmith.git.converters.GsonDoubleToLongConverter;
 import com.appsmith.git.converters.GsonUnorderedToOrderedSetConverter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import com.google.gson.stream.JsonReader;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +27,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
@@ -90,17 +86,11 @@ public class FileUtilsImpl implements FileInterface {
 
                     Path baseRepo = Paths.get(gitServiceConfig.getGitRootPath()).resolve(baseRepoSuffix);
 
-                    // Gson to pretty format JSON file and keep Integer type as is by default GSON have behavior to
-                    // convert to Double
+                    // Gson to pretty format JSON file
+                    // Keep Long type as is by default GSON have behavior to convert to Double
+                    // Convert unordered set to ordered one
                     Gson gson = new GsonBuilder()
-                            .registerTypeAdapter(Double.class,  new JsonSerializer<Double>() {
-                                @Override
-                                public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
-                                    if(src == src.longValue())
-                                        return new JsonPrimitive(src.longValue());
-                                    return new JsonPrimitive(src);
-                                }
-                            })
+                            .registerTypeAdapter(Double.class,  new GsonDoubleToLongConverter())
                             .registerTypeAdapter(Set.class, new GsonUnorderedToOrderedSetConverter())
                             .disableHtmlEscaping()
                             .setPrettyPrinting()

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
@@ -437,13 +437,22 @@ public class GitExecutorImpl implements GitExecutor {
                 modifiedAssets.addAll(status.getRemoved());
                 modifiedAssets.addAll(status.getUncommittedChanges());
                 modifiedAssets.addAll(status.getUntracked());
+                response.setAdded(status.getAdded());
+                response.setRemoved(status.getRemoved());
+
                 long modifiedPages = 0L;
                 long modifiedQueries = 0L;
+                long modifiedJSObjects = 0L;
+                long modifiedDatasources = 0L;
                 for (String x : modifiedAssets) {
                     if (x.contains(GitDirectories.PAGE_DIRECTORY + "/")) {
                         modifiedPages++;
                     } else if (x.contains(GitDirectories.ACTION_DIRECTORY + "/")) {
                         modifiedQueries++;
+                    } else if (x.contains(GitDirectories.ACTION_COLLECTION_DIRECTORY + "/")) {
+                        modifiedJSObjects++;
+                    } else if (x.contains(GitDirectories.DATASOURCE_DIRECTORY + "/")) {
+                        modifiedDatasources++;
                     }
                 }
                 response.setModified(modifiedAssets);
@@ -451,6 +460,8 @@ public class GitExecutorImpl implements GitExecutor {
                 response.setIsClean(status.isClean());
                 response.setModifiedPages(modifiedPages);
                 response.setModifiedQueries(modifiedQueries);
+                response.setModifiedJSObjects(modifiedJSObjects);
+                response.setModifiedDatasources(modifiedDatasources);
 
                 BranchTrackingStatus trackingStatus = BranchTrackingStatus.of(git.getRepository(), branchName);
                 if (trackingStatus != null) {

--- a/app/server/appsmith-git/src/test/java/GsonDoubleToLongConverterTest.java
+++ b/app/server/appsmith-git/src/test/java/GsonDoubleToLongConverterTest.java
@@ -1,0 +1,38 @@
+import com.appsmith.git.converters.GsonDoubleToLongConverter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GsonDoubleToLongConverterTest {
+    private Gson gson;
+
+    @Before
+    public void setUp() {
+        gson = new GsonBuilder()
+                .registerTypeAdapter(Double.class, new GsonDoubleToLongConverter())
+                .create();
+    }
+
+    @Test
+    public void convert_whenNull_returnsNullString() {
+        String orderedData = gson.toJson((Object) null);
+        assertThat(orderedData).isEqualTo("null");
+    }
+
+    @Test
+    public void convert_withDoubleInput_returnsDoubleString() {
+        Double[] data = {1.00, 0.50, 1.50};
+        String orderedData = gson.toJson(data);
+        assertThat(orderedData).isEqualTo("[1,0.5,1.5]");
+    }
+
+    @Test
+    public void convert_withLongInput_returnsLongString() {
+        Long[] data = {1L, 10L, 100L};
+        String orderedData = gson.toJson(data);
+        assertThat(orderedData).isEqualTo("[1,10,100]");
+    }
+}

--- a/app/server/appsmith-git/src/test/java/GsonUnorderedToOrderedSetTest.java
+++ b/app/server/appsmith-git/src/test/java/GsonUnorderedToOrderedSetTest.java
@@ -1,0 +1,41 @@
+import com.appsmith.git.converters.GsonUnorderedToOrderedSetConverter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GsonUnorderedToOrderedSetTest {
+    private Gson gson;
+
+    @Before
+    public void setUp() {
+        gson = new GsonBuilder()
+                .registerTypeAdapter(Set.class, new GsonUnorderedToOrderedSetConverter())
+                .create();
+    }
+
+    @Test
+    public void convert_whenEmptySet_returnsEmptyArrayString() {
+        Set data = new HashSet();
+        String orderedData = gson.toJson(data);
+        assertThat(orderedData).isEqualTo("[]");
+    }
+
+    @Test
+    public void convert_whenNullSet_returnsNullString() {
+        String orderedData = gson.toJson((Object) null);
+        assertThat(orderedData).isEqualTo("null");
+    }
+
+    @Test
+    public void convert_withNonEmptySet_returnsOrderedArrayString() {
+        Set data = Set.of("abcd", "abc", "abcd1", "1abcd","xyz", "1xyz", "0xyz");
+        String orderedData = gson.toJson(data, Set.class);
+        assertThat(orderedData).isEqualTo("[\"0xyz\",\"1abcd\",\"1xyz\",\"abc\",\"abcd\",\"abcd1\",\"xyz\"]");
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/GitStatusDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/dtos/GitStatusDTO.java
@@ -10,8 +10,14 @@ import java.util.Set;
 @Data
 public class GitStatusDTO {
 
-        // Name of modified, added and deleted resources for local git repo
+        // Name of modified, added and deleted resources in local git repo
         Set<String> modified;
+
+        // Name of added resources to local git repo
+        Set<String> added;
+
+        // Name of deleted resources from local git repo
+        Set<String> removed;
 
         // Name of conflicting resources
         Set<String> conflicting;
@@ -23,6 +29,12 @@ public class GitStatusDTO {
 
         // # of modified actions
         Long modifiedQueries;
+
+        // # of modified JSObjects
+        Long modifiedJSObjects;
+
+        // # of modified JSObjects
+        Long modifiedDatasources;
 
         // # of local commits which are not present in remote repo
         Integer aheadCount;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -131,8 +131,8 @@ public enum AppsmithError {
     GIT_FILE_SYSTEM_ERROR(503, 5013, "Error while accessing the file system. {0}", AppsmithErrorAction.DEFAULT, null, ErrorType.GIT_CONFIGURATION_ERROR, ErrorReferenceDocUrl.FILE_PATH_NOT_SET),
     GIT_EXECUTION_TIMEOUT(504, 5014, "Git command execution exceeded the maximum allowed time, please contact Appsmith support for more details", AppsmithErrorAction.DEFAULT, null, ErrorType.CONNECTIVITY_ERROR, null),
     INCOMPATIBLE_IMPORTED_JSON(400, 4045, "Provided file is incompatible, please upgrade your instance to resolve this conflict.", AppsmithErrorAction.DEFAULT, null, ErrorType.BAD_REQUEST, null),
-    GIT_MERGE_CONFLICTS(400, 4046, "Merge conflicts found: {1}", AppsmithErrorAction.DEFAULT, null, ErrorType.GIT_ACTION_EXECUTION_ERROR, ErrorReferenceDocUrl.GIT_MERGE_CONFLICT),
-    GIT_PULL_CONFLICTS(400, 4047, "Merge conflicts found during the pull operation: {1}", AppsmithErrorAction.DEFAULT, null, ErrorType.GIT_ACTION_EXECUTION_ERROR, ErrorReferenceDocUrl.GIT_MERGE_CONFLICT),
+    GIT_MERGE_CONFLICTS(400, 4046, "Merge conflicts found: {0}", AppsmithErrorAction.DEFAULT, null, ErrorType.GIT_ACTION_EXECUTION_ERROR, ErrorReferenceDocUrl.GIT_MERGE_CONFLICT),
+    GIT_PULL_CONFLICTS(400, 4047, "Merge conflicts found during the pull operation: {0}", AppsmithErrorAction.DEFAULT, null, ErrorType.GIT_ACTION_EXECUTION_ERROR, ErrorReferenceDocUrl.GIT_PULL_CONFLICT),
     SSH_KEY_GENERATION_ERROR(500, 5015, "Failed to generate SSH keys, please contact Appsmith support for more details", AppsmithErrorAction.DEFAULT, null, ErrorType.GIT_CONFIGURATION_ERROR, null),
     GIT_UPSTREAM_CHANGES(400, 4048, "Looks like there are pending upstream changes. To prevent you from losing history, we will pull the changes and push them to your repo.", AppsmithErrorAction.DEFAULT, null, ErrorType.GIT_ACTION_EXECUTION_ERROR, ErrorReferenceDocUrl.GIT_UPSTREAM_CHANGES),
     ;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CompareDslActionDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CompareDslActionDTO.java
@@ -1,0 +1,15 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.dtos.DslActionDTO;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+public class CompareDslActionDTO implements Comparator<DslActionDTO>, Serializable {
+    // Method to compare DslActionDTO based on id
+    @Override
+    public int compare(DslActionDTO action1, DslActionDTO action2)
+    {
+        return action1.getId().compareTo(action2.getId());
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CompareDslActionDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/CompareDslActionDTO.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.helpers;
 
 import com.appsmith.server.dtos.DslActionDTO;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -8,8 +9,11 @@ import java.util.Comparator;
 public class CompareDslActionDTO implements Comparator<DslActionDTO>, Serializable {
     // Method to compare DslActionDTO based on id
     @Override
-    public int compare(DslActionDTO action1, DslActionDTO action2)
-    {
-        return action1.getId().compareTo(action2.getId());
+    public int compare(DslActionDTO action1, DslActionDTO action2) {
+        if (action1 != null && !StringUtils.isEmpty(action1.getId())
+                && action2 != null && !StringUtils.isEmpty(action2.getId())) {
+            return action1.getId().compareTo(action2.getId());
+        }
+        return 1;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -12,6 +12,7 @@ import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.ActionDTO;
+import com.appsmith.server.dtos.DslActionDTO;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
@@ -30,6 +31,7 @@ import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -305,7 +307,10 @@ public class GitFileUtils {
         layout.setActionsUsedInDynamicBindings(null);
         layout.setMongoEscapedWidgetNames(null);
         if (!CollectionUtils.isNullOrEmpty(layout.getLayoutOnLoadActions())) {
-            layout.getLayoutOnLoadActions().forEach(layoutAction -> layoutAction.forEach(actionDTO -> actionDTO.setDefaultActionId(null)));
+            layout.getLayoutOnLoadActions().forEach(layoutAction -> layoutAction
+                    .stream()
+                    .sorted(Comparator.comparing(DslActionDTO::getId))
+                    .forEach(actionDTO -> actionDTO.setDefaultActionId(null)));
         }
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -31,12 +31,12 @@ import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.helpers.BeanCopyUtils.copyNestedNonNullProperties;
@@ -306,11 +306,16 @@ public class GitFileUtils {
         layout.setAllOnPageLoadActionEdges(null);
         layout.setActionsUsedInDynamicBindings(null);
         layout.setMongoEscapedWidgetNames(null);
+        List<Set<DslActionDTO>> layoutOnLoadActions = layout.getLayoutOnLoadActions();
         if (!CollectionUtils.isNullOrEmpty(layout.getLayoutOnLoadActions())) {
-            layout.getLayoutOnLoadActions().forEach(layoutAction -> layoutAction
-                    .stream()
-                    .sorted(Comparator.comparing(DslActionDTO::getId))
-                    .forEach(actionDTO -> actionDTO.setDefaultActionId(null)));
+            // Sort actions based on id to commit to git in ordered manner
+            for (int dslActionIndex = 0; dslActionIndex < layoutOnLoadActions.size(); dslActionIndex++) {
+                TreeSet<DslActionDTO> sortedActions = new TreeSet<>(new CompareDslActionDTO());
+                sortedActions.addAll(layoutOnLoadActions.get(dslActionIndex));
+                sortedActions
+                        .forEach(actionDTO -> actionDTO.setDefaultActionId(null));
+                layoutOnLoadActions.set(dslActionIndex, sortedActions);
+            }
         }
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CompareDslActionDTOTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/CompareDslActionDTOTest.java
@@ -1,0 +1,78 @@
+package com.appsmith.server.helpers;
+
+import com.appsmith.server.dtos.DslActionDTO;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CompareDslActionDTOTest {
+
+    List<String> sortedActionIds = new LinkedList<>();
+    TreeSet<DslActionDTO> orderedActionSet = new TreeSet<>(new CompareDslActionDTO());
+
+    @Test
+    public void convert_whenNullActionIds_returnsSetInInputOrder() {
+        DslActionDTO action1 = new DslActionDTO();
+        DslActionDTO action2 = new DslActionDTO();
+        action1.setName("testName");
+        action2.setName("testName2");
+        Set<DslActionDTO> unorderedSet = Set.of(action1, action2);
+        orderedActionSet.addAll(unorderedSet);
+        List<String> sortedActionNames = new LinkedList<>();
+        for (DslActionDTO dslActionDTO : orderedActionSet) {
+            sortedActionNames.add(dslActionDTO.getName());
+        }
+        List<String> actionNames = new LinkedList<>();
+        for (DslActionDTO dslActionDTO : unorderedSet) {
+            actionNames.add(dslActionDTO.getName());
+        }
+        assertThat(sortedActionNames).isEqualTo(actionNames);
+    }
+
+    @Test
+    public void convert_whenEmptyActionIdSet_returnsSetInInputOrder() {
+        DslActionDTO action1 = new DslActionDTO();
+        DslActionDTO action2 = new DslActionDTO();
+        action1.setId("");
+        action2.setId("abcd");
+        Set<DslActionDTO> actionSet = Set.of(action1, action2);
+        orderedActionSet.addAll(actionSet);
+        for (DslActionDTO dslActionDTO : orderedActionSet) {
+            sortedActionIds.add(dslActionDTO.getId());
+        }
+        List<String> actionIds = new LinkedList<>();
+        for (DslActionDTO dslActionDTO : actionSet) {
+            actionIds.add(dslActionDTO.getId());
+        }
+        // Two lists are defined to be equal if they contain the same elements in the same order.
+        assertThat(sortedActionIds).isEqualTo(actionIds);
+    }
+
+    @Test
+    public void convert_whenNonEmptySet_returnsOrderedResult() {
+        DslActionDTO action1 = new DslActionDTO();
+        DslActionDTO action2 = new DslActionDTO();
+        DslActionDTO action3 = new DslActionDTO();
+        DslActionDTO action4 = new DslActionDTO();
+        DslActionDTO action5 = new DslActionDTO();
+        DslActionDTO action6 = new DslActionDTO();
+        action1.setId("abc");
+        action2.setId("0abc");
+        action3.setId("1abc");
+        action4.setId("abc0");
+        action5.setId("abc1");
+        action6.setId("abcd");
+        Set<DslActionDTO> actionSet = Set.of(action1, action2, action3, action4, action5, action6);
+        orderedActionSet.addAll(actionSet);
+        for (DslActionDTO dslActionDTO : orderedActionSet) {
+            sortedActionIds.add(dslActionDTO.getId());
+        }
+        // Two lists are defined to be equal if they contain the same elements in the same order.
+        assertThat(sortedActionIds).isEqualTo(List.of("0abc", "1abc", "abc", "abc0", "abc1", "abcd"));
+    }
+}


### PR DESCRIPTION
## Description

> As Set is an unordered datatype, this is causing unnecessary changes to the file system during the commit operation even if the user has not altered anything since the last commit.

Fixes #10932

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> JUnit TC
> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
