### PR TITLE
fix: 7794 Google Sheet Fails with Mixed Datatype

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -789,7 +789,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 dataType = DataType.NULL;
             }
             //Ignore incompatible datatypes after first row
-            if (inputDataType != dataType) {
+            if (dataTypeConversionMap != null && inputDataType != dataType) {
                 log.debug("DataType Error : [" + inputDataType + "] " + value + " is not of type " + dataType + " which is the datatype of the column, hence ignored in filter.");
                 dataType = DataType.NULL;
             }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/IFilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/IFilterDataServiceCE.java
@@ -18,9 +18,11 @@ public interface IFilterDataServiceCE {
     ArrayNode filterDataNew(ArrayNode items, UQIDataFilterParams uqiDataFilterParams);
 
     List<Map<String, Object>> executeFilterQueryOldFormat(String tableName, List<Condition> conditions, Map<String,
-            DataType> schema);
+            DataType> schema, Map<DataType, DataType> dataTypeConversionMaps);
 
     void insertAllData(String tableName, ArrayNode items, Map<String, DataType> schema);
+
+    void insertAllData(String tableName, ArrayNode items, Map<String, DataType> schema, Map<DataType, DataType> dataTypeConversionMap);
 
     String generateTable(Map<String, DataType> schema);
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
@@ -1,5 +1,6 @@
 package com.external.config;
 
+import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
@@ -208,7 +209,7 @@ public class GetValuesMethod implements Method {
         ArrayNode preFilteringResponse = this.objectMapper.valueToTree(collectedCells);
 
         if (isWhereConditionConfigured(methodConfig)) {
-            return filterDataService.filterData(preFilteringResponse, methodConfig.getWhereConditions());
+            return filterDataService.filterData(preFilteringResponse, methodConfig.getWhereConditions(), getDataTypeConversionMap());
         }
 
         return preFilteringResponse;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/Method.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/Method.java
@@ -1,5 +1,6 @@
 package com.external.config;
 
+import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.OAuth2;
@@ -16,6 +17,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 public interface Method {
 
@@ -69,5 +72,13 @@ public interface Method {
         }
         // By default, no transformation takes place
         return response;
+    }
+
+    default Map<DataType, DataType> getDataTypeConversionMap() {
+        Map<DataType, DataType> conversionMap = new HashMap<DataType, DataType>();
+        conversionMap.put(DataType.INTEGER, DataType.DOUBLE);
+        conversionMap.put(DataType.LONG, DataType.DOUBLE);
+        conversionMap.put(DataType.FLOAT, DataType.DOUBLE);
+        return conversionMap;
     }
 }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/Method.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/Method.java
@@ -74,6 +74,12 @@ public interface Method {
         return response;
     }
 
+    /**
+     * Method for custom DataType Mapping based on plugin,
+     * so here in GoogleSheet, DataTypes like Integer, Long, Float will be processed as Double as required.
+     * For example, another plugin may implement this method to process all DataType as String etc.
+     * @return  -   Map containing custom DataType to be considered against input DataType.
+     */
     default Map<DataType, DataType> getDataTypeConversionMap() {
         Map<DataType, DataType> conversionMap = new HashMap<DataType, DataType>();
         conversionMap.put(DataType.INTEGER, DataType.DOUBLE);


### PR DESCRIPTION
## Google Sheet Data filter and Float data processing issue with Mixed datatype

- Fix for Larger data introduced down the row grid
- Fix for mixed Numeric DataType like Number and Float
- Fix to ignore data of another DataType introduced down the line not Matching the Original DataType (first row datatype)

Fixes #7794 
Fixes #9667


## Type of change
- Bug fix (non-breaking change which fixes an issue) 
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?
- Manually tested
- Existing @Tests were checked to work fine
- Added new @Tests to test new implementation


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
