### PR TITLE
fix: Show newly created datasources on the entity explorer

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_all_sidebar_actions_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_all_sidebar_actions_spec.js
@@ -31,6 +31,7 @@ describe("API Panel Test Functionality ", function() {
       "Move to page",
       "Page1",
     );
+    cy.wait(2000);
     cy.get(".t--entity-name")
       .contains("FirstAPICopy")
       .click({ force: true });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_all_sidebar_actions_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_all_sidebar_actions_spec.js
@@ -1,6 +1,11 @@
 const commonlocators = require("../../../../locators/commonlocators.json");
 const testdata = require("../../../../fixtures/testdata.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
+const {
+  AggregateHelper,
+} = require("../../../../support/Pages/AggregateHelper");
+
+const helper = new AggregateHelper();
 
 describe("API Panel Test Functionality ", function() {
   it("Test API copy/Move/delete feature", function() {
@@ -11,23 +16,24 @@ describe("API Panel Test Functionality ", function() {
     cy.CreateAPI("FirstAPI");
     cy.enterDatasourceAndPath(testdata.baseUrl, "{{ '/random' }}");
     cy.log("Creation of FirstAPI Action successful");
-    //cy.GlobalSearchEntity("FirstAPI");
-    cy.xpath('//*[local-name()="g" and @id="Icon/Outline/more-vertical"]')
-      .last()
-      .should("be.hidden")
-      .invoke("show")
-      .click({ force: true });
-    cy.copyEntityToPage("SecondPage");
+    helper.ActionContextMenuByEntityName(
+      "FirstAPI",
+      "Copy to page",
+      "SecondPage",
+    );
     // click on learn how link
     cy.get(".t--learn-how-apis-link").click();
     // this should open in a global search modal
     cy.get(commonlocators.globalSearchModal);
     cy.get("body").click(0, 0);
-    cy.MoveAPIToPage("Page1");
+    helper.ActionContextMenuByEntityName(
+      "FirstAPICopy",
+      "Move to page",
+      "Page1",
+    );
     cy.get(".t--entity-name")
       .contains("FirstAPICopy")
       .click({ force: true });
     cy.get(apiwidget.resourceUrl).should("contain.text", "{{ '/random' }}");
-    cy.DeleteAPIFromSideBar();
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Entity_Renaming_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Entity_Renaming_spec.js
@@ -1,9 +1,14 @@
 const explorer = require("../../../../locators/explorerlocators.json");
 const firstApiName = "First";
 const secondApiName = "Second";
+const {
+  AggregateHelper,
+} = require("../../../../support/Pages/AggregateHelper");
+
+const helper = new AggregateHelper();
 
 describe("Api Naming conflict on a page test", function() {
-  it.skip("expects actions on the same page cannot have identical names", function() {
+  it("expects actions on the same page cannot have identical names", function() {
     cy.log("Login Successful");
     // create an API
     cy.NavigateToAPI_Panel();
@@ -14,7 +19,9 @@ describe("Api Naming conflict on a page test", function() {
     cy.CreateAPI(secondApiName);
 
     // try to rename one of the APIs with an existing API name
-    cy.hoverAndClickParticularIndex(2);
+    cy.get(`.t--entity-item:contains(${secondApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
     cy.selectAction("Edit Name");
     //cy.RenameEntity(tabname);
     cy.get(explorer.editEntity)
@@ -23,8 +30,14 @@ describe("Api Naming conflict on a page test", function() {
     //cy.RenameEntity(firstApiName);
     cy.validateMessage(firstApiName);
     cy.ClearSearch();
-    cy.DeleteAPIFromSideBar();
-    cy.DeleteAPIFromSideBar();
+    cy.get(`.t--entity-item:contains(${secondApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
+    cy.selectAction("Delete");
+    cy.get(`.t--entity-item:contains(${firstApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
+    cy.selectAction("Delete");
   });
 });
 
@@ -33,45 +46,64 @@ describe("Api Naming conflict on different pages test", function() {
     cy.log("Login Successful");
     // create a new API
     cy.CreateAPI(firstApiName);
-
+    helper.expandCollapseEntity("QUERIES/JS", true);
     // create a new page and an API on that page
     cy.Createpage("Page2");
     cy.CreateAPI(firstApiName);
+    helper.expandCollapseEntity("QUERIES/JS", true);
     cy.get(".t--entity-name")
       .contains(firstApiName)
       .should("exist");
-    cy.DeleteAPIFromSideBar();
-    cy.get(".t--entity-name")
-      .contains("Page2")
-      .trigger("mouseover");
-    cy.hoverAndClick();
+    cy.get(`.t--entity-item:contains(${firstApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
     cy.selectAction("Delete");
-    cy.wait(1000);
-    cy.DeleteAPIFromSideBar();
+    cy.get(`.t--entity-item:contains(Page2)`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
+    cy.selectAction("Delete");
+    cy.get(`.t--entity-item:contains(${firstApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
+    cy.selectAction("Delete");
   });
 });
 
 describe("Entity Naming conflict test", function() {
   it("expects JS objects and actions to not have identical names on the same page.", function() {
     cy.log("Login Successful");
-
+    helper.expandCollapseEntity("QUERIES/JS", true);
     // create JS object and name it
     cy.createJSObject('return "Hello World";');
-    cy.RenameEntity(firstApiName);
 
-    // create API and rename it, expect error to occur
-    cy.NavigateToAPI_Panel();
-    cy.CreateAPI(secondApiName);
-    cy.hoverAndClickParticularIndex(2);
+    cy.get(`.t--entity-item:contains('JSObject1')`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
     cy.selectAction("Edit Name");
     cy.get(explorer.editEntity)
       .last()
-      .type(secondApiName, { force: true });
-    cy.VerifyPopOverMessage(secondApiName + " is already being used.", true);
-    cy.ClearSearch();
+      .type(firstApiName, { force: true });
 
-    cy.deleteJSObject();
-    cy.DeleteAPIFromSideBar();
-    cy.NavigateToHome();
+    cy.CreateAPI(secondApiName);
+
+    cy.get(`.t--entity-item:contains(${secondApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
+    cy.selectAction("Edit Name");
+
+    cy.get(explorer.editEntity)
+      .last()
+      .type(firstApiName, { force: true });
+    cy.VerifyPopOverMessage(firstApiName + " is already being used.", true);
+    cy.get("body").click(0, 0);
+    cy.wait(2000);
+    cy.get(`.t--entity-item:contains(${firstApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
+    cy.selectAction("Delete");
+    cy.get(`.t--entity-item:contains(${secondApiName})`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
+    cy.selectAction("Delete");
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Widgets_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Widgets_spec.js
@@ -8,7 +8,6 @@ describe("Entity explorer tests related to widgets and validation", function() {
   });
 
   it("Widget edit/delete/copy to clipboard validation", function() {
-    cy.wait(30000);
     cy.CheckAndUnfoldEntityItem("WIDGETS");
     cy.selectEntityByName("Container4");
     cy.get(".t--entity-collapse-toggle")

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Hide_Page_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Pages/Hide_Page_spec.js
@@ -6,14 +6,14 @@ const pageTwo = "MyPage2";
 
 describe("Hide / Show page test functionality", function() {
   it("Hide page test ", function() {
-    cy.wait(30000);
     cy.Createpage(pageOne);
     cy.Createpage(pageTwo);
     cy.get(".t--entity-name")
       .contains("Page1")
       .click({ force: true });
-    cy.get(`.t--entity-name:contains('MyPage2')`).trigger("mouseover");
-    cy.hoverAndClick();
+    cy.get(`.t--entity-item:contains('MyPage2')`).within(() => {
+      cy.get(".t--context-menu").click({ force: true });
+    });
     cy.get(pages.hidePage).click({ force: true });
     cy.ClearSearch();
     cy.PublishtheApp();

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
@@ -1,8 +1,6 @@
 const queryLocators = require("../../../../locators/QueryEditor.json");
 const datasource = require("../../../../locators/DatasourcesEditor.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
-const commonlocators = require("../../../../locators/commonlocators.json");
-const explorer = require("../../../../locators/explorerlocators.json");
 import { AggregateHelper } from "../../../../support/Pages/AggregateHelper";
 const agHelper = new AggregateHelper();
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
@@ -107,7 +107,7 @@ describe("Entity explorer tests related to copy query", function() {
 
     cy.get(".t--entity-name")
       .contains("Query1")
-      .click();
+      .click({ force: true });
     agHelper.ActionContextMenuByEntityName("Query1", "Delete");
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
@@ -17,7 +17,7 @@ describe("Entity explorer tests related to copy query", function() {
     cy.Createpage(pageid);
     cy.get(".t--entity-name")
       .contains("Page1")
-      .click();
+      .click({ force: true });
     cy.wait(2000);
     cy.NavigateToDatasourceEditor();
     cy.get(datasource.PostgreSQL).click();
@@ -64,7 +64,7 @@ describe("Entity explorer tests related to copy query", function() {
   it("2. Create a page and copy query in explorer", function() {
     cy.get(".t--entity-name")
       .contains("Page1")
-      .click();
+      .click({ force: true });
     agHelper.ActionContextMenuByEntityName("Query1", "Copy to page", pageid);
     cy.CheckAndUnfoldEntityItem("QUERIES/JS");
     cy.get(".t--entity-name")

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/ExplorerTests/Entity_Explorer_CopyQuery_RenameDatasource_spec.js
@@ -84,7 +84,7 @@ describe("Entity explorer tests related to copy query", function() {
   it("3. Delete query and rename datasource in explorer", function() {
     cy.get(".t--entity-name")
       .contains("Page1")
-      .click();
+      .click({ force: true });
     cy.wait(2000);
     cy.generateUUID().then((uid) => {
       updatedName = uid;

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1858,6 +1858,7 @@ Cypress.Commands.add("Createpage", (pageName) => {
     expect(xhr.response.body.responseMeta.status).to.equal(201);
     if (pageName) {
       pageId = xhr.response.body.data.id;
+      cy.wait(2000);
       cy.get(`div[id=entity-${pageId}] .t--context-menu`).click({
         force: true,
       });

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1849,37 +1849,25 @@ Cypress.Commands.add("DeleteModal", () => {
     .click({ force: true });
 });
 
-Cypress.Commands.add("Createpage", (Pagename) => {
+Cypress.Commands.add("Createpage", (pageName) => {
+  let pageId;
   cy.get(pages.AddPage)
     .first()
     .click({ force: true });
-  cy.wait("@createPage").should(
-    "have.nested.property",
-    "response.body.responseMeta.status",
-    201,
-  );
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(2000);
-  cy.xpath(apiwidget.popover)
-    .last()
-    .should("be.hidden")
-    .invoke("show")
-    .click({ force: true });
-  cy.xpath(apiwidget.popover)
-    .last()
-    .click({ force: true });
-  /*  
-  cy.xpath(pages.popover)
-    .last()
-    .click({ force: true });
-    */
-  cy.get(pages.editName).click({ force: true });
-  cy.get(pages.editInput).type(Pagename + "{enter}");
-  pageidcopy = Pagename;
-  cy.get(generatePage.buildFromScratchActionCard).click();
-  cy.get("#loading").should("not.exist");
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(2000);
+  cy.wait("@createPage").then((xhr) => {
+    expect(xhr.response.body.responseMeta.status).to.equal(201);
+    if (pageName) {
+      pageId = xhr.response.body.data.id;
+      cy.get(`div[id=entity-${pageId}] .t--context-menu`).click({
+        force: true,
+      });
+      cy.get(pages.editName).click({ force: true });
+      cy.get(pages.editInput).type(pageName + "{enter}");
+      pageidcopy = pageName;
+      cy.get(generatePage.buildFromScratchActionCard).click();
+      cy.get("#loading").should("not.exist");
+    }
+  });
 });
 
 Cypress.Commands.add("Deletepage", (Pagename) => {

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1864,9 +1864,9 @@ Cypress.Commands.add("Createpage", (pageName) => {
       cy.get(pages.editName).click({ force: true });
       cy.get(pages.editInput).type(pageName + "{enter}");
       pageidcopy = pageName;
-      cy.get(generatePage.buildFromScratchActionCard).click();
-      cy.get("#loading").should("not.exist");
     }
+    cy.get(generatePage.buildFromScratchActionCard).click();
+    cy.get("#loading").should("not.exist");
   });
 });
 

--- a/app/client/src/pages/Editor/Explorer/Datasources.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources.tsx
@@ -108,7 +108,7 @@ const Datasources = React.memo(() => {
       searchKeyword={""}
       step={0}
     >
-      {appWideDS.length ? (
+      {datasourceElements.length ? (
         datasourceElements
       ) : (
         <EmptyComponent
@@ -117,7 +117,7 @@ const Datasources = React.memo(() => {
           mainText={createMessage(EMPTY_DATASOURCE_MAIN_TEXT)}
         />
       )}
-      {appWideDS.length > 0 && (
+      {datasourceElements.length > 0 && (
         <AddEntity
           action={addDatasource}
           entityId={pageId + "_datasources_add_new_datasource"}

--- a/app/client/src/pages/Editor/Explorer/Datasources.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources.tsx
@@ -1,5 +1,8 @@
 import React, { useCallback } from "react";
-import { useAppWideAndOtherDatasource } from "./hooks";
+import {
+  useAppWideAndOtherDatasource,
+  useDatasourceSuggestions,
+} from "./hooks";
 import { Datasource } from "entities/Datasource";
 import ExplorerDatasourceEntity from "./Datasources/DatasourceEntity";
 import { useSelector } from "store";
@@ -57,6 +60,7 @@ const Datasources = React.memo(() => {
     );
   }, [applicationId, pageId]);
   const activeDatasourceId = useDatasourceIdFromURL();
+  const datasourceSuggestions = useDatasourceSuggestions();
 
   const listDatasource = useCallback(() => {
     history.push(
@@ -66,7 +70,7 @@ const Datasources = React.memo(() => {
 
   const datasourceElements = React.useMemo(
     () =>
-      appWideDS.map((datasource: Datasource) => {
+      appWideDS.concat(datasourceSuggestions).map((datasource: Datasource) => {
         return (
           <ExplorerDatasourceEntity
             datasource={datasource}

--- a/app/client/src/pages/Editor/Explorer/Datasources.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources.tsx
@@ -97,11 +97,10 @@ const Datasources = React.memo(() => {
     <Entity
       addButtonHelptext={createMessage(CREATE_DATASOURCE_TOOLTIP)}
       className={"datasources"}
-      entityId={pageId + "_datasources"}
+      entityId="datasources_section"
       icon={null}
       isDefaultExpanded={isDatasourcesOpen === null ? true : isDatasourcesOpen}
       isSticky
-      key={pageId + "_datasources"}
       name="DATASOURCES"
       onCreate={addDatasource}
       onToggle={onDatasourcesToggle}
@@ -120,7 +119,7 @@ const Datasources = React.memo(() => {
       {datasourceElements.length > 0 && (
         <AddEntity
           action={addDatasource}
-          entityId={pageId + "_datasources_add_new_datasource"}
+          entityId="add_new_datasource"
           icon={<Icon name="plus" />}
           name={createMessage(ADD_DATASOURCE_BUTTON)}
           step={1}

--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
@@ -122,10 +122,10 @@ const ExplorerDatasourceEntity = React.memo(
           <DataSourceContextMenu
             className={EntityClassNames.CONTEXT_MENU}
             datasourceId={props.datasource.id}
-            entityId={`${props.datasource.id}-${props.pageId}`}
+            entityId={`${props.datasource.id}`}
           />
         }
-        entityId={`${props.datasource.id}-${props.pageId}`}
+        entityId={`${props.datasource.id}`}
         icon={icon}
         isDefaultExpanded={isDefaultExpanded}
         key={props.datasource.id}

--- a/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/EntityProperties.tsx
@@ -93,7 +93,7 @@ export function EntityProperties() {
   };
 
   useEffect(() => {
-    const element = document.getElementById(entityId);
+    const element = document.getElementById(`entity-${entityId}`);
     const rect = element?.getBoundingClientRect();
     if (ref.current && rect) {
       const top = rect?.top;

--- a/app/client/src/pages/Editor/Explorer/Entity/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/index.tsx
@@ -289,7 +289,7 @@ export const Entity = forwardRef(
             } t--entity-item`}
             data-guided-tour-id={`explorer-entity-${props.name}`}
             highlight={!!props.highlight}
-            id={props.entityId}
+            id={"entity-" + props.entityId}
             isSticky={props.isSticky === true}
             rightIconClickable={typeof props.onClickRightIcon === "function"}
             spaced={!!props.children}

--- a/app/client/src/pages/Editor/Explorer/EntityExplorer.test.tsx
+++ b/app/client/src/pages/Editor/Explorer/EntityExplorer.test.tsx
@@ -8,6 +8,12 @@ import { MockPageDSL } from "test/testCommon";
 import Sidebar from "components/editorComponents/Sidebar";
 import { generateReactKey } from "utils/generators";
 import { DEFAULT_ENTITY_EXPLORER_WIDTH } from "constants/AppConstants";
+import store from "store";
+import Datasources from "./Datasources";
+import { ReduxActionTypes } from "constants/ReduxActionConstants";
+import { mockDatasources } from "./mockTestData";
+import { updateCurrentPage } from "actions/pageActions";
+
 jest.useFakeTimers();
 describe("Entity Explorer tests", () => {
   it("Should render Widgets tree in entity explorer", () => {
@@ -208,5 +214,17 @@ describe("Entity Explorer tests", () => {
     active = component.container.querySelectorAll("div.widget > .active");
     expect(highlighted.length).toBe(1);
     expect(active.length).toBe(1);
+  });
+
+  it("checks datasources section in explorer", () => {
+    store.dispatch({
+      type: ReduxActionTypes.FETCH_DATASOURCES_SUCCESS,
+      payload: mockDatasources,
+    });
+    store.dispatch(updateCurrentPage("623188f81876bb1bcfab19fd"));
+    const component = render(<Datasources />);
+    expect(component.container.getElementsByClassName("t--entity").length).toBe(
+      5,
+    );
   });
 });

--- a/app/client/src/pages/Editor/Explorer/EntityExplorer.test.tsx
+++ b/app/client/src/pages/Editor/Explorer/EntityExplorer.test.tsx
@@ -16,6 +16,17 @@ import { updateCurrentPage } from "actions/pageActions";
 
 jest.useFakeTimers();
 describe("Entity Explorer tests", () => {
+  it("checks datasources section in explorer", () => {
+    store.dispatch({
+      type: ReduxActionTypes.FETCH_DATASOURCES_SUCCESS,
+      payload: mockDatasources,
+    });
+    store.dispatch(updateCurrentPage("623188f81876bb1bcfab19fd"));
+    const component = render(<Datasources />);
+    expect(component.container.getElementsByClassName("t--entity").length).toBe(
+      5,
+    );
+  });
   it("Should render Widgets tree in entity explorer", () => {
     const children: any = buildChildren([{ type: "TABS_WIDGET" }]);
     const dsl: any = widgetCanvasFactory.build({
@@ -214,17 +225,5 @@ describe("Entity Explorer tests", () => {
     active = component.container.querySelectorAll("div.widget > .active");
     expect(highlighted.length).toBe(1);
     expect(active.length).toBe(1);
-  });
-
-  it("checks datasources section in explorer", () => {
-    store.dispatch({
-      type: ReduxActionTypes.FETCH_DATASOURCES_SUCCESS,
-      payload: mockDatasources,
-    });
-    store.dispatch(updateCurrentPage("623188f81876bb1bcfab19fd"));
-    const component = render(<Datasources />);
-    expect(component.container.getElementsByClassName("t--entity").length).toBe(
-      5,
-    );
   });
 });

--- a/app/client/src/pages/Editor/Explorer/JSActions/JSActionContextMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSActions/JSActionContextMenu.tsx
@@ -149,7 +149,7 @@ export function JSCollectionEntityContextMenu(props: EntityContextMenuProps) {
         },
       ]}
       selectedValue=""
-      toggle={<ContextMenuTrigger />}
+      toggle={<ContextMenuTrigger className="t--context-menu" />}
     />
   );
 }

--- a/app/client/src/pages/Editor/Explorer/hooks.ts
+++ b/app/client/src/pages/Editor/Explorer/hooks.ts
@@ -134,6 +134,8 @@ const MAX_DATASOURCE_SUGGESTIONS = 3;
 export const useDatasourceSuggestions = () => {
   const datasourcesUsedInApplication = useCurrentApplicationDatasource();
   const otherDatasourceInOrg = useOtherDatasourcesInOrganization();
+  if (datasourcesUsedInApplication.length >= MAX_DATASOURCE_SUGGESTIONS)
+    return [];
   otherDatasourceInOrg.reverse();
   return otherDatasourceInOrg.slice(
     0,

--- a/app/client/src/pages/Editor/Explorer/hooks.ts
+++ b/app/client/src/pages/Editor/Explorer/hooks.ts
@@ -75,33 +75,70 @@ export const useDatasourcesPageMapInCurrentApplication = () => {
   }, [actions, reducerDatasources]);
 };
 
-export const useAppWideAndOtherDatasource = () => {
+export const useCurrentApplicationDatasource = () => {
   const actions = useSelector(getActions);
   const allDatasources = useSelector(getDatasources);
-  const appWideDatasourcesIds = actions.reduce((acc, action: ActionData) => {
-    if (
-      isStoredDatasource(action.config.datasource) &&
-      action.config.datasource.id
-    ) {
-      acc.add(action.config.datasource.id);
-    }
-    return acc;
-  }, new Set());
-  return allDatasources
-    .sort((ds1, ds2) =>
+  const datasourceIdsUsedInCurrentApplication = actions.reduce(
+    (acc, action: ActionData) => {
+      if (
+        isStoredDatasource(action.config.datasource) &&
+        action.config.datasource.id
+      ) {
+        acc.add(action.config.datasource.id);
+      }
+      return acc;
+    },
+    new Set(),
+  );
+  return allDatasources.filter((ds) =>
+    datasourceIdsUsedInCurrentApplication.has(ds.id),
+  );
+};
+
+export const useOtherDatasourcesInOrganization = () => {
+  const actions = useSelector(getActions);
+  const allDatasources = useSelector(getDatasources);
+  const datasourceIdsUsedInCurrentApplication = actions.reduce(
+    (acc, action: ActionData) => {
+      if (
+        isStoredDatasource(action.config.datasource) &&
+        action.config.datasource.id
+      ) {
+        acc.add(action.config.datasource.id);
+      }
+      return acc;
+    },
+    new Set(),
+  );
+  return allDatasources.filter(
+    (ds) => !datasourceIdsUsedInCurrentApplication.has(ds.id),
+  );
+};
+
+export const useAppWideAndOtherDatasource = () => {
+  const datasourcesUsedInApplication = useCurrentApplicationDatasource();
+  const otherDatasourceInOrg = useOtherDatasourcesInOrganization();
+
+  return {
+    appWideDS: datasourcesUsedInApplication.sort((ds1, ds2) =>
       ds1.name?.toLowerCase()?.localeCompare(ds2.name?.toLowerCase()),
-    )
-    .reduce(
-      (acc: any, ds) => {
-        if (appWideDatasourcesIds.has(ds.id)) {
-          acc.appWideDS = acc.appWideDS.concat(ds);
-        } else {
-          acc.otherDS = acc.otherDS.concat(ds);
-        }
-        return acc;
-      },
-      { appWideDS: [], otherDS: [] },
-    );
+    ),
+    otherDS: otherDatasourceInOrg.sort((ds1, ds2) =>
+      ds1.name?.toLowerCase()?.localeCompare(ds2.name?.toLowerCase()),
+    ),
+  };
+};
+
+const MAX_DATASOURCE_SUGGESTIONS = 3;
+
+export const useDatasourceSuggestions = () => {
+  const datasourcesUsedInApplication = useCurrentApplicationDatasource();
+  const otherDatasourceInOrg = useOtherDatasourcesInOrganization();
+  otherDatasourceInOrg.reverse();
+  return otherDatasourceInOrg.slice(
+    0,
+    MAX_DATASOURCE_SUGGESTIONS - datasourcesUsedInApplication.length,
+  );
 };
 
 export const useFilteredDatasources = (searchKeyword?: string) => {

--- a/app/client/src/pages/Editor/Explorer/mockTestData.ts
+++ b/app/client/src/pages/Editor/Explorer/mockTestData.ts
@@ -1,0 +1,191 @@
+export const mockDatasources = [
+  {
+    id: "61e0f447cd5225210fa81dd8",
+    name: "09bd6b2f",
+    pluginId: "5c9f512f96c1a50004819786",
+    organizationId: "607d2c9c1a5f642a171ebd9b",
+    datasourceConfiguration: {
+      connection: {
+        mode: "READ_WRITE",
+        ssl: {
+          authType: "DEFAULT",
+        },
+      },
+      endpoints: [
+        {
+          host: "localhost",
+          port: 5432,
+        },
+      ],
+      authentication: {
+        authenticationType: "dbAuth",
+        username: "postgres",
+        databaseName: "fakeapi",
+      },
+      sshProxyEnabled: false,
+    },
+    invalids: [],
+    messages: [
+      "You may not be able to access your localhost if Appsmith is running inside a docker container or on the cloud. To enable access to your localhost you may use ngrok to expose your local endpoint to the internet. Please check out Appsmith's documentation to understand more.",
+    ],
+    isConfigured: false,
+    isValid: true,
+    new: false,
+  },
+  {
+    id: "61e0e47bcd5225210fa81d59",
+    name: "2dcc265f",
+    pluginId: "5c9f512f96c1a50004819786",
+    organizationId: "607d2c9c1a5f642a171ebd9b",
+    datasourceConfiguration: {
+      connection: {
+        mode: "READ_WRITE",
+        ssl: {
+          authType: "DEFAULT",
+        },
+      },
+      endpoints: [
+        {
+          host: "localhost",
+          port: 5432,
+        },
+      ],
+      authentication: {
+        authenticationType: "dbAuth",
+        username: "postgres",
+        databaseName: "fakeapi",
+      },
+      sshProxyEnabled: false,
+    },
+  },
+  {
+    id: "61e0f171cd5225210fa81dad",
+    name: "f688c404",
+    pluginId: "5c9f512f96c1a50004819786",
+    organizationId: "607d2c9c1a5f642a171ebd9b",
+    datasourceConfiguration: {
+      connection: {
+        mode: "READ_WRITE",
+        ssl: {
+          authType: "DEFAULT",
+        },
+      },
+      endpoints: [
+        {
+          host: "localhost",
+          port: 5432,
+        },
+      ],
+      authentication: {
+        authenticationType: "dbAuth",
+        username: "postgres",
+        databaseName: "fakeapi",
+      },
+      sshProxyEnabled: false,
+    },
+  },
+  {
+    id: "61e0e47bcd5225210fa81d59",
+    name: "2dcc265f",
+    pluginId: "5c9f512f96c1a50004819786",
+    organizationId: "607d2c9c1a5f642a171ebd9b",
+    datasourceConfiguration: {
+      connection: {
+        mode: "READ_WRITE",
+        ssl: {
+          authType: "DEFAULT",
+        },
+      },
+      endpoints: [
+        {
+          host: "localhost",
+          port: 5432,
+        },
+      ],
+      authentication: {
+        authenticationType: "dbAuth",
+        username: "postgres",
+        databaseName: "fakeapi",
+      },
+      sshProxyEnabled: false,
+    },
+  },
+  {
+    id: "61e0f171cd5225210fa81dad",
+    name: "f688c404",
+    pluginId: "5c9f512f96c1a50004819786",
+    organizationId: "607d2c9c1a5f642a171ebd9b",
+    datasourceConfiguration: {
+      connection: {
+        mode: "READ_WRITE",
+        ssl: {
+          authType: "DEFAULT",
+        },
+      },
+      endpoints: [
+        {
+          host: "localhost",
+          port: 5432,
+        },
+      ],
+      authentication: {
+        authenticationType: "dbAuth",
+        username: "postgres",
+        databaseName: "fakeapi",
+      },
+      sshProxyEnabled: false,
+    },
+  },
+  {
+    id: "61e0e47bcd5225210fa81d59",
+    name: "qwerty12",
+    pluginId: "5c9f512f96c1a50004819786",
+    organizationId: "607d2c9c1a5f642a171ebd9b",
+    datasourceConfiguration: {
+      connection: {
+        mode: "READ_WRITE",
+        ssl: {
+          authType: "DEFAULT",
+        },
+      },
+      endpoints: [
+        {
+          host: "localhost",
+          port: 5432,
+        },
+      ],
+      authentication: {
+        authenticationType: "dbAuth",
+        username: "postgres",
+        databaseName: "fakeapi",
+      },
+      sshProxyEnabled: false,
+    },
+  },
+  {
+    id: "61e0f171cd5225210f121dad",
+    name: "poiuyt09",
+    pluginId: "5c9f512f96c1a50004819786",
+    organizationId: "607d2c9c1a5f642a171ebd9b",
+    datasourceConfiguration: {
+      connection: {
+        mode: "READ_WRITE",
+        ssl: {
+          authType: "DEFAULT",
+        },
+      },
+      endpoints: [
+        {
+          host: "localhost",
+          port: 5432,
+        },
+      ],
+      authentication: {
+        authenticationType: "dbAuth",
+        username: "postgres",
+        databaseName: "fakeapi",
+      },
+      sshProxyEnabled: false,
+    },
+  },
+];


### PR DESCRIPTION
## Description
Changes to show newly created datasource on the explorer. This will show up only if there are less 3 active datasource in the application.

Fixes #11031

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes













## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/show-default-datasources-in-explorer 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.63 **(0.07)** | 36.87 **(0.05)** | 34.95 **(0.09)** | 55.93 **(0.07)**
 :green_circle: | app/client/src/ce/constants/messages.ts | 76.8 **(0.05)** | 100 **(0)** | 31.12 **(0.14)** | 81.43 **(0)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Datasources.tsx | 95.24 **(5)** | 85.71 **(28.57)** | 71.43 **(28.57)** | 94.87 **(5.4)**
 :green_circle: | app/client/src/pages/Editor/Explorer/ExplorerIcons.tsx | 77.17 **(2.17)** | 36.67 **(6.67)** | 13.33 **(6.66)** | 81.18 **(2.36)**
 :green_circle: | app/client/src/pages/Editor/Explorer/helpers.tsx | 88.68 **(3.77)** | 59.76 **(7.32)** | 83.33 **(16.66)** | 86.96 **(4.35)**
 :green_circle: | app/client/src/pages/Editor/Explorer/hooks.ts | 29.8 **(6.93)** | 23.45 **(4.85)** | 21.82 **(9.58)** | 30.15 **(7.37)**
 :sparkles: :new: | **app/client/src/pages/Editor/Explorer/mockTestData.ts** | **100** | **100** | **100** | **100**
 :green_circle: | app/client/src/pages/Editor/Explorer/Datasources/DataSourceContextMenu.tsx | 83.33 **(27.77)** | 100 **(0)** | 25 **(25)** | 83.33 **(27.77)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx | 76.92 **(40.38)** | 30 **(30)** | 50 **(50)** | 76.92 **(40.38)**
 :green_circle: | app/client/src/reducers/entityReducers/datasourceReducer.ts | 7.69 **(1.28)** | 0 **(0)** | 2.17 **(2.17)** | 8.22 **(1.37)**
 :green_circle: | app/client/src/selectors/entitiesSelector.ts | 46.34 **(0.48)** | 8.05 **(0.67)** | 22.73 **(0.65)** | 42.2 **(0.61)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**
 :red_circle: | app/client/src/utils/helpers.tsx | 64.07 **(-3.73)** | 29.44 **(-4.45)** | 49.06 **(-9.43)** | 62.01 **(-3.93)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>