### PR TITLE
chore: Revert "fix: numeric type input widget should accept zero after decim…

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Inputv2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Inputv2_spec.js
@@ -32,303 +32,65 @@ describe("Input widget V2 - ", () => {
 
   it("3. Validate DataType - TEXT can be entered into Input widget", () => {
     [
-      {
-        input: "test",
-        expected: "test:test:true",
-      },
-      {
-        input: "test123",
-        expected: "test123:test123:true",
-      },
-      {
-        input: "123",
-        expected: "123:123:true",
-      },
-      {
-        input: "",
-        expected: "::true",
-      },
-      {
-        input: "$100.22",
-        expected: "$100.22:$100.22:true",
-      },
-      {
-        input: "test@appsmith.com",
-        expected: "test@appsmith.com:test@appsmith.com:true",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
+      "test:test:true",
+      "test123:test123:true",
+      "123:123:true",
+      "::true",
+      "$100.22:$100.22:true",
+      "test@appsmith.com:test@appsmith.com:true",
+    ].forEach((text) => enterAndTest(text.split(":")[0], text));
 
     cy.openPropertyPane(widgetName);
 
-    //required: on
     cy.get(".t--property-control-required label")
       .last()
       .click({ force: true });
 
     [
-      {
-        input: "test",
-        expected: "test:test:true",
-      },
-      {
-        input: "test123",
-        expected: "test123:test123:true",
-      },
-      {
-        input: "123",
-        expected: "123:123:true",
-      },
-      {
-        input: "-",
-        expected: "-:-:true",
-      },
-      {
-        input: "",
-        expected: "::false",
-      },
-      {
-        input: "$100.22",
-        expected: "$100.22:$100.22:true",
-      },
-      {
-        input: "test@appsmith.com",
-        expected: "test@appsmith.com:test@appsmith.com:true",
-      },
-      {
-        input: "",
-        expected: "::false",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
+      "test:test:true",
+      "test123:test123:true",
+      "123:123:true",
+      "-:-:true",
+      "::false",
+      "$100.22:$100.22:true",
+      "test@appsmith.com:test@appsmith.com:true",
+    ].forEach((text) => enterAndTest(text.split(":")[0], text));
   });
 
   it("4. Validate DataType - NUMBER can be entered into Input widget", () => {
     cy.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype", "Number");
     [
-      {
-        input: "invalid",
-        expected: "null:null:false",
-      },
-      {
-        input: "invalid123",
-        expected: "123:123:true",
-      },
-      {
-        input: "123",
-        expected: "123:123:true",
-      },
-      {
-        input: "-",
-        expected: "null:null:false",
-      },
-      {
-        input: "",
-        expected: "null:null:false",
-      },
-      {
-        input: "$100.22",
-        expected: "100.22:100.22:true",
-      },
-      {
-        input: "invalid@appsmith.com",
-        expected: "null:null:false",
-      },
-      {
-        input: "1.001",
-        expected: "1.001:1.001:true",
-      },
-      {
-        input: "1.1.",
-        expected: "null:null:false",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
-
-    //required: off
-    cy.get(".t--property-control-required label")
-      .last()
-      .click({ force: true });
-
-    cy.selectDropdownValue(".t--property-control-datatype", "Number");
-    [
-      {
-        input: "invalid",
-        expected: "null:null:true",
-      },
-      {
-        input: "invalid123",
-        expected: "123:123:true",
-      },
-      {
-        input: "123",
-        expected: "123:123:true",
-      },
-      {
-        input: "-",
-        expected: "null:null:false",
-      },
-      {
-        input: "",
-        expected: "null:null:true",
-      },
-      {
-        input: "$100.22",
-        expected: "100.22:100.22:true",
-      },
-      {
-        input: "invalid@appsmith.com",
-        expected: "null:null:false",
-      },
-      {
-        input: "1.001",
-        expected: "1.001:1.001:true",
-      },
-      {
-        input: "1.1.",
-        expected: "null:null:false",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
+      "test:",
+      "test123:123",
+      "123:123",
+      "-:-",
+      ":",
+      "$100.22:100.22",
+      "test@appsmith.com:",
+    ].forEach((text) => {
+      enterAndTest(text.split(":")[0], text.split(":")[1]);
+    });
   });
 
   it("5. Validate DataType - PASSWORD can be entered into Input widget", () => {
     cy.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype", "Password");
-    [
-      {
-        input: "test",
-        expected: "test:test:true",
+    ["test", "test123", "123", "-", "", "$100.22", "test@appsmith.com"].forEach(
+      (text) => {
+        enterAndTest(text, text);
       },
-      {
-        input: "test123",
-        expected: "test123:test123:true",
-      },
-      {
-        input: "123",
-        expected: "123:123:true",
-      },
-      {
-        input: "-",
-        expected: "-:-:true",
-      },
-      {
-        input: "",
-        expected: "::true",
-      },
-      {
-        input: "$100.22",
-        expected: "$100.22:$100.22:true",
-      },
-      {
-        input: "test@appsmith.com",
-        expected: "test@appsmith.com:test@appsmith.com:true",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
-
-    //required: on
-    cy.get(".t--property-control-required label")
-      .last()
-      .click({ force: true });
-
-    [
-      {
-        input: "test",
-        expected: "test:test:true",
-      },
-      {
-        input: "test123",
-        expected: "test123:test123:true",
-      },
-      {
-        input: "123",
-        expected: "123:123:true",
-      },
-      {
-        input: "-",
-        expected: "-:-:true",
-      },
-      {
-        input: "",
-        expected: "::false",
-      },
-      {
-        input: "$100.22",
-        expected: "$100.22:$100.22:true",
-      },
-      {
-        input: "test@appsmith.com",
-        expected: "test@appsmith.com:test@appsmith.com:true",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
+    );
   });
 
   it("6. Validate DataType - EMAIL can be entered into Input widget", () => {
     cy.openPropertyPane(widgetName);
     cy.selectDropdownValue(".t--property-control-datatype", "Email");
-    [
-      {
-        input: "test",
-        expected: "test:test:false",
+    ["test", "test123", "123", "-", "", "$100.22", "test@appsmith.com"].forEach(
+      (text) => {
+        enterAndTest(text, text);
       },
-      {
-        input: "test123",
-        expected: "test123:test123:false",
-      },
-      {
-        input: "123",
-        expected: "123:123:false",
-      },
-      {
-        input: "-",
-        expected: "-:-:false",
-      },
-      {
-        input: "",
-        expected: "::false",
-      },
-      {
-        input: "$100.22",
-        expected: "$100.22:$100.22:false",
-      },
-      {
-        input: "test@appsmith.com",
-        expected: "test@appsmith.com:test@appsmith.com:true",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
-
-    //required: off
-    cy.get(".t--property-control-required label")
-      .last()
-      .click({ force: true });
-
-    [
-      {
-        input: "test",
-        expected: "test:test:false",
-      },
-      {
-        input: "test123",
-        expected: "test123:test123:false",
-      },
-      {
-        input: "123",
-        expected: "123:123:false",
-      },
-      {
-        input: "-",
-        expected: "-:-:false",
-      },
-      {
-        input: "",
-        expected: "::true",
-      },
-      {
-        input: "$100.22",
-        expected: "$100.22:$100.22:false",
-      },
-      {
-        input: "test@appsmith.com",
-        expected: "test@appsmith.com:test@appsmith.com:true",
-      },
-    ].forEach(({ expected, input }) => enterAndTest(input, expected));
+    );
   });
 
   it("7. Validating other properties - Input validity with #valid", () => {
@@ -351,7 +113,7 @@ describe("Input widget V2 - ", () => {
     if (text) {
       cy.get(`.t--widget-${widgetName} input`)
         .click()
-        .type(text);
+        .type(text); //.should('have.value', text);
     }
     cy.get(".t--widget-textwidget").should("contain", expected);
   }

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Phone_input_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Phone_input_spec.js
@@ -81,11 +81,6 @@ describe("Phone input widget - ", () => {
   });
 
   it("should check that widget input resets on submit", () => {
-    cy.openPropertyPane("textwidget");
-    cy.updateCodeInput(
-      ".t--property-control-text",
-      `{{PhoneInput1.text}}:{{PhoneInput1.value}}`,
-    );
     cy.openPropertyPane(widgetName);
     cy.get(
       ".t--property-control-onsubmit .t--open-dropdown-Select-Action",
@@ -95,12 +90,8 @@ describe("Phone input widget - ", () => {
 
     cy.get(widgetInput).clear();
     cy.wait(300);
-    cy.get(widgetInput).type("1234567890");
-    cy.wait(300);
-    cy.get(".t--widget-textwidget").should("contain", "1234567890:1234567890");
-    cy.get(widgetInput).type("{enter}");
+    cy.get(widgetInput).type("1234567890{enter}");
     cy.wait(300);
     cy.get(widgetInput).should("contain.value", "");
-    cy.get(".t--widget-textwidget").should("contain", ":undefined");
   });
 });

--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -309,15 +309,20 @@ class BaseInputWidget<
     this.props.updateWidgetMetaProperty("isFocused", focusState);
   }
 
-  resetWidgetText() {
-    this.props.updateWidgetMetaProperty("text", "");
-  }
-
   onSubmitSuccess = (result: ExecutionResult) => {
     if (result.success && this.props.resetOnSubmit) {
       //Resets isDirty
       super.resetChildrenMetaProperty(this.props.widgetId);
-      this.resetWidgetText();
+      this.props.updateWidgetMetaProperty("text", "");
+
+      /*
+       *  Value is a derived property in CURRENCY_INPUT_WIDGET &
+       *  INPUT_WIDGET_V2, so only reset value in
+       *  PHONE_INPUT_WIDGET, where its not derived value.
+       */
+      if (this.props.type === "PHONE_INPUT_WIDGET") {
+        this.props.updateWidgetMetaProperty("value", undefined);
+      }
     }
   };
 

--- a/app/client/src/widgets/InputWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.js
@@ -5,8 +5,8 @@ export default {
     switch (props.inputType) {
       case "NUMBER":
         try {
-          isEmpty = _.isNil(props.inputText) || props.inputText === "";
-          value = isEmpty ? null : Number(props.inputText);
+          isEmpty = _.isNil(props.text) || props.text === "";
+          value = isEmpty ? null : Number(props.text);
           hasValidValue = Number.isFinite(value);
           break;
         } catch (e) {
@@ -15,12 +15,12 @@ export default {
       case "TEXT":
       case "EMAIL":
       case "PASSWORD":
-        value = props.inputText;
+        value = props.text;
         isEmpty = !value;
         hasValidValue = !!value;
         break;
       default:
-        value = props.inputText;
+        value = props.text;
         isEmpty = !value;
         hasValidValue = !!value;
         break;
@@ -74,14 +74,14 @@ export default {
           return false;
         } else if (parsedRegex) {
           /* email should conform to user specified regex */
-          return parsedRegex.test(props.inputText);
+          return parsedRegex.test(props.text);
         } else {
           return true;
         }
       case "TEXT":
       case "PASSWORD":
         if (parsedRegex) {
-          return parsedRegex.test(props.inputText);
+          return parsedRegex.test(props.text);
         } else {
           return hasValidValue;
         }
@@ -101,34 +101,11 @@ export default {
         ) {
           return false;
         } else if (parsedRegex) {
-          return parsedRegex.test(props.inputText);
+          return parsedRegex.test(props.text);
         } else {
           return hasValidValue;
         }
     }
-  },
-  //
-  getText: (props, moment, _) => {
-    let text;
-
-    switch (props.inputType) {
-      case "NUMBER":
-        if (_.isNil(props.inputText) || props.inputText === "") {
-          text = null;
-        } else {
-          text = Number(props.inputText);
-
-          if (isNaN(text)) {
-            text = null;
-          }
-        }
-        break;
-      default:
-        text = props.inputText;
-        break;
-    }
-
-    return text;
   },
   //
 };

--- a/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
@@ -9,7 +9,7 @@ describe("Derived property - ", () => {
       let isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: undefined,
+          text: undefined,
           isRequired: false,
         },
         null,
@@ -22,7 +22,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: "test",
+          text: "test",
           isRequired: true,
         },
         null,
@@ -35,7 +35,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: null,
+          text: null,
           isRequired: true,
         },
         null,
@@ -48,7 +48,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: undefined,
+          text: undefined,
           isRequired: true,
         },
         null,
@@ -61,7 +61,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: "",
+          text: "",
           isRequired: true,
         },
         null,
@@ -74,7 +74,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: 1,
+          text: 1,
           isRequired: true,
         },
         null,
@@ -87,7 +87,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: 1.1,
+          text: 1.1,
           isRequired: true,
         },
         null,
@@ -100,7 +100,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.TEXT,
-          inputText: "",
+          text: "",
           isRequired: false,
         },
         null,
@@ -113,7 +113,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.TEXT,
-          inputText: "",
+          text: "",
           isRequired: true,
         },
         null,
@@ -126,7 +126,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.TEXT,
-          inputText: "test",
+          text: "test",
           isRequired: true,
         },
         null,
@@ -139,7 +139,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "",
+          text: "",
           isRequired: false,
         },
         null,
@@ -152,7 +152,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "",
+          text: "",
           isRequired: true,
         },
         null,
@@ -165,7 +165,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "test@appsmith.com",
+          text: "test@appsmith.com",
           isRequired: true,
         },
         null,
@@ -178,7 +178,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.PASSWORD,
-          inputText: "",
+          text: "",
           isRequired: false,
         },
         null,
@@ -191,7 +191,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.PASSWORD,
-          inputText: "",
+          text: "",
           isRequired: true,
         },
         null,
@@ -204,7 +204,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.PASSWORD,
-          inputText: "admin",
+          text: "admin",
           isRequired: true,
         },
         null,
@@ -218,7 +218,7 @@ describe("Derived property - ", () => {
       let isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.TEXT,
-          inputText: "test",
+          text: "test",
           isRequired: true,
           validation: false,
         },
@@ -231,7 +231,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.TEXT,
-          inputText: "test",
+          text: "test",
           isRequired: true,
           validation: true,
         },
@@ -244,7 +244,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: 1,
+          text: 1,
           isRequired: true,
           validation: false,
         },
@@ -257,7 +257,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: 1,
+          text: 1,
           isRequired: true,
           validation: true,
         },
@@ -270,7 +270,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "test@appsmith.com",
+          text: "test@appsmith.com",
           isRequired: true,
           validation: false,
         },
@@ -283,7 +283,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "test@appsmith.com",
+          text: "test@appsmith.com",
           isRequired: true,
           validation: true,
         },
@@ -296,7 +296,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.PASSWORD,
-          inputText: "admin123",
+          text: "admin123",
           isRequired: true,
           validation: false,
         },
