### PR TITLE
fix: Match iframe by object not origin.

### DIFF
--- a/app/client/src/widgets/IframeWidget/component/index.tsx
+++ b/app/client/src/widgets/IframeWidget/component/index.tsx
@@ -75,16 +75,25 @@ function IframeComponent(props: IframeComponentProps) {
     widgetId,
   } = props;
 
+  const frameRef = useRef<HTMLIFrameElement>(null);
+
   const isFirstRender = useRef(true);
 
   const [message, setMessage] = useState("");
 
   useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const iframeWindow =
+        frameRef.current?.contentWindow ||
+        frameRef.current?.contentDocument?.defaultView;
+      // Accept messages only from the current iframe
+      if (event.source !== iframeWindow) return;
+      onMessageReceived(event);
+    };
     // add a listener
-    window.addEventListener("message", onMessageReceived, false);
+    window.addEventListener("message", handler, false);
     // clean up
-    return () =>
-      window.removeEventListener("message", onMessageReceived, false);
+    return () => window.removeEventListener("message", handler, false);
   }, []);
 
   useEffect(() => {
@@ -129,9 +138,9 @@ function IframeComponent(props: IframeComponentProps) {
       {message ? (
         message
       ) : srcDoc ? (
-        <iframe src={source} srcDoc={srcDoc} title={title} />
+        <iframe ref={frameRef} src={source} srcDoc={srcDoc} title={title} />
       ) : (
-        <iframe src={source} title={title} />
+        <iframe ref={frameRef} src={source} title={title} />
       )}
     </IframeContainer>
   );

--- a/app/client/src/widgets/IframeWidget/widget/index.tsx
+++ b/app/client/src/widgets/IframeWidget/widget/index.tsx
@@ -162,11 +162,6 @@ class IframeWidget extends BaseWidget<IframeWidgetProps, WidgetState> {
   };
 
   handleMessageReceive = (event: MessageEvent) => {
-    // Accept messages only from the current iframe
-    if (!this.props.source?.includes(event.origin)) {
-      return;
-    }
-
     this.props.updateWidgetMetaProperty("message", event.data, {
       triggerPropertyName: "onMessageReceived",
       dynamicString: this.props.onMessageReceived,


### PR DESCRIPTION
## Description

This PR moves to comparing the actual iframe contentwindow object with the postmessage source to invoke the onMessageReceived callback. This allows multiple iframes with same origin to keep their messages separate, as well as allows srcDocs to have postmessage in their code as well.

Fixes #11779 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Please note that even though #11779 only describes the srcDoc use case, it seems from the code that having multiple iframes with same origin will also be buggy with the existing implementation.

## How Has This Been Tested?

Brought up locally connecting to appsmith staging server, and tested the examples given in #11779 as well as the case where we have multiple iframes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
