### PR TITLE
fix: Update indexes for ActionCollection and NewAction to improve the query performance for getResourceByPageId

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -4993,4 +4993,36 @@ public class DatabaseChangelog {
         mongockTemplate.save(plugin);
     }
 
+    /**
+     * This migration introduces indexes on newAction, actionCollection to improve the query performance for queries like
+     * getResourceByPageId which excludes the deleted entries
+     */
+    @ChangeSet(order = "116", id = "update-index-for-newAction-actionCollection", author = "")
+    public void updateNewActionActionCollectionIndexes(MongockTemplate mongockTemplate) {
+
+        dropIndexIfExists(mongockTemplate, NewAction.class, "unpublishedAction_pageId");
+
+        ensureIndexes(mongockTemplate, NewAction.class,
+                makeIndex(fieldName(QNewAction.newAction.unpublishedAction) + "." + FieldName.PAGE_ID, FieldName.DELETED)
+                        .named("unpublishedActionPageId_deleted_compound_index")
+        );
+
+        ensureIndexes(mongockTemplate, NewAction.class,
+                makeIndex(fieldName(QNewAction.newAction.publishedAction) + "." + FieldName.PAGE_ID, FieldName.DELETED)
+                        .named("publishedActionPageId_deleted_compound_index")
+        );
+
+        dropIndexIfExists(mongockTemplate, ActionCollection.class, "unpublishedCollection_pageId");
+
+        ensureIndexes(mongockTemplate, ActionCollection.class,
+                makeIndex(fieldName(QActionCollection.actionCollection.unpublishedCollection) + "." + FieldName.PAGE_ID, FieldName.DELETED)
+                        .named("unpublishedCollectionPageId_deleted_compound_index")
+        );
+
+        ensureIndexes(mongockTemplate, ActionCollection.class,
+                makeIndex(fieldName(QActionCollection.actionCollection.publishedCollection) + "." + FieldName.PAGE_ID, FieldName.DELETED)
+                        .named("publishedCollectionPageId_deleted_compound_index")
+        );
+    }
+
 }


### PR DESCRIPTION
## Description

> Looking at the performance advisor from the MongoDB atlas we can see the issue is with the indexes which are present today for ActionCollection and NewAction, this PR updates the indexes as suggested and creates a compound indexes based on pageIds and deleted field.

Fixes https://github.com/appsmithorg/appsmith/issues/11139

## Type of change

- Bug fix (non-breaking change which fixes an issue)