### PR TITLE
chore: remove second scrollbar from git connect modal

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
@@ -75,6 +75,7 @@ export const UrlOptionContainer = styled.div`
 
   & .primary {
   }
+
   margin-bottom: ${(props) => `${props.theme.spaces[3]}px`};
   margin-top: ${(props) => `${props.theme.spaces[11]}px`};
 `;
@@ -100,9 +101,12 @@ const Container = styled.div`
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
+  scrollbar-width: none;
+
   &::-webkit-scrollbar-thumb {
     background-color: transparent;
   }
+
   &::-webkit-scrollbar {
     width: 0px;
   }


### PR DESCRIPTION
## Description

`* { scrollbar-width: thin; }` adds a scrollbar to every element, firefox takes this personally and adds a second scrollbar to git connect modal when the content starts overflowing.

This PR removes `scrollbar-width` from git-connect container.

Fixes #10844 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually.

Before changes:

![Bug: before changes](https://user-images.githubusercontent.com/45958978/152286543-d10eb833-9623-4146-af0b-d295e5eb5e7b.png)

After changes:

https://user-images.githubusercontent.com/1573771/155083564-b9280fbb-8931-4e0a-86d3-8fd3b4f71365.mov



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>