### PR TITLE
fix: Fix special char handling in pre-define env

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -27,8 +27,8 @@ init_env_file() {
     bash "$TEMPLATES_PATH/docker.env.sh" "$APPSMITH_MONGODB_USER" "$APPSMITH_MONGODB_PASSWORD" "$APPSMITH_ENCRYPTION_PASSWORD" "$APPSMITH_ENCRYPTION_SALT" > "$ENV_PATH"
   fi
 
-  printenv | grep -E '^APPSMITH_|^MONGO_' > "$TEMPLATES_PATH/pre-define.env"
-
+  # Build an env file with current env variables. We single-quote the values, as well as escaping any single-quote characters.
+  printenv | grep -E '^APPSMITH_|^MONGO_' | sed "s/'/'\"'\"'/; s/=/='/; s/$/'/" > "$TEMPLATES_PATH/pre-define.env"
 
   echo "Load environment configuration"
   set -o allexport


### PR DESCRIPTION
When starting the fat container with `APPSMITH_MONGODB_URI` variable set to a value that has query params, like `mongodb+srv://user:pass@appsmith.abcde.mongodb.net/testdb?retryWrites=true&w=majority`, then the fat container ignores it and goes ahead with using a local MongoDB server.

The problem is that we generated a `pre-define.env` file, that gets the following line (among many others like it):

```sh
APPSMITH_MONGODB_URI=mongodb+srv://user:pass@appsmith.abcde.mongodb.net/testdb?retryWrites=true&w=majority
```

This file is then sourced with `. pre-define.env`. When this runs, this file is evaluated like a shell script, and the shell's glob based file-name expansions take affect.

So for this line, the shell looks for a file that looks _like_ `mongodb+srv://user:pass@appsmith.abcde.mongodb.net/testdb?retryWrites=true&w=majority`, where there's any letter in place of the `?`, which is the glob definition of `?` character. Since it doesn't find any such files, it will turn this line into just `APPSMITH_MONGODB_URI=`, indicating that there's no files to expand the glob pattern into.

Now since the `APPSMITH_MONGODB_URI` is set to empty value, the fat container will proceed to use it's local MongoDB just fine.

This can be avoided by wrapping the value in quotes. Like

```sh
APPSMITH_MONGODB_URI='mongodb+srv://user:pass@appsmith.abcde.mongodb.net/testdb?retryWrites=true&w=majority'
```

In this case, the shell will take the value verbatim and won't attempt to do glob expansion (or any potential variable expansion, if the value has any `$` characters in it).

This PR adds a `sed` transformation to the generation of `pre-define.env` that:

1. Replaces `'` in each line with `'"'"'`, which is _kind of_ an escaped single-quote, in a single-quoted string.
2. Adds a `'` just after the `=` sign on each line.
3. Adds a `'` at the end of each line.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```sh
> export z="a'b=d?x"
> printenv | sed "s/'/'\"'\"'/; s/=/='/; s/$/'/" | grep '^z'
z='a'"'"'b=d?x'
```
