### PR TITLE
chore: upgrade jshint to fix security alert

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -69,7 +69,7 @@
     "interweave-autolink": "^4.4.2",
     "js-beautify": "^1.14.0",
     "js-sha256": "^0.9.0",
-    "jshint": "^2.13.1",
+    "jshint": "^2.13.4",
     "json-fn": "^1.1.1",
     "libphonenumber-js": "^1.9.44",
     "lint-staged": "^9.2.5",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -10479,9 +10479,10 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
 
-jshint@^2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.13.1.tgz#16bbbecdbb4564d3758d9de4f24926f8c7f8f835"
+jshint@^2.13.4:
+  version "2.13.4"
+  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.13.4.tgz#cee025a57c3f393d5455532d9ec7ccb018f890db"
+  integrity sha512-HO3bosL84b2qWqI0q+kpT/OpRJwo0R4ivgmxaO848+bo10rc50SkPnrtwSFXttW0ym4np8jbJvLwk5NziB7jIw==
   dependencies:
     cli "~1.0.0"
     console-browserify "1.1.x"
@@ -10489,7 +10490,6 @@ jshint@^2.13.1:
     htmlparser2 "3.8.x"
     lodash "~4.17.21"
     minimatch "~3.0.2"
-    shelljs "0.3.x"
     strip-json-comments "1.0.x"
 
 json-fn@^1.1.1:
@@ -15465,10 +15465,6 @@ shebang-regex@^3.0.0:
 shell-quote@1.7.2:
   version "1.7.2"
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz"
-
-shelljs@0.3.x:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Upgrade jshint

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: chore/bump-up-jshint 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.42 **(-0.03)** | 36.99 **(-0.02)** | 35.3 **(-0.09)** | 55.8 **(-0.04)**
 :red_circle: | app/client/src/components/ads/StepComponent.tsx | 40.91 **(-52.19)** | 66.67 **(-23.33)** | 0 **(-100)** | 40.91 **(-52.19)**
 :red_circle: | app/client/src/constants/IconConstants.tsx | 100 **(0)** | 83.33 **(-4.17)** | 100 **(0)** | 100 **(0)**
 :red_circle: | app/client/src/icons/ControlIcons.tsx | 68.42 **(-1.5)** | 100 **(0)** | 35.38 **(-3.08)** | 68.42 **(-1.5)**</details>