### PR TITLE
fix: UI of Input widget is not proper when icon is set and left aligned

### DIFF
--- a/app/client/src/widgets/BaseInputWidget/component/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/component/index.tsx
@@ -205,7 +205,6 @@ const InputComponentWrapper = styled((props) => (
         top: 3px;
       }
       input:not(:first-child) {
-        border-left: 1px solid transparent;
         line-height: 16px;
 
         &:hover:not(:focus) {


### PR DESCRIPTION

## Description

Steps To Reproduce
1. Drag and drop an Input widget
2. In Icon property from property pane set an icon
3. Observe that the left border of the widget is not displayed.

Fixes #11198 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>