### PR TITLE
fix: Updated drop down control memo usage

### DIFF
--- a/app/client/src/components/formControls/BaseControl.tsx
+++ b/app/client/src/components/formControls/BaseControl.tsx
@@ -1,10 +1,7 @@
 import { Component } from "react";
 import { ControlType } from "constants/PropertyControlConstants";
 import { InputType } from "components/constants";
-import {
-  ConditonalObject,
-  DynamicValues,
-} from "reducers/evaluationReducers/formEvaluationReducer";
+import { ConditonalObject } from "reducers/evaluationReducers/formEvaluationReducer";
 import { DropdownOption } from "components/ads/Dropdown";
 // eslint-disable-next-line @typescript-eslint/ban-types
 abstract class BaseControl<P extends ControlProps, S = {}> extends Component<
@@ -77,7 +74,6 @@ export interface ControlData {
   identifier?: string;
   sectionName?: string;
   disabled?: boolean;
-  dynamicFetchedValues?: DynamicValues; // Object that holds the output of the dynamic fetched values
 }
 export type FormConfig = Omit<ControlData, "configProperty"> & {
   configProperty?: string;

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -9,7 +9,9 @@ import {
   WrappedFieldInputProps,
   WrappedFieldMetaProps,
 } from "redux-form";
-import { DynamicValues } from "reducers/evaluationReducers/formEvaluationReducer";
+import { connect } from "react-redux";
+import { AppState } from "reducers";
+import { getDynamicFetchedValues } from "selectors/formSelectors";
 
 const DropdownSelect = styled.div`
   font-size: 14px;
@@ -27,23 +29,12 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
       width = this.props.customStyles.width;
     }
 
-    // Options will be set dynamically if the config has fetchOptionsConditionally set to true
-    let options = this.props.options;
-    let isLoading = false;
-    if (
-      this.props.fetchOptionsCondtionally &&
-      !!this.props.dynamicFetchedValues
-    ) {
-      options = this.props.dynamicFetchedValues.data;
-      isLoading = this.props.dynamicFetchedValues.isLoading;
-    }
-
     return (
       <DropdownSelect data-cy={this.props.configProperty} style={{ width }}>
         <Field
           component={renderDropdown}
           name={this.props.configProperty}
-          props={{ ...this.props, width, isLoading, options }} // Passing options and isLoading in props allows the component to get the updated values
+          props={{ ...this.props, width }} // Passing options and isLoading in props allows the component to get the updated values
           type={this.props?.isMultiSelect ? "select-multiple" : undefined}
         />
       </DropdownSelect>
@@ -55,39 +46,38 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
   }
 }
 
-function renderDropdown(props: {
-  input?: WrappedFieldInputProps;
-  meta?: WrappedFieldMetaProps;
-  props: DropDownControlProps;
-  width: string;
-  formName: string;
-  isLoading?: boolean;
-  options: DropdownOption[];
-  disabled?: boolean;
-}): JSX.Element {
+function renderDropdown(
+  props: {
+    input?: WrappedFieldInputProps;
+    meta?: Partial<WrappedFieldMetaProps>;
+    width: string;
+  } & DropDownControlProps,
+): JSX.Element {
   let selectedValue = props.input?.value;
   if (_.isUndefined(props.input?.value)) {
-    selectedValue = props?.props?.initialValue;
+    selectedValue = props?.initialValue;
   }
-
-  const selectedOption =
-    props.options.find(
-      (option: DropdownOption) => option.value === selectedValue,
-    ) || {};
+  let options: DropdownOption[] = [];
+  let selectedOption = {};
+  if (typeof props.options === "object" && Array.isArray(props.options)) {
+    options = props.options;
+    selectedOption =
+      options.find(
+        (option: DropdownOption) => option.value === selectedValue,
+      ) || {};
+  }
   return (
     <Dropdown
       boundary="window"
       disabled={props.disabled}
       dontUsePortal={false}
       dropdownMaxHeight="250px"
-      errorMsg={props.props?.errorText}
-      helperText={props.props?.info}
       isLoading={props.isLoading}
-      isMultiSelect={props?.props?.isMultiSelect}
+      isMultiSelect={props?.isMultiSelect}
       onSelect={props.input?.onChange}
       optionWidth={props.width}
-      options={props.options}
-      placeholder={props.props?.placeholderText}
+      options={options}
+      placeholder={props?.placeholderText}
       selected={selectedOption}
       showLabelOnly
       width={props.width}
@@ -103,7 +93,28 @@ export interface DropDownControlProps extends ControlProps {
   isMultiSelect?: boolean;
   isSearchable?: boolean;
   fetchOptionsCondtionally?: boolean;
-  dynamicFetchedValues?: DynamicValues;
+  isLoading: boolean;
 }
 
-export default DropDownControl;
+const mapStateToProps = (state: AppState, ownProps: DropDownControlProps) => {
+  try {
+    let isLoading = false;
+    let options: DropdownOption[] = ownProps.options;
+    if (ownProps.fetchOptionsCondtionally) {
+      const dynamicFetchedValues = getDynamicFetchedValues(
+        state,
+        ownProps.configProperty,
+      );
+      isLoading = dynamicFetchedValues.isLoading;
+      options = dynamicFetchedValues.data;
+    }
+    return { isLoading, options };
+  } catch (e) {
+    return {
+      isLoading: false,
+      options: ownProps.fetchOptionsCondtionally ? [] : ownProps.options,
+    };
+  }
+};
+
+export default connect(mapStateToProps)(DropDownControl);

--- a/app/client/src/components/formControls/EntitySelectorControl.tsx
+++ b/app/client/src/components/formControls/EntitySelectorControl.tsx
@@ -61,7 +61,7 @@ function EntitySelectorComponent(props: any) {
   };
 
   return (
-    <EntitySelectorContainer>
+    <EntitySelectorContainer key={`ES_${configProperty}`}>
       {schema &&
         schema.length > 0 &&
         schema.map(
@@ -74,8 +74,7 @@ function EntitySelectorComponent(props: any) {
                       ...dropDownFieldConfig,
                       ...singleSchema,
                       customStyles,
-                      configProperty: `${configProperty}.column_${index + 1}`,
-                      key: `${configProperty}.column_${index + 1}`,
+                      key: `ES_${singleSchema.configProperty}`,
                     }}
                     formName={props.formName}
                   />
@@ -85,14 +84,14 @@ function EntitySelectorComponent(props: any) {
                       ...inputFieldConfig,
                       ...singleSchema,
                       customStyles,
-                      configProperty: `${configProperty}.column_${index + 1}`,
-                      key: `${configProperty}.column_${index + 1}`,
+                      key: `ES_${singleSchema.configProperty}`,
                     }}
                     formName={props.formName}
                   />
                 )}
                 {index < schema.length - 1 && (
                   <CenteredIcon
+                    key={`ES_ICON_${configProperty}`}
                     name="double-arrow-right"
                     size={IconSize.SMALL}
                   />
@@ -117,7 +116,7 @@ export default function EntitySelectorControl(
     <EntitySelectorComponent
       configProperty={configProperty}
       formName={formName}
-      key={configProperty}
+      key={`ES_PARENT_${configProperty}`}
       name={configProperty}
       schema={schema}
     />

--- a/app/client/src/pages/Editor/FormControl.tsx
+++ b/app/client/src/pages/Editor/FormControl.tsx
@@ -51,7 +51,7 @@ function FormControl(props: FormControlProps) {
         props.formName,
         props?.multipleConfig,
       ),
-    [],
+    [props],
   );
 
   if (hidden) return null;
@@ -133,7 +133,12 @@ function FormConfig(props: FormConfigProps) {
   );
 }
 
-export default memo(FormControl);
+export default memo(FormControl, (prevProps, nextProps) => {
+  return (
+    prevProps === nextProps &&
+    prevProps.config.disabled === nextProps.config.disabled
+  );
+});
 
 function renderFormConfigTop(props: { config: ControlProps }) {
   const {

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -80,7 +80,6 @@ import Spinner from "components/ads/Spinner";
 import {
   ConditionalOutput,
   FormEvalOutput,
-  DynamicValues,
 } from "reducers/evaluationReducers/formEvaluationReducer";
 
 const QueryFormContainer = styled.form`
@@ -649,67 +648,34 @@ export function EditorJSONtoForm(props: Props) {
   };
 
   // Function to modify the section config based on the output of evaluations
-  const modifySectionConfig = (
-    section: any,
-    enabled: boolean,
-    dynamicFetchedValues: DynamicValues | undefined,
-  ): any => {
+  const modifySectionConfig = (section: any, enabled: boolean): any => {
     if (!enabled) {
       section.disabled = true;
     } else {
       section.disabled = false;
     }
-    if (!!dynamicFetchedValues) {
-      section.dynamicFetchedValues = dynamicFetchedValues;
-    }
 
     return section;
-  };
-
-  // Function to extract the object for dynamicValues if it is there in the evaluation state
-  const extractDynamicValuesIfPresent = (
-    conditionalOutput: ConditionalOutput,
-  ) => {
-    // By default, the section is enabled. This is to allow for the case where no conditional is provided.
-    // The evaluation state disables the section if the condition is not met. (Checkout formEval.ts)
-    let dynamicFetchedValues: DynamicValues | undefined;
-    if (conditionalOutput.hasOwnProperty("fetchDynamicValues")) {
-      dynamicFetchedValues = conditionalOutput.fetchDynamicValues;
-    }
-    return dynamicFetchedValues;
   };
 
   // Render function to render the V2 of form editor type (UQI)
   // Section argument is a nested config object, this function recursively renders the UI based on the config
   const renderEachConfigV2 = (formName: string, section: any, idx: number) => {
     let enabled = true;
-    let dynamicFetchedValues: DynamicValues | undefined;
     if (!!section) {
       if ("schema" in section && section.schema.length > 0) {
-        section.schema.forEach((subSection: any, index: number) => {
-          const configPropertyOfSubSection = `${
-            section.configProperty
-          }.column_${index + 1}`;
+        section.schema.forEach((subSection: any) => {
           const conditionalOutput = extractConditionalOutput({
             ...subSection,
-            configProperty: configPropertyOfSubSection,
           });
           enabled = checkIfSectionIsEnabled(conditionalOutput);
-          dynamicFetchedValues = extractDynamicValuesIfPresent(
-            conditionalOutput,
-          );
-          subSection = modifySectionConfig(
-            subSection,
-            enabled,
-            dynamicFetchedValues,
-          );
+          subSection = modifySectionConfig(subSection, enabled);
         });
       }
       // If the component is not allowed to render, return null
       const conditionalOutput = extractConditionalOutput(section);
       if (!checkIfSectionCanRender(conditionalOutput)) return null;
       enabled = checkIfSectionIsEnabled(conditionalOutput);
-      dynamicFetchedValues = extractDynamicValuesIfPresent(conditionalOutput);
     }
     if (section.hasOwnProperty("controlType")) {
       // If component is type section, render it's children
@@ -723,11 +689,7 @@ export function EditorJSONtoForm(props: Props) {
       }
       try {
         const { configProperty } = section;
-        const modifiedSection = modifySectionConfig(
-          section,
-          enabled,
-          dynamicFetchedValues,
-        );
+        const modifiedSection = modifySectionConfig(section, enabled);
         return (
           <FieldWrapper key={`${configProperty}_${idx}`}>
             <FormControl config={modifiedSection} formName={formName} />

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -116,7 +116,7 @@ function* fetchDynamicValuesSaga(
       fetchDynamicValueSaga,
       queueOfValuesToBeFetched[key],
       key,
-      evalOutput,
+      Object.assign({}, evalOutput),
     );
   }
   // Set the values to the state once all values are fetched

--- a/app/client/src/selectors/formSelectors.ts
+++ b/app/client/src/selectors/formSelectors.ts
@@ -1,13 +1,17 @@
 import { getFormValues, isValid, getFormInitialValues } from "redux-form";
 import { AppState } from "reducers";
 import { ActionData } from "reducers/entityReducers/actionsReducer";
-import { FormEvaluationState } from "reducers/evaluationReducers/formEvaluationReducer";
+import {
+  DynamicValues,
+  FormEvaluationState,
+} from "reducers/evaluationReducers/formEvaluationReducer";
 import { createSelector } from "reselect";
-import _ from "lodash";
+import { replace } from "lodash";
 import { getDataTree } from "./dataTreeSelectors";
 import { DataTree } from "entities/DataTree/dataTreeFactory";
 import { Action } from "entities/Action";
 import { EvaluationError } from "utils/DynamicBindingUtils";
+import { getActionIdFromURL } from "pages/Editor/Explorer/helpers";
 
 type GetFormData = (
   state: AppState,
@@ -29,6 +33,14 @@ export const getApiName = (state: AppState, id: string) => {
 
 export const getFormEvaluationState = (state: AppState): FormEvaluationState =>
   state.evaluations.formEvaluation;
+
+export const getDynamicFetchedValues = (
+  state: AppState,
+  configProperty: string,
+): DynamicValues =>
+  state.evaluations.formEvaluation[getActionIdFromURL() as string][
+    configProperty
+  ].fetchDynamicValues as DynamicValues;
 
 type ConfigErrorProps = { configProperty: string; formName: string };
 
@@ -53,7 +65,7 @@ export const getConfigErrors = createSelector(
         const actionError = action && action?.__evaluation__?.errors;
 
         // get the configProperty for this form control and format it to resemble the format used in the action details errors object.
-        const formattedConfig = _.replace(
+        const formattedConfig = replace(
           configProperty,
           "actionConfiguration",
           "config",

--- a/app/client/src/workers/formEval.ts
+++ b/app/client/src/workers/formEval.ts
@@ -85,11 +85,8 @@ const generateInitialEvalState = (formConfig: FormConfig) => {
     );
 
   if ("schema" in formConfig && !!formConfig.schema)
-    formConfig.schema.forEach((config: FormConfig, index: number) =>
-      generateInitialEvalState({
-        ...config,
-        configProperty: `${formConfig.configProperty}.column_${index + 1}`,
-      }),
+    formConfig.schema.forEach((config: FormConfig) =>
+      generateInitialEvalState({ ...config }),
     );
 };
 


### PR DESCRIPTION
## Description

We recently added memo to form control components to reduce the number of re-renders. This caused the functionality of dynamically fetching values. To overcome this, I connected the drop-down control directly to the redux state. This is a much better alternative than the initial method of passing everything down via the props and doing a deep diff on the complex props state. The selector is also called only if the particular option to enable dynamic value fetching is turned on for the component.

Fixes #10762 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
