### PR TITLE
fix: curl import tries to guess the content-type from the body if content-type header is not specified

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CurlImporterServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/CurlImporterServiceImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services;
 
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.services.ce.CurlImporterServiceCEImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -9,11 +10,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class CurlImporterServiceImpl extends CurlImporterServiceCEImpl implements CurlImporterService {
 
-    public CurlImporterServiceImpl(PluginService pluginService,
-                                   LayoutActionService layoutActionService,
-                                   NewPageService newPageService,
-                                   ResponseUtils responseUtils) {
-
-        super(pluginService, layoutActionService, newPageService, responseUtils);
+    public CurlImporterServiceImpl(
+            PluginService pluginService,
+            LayoutActionService layoutActionService,
+            NewPageService newPageService,
+            ResponseUtils responseUtils,
+            ObjectMapper objectMapper
+    ) {
+        super(pluginService, layoutActionService, newPageService, responseUtils, objectMapper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -371,11 +371,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
 
         }
 
-        if (contentType == null && !dataParts.isEmpty()) {
-            contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE;
-            headers.add(new Property(HttpHeaders.CONTENT_TYPE, contentType));
-
-        } else if (contentType == null && !formParts.isEmpty()) {
+        if (contentType == null && !formParts.isEmpty()) {
             contentType = MediaType.MULTIPART_FORM_DATA_VALUE;
             headers.add(new Property(HttpHeaders.CONTENT_TYPE, contentType));
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -438,7 +438,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
     private String guessTheContentType(List<String> dataParts, List<String> formParts) {
         if (!dataParts.isEmpty()) {
             final String data = dataParts.get(0);
-            final Pattern urlEncodedPattern = Pattern.compile("([A-Za-z0-9%./]+=[^\\s]+)");
+            final Pattern urlEncodedPattern = Pattern.compile("([A-Za-z0-9%._\\-/]+=[^\\s]+)");
             // if it's form url encoded?
             if (urlEncodedPattern.matcher(data).matches()) {
                 return MediaType.APPLICATION_FORM_URLENCODED_VALUE;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -338,7 +338,12 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
 
             } else if ("--data-urlencode".equals(state)) {
                 // The `token` is next to `--data-urlencode`.
-                dataParts.add(token);
+                // ignore the '=' at the start as the curl document says https://curl.se/docs/manpage.html#--data-urlencode
+                if (token.startsWith("=")) {
+                    dataParts.add(token.substring(1));
+                } else {
+                    dataParts.add(token);
+                }
 
             } else if (ARG_FORM.equals(state)) {
                 // The token is next to --form

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -311,33 +311,24 @@ public class CurlImporterServiceTest {
         );
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://loc");
-        assertEmptyBody(action);
-        assertBodyFormData(
-                action,
-                new Property("", "all of this exactly, but url encoded ")
-        );
+        assertBody(action,"all of this exactly, but url encoded ");
+        assertEmptyBodyFormData(action);
 
         action = curlImporterService.curlToAction(
                 "curl --data-urlencode 'spaced name=all of this exactly, but url encoded' http://loc"
         );
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://loc");
-        assertEmptyBody(action);
-        assertBodyFormData(
-                action,
-                new Property("spaced name", "all of this exactly, but url encoded")
-        );
+        assertBody(action,"spaced name=all of this exactly, but url encoded");
+        assertEmptyBodyFormData(action);
 
         action = curlImporterService.curlToAction(
                 "curl --data-urlencode 'awesome=details, all of this exactly, but url encoded' http://loc"
         );
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://loc");
-        assertEmptyBody(action);
-        assertBodyFormData(
-                action,
-                new Property("awesome", "details, all of this exactly, but url encoded")
-        );
+        assertBody(action,"awesome=details, all of this exactly, but url encoded");
+        assertEmptyBodyFormData(action);
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -693,12 +693,9 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
-        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
-        assertEmptyBody(action);
-        assertBodyFormData(
-                action,
-                new Property("{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}", "")
-        );
+        assertHeaders(action, new Property("Content-Type", "application/json"));
+        assertBody(action,"{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
+        assertEmptyBodyFormData(action);
     }
 
     @Test
@@ -769,12 +766,8 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://httpbin.org");
         assertPath(action, "/post");
-        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
-        assertEmptyBody(action);
-        assertBodyFormData(
-                action,
-                new Property("a\\n", "")
-        );
+        assertBody(action,"a\\n");
+        assertEmptyBodyFormData(action);
     }
 
     @Test
@@ -838,6 +831,9 @@ public class CurlImporterServiceTest {
 
     private static void assertEmptyBody(ActionDTO action) {
         assertThat(action.getActionConfiguration().getBody()).isNullOrEmpty();
+    }
+    private static void assertEmptyBodyFormData(ActionDTO action) {
+        assertThat(action.getActionConfiguration().getBodyFormData()).isNullOrEmpty();
     }
 
     private static void assertBody(ActionDTO action, String body) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -200,12 +200,12 @@ public class CurlImporterServiceTest {
 
         Mono<NewPage> branchedPageMono = defaultPageMono
                 .flatMap(defaultPage ->
-                    newPageService.findById(branchedPageId, AclPermission.MANAGE_PAGES)
-                            .flatMap(newPage -> {
-                                newPage.setDefaultResources(defaultPage.getDefaultResources());
-                                newPage.getDefaultResources().setBranchName("testBranch");
-                                return newPageService.save(newPage);
-                            })
+                        newPageService.findById(branchedPageId, AclPermission.MANAGE_PAGES)
+                                .flatMap(newPage -> {
+                                    newPage.setDefaultResources(defaultPage.getDefaultResources());
+                                    newPage.getDefaultResources().setBranchName("testBranch");
+                                    return newPageService.save(newPage);
+                                })
                 )
                 .cache();
 
@@ -311,7 +311,7 @@ public class CurlImporterServiceTest {
         );
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://loc");
-        assertBody(action,"all of this exactly, but url encoded ");
+        assertBody(action, "all of this exactly, but url encoded ");
         assertEmptyBodyFormData(action);
 
         action = curlImporterService.curlToAction(
@@ -319,7 +319,7 @@ public class CurlImporterServiceTest {
         );
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://loc");
-        assertBody(action,"spaced name=all of this exactly, but url encoded");
+        assertBody(action, "spaced name=all of this exactly, but url encoded");
         assertEmptyBodyFormData(action);
 
         action = curlImporterService.curlToAction(
@@ -327,7 +327,7 @@ public class CurlImporterServiceTest {
         );
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://loc");
-        assertBody(action,"awesome=details, all of this exactly, but url encoded");
+        assertBody(action, "awesome=details, all of this exactly, but url encoded");
         assertEmptyBodyFormData(action);
     }
 
@@ -607,7 +607,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "https://api.sloths.com");
         assertEmptyPath(action);
-        assertHeaders(action,  new Property("Content-Type", "application/x-www-form-urlencoded"));
+        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -694,7 +694,7 @@ public class CurlImporterServiceTest {
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
         assertHeaders(action, new Property("Content-Type", "application/json"));
-        assertBody(action,"{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
+        assertBody(action, "{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
         assertEmptyBodyFormData(action);
     }
 
@@ -766,7 +766,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://httpbin.org");
         assertPath(action, "/post");
-        assertBody(action,"a\\n");
+        assertBody(action, "a\\n");
         assertEmptyBodyFormData(action);
     }
 


### PR DESCRIPTION
## Description

Before if the content-type was not specified and there was a body value, curl import (in the new datasource page) was treating the request as form-urlencoded, but now it tries to guess the content-type for the request.
it checks for `x-www-form-urlencoded` or `json` or sends it as raw without any content-type header.

Fixes #7900

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested manually
- Unit tests are fixed for it

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
