### PR TITLE
chore: Add stopwatch to log execution time by process name

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.git.helpers;
 
 import com.appsmith.external.git.FileInterface;
 import com.appsmith.external.git.GitExecutor;
+import com.appsmith.external.helpers.Stopwatch;
 import com.appsmith.external.models.ApplicationGitReference;
 import com.appsmith.external.models.DatasourceStructure;
 import com.appsmith.git.configurations.GitServiceConfig;
@@ -80,6 +81,7 @@ public class FileUtilsImpl implements FileInterface {
         // Repo path will be:
         // baseRepo : root/orgId/defaultAppId/repoName/{applicationData}
         // Checkout to mentioned branch if not already checked-out
+        Stopwatch processStopwatch = new Stopwatch("FS application save");
         return gitExecutor.resetToLastCommit(baseRepoSuffix, branchName)
                 .then(gitExecutor.checkoutToBranch(baseRepoSuffix, branchName))
                 .flatMap(isSwitched -> {
@@ -159,6 +161,7 @@ public class FileUtilsImpl implements FileInterface {
                     if (!applicationGitReference.getDatasources().isEmpty()) {
                         scanAndDeleteFileForDeletedResources(validFileNames, baseRepo.resolve(DATASOURCE_DIRECTORY));
                     }
+                    processStopwatch.stopAndLogTimeInMillis();
                     return Mono.just(baseRepo);
                 });
     }
@@ -233,6 +236,7 @@ public class FileUtilsImpl implements FileInterface {
                                                                                     String repoName,
                                                                                     String branchName) {
 
+        Stopwatch processStopwatch = new Stopwatch("FS reconstruct application");
         Path baseRepoSuffix = Paths.get(organisationId, defaultApplicationId, repoName);
         ApplicationGitReference applicationGitReference = new ApplicationGitReference();
 
@@ -266,6 +270,7 @@ public class FileUtilsImpl implements FileInterface {
                     // Extract datasources
                     applicationGitReference.setDatasources(readFiles(baseRepoPath.resolve(DATASOURCE_DIRECTORY), gson));
 
+                    processStopwatch.stopAndLogTimeInMillis();
                     return applicationGitReference;
                 });
     }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
@@ -395,7 +395,7 @@ public class GitExecutorImpl implements GitExecutor {
                                                  String privateKey,
                                                  String publicKey,
                                                  Boolean refreshBranches) {
-        Stopwatch processStopwatch = new Stopwatch("JGIT listBranches");
+        Stopwatch processStopwatch = new Stopwatch("JGIT listBranches, refreshBranch: " + refreshBranches);
         Path baseRepoPath = createRepoPath(repoSuffix);
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": Get branches for the application " + repoSuffix);

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
@@ -6,6 +6,7 @@ import com.appsmith.external.dtos.GitLogDTO;
 import com.appsmith.external.dtos.GitStatusDTO;
 import com.appsmith.external.dtos.MergeStatusDTO;
 import com.appsmith.external.git.GitExecutor;
+import com.appsmith.external.helpers.Stopwatch;
 import com.appsmith.git.configurations.GitServiceConfig;
 import com.appsmith.git.constants.AppsmithBotAsset;
 import com.appsmith.git.constants.Constraint;
