### PR TITLE
fix: Added stricter validation for Mongo pipeline

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Aggregate.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/Aggregate.java
@@ -75,6 +75,13 @@ public class Aggregate extends MongoCommand {
             }
         } else {
             // The command expects the pipelines to be sent in an array. Parse and create a single element array
+
+            // check for enclosing curly bracket to make json validation more strict
+            final String jsonObject = this.pipeline.trim();
+            if (jsonObject.charAt(jsonObject.length() - 1) != '}') {
+                throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "Pipeline stage is not a valid JSON object.");
+            }
+
             Document document = parseSafely("Array of Pipelines", this.pipeline);
             ArrayList<Document> documentArrayList = new ArrayList<>();
             documentArrayList.add(document);


### PR DESCRIPTION
## Description



Fixes #5326, by making JSON string validation more strict.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test case is added [testAggregateCommandWithInvalidQuery](https://github.com/appsmithorg/appsmith/blob/9d8d980b356dab2d109bbc047b5c021d8d0de4f5/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java#L1441)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
