### PR TITLE
fix: Wait for evaluation before completing resetWidget and storeValue functions

### DIFF
--- a/app/client/cypress/fixtures/promisesBtn.json
+++ b/app/client/cypress/fixtures/promisesBtn.json
@@ -54,6 +54,23 @@
             }
           ],
           "dynamicPropertyPathList": []
+        },
+        {
+          "isVisible": true,
+          "inputType": "TEXT",
+          "label": "",
+          "widgetName": "Input1",
+          "type": "INPUT_WIDGET_V2",
+          "isLoading": false,
+          "parentColumnSpace": 74,
+          "parentRowSpace": 40,
+          "leftColumn": 2,
+          "rightColumn": 7,
+          "topRow": 0,
+          "bottomRow": 1,
+          "parentId": "0",
+          "defaultText": "Test",
+          "widgetId": "2lhsjdd5sg"
         }
       ]
     }

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/PromisesSpec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/PromisesSpec.ts
@@ -2,6 +2,7 @@ import { AggregateHelper } from "../../../../support/Pages/AggregateHelper";
 import { JSEditor } from "../../../../support/Pages/JSEditor";
 import { CommonLocators } from "../../../../support/Objects/CommonLocators";
 import { ApiPage } from "../../../../support/Pages/ApiPage";
+import publish from "../../../../locators/publishWidgetspage.json";
 
 const agHelper = new AggregateHelper();
 const jsEditor = new JSEditor();