@@ -309,7 +309,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.PASSWORD,
-          inputText: "admin123",
+          text: "admin123",
           isRequired: true,
           validation: true,
         },
@@ -324,7 +324,7 @@ describe("Derived property - ", () => {
       let isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.TEXT,
-          inputText: "test",
+          text: "test",
           isRequired: true,
           regex: "^test$",
         },
@@ -337,7 +337,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.TEXT,
-          inputText: "test123",
+          text: "test123",
           isRequired: true,
           regex: "^test$",
         },
@@ -350,7 +350,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: 1,
+          text: 1,
           isRequired: true,
           regex: "^1$",
         },
@@ -363,7 +363,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.NUMBER,
-          inputText: 2,
+          text: 2,
           isRequired: true,
           regex: "^1$",
         },
@@ -376,7 +376,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "test@appsmith.com",
+          text: "test@appsmith.com",
           isRequired: true,
           regex: "^test@appsmith.com$",
         },
@@ -389,7 +389,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "test123@appsmith.com",
+          text: "test123@appsmith.com",
           isRequired: true,
           regex: "^test@appsmith.com$",
         },
@@ -402,7 +402,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.PASSWORD,
-          inputText: "admin123",
+          text: "admin123",
           isRequired: true,
           regex: "^admin123$",
         },
