### PR TITLE
fix: Updated conditions for dropdown control to take in false also as value

### DIFF
--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -54,7 +54,7 @@ function renderDropdown(
   } & DropDownControlProps,
 ): JSX.Element {
   let selectedValue: string | string[];
-  if (_.isUndefined(props.input?.value)) {
+  if (_.isNil(props.input?.value)) {
     if (props.isMultiSelect)
       selectedValue = props?.initialValue ? (props.initialValue as string) : [];
     else
@@ -62,14 +62,14 @@ function renderDropdown(
         ? (props.initialValue as string[])
         : "";
   } else {
+    selectedValue = props.input?.value;
     if (props.isMultiSelect) {
-      selectedValue = props.input?.value ? props.input.value : [];
       if (!Array.isArray(selectedValue)) {
         selectedValue = [selectedValue];
       } else {
         selectedValue = [...new Set(selectedValue)];
       }
-    } else selectedValue = props.input?.value ? props.input.value : "";
+    }
   }
   let options: DropdownOption[] = [];
   let selectedOptions: DropdownOption[] = [];
@@ -84,7 +84,7 @@ function renderDropdown(
   }
   // Function to handle selction of options
   const onSelectOptions = (value: string | undefined) => {
-    if (value) {
+    if (!_.isNil(value)) {
       if (props.isMultiSelect) {
         if (Array.isArray(selectedValue)) {
           if (!selectedValue.includes(value))
@@ -99,7 +99,7 @@ function renderDropdown(
 
   // Function to handle deselction of options
   const onRemoveOptions = (value: string | undefined) => {
-    if (value) {
+    if (!_.isNil(value)) {
       if (props.isMultiSelect) {
         if (Array.isArray(selectedValue)) {
           if (selectedValue.includes(value))

--- a/app/client/src/pages/Editor/DataSourceEditor/JSONtoForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/JSONtoForm.tsx
@@ -135,7 +135,7 @@ export class JSONtoForm<
       } else {
         const value = _.get(values, fieldConfigProperty);
 
-        if (!value) {
+        if (_.isNil(value)) {
           _.set(errors, fieldConfigProperty, "This field is required");
         }
       }


### PR DESCRIPTION
## Description

Updated the conditions for checking the value as undefined or null for updating the dropdown selection and validation for form submit button if any of the fields value is `false`.

Fixes #11710 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Create an authenticated datasource and change the `Send Appsmith signature header` dropdown to `Yes` and then change it to `No`. Earlier the `Session Details Signature Key` input not used to go away but now it does go away and the validation of form works successfully.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/dropdown-control 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.82 **(0)** | 37.18 **(0.01)** | 35.2 **(0)** | 56.16 **(0)**
 :green_circle: | app/client/src/components/formControls/DropDownControl.tsx | 24.24 **(0.36)** | 2.3 **(0.19)** | 12.5 **(0)** | 23.08 **(0.35)**</details>