### PR TITLE
fix: Add showdown types

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -238,6 +238,7 @@
     "@types/redux-form": "^8.1.9",
     "@types/redux-mock-store": "^1.0.2",
     "@types/resize-observer-browser": "^0.1.5",
+    "@types/showdown": "^1.9.4",
     "@types/styled-components": "^5.1.3",
     "@types/styled-system": "^5.1.9",
     "@types/tern": "0.22.0",


### PR DESCRIPTION
## Description

Add showdown types package as a dev dependency for the client
As a fix for #7443 in PR #8121 we missed the package.json entry for `@types/showdown`

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
If all tests pass, this change shouldn't have effected the current client.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/add-showdown-types 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.72 **(0)** | 37.06 **(0.01)** | 35.79 **(0)** | 56.08 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>