### PR TITLE
fix: Update date ISO string validations (#11399)

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_Default_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/DatePicker_2_Default_spec.js
@@ -105,6 +105,16 @@ describe("DatePicker Widget Property pane tests with js bindings", function() {
     cy.closePropertyPane();
     cy.assertDateFormat();
   });
+
+  it("Datepicker default date validation with js binding and default date with moment object", function() {
+    cy.openPropertyPane("datepickerwidget2");
+    cy.testJsontext("defaultdate", `{{moment("1/1/2012")}}`);
+    cy.get(".t--widget-datepickerwidget2 .bp3-input").should(
+      "contain.value",
+      "01/01/2012 00:00",
+    );
+  });
+
   it("Datepicker default date validation with js binding", function() {
     cy.PublishtheApp();
     // eslint-disable-next-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
Cherry picking fix from #11399.

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:master and head branch: chore/fix-date-iso-validations 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.76 **(0)** | 37.09 **(-0.04)** | 35.81 **(0)** | 56.12 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :red_circle: | app/client/src/workers/validations.ts | 81.32 **(-0.63)** | 70.57 **(-0.66)** | 76.67 **(0)** | 82.39 **(-1)**</details>