### PR TITLE
fix: Set comment authors email address as reply to field in comment notification email

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/notifications/EmailSender.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/notifications/EmailSender.java
@@ -38,11 +38,11 @@ public class EmailSender {
         REPLY_TO = makeReplyTo();
     }
 
-    public Mono<Boolean> sendMail(String to, String subject, String text) {
-        return sendMail(to, subject, text, null);
+    public Mono<Boolean> sendMail(String to, String subject, String text, Map<String, ? extends Object> params) {
+        return sendMail(to, subject, text, params, null);
     }
 
-    public Mono<Boolean> sendMail(String to, String subject, String text, Map<String, ? extends Object> params) {
+    public Mono<Boolean> sendMail(String to, String subject, String text, Map<String, ? extends Object> params, String replyTo) {
 
         /**
          * Creating a publisher which sends email in a blocking fashion, subscribing on the bounded elastic
@@ -59,7 +59,7 @@ public class EmailSender {
                     }
                 })
                 .doOnNext(emailBody -> {
-                    sendMailSync(to, subject, emailBody);
+                    sendMailSync(to, subject, emailBody, replyTo);
                 })
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/notifications/EmailSender.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/notifications/EmailSender.java
@@ -7,6 +7,7 @@ import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -74,7 +75,7 @@ public class EmailSender {
      * @param subject Subject string.
      * @param text    HTML Body of the message. This method assumes UTF-8.
      */
-    private void sendMailSync(String to, String subject, String text) {
+    private void sendMailSync(String to, String subject, String text, String replyTo) {
         log.debug("Got request to send email to: {} with subject: {}", to, subject);
         // Don't send an email for local, dev or test environments
         if (!emailConfig.isEmailEnabled()) {
@@ -96,7 +97,9 @@ public class EmailSender {
             if (emailConfig.getMailFrom() != null) {
                 helper.setFrom(emailConfig.getMailFrom());
             }
-            if (REPLY_TO != null) {
+            if(StringUtils.hasLength(replyTo)) {
+                helper.setReplyTo(replyTo);
+            } else if (REPLY_TO != null) {
                 helper.setReplyTo(REPLY_TO);
             }
             helper.setSubject(subject);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EmailEventHandlerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EmailEventHandlerCEImpl.java
@@ -222,7 +222,9 @@ public class EmailEventHandlerCEImpl implements EmailEventHandlerCE {
         } else {
             templateParams.put("Replied", true);
         }
-        return emailSender.sendMail(receiverEmail, emailSubject, COMMENT_ADDED_EMAIL_TEMPLATE, templateParams);
+        return emailSender.sendMail(
+                receiverEmail, emailSubject, COMMENT_ADDED_EMAIL_TEMPLATE, templateParams, comment.getAuthorUsername()
+        );
     }
 
     private Mono<Boolean> geBotEmailSenderMono(Comment comment, String originHeader, Organization organization, Application application) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EmailEventHandlerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EmailEventHandlerTest.java
@@ -182,7 +182,7 @@ public class EmailEventHandlerTest {
         );
         // check email sender was called with expected template and subject
         Mockito.verify(emailSender, Mockito.times(1)).sendMail(
-                eq(emailReceiverUsername), eq(expectedEmailSubject), eq(COMMENT_ADDED_EMAIL_TEMPLATE), Mockito.anyMap()
+                eq(emailReceiverUsername), eq(expectedEmailSubject), eq(COMMENT_ADDED_EMAIL_TEMPLATE), Mockito.anyMap(), eq(authorUserName)
         );
     }
 
@@ -254,7 +254,7 @@ public class EmailEventHandlerTest {
 
         // check email sender was called with expected template and subject
         Mockito.verify(emailSender, Mockito.times(1)).sendMail(
-                eq(emailReceiverUsername), eq(expectedEmailSubject), eq(COMMENT_ADDED_EMAIL_TEMPLATE), Mockito.anyMap()
+                eq(emailReceiverUsername), eq(expectedEmailSubject), eq(COMMENT_ADDED_EMAIL_TEMPLATE), Mockito.anyMap(), eq(authorUserName)
         );
     }
 


### PR DESCRIPTION
## Description

When someone adds a comment to a thread, we send a email notification to the subscribers of that thread. The email has resply-to set to appsmith email address. If someone replies to that email, it's sent to an appsmith email address. This PR sets comment author's email address in the reply-to field so that replying to that email will be sent to the authors inbox.
Fixes #11016

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Unit tests
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
