### PR TITLE
fix: Modified root json for SMTP to comply with UQI aggregation rules

### DIFF
--- a/app/server/appsmith-plugins/smtpPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/smtpPlugin/src/main/resources/editor/root.json
@@ -1,15 +1,26 @@
 {
-  "command" : {
-    "label": "Commands",
-    "description": "Choose method you would like to use to send an email",
-    "configProperty": "actionConfiguration.formData.command",
-    "controlType": "DROP_DOWN",
-    "initialValue": "SEND",
-    "options": [
-      {
-        "label": "Send Email",
-        "fileName" : "send.json"
-      }
-    ]
-  }
+  "editor": [
+    {
+      "controlType": "SECTION",
+      "identifier": "SELECTOR",
+      "children": [
+        {
+          "label": "Commands",
+          "description": "Choose method you would like to use to send an email",
+          "configProperty": "actionConfiguration.formData.command",
+          "controlType": "DROP_DOWN",
+          "initialValue": "SEND",
+          "options": [
+            {
+              "label": "Send Email",
+              "value": "SEND"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "files": [
+    "send.json"
+  ]
 }


### PR DESCRIPTION
SMTP is registered as a UQI plugin, and hence needs to follow the format per UQI aggregation.