### PR TITLE
fix: remove dependencies from trigger fields

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -502,22 +502,12 @@ export default class DataTreeEvaluator {
 
     if (isWidget(entity)) {
       // Adding the dynamic triggers in the dependency list as they need linting whenever updated
-      // To keep linting in trigger fields in sync, nodes they depend on need to be added to their dependencies
-      const dynamicTriggerPathlist = entity.dynamicTriggerPathList;
-
-      if (dynamicTriggerPathlist && dynamicTriggerPathlist.length) {
-        dynamicTriggerPathlist.forEach((dynamicPath) => {
-          const propertyPath = dynamicPath.key;
-          const unevalPropValue = _.get(entity, propertyPath);
-          const { jsSnippets } = getDynamicBindings(unevalPropValue);
-          const existingDeps =
-            dependencies[`${entityName}.${propertyPath}`] || [];
-          dependencies[`${entityName}.${propertyPath}`] = existingDeps.concat(
-            jsSnippets.filter((jsSnippet) => !!jsSnippet),
-          );
+      // we don't make it dependent on anything else
+      if (entity.dynamicTriggerPathList) {
+        Object.values(entity.dynamicTriggerPathList).forEach(({ key }) => {
+          dependencies[`${entityName}.${key}`] = [];
         });
       }
-
       const widgetDependencies = addWidgetPropertyDependencies({
         entity,
         entityName,
@@ -1320,12 +1310,7 @@ export default class DataTreeEvaluator {
                 entity,
                 entityPropertyPath,
               );
-
-              const isATriggerPath =
-                isWidget(entity) &&
-                isPathADynamicTrigger(entity, entityPropertyPath);
-
-              if (isABindingPath || isATriggerPath) {
+              if (isABindingPath) {
                 didUpdateDependencyMap = true;
 
                 const { jsSnippets } = getDynamicBindings(


### PR DESCRIPTION
## Description
Don't make `trigger fields` dependent on anything else.
This PR annuls the changes in #10941 

Fixes #11136 



## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/revert-trigger-field-dependencies 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.69 **(-0.01)** | 37.05 **(-0.01)** | 35.75 **(0)** | 56.05 **(0)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/workers/DataTreeEvaluator.ts | 77.26 **(0.42)** | 58.22 **(0.22)** | 75.29 **(0.87)** | 77.02 **(0.58)**</details>