### PR TITLE
fix: Adds user set on load prop from actions to exported JSON file

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/InvisibleActionFields.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/InvisibleActionFields.java
@@ -1,0 +1,22 @@
+package com.appsmith.external.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * This class hold sensitive information related to an action,
+ * and fields that have a `@JsonIgnore` on them, so that such information
+ * can be serialized when an application is exported.
+ */
+@ToString
+@Getter
+@Setter
+@NoArgsConstructor
+public class InvisibleActionFields {
+
+    Boolean unpublishedUserSetOnLoad;
+    Boolean publishedUserSetOnLoad;
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
@@ -2,6 +2,7 @@ package com.appsmith.server.domains;
 
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DecryptedSensitiveFields;
+import com.appsmith.external.models.InvisibleActionFields;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
@@ -48,6 +49,8 @@ public class ApplicationJson {
     List<ActionCollection> actionCollectionList;
 
     Map<String, DecryptedSensitiveFields> decryptedFields;
+
+    Map<String, InvisibleActionFields> invisibleActionFields;
 
     Theme editModeTheme;
     Theme publishedTheme;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -5,6 +5,7 @@ import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DecryptedSensitiveFields;
+import com.appsmith.external.models.InvisibleActionFields;
 import com.appsmith.external.models.Policy;
 import com.appsmith.external.models.Property;
 import com.appsmith.server.constants.FieldName;
@@ -52,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -389,6 +391,7 @@ public class ImportExportApplicationServiceTests {
         testApplication.setName("ApplicationWithActionCollectionAndDatasource");
         testApplication = applicationPageService.createApplication(testApplication, orgId).block();
 
+        assert testApplication != null;
         final String appName = testApplication.getName();
         final Mono<ApplicationJson> resultMono = Mono.zip(
                 Mono.just(testApplication),
@@ -429,6 +432,16 @@ public class ImportExportApplicationServiceTests {
                     action.setActionConfiguration(actionConfiguration);
                     action.setDatasource(datasourceMap.get("DS2"));
 
+                    ActionDTO action2 = new ActionDTO();
+                    action2.setName("validAction2");
+                    action2.setPageId(testPage.getId());
+                    action2.setExecuteOnLoad(true);
+                    action2.setUserSetOnLoad(true);
+                    ActionConfiguration actionConfiguration2 = new ActionConfiguration();
+                    actionConfiguration2.setHttpMethod(HttpMethod.GET);
+                    action2.setActionConfiguration(actionConfiguration2);
+                    action2.setDatasource(datasourceMap.get("DS2"));
+
                     ActionCollectionDTO actionCollectionDTO1 = new ActionCollectionDTO();
                     actionCollectionDTO1.setName("testCollection1");
                     actionCollectionDTO1.setPageId(testPage.getId());
@@ -444,8 +457,7 @@ public class ImportExportApplicationServiceTests {
 
                     return layoutCollectionService.createCollection(actionCollectionDTO1)
                             .then(layoutActionService.createSingleAction(action))
-                            .flatMap(createdAction -> newActionService.findById(createdAction.getId(), READ_ACTIONS))
-                            .flatMap(newAction -> newActionService.generateActionByViewMode(newAction, false))
+                            .then(layoutActionService.createSingleAction(action2))
                             .then(layoutActionService.updateLayout(testPage.getId(), layout.getId(), layout))
                             .then(importExportApplicationService.exportApplicationById(testApp.getId(), ""));
                 })
@@ -520,10 +532,8 @@ public class ImportExportApplicationServiceTests {
                     assertThat(defaultPage.getPolicies()).isEmpty();
 
                     assertThat(actionList.isEmpty()).isFalse();
-                    assertThat(actionList).hasSize(2);
-                    NewAction validAction = actionList.get(0).getPluginType().equals(PluginType.JS) ?
-                            actionList.get(1) :
-                            actionList.get(0);
+                    assertThat(actionList).hasSize(3);
+                    NewAction validAction = actionList.stream().filter(action -> action.getId().equals("Page1_validAction")).findFirst().get();
                     assertThat(validAction.getApplicationId()).isNull();
                     assertThat(validAction.getPluginId()).isEqualTo(installedPlugin.getPackageName());
                     assertThat(validAction.getPluginType()).isEqualTo(PluginType.API);
@@ -559,6 +569,12 @@ public class ImportExportApplicationServiceTests {
                     DBAuth auth = (DBAuth) datasourceMap.get("DS2").getDatasourceConfiguration().getAuthentication();
                     assertThat(decryptedFields.getAuthType()).isEqualTo(auth.getClass().getName());
                     assertThat(decryptedFields.getPassword()).isEqualTo("awesome-password");
+
+                    final Map<String, InvisibleActionFields> invisibleActionFields = applicationJson.getInvisibleActionFields();
+
+                    Assert.assertEquals(3, invisibleActionFields.size());
+                    NewAction validAction2 = actionList.stream().filter(action -> action.getId().equals("Page1_validAction2")).findFirst().get();
+                    Assert.assertEquals(true, invisibleActionFields.get(validAction2.getId()).getUnpublishedUserSetOnLoad());
 
                     assertThat(applicationJson.getUnpublishedLayoutmongoEscapedWidgets()).isNotEmpty();
                     assertThat(applicationJson.getPublishedLayoutmongoEscapedWidgets()).isNotEmpty();


### PR DESCRIPTION
## Description
Added a temporary fix for missing action attribute `userSetOnLoad` in exported JSON files. This fixes the issue with explicit on page load actions not being triggered for imported apps. This fix is not a clean implementation however, since we're adding business logic in a separate field that is not easy to track. We'll be handling a proper fix in #11701 which will require a version upgrade for exported files.

Fixes #11698 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit test
- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
