### PR TITLE
chore: removed api calls to fetch default docs from github

### DIFF
--- a/app/client/src/components/editorComponents/GlobalSearch/index.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/index.tsx
@@ -32,7 +32,6 @@ import {
   getItemTitle,
   getItemPage,
   SEARCH_ITEM_TYPES,
-  useDefaultDocumentationResults,
   DocSearchItem,
   SearchItem,
   algoliaHighlightTag,
@@ -206,7 +205,6 @@ function GlobalSearch() {
   const refinements = useSelector(
     (state: AppState) => state.ui.globalSearch.filterContext.refinements,
   );
-  const defaultDocs = useDefaultDocumentationResults(modalOpen);
   const params = useParams<ExplorerURLParams>();
   const applicationId = useSelector(getCurrentApplicationId);
 
@@ -322,9 +320,7 @@ function GlobalSearch() {
       ];
     }
     if (isDocumentation(category) || isMenu(category)) {
-      documents = query
-        ? documentationSearchResults
-        : defaultDocs.concat(documentationSearchResults);
+      documents = documentationSearchResults;
     }
     if (isNavigation(category) || isDocumentation(category)) {
       currentSnippets = [];


### PR DESCRIPTION
## Description
The top 5 results on omnibar documentation search are default docs fetched from github (raw githug api). Removing this since we are fetching this from algolia itself by adding a "isDefault" attribute to these docs.

### Fixes #11857
### Fixes #11611 


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: chore/remove-def-docs 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.86 **(-0.02)** | 37.23 **(-0.01)** | 35.18 **(-0.04)** | 56.17 **(-0.02)**
 :red_circle: | app/client/src/components/editorComponents/GlobalSearch/githubHelper.ts | 23.53 **(-23.53)** | 0 **(-50)** | 0 **(-100)** | 23.08 **(-23.07)**
 :red_circle: | app/client/src/components/editorComponents/GlobalSearch/index.tsx | 52.35 **(-0.17)** | 16.84 **(-0.35)** | 34.48 **(0)** | 54.8 **(-0.18)**
 :red_circle: | app/client/src/components/editorComponents/GlobalSearch/utils.tsx | 60.67 **(-6.66)** | 21.6 **(-2.4)** | 46.43 **(-7.14)** | 61.98 **(-4.96)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>