### PR TITLE
fix: after JS object delete success move to page url

### DIFF
--- a/app/client/src/sagas/JSActionSagas.ts
+++ b/app/client/src/sagas/JSActionSagas.ts
@@ -27,7 +27,6 @@ import {
 } from "actions/jsActionActions";
 import {
   getJSCollection,
-  getJSCollections,
   getPageNameByPageId,
 } from "selectors/entitiesSelector";
 import history from "utils/history";
@@ -247,7 +246,6 @@ export function* deleteJSCollectionSaga(
 ) {
   try {
     const id = actionPayload.payload.id;
-    const jsActions = yield select(getJSCollections);
 
     const response = yield JSActionAPI.deleteJSCollection(id);
     const isValidResponse = yield validateResponse(response);
@@ -258,25 +256,12 @@ export function* deleteJSCollectionSaga(
         text: createMessage(JS_ACTION_DELETE_SUCCESS, response.data.name),
         variant: Variant.success,
       });
-      if (jsActions.length > 0) {
-        const getIndex = getIndexToBeRedirected(
-          jsActions,
-          actionPayload.payload.id,
-        );
-        if (getIndex) {
-          const jsAction = jsActions[getIndex];
-          history.push(
-            JS_COLLECTION_ID_URL(applicationId, pageId, jsAction.config.id),
-          );
-        } else {
-          history.push(
-            BUILDER_PAGE_URL({
-              applicationId,
-              pageId,
-            }),
-          );
-        }
-      }
+      history.push(
+        BUILDER_PAGE_URL({
+          applicationId,
+          pageId,
+        }),
+      );
       AppsmithConsole.info({
         logType: LOG_TYPE.ENTITY_DELETED,
         text: "JS object was deleted",


### PR DESCRIPTION
## Description
After deletion of js object, URL was redirected towards another js object causing pages to change. Instead, it will now redirect to the page make it consistent across Appsmith

Fixes #8502 

## Type of change
- Bugfix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: 8502-fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.72 **(0.01)** | 37.09 **(0.01)** | 35.78 **(0)** | 56.08 **(0.01)**
 :green_circle: | app/client/src/sagas/JSActionSagas.ts | 17.39 **(0.72)** | 2.13 **(0.17)** | 6.67 **(0)** | 20.61 **(0.9)**</details>