### PR TITLE
fix: Remove reset password button if form login is disabled

### DIFF
--- a/app/client/src/components/ads/CalloutV2.tsx
+++ b/app/client/src/components/ads/CalloutV2.tsx
@@ -32,6 +32,7 @@ export const Wrapper = styled.div<{ type?: CalloutType }>`
     font-size: 12px;
     line-height: 16px;
   }
+  
   a {
     font-style: normal;
     font-weight: 600;

--- a/app/client/src/components/ads/CalloutV2.tsx
+++ b/app/client/src/components/ads/CalloutV2.tsx
@@ -83,10 +83,12 @@ export function Callout(props: {
       )}
       <div>
         <h4>{props.title}</h4>
-        <a {...linkProps}>
-          {props.actionLabel}&nbsp;&nbsp;
-          <Icon name="right-arrow" size={IconSize.LARGE} />
-        </a>
+        {props.actionLabel && (
+          <a {...linkProps}>
+            {props.actionLabel}&nbsp;&nbsp;
+            <Icon name="right-arrow" size={IconSize.LARGE} />
+          </a>
+        )}
       </div>
     </Wrapper>
   );

--- a/app/client/src/pages/Settings/DisconnectService.tsx
+++ b/app/client/src/pages/Settings/DisconnectService.tsx
@@ -47,7 +47,7 @@ export function DisconnectService(props: {
     <Container>
       <HeaderDanger>{createMessage(DANGER_ZONE)}</HeaderDanger>
       <Info>{props.subHeader}</Info>
-      <Callout actionLabel="Learn More" title={props.warning} type="Warning" />
+      <Callout title={props.warning} type="Warning" />
       <DisconnectButton
         onClick={props.disconnect}
         text="Disconnect"

--- a/app/client/src/pages/UserProfile/General.tsx
+++ b/app/client/src/pages/UserProfile/General.tsx
@@ -24,6 +24,8 @@ import {
   TextLoader,
 } from "./StyledComponents";
 import { getCurrentUser as refreshCurrentUser } from "actions/authActions";
+import { getAppsmithConfigs } from "@appsmith/configs";
+const { disableLoginForm } = getAppsmithConfigs();
 
 const ForgotPassword = styled.a`
   margin-top: 12px;
@@ -105,9 +107,11 @@ function General() {
           {isFetchingUser && <TextLoader className={Classes.SKELETON} />}
           {!isFetchingUser && <Text type={TextType.P1}>{user?.email}</Text>}
 
-          <ForgotPassword onClick={forgotPassword}>
-            Reset Password
-          </ForgotPassword>
+          {!disableLoginForm && (
+            <ForgotPassword onClick={forgotPassword}>
+              Reset Password
+            </ForgotPassword>
+          )}
         </div>
       </FieldWrapper>
       {/* <InputWrapper>

--- a/app/client/src/sagas/SuperUserSagas.tsx
+++ b/app/client/src/sagas/SuperUserSagas.tsx
@@ -84,7 +84,7 @@ function* SaveAdminSettingsSaga(action: ReduxAction<Record<string, string>>) {
   }
 }
 
-const RESTART_POLL_TIMEOUT = 30000;
+const RESTART_POLL_TIMEOUT = 60000;
 const RESTART_POLL_INTERVAL = 2000;
 
 function* RestartServerPoll() {

--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -32,7 +32,7 @@ if ! test -f "$KEY_FILE" || ! test -f "$CERT_FILE"; then
     exit
 fi
 
-ENV_FILE=../../stacks/configuration/docker.env
+ENV_FILE=../../.env
 if ! test -f "$ENV_FILE"; then
     echo "
         Please populate the .env at the root of the project and run again


### PR DESCRIPTION
## Description

> Remove reset password button on Edit profile page, if form login is disabled. This is because it should work only for form login. The password can be reset for other log-in options viz Google/Github on the respective platforms.
> Increase the restart banner timeout from 30s to 60s.

Fixes #11593 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested reset password button shows up only when form login is enabled.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: hotfix/reset_pwd_btn 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.72 **(0)** | 37.02 **(0.01)** | 35.18 **(0)** | 56.06 **(0.01)**
 :green_circle: | app/client/src/components/ads/CalloutV2.tsx | 73.68 **(0)** | 56.25 **(6.25)** | 75 **(0)** | 73.68 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>