### PR TITLE
fix: Fixes confirmation modal flickering bug

### DIFF
--- a/app/client/src/pages/Editor/RequestConfirmationModal.tsx
+++ b/app/client/src/pages/Editor/RequestConfirmationModal.tsx
@@ -44,7 +44,6 @@ class RequestConfirmationModal extends React.Component<Props> {
   };
 
   onKeyUp = (event: KeyboardEvent) => {
-    event.preventDefault();
     // Sometimes calling the shortcut keys "Cmd + Enter" also triggers the onConfirm function below
     // so We check if no multiple keys are being pressed currently before executing this block of code.
     if (!(event.metaKey || event.ctrlKey) && event.keyCode === Keys.ENTER) {

--- a/app/client/src/pages/Editor/RequestConfirmationModal.tsx
+++ b/app/client/src/pages/Editor/RequestConfirmationModal.tsx
@@ -44,7 +44,13 @@ class RequestConfirmationModal extends React.Component<Props> {
   };
 
   onKeyUp = (event: KeyboardEvent) => {
-    if (event.keyCode === Keys.ENTER) {
+    event.preventDefault();
+    // Sometimes calling the shortcut keys "Cmd + Enter" also triggers the onConfirm function below
+    // so We check if no multiple keys are being pressed currently before executing this block of code.
+    if (
+      !((event.metaKey || event.ctrlKey) && event.keyCode === Keys.ENTER) &&
+      event.keyCode === Keys.ENTER
+    ) {
       // please note: due to the way the state is being updated, the last action will always correspond to the right Action Modal.
       // this is not a bug.
       this.onConfirm(this.props.modals[this.props.modals.length - 1]);

--- a/app/client/src/pages/Editor/RequestConfirmationModal.tsx
+++ b/app/client/src/pages/Editor/RequestConfirmationModal.tsx
@@ -47,10 +47,7 @@ class RequestConfirmationModal extends React.Component<Props> {
     event.preventDefault();
     // Sometimes calling the shortcut keys "Cmd + Enter" also triggers the onConfirm function below
     // so We check if no multiple keys are being pressed currently before executing this block of code.
-    if (
-      !((event.metaKey || event.ctrlKey) && event.keyCode === Keys.ENTER) &&
-      event.keyCode === Keys.ENTER
-    ) {
+    if (!(event.metaKey || event.ctrlKey) && event.keyCode === Keys.ENTER) {
       // please note: due to the way the state is being updated, the last action will always correspond to the right Action Modal.
       // this is not a bug.
       this.onConfirm(this.props.modals[this.props.modals.length - 1]);


### PR DESCRIPTION
This PR fixes the flickering of the Modal confirmation when running an action via cmd+enter shortcut.

Fixes #11612 

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/modal-flickering-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.82 **(0)** | 37.16 **(-0.01)** | 35.2 **(0)** | 56.16 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>