### PR TITLE
fix: Cyclic dependency error when action.clear is called

### DIFF
--- a/app/client/src/entities/DataTree/dataTreeAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeAction.ts
@@ -47,7 +47,7 @@ export const generateDataTreeAction = (
     pluginType: action.config.pluginType,
     config: action.config.actionConfiguration,
     dynamicBindingPathList,
-    data: action.data ? action.data.body : {},
+    data: action.data ? action.data.body : undefined,
     responseMeta: {
       statusCode: action.data?.statusCode,
       isExecutionSuccess: action.data?.isExecutionSuccess || false,

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -277,7 +277,6 @@ export default class DataTreeEvaluator {
         translateDiffEventToDataTreeDiffEvent(diff, localUnEvalTree),
       ),
     );
-    this.logs.push({ differences, translatedDiffs });
     const diffCheckTimeStop = performance.now();
     // Check if dependencies have changed
     const updateDependenciesStart = performance.now();

--- a/app/client/src/workers/evaluationUtils.test.ts
+++ b/app/client/src/workers/evaluationUtils.test.ts
@@ -8,13 +8,18 @@ import {
   PrivateWidgets,
 } from "entities/DataTree/dataTreeFactory";
 import {
+  DataTreeDiff,
+  DataTreeDiffEvent,
   getAllPaths,
   getAllPrivateWidgetsInDataTree,
   getDataTreeWithoutPrivateWidgets,
   isPrivateEntityPath,
   makeParentsDependOnChildren,
+  translateDiffEventToDataTreeDiffEvent,
 } from "./evaluationUtils";
 import { warn as logWarn } from "loglevel";
+import { Diff } from "deep-diff";
+import _ from "lodash";
 
 // to check if logWarn was called.
 // use jest.unmock, if the mock needs to be removed.
@@ -272,5 +277,120 @@ describe("makeParentsDependOnChildren", () => {
       "makeParentsDependOnChild - Widget1.defaultText is not present in dataTree.",
       "This might result in a cyclic dependency.",
     );
+  });
+});
+
+describe("translateDiffEvent", () => {
+  it("noop when diff path does not exist", () => {
+    const noDiffPath: Diff<any, any> = {
+      kind: "E",
+      lhs: undefined,
+      rhs: undefined,
+    };
+    const result = translateDiffEventToDataTreeDiffEvent(noDiffPath, {});
+    expect(result).toStrictEqual({
+      payload: {
+        propertyPath: "",
+        value: "",
+      },
+      event: DataTreeDiffEvent.NOOP,
+    });
+  });
+  it("translates new and delete events", () => {
+    const diffs: Diff<any, any>[] = [
+      {
+        kind: "N",
+        path: ["Widget1"],
+        rhs: {},
+      },
+      {
+        kind: "N",
+        path: ["Widget1", "name"],
+        rhs: "Widget1",
+      },
+      {
+        kind: "D",
+        path: ["Widget1"],
+        lhs: {},
+      },
+      {
+        kind: "D",
+        path: ["Widget1", "name"],
+        lhs: "Widget1",
+      },
+      {
+        kind: "E",
+        path: ["Widget2", "name"],
+        rhs: "test",
+        lhs: "test2",
+      },
+    ];
+
+    const expectedTranslations: DataTreeDiff[] = [
+      {
+        payload: {
+          propertyPath: "Widget1",
+        },
+        event: DataTreeDiffEvent.NEW,
+      },
+      {
+        payload: {
+          propertyPath: "Widget1.name",
+        },
+        event: DataTreeDiffEvent.NEW,
+      },
+      {
+        payload: {
+          propertyPath: "Widget1",
+        },
+        event: DataTreeDiffEvent.DELETE,
+      },
+      {
+        payload: {
+          propertyPath: "Widget1.name",
+        },
+        event: DataTreeDiffEvent.DELETE,
+      },
+      {
+        payload: {
+          propertyPath: "",
+          value: "",
+        },
+        event: DataTreeDiffEvent.NOOP,
+      },
+    ];
+
+    const actualTranslations = _.flatten(
+      diffs.map((diff) => translateDiffEventToDataTreeDiffEvent(diff, {})),
+    );
+
+    expect(expectedTranslations).toStrictEqual(actualTranslations);
+  });
+
+  it("properly categorises the edit events", () => {
+    const diffs: Diff<any, any>[] = [
+      {
+        kind: "E",
+        path: ["Widget2", "name"],
+        rhs: "test",
+        lhs: "test2",
+      },
+    ];
+
+    const expectedTranslations: DataTreeDiff[] = [
+      {
+        payload: {
+          propertyPath: "",
+          value: "",
+        },
+        event: DataTreeDiffEvent.NOOP,
+      },
+    ];
+
+    const actualTranslations = _.flatten(
+      diffs.map((diff) => translateDiffEventToDataTreeDiffEvent(diff, {})),
+    );
+
+    expect(expectedTranslations).toStrictEqual(actualTranslations);
   });
 });

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -118,7 +118,7 @@ export const translateDiffEventToDataTreeDiffEvent = (
   }
 
   const propertyPath = convertPathToString(difference.path);
-  //we do not need evaluate these paths coz these are internal paths
+  //we do not need to evaluate these paths' coz these are internal paths
   const isUninterestingPathForUpdateTree = isUninterestingChangeForDependencyUpdate(
     propertyPath,
   );

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -163,11 +163,17 @@ export const translateDiffEventToDataTreeDiffEvent = (
       } else if (difference.lhs === undefined || difference.rhs === undefined) {
         // Handle static value changes that change structure that can lead to
         // old bindings being eligible
-        if (difference.lhs === undefined && isTrueObject(difference.rhs)) {
+        if (
+          difference.lhs === undefined &&
+          (isTrueObject(difference.rhs) || Array.isArray(difference.rhs))
+        ) {
           result.event = DataTreeDiffEvent.NEW;
           result.payload = { propertyPath };
         }
-        if (difference.rhs === undefined && isTrueObject(difference.lhs)) {
+        if (
+          difference.rhs === undefined &&
+          (isTrueObject(difference.lhs) || Array.isArray(difference.lhs))
+        ) {
           result.event = DataTreeDiffEvent.DELETE;
           result.payload = { propertyPath };
         }


### PR DESCRIPTION
## Description
When there is a binding to a specific node in an API/Query response like `{{ Api1.data[3].name }}` and action.clear is called, there is a cyclic dependency. 

- This only happens when the input where this binding is present, gets updated first
- The dependency becomes very specific (`Input1.defaultText: Api1.data[3].name`) 
- On action.clear, the difference was not being translated correctly and hence the dependency was not rectified
- This caused the cyclic dependency


Fixes #11633 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> TODO

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/cyclic-dependency-array-index-binding 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 77.35 **(-0.04)** | 58.45 **(0)** | 75.58 **(0)** | 77.13 **(-0.04)**
 :green_circle: | app/client/src/workers/evaluationUtils.ts | 59.53 **(0.23)** | 58.5 **(-0.09)** | 65.63 **(0)** | 59.08 **(0.27)**</details>