@@ -86,6 +87,7 @@ public class GitExecutorImpl implements GitExecutor {
 
         final String finalAuthorName = StringUtils.isEmptyOrNull(authorName) ? AppsmithBotAsset.APPSMITH_BOT_USERNAME : authorName;
         final String finalAuthorEmail = StringUtils.isEmptyOrNull(authorEmail) ? AppsmithBotAsset.APPSMITH_BOT_EMAIL : authorEmail;
+        Stopwatch processStopwatch = new Stopwatch("JGIT commit");
         return Mono.fromCallable(() -> {
             log.debug("Trying to commit to local repo path, {}", path);
             Path repoPath = path;
@@ -107,6 +109,7 @@ public class GitExecutorImpl implements GitExecutor {
                         .setAuthor(finalAuthorName, finalAuthorEmail)
                         .setCommitter(finalAuthorName, finalAuthorEmail)
                         .call();
+                processStopwatch.stopAndLogTimeInMillis();
                 return "Committed successfully!";
             }
         })
@@ -135,6 +138,7 @@ public class GitExecutorImpl implements GitExecutor {
      */
     @Override
     public Mono<List<GitLogDTO>> getCommitHistory(Path repoSuffix) {
+        Stopwatch processStopwatch = new Stopwatch("JGIT commit history");
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": get commit history for  " + repoSuffix);
             List<GitLogDTO> commitLogs = new ArrayList<>();
@@ -150,8 +154,10 @@ public class GitExecutorImpl implements GitExecutor {
                             revCommit.getFullMessage(),
                             ISO_FORMATTER.format(new Date(revCommit.getCommitTime() * 1000L).toInstant())
                     );
+                    processStopwatch.stopAndLogTimeInMillis();
                     commitLogs.add(gitLog);
                 });
+
                 return commitLogs;
             }
         })
@@ -179,6 +185,7 @@ public class GitExecutorImpl implements GitExecutor {
                                         String branchName) {
         // We can safely assume that repo has been already initialised either in commit or clone flow and can directly
         // open the repo
+        Stopwatch processStopwatch = new Stopwatch("JGIT push");
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": pushing changes to remote " + remoteUrl);
             // open the repo
@@ -197,6 +204,7 @@ public class GitExecutorImpl implements GitExecutor {
                         );
                 // We can support username and password in future if needed
                 // pushCommand.setCredentialsProvider(new UsernamePasswordCredentialsProvider("username", "password"));
+                processStopwatch.stopAndLogTimeInMillis();
                 return result.substring(0, result.length() - 1);
             }
         })
@@ -218,6 +226,7 @@ public class GitExecutorImpl implements GitExecutor {
                            String privateKey,
                            String publicKey) {
 
+        Stopwatch processStopwatch = new Stopwatch("JGIT clone");
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": Cloning the repo from the remote " + remoteUrl);
             final TransportConfigCallback transportConfigCallback = new SshTransportConfigCallback(privateKey, publicKey);
@@ -234,8 +243,8 @@ public class GitExecutorImpl implements GitExecutor {
             String branchName = git.getRepository().getBranch();
 
             repositoryHelper.updateRemoteBranchTrackingConfig(branchName, git);
-
             git.close();
+            processStopwatch.stopAndLogTimeInMillis();
             return branchName;
         })
         .timeout(Duration.ofMillis(Constraint.REMOTE_TIMEOUT_MILLIS))
@@ -246,6 +255,7 @@ public class GitExecutorImpl implements GitExecutor {
     public Mono<String> createAndCheckoutToBranch(Path repoSuffix, String branchName) {
         // We can safely assume that repo has been already initialised either in commit or clone flow and can directly
         // open the repo
+        Stopwatch processStopwatch = new Stopwatch("JGIT createBranch");
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": Creating branch  " + branchName + "for the repo " + repoSuffix);
             // open the repo
@@ -259,6 +269,7 @@ public class GitExecutorImpl implements GitExecutor {
                         .call();
 
                 repositoryHelper.updateRemoteBranchTrackingConfig(branchName, git);
+                processStopwatch.stopAndLogTimeInMillis();
                 return git.getRepository().getBranch();
             }
         })
