### PR TITLE
fix: Spacing for encrypted tag for form control

### DIFF
--- a/app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx
+++ b/app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx
@@ -123,6 +123,12 @@ const StyledFormLabel = styled.label<{ config?: ControlProps }>`
   }
 `;
 
+const FormEncrytedSection = styled.div`
+  display: flex;
+  margin-left: 12px;
+  align-items: center;
+`;
+
 interface FormLabelProps {
   config?: ControlProps;
   children: JSX.Element | React.ReactNode;
@@ -150,4 +156,5 @@ export {
   FormInputHelperText,
   FormInfoText,
   FormSubtitleText,
+  FormEncrytedSection,
 };

--- a/app/client/src/pages/Editor/FormControl.tsx
+++ b/app/client/src/pages/Editor/FormControl.tsx
@@ -13,6 +13,7 @@ import {
   FormInfoText,
   FormSubtitleText,
   FormInputSwitchToJsonButton,
+  FormEncrytedSection,
 } from "components/editorComponents/form/fields/StyledFormComponents";
 import { FormIcons } from "icons/FormIcons";
 import { AppState } from "reducers";
@@ -153,12 +154,12 @@ function renderFormConfigTop(props: { config: ControlProps }) {
           <p className="label-icon-wrapper">
             {label} {isRequired && "*"}{" "}
             {encrypted && (
-              <>
+              <FormEncrytedSection>
                 <FormIcons.LOCK_ICON height={12} keepColors width={12} />
                 <FormSubtitleText config={props.config}>
                   Encrypted
                 </FormSubtitleText>
-              </>
+              </FormEncrytedSection>
             )}
             {tooltipText && (
               <Tooltip content={tooltipText} hoverOpenDelay={1000}>


### PR DESCRIPTION


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/encryted-tage-form-spacing 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx | 67.86 **(2.48)** | 17.39 **(1.83)** | 0 **(0)** | 67.86 **(2.48)**</details>