### PR TITLE
fix: Prevent content-type header from changing when switching to raw mode in API pane

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Multipart_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_Multipart_spec.js
@@ -25,6 +25,7 @@ describe("API Panel request body", function() {
     cy.SelectAction(testdata.getAction);
 
     cy.contains(apiEditor.bodyTab).click();
+    cy.get(`[data-cy=${testdata.apiContentTypeNone}]`).click();
     cy.get(testdata.noBodyErrorMessageDiv).should("exist");
     cy.get(testdata.noBodyErrorMessageDiv).contains(
       testdata.noBodyErrorMessage,

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -67,6 +67,7 @@ import {
 } from "utils/ApiPaneUtils";
 import { updateReplayEntity } from "actions/pageActions";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
+import { getDisplayFormat } from "selectors/apiPaneSelectors";
 
 function* syncApiParamsSaga(
   actionPayload: ReduxActionWithMeta<string, { field: string }>,
@@ -138,7 +139,8 @@ function* handleUpdateBodyContentType(
 ) {
   const { apiId, title } = action.payload;
   const { values } = yield select(getFormData, API_EDITOR_FORM_NAME);
-  // this is a previous value gotten before the updated content type has been set
+
+  // this is the previous value gotten before the new content type has been set
   const previousContentType =
     values.actionConfiguration?.formData?.apiContentType;
 
@@ -150,31 +152,37 @@ function* handleUpdateBodyContentType(
     return;
   }
 
-  // this is the update for the new api contentType
-  // update the api content type so it can be persisted.
+  // this is the update for the new apicontentType
+  // Quick Context: APiContentype is the field that represents the content type the user wants while in RAW mode.
+  // users should be able to set the content type to whatever they want.
   let formData = { ...values.actionConfiguration.formData };
   if (formData === undefined) formData = {};
-  formData["apiContentType"] = title;
+  formData["apiContentType"] =
+    title === POST_BODY_FORMAT_OPTIONS.RAW ||
+    title === POST_BODY_FORMAT_OPTIONS.NONE
+      ? previousContentType
+      : title;
 
   yield put(
     change(API_EDITOR_FORM_NAME, "actionConfiguration.formData", formData),
   );
 
-  if (displayFormatValue === POST_BODY_FORMAT_OPTIONS.RAW) {
-    // update the content type header if raw has been selected
-    yield put({
-      type: ReduxActionTypes.SET_EXTRA_FORMDATA,
-      payload: {
-        id: apiId,
-        values: {
-          displayFormat: {
-            label: displayFormatValue,
-            value: displayFormatValue,
-          },
+  // Quick Context: The extra formadata action is responsible for updating the current multi switch mode you see on api editor body tab
+  // whenever a user selects a new content type through the tab e.g application/json, this action is dispatched to update that value, which is then read in the PostDataBody file
+  // to show the appropriate content type section.
+
+  yield put({
+    type: ReduxActionTypes.SET_EXTRA_FORMDATA,
+    payload: {
+      id: apiId,
+      values: {
+        displayFormat: {
+          label: title,
+          value: title,
         },
       },
-    });
-  }
+    },
+  });
 
   const headers = cloneDeep(values.actionConfiguration.headers);
 
@@ -186,24 +194,18 @@ function* handleUpdateBodyContentType(
   );
   const indexToUpdate = getIndextoUpdate(headers, contentTypeHeaderIndex);
 
-  // If the user has selected "None" as the body type & there was a content-type
+  // If the user has selected "None" or "Raw" as the body type & there was a content-type
   // header present in the API configuration, keep the previous content type header
-  // but if the user has selected "raw", set the content header to text/plain
+  // this is done to ensure user input isn't cleared off if they switch to raw or none mode.
+  // however if the user types in a new value, we use the updated value (formValueChangeSaga - line 426).
   if (
-    displayFormatValue === POST_BODY_FORMAT_OPTIONS.NONE &&
+    (displayFormatValue === POST_BODY_FORMAT_OPTIONS.NONE ||
+      displayFormatValue === POST_BODY_FORMAT_OPTIONS.RAW) &&
     indexToUpdate !== -1
   ) {
     headers[indexToUpdate] = {
       key: previousContentType ? CONTENT_TYPE_HEADER_KEY : "",
       value: previousContentType ? previousContentType : "",
-    };
-  } else if (
-    displayFormatValue === POST_BODY_FORMAT_OPTIONS.RAW &&
-    indexToUpdate !== -1
-  ) {
-    headers[indexToUpdate] = {
-      key: CONTENT_TYPE_HEADER_KEY,
-      value: POST_BODY_FORMAT_OPTIONS.RAW,
     };
   } else {
     headers[indexToUpdate] = {
@@ -212,6 +214,7 @@ function* handleUpdateBodyContentType(
     };
   }
 
+  // update the new header values.
   yield put(
     change(API_EDITOR_FORM_NAME, "actionConfiguration.headers", headers),
   );
@@ -235,18 +238,19 @@ function* handleUpdateBodyContentType(
 }
 
 function* initializeExtraFormDataSaga() {
-  const state = yield select();
-  const { extraformData } = state.ui.apiPane;
   const formData = yield select(getFormData, API_EDITOR_FORM_NAME);
   const { values } = formData;
-  // const headers = get(values, "actionConfiguration.headers");
-  const apiContentType = get(
-    values,
-    "actionConfiguration.formData.apiContentType",
-  );
 
-  if (!extraformData[values.id]) {
-    yield call(setHeaderFormat, values.id, apiContentType);
+  // when initializing, check if theres a display format present, if not use Json display format as default.
+  const extraFormData = yield select(getDisplayFormat, values.id);
+
+  // as a fail safe, if no display format is present, use Raw mode
+  const rawApiContentType = extraFormData?.displayFormat?.value
+    ? extraFormData?.displayFormat?.value
+    : POST_BODY_FORMAT_OPTIONS.RAW;
+
+  if (!extraFormData) {
+    yield call(setHeaderFormat, values.id, rawApiContentType);
   }
 }
 
@@ -296,6 +300,7 @@ function* changeApiSaga(
 function* setHeaderFormat(apiId: string, apiContentType?: string) {
   // use the current apiContentType to set appropriate Headers for action
   let displayFormat;
+
   if (apiContentType) {
     if (apiContentType === POST_BODY_FORMAT_OPTIONS.NONE) {
       displayFormat = {
@@ -336,17 +341,20 @@ export function* updateFormFields(
   const value = actionPayload.payload;
   log.debug("updateFormFields: " + JSON.stringify(value));
   const { values } = yield select(getFormData, API_EDITOR_FORM_NAME);
+
+  // get current content type of the action
   let apiContentType = values.actionConfiguration.formData.apiContentType;
 
-  if (field === "actionConfiguration.httpMethod") {
-    const { actionConfiguration } = values;
-    if (!actionConfiguration.headers) return;
+  const { actionConfiguration } = values;
 
-    const actionConfigurationHeaders = cloneDeep(actionConfiguration.headers);
-    const contentTypeHeaderIndex = actionConfigurationHeaders.findIndex(
-      (header: { key: string; value: string }) =>
-        header?.key?.trim().toLowerCase() === CONTENT_TYPE_HEADER_KEY,
-    );
+  const actionConfigurationHeaders = cloneDeep(actionConfiguration.headers);
+  const contentTypeHeaderIndex = actionConfigurationHeaders.findIndex(
+    (header: { key: string; value: string }) =>
+      header?.key?.trim().toLowerCase() === CONTENT_TYPE_HEADER_KEY,
+  );
+
+  if (field === "actionConfiguration.httpMethod") {
+    if (!actionConfiguration.headers) return;
 
     if (value !== HTTP_METHOD.GET) {
       // if user switches to other methods that is not GET and apiContentType is undefined set default apiContentType to JSON.
@@ -370,14 +378,7 @@ export function* updateFormFields(
         };
       }
     }
-    // change apiContentType when user changes api Http Method
-    yield put(
-      change(
-        API_EDITOR_FORM_NAME,
-        "actionConfiguration.formData.apiContentType",
-        apiContentType,
-      ),
-    );
+
     yield put(
       change(
         API_EDITOR_FORM_NAME,
@@ -385,9 +386,13 @@ export function* updateFormFields(
         actionConfigurationHeaders,
       ),
     );
-  } else if (field.includes("actionConfiguration.headers")) {
+  } else if (
+    field === `actionConfiguration.headers[${contentTypeHeaderIndex}].value`
+  ) {
     const apiId = get(values, "id");
-    yield call(setHeaderFormat, apiId, apiContentType);
+    // when the user specifically sets a new content type value, we check if the input value is a supported post body type and switch to it
+    // if it does not we set the default to Raw mode.
+    yield call(setHeaderFormat, apiId, actionPayload.payload);
   }
 }
 
@@ -424,29 +429,17 @@ function* formValueChangeSaga(
       }),
     );
     // when user types a content type value, update actionConfiguration.formData.apiContent type as well.
+    // we don't do this initally because we want to specifically catch user editing the content-type value
     if (
       field === `actionConfiguration.headers[${contentTypeHeaderIndex}].value`
     ) {
-      if (
-        // if the value is not a registered content type, make the default apiContentType raw but don't change header
-        Object.values(POST_BODY_FORMAT_OPTIONS).includes(actionPayload.payload)
-      ) {
-        yield put(
-          change(
-            API_EDITOR_FORM_NAME,
-            "actionConfiguration.formData.apiContentType",
-            actionPayload.payload,
-          ),
-        );
-      } else {
-        yield put(
-          change(
-            API_EDITOR_FORM_NAME,
-            "actionConfiguration.formData.apiContentType",
-            POST_BODY_FORMAT_OPTIONS.RAW,
-          ),
-        );
-      }
+      yield put(
+        change(
+          API_EDITOR_FORM_NAME,
+          "actionConfiguration.formData.apiContentType",
+          actionPayload.payload,
+        ),
+      );
     }
   }
   yield all([

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -347,6 +347,7 @@ export function* updateFormFields(
 
   const { actionConfiguration } = values;
 
+  if (!actionConfiguration.headers) return;
   const actionConfigurationHeaders = cloneDeep(actionConfiguration.headers);
   const contentTypeHeaderIndex = actionConfigurationHeaders.findIndex(
     (header: { key: string; value: string }) =>
@@ -354,8 +355,6 @@ export function* updateFormFields(
   );
 
   if (field === "actionConfiguration.httpMethod") {
-    if (!actionConfiguration.headers) return;
-
     if (value !== HTTP_METHOD.GET) {
       // if user switches to other methods that is not GET and apiContentType is undefined set default apiContentType to JSON.
       if (apiContentType === POST_BODY_FORMAT_OPTIONS.NONE)

--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -344,17 +344,16 @@ export function* updateFormFields(
 
   // get current content type of the action
   let apiContentType = values.actionConfiguration.formData.apiContentType;
-
-  const { actionConfiguration } = values;
-
-  if (!actionConfiguration.headers) return;
-  const actionConfigurationHeaders = cloneDeep(actionConfiguration.headers);
-  const contentTypeHeaderIndex = actionConfigurationHeaders.findIndex(
-    (header: { key: string; value: string }) =>
-      header?.key?.trim().toLowerCase() === CONTENT_TYPE_HEADER_KEY,
-  );
-
   if (field === "actionConfiguration.httpMethod") {
+    const { actionConfiguration } = values;
+    if (!actionConfiguration.headers) return;
+
+    const actionConfigurationHeaders = cloneDeep(actionConfiguration.headers);
+    const contentTypeHeaderIndex = actionConfigurationHeaders.findIndex(
+      (header: { key: string; value: string }) =>
+        header?.key?.trim().toLowerCase() === CONTENT_TYPE_HEADER_KEY,
+    );
+
     if (value !== HTTP_METHOD.GET) {
       // if user switches to other methods that is not GET and apiContentType is undefined set default apiContentType to JSON.
       if (apiContentType === POST_BODY_FORMAT_OPTIONS.NONE)
@@ -385,13 +384,6 @@ export function* updateFormFields(
         actionConfigurationHeaders,
       ),
     );
-  } else if (
-    field === `actionConfiguration.headers[${contentTypeHeaderIndex}].value`
-  ) {
-    const apiId = get(values, "id");
-    // when the user specifically sets a new content type value, we check if the input value is a supported post body type and switch to it
-    // if it does not we set the default to Raw mode.
-    yield call(setHeaderFormat, apiId, actionPayload.payload);
   }
 }
 
@@ -439,6 +431,10 @@ function* formValueChangeSaga(
           actionPayload.payload,
         ),
       );
+      const apiId = get(values, "id");
+      // when the user specifically sets a new content type value, we check if the input value is a supported post body type and switch to it
+      // if it does not we set the default to Raw mode.
+      yield call(setHeaderFormat, apiId, actionPayload.payload);
     }
   }
   yield all([

--- a/app/client/src/selectors/apiPaneSelectors.ts
+++ b/app/client/src/selectors/apiPaneSelectors.ts
@@ -1,0 +1,11 @@
+import { AppState } from "reducers";
+
+type GetFormData = (
+  state: AppState,
+  apiId: string,
+) => { label: string; value: string };
+
+export const getDisplayFormat: GetFormData = (state, apiId) => {
+  const displayFormat = state.ui.apiPane.extraformData[apiId];
+  return displayFormat;
+};


### PR DESCRIPTION
This PR fixes post body type switcher in API editor, Prior to this PR, switching the post body to Raw changes the content-type to "text/plain", This fixes that by preserving the previous content-type when user switches to raw or none body type. It also gives users the flexibility to use any non supported content type, while in Raw body mode.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/post-body-switcher 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.76 **(0.01)** | 37.12 **(-0.02)** | 35.81 **(0)** | 56.11 **(0)**
 :green_circle: | app/client/src/sagas/ApiPaneSagas.ts | 16.59 **(1.02)** | 1.3 **(-0.13)** | 9.09 **(0)** | 18.75 **(1.26)**
 :sparkles: :new: | **app/client/src/selectors/apiPaneSelectors.ts** | **50** | **100** | **0** | **33.33**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**</details>