### PR TITLE
fix: send `confirmBeforeExecute` attribute with page execution order info

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/DslActionDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/DslActionDTO.java
@@ -24,6 +24,7 @@ public class DslActionDTO {
     String name;
     String collectionId;
     Boolean clientSideExecution;
+    Boolean confirmBeforeExecute;
     PluginType pluginType;
     Set<String> jsonPathKeys;
     Integer timeoutInMillisecond = DEFAULT_ACTION_EXECUTION_TIMEOUT_MS;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
@@ -992,6 +992,7 @@ public class PageLoadActionsUtilCEImpl implements PageLoadActionsUtilCE {
         dslActionDTO.setName(actionDTO.getValidName());
         dslActionDTO.setCollectionId(actionDTO.getCollectionId());
         dslActionDTO.setClientSideExecution(actionDTO.getClientSideExecution());
+        dslActionDTO.setConfirmBeforeExecute(actionDTO.getConfirmBeforeExecute());
         if (actionDTO.getDefaultResources() != null) {
             dslActionDTO.setDefaultActionId(actionDTO.getDefaultResources().getActionId());
             dslActionDTO.setDefaultCollectionId(actionDTO.getDefaultResources().getCollectionId());


### PR DESCRIPTION
## Description
* send `confirmBeforeExecute` attribute with page execution order info to let the client know if it needs to ask user for confirmation before action gets executed. 

Related to issue #11417

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
