### PR TITLE
Remove CORS allow-star from RTS

### DIFF
--- a/app/rts/src/server.ts
+++ b/app/rts/src/server.ts
@@ -48,10 +48,6 @@ function main() {
     const server = new http.Server(app);
     const io = new Server(server, {
         path: RTS_BASE_PATH,
-        // TODO: Remove this CORS configuration.
-        cors: {
-            origin: "*",
-        },
     });
 
     const port = 8091;


### PR DESCRIPTION
## Description

We don't need to allow all origins to access the RTS API anymore.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
