### PR TITLE
chore: Add a new section in PR template for how-to apps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,11 @@ Fixes # (issue)
 - Test A
 - Test B
 
+## Suggested How-to Apps
+
+> Please suggest couple ideas for how-to apps, to help us better explain the usability of this feature/bug to the community.
+> e.g. - How to populate table from query response
+
 ## Checklist:
 
 - [ ] My code follows the style guidelines of this project


### PR DESCRIPTION
Adding this section to proactively create related community how-to apps for obvious cases.

@mohanarpit can we add a label to the PR automatically, if contributor has listed some scenarios?