### PR TITLE
fix: Icon Selector width on propety pane resize

### DIFF
--- a/app/client/src/components/propertyControls/IconSelectControl.tsx
+++ b/app/client/src/components/propertyControls/IconSelectControl.tsx
@@ -163,7 +163,7 @@ class IconSelectControl extends BaseControl<
     const { defaultIconName, propertyValue: iconName } = this.props;
     const { activeIcon } = this.state;
     const containerWidth =
-      this.iconSelectTargetRef.current?.getBoundingClientRect().width || 0;
+      this.iconSelectTargetRef.current?.getBoundingClientRect?.()?.width || 0;
 
     return (
       <>

--- a/app/client/src/components/propertyControls/IconSelectControl.tsx
+++ b/app/client/src/components/propertyControls/IconSelectControl.tsx
@@ -92,7 +92,6 @@ export interface IconSelectControlProps extends ControlProps {
 
 export interface IconSelectControlState {
   activeIcon: IconType;
-  popoverTargetWidth: number | undefined;
   isOpen: boolean;
 }
 
@@ -114,7 +113,6 @@ class IconSelectControl extends BaseControl<
   private initialItemIndex: number;
   private filteredItems: Array<IconType>;
   private searchInput: React.RefObject<HTMLInputElement>;
-  private timer?: number;
 
   constructor(props: IconSelectControlProps) {
     super(props);
@@ -125,7 +123,6 @@ class IconSelectControl extends BaseControl<
     this.filteredItems = [];
     this.state = {
       activeIcon: props.propertyValue ?? NONE,
-      popoverTargetWidth: 0,
       isOpen: false,
     };
   }
@@ -149,24 +146,11 @@ class IconSelectControl extends BaseControl<
   );
 
   componentDidMount() {
-    this.timer = setTimeout(() => {
-      const iconSelectTargetElement = this.iconSelectTargetRef.current;
-      this.setState((prevState: IconSelectControlState) => {
-        return {
-          ...prevState,
-          popoverTargetWidth: iconSelectTargetElement?.getBoundingClientRect()
-            .width,
-        };
-      });
-    }, 0);
     // keydown event is attached to body so that it will not interfere with the keydown handler in GlobalHotKeys
     document.body.addEventListener("keydown", this.handleKeydown);
   }
 
   componentWillUnmount() {
-    if (this.timer) {
-      clearTimeout(this.timer);
-    }
     document.body.removeEventListener("keydown", this.handleKeydown);
   }
 
@@ -177,10 +161,14 @@ class IconSelectControl extends BaseControl<
 
   public render() {
     const { defaultIconName, propertyValue: iconName } = this.props;
-    const { activeIcon, popoverTargetWidth } = this.state;
+    const { activeIcon } = this.state;
     return (
       <>
-        <IconSelectContainerStyles targetWidth={popoverTargetWidth} />
+        <IconSelectContainerStyles
+          targetWidth={
+            this.iconSelectTargetRef.current?.getBoundingClientRect().width
+          }
+        />
         <TypedSelect
           activeItem={activeIcon || defaultIconName || NONE}
           className="icon-select-container"

--- a/app/client/src/components/propertyControls/IconSelectControl.tsx
+++ b/app/client/src/components/propertyControls/IconSelectControl.tsx
@@ -162,13 +162,12 @@ class IconSelectControl extends BaseControl<
   public render() {
     const { defaultIconName, propertyValue: iconName } = this.props;
     const { activeIcon } = this.state;
+    const containerWidth =
+      this.iconSelectTargetRef.current?.getBoundingClientRect().width || 0;
+
     return (
       <>
-        <IconSelectContainerStyles
-          targetWidth={
-            this.iconSelectTargetRef.current?.getBoundingClientRect().width
-          }
-        />
+        <IconSelectContainerStyles targetWidth={containerWidth} />
         <TypedSelect
           activeItem={activeIcon || defaultIconName || NONE}
           className="icon-select-container"


### PR DESCRIPTION
## Description

Icon Selector's width was not recalculated when the property pane was resized.
This also fixes an issue in JSONForm Widget where it is unable to display Icon Selector if the property pane section is hidden initially.

Thanks, @ashit-rath for coming up with a good solution.

Fixes #11735 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/icon-selector-width 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.87 **(-0.01)** | 37.25 **(0.02)** | 35.23 **(-0.01)** | 56.2 **(-0.01)**
 :green_circle: | app/client/src/components/propertyControls/IconSelectControl.tsx | 91.3 **(-0.48)** | 76.11 **(3.21)** | 95.83 **(-0.32)** | 91.34 **(-0.33)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>