### PR TITLE
feat: Refactor helm ingress template to configure without domain

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -215,7 +215,7 @@ helm install stable-appsmith/appsmith --generate-name \
 --set ingress.annotations."kubernetes\.io/ingress\.class"=nginx \
 --set service.type=ClusterIP
 ```
-- If you have installed Appsmith Helm chart, please run the `Helm Upgrade` command to upgrade the existing installation
+- If you have installed Appsmith Helm chart, please run the `helm upgrade` command to upgrade the existing installation
 ```
 helm upgrade --set ingress.enabled=true stable-appsmith/appsmith appsmith
 

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -206,6 +206,22 @@ helm install \
   stable-appsmith/appsmith --generate-name
 ```
 
+## Expose Appsmith
+- If you wish to publish your Appsmith to the world through the Internet, you will need to setup the Ingress controller firstly. Please refer to the section **Kubernetes NGINX Ingress Controller** in the [Prerequisites](https://github.com/appsmithorg/appsmith/tree/release/deploy/helm#prerequisites)
+- In case of you have not install the Helm chart yet, you can run the below command to install it with exposing Appsmith
+```
+helm install stable-appsmith/appsmith --generate-name \
+--set ingress.enabled=true \
+--set ingress.annotations."kubernetes\.io/ingress\.class"=nginx \
+--set service.type=ClusterIP
+```
+- If you have installed Appsmith Helm chart, please run the `Helm Upgrade` command to upgrade the existing installation
+```
+helm upgrade --set ingress.enabled=true stable-appsmith/appsmith appsmith
+
+# Or this command if you are using values.yaml file
+helm upgrade --values values.yaml stable-appsmith/appsmith appsmith
+```
 ## Troubleshooting
 If at any time you encounter an error during the installation process, reach out to support@appsmith.com or join our Discord Server
 

--- a/deploy/helm/Setup-https.md
+++ b/deploy/helm/Setup-https.md
@@ -74,8 +74,6 @@ helm install appsmith/appsmith --generate-name \
 --set ingress.annotations."kubernetes\.io/ingress\.class"=nginx \
 --set ingress.annotations."cert-manager\.io/cluster-issuer"=letsencrypt-prod \
 --set ingress.hosts[0].host=DOMAIN \
---set ingress.hosts[0].paths[0].path=/ \
---set ingress.hosts[0].paths[0].pathType=ImplementationSpecific \
 --set ingress.certManagerTls[0].hosts[0]=DOMAIN \
 --set ingress.certManagerTls[0].secretName=letsencrypt-prod
 ```

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,10 +1,13 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
+{{- if not .Values.ingress.hosts }}
+  kubectl get ingress --namespace {{ .Release.Namespace }}
 {{- end }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+Please update your DNS records with your domain by the address. You can use following command to get Appsmith address:
+  kubectl get ingress --namespace {{ .Release.Namespace }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "appsmith.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -19,4 +22,5 @@
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+To expose your Appsmith service to be accessible from the Internet, please refer to our docs here https://github.com/appsmithorg/appsmith/tree/release/deploy/helm#expose-appsmith
 {{- end }}

--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -45,15 +45,12 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    {{- if not .Values.ingress.hosts }}
+    - host:
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+          - path: /
+            pathType: ImplementationSpecific
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
@@ -64,6 +61,22 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
+    {{- end }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
     {{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -117,9 +117,6 @@ ingress:
     # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   hosts: []
     # - host: appsmith-domain.me
-    #   paths:
-    #     - path: /
-    #       pathType: ImplementationSpecific
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hosts` parameter
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret


### PR DESCRIPTION

## Description
- Refactor Helm ingress template with default path. Add flow to configure template in case no domain provided
- Update document follow implementation. Add section Expose Appsmitth 


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

- Follow section Expose Appsmith in document & able to get the public address for Appsmith 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
