### PR TITLE
chore: Save data of all performance runs

### DIFF
--- a/app/client/perf/src/ci/supabase.js
+++ b/app/client/perf/src/ci/supabase.js
@@ -95,8 +95,8 @@ const saveData = async (results) => {
       const runs = results[action][metric];
       runs.forEach((value, i) => {
         row["value"] = value;
+        rows.push(row);
       });
-      rows.push(row);
     });
   });
 


### PR DESCRIPTION
We are saving only the last performance run data when there are multiple runs.
This PR fixes it.
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>