### PR TITLE
fix: rating widgets flickering when value is reduced.

### DIFF
--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -246,11 +246,23 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
     return (
       (this.props.rate || this.props.rate === 0) && (
         <RateComponent
+          activeColor={this.props.activeColor}
+          bottomRow={this.props.bottomRow}
+          inactiveColor={this.props.inactiveColor}
+          isAllowHalf={this.props.isAllowHalf}
+          isDisabled={this.props.isDisabled}
+          isLoading={this.props.isLoading}
+          key={this.props.widgetId}
+          leftColumn={this.props.leftColumn}
+          maxCount={this.props.maxCount}
           onValueChanged={this.valueChangedHandler}
           readonly={this.props.isDisabled}
+          rightColumn={this.props.rightColumn}
+          size={this.props.size}
+          tooltips={this.props.tooltips}
+          topRow={this.props.topRow}
           value={this.props.rate}
-          {...this.props}
-          key={this.props.widgetId}
+          widgetId={this.props.widgetId}
         />
       )
     );


### PR DESCRIPTION
## Description
- When we change the value of the Rating widget we can see the stars flicker (flash).
- This was due to the value prop override caused by spreading `{...this.props}`. Thanks @sbalaji1192 for the insights on derived properties.

Fixes #10697 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Tested Manually on the Canvas.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>