### PR TITLE
feat: Keyboard accessible property pane header

### DIFF
--- a/app/client/src/components/ads/Button.tsx
+++ b/app/client/src/components/ads/Button.tsx
@@ -378,7 +378,8 @@ const ButtonStyles = css<ThemeProp & ButtonProps>`
       fill: ${(props) => btnColorStyles(props, "main").txtColor};
     }
   }
-  &:hover {
+  &:hover,
+  &:focus {
     text-decoration: none;
     background-color: ${(props) => btnColorStyles(props, "hover").bgColor};
     color: ${(props) => btnColorStyles(props, "hover").txtColor};

--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -687,14 +687,6 @@ export function RenderDropdownOptions(props: DropdownOptionsProps) {
         maxHeight={props.dropdownMaxHeight || "auto"}
       >
         {options.map((option: DropdownOption, index: number) => {
-          if (renderOption) {
-            return renderOption({
-              option,
-              index,
-              optionClickHandler,
-              optionWidth,
-            });
-          }
           let isSelected = false;
           if (
             props.isMultiSelect &&
@@ -707,6 +699,15 @@ export function RenderDropdownOptions(props: DropdownOptionsProps) {
           } else {
             isSelected =
               (props.selected as DropdownOption).value === option.value;
+          }
+          if (renderOption) {
+            return renderOption({
+              option,
+              index,
+              optionClickHandler,
+              optionWidth,
+              isSelectedNode: isSelected,
+            });
           }
           return !option.isSectionHeader ? (
             <OptionWrapper

--- a/app/client/src/pages/Editor/PropertyPane/ConnectDataCTA.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/ConnectDataCTA.tsx
@@ -30,10 +30,11 @@ const StyledDiv = styled.div`
   props.theme.spaces[7]}px;
   margin: ${(props) => props.theme.spaces[2]}px 0px;
 
