### PR TITLE
fix: Button Icon Alignment on Icon Change

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Button_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Button_spec.js
@@ -8,6 +8,8 @@ const modalWidgetPage = require("../../../../locators/ModalWidget.json");
 const datasource = require("../../../../locators/DatasourcesEditor.json");
 const queryLocators = require("../../../../locators/QueryEditor.json");
 
+const iconAlignmentProperty = ".t--property-control-iconalignment";
+
 describe("Button Widget Functionality", function() {
   before(() => {
     cy.addDsl(dsl);
@@ -15,6 +17,52 @@ describe("Button Widget Functionality", function() {
 
   beforeEach(() => {
     cy.openPropertyPane("buttonwidget");
+  });
+
+  it("Icon alignment should not change when changing the icon", () => {
+    // Add an icon
+    cy.get(".t--property-control-icon .bp3-icon-caret-down").click({
+      force: true,
+    });
+
+    cy.get(".bp3-icon-add")
+      .first()
+      .click({
+        force: true,
+      });
+
+    // Assert if the icon exists
+    cy.get(`${widgetsPage.buttonWidget} .bp3-icon-add`).should("exist");
+    // Change icon alignment to right
+    cy.get(`${iconAlignmentProperty} .t--button-tab-right`)
+      .last()
+      .click({
+        force: true,
+      });
+    cy.wait(200);
+    // Assert if the icon appears on the right hand side of the button text
+    cy.get(widgetsPage.buttonWidget)
+      .contains("Submit")
+      .children("span")
+      .should("have.length", 2);
+    cy.get(`${widgetsPage.buttonWidget} span.bp3-button-text`)
+      .next()
+      .should("have.class", "bp3-icon-add");
+    // Change the existing icon
+    cy.get(".t--property-control-icon .bp3-icon-caret-down").click({
+      force: true,
+    });
+    cy.get(".bp3-icon-airplane")
+      .first()
+      .click({
+        force: true,
+      });
+    // Assert if the icon changes
+    // Assert if the icon still exists on the right side of the text
+    cy.get(`${widgetsPage.buttonWidget} .bp3-icon-airplane`)
+      .should("exist")
+      .prev()
+      .should("have.text", "Submit");
   });
 
   it("Button-Color Validation", function() {

--- a/app/client/src/widgets/ButtonWidget/widget/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/widget/index.tsx
@@ -259,6 +259,7 @@ class ButtonWidget extends BaseWidget<ButtonWidgetProps, ButtonWidgetState> {
               }
               return propertiesToUpdate;
             },
+            dependencies: ["iconAlign"],
             validation: {
               type: ValidationTypes.TEXT,
             },


### PR DESCRIPTION
## Description
- Button Icon Alignment resets to `Alignment.Left` after we select a new icon. Fix was simple the `IconName` property with an updatehook was missing - `dependencies: ["iconAlign"]`

Fixes #11808 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested Manually on the Canvas.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/button-icon-alignment 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.88 **(0)** | 37.25 **(0.01)** | 35.22 **(0)** | 56.2 **(0.01)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**
 :green_circle: | app/client/src/utils/helpers.tsx | 68.14 **(0.34)** | 34.44 **(0.55)** | 58.49 **(0)** | 66.38 **(0.44)**</details>