### PR TITLE
chore: Remove theme ids during git commit

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -189,17 +189,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
 
                     // Refactor application to remove the ids
                     final String organizationId = application.getOrganizationId();
-                    application.setOrganizationId(null);
-                    application.setPages(null);
-                    application.setPublishedPages(null);
-                    application.setModifiedBy(null);
-                    application.setUpdatedAt(null);
-                    application.setLastDeployedAt(null);
-                    application.setLastEditedAt(null);
-                    application.setUpdatedAt(null);
-                    application.setGitApplicationMetadata(null);
-                    application.setPolicies(null);
-                    application.setUserPermissions(null);
+                    removeUnwantedFieldsFromApplicationDuringExport(application);
                     examplesOrganizationCloner.makePristine(application);
                     applicationJson.setExportedApplication(application);
 
@@ -1552,5 +1542,21 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
         } else {
             return themeRepository.save(theme);
         }
+    }
+
+    private void removeUnwantedFieldsFromApplicationDuringExport(Application application) {
+            application.setOrganizationId(null);
+            application.setPages(null);
+            application.setPublishedPages(null);
+            application.setModifiedBy(null);
+            application.setUpdatedAt(null);
+            application.setLastDeployedAt(null);
+            application.setLastEditedAt(null);
+            application.setUpdatedAt(null);
+            application.setGitApplicationMetadata(null);
+            application.setPolicies(null);
+            application.setUserPermissions(null);
+            application.setEditModeThemeId(null);
+            application.setPublishedModeThemeId(null);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -265,6 +265,8 @@ public class ImportExportApplicationServiceTests {
                     assertThat(exportedApplication.getLastEditedAt()).isNull();
                     assertThat(exportedApplication.getLastDeployedAt()).isNull();
                     assertThat(exportedApplication.getGitApplicationMetadata()).isNull();
+                    assertThat(exportedApplication.getEditModeThemeId()).isNull();
+                    assertThat(exportedApplication.getPublishedModeThemeId()).isNull();
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

> This PR removes the theme ids during the git commit as this info is already present in `editModeTheme` and `publishedTheme` 