@@ -270,6 +281,7 @@ public class GitExecutorImpl implements GitExecutor {
     public Mono<Boolean> deleteBranch(Path repoSuffix, String branchName) {
         // We can safely assume that repo has been already initialised either in commit or clone flow and can directly
         // open the repo
+        Stopwatch processStopwatch = new Stopwatch("JGIT deleteBranch");
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": Deleting branch  " + branchName + "for the repo " + repoSuffix);
             // open the repo
@@ -280,6 +292,7 @@ public class GitExecutorImpl implements GitExecutor {
                         .setBranchNames(branchName)
                         .setForce(Boolean.TRUE)
                         .call();
+                processStopwatch.stopAndLogTimeInMillis();
                 if(deleteBranchList.isEmpty()) {
                     return Boolean.FALSE;
                 }
@@ -293,6 +306,7 @@ public class GitExecutorImpl implements GitExecutor {
     @Override
     public Mono<Boolean> checkoutToBranch(Path repoSuffix, String branchName) {
 
+        Stopwatch processStopwatch = new Stopwatch("JGIT checkoutBranch");
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": Switching to the branch " + branchName);
             // We can safely assume that repo has been already initialised either in commit or clone flow and can directly
@@ -309,6 +323,7 @@ public class GitExecutorImpl implements GitExecutor {
                         .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.SET_UPSTREAM)
                         .call()
                         .getName();
+                processStopwatch.stopAndLogTimeInMillis();
                 return StringUtils.equalsIgnoreCase(checkedOutBranch, "refs/heads/"+branchName);
             }
         })
