### PR TITLE
fix: advanced of calling api of git status on git sync modal

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -155,7 +155,7 @@ function Deploy() {
   const commitButtonText = createMessage(COMMIT_AND_PUSH);
 
   useEffect(() => {
-    dispatch(fetchGitStatusInit());
+    if (!isFetchingGitStatus) dispatch(fetchGitStatusInit());
     return () => {
       dispatch(clearCommitSuccessfulState());
     };

--- a/app/client/src/pages/Editor/gitSync/Tabs/Merge.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Merge.tsx
@@ -178,8 +178,8 @@ export default function Merge() {
   }, [currentBranch, selectedBranchOption.value, dispatch]);
 
   useEffect(() => {
-    dispatch(fetchGitStatusInit());
-    dispatch(fetchBranchesInit());
+    if (!isFetchingGitStatus) dispatch(fetchGitStatusInit());
+    if (!isFetchingBranches) dispatch(fetchBranchesInit());
     return () => {
       dispatch(resetMergeStatus());
     };


### PR DESCRIPTION
## Description

> When open git sync modal, switch deploy and merge tab, fetch api of git status is not called while fetching of git status, 

Fixes 

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please check above description

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: git-sync-advanced 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.71 **(-0.01)** | 37.01 **(0)** | 35.17 **(-0.01)** | 56.05 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 77.26 **(-0.13)** | 58.22 **(-0.23)** | 75.29 **(-0.29)** | 77.02 **(-0.15)**
 :red_circle: | app/client/src/workers/evaluationUtils.ts | 58.37 **(-0.36)** | 57.14 **(0.07)** | 64.52 **(-0.56)** | 57.7 **(-0.43)**</details>