### PR TITLE
fix: audio widget blobURL autocompletion

### DIFF
--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -476,7 +476,7 @@ export const entityDefinitions: Record<string, unknown> = {
       "Audio recorder widget allows users to record using their microphone, listen to the playback, and export the data to a data source.",
     "!url": "https://docs.appsmith.com/widget-reference/recorder",
     isVisible: isVisible,
-    blobUrl: "string",
+    blobURL: "string",
     dataURL: "string",
     rawBinary: "string",
   },


### PR DESCRIPTION
## Description
Changes autocompletion hint from `blobUrl ` to `blobURL`

Fixes #11659 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
