### PR TITLE
fix: S3 plugin: remove `Expiry Duration` config from  `Read file` query

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/read.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/read.json
@@ -31,12 +31,6 @@
           "initialValue": ""
         },
         {
-          "label": "Expiry Duration of Signed URL (Minutes)",
-          "configProperty": "actionConfiguration.formData.read.expiry",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
-          "initialValue": "5"
-        },
-        {
           "label": "Base64 Encode File - Yes/No",
           "configProperty": "actionConfiguration.formData.read.usingBase64Encoding",
           "controlType": "DROP_DOWN",


### PR DESCRIPTION
## Description
- This PR removes the `Expiry Duration` field from the `Read file` command of `S3` plugin.
- An `Expiry Duration` field got added to `Read file` command mistakenly some time post migration to UQI schema. This field did not exist with the read command before the migration and does not get used even now.

Fixes #11115 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
