### PR TITLE
fix: Update api params for dynamic fetched values

### DIFF
--- a/app/client/src/actions/evaluationActions.ts
+++ b/app/client/src/actions/evaluationActions.ts
@@ -8,6 +8,7 @@ import { DataTree } from "entities/DataTree/dataTreeFactory";
 import { DependencyMap } from "utils/DynamicBindingUtils";
 import { Diff } from "deep-diff";
 import { QueryActionConfig } from "../entities/Action";
+import { FormEvalActionPayload } from "sagas/FormEvaluationSaga";
 
 export const FIRST_EVAL_REDUX_ACTIONS = [
   // Pages
@@ -116,9 +117,11 @@ export const initFormEvaluations = (
 export const startFormEvaluations = (
   formId: string,
   formData: QueryActionConfig,
+  datasourceId: string,
+  pluginId: string,
 ) => {
   return {
     type: ReduxActionTypes.RUN_FORM_EVALUATION,
-    payload: { formId, actionConfiguration: formData },
+    payload: { formId, actionConfiguration: formData, datasourceId, pluginId },
   };
 };

--- a/app/client/src/actions/evaluationActions.ts
+++ b/app/client/src/actions/evaluationActions.ts
@@ -8,7 +8,6 @@ import { DataTree } from "entities/DataTree/dataTreeFactory";
 import { DependencyMap } from "utils/DynamicBindingUtils";
 import { Diff } from "deep-diff";
 import { QueryActionConfig } from "../entities/Action";
-import { FormEvalActionPayload } from "sagas/FormEvaluationSaga";
 
 export const FIRST_EVAL_REDUX_ACTIONS = [
   // Pages

--- a/app/client/src/api/PluginApi.ts
+++ b/app/client/src/api/PluginApi.ts
@@ -60,8 +60,9 @@ class PluginsApi extends Api {
   // Definition to fetch the dynamic data via the URL passed in the config
   static fetchDynamicFormValues(
     url: string,
+    body: Record<string, any>,
   ): AxiosPromise<GenericApiResponse<DropdownOption[]>> {
-    return Api.get(url);
+    return Api.post(url, body);
   }
 }
 

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -58,7 +58,12 @@ type ReduxDispatchProps = {
   runAction: (actionId: string) => void;
   deleteAction: (id: string, name: string) => void;
   changeQueryPage: (queryId: string) => void;
-  runFormEvaluation: (formId: string, formData: QueryActionConfig) => void;
+  runFormEvaluation: (
+    formId: string,
+    formData: QueryActionConfig,
+    datasourceId: string,
+    pluginId: string,
+  ) => void;
   initFormEvaluation: (
     editorConfig: any,
     settingConfig: any,
@@ -157,6 +162,8 @@ class QueryEditor extends React.Component<Props> {
       this.props.runFormEvaluation(
         this.props.formData.id,
         this.props.formData.actionConfiguration,
+        this.props.formData.datasource.id,
+        this.props.formData.pluginId,
       );
     }
   }
@@ -296,8 +303,13 @@ const mapDispatchToProps = (dispatch: any): ReduxDispatchProps => ({
   changeQueryPage: (queryId: string) => {
     dispatch(changeQuery(queryId));
   },
-  runFormEvaluation: (formId: string, formData: QueryActionConfig) => {
-    dispatch(startFormEvaluations(formId, formData));
+  runFormEvaluation: (
+    formId: string,
+    formData: QueryActionConfig,
+    datasourceId: string,
+    pluginId: string,
+  ) => {
+    dispatch(startFormEvaluations(formId, formData, datasourceId, pluginId));
   },
   initFormEvaluation: (
     editorConfig: any,

--- a/app/client/src/reducers/evaluationReducers/formEvaluationReducer.ts
+++ b/app/client/src/reducers/evaluationReducers/formEvaluationReducer.ts
@@ -9,7 +9,7 @@ export type DynamicValues = {
   hasStarted: boolean;
   hasFetchFailed: boolean;
   data: any;
-  config: { url: string; method: string; params?: string[] };
+  config: { url: string; method: string; params: Record<string, any> };
 };
 
 export type ConditonalObject = Record<string, any>;

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -99,8 +99,8 @@ function* setFormEvaluationSagaAsync(
             queueOfValuesToBeFetched,
             formId,
             evalOutput,
-            action.payload.datasourceId,
-            action.payload.pluginId,
+            action.payload.datasourceId ? action.payload.datasourceId : "",
+            action.payload.pluginId ? action.payload.pluginId : "",
           );
         }
       }

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -22,6 +22,8 @@ let isEvaluating = false; // Flag to maintain the queue of evals
 
 export type FormEvalActionPayload = {
   formId: string;
+  datasourceId?: string;
+  pluginId?: string;
   actionConfiguration?: ActionConfig;
   editorConfig?: FormConfig[];
   settingConfig?: FormConfig[];
@@ -97,6 +99,8 @@ function* setFormEvaluationSagaAsync(
             queueOfValuesToBeFetched,
             formId,
             evalOutput,
+            action.payload.datasourceId,
+            action.payload.pluginId,
           );
         }
       }
@@ -112,12 +116,17 @@ function* fetchDynamicValuesSaga(
   queueOfValuesToBeFetched: Record<string, ConditionalOutput>,
   formId: string,
   evalOutput: FormEvalOutput,
+  datasourceId: string,
+  pluginId: string,
 ) {
   for (const key of Object.keys(queueOfValuesToBeFetched)) {
     evalOutput[key].fetchDynamicValues = yield call(
       fetchDynamicValueSaga,
       queueOfValuesToBeFetched[key],
       Object.assign({}, evalOutput[key].fetchDynamicValues as DynamicValues),
+      formId,
+      datasourceId,
+      pluginId,
     );
   }
   // Set the values to the state once all values are fetched
@@ -130,15 +139,23 @@ function* fetchDynamicValuesSaga(
 function* fetchDynamicValueSaga(
   value: ConditionalOutput,
   dynamicFetchedValues: DynamicValues,
+  actionId: string,
+  datasourceId: string,
+  pluginId: string,
 ) {
   try {
     const { config } = value.fetchDynamicValues as DynamicValues;
-    const { url } = config;
+    const { params, url } = config;
 
     dynamicFetchedValues.hasStarted = true;
 
     // Call the API to fetch the dynamic values
-    const response = yield call(PluginsApi.fetchDynamicFormValues, url);
+    const response = yield call(PluginsApi.fetchDynamicFormValues, url, {
+      actionId,
+      datasourceId,
+      pluginId,
+      ...params,
+    });
     dynamicFetchedValues.isLoading = false;
     if (!!response && response instanceof Array) {
       dynamicFetchedValues.data = response;

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -127,6 +127,7 @@ function* fetchDynamicValuesSaga(
       formId,
       datasourceId,
       pluginId,
+      key,
     );
   }
   // Set the values to the state once all values are fetched
@@ -142,6 +143,7 @@ function* fetchDynamicValueSaga(
   actionId: string,
   datasourceId: string,
   pluginId: string,
+  configProperty: string,
 ) {
   try {
     const { config } = value.fetchDynamicValues as DynamicValues;
@@ -152,6 +154,7 @@ function* fetchDynamicValueSaga(
     // Call the API to fetch the dynamic values
     const response = yield call(PluginsApi.fetchDynamicFormValues, url, {
       actionId,
+      configProperty,
       datasourceId,
       pluginId,
       ...params,

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -110,7 +110,14 @@ function* changeQuerySaga(actionPayload: ReduxAction<{ id: string }>) {
   // Set the initialValues in the state for redux-form lib
   yield put(initialize(QUERY_EDITOR_FORM_NAME, formInitialValues));
   // Once the initial values are set, we can run the evaluations based on them.
-  yield put(startFormEvaluations(id, formInitialValues.actionConfiguration));
+  yield put(
+    startFormEvaluations(
+      id,
+      formInitialValues.actionConfiguration,
+      action.datasource.id,
+      pluginId,
+    ),
+  );
 
   yield put(
     updateReplayEntity(


### PR DESCRIPTION
## Description

The new dynamic value fetch system for dropdowns of UQI forms was a GET request. This fix changes that request to a POST request so that we can send extra payload with the call like `datasourceId`, `pluginId` and `actionId`.

Fixes #10762 

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/10762-update-api-params-for-uqi-dynamic-vals 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/sagas/FormEvaluationSaga.ts | 23.38 **(0)** | 10 **(-1.54)** | 25 **(0)** | 28.13 **(0)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>