### PR TITLE
fix: polish git-sync feature

### DIFF
--- a/app/client/src/ce/constants/messages.test.ts
+++ b/app/client/src/ce/constants/messages.test.ts
@@ -27,6 +27,7 @@ import {
   FETCH_MERGE_STATUS,
   FETCH_MERGE_STATUS_FAILURE,
   GENERATE_KEY,
+  GIT_COMMIT_MESSAGE_PLACEHOLDER,
   GIT_CONFLICTING_INFO,
   GIT_DISCONNECTION_SUBMENU,
   GIT_UPSTREAM_CHANGES,
@@ -101,7 +102,10 @@ describe("git-sync messages", () => {
       key: "GIT_USER_UPDATED_SUCCESSFULLY",
       value: "Git user updated successfully",
     },
-    { key: "REMOTE_URL_INPUT_PLACEHOLDER", value: "Paste your URL here" },
+    {
+      key: "REMOTE_URL_INPUT_PLACEHOLDER",
+      value: "git://example.com:user/repo.git",
+    },
     { key: "COPIED_SSH_KEY", value: "Copied SSH Key" },
     {
       key: "INVALID_USER_DETAILS_MSG",
@@ -177,6 +181,10 @@ describe("git-sync messages", () => {
     { key: "DISCONNECT", value: "DISCONNECT" },
     { key: "GIT_DISCONNECTION_SUBMENU", value: "Git Connection > Disconnect" },
     { key: "USE_DEFAULT_CONFIGURATION", value: "Use default configuration" },
+    {
+      key: "GIT_COMMIT_MESSAGE_PLACEHOLDER",
+      value: "Your commit message here",
+    },
   ];
   const functions = [
     CANNOT_MERGE_DUE_TO_UNCOMMITTED_CHANGES,
@@ -205,6 +213,7 @@ describe("git-sync messages", () => {
     FETCH_MERGE_STATUS,
     FETCH_MERGE_STATUS_FAILURE,
     GENERATE_KEY,
+    GIT_COMMIT_MESSAGE_PLACEHOLDER,
     GIT_CONFLICTING_INFO,
     GIT_DISCONNECTION_SUBMENU,
     GIT_UPSTREAM_CHANGES,

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -610,7 +610,9 @@ export const ERROR_WHILE_PULLING_CHANGES = () => "ERROR WHILE PULLING CHANGES";
 export const SUBMIT = () => "SUBMIT";
 export const GIT_USER_UPDATED_SUCCESSFULLY = () =>
   "Git user updated successfully";
-export const REMOTE_URL_INPUT_PLACEHOLDER = () => "Paste your URL here";
+export const REMOTE_URL_INPUT_PLACEHOLDER = () =>
+  "git://example.com:user/repo.git";
+export const GIT_COMMIT_MESSAGE_PLACEHOLDER = () => "Your commit message here";
 export const COPIED_SSH_KEY = () => "Copied SSH Key";
 export const INVALID_USER_DETAILS_MSG = () => "Please enter valid user details";
 export const PASTE_SSH_URL_INFO = () =>

--- a/app/client/src/components/ads/NotificationBanner.tsx
+++ b/app/client/src/components/ads/NotificationBanner.tsx
@@ -94,12 +94,6 @@ const TextContainer = styled.div`
 const CloseButtonContainer = styled.div`
   display: flex;
   justify-items: center;
-
-  & button {
-    position: unset;
-    top: unset;
-    right: 3px;
-  }
 `;
 const IconContainer = styled.div``;
 const LearnMoreContainer = styled.div``;

--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -12,13 +12,13 @@ body {
   background-color: #FFF !important;
 }
 
-body.dragging *{
+body.dragging * {
   cursor: grabbing !important;
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  monospace;
 }
 
 * {
@@ -39,10 +39,10 @@ span.bp3-popover-target > * {
 }
 
 div.bp3-popover-arrow {
-  display:none;
+  display: none;
 }
 
-.bp3-button.bp3-loading{
+.bp3-button.bp3-loading {
   cursor: default !important;
 }
 
@@ -55,6 +55,7 @@ div.bp3-popover-arrow {
   border-radius: 4px !important;
   box-shadow: none !important;
 }
+
 .Toastify__toast-body {
   margin: 0 !important;
 }
@@ -84,7 +85,7 @@ div.bp3-popover-arrow {
   margin-top: 8px !important;
 }
 
-.layout-control.bp3-popover.bp3-minimal{
+.layout-control.bp3-popover.bp3-minimal {
   margin-top: 8px !important;
 }
 
@@ -102,7 +103,7 @@ div.bp3-popover-arrow {
   border-color: #E7E7E7 !important;
 }
 
-.tox:not([dir=rtl]) .tox-toolbar__group:not(:last-of-type), .tox .tox-statusbar  {
+.tox:not([dir=rtl]) .tox-toolbar__group:not(:last-of-type), .tox .tox-statusbar {
   border-color: #E7E7E7 !important;
 }
 
@@ -110,6 +111,7 @@ div.bp3-popover-arrow {
   background: white !important;
   border-bottom: 1px solid #E7E7E7 !important;
 }
+
 /* making both the Modal layer and the Dropdown layer */
 .bp3-modal-widget, .appsmith_widget_0 > .bp3-portal {
   z-index: 2 !important;
@@ -118,4 +120,8 @@ div.bp3-popover-arrow {
 /* Portals on the Modal widget */
 .bp3-modal-widget .bp3-portal {
   z-index: 21 !important;
+}
+
+.bp3-overlay-backdrop {
+  background-color: rgba(16, 22, 26, 0.7) !important;
 }

--- a/app/client/src/pages/Editor/gitSync/GitSyncModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/GitSyncModal.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import Dialog from "components/ads/DialogComponent";
 import {
   getActiveGitSyncModalTab,
+  getIsGitConnected,
   getIsGitSyncModalOpen,
 } from "selectors/gitSyncSelectors";
 import { useDispatch, useSelector } from "react-redux";
-import { useCallback } from "react";
 import { setIsGitSyncModalOpen } from "actions/gitSyncActions";
 import Menu from "./Menu";
 import { Classes, MENU_HEIGHT, MENU_ITEM, MENU_ITEMS_MAP } from "./constants";
@@ -18,7 +18,6 @@ import GitErrorPopup from "./components/GitErrorPopup";
 import styled, { useTheme } from "styled-components";
 import { get } from "lodash";
 import { GitSyncModalTab } from "entities/GitSync";
-import { getIsGitConnected } from "selectors/gitSyncSelectors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 
 const Container = styled.div`
@@ -28,7 +27,6 @@ const Container = styled.div`
   flex-direction: column;
   position: relative;
   overflow-y: hidden;
-  padding: 0px 10px 0px 10px;
 `;
 
 const BodyContainer = styled.div`
@@ -42,11 +40,19 @@ const MenuContainer = styled.div`
 
 const CloseBtnContainer = styled.div`
   position: absolute;
-  right: ${(props) => props.theme.spaces[1]}px;
-  top: ${(props) => props.theme.spaces[5]}px;
+  right: 0;
+  top: 0;
 
   padding: ${(props) => props.theme.spaces[1]}px;
   border-radius: ${(props) => props.theme.radii[1]}px;
+`;
+
+const GitSyncTabsContainer = styled.div``;
+
+const StyledDialog = styled(Dialog)`
+  &.${Classes.GIT_SYNC_MODAL} .bp3-dialog-body {
+    margin-top: 0;
+  }
 `;
 
 const ComponentsByTab = {
@@ -73,7 +79,7 @@ function GitSyncModal() {
 
   const setActiveTabIndex = useCallback(
     (index: number) =>
-      dispatch(setIsGitSyncModalOpen({ isOpen: !!isModalOpen, tab: index })),
+      dispatch(setIsGitSyncModalOpen({ isOpen: isModalOpen, tab: index })),
     [dispatch, setIsGitSyncModalOpen, isModalOpen],
   );
 
@@ -113,8 +119,8 @@ function GitSyncModal() {
   const BodyComponent = ComponentsByTab[activeMenuItemKey];
 
   return (
-    <>
-      <Dialog
+    <GitSyncTabsContainer>
+      <StyledDialog
         canEscapeKeyClose
         canOutsideClickClose
         className={Classes.GIT_SYNC_MODAL}
@@ -156,9 +162,9 @@ function GitSyncModal() {
             />
           </CloseBtnContainer>
         </Container>
-      </Dialog>
+      </StyledDialog>
       <GitErrorPopup />
-    </>
+    </GitSyncTabsContainer>
   );
 }
 

--- a/app/client/src/pages/Editor/gitSync/QuickGitActions/BranchButton.tsx
+++ b/app/client/src/pages/Editor/gitSync/QuickGitActions/BranchButton.tsx
@@ -57,6 +57,7 @@ function BranchButton() {
   return (
     <Popover2
       content={<BranchList setIsPopupOpen={setIsOpen} />}
+      hasBackdrop
       isOpen={isOpen}
       minimal
       modifiers={{ offset: { enabled: true, options: { offset: [7, 10] } } }}
@@ -74,7 +75,7 @@ function BranchButton() {
         boundary="window"
         content={currentBranch || ""}
         disabled={!isEllipsisActive(labelTarget.current)}
-        hoverOpenDelay={1000}
+        hoverOpenDelay={1}
         position={Position.TOP_LEFT}
       >
         <ButtonContainer className="t--branch-button">

--- a/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
+++ b/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
@@ -4,20 +4,20 @@ import styled from "styled-components";
 import BranchButton from "./BranchButton";
 
 import {
-  COMMIT_CHANGES,
-  PULL_CHANGES,
-  MERGE,
   CANNOT_PULL_WITH_LOCAL_UNCOMMITTED_CHANGES,
-  CONNECT_GIT,
+  COMING_SOON,
+  COMMIT_CHANGES,
   CONFLICTS_FOUND,
+  CONNECT_GIT,
+  CONNECT_GIT_BETA,
+  CONNECTING_TO_REPO_DISABLED,
+  createMessage,
+  DURING_ONBOARDING_TOUR,
+  GIT_SETTINGS,
+  MERGE,
   NO_COMMITS_TO_PULL,
   NOT_LIVE_FOR_YOU_YET,
-  COMING_SOON,
-  CONNECTING_TO_REPO_DISABLED,
-  DURING_ONBOARDING_TOUR,
-  createMessage,
-  GIT_SETTINGS,
-  CONNECT_GIT_BETA,
+  PULL_CHANGES,
 } from "@appsmith/constants/messages";
 
 import Tooltip from "components/ads/Tooltip";
@@ -34,12 +34,12 @@ import {
 import { GitSyncModalTab } from "entities/GitSync";
 import getFeatureFlags from "utils/featureFlags";
 import {
-  getGitStatus,
-  getIsGitConnected,
-  getPullInProgress,
-  getIsFetchingGitStatus,
-  getPullFailed,
   getCountOfChangesToCommit,
+  getGitStatus,
+  getIsFetchingGitStatus,
+  getIsGitConnected,
+  getPullFailed,
+  getPullInProgress,
 } from "selectors/gitSyncSelectors";
 import SpinnerLoader from "pages/common/SpinnerLoader";
 import { inGuidedTour } from "selectors/onboardingSelectors";
@@ -61,12 +61,15 @@ const QuickActionButtonContainer = styled.div<{ disabled?: boolean }>`
     ${(props) => props.theme.spaces[2]}px;
   margin: 0 ${(props) => props.theme.spaces[2]}px;
   cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
+
   &:hover {
     background-color: ${(props) =>
       props.theme.colors.editorBottomBar.buttonBackgroundHover};
   }
+
   position: relative;
   overflow: visible;
+
   .count {
     position: absolute;
     width: 20px;
@@ -106,8 +109,10 @@ function QuickActionButton({
   onClick,
   tooltipText,
 }: QuickActionButtonProps) {
+  const content = capitalizeFirstLetter(tooltipText);
+
   return (
-    <Tooltip content={capitalizeFirstLetter(tooltipText)} hoverOpenDelay={1000}>
+    <Tooltip content={content} hoverOpenDelay={10}>
       <QuickActionButtonContainer
         className={className}
         disabled={disabled}
@@ -120,9 +125,7 @@ function QuickActionButton({
         ) : (
           <div>
             <Icon name={icon} size={IconSize.XL} />
-            {count > 0 && (
-              <span className="count">{count > 9 ? `${9}+` : count}</span>
-            )}
+            {count > 0 && <span className="count">{count}</span>}
           </div>
         )}
       </QuickActionButtonContainer>
@@ -213,9 +216,11 @@ const Container = styled.div`
 
 const StyledIcon = styled(GitCommitLine)`
   cursor: default;
+
   & path {
     fill: ${Colors.DARK_GRAY};
   }
+
   margin-right: ${(props) => props.theme.spaces[3]}px;
 `;
 
@@ -231,10 +236,10 @@ const PlaceholderButton = styled.div`
 
 function ConnectGitPlaceholder() {
   const dispatch = useDispatch();
-  const isInOnboarding = useSelector(inGuidedTour);
+  const isInGuidedTour = useSelector(inGuidedTour);
 
-  const isTooltipEnabled = !getFeatureFlags().GIT || isInOnboarding;
-  const tooltipContent = !isInOnboarding ? (
+  const isTooltipEnabled = !getFeatureFlags().GIT || isInGuidedTour;
+  const tooltipContent = !isInGuidedTour ? (
     <>
       <div>{createMessage(NOT_LIVE_FOR_YOU_YET)}</div>
       <div>{createMessage(COMING_SOON)}</div>
@@ -245,7 +250,7 @@ function ConnectGitPlaceholder() {
       <div>{createMessage(DURING_ONBOARDING_TOUR)}</div>
     </>
   );
-  const isGitConnectionEnabled = getFeatureFlags().GIT && !isInOnboarding;
+  const isGitConnectionEnabled = getFeatureFlags().GIT && !isInGuidedTour;
 
   return (
     <Container>

--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -218,6 +218,7 @@ function Deploy() {
             fill
             height={`${Math.min(autogrowHeight, 80)}px`}
             onChange={setCommitMessage}
+            placeholder={"Your commit message here"}
             ref={commitInputRef}
             trimValue={false}
             useTextArea

--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
@@ -1,23 +1,27 @@
 import React, {
-  useState,
-  useEffect,
-  useRef,
-  useMemo,
   useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
-import { Subtitle, Title, Space } from "../components/StyledComponents";
+import { Space, Subtitle, Title } from "../components/StyledComponents";
 import {
+  CONNECT_BTN_LABEL,
   CONNECT_TO_GIT,
   CONNECT_TO_GIT_SUBTITLE,
+  CONNECTING_REPO,
+  createMessage,
+  GENERATE_KEY,
+  LEARN_MORE,
+  PASTE_SSH_URL_INFO,
   REMOTE_URL,
   REMOTE_URL_INFO,
-  createMessage,
   REMOTE_URL_INPUT_PLACEHOLDER,
-  CONNECTING_REPO,
-  LEARN_MORE,
+  UPDATE_CONFIG,
 } from "@appsmith/constants/messages";
 import styled from "styled-components";
-import TextInput from "components/ads/TextInput";
+import TextInput, { emailValidator } from "components/ads/TextInput";
 import UserGitProfileSettings from "../components/UserGitProfileSettings";
 import { AUTH_TYPE_OPTIONS } from "../constants";
 import { Colors } from "constants/Colors";
@@ -39,19 +43,11 @@ import {
   setIsGitSyncModalOpen,
   updateLocalGitConfigInit,
 } from "actions/gitSyncActions";
-import { emailValidator } from "components/ads/TextInput";
 import { isEqual } from "lodash";
-import {
-  UPDATE_CONFIG,
-  CONNECT_BTN_LABEL,
-  PASTE_SSH_URL_INFO,
-  GENERATE_KEY,
-} from "@appsmith/constants/messages";
 import {
   getGlobalGitConfig,
   getIsFetchingGlobalGitConfig,
   getIsFetchingLocalGitConfig,
-  // getIsGitSyncModalOpen,
   getLocalGitConfig,
   getRemoteUrlDocUrl,
   getTempRemoteUrl,
@@ -276,7 +272,7 @@ function GitConnection({ isImport }: Props) {
   };
 
   const isUseGlobalProfileFlagUpdated =
-    !!useGlobalConfigInputVal !== !!useGlobalProfile;
+    useGlobalConfigInputVal !== !!useGlobalProfile;
 
   const submitButtonDisabled = useMemo(() => {
     const isAuthInfoUpdated = isAuthorInfoUpdated();

--- a/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
@@ -44,7 +44,6 @@ import { isEllipsisActive } from "utils/helpers";
 import { getIsStartingWithRemoteBranches } from "pages/Editor/gitSync/utils";
 
 import SegmentHeader from "components/ads/ListSegmentHeader";
-import BetaTag from "./BetaTag";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 
 const ListContainer = styled.div`
@@ -347,7 +346,7 @@ function Header({
         >
           <Tooltip
             content={createMessage(SYNC_BRANCHES)}
-            hoverOpenDelay={1000}
+            hoverOpenDelay={10}
             modifiers={{
               flip: { enabled: false },
             }}
@@ -363,9 +362,6 @@ function Header({
             />
           </Tooltip>
         </span>
-        <div style={{ marginLeft: 6 }}>
-          <BetaTag />
-        </div>
       </div>
       <Icon
         className="t--close-branch-list"

--- a/app/client/src/pages/Editor/gitSync/components/DeployPreview.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/DeployPreview.tsx
@@ -8,19 +8,19 @@ import { ReactComponent as RightArrow } from "assets/icons/ads/arrow-right-line.
 import { getApplicationViewerPageURL } from "constants/routes";
 import { useSelector } from "store";
 import {
+  getApplicationLastDeployedAt,
   getCurrentApplicationId,
   getCurrentPageId,
 } from "selectors/editorSelectors";
 import {
-  LATEST_DP_TITLE,
-  LATEST_DP_SUBTITLE,
   createMessage,
+  LATEST_DP_SUBTITLE,
+  LATEST_DP_TITLE,
 } from "@appsmith/constants/messages";
-import Text, { TextType, Case } from "components/ads/Text";
+import Text, { Case, TextType } from "components/ads/Text";
 import { Colors } from "constants/Colors";
 import SuccessTick from "pages/common/SuccessTick";
 import { howMuchTimeBeforeText } from "utils/helpers";
-import { getApplicationLastDeployedAt } from "selectors/editorSelectors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 
 const Container = styled.div`
@@ -35,6 +35,7 @@ const ButtonWrapper = styled.div`
   flex-direction: row;
   padding-top: 2px;
   cursor: pointer;
+
   :hover {
     text-decoration: underline;
   }
@@ -45,6 +46,7 @@ const IconWrapper = styled.div`
   justify-content: center;
   align-items: center;
   display: flex;
+
   svg {
     path {
       fill: ${Colors.GREY_9};
@@ -78,6 +80,9 @@ export default function DeployPreview(props: { showSuccess: boolean }) {
   const lastDeployedAtMsg = lastDeployedAt
     ? `${createMessage(LATEST_DP_SUBTITLE)} ${howMuchTimeBeforeText(
         lastDeployedAt,
+        {
+          lessThanAMinute: true,
+        },
       )} ago`
     : "";
   return lastDeployedAt ? (

--- a/app/client/src/pages/Editor/gitSync/components/DeployedKeyUI.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/DeployedKeyUI.tsx
@@ -93,7 +93,7 @@ type DeployedKeyUIProps = {
 };
 
 const NotificationBannerContainer = styled.div`
-  max-width: 456px;
+  max-width: calc(100% - 30px);
 `;
 
 function CopySSHKey(showCopied: boolean, copyToClipboard: () => void) {

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -424,6 +424,7 @@ export const scrollbarWidth = () => {
 // To { isValid: false, settings.color: false}
 export const flattenObject = (data: Record<string, any>) => {
   const result: Record<string, any> = {};
+
   function recurse(cur: any, prop: any) {
     if (Object(cur) !== cur) {
       result[prop] = cur;
@@ -440,6 +441,7 @@ export const flattenObject = (data: Record<string, any>) => {
       if (isEmpty && prop) result[prop] = {};
     }
   }
+
   recurse(data, "");
   return result;
 };
@@ -492,10 +494,15 @@ export const stopClickEventPropagation = (
  * @param date 2021-09-08T14:14:12Z
  *
  */
-export const howMuchTimeBeforeText = (date: string) => {
+export const howMuchTimeBeforeText = (
+  date: string,
+  options: { lessThanAMinute: boolean } = { lessThanAMinute: false },
+) => {
   if (!date || !moment.isMoment(moment(date))) {
     return "";
   }
+
+  const { lessThanAMinute } = options;
 
   const now = moment();
   const checkDate = moment(date);
@@ -510,7 +517,10 @@ export const howMuchTimeBeforeText = (date: string) => {
   else if (days > 0) return `${days} day${days > 1 ? "s" : ""}`;
   else if (hours > 0) return `${hours} hr${hours > 1 ? "s" : ""}`;
   else if (minutes > 0) return `${minutes} min${minutes > 1 ? "s" : ""}`;
-  else return `${seconds} sec${seconds > 1 ? "s" : ""}`;
+  else
+    return lessThanAMinute
+      ? "less than a minute"
+      : `${seconds} sec${seconds > 1 ? "s" : ""}`;
 };
 
 /**


### PR DESCRIPTION
## Description

Git Sync feature has some loose ends, visually speaking. This PR addresses a few of those concerns.

Fixes #11558 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually for visual changes, and yarn test:unit for unit tests.

## Changes

Changes so far:

1. Faster tooltips for bottom bar quick actions
2. Branch popover has a backdrop like the modals do.
3. More than 9 changes are reported as it is
4. Recent commit shows "less than a minute" ago
5. BETA tag removed from popover
6. Faster tooltips for sync branch button in popover
7. Placeholder for commit message
8. Relevant placeholder for git remote input
9. Padding for content in modal is decreased
10. Notification banner is aligned with SSH key box

https://user-images.githubusercontent.com/1573771/157437661-0d00675f-91de-4400-aa35-d6a1475f07b2.mov

https://user-images.githubusercontent.com/1573771/157438263-904674cd-e0f0-4510-8a9c-7b14ffe08e20.mov

![Screenshot 2022-03-09 at 5 36 46 PM](https://user-images.githubusercontent.com/1573771/157438926-f1e77f26-768a-4cbc-9347-5a6799a88a07.png)

![Screenshot 2022-03-09 at 5 38 57 PM](https://user-images.githubusercontent.com/1573771/157439350-54a2a65c-281f-4e2e-a971-4cb11d2d8946.png)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: 11558-polish-git-sync 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.87 **(-0.01)** | 37.23 **(0)** | 35.25 **(0.01)** | 56.2 **(-0.01)**
 :green_circle: | app/client/src/ce/constants/messages.ts | 76.65 **(0.03)** | 100 **(0)** | 30.75 **(0.11)** | 81.96 **(0.04)**
 :green_circle: | app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx | 65.71 **(-0.64)** | 44 **(1.69)** | 34.78 **(0)** | 67.68 **(-0.69)**
 :red_circle: | app/client/src/pages/Editor/gitSync/components/BranchList.tsx | 23.49 **(-0.46)** | 10.13 **(0)** | 2.5 **(0)** | 25.5 **(-0.5)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(0)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/utils/helpers.tsx | 67.47 **(-0.47)** | 34.09 **(-0.79)** | 58.82 **(0)** | 65.64 **(-0.58)**
 :x: | ~~app/client/src/pages/Editor/gitSync/components/BetaTag.tsx~~ | ~~75~~ | ~~100~~ | ~~0~~ | ~~75~~</details>