### PR TITLE
fix: long page name text cutting off in preview mode

### DIFF
--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -261,13 +261,13 @@ export const trimTrailingSlash = (path: string) => {
  * this function is meant for checking the existence of ellipsis by CSS.
  * Since ellipsis by CSS are not part of DOM, we are checking with scroll width\height and offsetidth\height.
  * ScrollWidth\ScrollHeight is always greater than the offsetWidth\OffsetHeight when ellipsis made by CSS is active.
- *
+ * Using clientWidth to fix this https://stackoverflow.com/a/21064102/8692954
  * @param element
  */
 export const isEllipsisActive = (element: HTMLElement | null) => {
   return (
     element &&
-    (element.offsetWidth < element.scrollWidth ||
+    (element.clientWidth < element.scrollWidth ||
       element.offsetHeight < element.scrollHeight)
   );
 };


### PR DESCRIPTION
## Description

Completed fix for Page Name in preview mode, Deploy Mode was done in #10667 

Fixes #9969

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Visual testing


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>