### PR TITLE
fix: Fix git connect failure for repo with yml CI files

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
@@ -63,7 +63,7 @@ public class FileUtilsImpl implements FileInterface {
 
     private static final String VIEW_MODE_URL_TEMPLATE = "{{viewModeUrl}}";
 
-    private static final Pattern FILE_EXTENSION_PATTERN = Pattern.compile("(.*?)\\.(md|git|gitignore)$");
+    private static final Pattern FILE_EXTENSION_PATTERN = Pattern.compile("(.*?)\\.(md|git|gitignore|yml)$");
 
 
     /**


### PR DESCRIPTION
## Description

>  When the user tries to connect a repo(gitLab or any) and if the repo contains `.yml` file connect fails with error.
 `.yml` files are used for CI purpose and we should allow such scenarios.

Fixes #11430 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
