### PR TITLE
fix: S3 plugin: provide support for MinIO 

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
@@ -6,6 +6,7 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException
 import com.appsmith.external.models.Condition;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
+import com.appsmith.external.models.Property;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.CollectionUtils;
@@ -287,5 +288,23 @@ public class PluginUtils {
 
     public static List<String> parseList(String arrayString) throws IOException {
         return objectMapper.readValue(arrayString, ArrayList.class);
+    }
+
+    public static <T> T getValueSafelyFromPropertyList(List<Property> properties, int index, Class<T> type,
+                                                       T defaultValue) {
+        if (CollectionUtils.isEmpty(properties) || index > properties.size() - 1 || properties.get(index) == null
+                || properties.get(index).getValue() == null) {
+            return defaultValue;
+        }
+
+        return (T) properties.get(index).getValue();
+    }
+
+    public static <T> T getValueSafelyFromPropertyList(List<Property> properties, int index, Class<T> type) {
+        return getValueSafelyFromPropertyList(properties, index, type, null);
+    }
+
+    public static Object getValueSafelyFromPropertyList(List<Property> properties, int index) {
+        return getValueSafelyFromPropertyList(properties, index, Object.class);
     }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/DatasourceUtils.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/utils/DatasourceUtils.java
@@ -1,8 +1,10 @@
 package com.external.utils;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
@@ -17,6 +19,7 @@ import java.util.regex.Pattern;
 
 import static com.amazonaws.regions.Regions.DEFAULT_REGION;
 import static com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError.PLUGIN_ERROR;
+import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
 import static com.external.plugins.AmazonS3Plugin.CUSTOM_ENDPOINT_INDEX;
 import static com.external.plugins.AmazonS3Plugin.CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX;
 import static com.external.plugins.AmazonS3Plugin.S3_SERVICE_PROVIDER_PROPERTY_INDEX;
@@ -59,6 +62,7 @@ public class DatasourceUtils {
         WASABI ("wasabi"),
         DIGITAL_OCEAN_SPACES ("digital-ocean-spaces"),
         DREAM_OBJECTS ("dream-objects"),
+        MINIO ("minio"),
         OTHER ("other");
 
         private String name;
@@ -184,6 +188,31 @@ public class DatasourceUtils {
                             DREAM_OBJECTS_REGION_GROUP_INDEX);
 
                     break;
+                case MINIO:
+                    region = getUserProvidedRegion(properties);
+                    if (StringUtils.isBlank(region)) {
+                        /**
+                         * Set a default region in case user has not provided a region.
+                         * Minio server can be configured to work both ways - with or without region attribute. Hence,
+                         * it is upto the user to know whether the Minio server they want to connect to has been
+                         * configured with a region or not.
+                         * As per my experimentation, in case the Minio server has not been configured with a region
+                         * attribute, then any placeholder value will work. However, I am going with US_EAST_1 here
+                         * since this the value that Minio documentation uses to show example applications.
+                         * Ref: https://docs.min.io/docs/how-to-use-aws-sdk-for-java-with-minio-server.html
+                         */
+                        region = Regions.US_EAST_1.getName();
+                    }
+
+                    ClientConfiguration clientConfiguration = new ClientConfiguration();
+                    clientConfiguration.setSignerOverride("AWSS3V4SignerType");
+
+                    /* Ref: https://docs.min.io/docs/how-to-use-aws-sdk-for-java-with-minio-server.html */
+                    s3ClientBuilder = s3ClientBuilder
+                            .withPathStyleAccessEnabled(true)
+                            .withClientConfiguration(clientConfiguration);
+
+                    break;
                 default:
                     region = (String) properties.get(CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX).getValue();
             }
@@ -193,6 +222,10 @@ public class DatasourceUtils {
         }
 
         return s3ClientBuilder;
+    }
+
+    private static String getUserProvidedRegion(List<Property> properties) {
+        return getValueSafelyFromPropertyList(properties, CUSTOM_ENDPOINT_REGION_PROPERTY_INDEX, String.class);
     }
 
     /**

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/create.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/create.json
@@ -41,7 +41,7 @@
               "value": "YES"
             },
             {
-              "label": "Text / Binary",
+              "label": "Text",
               "value": "NO"
             }
           ]

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/form.json
@@ -39,6 +39,10 @@
               "value": "dream-objects"
             },
             {
+              "label": "MinIO",
+              "value": "minio"
+            },
+            {
               "label": "Other",
               "value": "other"
             }
@@ -48,6 +52,7 @@
           "label": "Access Key",
           "configProperty": "datasourceConfiguration.authentication.username",
           "controlType": "INPUT_TEXT",
+          "isRequired": true,
           "initialValue": ""
         },
         {
@@ -56,14 +61,16 @@
           "controlType": "INPUT_TEXT",
           "dataType": "PASSWORD",
           "initialValue": "",
+          "isRequired": true,
           "encrypted": true
         },
         {
-          "label": "Endpoint URL",
+          "label": "Endpoint URL (with or without protocol and port no)",
           "configProperty": "datasourceConfiguration.endpoints[0].host",
           "controlType": "INPUT_TEXT",
           "initialValue": "",
-          "placeholderText": "user-storage.de-fra1.upcloudobjects.com",
+          "isRequired": true,
+          "placeholderText": "https://user-storage.de-fra1.upcloudobjects.com",
           "hidden": {
             "path": "datasourceConfiguration.properties[1].value",
             "comparison": "EQUALS",
@@ -84,9 +91,19 @@
           "initialValue": "",
           "placeholderText": "de-fra1",
           "hidden": {
-            "path": "datasourceConfiguration.properties[1].value",
-            "comparison": "NOT_EQUALS",
-            "value": "other"
+            "conditionType": "AND",
+            "conditions": [
+              {
+                "path": "datasourceConfiguration.properties[1].value",
+                "comparison": "NOT_EQUALS",
+                "value": "other"
+              },
+              {
+                "path": "datasourceConfiguration.properties[1].value",
+                "comparison": "NOT_EQUALS",
+                "value": "minio"
+              }
+            ]
           }
         }
       ]

--- a/app/server/appsmith-plugins/graphqlPlugin/plugin.properties
+++ b/app/server/appsmith-plugins/graphqlPlugin/plugin.properties
@@ -1,0 +1,5 @@
+plugin.id=graphql-plugin
+plugin.class=com.external.plugins.GraphQLPlugin
+plugin.version=1.0-SNAPSHOT
+plugin.provider=tech@appsmith.com
+plugin.dependencies=

--- a/app/server/appsmith-plugins/graphqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/graphqlPlugin/pom.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.appsmith</groupId>
+        <artifactId>appsmith-plugins</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.external.plugins</groupId>
+    <artifactId>graphqlPlugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>graphqlPlugin</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <plugin.id>graphql-plugin</plugin.id>
+        <plugin.class>com.external.plugins.GraphQLPlugin</plugin.class>
+        <plugin.version>1.0-SNAPSHOT</plugin.version>
+        <plugin.provider>tech@appsmith.com</plugin.provider>
+        <plugin.dependencies/>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>5.2.3.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.2.3.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>5.2.3.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.projectreactor</groupId>
+                    <artifactId>reactor-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-web</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.5.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.10.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.10.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if Gson is preferred -->
+            <version>0.11.2</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito2 -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>2.5.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.2.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <id>shade-plugin-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>false</minimizeJar>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Plugin-Id>${plugin.id}</Plugin-Id>
+                                        <Plugin-Class>${plugin.class}</Plugin-Class>
+                                        <Plugin-Version>${plugin.version}</Plugin-Version>
+                                        <Plugin-Provider>${plugin.provider}</Plugin-Provider>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.jsonwebtoken</groupId>
+                                    <artifactId>jjwt-api</artifactId>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>io.jsonwebtoken</groupId>
+                                    <artifactId>jjwt-impl</artifactId>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>io.jsonwebtoken</groupId>
+                                    <artifactId>jjwt-jackson</artifactId>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/connections/APIConnection.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/connections/APIConnection.java
@@ -1,0 +1,7 @@
+package com.external.connections;
+
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+
+// Parent type for all API connections that need to be created during datasource create method.
+public abstract class APIConnection implements ExchangeFilterFunction {
+}

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -1,0 +1,52 @@
+package com.external.plugins;
+
+import com.appsmith.external.models.ActionConfiguration;
+import com.appsmith.external.models.ActionExecutionResult;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.DatasourceTestResult;
+import com.appsmith.external.plugins.BasePlugin;
+import com.appsmith.external.plugins.PluginExecutor;
+import com.appsmith.external.plugins.SmartSubstitutionInterface;
+import com.external.connections.APIConnection;
+import lombok.extern.slf4j.Slf4j;
+import org.pf4j.Extension;
+import org.pf4j.PluginWrapper;
+import reactor.core.publisher.Mono;
+import java.util.Set;
+
+public class GraphQLPlugin extends BasePlugin {
+
+    public GraphQLPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+
+    @Slf4j
+    @Extension
+    public static class RestApiPluginExecutor implements PluginExecutor<APIConnection>, SmartSubstitutionInterface {
+
+        @Override
+        public Mono<ActionExecutionResult> execute(APIConnection connection, DatasourceConfiguration datasourceConfiguration, ActionConfiguration actionConfiguration) {
+            return null;
+        }
+
+        @Override
+        public Mono<APIConnection> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
+            return null;
+        }
+
+        @Override
+        public void datasourceDestroy(APIConnection connection) {
+
+        }
+
+        @Override
+        public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
+            return null;
+        }
+
+        @Override
+        public Mono<DatasourceTestResult> testDatasource(DatasourceConfiguration datasourceConfiguration) {
+            return null;
+        }
+    }
+}

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/resources/form.json
@@ -1,0 +1,235 @@
+{
+  "form": [
+    {
+      "sectionName": "General",
+      "children": [
+        {
+          "label": "URL",
+          "configProperty": "datasourceConfiguration.url",
+          "controlType": "INPUT_TEXT",
+          "isRequired": true,
+          "placeholderText": "https://example.com"
+        },
+        {
+          "label": "Headers",
+          "configProperty": "datasourceConfiguration.headers",
+          "controlType": "KEY_VAL_INPUT"
+        },
+        {
+          "label": "Query Params",
+          "configProperty": "datasourceConfiguration.queryParameters",
+          "controlType": "KEY_VAL_INPUT"
+        },
+        {
+          "label": "Send Authentication Information Key (Do not edit)",
+          "configProperty": "datasourceConfiguration.properties[0].key",
+          "controlType": "INPUT_TEXT",
+          "hidden": true,
+          "initialValue": "isSendSessionEnabled"
+        },
+        {
+          "label": "Send Appsmith signature header (X-APPSMITH-SIGNATURE)",
+          "configProperty": "datasourceConfiguration.properties[0].value",
+          "controlType": "DROP_DOWN",
+          "isRequired": true,
+          "initialValue": "N",
+          "options": [
+            {
+              "label": "Yes",
+              "value": "Y"
+            },
+            {
+              "label": "No",
+              "value": "N"
+            }
+          ]
+        },
+        {
+          "label": "Session Details Signature Key Key (Do not edit)",
+          "configProperty": "datasourceConfiguration.properties[1].key",
+          "controlType": "INPUT_TEXT",
+          "hidden": true,
+          "initialValue": "sessionSignatureKey"
+        },
+        {
+          "label": "Session Details Signature Key",
+          "configProperty": "datasourceConfiguration.properties[1].value",
+          "controlType": "INPUT_TEXT",
+          "hidden": {
+            "path": "datasourceConfiguration.properties[0].value",
+            "comparison": "EQUALS",
+            "value": "N"
+          }
+        },
+        {
+          "label": "Authentication Type",
+          "configProperty": "datasourceConfiguration.authentication.authenticationType",
+          "controlType": "DROP_DOWN",
+          "options": [
+            {
+              "label": "None",
+              "value": "dbAuth"
+            },
+            {
+              "label": "Basic",
+              "value": "basic"
+            },
+            {
+              "label": "OAuth 2.0",
+              "value": "oAuth2"
+            },
+            {
+              "label": "API Key",
+              "value": "apiKey"
+            },
+            {
+              "label": "Bearer Token",
+              "value": "bearerToken"
+            }
+          ]
+        },
+        {
+          "label": "Grant Type",
+          "configProperty": "datasourceConfiguration.authentication.grantType",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": true
+        },
+        {
+          "label": "Access Token URL",
+          "configProperty": "datasourceConfiguration.authentication.accessTokenUrl",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Client Id",
+          "configProperty": "datasourceConfiguration.authentication.clientId",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Client Secret",
+          "configProperty": "datasourceConfiguration.authentication.clientSecret",
+          "dataType": "PASSWORD",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Scope(s)",
+          "configProperty": "datasourceConfiguration.authentication.scopeString",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Header Prefix",
+          "configProperty": "datasourceConfiguration.authentication.headerPrefix",
+          "controlType": "INPUT_TEXT",
+          "placeholderText": "Bearer (default)",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Add token to",
+          "configProperty": "datasourceConfiguration.authentication.isTokenHeader",
+          "controlType": "DROP_DOWN",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          },
+          "options": [
+            {
+              "label": "Header",
+              "value": true
+            },
+            {
+              "label": "Query parameters",
+              "value": false
+            }
+          ]
+        },
+        {
+          "label": "Audience(s)",
+          "configProperty": "datasourceConfiguration.authentication.audience",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Resource(s)",
+          "configProperty": "datasourceConfiguration.authentication.resource",
+          "controlType": "INPUT_TEXT",
+          "isRequired": false,
+          "hidden": {
+            "path": "datasourceConfiguration.authentication.authenticationType",
+            "comparison": "NOT_EQUALS",
+            "value": "oAuth2"
+          }
+        },
+        {
+          "label": "Send scope with refresh token",
+          "configProperty": "datasourceConfiguration.authentication.sendScopeWithRefreshToken",
+          "controlType": "DROP_DOWN",
+          "isRequired": true,
+          "initialValue": false,
+          "options": [
+            {
+              "label": "Yes",
+              "value": true
+            },
+            {
+              "label": "No",
+              "value": false
+            }
+          ]
+        },
+        {
+          "label": "Send client credentials with (on refresh token)",
+          "configProperty": "datasourceConfiguration.authentication.refreshTokenClientCredentialsLocation",
+          "controlType": "DROP_DOWN",
+          "isRequired": true,
+          "initialValue": "BODY",
+          "options": [
+            {
+              "label": "Body",
+              "value": "BODY"
+            },
+            {
+              "label": "Header",
+              "value": "HEADER"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/app/server/appsmith-plugins/pom.xml
+++ b/app/server/appsmith-plugins/pom.xml
@@ -69,6 +69,7 @@
         <module>redshiftPlugin</module>
         <module>amazons3Plugin</module>
         <module>googleSheetsPlugin</module>
+        <module>graphqlPlugin</module>
         <module>snowflakePlugin</module>
         <module>arangoDBPlugin</module>
         <module>jsPlugin</module>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -110,12 +110,12 @@ public class DatabaseChangelog2 {
     public void addArangoDBPlugin(MongockTemplate mongoTemplate) {
         Plugin plugin = new Plugin();
         plugin.setName("GraphQL");
-        plugin.setType(PluginType.DB); // TODO: make it API
+        plugin.setType(PluginType.API);
         plugin.setPackageName("graphql-plugin");
-        plugin.setUiComponent("DbEditorForm"); // TODO: make it ApiEditorForm
-        plugin.setDatasourceComponent("AutoForm"); // TODO: make it GraphQLDatasourceFOrm
+        plugin.setUiComponent("ApiEditorForm"); // TODO: make it ApiEditorForm -> GraphQLEditorForm
+        plugin.setDatasourceComponent("AutoForm");
         plugin.setResponseType(Plugin.ResponseType.JSON);
-        plugin.setIconLocation("https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg"); // TODO: upload
+        plugin.setIconLocation("https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg"); // TODO: update
         plugin.setDocumentationLink("https://docs.appsmith.com/datasource-reference/querying-graphql-db");
         plugin.setDefaultInstall(true);
         try {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -1,20 +1,29 @@
 package com.appsmith.server.migrations;
 
 import com.appsmith.server.domains.NewAction;
+import com.appsmith.server.domains.Organization;
+import com.appsmith.server.domains.OrganizationPlugin;
 import com.appsmith.server.domains.Plugin;
+import com.appsmith.server.domains.PluginType;
 import com.appsmith.server.domains.QNewAction;
 import com.appsmith.server.domains.QPlugin;
 import com.appsmith.server.dtos.ActionDTO;
+import com.appsmith.server.dtos.OrganizationPluginStatus;
 import com.github.cloudyrock.mongock.ChangeLog;
 import com.github.cloudyrock.mongock.ChangeSet;
 import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl.MongockTemplate;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.util.CollectionUtils;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.appsmith.server.repositories.BaseAppsmithRepositoryImpl.fieldName;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -76,6 +85,46 @@ public class DatabaseChangelog2 {
                     NewAction.class
             );
         }
+    }
+
+    // TODO: refactor to avoid duplication
+    private void installPluginToAllOrganizations(MongockTemplate mongockTemplate, String pluginId) {
+        for (Organization organization : mongockTemplate.findAll(Organization.class)) {
+            if (CollectionUtils.isEmpty(organization.getPlugins())) {
+                organization.setPlugins(new HashSet<>());
+            }
+
+            final Set<String> installedPlugins = organization.getPlugins()
+                    .stream().map(OrganizationPlugin::getPluginId).collect(Collectors.toSet());
+
+            if (!installedPlugins.contains(pluginId)) {
+                organization.getPlugins()
+                        .add(new OrganizationPlugin(pluginId, OrganizationPluginStatus.FREE));
+            }
+
+            mongockTemplate.save(organization);
+        }
+    }
+
+    @ChangeSet(order = "003", id = "add-graphql-plugin", author = "")
+    public void addArangoDBPlugin(MongockTemplate mongoTemplate) {
+        Plugin plugin = new Plugin();
+        plugin.setName("GraphQL");
+        plugin.setType(PluginType.DB); // TODO: make it API
+        plugin.setPackageName("graphql-plugin");
+        plugin.setUiComponent("DbEditorForm"); // TODO: make it ApiEditorForm
+        plugin.setDatasourceComponent("AutoForm"); // TODO: make it GraphQLDatasourceFOrm
+        plugin.setResponseType(Plugin.ResponseType.JSON);
+        plugin.setIconLocation("https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg"); // TODO: upload
+        plugin.setDocumentationLink("https://docs.appsmith.com/datasource-reference/querying-graphql-db");
+        plugin.setDefaultInstall(true);
+        try {
+            mongoTemplate.insert(plugin);
+        } catch (DuplicateKeyException e) {
+            log.warn(plugin.getPackageName() + " already present in database.");
+        }
+
+        installPluginToAllOrganizations(mongoTemplate, plugin.getId());
     }
 
 }


### PR DESCRIPTION
## Description
- Allow S3 plugin to connect with MinIO instance when 
  - over unsecured connection (http)
  - when secured via CA signed certificate (https)
- Note: Even with this change S3 plugin will not support secured connection over self signed certificates. This issue is tracked via <>. It will be taken up via a different PR. 

Fixes #11685 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
