### PR TITLE
feat: Self-signed certificates for REST APIs

### DIFF
--- a/app/client/src/entities/Datasource/RestAPIForm.ts
+++ b/app/client/src/entities/Datasource/RestAPIForm.ts
@@ -8,6 +8,11 @@ export enum AuthType {
   bearerToken = "bearerToken",
 }
 
+export enum SSLType {
+  DEFAULT = "DEFAULT",
+  SELF_SIGNED_CERTIFICATE = "SELF_SIGNED_CERTIFICATE",
+}
+
 export enum ApiKeyAuthType {
   QueryParams = "queryParams",
   Header = "header",
@@ -25,6 +30,20 @@ export type Authentication =
   | ApiKey
   | BearerToken;
 
+export interface Connection {
+  ssl: SSL;
+}
+
+export interface SSL {
+  authType: SSLType;
+  certificateFile: Certificate;
+}
+
+export interface Certificate {
+  name: string;
+  base64Content: string | ArrayBuffer | null;
+}
+
 export interface ApiDatasourceForm {
   datasourceId: string;
   pluginId: string;
@@ -37,6 +56,7 @@ export interface ApiDatasourceForm {
   sessionSignatureKey: string;
   authType: AuthType;
   authentication?: Authentication;
+  connection?: Connection;
 }
 
 export interface Oauth2Common {

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -38,6 +38,7 @@ import {
   ApiKeyAuthType,
   AuthType,
   GrantType,
+  SSLType,
 } from "entities/Datasource/RestAPIForm";
 import {
   createMessage,
@@ -457,8 +458,46 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
           )}
         </FormInputContainer>
         {this.renderAuthFields()}
+        <FormInputContainer data-replay-id={btoa("ssl")}>
+          {this.renderDropdownControlViaFormControl(
+            "connection.ssl.authType",
+            [
+              {
+                label: "No",
+                value: "DEFAULT",
+              },
+              {
+                label: "Yes",
+                value: "SELF_SIGNED_CERTIFICATE",
+              },
+            ],
+            "Use Self-signed certificate",
+            "",
+            true,
+            "",
+            "DEFAULT",
+          )}
+        </FormInputContainer>
+        {this.renderSelfSignedCertificateFields()}
       </>
     );
+  };
+
+  renderSelfSignedCertificateFields = () => {
+    const { connection } = this.props.formData;
+    if (connection?.ssl.authType === SSLType.SELF_SIGNED_CERTIFICATE) {
+      return (
+        <Collapsible defaultIsOpen title="Certificate Details">
+          {this.renderFilePickerControlViaFormControl(
+            "connection.ssl.certificateFile",
+            "Upload Certificate",
+            "",
+            false,
+            true,
+          )}
+        </Collapsible>
+      );
+    }
   };
 
   renderAuthFields = () => {
@@ -877,6 +916,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
     placeholderText: string,
     isRequired: boolean,
     subtitle?: string,
+    initialValue?: any,
   ) {
     const config = {
       id: "",
@@ -890,6 +930,7 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
       conditionals: {},
       placeholderText: placeholderText,
       formName: DATASOURCE_REST_API_FORM,
+      initialValue: initialValue,
     };
     return (
       <FormControl
@@ -912,6 +953,34 @@ class DatasourceRestAPIEditor extends React.Component<Props> {
       isValid: false,
       controlType: "KEYVALUE_ARRAY",
       placeholderText: placeholderText,
+      label: label,
+      conditionals: {},
+      formName: DATASOURCE_REST_API_FORM,
+      isRequired: isRequired,
+    };
+    return (
+      <FormControl
+        config={config}
+        formName={DATASOURCE_REST_API_FORM}
+        multipleConfig={[]}
+      />
+    );
+  }
+
+  renderFilePickerControlViaFormControl(
+    configProperty: string,
+    label: string,
+    placeholderText: string,
+    isRequired: boolean,
+    encrypted: boolean,
+  ) {
+    const config = {
+      id: "",
+      configProperty: configProperty,
+      isValid: false,
+      controlType: "FILE_PICKER",
+      placeholderText: placeholderText,
+      encrypted: encrypted,
       label: label,
       conditionals: {},
       formName: DATASOURCE_REST_API_FORM,

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -11,6 +11,7 @@ import {
   Basic,
   ApiKey,
   BearerToken,
+  SSLType,
 } from "entities/Datasource/RestAPIForm";
 import _ from "lodash";
 
@@ -22,6 +23,11 @@ export const datasourceToFormValues = (
     "datasourceConfiguration.authentication.authenticationType",
     AuthType.NONE,
   );
+  const connection = _.get(datasource, "datasourceConfiguration.connection", {
+    ssl: {
+      authType: SSLType.DEFAULT,
+    },
+  });
   const authentication = datasourceToFormAuthentication(authType, datasource);
   const isSendSessionEnabled =
     _.get(datasource, "datasourceConfiguration.properties[0].value", "N") ===
@@ -43,6 +49,7 @@ export const datasourceToFormValues = (
     sessionSignatureKey: sessionSignatureKey,
     authType: authType,
     authentication: authentication,
+    connection: connection,
   };
 };
 
@@ -69,6 +76,7 @@ export const formValuesToDatasource = (
         { key: "sessionSignatureKey", value: form.sessionSignatureKey },
       ],
       authentication: authentication,
+      connection: form.connection,
     },
   } as Datasource;
 };

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/ExceptionHelper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/ExceptionHelper.java
@@ -1,0 +1,14 @@
+package com.appsmith.external.helpers;
+
+public class ExceptionHelper {
+
+    public static Throwable getRootCause(Throwable e) {
+        Throwable cause = null;
+        Throwable result = e;
+
+        while (null != (cause = result.getCause()) && (result != cause)) {
+            result = cause;
+        }
+        return result;
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/SSLHelper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/SSLHelper.java
@@ -1,0 +1,53 @@
+package com.appsmith.external.helpers;
+
+import com.appsmith.external.models.UploadedFile;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+public class SSLHelper {
+
+    private static final String X_509_TYPE = "X.509";
+    private static final String CERT_ALIAS = "caCert";
+    private static final String SSL_PROTOCOL = "TLS";
+
+    public static SSLContext getSslContext(UploadedFile certificate)
+            throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException, KeyManagementException {
+
+        final TrustManagerFactory trustManagerFactory = getSslTrustManagerFactory(certificate);
+
+        SSLContext sslContext = SSLContext.getInstance(SSL_PROTOCOL);
+        sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+
+        return sslContext;
+    }
+
+    public static TrustManagerFactory getSslTrustManagerFactory(UploadedFile certificate)
+            throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+        InputStream certificateIs =
+                new ByteArrayInputStream(certificate.getDecodedContent());
+        CertificateFactory certificateFactory = CertificateFactory.getInstance(X_509_TYPE);
+        X509Certificate caCertificate =
+                (X509Certificate) certificateFactory.generateCertificate(certificateIs);
+
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null);
+        keyStore.setCertificateEntry(CERT_ALIAS, caCertificate);
+
+        TrustManagerFactory trustManagerFactory =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(keyStore);
+
+        return trustManagerFactory;
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionExecutionResult.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionExecutionResult.java
@@ -2,6 +2,7 @@ package com.appsmith.external.models;
 
 import com.appsmith.external.exceptions.BaseException;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.helpers.ExceptionHelper;
 import com.appsmith.external.plugins.AppsmithPluginErrorUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
@@ -56,6 +57,6 @@ public class ActionExecutionResult {
     }
 
     public void setErrorInfo(Throwable error) {
-        this.setErrorInfo(error, null);
+        this.setErrorInfo(ExceptionHelper.getRootCause(error), null);
     }
 }

--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/SSLUtils.java
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/java/com/external/utils/SSLUtils.java
@@ -2,52 +2,19 @@ package com.external.utils;
 
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.helpers.SSLHelper;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.SSLDetails;
 import com.arangodb.ArangoDB.Builder;
 import org.pf4j.util.StringUtils;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.security.KeyManagementException;
-import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 
 public class SSLUtils {
-
-    private static final String X_509_TYPE = "X.509";
-    private static final String CERT_ALIAS = "caCert";
-    private static final String SSL_PROTOCOL = "TLS";
-
-    public static SSLContext getSslContext(DatasourceConfiguration datasourceConfiguration) throws CertificateException
-            , KeyStoreException, IOException, NoSuchAlgorithmException, KeyManagementException {
-        InputStream certificateIs =
-                new ByteArrayInputStream(datasourceConfiguration.getConnection().getSsl()
-                        .getCaCertificateFile().getDecodedContent());
-        CertificateFactory certificateFactory = CertificateFactory.getInstance(X_509_TYPE);
-        X509Certificate caCertificate =
-                (X509Certificate) certificateFactory.generateCertificate(certificateIs);
-
-        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keyStore.load(null);
-        keyStore.setCertificateEntry(CERT_ALIAS, caCertificate);
-
-        TrustManagerFactory trustManagerFactory =
-                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        trustManagerFactory.init(keyStore);
-
-        SSLContext sslContext = SSLContext.getInstance(SSL_PROTOCOL);
-        sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
-
-        return sslContext;
-    }
 
     public static boolean isCaCertificateAvailable(DatasourceConfiguration datasourceConfiguration) {
         if (datasourceConfiguration.getConnection() != null
@@ -97,7 +64,7 @@ public class SSLUtils {
             case FILE:
             case BASE64_STRING:
                 try {
-                    builder.sslContext(getSslContext(datasourceConfiguration));
+                    builder.sslContext(SSLHelper.getSslContext(datasourceConfiguration.getConnection().getSsl().getCaCertificateFile()));
                 } catch (CertificateException | KeyStoreException | IOException | NoSuchAlgorithmException
                         | KeyManagementException e) {
                     throw new AppsmithPluginException(

--- a/app/server/appsmith-plugins/restApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/restApiPlugin/pom.xml
@@ -134,6 +134,10 @@
             <version>5.2.3.RELEASE</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/app/server/appsmith-plugins/restApiPlugin/pom.xml
+++ b/app/server/appsmith-plugins/restApiPlugin/pom.xml
@@ -137,6 +137,7 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -5,6 +5,7 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.helpers.DataTypeStringUtils;
 import com.appsmith.external.helpers.MustacheHelper;
+import com.appsmith.external.helpers.SSLHelper;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionRequest;
 import com.appsmith.external.models.ActionExecutionResult;
@@ -13,6 +14,8 @@ import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.PaginationField;
 import com.appsmith.external.models.PaginationType;
 import com.appsmith.external.models.Property;
+import com.appsmith.external.models.SSLDetails;
+import com.appsmith.external.models.UploadedFile;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.external.plugins.SmartSubstitutionInterface;
@@ -40,6 +43,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -48,6 +52,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.tcp.DefaultSslContextSpec;
 import reactor.util.function.Tuple2;
 
 import javax.crypto.SecretKey;
@@ -57,6 +64,9 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -270,7 +280,32 @@ public class RestApiPlugin extends BasePlugin {
             }
 
             // Initializing webClient to be used for http call
-            WebClient.Builder webClientBuilder = WebClient.builder();
+            final ConnectionProvider provider = ConnectionProvider
+                    .builder("rest-api-provider")
+                    .build();
+
+            HttpClient httpClient = HttpClient.create(provider)
+                    .secure(sslContextSpec -> {
+
+                        final DefaultSslContextSpec sslContextSpec1 = DefaultSslContextSpec.forClient();
+
+                        if (datasourceConfiguration.getConnection() != null &&
+                                datasourceConfiguration.getConnection().getSsl() != null &&
+                                datasourceConfiguration.getConnection().getSsl().getAuthType() == SSLDetails.AuthType.SELF_SIGNED_CERTIFICATE) {
+
+                            sslContextSpec1.configure(sslContextBuilder -> {
+                                try {
+                                    final UploadedFile certificateFile = datasourceConfiguration.getConnection().getSsl().getCertificateFile();
+                                    sslContextBuilder.trustManager(SSLHelper.getSslTrustManagerFactory(certificateFile));
+                                } catch (CertificateException | KeyStoreException | IOException | NoSuchAlgorithmException e) {
+                                    e.printStackTrace();
+                                }
+                            });
+                        }
+                        sslContextSpec.sslContext(sslContextSpec1);
+                    });
+
+            WebClient.Builder webClientBuilder = WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient));
 
             // Adding headers from datasource
             if (datasourceConfiguration.getHeaders() != null) {


### PR DESCRIPTION
## Description

Enabled use of self-signed certificates for REST APIs. We're expected to create a datasource for all APIs that need this feature. Addition is non-intrusive to existing actions because of null check and exact value checks.

I've also updated the error handling to always go to the root of the exception since that might help us debug issues more easily. Might want to take up handling different types of errors to give more sensible messages in a separate issue.

<img width="408" alt="Screenshot 2022-02-09 at 4 35 56 PM" src="https://user-images.githubusercontent.com/5298848/153186059-aaa2f8d8-e2bd-4a39-a263-4493fa223e53.png">


https://user-images.githubusercontent.com/5298848/153184897-b5d78a15-3a59-4c53-b128-e826cdf00278.mov

Fixes #4608 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?
- Manually tested since we haven't mocked out client yet. Should invest in this infra soon

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/self-signed-certs-for-rest 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.43 **(-0.01)** | 36.99 **(-0.01)** | 35.3 **(0)** | 55.81 **(-0.01)**
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx | 24.66 **(-0.34)** | 13.51 **(-0.57)** | 2.56 **(-0.14)** | 27.18 **(-0.48)**
 :red_circle: | app/client/src/transformers/RestAPIDatasourceFormTransformer.ts | 14.67 **(-0.19)** | 0 **(0)** | 0 **(0)** | 13.43 **(-0.21)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>