@@ -9,127 +10,204 @@ const locator = new CommonLocators();
 const apiPage = new ApiPage();
 
 describe("Validate basic operations on Entity explorer JSEditor structure", () => {
-
-    before(() => {
+  it("1. Verify storeValue via .then direct Promises", () => {
+    const date = new Date().toDateString();
+    cy.fixture("promisesBtn").then((val: any) => {
+      agHelper.AddDsl(val);
     });
+    agHelper.SelectEntityByName("WIDGETS"); //to expand widgets
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      "{{storeValue('date', Date()).then(() => showAlert(appsmith.store.date))}}",
+      true,
+      true,
+    );
+    agHelper.ClickButton("Submit");
+    cy.log("Date is:" + date);
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .should("contain.text", date);
+  });
 
-    it("1. Verify storeValue via .then direct Promises", () => {
-        let date = new Date().toDateString();
-        cy.fixture('promisesBtn').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        agHelper.SelectEntityByName("WIDGETS")//to expand widgets
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', "{{storeValue('date', Date()).then(() => showAlert(appsmith.store.date))}}", true, true);
-        agHelper.ClickButton('Submit')
-        cy.log("Date is:" + date)
-        cy.get(locator._toastMsg)
-            .should("have.length", 1)
-            .should("contain.text", date);
+  it("1.1. Verify resetWidget via .then direct Promises", () => {
+    cy.fixture("promisesBtn").then((val: any) => {
+      agHelper.AddDsl(val);
     });
+    agHelper.SelectEntityByName("WIDGETS"); //to expand widgets
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      "{{resetWidget('Input1').then(() => showAlert(Input1.text))}}",
+      true,
+      true,
+    );
+    agHelper.DeployApp();
+    cy.get(publish.inputWidget + " " + "input").type("Update value");
 
-    it("2. Verify resolve & chaining via direct Promises", () => {
-        cy.fixture('promisesBtn').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        agHelper.SelectEntityByName("WIDGETS")
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', `{{new Promise((resolve)=>{
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .should("contain.text", "Test");
+
+    cy.get(publish.backToEditor).click({ force: true });
+  });
+
+  it("2. Verify resolve & chaining via direct Promises", () => {
+    cy.fixture("promisesBtn").then((val: any) => {
+      agHelper.AddDsl(val);
+    });
+    agHelper.SelectEntityByName("WIDGETS");
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      `{{new Promise((resolve)=>{
             resolve("We are on planet")
         }).then((res)=>{
             return res+ " Earth"
         }).then((res)=> {
             showAlert(res, 'success')
-        })}}`, true, true);
-        agHelper.ClickButton('Submit')
-        cy.get(locator._toastMsg)
-            .should("have.length", 1)
-            .should("contain.text", "We are on planet Earth");
-    });
+        })}}`,
+      true,
+      true,
+    );
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .should("contain.text", "We are on planet Earth");
+  });
 
-    it("3. Verify Async Await in direct Promises", () => {
-        cy.fixture('promisesBtn').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        apiPage.CreateAndFillApi("https://randomuser.me/api/", "RandomUser")
-        apiPage.CreateAndFillApi("https://api.genderize.io?name={{this.params.country}}", "Genderize")
-        apiPage.ValidateQueryParams({ key: "name", value: "{{this.params.country}}" }); // verifies Bug 10055
-        agHelper.SelectEntityByName("WIDGETS")
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', `{{(async function(){
+  it("3. Verify Async Await in direct Promises", () => {
+    cy.fixture("promisesBtn").then((val: any) => {
+      agHelper.AddDsl(val);
+    });
+    apiPage.CreateAndFillApi("https://randomuser.me/api/", "RandomUser");
+    apiPage.CreateAndFillApi(
+      "https://api.genderize.io?name={{this.params.country}}",
+      "Genderize",
+    );
+    apiPage.ValidateQueryParams({
+      key: "name",
+      value: "{{this.params.country}}",
+    }); // verifies Bug 10055
+    agHelper.SelectEntityByName("WIDGETS");
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      `{{(async function(){
             const user = await RandomUser.run();
             const gender = await Genderize.run({ country: user.results[0].location.country});
             await storeValue("Gender", gender);
             await showAlert("Your country is "+ JSON.stringify(appsmith.store.Gender.name), 'warning');
             await showAlert("You could be a "+ JSON.stringify(appsmith.store.Gender.gender), 'warning');
-          })()}}`, true, true);
-        agHelper.ClickButton('Submit')
-        cy.get(locator._toastMsg).should("have.length", 2)
-        cy.get(locator._toastMsg).first().should("contain.text", "Your country is");
-        cy.get(locator._toastMsg).last().contains(/male|female|null/g)
-    });
+          })()}}`,
+      true,
+      true,
+    );
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg).should("have.length", 2);
+    cy.get(locator._toastMsg)
+      .first()
+      .should("contain.text", "Your country is");
+    cy.get(locator._toastMsg)
+      .last()
+      .contains(/male|female|null/g);
+  });
 
-    it("4. Verify .then & .catch via direct Promises", () => {
-        cy.fixture('promisesBtnImg').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        apiPage.CreateAndFillApi("https://source.unsplash.com/collection/8439505", "Christmas")
-        agHelper.SelectEntityByName("WIDGETS")//to expand widgets
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', `{{
+  it("4. Verify .then & .catch via direct Promises", () => {
+    cy.fixture("promisesBtnImg").then((val: any) => {
+      agHelper.AddDsl(val);
+    });
+    apiPage.CreateAndFillApi(
+      "https://source.unsplash.com/collection/8439505",
+      "Christmas",
+    );
+    agHelper.SelectEntityByName("WIDGETS"); //to expand widgets
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      `{{
             (function(){
                   return Christmas.run()
               .then(() => showAlert("You have a beautiful picture", 'success') )
               .catch(() => showAlert('Oops!', 'error'))
               })()
-          }}`, true, true);
-        agHelper.SelectEntityByName("Image1");
-        jsEditor.EnterJSContext('image', `{{Christmas.data}}`, true);
-        agHelper.WaitUntilEleDisappear(locator._toastMsg, 'will be executed automatically on page load')
-        agHelper.ClickButton('Submit')
-        cy.get(locator._toastMsg).should("have.length", 1).contains(/You have a beautiful picture|Oops!/g)
-    });
+          }}`,
+      true,
+      true,
+    );
+    agHelper.SelectEntityByName("Image1");
+    jsEditor.EnterJSContext("image", `{{Christmas.data}}`, true);
+    agHelper.WaitUntilEleDisappear(
+      locator._toastMsg,
+      "will be executed automatically on page load",
+    );
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .contains(/You have a beautiful picture|Oops!/g);
+  });
 
-    it("5. Verify .then & .catch via JS Objects in Promises", () => {
-        cy.fixture('promisesBtn').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        apiPage.CreateAndFillApi("https://favqs.com/api/qotd", "InspiringQuotes")
-        jsEditor.CreateJSObject(`const user = 'You';
+  it("5. Verify .then & .catch via JS Objects in Promises", () => {
+    cy.fixture("promisesBtn").then((val: any) => {
+      agHelper.AddDsl(val);
+    });
+    apiPage.CreateAndFillApi("https://favqs.com/api/qotd", "InspiringQuotes");
+    jsEditor.CreateJSObject(`const user = 'You';
         return InspiringQuotes.run().then((res) => {showAlert("Today's quote for "+ user + " is "+ JSON.stringify(res.quote.body), 'success')}).catch(() => showAlert("Unable to fetch quote for "+ user, 'warning'))`);
-        agHelper.SelectEntityByName("WIDGETS")//to expand widgets
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', `{{JSObject1.myFun1()}}`, true, true);
-        agHelper.ClickButton('Submit')
-        cy.get(locator._toastMsg).should("have.length", 1).should("contain.text", "Today's quote for You");
-    });
+    agHelper.SelectEntityByName("WIDGETS"); //to expand widgets
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext("onclick", `{{JSObject1.myFun1()}}`, true, true);
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .should("contain.text", "Today's quote for You");
+  });
 
