### PR TITLE
chore: Fix casing of plugin names

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -1,0 +1,40 @@
+package com.appsmith.server.migrations;
+
+import com.appsmith.server.domains.Plugin;
+import com.appsmith.server.domains.QPlugin;
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import static com.appsmith.server.repositories.BaseAppsmithRepositoryImpl.fieldName;
+
+@Slf4j
+@ChangeLog(order = "002")
+public class DatabaseChangelog2 {
+
+    @ChangeSet(order = "001", id = "fix-plugin-title-casing", author = "")
+    public void fixPluginTitleCasing(MongockTemplate mongockTemplate) {
+        mongockTemplate.updateFirst(
+                Query.query(Criteria.where(fieldName(QPlugin.plugin.packageName)).is("mysql-plugin")),
+                Update.update(fieldName(QPlugin.plugin.name), "MySQL"),
+                Plugin.class
+        );
+
+        mongockTemplate.updateFirst(
+                Query.query(Criteria.where(fieldName(QPlugin.plugin.packageName)).is("mssql-plugin")),
+                Update.update(fieldName(QPlugin.plugin.name), "Microsoft SQL Server"),
+                Plugin.class
+        );
+
+        mongockTemplate.updateFirst(
+                Query.query(Criteria.where(fieldName(QPlugin.plugin.packageName)).is("elasticsearch-plugin")),
+                Update.update(fieldName(QPlugin.plugin.name), "Elasticsearch"),
+                Plugin.class
+        );
+    }
+
+}


### PR DESCRIPTION
Also taking this opportunity to create a new Changelog class, with incremented order at the class-annotation level. Let's add all future migrations to this class instead?

Partially resolves https://github.com/appsmithorg/appsmith/issues/10848.
