### PR TITLE
Add action name to confirmation modal

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -937,7 +937,7 @@ export const WELCOME_FORM_NON_SUPER_USER_ROLE = () => "Role";
 export const WELCOME_FORM_NON_SUPER_USER_USE_CASE = () =>
   "What are you planning to use Appsmith for?";
 export const QUERY_CONFIRMATION_MODAL_MESSAGE = () =>
-  "Are you sure you want to perform this action?";
+  `Are you sure you want to run `;
 export const ENTITY_EXPLORER_TITLE = () => "NAVIGATION";
 export const MULTI_SELECT_PROPERTY_PANE_MESSAGE = () =>
   `Select a widget to see it's properties`;

--- a/app/client/src/components/ads/DialogComponent.tsx
+++ b/app/client/src/components/ads/DialogComponent.tsx
@@ -10,6 +10,7 @@ const StyledDialog = styled(Dialog)<{
   maxHeight?: string;
   maxWidth?: string;
   showHeaderUnderline?: boolean;
+  noModalBodyMarginTop?: boolean;
 }>`
   && {
     border-radius: 0;
@@ -78,7 +79,7 @@ const StyledDialog = styled(Dialog)<{
 
     & .${Classes.DIALOG_BODY} {
       margin: 0;
-      margin-top: 24px;
+      margin-top: ${(props) => (props.noModalBodyMarginTop ? "0px" : "24px")};
       overflow: auto;
     }
 
@@ -120,6 +121,7 @@ type DialogComponentProps = {
   canEscapeKeyClose?: boolean;
   className?: string;
   maxWidth?: string;
+  noModalBodyMarginTop?: boolean;
 };
 
 export function DialogComponent(props: DialogComponentProps) {
@@ -170,6 +172,7 @@ export function DialogComponent(props: DialogComponentProps) {
         isOpen={isOpen}
         maxHeight={props.maxHeight}
         maxWidth={props.maxWidth}
+        noModalBodyMarginTop={props.noModalBodyMarginTop}
         onClose={onClose}
         onOpening={props.onOpening}
         setMaxWidth={props.setMaxWidth}

--- a/app/client/src/pages/Editor/RequestConfirmationModal.tsx
+++ b/app/client/src/pages/Editor/RequestConfirmationModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "actions/pluginActionActions";
 import DialogComponent from "components/ads/DialogComponent";
 import styled from "styled-components";
-import Button, { Category, Size } from "components/ads/Button";
+import Button, { Category } from "components/ads/Button";
 import {
   createMessage,
   QUERY_CONFIRMATION_MODAL_MESSAGE,
@@ -85,34 +85,38 @@ class RequestConfirmationModal extends React.Component<Props> {
             isOpen={modalInfo?.modalOpen}
             key={index}
             maxHeight={"80vh"}
+            noModalBodyMarginTop
             onClose={() => this.handleClose(modalInfo)}
-            title="Confirm Action"
+            title="Confirmation Dialog"
             width={"580px"}
           >
             <ModalBody>
-              {createMessage(QUERY_CONFIRMATION_MODAL_MESSAGE)}
+              {createMessage(QUERY_CONFIRMATION_MODAL_MESSAGE)}{" "}
+              <b>{modalInfo.name}</b> ?
             </ModalBody>
             <ModalFooter>
               <Button
                 category={Category.tertiary}
                 cypressSelector="t--cancel-modal-btn"
+                height="40"
                 onClick={() => {
                   dispatch(cancelActionConfirmationModal(modalInfo.name));
                   this.handleClose(modalInfo);
                 }}
-                size={Size.medium}
                 tag="button"
-                text="Cancel"
+                text="No"
                 type="button"
+                width="136px"
               />
               <Button
                 category={Category.primary}
                 cypressSelector="t--confirm-modal-btn"
+                height="40"
                 onClick={() => this.onConfirm(modalInfo)}
-                size={Size.medium}
                 tag="button"
-                text="Confirm"
+                text="Yes"
                 type="button"
+                width="136px"
               />
             </ModalFooter>
           </DialogComponent>


### PR DESCRIPTION
This PR introduces an action name to the run action confirmation modal. Prior to this PR the run action confirmation modal message was generic and did nothing to indicate what action the modal confirmation is for. This PR fixes that.

<img width="1440" alt="Screen Shot 2022-03-11 at 6 07 25 PM" src="https://user-images.githubusercontent.com/37867493/157915445-f1f208bf-61c4-451e-a760-d93c4280afcb.png">

Fixes #10713 

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
