### PR TITLE
fix: handle main container height

### DIFF
--- a/app/client/src/widgets/CanvasWidget.tsx
+++ b/app/client/src/widgets/CanvasWidget.tsx
@@ -3,10 +3,7 @@ import { WidgetProps } from "widgets/BaseWidget";
 import ContainerWidget, {
   ContainerWidgetProps,
 } from "widgets/ContainerWidget/widget";
-import {
-  GridDefaults,
-  MAIN_CONTAINER_WIDGET_ID,
-} from "constants/WidgetConstants";
+import { GridDefaults } from "constants/WidgetConstants";
 import DropTargetComponent from "components/editorComponents/DropTargetComponent";
 import { getCanvasSnapRows } from "utils/WidgetPropsUtils";
 import { getCanvasClassName } from "utils/generators";
@@ -71,10 +68,7 @@ class CanvasWidget extends ContainerWidget {
 
     const style: CSSProperties = {
       width: "100%",
-      height:
-        this.props.widgetId === MAIN_CONTAINER_WIDGET_ID
-          ? "100%"
-          : `${height}px`,
+      height: `${height}px`,
       background: "none",
       position: "relative",
     };


### PR DESCRIPTION

Reverts appsmithorg/appsmith#11461

Fixes #10352


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: revert-11461-fix/handle-maincontainer-height 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :green_circle: | app/client/src/widgets/CanvasWidget.tsx | 95.92 **(0)** | 66.67 **(2.38)** | 100 **(0)** | 97.83 **(0)**</details>