### PR TITLE
fix: Rating Widget inactive-color.

### DIFF
--- a/app/client/src/widgets/RateWidget/component/index.tsx
+++ b/app/client/src/widgets/RateWidget/component/index.tsx
@@ -9,6 +9,7 @@ import { RateSize, RATE_SIZES } from "../constants";
 import TooltipComponent from "components/ads/Tooltip";
 import { disable } from "constants/DefaultTheme";
 import { ComponentProps } from "widgets/BaseComponent";
+import { Colors } from "constants/Colors";
 
 /*
   Note:
@@ -135,7 +136,7 @@ function RateComponent(props: RateComponentProps) {
       <Rating
         emptySymbol={
           <Star
-            color={inactiveColor}
+            color={inactiveColor || Colors.ALTO_3}
             icon={IconNames.STAR}
             iconSize={RATE_SIZES[size]}
           />


### PR DESCRIPTION
## Description
- The Rating widget has 2 color properties - active color & inactive color. When we select the value "No color", both activeColor & inactiveColor props receive no value and default to black color for both states.
- My solution was to default to the - #D6D6D6 color when we pass "No color" for the inactive value rather than the browser's default black color, if the user wants black for the inactive value he can simple choose black from the color-picker.

Fixes #10766

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Tested Manually on the Canvas.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/10766-rating-inactive-color 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 54.99 **(0)** | 36.31 **(-0.01)** | 34.68 **(0)** | 55.37 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/widgets/RateWidget/component/index.tsx | 34.21 **(1.78)** | 16.67 **(-1.51)** | 0 **(0)** | 39.39 **(1.89)**</details>