### PR TITLE
fix: Make the dropdown to have at least one selected value

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -851,7 +851,11 @@ export default function Dropdown(props: DropdownProps) {
           (option: DropdownOption) => option.value !== optionToBeRemoved.value,
         );
       }
-      setSelected(selectedOptions);
+      if (Array.isArray(selectedOptions)) {
+        if (selectedOptions.length !== 0) setSelected(selectedOptions);
+      } else {
+        setSelected(selectedOptions);
+      }
       removeSelectedOption &&
         removeSelectedOption(optionToBeRemoved.value, optionToBeRemoved);
     },


### PR DESCRIPTION
## Description

Makes the dropdown have at least one selected value so that clicking the selected item again doesn't unselect it and make the dropdown empty

Fixes #11484 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/dropdown-unselect 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.72 **(0)** | 37.05 **(-0.01)** | 35.79 **(0)** | 56.08 **(0)**
 :red_circle: | app/client/src/components/ads/Dropdown.tsx | 80 **(-0.93)** | 60.36 **(-0.73)** | 69.44 **(0)** | 78.99 **(-0.67)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>