### PR TITLE
fix: Update date ISO string validations

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_Default_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_Default_spec.js
@@ -105,6 +105,16 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
     cy.closePropertyPane();
     cy.assertDateFormat();
   });
+
+  it("Datepicker default date validation with js binding and default date with moment object", function() {
+    cy.openPropertyPane("datepickerwidget2");
+    cy.testJsontext("defaultdate", `{{moment("1/1/2012")}}`);
+    cy.get(".t--widget-datepickerwidget2 .bp3-input").should(
+      "contain.value",
+      "01/01/2012 00:00",
+    );
+  });
+
   it("Datepicker default date validation with js binding", function() {
     cy.PublishtheApp();
     // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -790,7 +790,6 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
         message = `Value does not match: ${getExpectedType(config)}`;
       } else {
         isValid = true;
-        parsed = value;
       }
     } else if (typeof value === "object" && moment(value).isValid()) {
       //Date and moment object

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -818,11 +818,16 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
       message = `Value does not match: ${getExpectedType(config)}`;
     }
 
-    return {
+    const result: ValidationResponse = {
       isValid,
       parsed,
-      messages: [message],
     };
+
+    if (message) {
+      result.messages = [message];
+    }
+
+    return result;
   },
   [ValidationTypes.FUNCTION]: (
     config: ValidationConfig,

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -778,32 +778,26 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     value: unknown,
     props: Record<string, unknown>,
   ): ValidationResponse => {
-    const invalidResponse = {
-      isValid: false,
-      parsed: config.params?.default,
-      messages: [`Value does not match: ${getExpectedType(config)}`],
-    };
-    if (value === undefined || value === null || !isString(value)) {
-      if (!config.params?.required) {
-        return {
-          isValid: true,
-          parsed: value,
-        };
-      }
-      return invalidResponse;
-    }
-    if (isString(value)) {
-      if (value === "" && !config.params?.required) {
-        return {
-          isValid: true,
-          parsed: config.params?.default,
-        };
-      } else if (value === "" && config.params?.required) {
-        return invalidResponse;
-      }
+    let isValid = false;
+    let parsed = value;
+    let message = "";
 
-      if (!moment(value).isValid()) return invalidResponse;
+    if (_.isNil(value) || value === "") {
+      parsed = config.params?.default;
 
+      if (config.params?.required) {
+        isValid = false;
+        message = `Value does not match: ${getExpectedType(config)}`;
+      } else {
+        isValid = true;
+        parsed = value;
+      }
+    } else if (typeof value === "object" && moment(value).isValid()) {
+      //Date and moment object
+      isValid = true;
+      parsed = moment(value).toISOString(true);
+    } else if (isString(value)) {
+      //Date string
       if (
         value === moment(value).toISOString() ||
         value === moment(value).toISOString(true)
@@ -812,11 +806,24 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
           isValid: true,
           parsed: value,
         };
+      } else if (moment(value).isValid()) {
+        isValid = true;
+        parsed = moment(value).toISOString(true);
+      } else {
+        isValid = false;
+        message = `Value does not match: ${getExpectedType(config)}`;
+        parsed = config.params?.default;
       }
-      if (moment(value).isValid())
-        return { isValid: true, parsed: moment(value).toISOString(true) };
+    } else {
+      isValid = false;
+      message = `Value does not match: ${getExpectedType(config)}`;
     }
-    return invalidResponse;
+
+    return {
+      isValid,
+      parsed,
+      messages: [message],
+    };
   },
   [ValidationTypes.FUNCTION]: (
     config: ValidationConfig,


### PR DESCRIPTION


## Description

In the worker thread, we were using lodash's cloneDeep function to clone the data tree, we recently started using a new library to clone to improve performance ([PR](https://github.com/appsmithorg/appsmith/pull/11001/files)).
Due to this change, Datepicker defaultValue is no longer evaluating to string, it gets evaluated to moment object, which results in the above error.

Fixes #11381 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/datepicker-validations 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.77 **(0)** | 37.1 **(-0.03)** | 35.82 **(0)** | 56.12 **(-0.01)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/workers/validations.ts | 81.32 **(-0.63)** | 70.57 **(-0.66)** | 76.67 **(0)** | 82.39 **(-1)**</details>