### PR TITLE
chore: introduce lookup tables inplace of switch

### DIFF
--- a/app/client/src/components/ads/Icon.tsx
+++ b/app/client/src/components/ads/Icon.tsx
@@ -157,189 +157,34 @@ export enum IconSize {
   XXXXL = "extraExtraExtraExtraLarge",
 }
 
-export const sizeHandler = (size?: IconSize) => {
-  let iconSize = 0;
-  switch (size) {
-    case IconSize.XXS:
-      iconSize = theme.iconSizes.XXS;
-      break;
-    case IconSize.XS:
-      iconSize = theme.iconSizes.XS;
-      break;
-    case IconSize.SMALL:
-      iconSize = theme.iconSizes.SMALL;
-      break;
-    case IconSize.MEDIUM:
-      iconSize = theme.iconSizes.MEDIUM;
-      break;
-    case IconSize.LARGE:
-      iconSize = theme.iconSizes.LARGE;
-      break;
-    case IconSize.XL:
-      iconSize = theme.iconSizes.XL;
-      break;
-    case IconSize.XXL:
-      iconSize = theme.iconSizes.XXL;
-      break;
-    case IconSize.XXXL:
-      iconSize = theme.iconSizes.XXXL;
-      break;
-    case IconSize.XXXXL:
-      iconSize = theme.iconSizes.XXXXL;
-      break;
-    default:
-      iconSize = theme.iconSizes.SMALL;
-      break;
-  }
-  return iconSize;
+const ICON_SIZE_LOOKUP = {
+  [IconSize.XXS]: theme.iconSizes.XXS,
+  [IconSize.XS]: theme.iconSizes.XS,
+  [IconSize.SMALL]: theme.iconSizes.SMALL,
+  [IconSize.MEDIUM]: theme.iconSizes.MEDIUM,
+  [IconSize.LARGE]: theme.iconSizes.LARGE,
+  [IconSize.XL]: theme.iconSizes.XL,
+  [IconSize.XXL]: theme.iconSizes.XXL,
+  [IconSize.XXXL]: theme.iconSizes.XXXL,
+  [IconSize.XXXXL]: theme.iconSizes.XXXXL,
+  undefined: theme.iconSizes.SMALL,
 };
 
-export const IconCollection = [
-  "HEADING_ONE",
-  "HEADING_THREE",
-  "HEADING_TWO",
-  "PARAGRAPH",
-  "PARAGRAPH_TWO",
-  "add-more",
-  "add-more-fill",
-  "arrow-forward",
-  "arrow-left",
-  "double-arrow-right",
-  "swap-horizontal",
-  "billing",
-  "book",
-  "book-line",
-  "bug",
-  "cancel",
-  "cap-dot",
-  "cap-solid",
-  "card-context-menu",
-  "chat",
-  "checkbox-circle-line",
-  "check-line",
-  "chevron-left",
-  "chevron-right",
-  "close",
-  "close-circle",
-  "close-modal",
-  "close-x",
-  "column",
-  "comment-context-menu",
-  "context-menu",
-  "cross",
-  "danger",
-  "database-2-line",
-  "datasource",
-  "delete",
-  "delete-blank",
-  "desktop",
-  "discord",
-  "down-arrow-2",
-  "downArrow",
-  "download",
-  "duplicate",
-  "edit",
-  "edit-line",
-  "edit-box-line",
-  "emoji",
-  "enterprise",
-  "error",
-  "expand-less",
-  "expand-more",
-  "eye-on",
-  "eye-off",
-  "file-transfer",
-  "filter",
-  "fluid",
-  "fork",
-  "gear",
-  "general",
-  "git-branch",
-  "git-commit",
-  "git-pull-request",
-  "guide",
-  "help",
-  "info",
-  "invite-user",
-  "left-arrow",
-  "left-arrow-2",
-  "lightning",
-  "line-dashed",
-  "line-dotted",
-  "lightbulb-flash-line",
-  "link",
-  "link-2",
-  "logout",
-  "manage",
-  "magic-line",
-  "mobile",
-  "more-2-fill",
-  "news-paper",
-  "no-response",
-  "open",
-  "oval-check",
-  "oval-check-fill",
-  "pin",
-  "pin-3",
-  "play",
-  "plus",
-  "query",
-  "reaction",
-  "reaction-2",
-  "read-pin",
-  "right-arrow",
-  "right-arrow-2",
-  "rocket",
-  "search",
-  "send-button",
-  "settings-2-line",
-  "share",
-  "share-2",
-  "share-box",
-  "share-line",
-  "shine",
-  "star-line",
-  "star-fill",
-  "success",
-  "support",
-  "tables",
-  "tablet",
-  "trash",
-  "trash-outline",
-  "trending-flat",
-  "unpin",
-  "unread-pin",
-  "upArrow",
-  "upload",
-  "user",
-  "user-2",
-  "view-all",
-  "view-less",
-  "wand",
-  "warning",
-  "warning-line",
-  "warning-triangle",
-  "workspace",
-  "git-branch",
-  "snippet",
-  "edit-underline",
-  "down-arrow",
-  "loader",
-  "setting",
-  "widget",
-  "dropdown",
-  "refresh",
-  "key",
-] as const;
-
-export type IconName = typeof IconCollection[number];
+export const sizeHandler = (size?: IconSize): number => {
+  return (
+    ICON_SIZE_LOOKUP[size as keyof typeof ICON_SIZE_LOOKUP] ||
+    theme.iconSizes.SMALL
+  );
+};
 
 export const IconWrapper = styled.span<IconProps>`
   &:focus {
     outline: none;
   }
+
   display: flex;
   align-items: center;
+
   svg {
     width: ${(props) => sizeHandler(props.size)}px;
     height: ${(props) => sizeHandler(props.size)}px;
@@ -356,6 +201,7 @@ export const IconWrapper = styled.span<IconProps>`
           `
         : ""};
     ${(props) => (props.invisible ? `visibility: hidden;` : null)};
+
     &:hover {
       cursor: ${(props) => (props.clickable ? "pointer" : "default")};
       ${(props) =>
@@ -370,6 +216,151 @@ export const IconWrapper = styled.span<IconProps>`
     }
   }
 `;
+
+function getControlIcon(iconName: string) {
+  const ControlIcon = ControlIcons[iconName];
+  return <ControlIcon height={24} width={24} />;
+}
+
+const ICON_LOOKUP = {
+  undefined: null,
+  HEADING_ONE: getControlIcon("HEADING_ONE"),
+  HEADING_THREE: getControlIcon("HEADING_THREE"),
+  HEADING_TWO: getControlIcon("HEADING_TWO"),
+  PARAGRAPH: getControlIcon("PARAGRAPH"),
+  PARAGRAPH_TWO: getControlIcon("PARAGRAPH_TWO"),
+  "add-more": <AddMoreIcon />,
+  "add-more-fill": <AddMoreFillIcon />,
+  "arrow-forward": <ArrowForwardIcon />,
+  "arrow-left": <ArrowLeft />,
+  "book-line": <BookLineIcon />,
+  "cap-dot": <CapDotIcon />,
+  "cap-solid": <CapSolidIcon />,
+  "card-context-menu": <CardContextMenu />,
+  "check-line": <CheckLineIcon />,
+  "chevron-left": <ChevronLeft />,
+  "chevron-right": <ChevronRight />,
+  "close-circle": <CloseCircleIcon />,
+  "close-modal": <CloseLineIcon />,
+  "close-x": <CloseLineIcon />,
+  "comment-context-menu": <CommentContextMenu />,
+  "context-menu": <ContextMenuIcon />,
+  "database-2-line": <Database2Line />,
+  "delete-blank": <DeleteBin7 />,
+  "double-arrow-right": <DoubleArrowRightIcon />,
+  "down-arrow": <DownArrowIcon />,
+  "down-arrow-2": <ArrowDownLineIcon />,
+  "edit-box-line": <EditBoxLineIcon />,
+  "edit-line": <EditLineIcon />,
+  "edit-underline": <EditUnderlineIcon />,
+  "expand-less": <ExpandLess />,
+  "expand-more": <ExpandMore />,
+  "eye-off": <EyeOff />,
+  "eye-on": <EyeOn />,
+  "file-transfer": <FileTransfer />,
+  "git-branch": <GitBranchLineIcon />,
+  "git-commit": <GitCommit />,
+  "git-pull-request": <GitPullRequst />,
+  "invite-user": <InviteUserIcon />,
+  "left-arrow-2": <LeftArrowIcon2 />,
+  "lightbulb-flash-line": <LightbulbFlashLine />,
+  "line-dashed": <LineDashedIcon />,
+  "line-dotted": <LineDottedIcon />,
+  "link-2": <Link2 />,
+  "magic-line": <MagicLineIcon />,
+  "more-2-fill": <More2FillIcon />,
+  "news-paper": <NewsPaperLine />,
+  "no-response": <NoResponseIcon />,
+  "oval-check": <OvalCheck />,
+  "oval-check-fill": <OvalCheckFill />,
+  "pin-3": <Pin3 />,
+  "reaction-2": <Reaction2 />,
+  "read-pin": <ReadPin />,
+  "right-arrow": <RightArrowIcon />,
+  "right-arrow-2": <RightArrowIcon2 />,
+  "send-button": <SendButton />,
+  "settings-2-line": <Settings2LineIcon />,
+  "share-2": <ShareIcon2 />,
+  "share-box": <ShareBoxFillIcon />,
+  "share-line": <ShareLineIcon />,
+  "star-fill": <StarFillIcon />,
+  "star-line": <StarLineIcon />,
+  "swap-horizontal": <ArrowLeftRightIcon />,
+  "trash-outline": <TrashOutline />,
+  "trending-flat": <TrendingFlat />,
+  "unread-pin": <UnreadPin />,
+  "user-2": <UserV2Icon />,
+  "view-all": <RightArrowIcon />,
+  "view-less": <LeftArrowIcon />,
+  "warning-line": <WarningLineIcon />,
+  "warning-triangle": <WarningTriangleIcon />,
+  billing: <BillingIcon />,
+  book: <BookIcon />,
+  bug: <BugIcon />,
+  cancel: <CancelIcon />,
+  chat: <Chat />,
+  close: <CloseIcon />,
+  column: <ColumnIcon />,
+  cross: <CrossIcon />,
+  danger: <ErrorIcon />,
+  datasource: <DatasourceIcon />,
+  delete: <Trash />,
+  desktop: <DesktopIcon />,
+  discord: <DiscordIcon />,
+  downArrow: <DownArrow />,
+  download: <Download />,
+  dropdown: <DropdownIcon />,
+  duplicate: <DuplicateIcon />,
+  edit: <EditIcon />,
+  emoji: <Emoji />,
+  enterprise: <MagicLineIcon />,
+  error: <ErrorIcon />,
+  filter: <Filter />,
+  fluid: <FluidIcon />,
+  fork: <GitMerge />,
+  gear: <GearIcon />,
+  general: <GeneralIcon />,
+  guide: <GuideIcon />,
+  help: <HelpIcon />,
+  info: <InfoIcon />,
+  key: <KeyIcon />,
+  lightning: <LightningIcon />,
+  link: <LinkIcon />,
+  loader: <LoaderLineIcon />,
+  logout: <LogoutIcon />,
+  manage: <ManageIcon />,
+  mobile: <MobileIcon />,
+  open: <OpenIcon />,
+  pin: <Pin />,
+  play: <PlayIcon />,
+  plus: <CreateNewIcon />,
+  query: <QueryIcon />,
+  reaction: <Reaction />,
+  refresh: <RefreshLineIcon />,
+  rocket: <RocketIcon />,
+  search: <SearchIcon />,
+  setting: <SettingIcon />,
+  share: <ShareForwardIcon />,
+  shine: <ShineIcon />,
+  snippet: <Snippet />,
+  success: <SuccessIcon />,
+  support: <SupportIcon />,
+  tables: <TableIcon />,
+  tablet: <TabletIcon />,
+  trash: <Trash />,
+  unpin: <Unpin />,
+  upArrow: <UpArrow />,
+  upload: <Upload />,
+  user: <UserIcon />,
+  wand: <WandIcon />,
+  warning: <WarningIcon />,
+  widget: <WidgetIcon />,
+  workspace: <WorkspaceIcon />,
+};
+
+export const IconCollection = Object.keys(ICON_LOOKUP);
+
+export type IconName = typeof IconCollection[number];
 
 export type IconProps = {
   size?: IconSize;
@@ -386,399 +377,9 @@ export type IconProps = {
 
 const Icon = forwardRef(
   (props: IconProps & CommonComponentProps, ref: Ref<HTMLSpanElement>) => {
-    let returnIcon;
-    switch (props.name) {
-      case "HEADING_ONE":
-      case "HEADING_TWO":
-      case "HEADING_THREE":
-      case "PARAGRAPH":
-      case "PARAGRAPH_TWO":
-        const ControlIcon = ControlIcons[props.name];
-        returnIcon = <ControlIcon height={24} width={24} />;
-        break;
-      case "add-more":
-        returnIcon = <AddMoreIcon />;
-        break;
-      case "add-more-fill":
-        returnIcon = <AddMoreFillIcon />;
-        break;
-      case "arrow-forward":
-        returnIcon = <ArrowForwardIcon />;
-        break;
-      case "double-arrow-right":
-        returnIcon = <DoubleArrowRightIcon />;
-        break;
-      case "arrow-left":
-        returnIcon = <ArrowLeft />;
-        break;
-      case "swap-horizontal":
-        returnIcon = <ArrowLeftRightIcon />;
-        break;
-      case "billing":
-        returnIcon = <BillingIcon />;
-        break;
-      case "book":
-        returnIcon = <BookIcon />;
-        break;
-      case "book-line":
-        returnIcon = <BookLineIcon />;
-        break;
-      case "bug":
-        returnIcon = <BugIcon />;
-        break;
-      case "cancel":
-        returnIcon = <CancelIcon />;
-        break;
-      case "cap-dot":
-        returnIcon = <CapDotIcon />;
-        break;
-      case "cap-solid":
-        returnIcon = <CapSolidIcon />;
-        break;
-      case "card-context-menu":
-        returnIcon = <CardContextMenu />;
-        break;
-      case "chat":
-        returnIcon = <Chat />;
-        break;
-      case "check-line":
-        returnIcon = <CheckLineIcon />;
-        break;
-      case "chevron-left":
-        returnIcon = <ChevronLeft />;
-        break;
-      case "chevron-right":
-        returnIcon = <ChevronRight />;
-        break;
-      case "close":
-        returnIcon = <CloseIcon />;
-        break;
-      case "close-circle":
-        returnIcon = <CloseCircleIcon />;
-        break;
-      case "close-modal":
-      case "close-x":
-        returnIcon = <CloseLineIcon />;
-        break;
-      case "column":
-        returnIcon = <ColumnIcon />;
-        break;
-      case "comment-context-menu":
-        returnIcon = <CommentContextMenu />;
-        break;
-      case "context-menu":
-        returnIcon = <ContextMenuIcon />;
-        break;
-      case "cross":
-        returnIcon = <CrossIcon />;
-        break;
-      case "danger":
-        returnIcon = <ErrorIcon />;
-        break;
-      case "database-2-line":
-        returnIcon = <Database2Line />;
-        break;
-      case "datasource":
-        returnIcon = <DatasourceIcon />;
-        break;
-      case "delete":
-        returnIcon = <Trash />;
-        break;
-      case "delete-blank":
-        returnIcon = <DeleteBin7 />;
-        break;
-      case "desktop":
-        returnIcon = <DesktopIcon />;
-        break;
-      case "discord":
-        returnIcon = <DiscordIcon />;
-        break;
-      case "down-arrow-2":
-        returnIcon = <ArrowDownLineIcon />;
-        break;
-      case "downArrow":
-        returnIcon = <DownArrow />;
-        break;
-      case "download":
-        returnIcon = <Download />;
-        break;
-      case "duplicate":
-        returnIcon = <DuplicateIcon />;
-        break;
-      case "edit":
-        returnIcon = <EditIcon />;
-        break;
-      case "edit-line":
-        returnIcon = <EditLineIcon />;
-        break;
-      case "edit-box-line":
-        returnIcon = <EditBoxLineIcon />;
-        break;
-      case "emoji":
-        returnIcon = <Emoji />;
-        break;
-      case "enterprise":
-        returnIcon = <MagicLineIcon />;
-        break;
-      case "error":
-        returnIcon = <ErrorIcon />;
-        break;
-      case "expand-less":
-        returnIcon = <ExpandLess />;
-        break;
-      case "expand-more":
-        returnIcon = <ExpandMore />;
-        break;
-      case "eye-on":
-        returnIcon = <EyeOn />;
-        break;
-      case "eye-off":
-        returnIcon = <EyeOff />;
-        break;
-      case "file-transfer":
-        returnIcon = <FileTransfer />;
-        break;
-      case "filter":
-        returnIcon = <Filter />;
-        break;
-      case "fluid":
-        returnIcon = <FluidIcon />;
-        break;
-      case "fork":
-        returnIcon = <GitMerge />;
-        break;
-      case "gear":
-        returnIcon = <GearIcon />;
-        break;
-      case "general":
-        returnIcon = <GeneralIcon />;
-        break;
-      case "git-branch":
-        returnIcon = <GitBranchLineIcon />;
-        break;
-      case "git-commit":
-        returnIcon = <GitCommit />;
-        break;
-      case "git-pull-request":
-        returnIcon = <GitPullRequst />;
-        break;
-      case "guide":
-        returnIcon = <GuideIcon />;
-        break;
-      case "help":
-        returnIcon = <HelpIcon />;
-        break;
-      case "info":
-        returnIcon = <InfoIcon />;
-        break;
-      case "invite-user":
-        returnIcon = <InviteUserIcon />;
-        break;
-      case "key":
-        returnIcon = <KeyIcon />;
-        break;
-      case "left-arrow-2":
-        returnIcon = <LeftArrowIcon2 />;
-        break;
-      case "lightning":
-        returnIcon = <LightningIcon />;
-        break;
-      case "lightbulb-flash-line":
-        returnIcon = <LightbulbFlashLine />;
-        break;
-      case "line-dashed":
-        returnIcon = <LineDashedIcon />;
-        break;
-      case "line-dotted":
-        returnIcon = <LineDottedIcon />;
-        break;
-      case "link":
-        returnIcon = <LinkIcon />;
-        break;
-      case "link-2":
-        returnIcon = <Link2 />;
-        break;
-      case "logout":
-        returnIcon = <LogoutIcon />;
-        break;
-      case "manage":
-        returnIcon = <ManageIcon />;
-        break;
-      case "magic-line":
-        returnIcon = <MagicLineIcon />;
-        break;
-      case "mobile":
-        returnIcon = <MobileIcon />;
-        break;
-      case "more-2-fill":
-        returnIcon = <More2FillIcon />;
-        break;
-      case "news-paper":
-        returnIcon = <NewsPaperLine />;
-        break;
-      case "no-response":
-        returnIcon = <NoResponseIcon />;
-        break;
-      case "open":
-        returnIcon = <OpenIcon />;
-        break;
-      case "oval-check":
-        returnIcon = <OvalCheck />;
-        break;
-      case "oval-check-fill":
-        returnIcon = <OvalCheckFill />;
-        break;
-      case "pin":
-        returnIcon = <Pin />;
-        break;
-      case "pin-3":
-        returnIcon = <Pin3 />;
-        break;
-      case "play":
-        returnIcon = <PlayIcon />;
-        break;
-      case "plus":
-        returnIcon = <CreateNewIcon />;
-        break;
-      case "query":
-        returnIcon = <QueryIcon />;
-        break;
-      case "reaction":
-        returnIcon = <Reaction />;
-        break;
-      case "reaction-2":
-        returnIcon = <Reaction2 />;
-        break;
-      case "read-pin":
-        returnIcon = <ReadPin />;
-        break;
-      case "right-arrow":
-        returnIcon = <RightArrowIcon />;
-        break;
-      case "right-arrow-2":
-        returnIcon = <RightArrowIcon2 />;
-        break;
-      case "rocket":
-        returnIcon = <RocketIcon />;
-        break;
-      case "search":
-        returnIcon = <SearchIcon />;
-        break;
-      case "send-button":
-        returnIcon = <SendButton />;
-        break;
-      case "settings-2-line":
-        returnIcon = <Settings2LineIcon />;
-        break;
-      case "share":
-        returnIcon = <ShareForwardIcon />;
-        break;
-      case "share-2":
-        returnIcon = <ShareIcon2 />;
-        break;
-      case "share-box":
-        returnIcon = <ShareBoxFillIcon />;
-        break;
-      case "share-line":
-        returnIcon = <ShareLineIcon />;
-        break;
-      case "shine":
-        returnIcon = <ShineIcon />;
-        break;
-      case "star-line":
-        returnIcon = <StarLineIcon />;
-        break;
-      case "star-fill":
-        returnIcon = <StarFillIcon />;
-        break;
-      case "success":
-        returnIcon = <SuccessIcon />;
-        break;
-      case "support":
-        returnIcon = <SupportIcon />;
-        break;
-      case "tables":
-        returnIcon = <TableIcon />;
-        break;
-      case "tablet":
-        returnIcon = <TabletIcon />;
-        break;
-      case "trash":
-        returnIcon = <Trash />;
-        break;
-      case "trash-outline":
-        returnIcon = <TrashOutline />;
-        break;
-      case "trending-flat":
-        returnIcon = <TrendingFlat />;
-        break;
-      case "unpin":
-        returnIcon = <Unpin />;
-        break;
-      case "unread-pin":
-        returnIcon = <UnreadPin />;
-        break;
-      case "upArrow":
-        returnIcon = <UpArrow />;
-        break;
-      case "upload":
-        returnIcon = <Upload />;
-        break;
-      case "user":
-        returnIcon = <UserIcon />;
-        break;
-      case "user-2":
-        returnIcon = <UserV2Icon />;
-        break;
-      case "view-all":
-        returnIcon = <RightArrowIcon />;
-        break;
-      case "view-less":
-        returnIcon = <LeftArrowIcon />;
-        break;
-      case "wand":
-        returnIcon = <WandIcon />;
-        break;
-      case "warning":
-        returnIcon = <WarningIcon />;
-        break;
-      case "warning-line":
-        returnIcon = <WarningLineIcon />;
-        break;
-      case "warning-triangle":
-        returnIcon = <WarningTriangleIcon />;
-        break;
-      case "setting":
-        returnIcon = <SettingIcon />;
-        break;
-      case "workspace":
-        returnIcon = <WorkspaceIcon />;
-        break;
-      case "snippet":
-        returnIcon = <Snippet />;
-        break;
-      case "edit-underline":
-        returnIcon = <EditUnderlineIcon />;
-        break;
-      case "down-arrow":
-        returnIcon = <DownArrowIcon />;
-        break;
-      case "loader":
-        returnIcon = <LoaderLineIcon />;
-        break;
-      case "widget":
-        returnIcon = <WidgetIcon />;
-        break;
-      case "dropdown":
-        returnIcon = <DropdownIcon />;
-        break;
-      case "refresh":
-        returnIcon = <RefreshLineIcon />;
-        break;
-      default:
-        returnIcon = null;
-        break;
-    }
+    const iconName = props.name;
+    const returnIcon =
+      ICON_LOOKUP[iconName as keyof typeof ICON_LOOKUP] || null;
 
     const clickable = props.clickable === undefined ? true : props.clickable;
 

--- a/app/client/src/components/ads/common.tsx
+++ b/app/client/src/components/ads/common.tsx
@@ -83,24 +83,17 @@ export enum ToastTypeOptions {
   error = "error",
 }
 
-export const ToastVariant = (type: any) => {
-  let variant: Variant;
-  switch (type) {
-    case toast.TYPE.ERROR === type:
-      variant = Variant.danger;
-      break;
-    case toast.TYPE.INFO === type:
-      variant = Variant.info;
-      break;
-    case toast.TYPE.SUCCESS === type:
-      variant = Variant.success;
-      break;
-    case toast.TYPE.WARNING === type:
-      variant = Variant.warning;
-      break;
-    default:
-      variant = Variant.info;
-      break;
-  }
-  return variant;
+const TOAST_VARIANT_LOOKUP = {
+  [toast.TYPE.ERROR]: Variant.danger,
+  [toast.TYPE.INFO]: Variant.info,
+  [toast.TYPE.SUCCESS]: Variant.success,
+  [toast.TYPE.WARNING]: Variant.warning,
+  undefined: Variant.info,
+};
+
+export const ToastVariant = (type: any): Variant => {
+  return (
+    TOAST_VARIANT_LOOKUP[type as keyof typeof TOAST_VARIANT_LOOKUP] ||
+    Variant.info
+  );
 };


### PR DESCRIPTION
## Description

There are few places in code where we are using switch control flow. Switch itself if not bad, but in our cases, we are simply returning or using cases for one-to-one mapping. This PR brings that 1-1 mapping to a lookup table.

Lookup tables have added benefit of being faster than control structures, the case checks are replaced with keys lookup in the table.

Fixes #11224 

## Type of change

- Performance enhancement
- Code cleanup

## How Has This Been Tested?

Manually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: 11224-lookup-tables 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.7 **(0.16)** | 37.06 **(0.06)** | 35.76 **(0.01)** | 56.05 **(0.18)**
 :green_circle: | app/client/src/components/ads/Icon.tsx | 99.39 **(45.74)** | 84.21 **(46.36)** | 100 **(0)** | 99.39 **(45.84)**
 :green_circle: | app/client/src/components/ads/common.tsx | 92.68 **(20.13)** | 75 **(15)** | 62.5 **(0)** | 91.67 **(22.1)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**</details>