-    it("6. Verify Promise.race", () => {
-        cy.fixture('promisesBtn').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        apiPage.CreateAndFillApi("https://api.agify.io?name={{this.params.person}}", "Agify")
-        apiPage.ValidateQueryParams({ key: "name", value: "{{this.params.person}}" }); // verifies Bug 10055
-        agHelper.SelectEntityByName("WIDGETS")
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', `{{Promise.race([Agify.run({person:'Melinda' }),Agify.run({person:'Trump'})]).then((res) => { showAlert('Winner is ' + JSON.stringify(res.name), 'success')})}}`, true, true);
-        agHelper.ClickButton('Submit')
-        cy.get(locator._toastMsg).should("have.length", 1).contains(/Melinda|Trump/g)
+  it("6. Verify Promise.race", () => {
+    cy.fixture("promisesBtn").then((val: any) => {
+      agHelper.AddDsl(val);
     });
+    apiPage.CreateAndFillApi(
+      "https://api.agify.io?name={{this.params.person}}",
+      "Agify",
+    );
+    apiPage.ValidateQueryParams({
+      key: "name",
+      value: "{{this.params.person}}",
+    }); // verifies Bug 10055
+    agHelper.SelectEntityByName("WIDGETS");
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      `{{Promise.race([Agify.run({person:'Melinda' }),Agify.run({person:'Trump'})]).then((res) => { showAlert('Winner is ' + JSON.stringify(res.name), 'success')})}}`,
+      true,
+      true,
+    );
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .contains(/Melinda|Trump/g);
+  });
 
-    it("7. Verify maintaining context via direct Promises", () => {
-        cy.fixture('promisesBtnList').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        apiPage.CreateAndFillApi("https://api.jikan.moe/v3/search/anime?q={{this.params.name}}", "GetAnime")
-        agHelper.SelectEntityByName("WIDGETS")//to expand widgets
-        agHelper.SelectEntityByName("List1");
-        jsEditor.EnterJSContext('items', `[
+  it("7. Verify maintaining context via direct Promises", () => {
+    cy.fixture("promisesBtnList").then((val: any) => {
+      agHelper.AddDsl(val);
+    });
+    apiPage.CreateAndFillApi(
+      "https://api.jikan.moe/v3/search/anime?q={{this.params.name}}",
+      "GetAnime",
+    );
+    agHelper.SelectEntityByName("WIDGETS"); //to expand widgets
+    agHelper.SelectEntityByName("List1");
+    jsEditor.EnterJSContext(
+      "items",
+      `[
             {
               "name": {{GetAnime.data.results[0].title}},
               "img": {{GetAnime.data.results[0].image_url}},
               "synopsis": {{GetAnime.data.results[0].synopsis}}
-              }, 
+              },
             {
               "name": {{GetAnime.data.results[3].title}},
               "img": {{GetAnime.data.results[3].image_url}},
@@ -140,29 +218,53 @@ describe("Validate basic operations on Entity explorer JSEditor structure", () =
               "img": {{GetAnime.data.results[2].image_url}},
               "synopsis": {{GetAnime.data.results[2].synopsis}}
             }
-          ]`, true);
-        agHelper.WaitUntilEleDisappear(locator._toastMsg, 'will be executed automatically on page load')
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', `{{(function(){
+          ]`,
+      true,
+    );
+    agHelper.WaitUntilEleDisappear(
+      locator._toastMsg,
+      "will be executed automatically on page load",
+    );
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      `{{(function(){
             const anime = "fruits basket : the final";
             return GetAnime.run({ name: anime })
               .then(() => showAlert("Showing results for : "+ anime, 'success'))
-          })()}}`, true, true);
-        agHelper.ClickButton('Submit')
-        cy.get(locator._toastMsg).should("have.length", 1).should("have.text", 'Showing results for : fruits basket : the final');
-    });
+          })()}}`,
+      true,
+      true,
+    );
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .should("have.text", "Showing results for : fruits basket : the final");
+  });
 
-    it.skip("8. Verify Promise.all", () => {
-        cy.fixture('promisesBtn').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-        apiPage.CreateAndFillApi("https://api.agify.io?name={{this.params.person}}", "Agify")
-        apiPage.ValidateQueryParams({ key: "name", value: "{{this.params.person}}" }); // verifies Bug 10055
-        agHelper.SelectEntityByName("WIDGETS")
-        agHelper.SelectEntityByName("Button1");
-        jsEditor.EnterJSContext('onclick', `{{Promise.race([Agify.run({person:'Melinda' }),Agify.run({person:'Trump'})]).then((res) => { showAlert('Winner is ' + JSON.stringify(res.name))})}}`, true, true);
-        agHelper.ClickButton('Submit')
-        cy.get(locator._toastMsg).should("have.length", 1).contains(/Melinda|Trump|null/g)
+  it.skip("8. Verify Promise.all", () => {
+    cy.fixture("promisesBtn").then((val: any) => {
+      agHelper.AddDsl(val);
     });
-
+    apiPage.CreateAndFillApi(
+      "https://api.agify.io?name={{this.params.person}}",
+      "Agify",
+    );
+    apiPage.ValidateQueryParams({
+      key: "name",
+      value: "{{this.params.person}}",
+    }); // verifies Bug 10055
+    agHelper.SelectEntityByName("WIDGETS");
+    agHelper.SelectEntityByName("Button1");
+    jsEditor.EnterJSContext(
+      "onclick",
+      `{{Promise.race([Agify.run({person:'Melinda' }),Agify.run({person:'Trump'})]).then((res) => { showAlert('Winner is ' + JSON.stringify(res.name))})}}`,
+      true,
+      true,
+    );
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .contains(/Melinda|Trump|null/g);
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/PromisesSpec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/PromisesSpec.ts
@@ -31,8 +31,8 @@ describe("Validate basic operations on Entity explorer JSEditor structure", () =
   });
 
   it("1.1. Verify resetWidget via .then direct Promises", () => {
-    cy.fixture("promisesBtn").then((val: any) => {
-      agHelper.AddDsl(val);
+    cy.fixture("promisesBtn").then((dsl: any) => {
+      agHelper.AddDsl(dsl);
     });
     agHelper.SelectEntityByName("WIDGETS"); //to expand widgets
     agHelper.SelectEntityByName("Button1");

--- a/app/client/src/actions/batchActions.ts
+++ b/app/client/src/actions/batchActions.ts
@@ -1,11 +1,15 @@
-import { ReduxAction, ReduxActionTypes } from "constants/ReduxActionConstants";
+import {
+  EvaluationReduxAction,
+  ReduxAction,
+  ReduxActionTypes,
+} from "constants/ReduxActionConstants";
 
-export const batchAction = (action: ReduxAction<any>) => ({
+export const batchAction = (action: EvaluationReduxAction<any>) => ({
   type: ReduxActionTypes.BATCHED_UPDATE,
   payload: action,
 });
 
-export type BatchAction<T> = ReduxAction<ReduxAction<T>>;
+export type BatchAction<T> = ReduxAction<EvaluationReduxAction<T>>;
 
 export const batchActionSuccess = (actions: ReduxAction<any>[]) => ({
   type: ReduxActionTypes.BATCH_UPDATES_SUCCESS,

--- a/app/client/src/actions/metaActions.ts
+++ b/app/client/src/actions/metaActions.ts
@@ -31,6 +31,7 @@ export const resetWidgetMetaProperty = (
     payload: {
       widgetId,
     },
+    postEvalActions: [{ type: ReduxActionTypes.RESET_WIDGET_META_EVALUATED }],
   });
 };
 

--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -3,9 +3,9 @@ import {
   EvaluationReduxAction,
   ReduxAction,
   ReduxActionTypes,
-  ReduxActionWithoutPayload,
   UpdateCanvasPayload,
   ReduxActionErrorTypes,
+  AnyReduxAction,
 } from "constants/ReduxActionConstants";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { WidgetOperation } from "widgets/BaseWidget";
@@ -17,7 +17,7 @@ import { GenerateTemplatePageRequest } from "../api/PageApi";
 import {
   WidgetReduxActionTypes,
   ReplayReduxActionTypes,
-} from "../constants/ReduxActionConstants";
+} from "constants/ReduxActionConstants";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import { Replayable } from "entities/Replay/ReplayEntity/ReplayEditor";
 
@@ -77,7 +77,7 @@ export const fetchPublishedPage = (pageId: string, bustCache = false) => ({
 });
 
 export const fetchPageSuccess = (
-  postEvalActions: Array<ReduxAction<unknown> | ReduxActionWithoutPayload>,
+  postEvalActions: Array<AnyReduxAction>,
 ): EvaluationReduxAction<undefined> => {
   return {
     type: ReduxActionTypes.FETCH_PAGE_SUCCESS,
@@ -87,7 +87,7 @@ export const fetchPageSuccess = (
 };
 
 export const fetchPublishedPageSuccess = (
-  postEvalActions: Array<ReduxAction<unknown> | ReduxActionWithoutPayload>,
+  postEvalActions: Array<AnyReduxAction>,
 ): EvaluationReduxAction<undefined> => ({
   type: ReduxActionTypes.FETCH_PUBLISHED_PAGE_SUCCESS,
   postEvalActions,
@@ -321,17 +321,27 @@ export const setAppMode = (payload: APP_MODE): ReduxAction<APP_MODE> => {
 
 export const updateAppTransientStore = (
   payload: Record<string, unknown>,
-): ReduxAction<Record<string, unknown>> => ({
+): EvaluationReduxAction<Record<string, unknown>> => ({
   type: ReduxActionTypes.UPDATE_APP_TRANSIENT_STORE,
   payload,
+  postEvalActions: [
+    {
+      type: ReduxActionTypes.UPDATE_APP_STORE_EVALUATED,
+    },
+  ],
 });
 
 export const updateAppPersistentStore = (
   payload: Record<string, unknown>,
-): ReduxAction<Record<string, unknown>> => {
+): EvaluationReduxAction<Record<string, unknown>> => {
   return {
     type: ReduxActionTypes.UPDATE_APP_PERSISTENT_STORE,
     payload,
+    postEvalActions: [
+      {
+        type: ReduxActionTypes.UPDATE_APP_STORE_EVALUATED,
+      },
+    ],
   };
 };
 

--- a/app/client/src/actions/pluginActionActions.ts
+++ b/app/client/src/actions/pluginActionActions.ts
@@ -1,6 +1,7 @@
 import { ActionResponse, PaginationField } from "api/ActionAPI";
 import {
   EvaluationReduxAction,
+  AnyReduxAction,
   ReduxAction,
   ReduxActionErrorTypes,
   ReduxActionTypes,
@@ -30,7 +31,7 @@ export type FetchActionsPayload = {
 
 export const fetchActions = (
   { applicationId }: { applicationId: string },
-  postEvalActions: Array<ReduxAction<unknown> | ReduxActionWithoutPayload>,
+  postEvalActions: Array<AnyReduxAction>,
 ): EvaluationReduxAction<unknown> => {
   return {
     type: ReduxActionTypes.FETCH_ACTIONS_INIT,
@@ -52,7 +53,7 @@ export const fetchActionsForView = ({
 
 export const fetchActionsForPage = (
   pageId: string,
-  postEvalActions: Array<ReduxAction<unknown> | ReduxActionWithoutPayload> = [],
+  postEvalActions: Array<AnyReduxAction> = [],
 ): EvaluationReduxAction<unknown> => {
   return {
     type: ReduxActionTypes.FETCH_ACTIONS_FOR_PAGE_INIT,
@@ -63,7 +64,7 @@ export const fetchActionsForPage = (
 
 export const fetchActionsForPageSuccess = (
   actions: Action[],
-  postEvalActions?: Array<ReduxAction<unknown> | ReduxActionWithoutPayload>,
+  postEvalActions?: Array<AnyReduxAction>,
 ): EvaluationReduxAction<unknown> => {
   return {
     type: ReduxActionTypes.FETCH_ACTIONS_FOR_PAGE_SUCCESS,

--- a/app/client/src/constants/ReduxActionConstants.tsx
+++ b/app/client/src/constants/ReduxActionConstants.tsx
@@ -3,7 +3,7 @@ import { PageAction } from "constants/AppsmithActionConstants/ActionConstants";
 import { Org } from "./orgConstants";
 import { ERROR_CODES } from "@appsmith/constants/ApiConstants";
 import { AppLayoutConfig } from "reducers/entityReducers/pageListReducer";
-import { GitApplicationMetadata } from "../api/ApplicationApi";
+import { GitApplicationMetadata } from "api/ApplicationApi";
 
 export const ReduxSagaChannels = {
   WEBSOCKET_APP_LEVEL_WRITE_CHANNEL: "WEBSOCKET_APP_LEVEL_WRITE_CHANNEL",
@@ -409,6 +409,7 @@ export const ReduxActionTypes = {
   SET_META_PROP: "SET_META_PROP",
   RESET_CHILDREN_WIDGET_META: "RESET_CHILDREN_WIDGET_META",
   RESET_WIDGET_META: "RESET_WIDGET_META",
+  RESET_WIDGET_META_EVALUATED: "RESET_WIDGET_META_EVALUATED",
   UPDATE_WIDGET_NAME_INIT: "UPDATE_WIDGET_NAME_INIT",
   UPDATE_WIDGET_NAME_SUCCESS: "UPDATE_WIDGET_NAME_SUCCESS",
   FETCH_ACTIONS_FOR_PAGE_INIT: "FETCH_ACTIONS_FOR_PAGE_INIT",
@@ -491,6 +492,7 @@ export const ReduxActionTypes = {
     "TOGGLE_PROPERTY_PANE_WIDGET_NAME_EDIT",
   UPDATE_APP_PERSISTENT_STORE: "UPDATE_APP_PERSISTENT_STORE",
   UPDATE_APP_TRANSIENT_STORE: "UPDATE_APP_TRANSIENT_STORE",
+  UPDATE_APP_STORE_EVALUATED: "UPDATE_APP_STORE_EVALUATED",
   SET_ACTION_TO_EXECUTE_ON_PAGELOAD: "SET_ACTION_TO_EXECUTE_ON_PAGELOAD",
   TOGGLE_ACTION_EXECUTE_ON_LOAD_SUCCESS:
     "TOGGLE_ACTION_EXECUTE_ON_LOAD_SUCCESS",
@@ -858,8 +860,10 @@ export interface ReduxActionWithCallbacks<T, S, E> extends ReduxAction<T> {
   onErrorCallback?: (error: E) => void;
 }
 
+export type AnyReduxAction = ReduxAction<unknown> | ReduxActionWithoutPayload;
+
 export interface EvaluationReduxAction<T> extends ReduxAction<T> {
-  postEvalActions?: Array<ReduxAction<any> | ReduxActionWithoutPayload>;
+  postEvalActions?: Array<AnyReduxAction>;
 }
 
 export interface PromisePayload {

--- a/app/client/src/sagas/ActionExecution/ResetWidgetActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/ResetWidgetActionSaga.ts
@@ -1,4 +1,4 @@
-import { put, select } from "redux-saga/effects";
+import { put, select, take } from "redux-saga/effects";
 import { getWidgetByName } from "sagas/selectors";
 import {
   resetChildrenMetaProperty,
@@ -14,6 +14,7 @@ import {
   TriggerFailureError,
 } from "sagas/ActionExecution/errorUtils";
 import { getType, Types } from "utils/TypeHelpers";
+import { ReduxActionTypes } from "constants/ReduxActionConstants";
 
 export default function* resetWidgetActionSaga(
   payload: ResetWidgetDescription["payload"],
@@ -37,6 +38,8 @@ export default function* resetWidgetActionSaga(
   if (payload.resetChildren) {
     yield put(resetChildrenMetaProperty(widget.widgetId));
   }
+
+  yield take(ReduxActionTypes.RESET_WIDGET_META_EVALUATED);
 
   AppsmithConsole.info({
     text: `resetWidget('${payload.widgetName}', ${payload.resetChildren}) was triggered`,

--- a/app/client/src/sagas/ActionExecution/StoreActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/StoreActionSaga.ts
@@ -1,4 +1,4 @@
-import { put, select } from "redux-saga/effects";
+import { put, select, take } from "redux-saga/effects";
 import { getAppStoreName } from "constants/AppConstants";
 import localStorage from "utils/localStorage";
 import {
@@ -10,6 +10,7 @@ import { getAppStoreData } from "selectors/entitiesSelector";
 import { StoreValueActionDescription } from "entities/DataTree/actionTriggers";
 import { getCurrentGitBranch } from "selectors/gitSyncSelectors";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
+import { ReduxActionTypes } from "constants/ReduxActionConstants";
 
 export default function* storeValueLocally(
   action: StoreValueActionDescription["payload"],
@@ -38,4 +39,5 @@ export default function* storeValueLocally(
       text: `store('${action.key}', '${action.value}', false)`,
     });
   }
+  yield take(ReduxActionTypes.UPDATE_APP_STORE_EVALUATED);
 }

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -20,10 +20,7 @@ import {
 import { find, get, some } from "lodash";
 import LOG_TYPE from "../entities/AppsmithConsole/logtype";
 import { put, select } from "redux-saga/effects";
-import {
-  ReduxAction,
-  ReduxActionWithoutPayload,
-} from "constants/ReduxActionConstants";
+import { AnyReduxAction } from "constants/ReduxActionConstants";
 import { Toaster } from "components/ads/Toast";
 import { Variant } from "components/ads/common";
 import AppsmithConsole from "../utils/AppsmithConsole";
@@ -139,12 +136,10 @@ function logLatestEvalPropertyErrors(
           // Reformatting eval errors here to a format usable by the debugger
           const errorMessages = errors.map((e) => {
             // Error format required for the debugger
-            const formattedError = {
+            return {
               message: e.errorMessage,
               type: e.errorType,
             };
-
-            return formattedError;
           });
 
           const analyticsData = isWidget(entity)
@@ -336,9 +331,7 @@ export function* logSuccessfulBindings(
   });
 }
 
-export function* postEvalActionDispatcher(
-  actions: Array<ReduxAction<unknown> | ReduxActionWithoutPayload>,
-) {
+export function* postEvalActionDispatcher(actions: Array<AnyReduxAction>) {
   for (const action of actions) {
     yield put(action);
   }
@@ -351,14 +344,14 @@ export function* updateTernDefinitions(
   updates?: DataTreeDiff[],
 ) {
   let shouldUpdate: boolean;
-  // No updates means it was a first Eval
+  // No updates, means it was a first Eval
   if (!updates) {
     shouldUpdate = true;
   } else if (updates.length === 0) {
     // update length is 0 means no significant updates
     shouldUpdate = false;
   } else {
-    // Only when new field is added or deleted, we want to re create the def
+    // Only when new field is added or deleted, we want to re-create the def
     shouldUpdate = some(updates, (update) => {
       return (
         update.event === DataTreeDiffEvent.NEW ||


### PR DESCRIPTION
## Description

If we don't let the evaluation finish before completing resetWidget and storeValue, next function in promise chain is executed before it's effects are reflected in the data tree


Fixes #11110 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

TODO

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/reset-and-store-wait-till-evaluation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.53 **(-0.01)** | 37 **(-0.01)** | 35.76 **(0)** | 55.87 **(-0.01)**
 :red_circle: | app/client/src/components/editorComponents/form/fields/StyledFormComponents.tsx | 65.38 **(-2.48)** | 15.56 **(-1.83)** | 0 **(0)** | 65.38 **(-2.48)**
 :red_circle: | app/client/src/sagas/EvaluationsSaga.ts | 19.38 **(-0.71)** | 1.98 **(-0.15)** | 7.41 **(-0.59)** | 22.11 **(-0.93)**
 :green_circle: | app/client/src/sagas/PostEvaluationSagas.ts | 16.55 **(0.11)** | 0 **(0)** | 0 **(0)** | 20.17 **(0.17)**
 :green_circle: | app/client/src/sagas/ActionExecution/ResetWidgetActionSaga.ts | 42.86 **(0.75)** | 0 **(0)** | 0 **(0)** | 45 **(0.56)**
 :green_circle: | app/client/src/sagas/ActionExecution/StoreActionSaga.ts | 34.48 **(1.15)** | 0 **(0)** | 0 **(0)** | 38.46 **(0.96)**</details>