@@ -415,7 +415,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.PASSWORD,
-          inputText: "admin1234",
+          text: "admin1234",
           isRequired: true,
           regex: "^admin123$",
         },
@@ -430,7 +430,7 @@ describe("Derived property - ", () => {
       let isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "test@appsmith.com",
+          text: "test@appsmith.com",
           isRequired: true,
         },
         null,
@@ -442,7 +442,7 @@ describe("Derived property - ", () => {
       isValid = derivedProperty.isValid(
         {
           inputType: InputTypes.EMAIL,
-          inputText: "test",
+          text: "test",
           isRequired: true,
         },
         null,
@@ -451,106 +451,5 @@ describe("Derived property - ", () => {
 
       expect(isValid).toBeFalsy();
     });
-  });
-
-  describe("getText property", () => {
-    let text = derivedProperty.getText(
-      {
-        inputType: InputTypes.TEXT,
-        inputText: "test",
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe("test");
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.PASSWORD,
-        inputText: "test1",
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe("test1");
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.EMAIL,
-        inputText: "test@appsmith.com",
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe("test@appsmith.com");
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.NUMBER,
-        inputText: "",
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe(null);
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.NUMBER,
-        inputText: undefined,
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe(null);
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.NUMBER,
-        inputText: null,
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe(null);
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.NUMBER,
-        inputText: 1,
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe(1);
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.NUMBER,
-        inputText: "1.01",
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe(1.01);
-
-    text = derivedProperty.getText(
-      {
-        inputType: InputTypes.NUMBER,
-        inputText: "1.00",
-      },
-      null,
-      _,
-    );
-
-    expect(text).toBe(1);
   });
 });

--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -264,11 +264,6 @@ class PhoneInputWidget extends BaseInputWidget<
     super.handleKeyDown(e);
   };
 
-  resetWidgetText = () => {
-    super.resetWidgetText();
-    this.props.updateWidgetMetaProperty("value", undefined);
-  };
-
   getPageView() {
     const value = this.props.text ?? "";
     const isInvalid =


### PR DESCRIPTION
…al point (#11579)"

This reverts commit 342fec4462bcbc55f658e02360ae4a8ed5a27657.

## Description
The solution provided in https://github.com/appsmithorg/appsmith/pull/11579 is causing an issue when Input widget is placed inside the List widget since it won't support derived properties.

Fixes #11833 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/revert-input-widget-numeric-type-changes 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.85 **(-0.03)** | 37.2 **(-0.04)** | 35.22 **(0)** | 56.16 **(-0.03)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :red_circle: | app/client/src/widgets/BaseInputWidget/widget/index.tsx | 65 **(-2.5)** | 6.25 **(-0.89)** | 66.67 **(5.13)** | 68.42 **(-2.63)**
 :red_circle: | app/client/src/widgets/InputWidgetV2/widget/derived.js | 78.72 **(-1.98)** | 77.36 **(-1.33)** | 100 **(0)** | 78.72 **(-1.98)**
 :red_circle: | app/client/src/widgets/InputWidgetV2/widget/index.tsx | 73.6 **(-10.61)** | 60.87 **(-9.13)** | 81.25 **(3.47)** | 72.95 **(-10.83)**
 :green_circle: | app/client/src/widgets/PhoneInputWidget/widget/index.tsx | 40.63 **(1.24)** | 6.52 **(0)** | 42.86 **(2.86)** | 40.43 **(1.25)**</details>