-  a:first-child {
+  button:first-child {
     margin-top: ${(props) => props.theme.spaces[2]}px;
+    width: 100%;
   }
-  a:nth-child(2) {
+  button:nth-child(2) {
     border: none;
     background-color: transparent;
     text-transform: none;
@@ -43,7 +44,7 @@ const StyledDiv = styled.div`
     ${(props) => getTypographyByKey(props, "p3")}
     margin-top: ${(props) => props.theme.spaces[2]}px;
 
-    :hover {
+    :hover, :focus {
       text-decoration: underline;
     }
   }
@@ -95,11 +96,15 @@ function ConnectDataCTA(props: ConnectDataCTAProps) {
         category={Category.primary}
         onClick={onClick}
         size={Size.large}
+        tabIndex={0}
+        tag="button"
         text="CONNECT DATA"
       />
       <Button
         category={Category.tertiary}
         onClick={openHelpModal}
+        tabIndex={0}
+        tag="button"
         text="Learn more"
       />
     </StyledDiv>

--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, useCallback } from "react";
+import React, { memo, useMemo, useCallback, useEffect } from "react";
 import styled from "styled-components";
 import Icon, { IconSize } from "components/ads/Icon";
 import Dropdown, {
@@ -125,6 +125,7 @@ const OptionWrapper = styled.div<{ hasError: boolean; fillIconColor: boolean }>`
 
 const OptionContentWrapper = styled.div<{
   hasError: boolean;
+  isSelected: boolean;
 }>`
   padding: ${(props) => props.theme.spaces[2] + 1}px
     ${(props) => props.theme.spaces[5]}px;
@@ -134,6 +135,10 @@ const OptionContentWrapper = styled.div<{
   line-height: 8px;
   flex: 1;
   min-width: 0;
+  background-color: ${(props) =>
+    props.isSelected &&
+    !props.hasError &&
+    props.theme.colors.dropdown.hovered.bg};
 
   span:first-child {
     font-size: 10px;
@@ -210,7 +215,7 @@ const useDependencyList = (name: string) => {
   const dependencyOptions =
     entityDependencies?.directDependencies.map((e) => ({
       label: e,
-      value: getEntityId(e),
+      value: getEntityId(e) ?? e,
     })) ?? [];
   const inverseDependencyOptions =
     entityDependencies?.inverseDependencies.map((e) => ({
@@ -245,12 +250,28 @@ function OptionNode(props: any) {
     });
   };
 
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!props.isSelectedNode) return;
+    if (e.key === " " || e.key === "Enter") onClick();
+  };
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [props.isSelectedNode]);
+
   return (
     <OptionWrapper
       fillIconColor={!entityInfo?.datasourceName}
       hasError={!!entityInfo?.hasError}
     >
-      <OptionContentWrapper hasError={!!entityInfo?.hasError} onClick={onClick}>
+      <OptionContentWrapper
+        hasError={!!entityInfo?.hasError}
+        isSelected={props.isSelectedNode}
+        onClick={onClick}
+      >
         <span>{entityInfo?.icon}</span>
         <Text type={TextType.H6}>
           {props.option.label}{" "}
@@ -297,6 +318,7 @@ const TriggerNode = memo((props: TriggerNodeProps) => {
         <Tooltip
           content={tooltipText}
           disabled={props.isOpen}
+          openOnTargetFocus={false}
           position={props.tooltipPosition}
         >
           {props.entityCount ? `${props.entityCount} ${ENTITY}` : "No Entity"}
@@ -360,7 +382,12 @@ function PropertyPaneConnections(props: PropertyPaneConnectionsProps) {
         height={`${CONNECTION_HEIGHT}px`}
         options={dependencies.dependencyOptions}
         renderOption={(optionProps) => {
-          return <OptionNode option={optionProps.option} />;
+          return (
+            <OptionNode
+              isSelectedNode={optionProps.isSelectedNode}
+              option={optionProps.option}
+            />
+          );
         }}
         selected={selectedOption}
         showDropIcon={false}

--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneView.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneView.tsx
@@ -73,7 +73,7 @@ function PropertyPaneView(
         tooltipPosition: "bottom-right",
         icon: (
           <button
-            className="p-1 hover:bg-warmGray-100 group t--copy-widget"
+            className="p-1 hover:bg-warmGray-100 focus:bg-warmGray-100 group t--copy-widget"
             onClick={onCopy}
           >
             <CopyIcon className="w-4 h-4 text-gray-500" />
@@ -85,7 +85,7 @@ function PropertyPaneView(
         tooltipPosition: "bottom-right",
         icon: (
           <button
-            className="p-1 hover:bg-warmGray-100 group t--delete-widget"
+            className="p-1 hover:bg-warmGray-100 focus:bg-warmGray-100 group t--delete-widget"
             onClick={onDelete}
           >
             <DeleteIcon className="w-4 h-4 text-gray-500" />


### PR DESCRIPTION
## Description

The header section of the property pane includes the copy, delete, connect data buttons and incoming and outgoing entities dropdown is made accessible via keyboard.

Use `Tab` keys to shift focus and `Enter` | `Space` to interact with a component in focus.
In case of dropdown, make use of `ArrowUp` and `ArrowDown` keys to change the selection and `Enter` | `Space` to click the selected option. `Esc` to close the dropdown.

Fixes #11338 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: kbd-accessible-pp-header 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.7 **(-0.05)** | 37.06 **(-0.08)** | 35.77 **(-0.04)** | 56.06 **(-0.05)**
 :red_circle: | app/client/src/entities/DataTree/dataTreeWidget.ts | 98.08 **(0)** | 75 **(-8.33)** | 100 **(0)** | 97.83 **(0)**
 :red_circle: | app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx | 60.75 **(-6.26)** | 28.46 **(-3.36)** | 43.24 **(-5.24)** | 62.14 **(-5.23)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx | 66.67 **(-14.28)** | 0 **(-53.06)** | 60 **(-10.59)** | 67.65 **(-13.36)**
 :red_circle: | app/client/src/widgets/SelectWidget/component/index.styled.tsx | 43.75 **(-1.7)** | 21.88 **(0)** | 0 **(0)** | 48.28 **(-1.72)**
 :red_circle: | app/client/src/widgets/SelectWidget/component/index.tsx | 25 **(-2.78)** | 0 **(0)** | 7.14 **(0.47)** | 25.4 **(-1.87)**
 :red_circle: | app/client/src/widgets/SelectWidget/widget/index.tsx | 49.02 **(-5.91)** | 0 **(-22.22)** | 46.15 **(-3.85)** | 51.06 **(-4.82)**
 :red_circle: | app/client/src/workers/evaluationUtils.ts | 58.37 **(0)** | 56.61 **(-0.53)** | 64.52 **(0)** | 57.7 **(0)**</details>