@@ -322,7 +337,10 @@ public class GitExecutorImpl implements GitExecutor {
                                                 String branchName,
                                                 String privateKey,
                                                 String publicKey) throws IOException {
+
+        Stopwatch processStopwatch = new Stopwatch("JGIT pull");
         TransportConfigCallback transportConfigCallback = new SshTransportConfigCallback(privateKey, publicKey);
+
         try (Git git = Git.open(createRepoPath(repoSuffix).toFile())) {
             return Mono.fromCallable(() -> {
                 log.debug(Thread.currentThread().getName() + ": Pull changes from remote  " + remoteUrl + " for the branch "+ branchName);
@@ -351,8 +369,10 @@ public class GitExecutorImpl implements GitExecutor {
                         //On merge conflicts abort the merge => git merge --abort
                         git.getRepository().writeMergeCommitMsg(null);
                         git.getRepository().writeMergeHeads(null);
+                        processStopwatch.stopAndLogTimeInMillis();
                         throw new org.eclipse.jgit.errors.CheckoutConflictException(mergeConflictFiles.toString());
                     }
+                    processStopwatch.stopAndLogTimeInMillis();
                     return mergeStatus;
             })
             .onErrorResume(error -> {
@@ -375,6 +395,7 @@ public class GitExecutorImpl implements GitExecutor {
                                                  String privateKey,
                                                  String publicKey,
                                                  Boolean refreshBranches) {
+        Stopwatch processStopwatch = new Stopwatch("JGIT listBranches");
         Path baseRepoPath = createRepoPath(repoSuffix);
         return Mono.fromCallable(() -> {
             log.debug(Thread.currentThread().getName() + ": Get branches for the application " + repoSuffix);
@@ -412,6 +433,7 @@ public class GitExecutorImpl implements GitExecutor {
                 }
             }
             git.close();
+            processStopwatch.stopAndLogTimeInMillis();
             return branchList;
         })
         .timeout(Duration.ofMillis(Constraint.REMOTE_TIMEOUT_MILLIS))
@@ -427,6 +449,7 @@ public class GitExecutorImpl implements GitExecutor {
      */
     @Override
     public Mono<GitStatusDTO> getStatus(Path repoPath, String branchName) {
+        Stopwatch processStopwatch = new Stopwatch("JGIT status");
         return Mono.fromCallable(() -> {
             try (Git git = Git.open(repoPath.toFile())) {
                 log.debug(Thread.currentThread().getName() + ": Get status for repo  " + repoPath + ", branch " + branchName);
@@ -479,8 +502,12 @@ public class GitExecutorImpl implements GitExecutor {
                 // Remove modified changes from current branch so that checkout to other branches will be possible
                 if (!status.isClean()) {
                     return resetToLastCommit(git)
-                            .thenReturn(response);
+                            .map(ref -> {
+                                processStopwatch.stopAndLogTimeInMillis();
+                                return response;
+                            });
                 }
+                processStopwatch.stopAndLogTimeInMillis();
                 return Mono.just(response);
             }
         })
@@ -492,6 +519,7 @@ public class GitExecutorImpl implements GitExecutor {
     @Override
     public Mono<String> mergeBranch(Path repoSuffix, String sourceBranch, String destinationBranch) {
         return Mono.fromCallable(() -> {
+            Stopwatch processStopwatch = new Stopwatch("JGIT merge");
             log.debug(Thread.currentThread().getName() + ": Merge branch  " + sourceBranch + " on " + destinationBranch);
             try (Git git = Git.open(createRepoPath(repoSuffix).toFile())) {
                 try {
@@ -499,11 +527,13 @@ public class GitExecutorImpl implements GitExecutor {
                     git.checkout().setName(destinationBranch).setCreateBranch(false).call();
 
                     MergeResult mergeResult = git.merge().include(git.getRepository().findRef(sourceBranch)).setStrategy(MergeStrategy.RECURSIVE).call();
+                    processStopwatch.stopAndLogTimeInMillis();
                     return mergeResult.getMergeStatus().name();
                 } catch (GitAPIException e) {
                     //On merge conflicts abort the merge => git merge --abort
                     git.getRepository().writeMergeCommitMsg(null);
                     git.getRepository().writeMergeHeads(null);
+                    processStopwatch.stopAndLogTimeInMillis();
                     throw new Exception(e);
                 }
             }
@@ -523,16 +553,19 @@ public class GitExecutorImpl implements GitExecutor {
 
     @Override
     public Mono<String> fetchRemote(Path repoSuffix, String publicKey, String privateKey, boolean isRepoPath) {
+        Stopwatch processStopwatch = new Stopwatch("JGIT fetch");
         Path repoPath = Boolean.TRUE.equals(isRepoPath) ? repoSuffix : createRepoPath(repoSuffix);
         return Mono.fromCallable(() -> {
             TransportConfigCallback config = new SshTransportConfigCallback(privateKey, publicKey);
             try (Git git = Git.open(repoPath.toFile())) {
                 log.debug(Thread.currentThread().getName() + ": fetch remote repo " + git.getRepository());
-                return git.fetch()
+                String fetchMessages = git.fetch()
                         .setRemoveDeletedRefs(true)
                         .setTransportConfigCallback(config)
                         .call()
                         .getMessages();
+                processStopwatch.stopAndLogTimeInMillis();
+                return fetchMessages;
             }
         })
         .onErrorResume(error -> {
@@ -545,8 +578,9 @@ public class GitExecutorImpl implements GitExecutor {
 
     @Override
     public Mono<MergeStatusDTO> isMergeBranch(Path repoSuffix, String sourceBranch, String destinationBranch) {
+        Stopwatch processStopwatch = new Stopwatch("JGIT mergeablityCheck");
         return Mono.fromCallable(() -> {
-            log.debug(Thread.currentThread().getName() + ": Merge status for the branch  " + sourceBranch + " on " + destinationBranch);
+            log.debug(Thread.currentThread().getName() + ": Check mergeability for repo {} with src: {}, dest: {}", repoSuffix, sourceBranch, destinationBranch);
 
             try (Git git = Git.open(createRepoPath(repoSuffix).toFile())) {
 
@@ -559,6 +593,7 @@ public class GitExecutorImpl implements GitExecutor {
                         mergeStatus.setMergeAble(false);
                         mergeStatus.setConflictingFiles(((CheckoutConflictException) e).getConflictingPaths());
                         git.close();
+                        processStopwatch.stopAndLogTimeInMillis();
                         return mergeStatus;
                     }
                 }
@@ -596,7 +631,10 @@ public class GitExecutorImpl implements GitExecutor {
             try {
                 // Revert uncommitted changes if any
                 return resetToLastCommit(repoSuffix, destinationBranch)
-                        .thenReturn(status);
+                        .map(ignore -> {
+                            processStopwatch.stopAndLogTimeInMillis();
+                            return status;
+                        });
             } catch (GitAPIException | IOException e) {
                 log.error("Error for hard resetting to latest commit {0}", e);
                 return Mono.error(e);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Stopwatch.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Stopwatch.java
@@ -8,8 +8,8 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class Stopwatch {
 
-    public String processName;
-    StopWatch watch = new StopWatch();
+    private final String processName;
+    private final StopWatch watch = new StopWatch();
 
     public Stopwatch(String processName) {
         this.processName = processName;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Stopwatch.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/Stopwatch.java
@@ -1,0 +1,23 @@
+package com.appsmith.external.helpers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.time.StopWatch;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class Stopwatch {
+
+    public String processName;
+    StopWatch watch = new StopWatch();
+
+    public Stopwatch(String processName) {
+        this.processName = processName;
+        this.watch.start();
+    }
+
+    public void stopAndLogTimeInMillis() {
+        this.watch.stop();
+        log.debug("Process: {}, Time elapsed: {}ms", this.processName, this.watch.getTime(TimeUnit.MILLISECONDS));
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -115,7 +115,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
     public Mono<ApplicationJson> exportApplicationById(String applicationId, SerialiseApplicationObjective serialiseFor) {
 
         // Start the stopwatch to log the execution time
-        Stopwatch processStopwatch = new Stopwatch("Export application");
+        Stopwatch processStopwatch = new Stopwatch("Export application, with id: " + applicationId);
         /*
             1. Fetch application by id
             2. Fetch pages from the application

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.solutions.ce;
 
 import com.appsmith.external.helpers.BeanCopyUtils;
+import com.appsmith.external.helpers.Stopwatch;
 import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.AuthenticationResponse;
 import com.appsmith.external.models.BaseDomain;
@@ -113,6 +114,8 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
      */
     public Mono<ApplicationJson> exportApplicationById(String applicationId, SerialiseApplicationObjective serialiseFor) {
 
+        // Start the stopwatch to log the execution time
+        Stopwatch processStopwatch = new Stopwatch("Export application");
         /*
             1. Fetch application by id
             2. Fetch pages from the application
@@ -427,6 +430,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                     }
                                 }
 
+                                processStopwatch.stopAndLogTimeInMillis();
                                 return applicationJson;
                             });
                 })
@@ -534,6 +538,10 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
             6. Extract and save pages in the application
             7. Extract and save actions in the application
          */
+
+        // Start the stopwatch to log the execution time
+        Stopwatch processStopwatch = new Stopwatch("Import application");
+
         ApplicationJson importedDoc = JsonSchemaMigration.migrateApplicationToLatestSchema(applicationJson);
 
         Map<String, String> pluginMap = new HashMap<>();
@@ -1070,7 +1078,11 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 return mapActionIdWithPageLayout(newPage, actionIdMap)
                                         .flatMap(newPageService::save);
                             })
-                            .then(applicationService.update(importedApplication.getId(), importedApplication));
+                            .then(applicationService.update(importedApplication.getId(), importedApplication))
+                            .map(application -> {
+                                processStopwatch.stopAndLogTimeInMillis();
+                                return application;
+                            });
                 });
 
         // Import Application is currently a slow API because it needs to import and create application, pages, actions


### PR DESCRIPTION
## Description

Git APIs are slow today and these also involves a lot of operation:
- Hydration and rehydration from and to Mongo DB
- Copying the serialized objects file system
- Working with local as well as remote git APIs

Current PR simply logs the execution time in milliseconds for the above-mentioned tasks, which can be utilized to optimize the implementation

Fixes #11068 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
