### PR TITLE
fix: Fixes UI and functionality issues on the Curl editor page

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx
@@ -10,9 +10,9 @@ import { BuilderRouteParams } from "constants/routes";
 import { curlImportFormValues, curlImportSubmitHandler } from "./helpers";
 import { createNewApiName } from "utils/AppsmithUtils";
 import { Colors } from "constants/Colors";
-import Button from "components/editorComponents/Button";
 import CurlLogo from "assets/images/Curl-logo.svg";
 import CloseEditor from "../../../components/editorComponents/CloseEditor";
+import Button, { Size } from "components/ads/Button";
 
 const StyledForm = styled(Form)`
   flex: 1;
@@ -50,7 +50,6 @@ const CurlImportFormContainer = styled.div`
 
 const CurlImport = styled.div`
   font-size: 20px;
-  padding: 20px;
 
   .backBtn {
     padding-bottom: 3px;
@@ -65,10 +64,11 @@ const CurlImport = styled.div`
 
 const CurlContainer = styled.div`
   margin-top: 20px;
-  padding-left: 70px;
-  padding-right: 70px;
+  padding-left: 16px;
+  padding-right: 16px;
 
   .inputLabel {
+    margin-bottom: 5px;
     font-weight: 500;
     font-size: 14px;
     color: ${Colors.BLUE_BAYOUX};
@@ -76,25 +76,38 @@ const CurlContainer = styled.div`
 `;
 
 const DividerLine = styled.div`
-  border: 1px solid ${Colors.CONCRETE};
+  border: 2px solid ${Colors.CONCRETE};
 `;
 
 const Header = styled.div`
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 10px;
+  margin-bottom: 15px;
+  display: flex;
+  justify-content: space-between;
+  align-content: center;
+
   .header {
+    display: flex;
+    width: auto;
+    align-items: center;
+  }
+
+  .text {
     font-weight: 500;
     font-size: 24px;
     line-height: 32px;
-    padding-left: 20px;
-    padding-top: 10px;
+    padding-left: 10px;
+  }
+  .curlImageContainer {
+    background-color: ${Colors.GREY_2};
+    border-radius: 9999px;
   }
   .curlImage {
-    float: left;
-    margin-top: -5px;
-    padding-right: 10px;
+    padding: 8px;
   }
