### PR TITLE
fix: disable of calling get of git status api while fetching git status

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -155,7 +155,7 @@ function Deploy() {
   const commitButtonText = createMessage(COMMIT_AND_PUSH);
 
   useEffect(() => {
-    dispatch(fetchGitStatusInit());
+    if (!isFetchingGitStatus) dispatch(fetchGitStatusInit());
     return () => {
       dispatch(clearCommitSuccessfulState());
     };

--- a/app/client/src/pages/Editor/gitSync/Tabs/Merge.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Merge.tsx
@@ -178,8 +178,8 @@ export default function Merge() {
   }, [currentBranch, selectedBranchOption.value, dispatch]);
 
   useEffect(() => {
-    dispatch(fetchGitStatusInit());
-    dispatch(fetchBranchesInit());
+    if (!isFetchingGitStatus) dispatch(fetchGitStatusInit());
+    if (!isFetchingBranches) dispatch(fetchBranchesInit());
     return () => {
       dispatch(resetMergeStatus());
     };


### PR DESCRIPTION
## Description

> When switch deploy and merge tab on git sync modal, calling git status api shouldn't be double while fetching it.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please follow above description

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: git-sync-advanced 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**</details>