### PR TITLE
fix: Fix removal of env variables not working in NGINX

### DIFF
--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -33,7 +33,7 @@ const fs = require("fs")
 const indexPath = "/opt/appsmith/index.html.original"
 const content = fs.readFileSync(indexPath, "utf8").replace(
 	/\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
-	(placeholder, name) => (process.env[name] || placeholder)
+	(placeholder, name) => (process.env[name] || "")
 )
 fs.writeFileSync(indexPath, content)
 '

--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -24,18 +24,19 @@ fi
 
 bash "$APP_TEMPLATE" "$APPSMITH_CUSTOM_DOMAIN" > /etc/nginx/sites-available/default
 
-if [[ ! -f /opt/appsmith/editor/.index.html.original ]]; then
-  cp -v /opt/appsmith/editor/index.html /opt/appsmith/index.html.original
+index_html_served=/opt/appsmith/editor/index.html
+index_html_original=/opt/appsmith/index.html.original
+if [[ ! -f $index_html_original ]]; then
+  cp -v "$index_html_served" "$index_html_original"
 fi
 
 node -e '
 const fs = require("fs")
-const indexPath = "/opt/appsmith/index.html.original"
-const content = fs.readFileSync(indexPath, "utf8").replace(
+const content = fs.readFileSync("'"$index_html_original"'", "utf8").replace(
 	/\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
 	(placeholder, name) => (process.env[name] || "")
 )
-fs.writeFileSync(indexPath, content)
+fs.writeFileSync("'"$index_html_served"'", content)
 '
 
 exec nginx -g "daemon off;"

--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -24,9 +24,13 @@ fi
 
 bash "$APP_TEMPLATE" "$APPSMITH_CUSTOM_DOMAIN" > /etc/nginx/sites-available/default
 
+if [[ ! -f /opt/appsmith/editor/.index.html.original ]]; then
+  cp -v /opt/appsmith/editor/index.html /opt/appsmith/index.html.original
+fi
+
 node -e '
 const fs = require("fs")
-const indexPath = "/opt/appsmith/editor/index.html"
+const indexPath = "/opt/appsmith/index.html.original"
 const content = fs.readFileSync(indexPath, "utf8").replace(
 	/\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
 	(placeholder, name) => (process.env[name] || placeholder)


### PR DESCRIPTION
When interpolating env variables in the index.html file, we are overwriting the index.html file with placehoders and are doing this everytime there is a change.

This means if an env variable is _added_, it's value will be interpolated. But if one is modified or removed, this doesn't affect anything, since the placeholder is lost and there is no way for us to affect this change.

This PR fixed the problem by keeping a copy of the original index.html on first-start, and using that to interpolate every time.

Fixes #11848
