### PR TITLE
fix: Fix apiContentType bug

### DIFF
--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -343,7 +343,10 @@ export function* updateFormFields(
   const { values } = yield select(getFormData, API_EDITOR_FORM_NAME);
 
   // get current content type of the action
-  let apiContentType = values.actionConfiguration.formData.apiContentType;
+  let apiContentType =
+    values?.actionConfiguration?.formData?.apiContentType ||
+    POST_BODY_FORMAT_OPTIONS.JSON;
+
   if (field === "actionConfiguration.httpMethod") {
     const { actionConfiguration } = values;
     if (!actionConfiguration.headers) return;


### PR DESCRIPTION
Make apiContentType nullable

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/make-apiContentType-nullable 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.72 **(0)** | 37 **(-0.01)** | 35.01 **(0)** | 56.06 **(0)**
 :red_circle: | app/client/src/sagas/ApiPaneSagas.ts | 16.59 **(0)** | 1.19 **(-0.11)** | 9.09 **(0)** | 18.75 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>