### PR TITLE
chore: Add asterisk for mandatory fields

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/authentication/index.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication/index.tsx
@@ -85,6 +85,7 @@ const Google_Auth: AdminConfigType = {
       controlType: SettingTypes.TEXTINPUT,
       controlSubType: SettingSubtype.TEXT,
       label: "Client ID",
+      isRequired: true,
     },
     {
       id: "APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET",
@@ -93,6 +94,7 @@ const Google_Auth: AdminConfigType = {
       controlType: SettingTypes.TEXTINPUT,
       controlSubType: SettingSubtype.TEXT,
       label: "Client Secret",
+      isRequired: true,
     },
     {
       id: "APPSMITH_SIGNUP_ALLOWED_DOMAINS",
@@ -130,6 +132,7 @@ const Github_Auth: AdminConfigType = {
       controlType: SettingTypes.TEXTINPUT,
       controlSubType: SettingSubtype.TEXT,
       label: "Client ID",
+      isRequired: true,
     },
     {
       id: "APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET",
@@ -138,6 +141,7 @@ const Github_Auth: AdminConfigType = {
       controlType: SettingTypes.TEXTINPUT,
       controlSubType: SettingSubtype.TEXT,
       label: "Client Secret",
+      isRequired: true,
     },
   ],
 };

--- a/app/client/src/ce/pages/AdminSettings/config/types.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/types.ts
@@ -49,6 +49,7 @@ export interface Setting {
   isDisabled?: (values: Record<string, any>) => boolean;
   calloutType?: "Info" | "Warning";
   advanced?: Setting[];
+  isRequired?: boolean;
 }
 
 export interface Category {

--- a/app/client/src/components/ads/TagInputComponent.tsx
+++ b/app/client/src/components/ads/TagInputComponent.tsx
@@ -68,19 +68,22 @@ type TagInputProps = {
  * @param props : TagInputProps
  */
 function TagInputComponent(props: TagInputProps) {
-  const _values =
+  const inputValues =
     props.input.value && props.input.value.length > 0
       ? props.input.value.split(",")
       : [];
 
-  const [values, setValues] = useState<string[]>(_values || []);
+  const [values, setValues] = useState<string[]>(inputValues || []);
   const [currentValue, setCurrentValue] = useState<string>("");
 
   useEffect(() => {
-    if (_values.length === 0 && values.length > 0) {
+    if (inputValues.length === 0 && values.length > 0) {
       setValues([]);
     }
-  }, [_values, values]);
+    if (inputValues.length > 0 && values.length === 0) {
+      setValues(inputValues);
+    }
+  }, [inputValues, values]);
 
   const validateEmail = (newValues: string[]) => {
     if (newValues && newValues.length > 0) {
@@ -167,7 +170,7 @@ function TagInputComponent(props: TagInputProps) {
         tagProps={{
           round: true,
         }}
-        values={_values || [""]}
+        values={inputValues || [""]}
       />
     </TagInputWrapper>
   );

--- a/app/client/src/components/ads/TextInput.tsx
+++ b/app/client/src/components/ads/TextInput.tsx
@@ -153,6 +153,7 @@ const StyledInput = styled((props) => {
     "useTextArea",
     "border",
     "asyncControl",
+    "handleCopy",
   ];
 
   const HtmlTag = props.useTextArea ? "textarea" : "input";

--- a/app/client/src/pages/Settings/FormGroup/Common.tsx
+++ b/app/client/src/pages/Settings/FormGroup/Common.tsx
@@ -51,6 +51,11 @@ export const StyledSubtext = styled.p`
   color: ${Colors.GRAY};
 `;
 
+export const StyledAsterisk = styled.span`
+  color: ${Colors.ERROR_RED};
+  margin-left: 2px;
+`;
+
 export function FormGroup({ children, className, setting }: FieldHelperProps) {
   return (
     <StyledFormGroup
@@ -60,6 +65,7 @@ export function FormGroup({ children, className, setting }: FieldHelperProps) {
       <StyledLabel data-testid="admin-settings-form-group-label">
         {createMessage(() => setting.label || "")}
       </StyledLabel>
+      {setting.isRequired && <StyledAsterisk>*</StyledAsterisk>}
       {setting.helpText && (
         <Tooltip content={createMessage(() => setting.helpText || "")}>
           <StyledIcon


### PR DESCRIPTION
## Description

> Add asterisk for mandatory fields to give users a better User experience on the Admin settings page.

Fixes #11824 

## Type of change

- Updating UX

## How Has This Been Tested?

- Tested UI for Admin settings page to show asterisk on all mandatory fields.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: chore/mandatory-fields 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.88 **(0)** | 37.24 **(0.01)** | 35.22 **(0)** | 56.19 **(0)**
 :red_circle: | app/client/src/components/ads/TagInputComponent.tsx | 12.7 **(-0.41)** | 3.77 **(-0.31)** | 0 **(0)** | 13.56 **(-0.48)**
 :red_circle: | app/client/src/pages/Settings/FormGroup/Common.tsx | 100 **(0)** | 86.36 **(-2.53)** | 100 **(0)** | 100 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**</details>