### PR TITLE
chore: Added analytics event to track datasource dropdown usage in query editors

### DIFF
--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -54,7 +54,7 @@ import {
 } from "actions/evaluationActions";
 import { updateReplayEntity } from "actions/pageActions";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
-import { EventLocation } from "utils/AnalyticsUtil";
+import AnalyticsUtil, { EventLocation } from "utils/AnalyticsUtil";
 import {
   ActionData,
   ActionDataState,
@@ -150,6 +150,8 @@ function* formValueChangeSaga(
 
     // Update the datasource of the form as well
     yield put(autofill(QUERY_EDITOR_FORM_NAME, "datasource", datasource));
+
+    AnalyticsUtil.logEvent("SWITCH_DATASOURCE");
 
     return;
   }

--- a/app/client/src/sagas/SaaSPaneSagas.ts
+++ b/app/client/src/sagas/SaaSPaneSagas.ts
@@ -26,6 +26,7 @@ import { autofill } from "redux-form";
 import { get } from "lodash";
 import { updateReplayEntity } from "actions/pageActions";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
+import AnalyticsUtil from "utils/AnalyticsUtil";
 
 function* handleDatasourceCreatedSaga(actionPayload: ReduxAction<Datasource>) {
   const plugin = yield select(getPlugin, actionPayload.payload.pluginId);
@@ -82,6 +83,8 @@ function* formValueChangeSaga(
 
     // Update the datasource of the form as well
     yield put(autofill(SAAS_EDITOR_FORM, "datasource", datasource));
+
+    AnalyticsUtil.logEvent("SWITCH_DATASOURCE");
 
     return;
   }

--- a/app/client/src/utils/AnalyticsUtil.tsx
+++ b/app/client/src/utils/AnalyticsUtil.tsx
@@ -15,6 +15,7 @@ export type EventLocation =
   | "OMNIBAR";
 
 export type EventName =
+  | "SWITCH_DATASOURCE"
   | "LOGIN_CLICK"
   | "SIGNUP_CLICK"
   | "PAGE_VIEW"


### PR DESCRIPTION
## Description
Added analytics event to track datasource dropdown usage in query editors

## Type of change
- Analytics

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: chore/datasource_switcher_analytics 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/sagas/QueryPaneSagas.ts | 23.08 **(0.42)** | 10 **(0)** | 18.18 **(0)** | 27.1 **(0.43)**
 :green_circle: | app/client/src/sagas/SaaSPaneSagas.ts | 38.18 **(0.44)** | 25 **(0)** | 50 **(0)** | 46.51 **(0.17)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>