### PR TITLE
chore: Upgrading socket.io in rts to 4.4.1

### DIFF
--- a/app/rts/package.json
+++ b/app/rts/package.json
@@ -17,8 +17,8 @@
     "express": "^4.17.1",
     "loglevel": "^1.7.1",
     "mongodb": "^3.6.4",
-    "socket.io": "^4.1.3",
-    "socket.io-adapter": "^2.3.2",
+    "socket.io": "^4.4.1",
+    "socket.io-adapter": "^2.3.3",
     "source-map-support": "^0.5.19",
     "typescript": "^4.2.3"
   }


### PR DESCRIPTION
Upgrading socket.io in rts to 4.4.1 