### PR TITLE
chore: Use `latest-dev` for watchtower

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./stacks:/appsmith-stacks
 
   auto_update:
-    image: containrrr/watchtower
+    image: containrrr/watchtower:latest-dev
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check every hour.


### PR DESCRIPTION
This is an inconsistency fix. We are already providing the `latest-dev` from our documentation, it's just not set so in this example file.
