### PR TITLE
fix: limit commit message area expansion and text spillover

### DIFF
--- a/app/client/src/components/ads/TextInput.tsx
+++ b/app/client/src/components/ads/TextInput.tsx
@@ -75,6 +75,7 @@ export type TextInputProps = CommonComponentProps & {
   $padding?: string;
   useTextArea?: boolean;
   isCopy?: boolean;
+  style?: any;
 };
 
 type boxReturnType = {
@@ -125,7 +126,6 @@ const InputLoader = styled.div<{
       : "100%"};
 
   height: ${(props) => props.$height || "36px"};
-  border-radius: 0;
 `;
 
 const StyledInput = styled((props) => {
@@ -217,7 +217,7 @@ const InputWrapper = styled.div<{
 }>`
   position: relative;
   display: flex;
-  align-items: center;  
+  align-items: center;
   width: ${(props) =>
     props.fill ? "100%" : props.width ? props.width : "260px"};
   height: ${(props) => props.height || "36px"};
@@ -241,7 +241,7 @@ const InputWrapper = styled.div<{
   .${Classes.TEXT} {
     color: ${(props) => props.theme.colors.danger.main};
   }
-  ​ .helper {
+  .helper {
     .${Classes.TEXT} {
       color: ${(props) => props.theme.colors.textInput.helper};
     }

--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -73,6 +73,7 @@ const SectionTitle = styled.div`
   ${(props) => getTypographyByKey(props, "p1")};
   color: ${Colors.CHARCOAL};
   display: inline-flex;
+
   & .branch {
     color: ${Colors.CRUSTA};
     width: 240px;
@@ -84,9 +85,11 @@ const SectionTitle = styled.div`
 
 const Container = styled.div`
   width: 100%;
+
   && ${LabelContainer} span {
     color: ${Colors.CHARCOAL};
   }
+
   .bp3-popover-target {
     width: fit-content;
   }
@@ -220,7 +223,9 @@ function Deploy() {
             onChange={setCommitMessage}
             placeholder={"Your commit message here"}
             ref={commitInputRef}
+            style={{ resize: "none" }}
             trimValue={false}
+            useTextArea
             value={commitMessageDisplay}
           />
         </SubmitWrapper>

--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -221,7 +221,6 @@ function Deploy() {
             placeholder={"Your commit message here"}
             ref={commitInputRef}
             trimValue={false}
-            useTextArea
             value={commitMessageDisplay}
           />
         </SubmitWrapper>


### PR DESCRIPTION
## Description

We were using a text area in the commit message box which was causing issues on Mac, Windows; on Chrome, Firefox. This PR removes that, and fixes the issue.

Fixes #11237 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually.

Before changes:

https://user-images.githubusercontent.com/1573771/155091047-3b0cf8e7-ac27-45cb-87e2-0d009dafc586.mov

After changes (Mac, Firefox):

![Screenshot 2022-02-22 at 4 06 46 PM](https://user-images.githubusercontent.com/1573771/155115627-7f83bef0-ec99-4f7f-95b3-3659c3289f28.png)


https://user-images.githubusercontent.com/1573771/155115648-7cb35e00-c945-4495-a904-07851790258f.mov





## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes








## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: 11237-fix-commit-message-box 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.89 **(0)** | 37.24 **(-0.01)** | 35.28 **(0)** | 56.22 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>