### PR TITLE
feat: Add api to check the git connection after the key is regenerated

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
@@ -48,6 +48,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -667,6 +668,21 @@ public class GitExecutorImpl implements GitExecutor {
                 return git.getRepository().getBranch();
             }
         }).subscribeOn(scheduler);
+    }
+
+    @Override
+    public Mono<Boolean> testConnection(String publicKey, String privateKey, String remoteUrl) {
+        return Mono.fromCallable(() -> {
+            TransportConfigCallback transportConfigCallback = new SshTransportConfigCallback(privateKey, publicKey);
+            Git.lsRemoteRepository()
+                    .setTransportConfigCallback(transportConfigCallback)
+                    .setRemote(remoteUrl)
+                    .setHeads(true)
+                    .setTags(true)
+                    .call();
+            return true;
+        }).timeout(Duration.ofMillis(Constraint.REMOTE_TIMEOUT_MILLIS))
+                .subscribeOn(scheduler);
     }
 
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/GitExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/git/GitExecutor.java
@@ -163,4 +163,13 @@ public interface GitExecutor {
      * @return created branch name
      */
     Mono<String> checkoutRemoteBranch(Path repoSuffix, String branchName);
+
+    /**
+     *
+     * @param publicKey public key
+     * @param privateKey private key
+     * @param remoteUrl remote repo ssh url
+     * @return boolean if the connection can be established with the given keys
+     */
+    Mono<Boolean> testConnection(String publicKey, String privateKey, String remoteUrl);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/AnalyticsEvents.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/AnalyticsEvents.java
@@ -28,7 +28,8 @@ public enum AnalyticsEvents {
     GIT_DISCONNECT,
     GIT_CHECKOUT_BRANCH,
     GIT_CHECKOUT_REMOTE_BRANCH,
-    GIT_IMPORT
+    GIT_IMPORT,
+    GIT_TEST_CONNECTION
     ;
 
     private final String eventName;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/GitControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/GitControllerCE.java
@@ -201,5 +201,11 @@ public class GitControllerCE {
                 .map(result -> new ResponseDTO<>(HttpStatus.CREATED.value(), result, null));
     }
 
+    @GetMapping("/test-connection/{defaultApplicationId}")
+    public Mono<ResponseDTO<Boolean>> testGitConnection(@PathVariable String defaultApplicationId) {
+        return service.testConnection(defaultApplicationId)
+                .map(result -> new ResponseDTO<>((HttpStatus.OK.value()), result, null));
+    }
+
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCE.java
@@ -63,4 +63,6 @@ public interface GitServiceCE {
 
     Mono<GitAuth> generateSSHKey();
 
+    Mono<Boolean> testConnection(String defaultApplicationId);
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
@@ -2087,25 +2087,44 @@ public class GitServiceCEImpl implements GitServiceCE {
         return getApplicationById(defaultApplicationId)
                 .flatMap(application -> {
                     GitApplicationMetadata gitApplicationMetadata = application.getGitApplicationMetadata();
-                    if(isInvalidDefaultApplicationGitMetadata(gitApplicationMetadata)) {
+                    if (isInvalidDefaultApplicationGitMetadata(gitApplicationMetadata)) {
                         return Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_SSH_CONFIGURATION));
                     }
                     return gitExecutor.testConnection(
                             gitApplicationMetadata.getGitAuth().getPublicKey(),
                             gitApplicationMetadata.getGitAuth().getPrivateKey(),
                             gitApplicationMetadata.getRemoteUrl()
-                    ).onErrorResume(error -> {
-                        if (error instanceof TransportException) {
-                            return Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_SSH_CONFIGURATION));
-                        }
-                        if (error instanceof InvalidRemoteException) {
-                            return Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_CONFIGURATION, error.getMessage()));
-                        }
-                        if (error instanceof TimeoutException) {
-                            return Mono.error(new AppsmithException(AppsmithError.GIT_EXECUTION_TIMEOUT));
-                        }
-                        return Mono.error(new AppsmithException(AppsmithError.GIT_GENERIC_ERROR, error.getMessage()));
-                    });
+                    ).zipWith(Mono.just(application))
+                            .onErrorResume(error -> {
+                                log.error("Error while testing the connection to th remote repo " + gitApplicationMetadata.getRemoteUrl() + " ", error);
+                                return addAnalyticsForGitOperation(
+                                        AnalyticsEvents.GIT_TEST_CONNECTION.getEventName(),
+                                        application,
+                                        error.getClass().getName(),
+                                        error.getMessage(),
+                                        application.getGitApplicationMetadata().getIsRepoPrivate()
+                                ).flatMap(application1 -> {
+                                    if (error instanceof TransportException) {
+                                        return Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_SSH_CONFIGURATION));
+                                    }
+                                    if (error instanceof InvalidRemoteException) {
+                                        return Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_CONFIGURATION, error.getMessage()));
+                                    }
+                                    if (error instanceof TimeoutException) {
+                                        return Mono.error(new AppsmithException(AppsmithError.GIT_EXECUTION_TIMEOUT));
+                                    }
+                                    return Mono.error(new AppsmithException(AppsmithError.GIT_GENERIC_ERROR, error.getMessage()));
+                                });
+
+                            });
+                })
+                .flatMap(objects -> {
+                    Application application = objects.getT2();
+                    return addAnalyticsForGitOperation(
+                            AnalyticsEvents.GIT_TEST_CONNECTION.getEventName(),
+                            application,
+                            application.getGitApplicationMetadata().getIsRepoPrivate()
+                    ).thenReturn(objects.getT1());
                 });
     }
 


### PR DESCRIPTION
## Description

> A user should have an option to regenerate the ssh keys for the git connected applications in case the key is compromised. This change set adds an API to test the connection after the key is regenerated by the user. 

Fixes #10299


## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally
- TC's on the way

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
