### PR TITLE
fix: do not show errors for private widgets

### DIFF
--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -544,8 +544,11 @@ export const addErrorToEntityProperty = (
   path: string,
 ) => {
   const { entityName, propertyPath } = getEntityNameAndPropertyPath(path);
+  const isPrivateEntityPath = getAllPrivateWidgetsInDataTree(dataTree)[
+    entityName
+  ];
   const logBlackList = _.get(dataTree, `${entityName}.logBlackList`, {});
-  if (propertyPath && !(propertyPath in logBlackList)) {
+  if (propertyPath && !(propertyPath in logBlackList) && !isPrivateEntityPath) {
     const existingErrors = _.get(
       dataTree,
       `${entityName}.${EVAL_ERROR_PATH}['${propertyPath}']`,


### PR DESCRIPTION
## Description

Valid errors in `list widget` children are captured in the list widget itself. These errors are captured in `listwidget.template` . The private widgets (List widget children) add redundant errors to the debugger, sometimes these errors are wrong (`currentItem not defined`) because these widgets do not have access to currentItem and currentIndex during evaluations. For example, when there is an error in `Button1` widget present in the list widget, 

Before 

<img width="1276" alt="Screenshot 2022-03-15 at 21 19 05" src="https://user-images.githubusercontent.com/46670083/158464914-20fddbaa-ece9-43ef-9a62-7f7daf84e43e.png">

Now


<img width="1281" alt="Screenshot 2022-03-15 at 21 19 44" src="https://user-images.githubusercontent.com/46670083/158465055-28b774f4-e1f0-46a8-803c-670de616150b.png">

Fixes #8677 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Functions used have been unit tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/currentItem-not-defined 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.88 **(0)** | 37.25 **(0.01)** | 35.22 **(0)** | 56.2 **(0.01)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**
 :green_circle: | app/client/src/workers/evaluationUtils.ts | 59.4 **(0.1)** | 58.79 **(0.2)** | 65.63 **(0)** | 58.92 **(0.11)**</details>