### PR TITLE
feat: Added a flow to create a GraphQL datasource 

### DIFF
--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -1,6 +1,7 @@
 import { EmbeddedRestDatasource } from "entities/Datasource";
 import { DynamicPath } from "../../utils/DynamicBindingUtils";
 import _ from "lodash";
+import { Plugin } from "api/PluginApi";
 
 export enum PluginType {
   API = "API",
@@ -167,4 +168,8 @@ export function isQueryAction(action: Action): action is QueryAction {
 
 export function isSaaSAction(action: Action): action is SaaSAction {
   return action.pluginType === PluginType.SAAS;
+}
+
+export function getGraphQLPlugin(plugins: Plugin[]): Plugin | undefined {
+  return plugins.find((p) => p.packageName === "graphql-plugin");
 }

--- a/app/client/src/pages/Editor/IntegrationEditor/NewApi.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/NewApi.tsx
@@ -11,7 +11,7 @@ import { Plugin } from "api/PluginApi";
 import { createNewApiAction } from "actions/apiPaneActions";
 import AnalyticsUtil, { EventLocation } from "utils/AnalyticsUtil";
 import { CURL } from "constants/AppsmithActionConstants/ActionConstants";
-import { PluginType } from "entities/Action";
+import { getGraphQLPlugin, PluginType } from "entities/Action";
 import { Spinner } from "@blueprintjs/core";
 import { getQueryParams } from "utils/AppsmithUtils";
 import { GenerateCRUDEnabledPluginMap } from "../../../api/PluginApi";
@@ -238,6 +238,16 @@ function NewApiScreen(props: Props) {
     }
   };
 
+  const API_PLUGINS = plugins.filter(
+    (p) => p.type === PluginType.SAAS || p.type === PluginType.REMOTE,
+  );
+
+  const graphqlPlugin = getGraphQLPlugin(plugins);
+
+  if (graphqlPlugin) {
+    API_PLUGINS.push(graphqlPlugin);
+  }
+
   return (
     <StyledContainer>
       <ApiCardsContainer>
@@ -289,40 +299,34 @@ function NewApiScreen(props: Props) {
             </CardContentWrapper>
           </ApiCard>
         )}
-        {plugins
-          .filter(
-            (p) => p.type === PluginType.SAAS || p.type === PluginType.REMOTE,
-          )
-          .map((p) => (
-            <ApiCard
-              className={`t--createBlankApi-${p.packageName}`}
-              key={p.id}
-              onClick={() => {
-                AnalyticsUtil.logEvent("CREATE_DATA_SOURCE_CLICK", {
-                  pluginName: p.name,
-                  pluginPackageName: p.packageName,
-                });
-                handleOnClick(API_ACTION.CREATE_DATASOURCE_FORM, {
-                  pluginId: p.id,
-                });
-              }}
-            >
-              <CardContentWrapper>
-                <div className="content-icon-wrapper">
-                  <img
-                    alt={p.name}
-                    className={
-                      "content-icon saasImage t--saas-" +
-                      p.packageName +
-                      "-image"
-                    }
-                    src={p.iconLocation}
-                  />
-                </div>
-                <p className="t--plugin-name textBtn">{p.name}</p>
-              </CardContentWrapper>
-            </ApiCard>
-          ))}
+        {API_PLUGINS.map((p) => (
+          <ApiCard
+            className={`t--createBlankApi-${p.packageName}`}
+            key={p.id}
+            onClick={() => {
+              AnalyticsUtil.logEvent("CREATE_DATA_SOURCE_CLICK", {
+                pluginName: p.name,
+                pluginPackageName: p.packageName,
+              });
+              handleOnClick(API_ACTION.CREATE_DATASOURCE_FORM, {
+                pluginId: p.id,
+              });
+            }}
+          >
+            <CardContentWrapper>
+              <div className="content-icon-wrapper">
+                <img
+                  alt={p.name}
+                  className={
+                    "content-icon saasImage t--saas-" + p.packageName + "-image"
+                  }
+                  src={p.iconLocation}
+                />
+              </div>
+              <p className="t--plugin-name textBtn">{p.name}</p>
+            </CardContentWrapper>
+          </ApiCard>
+        ))}
       </ApiCardsContainer>
     </StyledContainer>
   );

--- a/app/client/src/sagas/PluginSagas.ts
+++ b/app/client/src/sagas/PluginSagas.ts
@@ -27,7 +27,7 @@ import {
 import { GenericApiResponse } from "api/ApiResponses";
 import PluginApi from "api/PluginApi";
 import log from "loglevel";
-import { PluginType } from "entities/Action";
+import { getGraphQLPlugin, PluginType } from "entities/Action";
 import {
   FormEditorConfigs,
   FormSettingsConfigs,
@@ -70,6 +70,7 @@ function* fetchPluginFormConfigsSaga() {
     // can exist without a saved datasource
     const apiPlugin = plugins.find((plugin) => plugin.type === PluginType.API);
     const jsPlugin = plugins.find((plugin) => plugin.type === PluginType.JS);
+    const graphqlPlugin = getGraphQLPlugin(plugins);
     if (apiPlugin) {
       pluginIdFormsToFetch.add(apiPlugin.id);
     }
@@ -85,6 +86,10 @@ function* fetchPluginFormConfigsSaga() {
 
     if (jsPlugin) {
       pluginIdFormsToFetch.add(jsPlugin.id);
+    }
+
+    if (graphqlPlugin) {
+      pluginIdFormsToFetch.add(graphqlPlugin.id);
     }
     const formConfigs: Record<string, any[]> = {};
     const editorConfigs: FormEditorConfigs = {};

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -107,7 +107,7 @@ public class DatabaseChangelog2 {
     }
 
     @ChangeSet(order = "003", id = "add-graphql-plugin", author = "")
-    public void addArangoDBPlugin(MongockTemplate mongoTemplate) {
+    public void addGraphQLPlugin(MongockTemplate mongoTemplate) {
         Plugin plugin = new Plugin();
         plugin.setName("GraphQL");
         plugin.setType(PluginType.API);


### PR DESCRIPTION
## Description

- Note: Currently it is being merged to development branch feat/graphql.
- You can create GraphQL datasource
- You can update the datasource
- You can click and navigate to GraphQL API Editor : ( for now the Editor rendered is similar to the normal API Editor but eventually it will be changed in different PRs.)

Fixes #10545 #10547

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual by creating a graphql datasource

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
