### PR TITLE
fix: 10527 Google Sheet crud generation header issue

### DIFF
--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/hooks.ts
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/hooks.ts
@@ -70,7 +70,7 @@ export const useDatasourceOptions = ({
 const GOOGLE_SHEET_METHODS = {
   GET_ALL_SPREADSHEETS: "LIST", // Get all the spreadsheets
   GET_ALL_SHEETS: "INFO", // fetch all the sub-sheets
-  GET_ALL_COLUMNS: "GET", // Get column names
+  GET_ALL_COLUMNS: "GET_STRUCTURE", // Get column names
 };
 
 const demoRequest: Record<any, string> = {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
@@ -88,6 +88,13 @@ public class Condition {
         return true;
     }
 
+    /**
+     * To generate condition list based on selected condition
+     * Mandatory inputs validated are path and operator
+     * Value is optional and considered as a null input
+     * @param configurationList
+     * @return
+     */
     public static List<Condition> generateFromConfiguration(List<Object> configurationList) {
         List<Condition> conditionList = new ArrayList<>();
 
@@ -96,7 +103,7 @@ public class Condition {
             if (condition.entrySet().isEmpty()) {
                 // Its an empty object set by the client for UX. Ignore the same
                 continue;
-            } else if (!condition.keySet().containsAll(Set.of("path", "operator", "value"))) {
+            } else if (!condition.keySet().containsAll(Set.of("path", "operator"))) {
                 throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "Filtering Condition not configured properly");
             }
             conditionList.add(new Condition(

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
@@ -73,11 +73,15 @@ public class Condition {
         return condition;
     }
 
+    /**
+     * To evaluate 'Path' and 'Operator' to be available for filtering
+     * 'Values' not evaluated for availability, to support searching empty values
+     * @param condition
+     * @return  Boolean
+     */
     public static Boolean isValid(Condition condition) {
 
-        if (StringUtils.isEmpty(condition.getPath()) ||
-                (condition.getOperator() == null) ||
-                StringUtils.isEmpty((CharSequence) condition.getValue())) {
+        if (StringUtils.isEmpty(condition.getPath()) || (condition.getOperator() == null)) {
             return false;
         }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -457,7 +457,13 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
             sb.append("\"" + path + "\"");
             sb.append(" ");
-            sb.append(sqlOp);
+            boolean isPrepareStmt = true;
+            if (value.equals(" ") && operator.name().equals("EQ")) {
+                sb.append("IS NULL");
+                isPrepareStmt = false;
+            } else {
+                sb.append(sqlOp);
+            }
             sb.append(" ");
 
             // These are array operations. Convert value into appropriate format and then append
@@ -485,7 +491,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 value = valueBuilder.toString();
                 sb.append(value);
 
-            } else {
+            } else if (isPrepareStmt) {
                 // Not an array. Simply add a placeholder
                 sb.append("?");
                 values.add(new PreparedStatementValueDTO(value, schema.get(path)));

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -432,8 +432,9 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
     private String generateWhereClauseOldFormat(List<Condition> conditions, LinkedList<PreparedStatementValueDTO> values, Map<String, DataType> schema) {
 
         StringBuilder sb = new StringBuilder();
-
+        Boolean isEmptyConditionValue = false;
         Boolean firstCondition = true;
+
         for (Condition condition : conditions) {
 
             if (firstCondition) {
@@ -457,10 +458,10 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
 
             sb.append("\"" + path + "\"");
             sb.append(" ");
-            boolean isPrepareStmt = true;
-            if (value.equals(StringUtils.SPACE) && operator.name().equals("EQ")) {
+
+            if (value.equals(StringUtils.EMPTY) && operator.name().equals("EQ")) {
                 sb.append("IS NULL");
-                isPrepareStmt = false;
+                isEmptyConditionValue = true;
             } else {
                 sb.append(sqlOp);
             }
@@ -491,7 +492,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
                 value = valueBuilder.toString();
                 sb.append(value);
 
-            } else if (isPrepareStmt) {
+            } else if (!isEmptyConditionValue) {
                 // Not an array. Simply add a placeholder
                 sb.append("?");
                 values.add(new PreparedStatementValueDTO(value, schema.get(path)));

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -458,7 +458,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
             sb.append("\"" + path + "\"");
             sb.append(" ");
             boolean isPrepareStmt = true;
-            if (value.equals(" ") && operator.name().equals("EQ")) {
+            if (value.equals(StringUtils.SPACE) && operator.name().equals("EQ")) {
                 sb.append("IS NULL");
                 isPrepareStmt = false;
             } else {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/services/ce/FilterDataServiceCE.java
@@ -471,7 +471,7 @@ public class FilterDataServiceCE implements IFilterDataServiceCE {
             sb.append(" ");
 
             // These are array operations. Convert value into appropriate format and then append
-            if ((value != null || (value != null && !value.equals(StringUtils.EMPTY))) &&
+            if (!(value == null || StringUtils.EMPTY.equals(value)) &&    //value should not be EMPTY or null
                     (operator == ConditionalOperator.IN || operator == ConditionalOperator.NOT_IN)) {
 
                 StringBuilder valueBuilder = new StringBuilder("(");

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -155,6 +155,59 @@ public class FilterDataServiceTest {
     }
 
     @Test
+    public void testFilterEmptyCondition() {
+        String data = "[\n" +
+                "  {\n" +
+                "    \"id\": 2381224,\n" +
+                "    \"email\": \"michael.lawson@reqres.in\",\n" +
+                "    \"userName\": \"Michael Lawson\",\n" +
+                "    \"productName\": \"Chicken Sandwich\",\n" +
+                "    \"orderAmount\": 4.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 2736212,\n" +
+                "    \"email\": \"lindsay.ferguson@reqres.in\",\n" +
+                "    \"userName\": \"Lindsay Ferguson\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 9.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 6788734,\n" +
+                "    \"email\": \"tobias.funke@reqres.in\",\n" +
+                "    \"userName\": \"Tobias Funke\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 19.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  }\n" +
+                "]";
+
+        try {
+            ArrayNode items = (ArrayNode) objectMapper.readTree(data);
+
+            List<Condition> whereConditionList = new ArrayList<>();
+
+            Condition condition = new Condition("productName", "EQ", "");
+            whereConditionList.add(condition);
+
+            //Precondition for whereConditionList implemented in GetValuesMethod.isWhereConditionConfigured(..)
+            whereConditionList.stream()
+                    .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
+                    .forEach(val -> val.setValue(" ")); // Setting null fails in null validation
+
+            ArrayNode filteredData = filterDataService.filterData(items, whereConditionList);
+
+            assertEquals(filteredData.size(), 2);
+
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
     public void testFilterInConditionForStrings() {
         String data = "[\n" +
                 "  {\n" +

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -203,6 +203,57 @@ public class FilterDataServiceTest {
     }
 
     @Test
+    public void testFilterEmptyAndNonEmptyCondition() {
+        String data = "[\n" +
+                "  {\n" +
+                "    \"id\": 2381224,\n" +
+                "    \"email\": \"michael.lawson@reqres.in\",\n" +
+                "    \"userName\": \"Michael Lawson\",\n" +
+                "    \"productName\": \"Chicken Sandwich\",\n" +
+                "    \"orderAmount\": 4.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 2736212,\n" +
+                "    \"email\": \"lindsay.ferguson@reqres.in\",\n" +
+                "    \"userName\": \"Lindsay Ferguson\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 9.99,\n" +
+                "    \"orderStatus\": \"READY\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": 6788734,\n" +
+                "    \"email\": \"tobias.funke@reqres.in\",\n" +
+                "    \"userName\": \"Tobias Funke\",\n" +
+                "    \"productName\": \"\",\n" +
+                "    \"orderAmount\": 19.99,\n" +
+                "    \"orderStatus\": \"NOT READY\"\n" +
+                "  }\n" +
+                "]";
+
+        try {
+            ArrayNode items = (ArrayNode) objectMapper.readTree(data);
+
+            List<Condition> whereConditionList = new ArrayList<>();
+
+            Condition condition1 = new Condition("orderStatus", "EQ", "READY");
+            whereConditionList.add(condition1);
+
+            Condition condition2 = new Condition("productName", "EQ", null); //The UI sends null when that field is untouched
+            whereConditionList.add(condition2);
+
+            ArrayNode filteredData = filterDataService.filterData(items, whereConditionList);
+
+            assertEquals(filteredData.size(), 1);
+
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
     public void testFilterInConditionForStrings() {
         String data = "[\n" +
                 "  {\n" +

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -191,11 +191,6 @@ public class FilterDataServiceTest {
             Condition condition = new Condition("productName", "EQ", "");
             whereConditionList.add(condition);
 
-            //Precondition for whereConditionList implemented in GetValuesMethod.isWhereConditionConfigured(..)
-            whereConditionList.stream()
-                    .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
-                    .forEach(val -> val.setValue(" ")); // Setting null fails in null validation
-
             ArrayNode filteredData = filterDataService.filterData(items, whereConditionList);
 
             assertEquals(filteredData.size(), 2);

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetStructureMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetStructureMethod.java
@@ -1,0 +1,194 @@
+package com.external.config;
+
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.services.FilterDataService;
+import com.external.domains.RowObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class GetStructureMethod implements Method {
+
+    ObjectMapper objectMapper;
+    FilterDataService filterDataService;
+
+    public GetStructureMethod(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.filterDataService = FilterDataService.getInstance();
+    }
+
+    // Used to capture the range of columns in this request. The handling for this regex makes sure that
+    // all possible combinations of A1 notation for a range map to a common format
+    Pattern findAllRowsPattern = Pattern.compile("([a-zA-Z]*)\\d*:([a-zA-Z]*)\\d*");
+
+    // The starting row for a range is captured using this pattern to find its relative index from table heading
+    Pattern findOffsetRowPattern = Pattern.compile("(\\d+):");
+
+    @Override
+    public boolean validateMethodRequest(MethodConfig methodConfig) {
+        if (methodConfig.getTableHeaderIndex() != null && !methodConfig.getTableHeaderIndex().isBlank()) {
+            try {
+                if (Integer.parseInt(methodConfig.getTableHeaderIndex()) <= 0) {
+                    throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Unexpected value for table header index. Please use a number starting from 1");
+                }
+            } catch (NumberFormatException e) {
+                throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                        "Unexpected format for table header index. Please use a number starting from 1");
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public WebClient.RequestHeadersSpec<?> getClient(WebClient webClient, MethodConfig methodConfig) {
+
+        final List<String> ranges = validateInputs(methodConfig);
+
+        UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_SHEETS_API_URL,
+                methodConfig.getSpreadsheetId() /* spreadsheet Id */
+                        + "/values:batchGet"
+        );
+        uriBuilder.queryParam("majorDimension", "ROWS");
+        uriBuilder.queryParam("ranges", ranges);
+
+        return webClient.method(HttpMethod.GET)
+                .uri(uriBuilder.build(false).toUri())
+                .body(BodyInserters.empty());
+    }
+
+    private List<String> validateInputs(MethodConfig methodConfig) {
+        int tableHeaderIndex = 1;
+        if (methodConfig.getTableHeaderIndex() != null && !methodConfig.getTableHeaderIndex().isBlank()) {
+            try {
+                tableHeaderIndex = Integer.parseInt(methodConfig.getTableHeaderIndex());
+                if (tableHeaderIndex <= 0) {
+                    tableHeaderIndex = 1;
+                }
+            } catch (NumberFormatException e) {
+                // Should have already been caught
+            }
+        }
+        if ("ROWS".equalsIgnoreCase(methodConfig.getQueryFormat())) {
+            int rowOffset = 0;
+            try {
+                rowOffset = Integer.parseInt(methodConfig.getRowOffset());
+            } catch (NumberFormatException e) {
+                // Should have already been caught
+            }
+            int rowLimit = 1;
+            try {
+                rowLimit = Integer.parseInt(methodConfig.getRowLimit());
+                return List.of(
+                        "'" + methodConfig.getSheetName() + "'!" + tableHeaderIndex + ":" + tableHeaderIndex,
+                        "'" + methodConfig.getSheetName() + "'!" + (tableHeaderIndex + rowOffset + 1) + ":" + (tableHeaderIndex + rowOffset + rowLimit));
+
+            } catch (NumberFormatException e) {
+                // Should have already been caught
+            }
+        } else if ("RANGE".equalsIgnoreCase(methodConfig.getQueryFormat())) {
+            Matcher matcher = findAllRowsPattern.matcher(methodConfig.getSpreadsheetRange());
+            matcher.find();
+            return List.of(
+                    "'" + methodConfig.getSheetName() + "'!" + matcher.group(1) + tableHeaderIndex + ":" + matcher.group(2) + tableHeaderIndex,
+                    "'" + methodConfig.getSheetName() + "'!" + methodConfig.getSpreadsheetRange());
+        }
+        return List.of();
+    }
+
+    @Override
+    public JsonNode transformResponse(JsonNode response, MethodConfig methodConfig) {
+        if (response == null) {
+            throw new AppsmithPluginException( AppsmithPluginError.PLUGIN_ERROR, "Missing a valid response object.");
+        }
+
+        ArrayNode valueRanges = (ArrayNode) response.get("valueRanges");
+        ArrayNode headers = (ArrayNode) valueRanges.get(0).get("values");
+        ArrayNode values = valueRanges.get(1) != null ? (ArrayNode) valueRanges.get(1).get("values") : null;
+        int valueSize = 0;
+
+        if (headers == null || headers.isEmpty()) {
+            return this.objectMapper.createArrayNode();
+        }
+        if (values != null) {
+            for (int i = 0; i < values.size(); i++) {
+                valueSize = Math.max(valueSize, values.get(i).size());
+            }
+        }
+
+        headers = (ArrayNode) headers.get(0);
+        Set<String> columnsSet = sanitizeHeaders(headers, valueSize);
+        ArrayNode preFilteringResponse = null;
+        final List<Map<String, String>> collectedCells = new LinkedList<>();
+        final String[] headerArray = columnsSet.toArray(new String[0]);
+
+        if (values != null && values.size() > 0) {
+            final String valueRange = valueRanges.get(1).get("range").asText();
+            final Matcher matcher = findOffsetRowPattern.matcher(valueRange);
+            matcher.find();
+            final int rowOffset = Integer.parseInt(matcher.group(1));
+            final int tableHeaderIndex = Integer.parseInt(methodConfig.getTableHeaderIndex());
+
+            for (int i = 0; i < values.size(); i++) {
+                ArrayNode row = (ArrayNode) values.get(i);
+                RowObject rowObject = new RowObject( headerArray,
+                        objectMapper.convertValue(row, String[].class),
+                        rowOffset - tableHeaderIndex + i - 1);
+                collectedCells.add(rowObject.getValueMap());
+            }
+        } else {
+            RowObject rowObject = new RowObject(headerArray, new String[0], 0);
+            collectedCells.add(rowObject.getValueMap());
+
+        }
+
+        preFilteringResponse = this.objectMapper.valueToTree(collectedCells);
+
+        return preFilteringResponse;
+    }
+
+    private Set<String> sanitizeHeaders(ArrayNode headers, int valueSize) {
+        final Set<String> headerSet = new LinkedHashSet<>();
+        int headerSize = headers.size();
+        final int size = Math.max(headerSize, valueSize);
+
+        // Manipulation to find valid headers for all columns
+        for (int j = 0; j < size; j++) {
+            String headerValue = "";
+
+            if (j < headerSize) {
+                headerValue = headers.get(j).asText();
+            }
+            if (headerValue.isBlank()) {
+                headerValue = "Column-" + (j + 1);
+            }
+
+            int count = 1;
+            String tempHeaderValue = headerValue;
+            while (headerSet.contains(tempHeaderValue)) {
+                tempHeaderValue += "_" + count++;
+            }
+            headerValue = tempHeaderValue;
+
+            headerSet.add(headerValue);
+        }
+
+        return headerSet;
+    }
+}

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
@@ -4,6 +4,7 @@ import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
+import com.appsmith.external.models.Property;
 import com.appsmith.external.services.FilterDataService;
 import com.external.domains.RowObject;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -250,6 +251,12 @@ public class GetValuesMethod implements Method {
         if (whereConditions == null || whereConditions.size() == 0) {
             return false;
         }
+
+        //Change empty condition value("") to " " to bypass Null validation
+        whereConditions.stream()
+                .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
+                .forEach(val -> val.setValue(" "));
+
 
         // At least 1 condition exists
         return true;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
@@ -4,14 +4,12 @@ import com.appsmith.external.constants.DataType;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.Condition;
-import com.appsmith.external.models.Property;
 import com.appsmith.external.services.FilterDataService;
 import com.external.domains.RowObject;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -252,12 +250,6 @@ public class GetValuesMethod implements Method {
         if (whereConditions == null || whereConditions.size() == 0) {
             return false;
         }
-
-        //Change empty condition value("") to " " to bypass Null validation
-        whereConditions.stream()
-                .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
-                .forEach(val -> val.setValue(StringUtils.SPACE));
-
 
         // At least 1 condition exists
         return true;

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GetValuesMethod.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -255,7 +256,7 @@ public class GetValuesMethod implements Method {
         //Change empty condition value("") to " " to bypass Null validation
         whereConditions.stream()
                 .filter(val -> val.getValue().equals("") && val.getOperator().name().equals("EQ"))
-                .forEach(val -> val.setValue(" "));
+                .forEach(val -> val.setValue(StringUtils.SPACE));
 
 
         // At least 1 condition exists

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GoogleSheetsMethodStrategy.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/GoogleSheetsMethodStrategy.java
@@ -27,6 +27,8 @@ public class GoogleSheetsMethodStrategy {
                 return new DeleteSheetMethod(objectMapper);
             case MethodIdentifiers.GET:
                 return new GetValuesMethod(objectMapper);
+            case MethodIdentifiers.GET_STRUCTURE:
+                return new GetStructureMethod(objectMapper);
             case MethodIdentifiers.INFO:
                 return new InfoMethod(objectMapper);
             case MethodIdentifiers.LIST:

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodIdentifiers.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodIdentifiers.java
@@ -2,6 +2,7 @@ package com.external.config;
 
 public class MethodIdentifiers {
     public static final String GET = "GET";
+    public static final String GET_STRUCTURE = "GET_STRUCTURE";
     public static final String APPEND = "APPEND";
     public static final String BULK_APPEND = "BULK_APPEND";
     public static final String UPDATE = "UPDATE";

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/GetStructureMethodTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/GetStructureMethodTest.java
@@ -1,0 +1,147 @@
+package com.external.config;
+
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.external.constants.GoogleSheets;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class GetStructureMethodTest {
+
+    @Test
+    public void testTransformResponse_missingJSON_throwsException() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        GetStructureMethod getStructureMethod = new GetStructureMethod(objectMapper);
+        try {
+            getStructureMethod.transformResponse(null, null);
+        } catch (AppsmithPluginException e) {
+            Assert.assertTrue("Missing a valid response object.".equalsIgnoreCase(e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testTransformResponse_missingValues_returnsEmpty() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        final String jsonString = "{\"valueRanges\":[{},{}]}";
+
+        JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+        Assert.assertNotNull(jsonNode);
+
+        GetStructureMethod getStructureMethod = new GetStructureMethod(objectMapper);
+        JsonNode result = getStructureMethod.transformResponse(jsonNode, null);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testTransformResponse_emptyJSON_returnsEmpty() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        final String jsonString = "{\"valueRanges\":[" +
+                "{\"range\":\"Sheet1!A1:D1\"," +
+                "\"majorDimension\":\"ROWS\"," +
+                "\"values\":[[\"Some\",\"123\",\"values\",\"to\"]]}" +
+                "]}";
+
+        JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+        Assert.assertNotNull(jsonNode);
+
+        GetStructureMethod getStructureMethod = new GetStructureMethod(objectMapper);
+        JsonNode result = getStructureMethod.transformResponse(jsonNode, new MethodConfig(List.of()).toBuilder().tableHeaderIndex("1").build());
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+        Assert.assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testTransformResponse_emptyStartingRows_toListOfObjects() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        final String jsonString = "{\"valueRanges\":[" +
+                "{\"range\":\"Sheet1!A1:D1\"," +
+                "\"majorDimension\":\"ROWS\"," +
+                "\"values\":[[\"Some\",\"123\",\"values\",\"to\"]]}," +
+                "{\"range\":\"Sheet1!A2:D6\"," +
+                "\"majorDimension\":\"ROWS\"," +
+                "\"values\":[[],[],[],[\"Some\",\"123\",\"values\",\"to\"],[\"work\",\"with\",\"and\",\"manipulate\"],[\"q\",\"w\",\"e\",\"r\"],[\"a\",\"s\",\"d\",\"f\"],[\"z\",\"x\",\"c\",\"v\"]]}" +
+                "]}";
+
+        JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+        Assert.assertNotNull(jsonNode);
+
+        GetStructureMethod getStructureMethod = new GetStructureMethod(objectMapper);
+        JsonNode result = getStructureMethod.transformResponse(jsonNode, new MethodConfig(List.of()).toBuilder().tableHeaderIndex("1").build());
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray() && result.size() == 8);
+
+        Assert.assertTrue("".equalsIgnoreCase(result.get(0).get("Some").asText()));
+        Assert.assertTrue("Some".equalsIgnoreCase(result.get(3).get("Some").asText()));
+    }
+
+    @Test
+    public void testTransformResponse_emptyRows_returnsIndices() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        final String jsonString = "{\"valueRanges\":[" +
+                "{\"range\":\"Sheet1!A1:D1\"," +
+                "\"majorDimension\":\"ROWS\"," +
+                "\"values\":[[\"Some\",\"123\",\"values\",\"to\"]]}," +
+                "{\"range\":\"Sheet1!A2:D6\"," +
+                "\"majorDimension\":\"ROWS\"," +
+                "\"values\":[[],[],[]]}" +
+                "]}";
+
+        JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+        Assert.assertNotNull(jsonNode);
+
+        GetStructureMethod getStructureMethod = new GetStructureMethod(objectMapper);
+        JsonNode result = getStructureMethod.transformResponse(jsonNode, new MethodConfig(List.of()).toBuilder().tableHeaderIndex("1").build());
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals(0, result.get(0).get(GoogleSheets.ROW_INDEX).asInt());
+    }
+
+    @Test
+    public void transformResponse() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        final String jsonString = "{\"valueRanges\":\n" +
+                "[ {\n" +
+                "  \"range\" : \"Sheet1!A1:Z1\",\n" +
+                "  \"majorDimension\" : \"ROWS\",\n" +
+                "  \"values\" : [ [ \"The timeline includes other auxillary functions each team will need to perform such as supporting the community with feature requests, fixing bugs, clearing tech debt, improving performance, re-architecting parts of the codebase, writing documentation, etc.\" ] ]\n" +
+                "}, {\n" +
+                "  \"range\" : \"Sheet1!A2:Z4\",\n" +
+                "  \"majorDimension\" : \"ROWS\",\n" +
+                "  \"values\" : [ [ \"Quarter\", \"Projects\", \"Teams\", \"Frontend\", \"Backend\", \"QA\" ], [ \"\", \"Add 15 Widgets\", \"Widget Team\", \"0\", \"0\" ], [ \"\", \"Add 20 SAAS Integrations\", \"Integrations\", \"1\", \"1\", \"\", \"1\" ] ]\n" +
+                "} ]}";
+
+        JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+        Assert.assertNotNull(jsonNode);
+
+        GetStructureMethod getStructureMethod = new GetStructureMethod(objectMapper);
+        JsonNode result = getStructureMethod.transformResponse(jsonNode, new MethodConfig(List.of()).toBuilder().tableHeaderIndex("1").build());
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isArray());
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals(0, result.get(0).get(GoogleSheets.ROW_INDEX).asInt());
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCE.java
@@ -14,6 +14,8 @@ public interface DatasourceStructureSolutionCE {
 
     Mono<DatasourceStructure> getStructure(Datasource datasource, boolean ignoreCache);
 
+    Mono<DatasourceStructure> getStructure(String datasourceId, List<Property> pluginSpecifiedTemplates, boolean ignoreCache);
+
     Mono<ActionExecutionResult> getDatasourceMetadata(String datasourceId, List<Property> pluginSpecifiedTemplates);
 
 }


### PR DESCRIPTION
## Description
The CRUD operation cannot be performed when there are no rows in the google sheet.
A fix was made so that even if there are no rows the crud operation can be performed.

Fixes #10527

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?
Manual
Unit Test 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>