-  .divider {
-    border: 1px solid ${Colors.CONCRETE};
-  }
+
   .closeBtn {
     position: absolute;
     left: 70%;
@@ -104,6 +117,16 @@ const Header = styled.div`
 const CurlLabel = styled.div`
   font-size: 12px;
   color: ${Colors.SLATE_GRAY};
+`;
+
+const ActionButtons = styled.div`
+  justify-self: flex-end;
+  display: flex;
+  align-items: center;
+
+  button:last-child {
+    margin-left: ${(props) => props.theme.spaces[7]}px;
+  }
 `;
 
 interface ReduxStateProps {
@@ -125,12 +148,26 @@ class CurlImportForm extends React.Component<Props> {
       <>
         <CloseEditor />
         <Header>
-          <p className="header">
-            <img alt="CURL" className="curlImage" src={CurlLogo} />
-            Import from CURL
-          </p>
-          <hr className="divider" />
+          <div className="header">
+            <div className="curlImageContainer">
+              <img alt="CURL" className="curlImage" src={CurlLogo} />
+            </div>
+            <p className="text">Import from CURL</p>
+          </div>
+
+          <ActionButtons className="t--formActionButtons">
+            <Button
+              className="importBtn t--importBtn"
+              isLoading={isImportingCurl}
+              onClick={handleSubmit(curlImportSubmitHandler)}
+              size={Size.large}
+              tag="button"
+              text="Import"
+              type="button"
+            />
+          </ActionButtons>
         </Header>
+        <DividerLine />
         <StyledForm onSubmit={handleSubmit(curlImportSubmitHandler)}>
           <CurlImport>
             <CurlContainer>
@@ -152,18 +189,6 @@ class CurlImportForm extends React.Component<Props> {
               </CurlImportFormContainer>
             </CurlContainer>
           </CurlImport>
-          <DividerLine />
-          <CurlImportFormContainer>
-            <Button
-              className="importBtn t--importBtn"
-              filled
-              intent="primary"
-              loading={isImportingCurl}
-              onClick={handleSubmit(curlImportSubmitHandler)}
-              size="small"
-              text="Import"
-            />
-          </CurlImportFormContainer>
         </StyledForm>
       </>
     );

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -72,6 +72,7 @@ import {
   INTEGRATION_EDITOR_URL,
   QUERIES_EDITOR_ID_URL,
   QUERIES_EDITOR_URL,
+  CURL_IMPORT_PAGE_PATH,
 } from "constants/routes";
 import { SAAS_EDITOR_API_ID_URL } from "pages/Editor/SaaSEditor/constants";
 import {
@@ -94,6 +95,9 @@ import {
   TriggerMeta,
 } from "sagas/ActionExecution/ActionExecutionSagas";
 import { requestModalConfirmationSaga } from "sagas/UtilSagas";
+import { getFormNames, getFormValues } from "redux-form";
+import { CURL_IMPORT_FORM } from "constants/forms";
+import { submitCurlImportForm } from "actions/importActions";
 
 enum ActionResponseDataTypes {
   BINARY = "BINARY",
@@ -359,25 +363,46 @@ function* runActionShortcutSaga() {
       trimQueryString(API_EDITOR_URL_WITH_SELECTED_PAGE_ID()),
       trimQueryString(INTEGRATION_EDITOR_URL()),
       trimQueryString(SAAS_EDITOR_API_ID_URL()),
+      CURL_IMPORT_PAGE_PATH, // check if the current location matches a curl editor page
     ],
     exact: true,
     strict: false,
   });
+
+  // get the current form name
+  const currentFormNames = yield select(getFormNames());
+
   if (!match || !match.params) return;
   const { apiId, pageId, queryId } = match.params;
   const actionId = apiId || queryId;
-  if (!actionId) return;
-  const trackerId = apiId
-    ? PerformanceTransactionName.RUN_API_SHORTCUT
-    : PerformanceTransactionName.RUN_QUERY_SHORTCUT;
-  PerformanceTracker.startTracking(trackerId, {
-    actionId,
-    pageId,
-  });
-  AnalyticsUtil.logEvent(trackerId as EventName, {
-    actionId,
-  });
-  yield put(runAction(actionId));
+  if (actionId) {
+    const trackerId = apiId
+      ? PerformanceTransactionName.RUN_API_SHORTCUT
+      : PerformanceTransactionName.RUN_QUERY_SHORTCUT;
+    PerformanceTracker.startTracking(trackerId, {
+      actionId,
+      pageId,
+    });
+    AnalyticsUtil.logEvent(trackerId as EventName, {
+      actionId,
+    });
+    yield put(runAction(actionId));
+  } else if (
+    !!currentFormNames &&
+    currentFormNames.includes(CURL_IMPORT_FORM) &&
+    !actionId
+  ) {
+    // if the current form names include the curl form and there are no actionIds i.e. its not an api or query
+    // get the form values and call the submit curl import form function with its data
+    const formValues = yield select(getFormValues(CURL_IMPORT_FORM));
+
+    // if the user has not edited the curl input field, assign an empty string to it, so it doesnt throw an error.
+    if (!formValues?.curl) formValues["curl"] = "";
+
+    yield put(submitCurlImportForm(formValues));
+  } else {
+    return;
+  }
 }
 
 function* runActionSaga(


### PR DESCRIPTION
This PR fixes the bad UI designs and UX on the Curl Editor Page, It also allows the use of Shortcuts on the curl editor page i.e. the CMD + Enter shortcut key, making it possible for users to use the shortcut key to execute Curl import queries.

Fixes #11029 

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-curl-editor-page 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/components/ads/Dropdown.tsx | 82.21 **(1.28)** | 61.85 **(0.76)** | 69.44 **(0)** | 81.03 **(1.37)**
 :red_circle: | app/client/src/pages/Editor/APIEditor/CurlImportForm.tsx | 74.29 **(-1.47)** | 88.89 **(1.39)** | 25 **(-8.33)** | 78.13 **(-1.87)**
 :green_circle: | app/client/src/sagas/ActionExecution/PluginActionSaga.ts | 18.6 **(0.38)** | 2.48 **(-0.27)** | 11.11 **(0)** | 21.36 **(0.51)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>