### PR TITLE
fix: handle main container height

### DIFF
--- a/app/client/src/widgets/CanvasWidget.tsx
+++ b/app/client/src/widgets/CanvasWidget.tsx
@@ -3,7 +3,10 @@ import { WidgetProps } from "widgets/BaseWidget";
 import ContainerWidget, {
   ContainerWidgetProps,
 } from "widgets/ContainerWidget/widget";
-import { GridDefaults } from "constants/WidgetConstants";
+import {
+  GridDefaults,
+  MAIN_CONTAINER_WIDGET_ID,
+} from "constants/WidgetConstants";
 import DropTargetComponent from "components/editorComponents/DropTargetComponent";
 import { getCanvasSnapRows } from "utils/WidgetPropsUtils";
 import { getCanvasClassName } from "utils/generators";
@@ -68,7 +71,10 @@ class CanvasWidget extends ContainerWidget {
 
     const style: CSSProperties = {
       width: "100%",
-      height: `${height}px`,
+      height:
+        this.props.widgetId === MAIN_CONTAINER_WIDGET_ID
+          ? "100%"
+          : `${height}px`,
       background: "none",
       position: "relative",
     };


### PR DESCRIPTION

## Description

> Fix Vertical scroll issue in embed mode as well fix Scroll issue in View Mode and Model View.  
-  Height is considered `100%` when widgetId is `MAIN_CONTAINER_WIDGET_ID` . 
-  rest all widget we consider height  `snapRows * GridDefaults.DEFAULT_GRID_ROW_HEIGHT`


Fixes #9858 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/handle-maincontainer-height 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :red_circle: | app/client/src/widgets/CanvasWidget.tsx | 95.92 **(0)** | 64.29 **(-2.38)** | 100 **(0)** | 97.83 **(0)**</details>