### PR TITLE
fix: page dragging in Pages editor

### DIFF
--- a/app/client/src/components/ads/DraggableList.tsx
+++ b/app/client/src/components/ads/DraggableList.tsx
@@ -168,12 +168,12 @@ function DraggableList(props: any) {
 
           if (!dragging.current && Math.abs(displacement.current) > 10) {
             dragging.current = props.dragging;
-            updateDragging(dragging.current);
+            updateDragging && updateDragging(dragging.current);
           }
         } else {
           if (dragging.current) {
             dragging.current = props.dragging;
-            updateDragging(dragging.current);
+            updateDragging && updateDragging(dragging.current);
           }
         }
 


### PR DESCRIPTION
## Description

Bug:
- Drag and drop a page on an overlap with another and the list items don't proceed to assume normal positions.
- The screen then crashes due to and undefined prop.

Fix:
- Validate if updateDragging is truthy before calling the function.

Fixes #11191

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Create multiple pages in an app.
2. Go to Pages Editor screen.
3. Drag n drop a page to re-order them. Attempt to drop the selected page in an overlapping position with another.
4. Observe that the pages assume standard positioning after the drop and re-order if necessary.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix_11191_page_dragging 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/ads/DraggableList.tsx | 35.87 **(0)** | 17.46 **(-1.18)** | 26.67 **(0)** | 38.75 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**</details>