### PR TITLE
fix: Remove references of messages.ts in worker files

### DIFF
--- a/app/client/src/constants/messages.ts
+++ b/app/client/src/constants/messages.ts
@@ -1001,12 +1001,3 @@ export const CONTEXT_MOVE = () => "Move to page";
 export const CONTEXT_COPY = () => "Copy to page";
 export const CONTEXT_DELETE = () => "Delete";
 export const CONTEXT_NO_PAGE = () => "No pages";
-
-// Validations
-export const VALIDATION_ARRAY_UNIQUE = () =>
-  "Array must be unique. Duplicate values found";
-export const VALIDATION_ARRAY_DUPLICATE_PROPERTY_VALUES = () =>
-  "Duplicate values found for the following properties, in the array entries, that must be unique --";
-export const VALIDATION_ARRAY_DISALLOWED_VALUE = () =>
-  "Value is not allowed in this array";
-export const VALIDATION_ARRAY_INVALID_ENTRY = () => "Invalid entry at index:";

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -24,13 +24,7 @@ import evaluate from "./evaluate";
 
 import getIsSafeURL from "utils/validation/getIsSafeURL";
 import * as log from "loglevel";
-import { QueryActionConfig } from "entities/Action";
-import {
-  VALIDATION_ARRAY_DISALLOWED_VALUE,
-  VALIDATION_ARRAY_DUPLICATE_PROPERTY_VALUES,
-  VALIDATION_ARRAY_INVALID_ENTRY,
-  VALIDATION_ARRAY_UNIQUE,
-} from "constants/messages";
+
 import { findDuplicateIndex } from "./helpers";
 export const UNDEFINED_VALIDATION = "UNDEFINED_VALIDATION";
 export const VALIDATION_ERROR_COUNT_THRESHOLD = 10;
@@ -176,7 +170,9 @@ function validateArray(
       return {
         isValid: false,
         parsed: config.params?.default || [],
-        messages: [`${VALIDATION_ARRAY_UNIQUE()} at index: ${duplicateIndex}`],
+        messages: [
+          `Array must be unique. Duplicate values found at index: ${duplicateIndex}`,
+        ],
       };
     }
   }
@@ -199,7 +195,7 @@ function validateArray(
         isValid: false,
         parsed: config.params?.default || [],
         messages: [
-          `${VALIDATION_ARRAY_DUPLICATE_PROPERTY_VALUES()} ${uniqueKeys.join(
+          `Duplicate values found for the following properties, in the array entries, that must be unique -- ${uniqueKeys.join(
             ",",
           )}.`,
         ],
@@ -211,7 +207,7 @@ function validateArray(
   value.every((entry, index) => {
     // Validate for allowed values
     if (shouldVerifyAllowedValues && !allowedValues.has(entry)) {
-      _messages.push(`${VALIDATION_ARRAY_DISALLOWED_VALUE()}: ${entry}`);
+      _messages.push(`Value is not allowed in this array: ${entry}`);
       _isValid = false;
     }
 
@@ -228,9 +224,7 @@ function validateArray(
       if (!childValidationResult.isValid) {
         _isValid = false;
         childValidationResult.messages?.forEach((message) =>
-          _messages.push(
-            `${VALIDATION_ARRAY_INVALID_ENTRY()} ${index}. ${message}`,
-          ),
+          _messages.push(`Invalid entry at index: ${index}. ${message}`),
         );
       }
     }


### PR DESCRIPTION
## Description

[`$RefreshReg$`](https://stackoverflow.com/questions/66472945/referenceerror-refreshreg-is-not-defined) issue shows up in the browsers log, when running the application using `yarn start`

This was introduced in #10886 ( mea culpa 😞 )

To fix this we need to remove all references to `messages.ts` from the files in the worker folder. This is until a proper fix that allows this reference is figured.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Existing tests must pass for this to be valid

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
