### PR TITLE
fix: reword datasource message

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -254,7 +254,7 @@ function DatasourceCard(props: DatasourceCardProps) {
             <Queries className={`t--queries-for-${plugin.type}`}>
               {queriesWithThisDatasource
                 ? `${queriesWithThisDatasource} ${QUERY} on this page`
-                : "No query is using this datasource"}
+                : "No query in this application is using this datasource"}
             </Queries>
           </div>
           <ButtonsWrapper className="action-wrapper">


### PR DESCRIPTION
## Description

Reword Message 
No query is using this datasource -> No query in this application is using this data source


Fixes #11477

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>