### PR TITLE
fix: onboarding not starting from intro modal

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/GuidedTour_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Onboarding/GuidedTour_spec.js
@@ -1,7 +1,17 @@
 const guidedTourLocators = require("../../../../locators/GuidedTour.json");
+const onboardingLocators = require("../../../../locators/FirstTimeUserOnboarding.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
 
 describe("Guided Tour", function() {
+  it("Guided tour should work when started from the editor", function() {
+    cy.generateUUID().then((uid) => {
+      cy.Signup(`${uid}@appsmith.com`, uid);
+    });
+    cy.get(onboardingLocators.introModalWelcomeTourBtn).should("be.visible");
+    cy.get(onboardingLocators.introModalWelcomeTourBtn).click();
+    cy.get(onboardingLocators.welcomeTourBtn).should("be.visible");
+  });
+
   it("Guided Tour", function() {
     // Start guided tour
     cy.get(commonlocators.homeIcon).click({ force: true });

--- a/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
+++ b/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
@@ -214,7 +214,7 @@ export default function IntroductionModal({ close }: IntroductionModalProps) {
             <div>
               <StyledButton
                 category={Category.tertiary}
-                className="t--introduction-modal-build-button my-6"
+                className="t--introduction-modal-welcome-tour-button my-6"
                 onClick={() => triggerWelcomeTour(dispatch)}
                 size={Size.large}
                 tag="button"

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -392,7 +392,6 @@ export function* initializeAppViewerSaga(
 }
 
 function* resetEditorSaga() {
-  yield put(resetEditorSuccess());
   yield put(resetRecentEntities());
   // End guided tour once user exits editor
   yield put(enableGuidedTour(false));
@@ -401,6 +400,7 @@ function* resetEditorSaga() {
   // might end up in preview mode if they were in preview mode
   // previously
   yield put(setPreviewModeAction(false));
+  yield put(resetEditorSuccess());
 }
 
 export function* waitForInit() {

--- a/app/client/src/sagas/OnboardingSagas.ts
+++ b/app/client/src/sagas/OnboardingSagas.ts
@@ -42,6 +42,7 @@ import {
 import {
   getCurrentApplicationId,
   getCurrentPageId,
+  getIsEditorInitialized,
 } from "selectors/editorSelectors";
 import { WidgetProps } from "widgets/BaseWidget";
 import { getNextWidgetName } from "./WidgetOperationUtils";
@@ -73,6 +74,12 @@ import { GuidedTourEntityNames } from "pages/Editor/GuidedTour/constants";
 import { navigateToCanvas } from "pages/Editor/Explorer/Widgets/utils";
 
 function* createApplication() {
+  // If we are starting onboarding from the editor wait for the editor to reset.
+  const isEditorInitialised = yield select(getIsEditorInitialized);
+  if (isEditorInitialised) {
+    yield take(ReduxActionTypes.RESET_EDITOR_SUCCESS);
+  }
+
   const userOrgs: Organization[] = yield select(getOnboardingOrganisations);
   const currentUser = yield select(getCurrentUser);
   const currentOrganizationId = currentUser.currentOrganizationId;


### PR DESCRIPTION

## Description

This broke after https://github.com/appsmithorg/appsmith/pull/11084. The [onboarding flow](https://github.com/appsmithorg/appsmith/blob/release/app/client/src/sagas/OnboardingSagas.ts#L75) was starting before the editor being reset, hence once the onboarding started it immediately gets terminated when the editor is being reset. 

The fix for this is to wait for editor being reset when we starting onboarding from the editor. Also we mark reset editor as success after all actions has been dispatched.

Fixes #11831 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/onboarding-not-starting 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.88 **(0)** | 37.24 **(0)** | 35.22 **(0)** | 56.19 **(-0.01)**
 :red_circle: | app/client/src/sagas/OnboardingSagas.ts | 21.62 **(-0.6)** | 1.19 **(-0.04)** | 4.35 **(0)** | 24.43 **(-0.57)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>