### PR TITLE
chore: Change watchtower to latest from latest-dev

### DIFF
--- a/app/server/appsmith-server/src/main/resources/docker-compose.yml
+++ b/app/server/appsmith-server/src/main/resources/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
 
   auto_update:
-    image: containrrr/watchtower:latest-dev
+    image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check interval in seconds.

--- a/deploy/aws_ami/docker-compose.yml
+++ b/deploy/aws_ami/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: unless-stopped
 
   auto_update:
-    image: containrrr/watchtower:latest-dev
+    image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check every hour.

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -52,7 +52,7 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
 
   auto_update:
-    image: containrrr/watchtower:latest-dev
+    image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check every hour.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./stacks:/appsmith-stacks
 
   auto_update:
-    image: containrrr/watchtower:latest-dev
+    image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # Update check every hour.


### PR DESCRIPTION
This is because watchtower:latest-dev doesn't run on ARM architectures.
