### PR TITLE
fix: Added root element as the ParentBoundary for TableFilterPane.

### DIFF
--- a/app/client/src/widgets/TableWidget/component/TableFilterPane.tsx
+++ b/app/client/src/widgets/TableWidget/component/TableFilterPane.tsx
@@ -80,7 +80,7 @@ class TableFilterPane extends Component<Props> {
         Prevent the FilterPane from overflowing the canvas when the 
         table widget is on the very top of the canvas.
       */
-      const boundaryParent = document.querySelector('[type="CANVAS_WIDGET"]');
+      const boundaryParent = document.querySelector("#root");
 
       return (
         <Popper


### PR DESCRIPTION
## Description

- When the Table is placed at the top of the Canvas the Filterplane overflows / gets out of the canvas. It was fixed before but due to some changes the `CANVAS_WIDGET` collapses in deploy mode.
- We are now using `id = root` element itself as the `BoundaryParent` and also have a save offset of 70.

Fixes #7996

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/table-filter-pane-overflow 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.82 **(0)** | 37.17 **(-0.01)** | 35.2 **(0)** | 56.16 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>