### PR TITLE
fix: 9824 Google Sheet to filter empty condition ver.2

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
@@ -88,6 +88,13 @@ public class Condition {
         return true;
     }
 
+    /**
+     * To generate condition list based on selected condition
+     * Mandatory inputs validated are path and operator
+     * Value is optional and considered as a null input
+     * @param configurationList
+     * @return
+     */
     public static List<Condition> generateFromConfiguration(List<Object> configurationList) {
         List<Condition> conditionList = new ArrayList<>();
 
@@ -96,7 +103,7 @@ public class Condition {
             if (condition.entrySet().isEmpty()) {
                 // Its an empty object set by the client for UX. Ignore the same
                 continue;
-            } else if (!condition.keySet().containsAll(Set.of("path", "operator", "value"))) {
+            } else if (!condition.keySet().containsAll(Set.of("path", "operator"))) {
                 throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "Filtering Condition not configured properly");
             }
             conditionList.add(new Condition(

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
@@ -73,11 +73,15 @@ public class Condition {
         return condition;
     }
 
+    /**
+     * To evaluate 'Path' and 'Operator' to be available for filtering
+     * 'Values' not evaluated for availability, to support searching empty values
+     * @param condition
+     * @return  Boolean
+     */
     public static Boolean isValid(Condition condition) {
 
-        if (StringUtils.isEmpty(condition.getPath()) ||
-                (condition.getOperator() == null) ||
-                StringUtils.isEmpty((CharSequence) condition.getValue())) {
+        if (StringUtils.isEmpty(condition.getPath()) || (condition.getOperator() == null)) {
             return false;
         }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -457,7 +457,13 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
             sb.append("\"" + path + "\"");
             sb.append(" ");
-            sb.append(sqlOp);
+            boolean isPrepareStmt = true;
+            if (value.equals(" ") && operator.name().equals("EQ")) {
+                sb.append("IS NULL");
+                isPrepareStmt = false;
+            } else {
+                sb.append(sqlOp);
+            }
             sb.append(" ");
 
             // These are array operations. Convert value into appropriate format and then append
@@ -485,7 +491,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 value = valueBuilder.toString();
                 sb.append(value);
 
-            } else {
+            } else if (isPrepareStmt) {
                 // Not an array. Simply add a placeholder
                 sb.append("?");
                 values.add(new PreparedStatementValueDTO(value, schema.get(path)));

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -432,8 +432,9 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
     private String generateWhereClauseOldFormat(List<Condition> conditions, LinkedList<PreparedStatementValueDTO> values, Map<String, DataType> schema) {
 
         StringBuilder sb = new StringBuilder();
-
+        Boolean isEmptyConditionValue = false;
         Boolean firstCondition = true;
+
         for (Condition condition : conditions) {
 
             if (firstCondition) {
@@ -457,10 +458,10 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
             sb.append("\"" + path + "\"");
             sb.append(" ");
-            boolean isPrepareStmt = true;
-            if (value.equals(StringUtils.SPACE) && operator.name().equals("EQ")) {
+
+            if (value.equals(StringUtils.EMPTY) && operator.name().equals("EQ")) {
                 sb.append("IS NULL");
-                isPrepareStmt = false;
+                isEmptyConditionValue = true;
             } else {
                 sb.append(sqlOp);
             }
@@ -491,7 +492,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 value = valueBuilder.toString();
                 sb.append(value);
 
-            } else if (isPrepareStmt) {
+            } else if (!isEmptyConditionValue) {
                 // Not an array. Simply add a placeholder
                 sb.append("?");
                 values.add(new PreparedStatementValueDTO(value, schema.get(path)));

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -458,7 +458,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
             sb.append("\"" + path + "\"");
             sb.append(" ");
             boolean isPrepareStmt = true;
-            if (value.equals(" ") && operator.name().equals("EQ")) {
+            if (value.equals(StringUtils.SPACE) && operator.name().equals("EQ")) {
                 sb.append("IS NULL");
                 isPrepareStmt = false;
             } else {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -471,7 +471,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
             sb.append(" ");
 
             // These are array operations. Convert value into appropriate format and then append
-            if ((value != null || (value != null && !value.equals(StringUtils.EMPTY))) &&
+            if (!(value == null || StringUtils.EMPTY.equals(value)) &&    //value should not be EMPTY or null
                     (operator == ConditionalOperator.IN || operator == ConditionalOperator.NOT_IN)) {
 
                 StringBuilder valueBuilder = new StringBuilder("(");

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -155,6 +155,59 @@ public class FilterDataServiceTest {
     }
 
     @Test
+    public void testFilterEmptyCondition() {
+        String data = "[\n" +
+                "  {\n" +
+                "    \"id\": 2381224,\n" +
+                "    \"email\": \"michael.lawson@reqres.in\",\n" +
+                "    \"userName\": \"Michael Lawson\",\n" +
+                "    \"productName\": \"Chicken Sandwich\",\n" +
+                "    \"orderAmount\": 4.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 2736212,\n" +
+                "    \"email\": \"lindsay.ferguson@reqres.in\",\n" +
+                "    \"userName\": \"Lindsay Ferguson\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 9.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 6788734,\n" +
+                "    \"email\": \"tobias.funke@reqres.in\",\n" +
+                "    \"userName\": \"Tobias Funke\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 19.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  }\n" +
+                "]";
+
+        try {
+            ArrayNode items = (ArrayNode) objectMapper.readTree(data);
+
+            List<Condition> whereConditionList = new ArrayList<>();
+
+            Condition condition = new Condition("productName", "EQ", "");
+            whereConditionList.add(condition);
+
+            //Precondition for whereConditionList implemented in GetValuesMethod.isWhereConditionConfigured(..)
+            whereConditionList.stream()
+                    .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
+                    .forEach(val -> val.setValue(" ")); // Setting null fails in null validation
+
+            ArrayNode filteredData = filterDataService.filterData(items, whereConditionList);
+
+            assertEquals(filteredData.size(), 2);
+
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
     public void testFilterInConditionForStrings() {
         String data = "[\n" +
                 "  {\n" +

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -203,6 +203,57 @@ public class FilterDataServiceTest {
     }
 
     @Test
+    public void testFilterEmptyAndNonEmptyCondition() {
+        String data = "[\n" +
+                "  {\n" +
+                "    \"id\": 2381224,\n" +
+                "    \"email\": \"michael.lawson@reqres.in\",\n" +
+                "    \"userName\": \"Michael Lawson\",\n" +
+                "    \"productName\": \"Chicken Sandwich\",\n" +
+                "    \"orderAmount\": 4.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 2736212,\n" +
+                "    \"email\": \"lindsay.ferguson@reqres.in\",\n" +
+                "    \"userName\": \"Lindsay Ferguson\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 9.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 6788734,\n" +
+                "    \"email\": \"tobias.funke@reqres.in\",\n" +
+                "    \"userName\": \"Tobias Funke\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 19.99,\n" +
+                "    \"orderStatus\": \"NOT READY\"\n" +
+                "  }\n" +
+                "]";
+
+        try {
+            ArrayNode items = (ArrayNode) objectMapper.readTree(data);
+
+            List<Condition> whereConditionList = new ArrayList<>();
+
+            Condition condition1 = new Condition("orderStatus", "EQ", "READY");
+            whereConditionList.add(condition1);
+
+            Condition condition2 = new Condition("productName", "EQ", null); //The UI sends null when that field is untouched
+            whereConditionList.add(condition2);
+
+            ArrayNode filteredData = filterDataService.filterData(items, whereConditionList);
+
+            assertEquals(filteredData.size(), 1);
+
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
     public void testFilterInConditionForStrings() {
         String data = "[\n" +
                 "  {\n" +

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -191,11 +191,6 @@ public class FilterDataServiceTest {
             Condition condition = new Condition("productName", "EQ", "");
             whereConditionList.add(condition);
 
-            //Precondition for whereConditionList implemented in GetValuesMethod.isWhereConditionConfigured(..)
-            whereConditionList.stream()
-                    .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
-                    .forEach(val -> val.setValue(" ")); // Setting null fails in null validation
-
             ArrayNode filteredData = filterDataService.filterData(items, whereConditionList);
 
             assertEquals(filteredData.size(), 2);

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
@@ -4,6 +4,7 @@ import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
+import com.appsmith.external.models.Property;
 import com.appsmith.external.services.FilterDataService;
 import com.external.domains.RowObject;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -250,6 +251,12 @@ public class GetValuesMethod implements Method {
         if (whereConditions == null || whereConditions.size() == 0) {
             return false;
         }
+
+        //Change empty condition value("") to " " to bypass Null validation
+        whereConditions.stream()
+                .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
+                .forEach(val -> val.setValue(" "));
+
 
         // At least 1 condition exists
         return true;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
@@ -4,14 +4,12 @@ import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
-import com.appsmith.external.models.Property;
 import com.appsmith.external.services.FilterDataService;
 import com.external.domains.RowObject;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -252,12 +250,6 @@ public class GetValuesMethod implements Method {
         if (whereConditions == null || whereConditions.size() == 0) {
             return false;
         }
-
-        //Change empty condition value("") to " " to bypass Null validation
-        whereConditions.stream()
-                .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
-                .forEach(val -> val.setValue(StringUtils.SPACE));
-
 
         // At least 1 condition exists
         return true;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -255,7 +256,7 @@ public class GetValuesMethod implements Method {
         //Change empty condition value("") to " " to bypass Null validation
         whereConditions.stream()
                 .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
-                .forEach(val -> val.setValue(" "));
+                .forEach(val -> val.setValue(StringUtils.SPACE));
 
 
         // At least 1 condition exists


### PR DESCRIPTION
## Description
To fetch data from Google Sheet with empty where condition, ie with no entry in Where Conditions, value field
For example, user needs this implementation as he want to search a member with no emailId from the googlesheet database.

**Features/Scenarios implemented and Tested regarding the values in the condition:**
1. When Value is Empty ""    - Pass
2. When Value is Null     null  -  Pass
3. When Value is Space  " "   - Pass
4. When Two conditions are  "" -  Pass
5. When Two conditions are null - Pass
6. When one Condition is Null and other empty - Pass
7. When both has value    - Pass
8. When both condition are empty  - Pass
9. Test for EQ  with empty / Null /  with_value   - Pass
10. Test for 'IN' for with  empty / Null     - Pass
11. Test for 'NOT_IN'  with  empty / Null     - Pass
12. Test for combination of  EQ  /   IN   /  NOT_IN    - Pass

Note : The UI will sent null, when we do not touch the field (ie Mouse down/Click), at present it is handled in the backend by capturing the nulls.
We may need to fix that in the front end, for which I will create a ticket later.


Fixes #9824

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually tested with Single and Multiple conditions
- Unit Test Added


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
