### PR TITLE
fix: make table button transparent when no color is selected

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
@@ -336,4 +336,19 @@ describe("Table Widget property pane feature validation", function() {
       .click({ force: true });
     cy.get(commonlocators.TextInside).should("have.text", "Tobias Funke");
   });
+
+  it("9. Table widget test on button when transparent", () => {
+    cy.openPropertyPane("tablewidget");
+    // Open column details of "id".
+    cy.editColumn("id");
+    // Changing column "Button" color to transparent
+
+    cy.get(widgetsPage.buttonColor).click({ force: true });
+    cy.xpath(widgetsPage.transparent).click();
+    cy.get(widgetsPage.tableBtn).should(
+      "have.css",
+      "background-color",
+      "rgba(0, 0, 0, 0)",
+    );
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Table_Widget_Add_button_spec.js
@@ -335,6 +335,9 @@ describe("Table Widget property pane feature validation", function() {
       .last()
       .click({ force: true });
     cy.get(commonlocators.TextInside).should("have.text", "Tobias Funke");
+    cy.get(".t--property-pane-back-btn").click({ force: true });
+    cy.wait(500);
+    cy.get(".t--property-pane-back-btn").click({ force: true });
   });
 
   it("9. Table widget test on button when transparent", () => {
@@ -345,7 +348,7 @@ describe("Table Widget property pane feature validation", function() {
 
     cy.get(widgetsPage.buttonColor).click({ force: true });
     cy.xpath(widgetsPage.transparent).click();
-    cy.get(widgetsPage.tableBtn).should(
+    cy.get(".td[data-colindex=5][data-rowindex=0] .bp3-button").should(
       "have.css",
       "background-color",
       "rgba(0, 0, 0, 0)",

--- a/app/client/cypress/locators/Widgets.json
+++ b/app/client/cypress/locators/Widgets.json
@@ -97,6 +97,7 @@
     "backgroundcolorPicker": ".t--property-control-backgroundcolour input",
     "backgroundcolorPickerNew": ".t--property-control-backgroundcolor input",
     "greenColor": "//div[@color='#03b365']",
+    "transparent": "//div[@color='transparent']",
     "yellowColor": "//div[@color='#FFC13D']",
     "blueColor": "//div[@color='#3366FF']",
     "toggleJsColor": ".t--property-control-textcolor .t--js-toggle",

--- a/app/client/src/components/ads/ColorPickerComponent.tsx
+++ b/app/client/src/components/ads/ColorPickerComponent.tsx
@@ -125,7 +125,10 @@ function ColorBoard(props: ColorBoardProps) {
           {props.selectedColor === color && <CheckedIcon />}
         </ColorTab>
       ))}
-      <EmptyColorIconWrapper onClick={() => props.selectColor("")}>
+      <EmptyColorIconWrapper
+        color="transparent"
+        onClick={() => props.selectColor("")}
+      >
         <NoColorIcon>
           <div className="line" />
         </NoColorIcon>

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -167,7 +167,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
               isSelected: isSelected,
               onCommandClick: (action: string, onComplete: () => void) =>
                 this.onCommandClick(rowIndex, action, onComplete),
-              backgroundColor: cellProperties.buttonColor || "rgb(3, 179, 101)",
+              backgroundColor: cellProperties.buttonColor || "transparent",
               buttonLabelColor: cellProperties.buttonLabelColor || "#FFFFFF",
               isDisabled: cellProperties.isDisabled || false,
               isCellVisible: cellProperties.isCellVisible ?? true,


### PR DESCRIPTION

## Description
Make table button transparent when no color is selected

Fixes #10276


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress test


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/button-color-does-not-change-to-transparent 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 68.63 **(-3.92)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>