### PR TITLE
fix: Fix startup failing if signup disabled is empty

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -34,8 +34,8 @@ public class CommonConfig {
     @Value("${appsmith.instance.name:}")
     private String instanceName;
 
-    @Value("${signup.disabled}")
-    private boolean isSignupDisabled;
+    @Setter(AccessLevel.NONE)
+    private boolean isSignupDisabled = false;
 
     @Setter(AccessLevel.NONE)
     private Set<String> adminEmails = Collections.emptySet();
@@ -109,6 +109,12 @@ public class CommonConfig {
     @Autowired
     public void setAdminEmails(@Value("${admin.emails}") String value) {
         adminEmails = Set.of(value.trim().split("\\s*,\\s*"));
+    }
+
+    @Autowired
+    public void setSignupDisabled(@Value("${signup.disabled}") String value) {
+        // If `true`, then disable signup. If anything else, including empty string, then signups will be enabled.
+        isSignupDisabled = "true".equalsIgnoreCase(value);
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -185,7 +185,7 @@ public class EnvManagerCEImpl implements EnvManagerCE {
                     }
 
                     if (changesCopy.containsKey(APPSMITH_SIGNUP_DISABLED.name())) {
-                        commonConfig.setSignupDisabled("true".equals(changesCopy.remove(APPSMITH_SIGNUP_DISABLED.name())));
+                        commonConfig.setSignupDisabled(changesCopy.remove(APPSMITH_SIGNUP_DISABLED.name()));
                     }
 
                     if (changesCopy.containsKey(APPSMITH_SIGNUP_ALLOWED_DOMAINS.name())) {


### PR DESCRIPTION
Fixes #11679 
