### PR TITLE
fix: Added channel timeout configurations for REST WebClient provider

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -69,6 +69,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -293,6 +294,8 @@ public class RestApiPlugin extends BasePlugin {
             // Initializing webClient to be used for http call
             final ConnectionProvider provider = ConnectionProvider
                     .builder("rest-api-provider")
+                    .maxIdleTime(Duration.ofSeconds(600))
+                    .maxLifeTime(Duration.ofSeconds(600))
                     .build();
 
             HttpClient httpClient = HttpClient.create(provider)


### PR DESCRIPTION
## Description
Unable to reproduce this issue on my local, but from [this](https://github.com/reactor/reactor-netty/issues/1774) issue thread, the changes made in this PR should do the trick.

Fixes #10642 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Cannot be tested as this is not reproducible locally. Will need to test on release. Have tested for existing behaviour manually.