### PR TITLE
fix: push js object after creation

### DIFF
--- a/app/client/src/pages/Editor/Explorer/JSActions/JSActionEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSActions/JSActionEntity.tsx
@@ -35,9 +35,11 @@ export const ExplorerJSCollectionEntity = memo(
       getJSCollection(state, props.id),
     ) as JSCollection;
     const navigateToJSCollection = useCallback(() => {
-      history.push(
-        JS_COLLECTION_ID_URL(applicationId, pageId, jsAction.id, {}),
-      );
+      if (jsAction.id) {
+        history.push(
+          JS_COLLECTION_ID_URL(applicationId, pageId, jsAction.id, {}),
+        );
+      }
     }, [pageId]);
     const contextMenu = (
       <JSCollectionEntityContextMenu

--- a/app/client/src/reducers/entityReducers/jsActionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/jsActionsReducer.tsx
@@ -40,29 +40,16 @@ const jsActionsReducer = createReducer(initialState, {
     });
   },
   [ReduxActionErrorTypes.FETCH_JS_ACTIONS_ERROR]: () => initialState,
-  [ReduxActionTypes.CREATE_JS_ACTION_INIT]: (
+  [ReduxActionTypes.CREATE_JS_ACTION_SUCCESS]: (
     state: JSCollectionDataState,
     action: ReduxAction<JSCollection>,
   ): JSCollectionDataState =>
     state.concat([
       {
-        config: { ...action.payload, id: action.payload.name },
+        config: { ...action.payload },
         isLoading: false,
       },
     ]),
-  [ReduxActionTypes.CREATE_JS_ACTION_SUCCESS]: (
-    state: JSCollectionDataState,
-    action: ReduxAction<JSCollection>,
-  ): JSCollectionDataState =>
-    state.map((a) => {
-      if (
-        a.config.pageId === action.payload.pageId &&
-        a.config.id === action.payload.name
-      ) {
-        return { ...a, config: action.payload };
-      }
-      return a;
-    }),
   [ReduxActionErrorTypes.CREATE_JS_ACTION_ERROR]: (
     state: JSCollectionDataState,
     action: ReduxAction<JSCollection>,


### PR DESCRIPTION
## Description
In case of a slow network, if the user clicks on the newly created js object before API finishes. Navigated path doesn't get js object id hence app crashes.

Fixes #10601 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: 10601-fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.44 **(0.01)** | 37 **(0.01)** | 35.3 **(0)** | 55.82 **(0.01)**
 :red_circle: | app/client/src/pages/Editor/Explorer/JSActions/JSActionEntity.tsx | 58.33 **(-2.54)** | 0 **(-100)** | 0 **(0)** | 58.33 **(-2.54)**
 :green_circle: | app/client/src/reducers/entityReducers/jsActionsReducer.tsx | 10.39 **(0.51)** | 0 **(0)** | 5.26 **(0.26)** | 10.67 **(0.54)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>