### PR TITLE
fix: Aspect ratio of video changes when Camera widget is longer in width than the aspect ratio

### DIFF
--- a/app/client/src/widgets/CameraWidget/component/index.tsx
+++ b/app/client/src/widgets/CameraWidget/component/index.tsx
@@ -44,6 +44,7 @@ import { ReactComponent as ExitFullScreenIcon } from "assets/icons/widget/camera
 
 const overlayerMixin = css`
   position: absolute;
+  height: 100%;
   width: 100%;
   object-fit: contain;
   top: 50%;
@@ -81,6 +82,7 @@ const CameraContainer = styled.div<CameraContainerProps>`
   }
 
   video {
+    height: 100%;
     width: 100%;
     object-fit: contain;
   }


### PR DESCRIPTION

## Description

The aspect ratio should be kept no matter how the widget width or height is resized

Fixes #10591 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/10591-camera-aspect-ratio-issue-in-width 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>