### PR TITLE
fix: Number type input should honour required property when value is an empty string

### DIFF
--- a/app/client/src/widgets/InputWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.js
@@ -5,8 +5,8 @@ export default {
     switch (props.inputType) {
       case "NUMBER":
         try {
-          isEmpty = _.isNil(props.text);
-          value = Number(props.text);
+          isEmpty = _.isNil(props.text) || props.text === "";
+          value = isEmpty ? null : Number(props.text);
           hasValidValue = Number.isFinite(value);
           break;
         } catch (e) {
@@ -87,12 +87,14 @@ export default {
         }
       case "NUMBER":
         if (
+          !_.isNil(value) &&
           !_.isNil(props.maxNum) &&
           Number.isFinite(props.maxNum) &&
           props.maxNum < value
         ) {
           return false;
         } else if (
+          !_.isNil(value) &&
           !_.isNil(props.minNum) &&
           Number.isFinite(props.minNum) &&
           props.minNum > value

--- a/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
@@ -31,11 +31,63 @@ describe("Derived property - ", () => {
 
       expect(isValid).toBeFalsy();
 
+      //Number input with required true and invalid value `null`
+      isValid = derivedProperty.isValid(
+        {
+          inputType: InputTypes.NUMBER,
+          text: null,
+          isRequired: true,
+        },
+        null,
+        _,
+      );
+
+      expect(isValid).toBeFalsy();
+
+      //Number input with required true and invalid value `undefined`
+      isValid = derivedProperty.isValid(
+        {
+          inputType: InputTypes.NUMBER,
+          text: undefined,
+          isRequired: true,
+        },
+        null,
+        _,
+      );
+
+      expect(isValid).toBeFalsy();
+
+      //Number input with required true and invalid value `""`
+      isValid = derivedProperty.isValid(
+        {
+          inputType: InputTypes.NUMBER,
+          text: "",
+          isRequired: true,
+        },
+        null,
+        _,
+      );
+
+      expect(isValid).toBeFalsy();
+
       //Number input with required true and valid value
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
           text: 1,
+          isRequired: true,
+        },
+        null,
+        _,
+      );
+
+      expect(isValid).toBeTruthy();
+
+      //Number input with required true and valid value
+      isValid = derivedProperty.isValid(
+        {
+          inputType: InputTypes.NUMBER,
+          text: 1.1,
           isRequired: true,
         },
         null,

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -363,7 +363,7 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
             parsedValue = Number(value);
 
             if (isNaN(parsedValue)) {
-              parsedValue = undefined;
+              parsedValue = null;
             }
           }
           break;


### PR DESCRIPTION
## Description
In Number type Input, when value is empty, it gets converted to `0`. As a result isValid check passes. as part of this commit we made sure that the empty string is handled properly in the isValid check.

Fixes #11438 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/number-type-input-required 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.74 **(0)** | 37.08 **(0.01)** | 35.82 **(0)** | 56.1 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/widgets/InputWidgetV2/widget/derived.js | 78.72 **(0)** | 77.36 **(2.89)** | 100 **(0)** | 78.72 **(0)**</details>