### PR TITLE
fix: Rest API UI issues (Empty DS headers, UI for Param tab, Save DS button, Placeholder)

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -551,7 +551,7 @@ function DefaultDropDownValueNode({
         : selected.value
       : placeholder
       ? placeholder
-      : "Please select a option.";
+      : "Please select an option.";
 
   function Label() {
     if (isMultiSelect && Array.isArray(selected) && selected.length) {

--- a/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
@@ -91,6 +91,8 @@ function ApiAuthentication(props: Props): JSX.Element {
     "",
   );
 
+  const datasourceUrl = get(datasource, "datasourceConfiguration.url", "");
+
   const hasError = !get(datasource, "isValid", true);
 
   const shouldSave = datasource && !("id" in datasource);
@@ -122,6 +124,7 @@ function ApiAuthentication(props: Props): JSX.Element {
       </DescriptionText>
       <Button
         category={Category.tertiary}
+        disabled={!datasourceUrl}
         onClick={onClick}
         size={Size.medium}
         tag="button"

--- a/app/client/src/pages/Editor/APIEditor/Form.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Form.tsx
@@ -695,7 +695,6 @@ function ApiEditorForm(props: Props) {
                           label="Params"
                           name="actionConfiguration.queryParameters"
                           pushFields
-                          removeTopPadding
                           theme={theme}
                         />
                       </TabSection>

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -768,7 +768,17 @@ function* storeAsDatasourceSaga() {
       value: actionHeaders,
     }),
   );
-  _.set(datasource, "datasourceConfiguration.headers", datasourceHeaders);
+
+  // Empty Headers getting created so filtering out the empty headers before setting it to datasource
+  const filteredDatasourceHeaders = datasourceHeaders.filter(
+    (d) => !(d.key === "" && d.key === ""),
+  );
+
+  _.set(
+    datasource,
+    "datasourceConfiguration.headers",
+    filteredDatasourceHeaders,
+  );
 
   yield put(createDatasourceFromForm(datasource));
   const createDatasourceSuccessAction = yield take(


### PR DESCRIPTION
## Description

1.  Filter Empty headers on saving the API as a datasource
2. Fixed UI for Param tab in which top padding was removed for key value headers
3. Placeholder text is fixed as `Please select an option` from `Please select a option`
4. Save DS button is disabled if the url is empty in the Auth Tab of API. 

Fixes #11071 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Click on `Create an API` in Datasource Page
2. Go to Param Tab and observe UI
3. Go to Auth Tab and Click on `Save as Datasource` button when url is empty and observe
4. Without adding any headers try to save api as a datasource then observe no empty headers are created now

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/rest-api 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.82 **(0)** | 37.17 **(0)** | 35.19 **(-0.01)** | 56.16 **(0)**
 :red_circle: | app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx | 50 **(-1.02)** | 26.67 **(0)** | 0 **(0)** | 51.02 **(-1.06)**
 :red_circle: | app/client/src/sagas/DatasourcesSagas.ts | 13.62 **(-0.08)** | 2.11 **(-0.03)** | 8.33 **(-0.37)** | 16.31 **(-0.12)**</details>