### PR TITLE
feat: S3 plugin: add command to delete multiple files at a time

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
@@ -6,10 +6,12 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException
 import com.appsmith.external.models.Condition;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -30,6 +32,8 @@ import static com.appsmith.external.constants.FieldName.VALUE;
 
 @Slf4j
 public class PluginUtils {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * - Regex to match everything inside double or single quotes, including the quotes.
@@ -279,5 +283,9 @@ public class PluginUtils {
         }
 
         return condition;
+    }
+
+    public static List<String> parseList(String arrayString) throws IOException {
+        return objectMapper.readValue(arrayString, ArrayList.class);
     }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/AmazonS3Action.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/AmazonS3Action.java
@@ -6,5 +6,6 @@ public enum AmazonS3Action {
     UPLOAD_MULTIPLE_FILES_FROM_BODY,
     READ_FILE,
     DELETE_FILE,
+    DELETE_MULTIPLE_FILES,
     LIST_BUCKETS
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/TemplateUtils.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/TemplateUtils.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInFormData;
-import static com.external.plugins.AmazonS3Plugin.DEFAULT_FILE_NAME;
 import static com.external.plugins.AmazonS3Plugin.DEFAULT_URL_EXPIRY_IN_MINUTES;
 import static com.external.plugins.AmazonS3Plugin.NO;
 import static com.external.plugins.AmazonS3Plugin.YES;
@@ -27,10 +26,15 @@ import static com.external.plugins.constants.FieldName.READ_USING_BASE64_ENCODIN
 public class TemplateUtils {
 
     public static String FILE_PICKER_DATA_EXPRESSION = "{{FilePicker1.files[0]}}";
+    public static String FILE_PICKER_MULTIPLE_FILES_DATA_EXPRESSION = "{{FilePicker1.files}}";
     public static String LIST_FILES_TEMPLATE_NAME = "List files";
     public static String READ_FILE_TEMPLATE_NAME = "Read file";
     public static String CREATE_FILE_TEMPLATE_NAME = "Create file";
+    public static String CREATE_MULTIPLE_FILES_TEMPLATE_NAME = "Create multiple files";
     public static String DELETE_FILE_TEMPLATE_NAME = "Delete file";
+    public static String DELETE_MULTIPLE_FILES_TEMPLATE_NAME = "Delete multiple files";
+    public static final String LIST_OF_FILES_STRING = "[\"file1.ext\", \"file2.ext\"]";
+    public static final String DEFAULT_DIR = "path/to/files";
 
     /**
      * This method adds templates for the following actions:
@@ -55,10 +59,32 @@ public class TemplateUtils {
         /* Template to create a new file in a bucket */
         templates.add(getCreateFileTemplate(bucketName, fileName));
 
+        /* Template to create multiple new files in a bucket */
+        templates.add(getCreateMultipleFilesTemplate(bucketName));
+
         /* Template to delete a file in a bucket */
         templates.add(getDeleteFileTemplate(bucketName, fileName));
 
+        /* Template to delete multiple files in a bucket */
+        templates.add(getDeleteMultipleFilesTemplate(bucketName));
+
         return templates;
+    }
+
+    private static Template getDeleteMultipleFilesTemplate(String bucketName) {
+        Map<String, Object> configMap = new HashMap<>();
+        setValueSafelyInFormData(configMap, COMMAND, AmazonS3Action.DELETE_MULTIPLE_FILES.name());
+        setValueSafelyInFormData(configMap, BUCKET, bucketName);
+
+        /**
+         * Since S3 uses UQI interface, a config map is used to indicate the required template. However, some
+         * properties like `actionConfiguration.path` cannot be configured via the config map since the config map only
+         * models the formData attribute. Such properties are configured via ActionConfiguration object.
+         */
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPath(LIST_OF_FILES_STRING);
+
+        return new Template(DELETE_MULTIPLE_FILES_TEMPLATE_NAME, configMap, actionConfiguration);
     }
 
     private static Template getDeleteFileTemplate(String bucketName, String fileName) {
@@ -72,7 +98,7 @@ public class TemplateUtils {
          * models the formData attribute. Such properties are configured via ActionConfiguration object.
          */
         ActionConfiguration actionConfiguration = new ActionConfiguration();
-        actionConfiguration.setPath(DEFAULT_FILE_NAME);
+        actionConfiguration.setPath(fileName);
 
         return new Template(DELETE_FILE_TEMPLATE_NAME, configMap, actionConfiguration);
     }
@@ -108,10 +134,29 @@ public class TemplateUtils {
          * models the formData attribute. Such properties are configured via ActionConfiguration object.
          */
         ActionConfiguration actionConfiguration = new ActionConfiguration();
-        actionConfiguration.setPath(DEFAULT_FILE_NAME);
+        actionConfiguration.setPath(fileName);
         actionConfiguration.setBody(FILE_PICKER_DATA_EXPRESSION);
 
         return new Template(CREATE_FILE_TEMPLATE_NAME, configMap, actionConfiguration);
+    }
+
+    private static Template getCreateMultipleFilesTemplate(String bucketName) {
+        Map<String, Object> configMap = new HashMap<>();
+        setValueSafelyInFormData(configMap, COMMAND, AmazonS3Action.UPLOAD_MULTIPLE_FILES_FROM_BODY.name());
+        setValueSafelyInFormData(configMap, BUCKET, bucketName);
+        setValueSafelyInFormData(configMap, CREATE_DATATYPE, YES);
+        setValueSafelyInFormData(configMap, CREATE_EXPIRY, DEFAULT_URL_EXPIRY_IN_MINUTES);
+
+        /**
+         * Since S3 uses UQI interface, a config map is used to indicate the required template. However, some
+         * properties like `actionConfiguration.path` cannot be configured via the config map since the config map only
+         * models the formData attribute. Such properties are configured via ActionConfiguration object.
+         */
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setPath(DEFAULT_DIR);
+        actionConfiguration.setBody(FILE_PICKER_MULTIPLE_FILES_DATA_EXPRESSION);
+
+        return new Template(CREATE_MULTIPLE_FILES_TEMPLATE_NAME, configMap, actionConfiguration);
     }
 
     private static Template getListFilesTemplate(String bucketName) {

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/delete_many.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/delete_many.json
@@ -1,0 +1,31 @@
+{
+  "identifier": "DELETE_MULTIPLE_FILES",
+  "controlType": "SECTION",
+  "conditionals": {
+    "show": "{{actionConfiguration.formData.command === 'DELETE_MULTIPLE_FILES'}}"
+  },
+  "children": [
+    {
+      "controlType": "SECTION",
+      "label": "Select Bucket to Query",
+      "children": [
+        {
+          "label": "Bucket Name",
+          "configProperty": "actionConfiguration.formData.bucket",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "evaluationSubstitutionType": "TEMPLATE",
+          "isRequired": true,
+          "initialValue": ""
+        },
+        {
+          "label": "List of Files",
+          "configProperty": "actionConfiguration.path",
+          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
+          "isRequired": true,
+          "initialValue": "",
+          "placeholderText": "[\"myDir/file1.txt\", \"myDir/file2.txt\"]"
+        }
+      ]
+    }
+  ]
+}

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/root.json
@@ -25,6 +25,10 @@
       {
         "label": "Delete file",
         "fileName" : "delete.json"
+      },
+      {
+        "label": "Delete multiple files",
+        "fileName" : "delete_many.json"
       }
     ]
   }


### PR DESCRIPTION
## Description
- Add a new command `Delete multiple files`. This command will allow users to delete many files at once. Currently, only one file can be deleted at a time. 
  - It takes an array of files as config parameter from the user e.g. `["file1", "file2"]`
- Add template for the new command.
- Unrelated:
  - Add template for the command `Create multiple files`

Fixes #10918

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
