### PR TITLE
fix: update current tree after evaluation for jsobjects

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -48,6 +48,7 @@ import {
   getParams,
   updateJSCollectionInDataTree,
   removeFunctionsAndVariableJSCollection,
+  updateEvaluatedJSCollection,
 } from "workers/evaluationUtils";
 import _ from "lodash";
 import { applyChange, Diff, diff } from "deep-diff";
@@ -697,7 +698,11 @@ export default class DataTreeEvaluator {
             _.set(currentTree, fullPropertyPath, evalPropertyValue);
             return currentTree;
           } else if (isJSAction(entity)) {
-            return currentTree;
+            return updateEvaluatedJSCollection(
+              currentTree,
+              fullPropertyPath,
+              evalPropertyValue,
+            );
           } else {
             return _.set(currentTree, fullPropertyPath, evalPropertyValue);
           }

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -839,3 +839,22 @@ export const overrideWidgetProperties = (
     }
   }
 };
+
+export const updateEvaluatedJSCollection = (
+  tree: DataTree,
+  fullPropertyPath: string,
+  evalPropertyValue: Record<string, unknown>,
+) => {
+  const pathArray = fullPropertyPath.split(".");
+  const jsCollectionName = pathArray[0];
+
+  if (
+    fullPropertyPath === `${jsCollectionName}.body` &&
+    isTrueObject(evalPropertyValue)
+  ) {
+    for (const key in evalPropertyValue) {
+      _.set(tree, `${jsCollectionName}.${key}`, evalPropertyValue[key]);
+    }
+  }
+  return tree;
+};


### PR DESCRIPTION


## Description

Previously, the current tree after evaluating a js collection's body doesn't get updated, so bindings still show up instead of their evaluated values.

Fixes #9645 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/update-evaluated-body-in-js-objects 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.72 **(0)** | 37.03 **(-0.02)** | 35.79 **(0)** | 56.07 **(-0.01)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :red_circle: | app/client/src/workers/evaluationUtils.ts | 57.75 **(-0.62)** | 55.96 **(-1.18)** | 63.49 **(-1.03)** | 56.87 **(-0.83)**</details>