### PR TITLE
fix: Fix links to old docs in client

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,7 +34,7 @@
         "value": ""
       },
       "APPSMITH_DISABLE_TELEMETRY": {
-        "description" : "We want to be transparent and request that you share anonymous usage data with us. This data is purely statistical in nature and helps us understand your needs & provide better support to your self-hosted instance. You can read more about what information is collected in our documentation https://docs.appsmith.com/v/v1.2.1/setup/telemetry",
+        "description" : "We want to be transparent and request that you share anonymous usage data with us. This data is purely statistical in nature and helps us understand your needs & provide better support to your self-hosted instance. You can read more about what information is collected in our documentation https://docs.appsmith.com/telemetry",
         "value": "false"
       }
    }

--- a/app/client/src/components/editorComponents/GlobalSearch/githubHelper.ts
+++ b/app/client/src/components/editorComponents/GlobalSearch/githubHelper.ts
@@ -3,28 +3,28 @@ import { DocSearchItem } from "./utils";
 export const defaultDocsConfig = [
   {
     link:
-      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.2.1/tutorials/building-a-store-catalog-manager/README.md",
+      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.3/tutorials/building-a-store-catalog-manager/README.md",
     title: "Tutorial",
     path: "master/tutorial-1",
     kind: "document",
   },
   {
     link:
-      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.2.1/core-concepts/connecting-to-data-sources/README.md",
+      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.3/core-concepts/connecting-to-data-sources/README.md",
     title: "Connecting to Data Sources",
     path: "master/core-concepts/connecting-to-data-sources",
     kind: "document",
   },
   {
     link:
-      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.2.1/core-concepts/displaying-data-read/README.md",
+      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.3/core-concepts/displaying-data-read/README.md",
     title: "Displaying Data (Read)",
     path: "master/core-concepts/displaying-data-read",
     kind: "document",
   },
   {
     link:
-      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.2.1/core-concepts/writing-code/README.md",
+      "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.3/core-concepts/writing-code/README.md",
     title: "Writing Code",
     path: "master/core-concepts/writing-code",
     kind: "document",
@@ -32,7 +32,7 @@ export const defaultDocsConfig = [
 ];
 
 const githubDocsAssetsPath =
-  "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.2.1/.gitbook";
+  "https://raw.githubusercontent.com/appsmithorg/appsmith-docs/v1.3/.gitbook";
 
 export const fetchRawGithubContentList = async () => {
   const data = await Promise.all(

--- a/app/client/src/pages/Editor/Explorer/JSDependencies.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSDependencies.tsx
@@ -86,7 +86,7 @@ function JSDependencies() {
   );
   const showDocs = React.useCallback((e: any) => {
     window.open(
-      "https://docs.appsmith.com/v/v1.2.1/core-concepts/writing-code/ext-libraries",
+      "https://docs.appsmith.com/core-concepts/writing-code/ext-libraries",
       "appsmith-docs:working-with-js-libraries",
     );
     e.stopPropagation();

--- a/app/client/src/pages/UserAuth/ForgotPassword.tsx
+++ b/app/client/src/pages/UserAuth/ForgotPassword.tsx
@@ -90,7 +90,7 @@ export const ForgotPassword = withTheme(
             <FormMessage
               actions={[
                 {
-                  url: "https://docs.appsmith.com/v/v1.2.1/setup/docker/email",
+                  url: "https://docs.appsmith.com/setup/instance-configuration/email",
                   text: "Configure Email service",
                   intent: "primary",
                 },

--- a/app/client/src/pages/organization/OrgInviteUsersForm.tsx
+++ b/app/client/src/pages/organization/OrgInviteUsersForm.tsx
@@ -339,7 +339,7 @@ function OrgInviteUsersForm(props: any) {
                 {allUsers.length === 0 && <NoEmailConfigImage />}
                 <span>You haven’t setup any email service yet</span>
                 <a
-                  href="https://docs.appsmith.com/v/v1.2.1/setup/docker/email"
+                  href="https://docs.appsmith.com/setup/instance-configuration/email"
                   rel="noopener noreferrer"
                   target="_blank"
                 >

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -28,7 +28,7 @@ export const entityDefinitions: Record<string, unknown> = {
           "!doc":
             "The user's geo location information. Only available when requested",
           "!url":
-            "https://docs.appsmith.com/v/v1.2.1/framework-reference/geolocation",
+            "https://docs.appsmith.com/framework-reference/appsmith#geolocation",
           getCurrentPosition:
             "fn(onSuccess: fn() -> void, onError: fn() -> void, options: object) -> void",
           watchPosition: "fn(options: object) -> void",
@@ -51,7 +51,7 @@ export const entityDefinitions: Record<string, unknown> = {
     return {
       "!doc":
         "Actions allow you to connect your widgets to your backend data in a secure manner.",
-      "!url": "https://docs.appsmith.com/v/v1.2.1/framework-reference/run",
+      "!url": "https://docs.appsmith.com/framework-reference/run",
       isLoading: "bool",
       data,
       responseMeta: {

--- a/app/client/src/widgets/MapWidget/widget/index.tsx
+++ b/app/client/src/widgets/MapWidget/widget/index.tsx
@@ -344,15 +344,15 @@ class MapWidget extends BaseWidget<MapWidgetProps, WidgetState> {
             <h1>{"Map Widget disabled"}</h1>
             <p>{"Map widget requires a Google Maps API Key"}</p>
             <p>
-              {"See our"}
+              {"See our "}
               <a
-                href="https://docs.appsmith.com/v/v1.2.1/setup/docker/google-maps"
+                href="https://docs.appsmith.com/setup/instance-configuration/google-maps"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                {" documentation "}
+                {"documentation"}
               </a>
-              {"to configure API Keys"}
+              {" to configure API Keys"}
             </p>
           </DisabledContainer>
         )}

--- a/deploy/docker/scripts/install_docker.sh
+++ b/deploy/docker/scripts/install_docker.sh
@@ -29,7 +29,7 @@ check_ports_occupied() {
     if [[ -n $port_check_output ]]; then
         echo "***************** ERROR *****************"
         echo "Appsmith requires ports 80 & 443 to be open. Please shut down any other service(s) that may be running on these ports."
-        echo "You can run appsmith on another port following this guide https://docs.appsmith.com/v/v1.2.1/troubleshooting-guide/deployment-errors"
+        echo "You can run appsmith on another port following this guide https://docs.appsmith.com/troubleshooting-guide/deployment-errors"
         echo "*****************************************"
         echo ""
         exit 1

--- a/deploy/heroku/README.MD
+++ b/deploy/heroku/README.MD
@@ -31,8 +31,8 @@ Quickly set up Appsmith to explore product functionality using Heroku.
       - Github Oauth:
         - `APPSMITH_OAUTH2_GITHUB_CLIENT_ID`: Client ID provided by Github for OAuth2 login
         - `APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET`: Client secret provided by Github for OAuth2 login
-    - `APPSMITH_GOOGLE_MAPS_API_KEY`: Google Maps API key which is required if you wish to leverage Google Maps widget. Read more at: https://docs.appsmith.com/v/v1.2.1/setup/docker/google-maps
-    - `APPSMITH_DISABLE_TELEMETRY`: We want to be transparent and request that you share anonymous usage data with us. This data is purely statistical in nature and helps us understand your needs & provide better support to your self-hosted instance. You can read more about what information is collected in our documentation https://docs.appsmith.com/v/v1.2.1/setup/telemetry
+    - `APPSMITH_GOOGLE_MAPS_API_KEY`: Google Maps API key which is required if you wish to leverage Google Maps widget. Read more at: <https://docs.appsmith.com/widget-reference/maps>.
+    - `APPSMITH_DISABLE_TELEMETRY`: We want to be transparent and request that you share anonymous usage data with us. This data is purely statistical in nature and helps us understand your needs & provide better support to your self-hosted instance. You can read more about what information is collected in our documentation <https://docs.appsmith.com/telemetry>.
     - Google reCAPTCHA v3 Configuration:
       - `APPSMITH_RECAPTCHA_SITE_KEY`: Google reCAPTCHA v3 site key, it is required if you wish to enable protection against spam/abusive users. Read more at: https://developers.google.com/recaptcha/docs/v3
       - `APPSMITH_RECAPTCHA_SECRET_KEY`: Google reCAPTCHA v3 verification secret key, it is required if you wish to enable spam protection in your backend server.


### PR DESCRIPTION
## Description

Fixes all links to old docs with new ones, ones that don't contain a hardcoded version number in them. These old links are misleading users to pages that contain old and often incorrect information.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/docs-links-in-client 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>