### PR TITLE
feat: Added migration to change default theme name

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Theme.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Theme.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 @Getter
@@ -19,8 +18,13 @@ public class Theme extends BaseDomain {
     public static final String LEGACY_THEME_NAME = "classic";
     public static final String DEFAULT_THEME_NAME = "classic";
 
-    @NotNull
+    // name will be used internally to identify system themes for import, export application and theme migration
+    // it'll never change. We need to remove this from API response in future when FE uses displayName everywhere
     private String name;
+
+    // displayName will be visible to users. Users can set their own input when saving/customising a theme
+    private String displayName;
+
     private String applicationId;
     private String organizationId;
     private Object config;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -5006,7 +5006,7 @@ public class DatabaseChangelog {
      * @param mongockTemplate
      * @throws IOException
      */
-    @ChangeSet(order = "117", id = "create-system-themes-v2", author = "")
+    @ChangeSet(order = "117", id = "create-system-themes-v2", author = "", runAlways = true)
     public void createSystemThemes2(MongockTemplate mongockTemplate) throws IOException {
         Index systemThemeIndex = new Index()
                 .on(fieldName(QTheme.theme.isSystemTheme), Sort.Direction.ASC)
@@ -5047,6 +5047,7 @@ public class DatabaseChangelog {
                 savedTheme = mongockTemplate.save(theme);
             } else { // theme already found, update
                 themeExists = true;
+                savedTheme.setDisplayName(theme.getDisplayName());
                 savedTheme.setPolicies(theme.getPolicies());
                 savedTheme.setConfig(theme.getConfig());
                 savedTheme.setProperties(theme.getProperties());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ThemeServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ThemeServiceCEImpl.java
@@ -229,6 +229,12 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepositoryCE, Theme, St
                     if(StringUtils.hasLength(targetThemeResource.getName())) {
                         currentTheme.setName(targetThemeResource.getName());
                     }
+
+                    if(StringUtils.hasLength(targetThemeResource.getDisplayName())) {
+                        currentTheme.setDisplayName(targetThemeResource.getDisplayName());
+                    } else {
+                        currentTheme.setDisplayName(currentTheme.getName());
+                    }
                     boolean newThemeCreated = false;
                     if (currentTheme.isSystemTheme()) {
                         // if this is a system theme, create a new one
@@ -284,10 +290,17 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepositoryCE, Theme, St
                             application.getPolicies(), Application.class, Theme.class
                     ));
 
+                    // need to remove it when FE adapts displayName everywhere
                     if(StringUtils.hasLength(resource.getName())) {
                         theme.setName(resource.getName());
                     } else {
                         theme.setName(theme.getName() + " copy");
+                    }
+
+                    if(StringUtils.hasLength(resource.getDisplayName())) {
+                        theme.setDisplayName(resource.getDisplayName());
+                    } else {
+                        theme.setDisplayName(theme.getName());
                     }
                     return repository.save(theme);
                 });
@@ -353,6 +366,10 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepositoryCE, Theme, St
                     if(StringUtils.hasLength(themeDto.getName())) {
                         theme.setName(themeDto.getName());
                     }
+
+                    if(StringUtils.hasLength(themeDto.getDisplayName())) {
+                        theme.setDisplayName(themeDto.getDisplayName());
+                    }
                     return repository.save(theme);
                 });
     }
@@ -362,7 +379,8 @@ public class ThemeServiceCEImpl extends BaseService<ThemeRepositoryCE, Theme, St
         if(theme == null) { // this application was exported without theme, assign the legacy theme to it
             return repository.getSystemThemeByName(Theme.LEGACY_THEME_NAME); // return the default theme
         } else if (theme.isSystemTheme()) {
-            return repository.getSystemThemeByName(theme.getName());
+            return repository.getSystemThemeByName(theme.getName())
+                    .switchIfEmpty(repository.getSystemThemeByName(Theme.DEFAULT_THEME_NAME));
         } else {
             theme.setApplicationId(null);
             theme.setOrganizationId(null);

--- a/app/server/appsmith-server/src/main/resources/system-themes.json
+++ b/app/server/appsmith-server/src/main/resources/system-themes.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Classic",
+    "displayName": "Classic",
     "config": {
       "colors": {
         "primaryColor": "#50AF6C",
@@ -270,6 +271,7 @@
   },
   {
     "name": "Default",
+    "displayName": "Modern",
     "config": {
       "colors": {
         "primaryColor": "#553DE9",
@@ -539,6 +541,7 @@
   },
   {
     "name": "Sharp",
+    "displayName": "Sharp",
     "config": {
       "colors": {
         "primaryColor": "#3B7DDD",
@@ -808,6 +811,7 @@
   },
   {
     "name": "Rounded",
+    "displayName": "Rounded",
     "config": {
       "colors": {
         "primaryColor": "#DE1593",

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -2472,7 +2472,7 @@ public class ApplicationServiceTest {
         testApplication.setName(appName);
 
         Theme theme = new Theme();
-        theme.setName("Custom theme");
+        theme.setDisplayName("Custom theme");
 
         Mono<Theme> createTheme = themeService.create(theme);
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ThemeServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ThemeServiceTest.java
@@ -254,7 +254,7 @@ public class ThemeServiceTest {
     public void cloneThemeToApplication_WhenSrcThemeIsCustomTheme_NewThemeCreated() {
         Application newApplication = createApplication("api_user", Set.of(MANAGE_APPLICATIONS));
         Theme customTheme = new Theme();
-        customTheme.setName("custom theme");
+        customTheme.setDisplayName("custom theme");
         customTheme.setPolicies(Set.copyOf(
                 policyUtils.generatePolicyFromPermission(Set.of(MANAGE_THEMES), "api_user").values()
         ));
@@ -270,7 +270,7 @@ public class ThemeServiceTest {
         StepVerifier.create(newAndOldThemeMono)
                 .assertNext(objects -> {
                     assertThat(objects.getT1().getId()).isNotEqualTo(objects.getT2().getId());
-                    assertThat(objects.getT1().getName()).isEqualTo(objects.getT2().getName());
+                    assertThat(objects.getT1().getDisplayName()).isEqualTo(objects.getT2().getDisplayName());
                 })
                 .verifyComplete();
     }
@@ -283,7 +283,7 @@ public class ThemeServiceTest {
         Mono<Tuple2<Theme, Theme>> newAndOldThemeMono = applicationRepository.save(srcApplication)
                 .flatMap(application -> {
                     Theme srcCustomTheme = new Theme();
-                    srcCustomTheme.setName("custom theme");
+                    srcCustomTheme.setDisplayName("custom theme");
                     srcCustomTheme.setApplicationId(application.getId());
                     srcCustomTheme.setPolicies(Set.copyOf(
                             policyUtils.generatePolicyFromPermission(Set.of(MANAGE_THEMES), "api_user").values()
@@ -306,7 +306,7 @@ public class ThemeServiceTest {
                     Theme srcTheme = objects.getT2();
 
                     assertThat(clonnedTheme.getId()).isNotEqualTo(srcTheme.getId());
-                    assertThat(clonnedTheme.getName()).isEqualTo(srcTheme.getName());
+                    assertThat(clonnedTheme.getDisplayName()).isEqualTo(srcTheme.getDisplayName());
                     assertThat(clonnedTheme.getApplicationId()).isNull();
                     assertThat(clonnedTheme.getOrganizationId()).isNull();
                 })
@@ -321,7 +321,7 @@ public class ThemeServiceTest {
         ).values();
 
         Theme customTheme = new Theme();
-        customTheme.setName("custom theme for edit mode");
+        customTheme.setDisplayName("custom theme for edit mode");
         customTheme.setPolicies(Set.copyOf(themePolicies));
 
         Mono<Tuple2<Theme, Theme>> applicationThemesMono = themeService.save(customTheme)
@@ -341,8 +341,8 @@ public class ThemeServiceTest {
                 .assertNext(objects -> {
                     Theme editTheme = objects.getT1();
                     Theme publishedTheme = objects.getT2();
-                    assertThat(editTheme.getName()).isEqualTo(customTheme.getName());
-                    assertThat(publishedTheme.getName()).isEqualToIgnoringCase("classic");
+                    assertThat(editTheme.getDisplayName()).isEqualTo(customTheme.getDisplayName());
+                    assertThat(publishedTheme.getDisplayName()).isEqualToIgnoringCase("classic");
                 }).verifyComplete();
     }
 
@@ -374,7 +374,7 @@ public class ThemeServiceTest {
 
     @WithUserDetails("api_user")
     @Test
-    public void publishTheme_WhenSystemThemeInEditModeAndCustomThemeInPublishedMode_PublisedCopyDeleted() {
+    public void publishTheme_WhenSystemThemeInEditModeAndCustomThemeInPublishedMode_PublishedCopyDeleted() {
         Mono<Theme> classicThemeMono = themeService.getSystemTheme("classic").cache();
 
         Theme customTheme = new Theme();
@@ -407,7 +407,7 @@ public class ThemeServiceTest {
         ).values();
 
         Theme customTheme = new Theme();
-        customTheme.setName("my-custom-theme");
+        customTheme.setDisplayName("my-custom-theme");
         customTheme.setPolicies(Set.copyOf(themePolicies));
 
         Mono<Tuple2<Theme, Theme>> appThemesMono = themeService.save(customTheme)
@@ -428,7 +428,7 @@ public class ThemeServiceTest {
                 .assertNext(objects -> {
                     Theme editModeTheme = objects.getT1();
                     Theme publishedModeTheme = objects.getT2();
-                    assertThat(editModeTheme.getName()).isEqualTo(publishedModeTheme.getName()); // same name
+                    assertThat(editModeTheme.getDisplayName()).isEqualTo(publishedModeTheme.getDisplayName()); // same name
                     assertThat(editModeTheme.getId()).isNotEqualTo(publishedModeTheme.getId()); // different id
                 }).verifyComplete();
     }
@@ -437,7 +437,7 @@ public class ThemeServiceTest {
     @Test
     public void updateTheme_WhenSystemThemeIsSet_NewThemeCreated() {
         Theme customTheme = new Theme();
-        customTheme.setName("My custom theme");
+        customTheme.setDisplayName("My custom theme");
 
         Mono<Tuple2<Theme, Theme>> appThemesMono = themeService.getSystemTheme("classic")
                 .flatMap(theme -> {
@@ -456,11 +456,11 @@ public class ThemeServiceTest {
                 .assertNext(objects -> {
                     Theme editModeTheme = objects.getT1(); // should be a new theme
                     Theme publishedModeTheme = objects.getT2(); // should be the system theme
-                    assertThat(editModeTheme.getName()).isEqualTo(customTheme.getName());
+                    assertThat(editModeTheme.getDisplayName()).isEqualTo(customTheme.getDisplayName());
                     assertThat(editModeTheme.getId()).isNotEqualTo(publishedModeTheme.getId()); // different id
                     assertThat(editModeTheme.isSystemTheme()).isFalse();
                     assertThat(publishedModeTheme.isSystemTheme()).isTrue();
-                    assertThat(publishedModeTheme.getName()).isEqualToIgnoringCase("classic");
+                    assertThat(publishedModeTheme.getDisplayName()).isEqualToIgnoringCase("classic");
                 }).verifyComplete();
     }
 
@@ -471,7 +471,7 @@ public class ThemeServiceTest {
                 Set.of(MANAGE_THEMES), "api_user"
         ).values();
         Theme customTheme = new Theme();
-        customTheme.setName("My custom theme");
+        customTheme.setDisplayName("My custom theme");
         customTheme.setPolicies(Set.copyOf(themePolicies));
 
         Mono<Theme> saveCustomThemeMono = themeService.save(customTheme);
@@ -485,7 +485,7 @@ public class ThemeServiceTest {
                     return applicationRepository.save(application);
                 }).flatMap(application -> {
                     Theme themeCustomization = new Theme();
-                    themeCustomization.setName("Updated name");
+                    themeCustomization.setDisplayName("Updated name");
                     return themeService.updateTheme(application.getId(), themeCustomization).then(Mono.zip(
                             themeService.getApplicationTheme(application.getId(), ApplicationMode.EDIT),
                             themeService.getApplicationTheme(application.getId(), ApplicationMode.PUBLISHED),
@@ -504,10 +504,10 @@ public class ThemeServiceTest {
                     assertThat(appBeforeUpdateTheme.getPublishedModeThemeId()).isEqualTo(publishedModeTheme.getId());
                     assertThat(editModeTheme.isSystemTheme()).isFalse();
                     assertThat(editModeTheme.getId()).isNotEqualTo(publishedModeTheme.getId()); // different id
-                    assertThat(editModeTheme.getName()).isEqualTo("Updated name");
+                    assertThat(editModeTheme.getDisplayName()).isEqualTo("Updated name");
 
                     assertThat(publishedModeTheme.isSystemTheme()).isTrue();
-                    assertThat(publishedModeTheme.getName()).isEqualToIgnoringCase("classic");
+                    assertThat(publishedModeTheme.getDisplayName()).isEqualToIgnoringCase("classic");
                 }).verifyComplete();
     }
 
@@ -541,7 +541,7 @@ public class ThemeServiceTest {
         ).values();
 
         Theme customTheme = new Theme();
-        customTheme.setName("my-custom-theme");
+        customTheme.setDisplayName("my-custom-theme");
         customTheme.setPolicies(Set.copyOf(themePolicies));
 
         Mono<Theme> appThemesMono = themeService.save(customTheme)
@@ -582,7 +582,7 @@ public class ThemeServiceTest {
         ).values();
 
         Theme customTheme = new Theme();
-        customTheme.setName("Classic");
+        customTheme.setDisplayName("Classic");
         customTheme.setPolicies(Set.copyOf(themePolicies));
 
         Mono<Tuple3<List<Theme>, Theme, Application>> tuple3Mono = themeService.save(customTheme).flatMap(theme -> {
@@ -592,7 +592,7 @@ public class ThemeServiceTest {
             return applicationRepository.save(application);
         }).flatMap(application -> {
             Theme theme = new Theme();
-            theme.setName("My custom theme");
+            theme.setDisplayName("My custom theme");
             return themeService.persistCurrentTheme(application.getId(), theme)
                     .map(theme1 -> Tuples.of(theme1, application));
         }).flatMap(persistedThemeAndApp ->
@@ -629,7 +629,7 @@ public class ThemeServiceTest {
                 })
                 .flatMap(savedApplication -> {
                     Theme theme = new Theme();
-                    theme.setName("My custom theme");
+                    theme.setDisplayName("My custom theme");
                     return themeService.persistCurrentTheme(savedApplication.getId(), theme)
                             .map(theme1 -> Tuples.of(theme1, savedApplication.getId()));
                 }).flatMap(persistedThemeAndAppId ->
@@ -669,7 +669,7 @@ public class ThemeServiceTest {
                 })
                 .flatMap(savedApplication -> {
                     Theme themeCustomization = new Theme();
-                    themeCustomization.setName("Updated name");
+                    themeCustomization.setDisplayName("Updated name");
                     return themeService.updateTheme(savedApplication.getId(), themeCustomization);
                 }).flatMap(customizedTheme -> themeService.archiveById(customizedTheme.getId()));
 
@@ -690,7 +690,7 @@ public class ThemeServiceTest {
                 })
                 .flatMap(savedApplication -> {
                     Theme themeCustomization = new Theme();
-                    themeCustomization.setName("Updated name");
+                    themeCustomization.setDisplayName("Updated name");
                     return themeService.persistCurrentTheme(savedApplication.getId(), themeCustomization);
                 })
                 .flatMap(customizedTheme -> themeService.archiveById(customizedTheme.getId())
@@ -705,6 +705,7 @@ public class ThemeServiceTest {
         Mono<Theme> updateThemeNameMono = themeService.getDefaultThemeId().flatMap(themeId -> {
             Theme theme = new Theme();
             theme.setName("My theme");
+            theme.setDisplayName("My theme");
             return themeService.updateName(themeId, theme);
         });
         StepVerifier.create(updateThemeNameMono).expectError(AppsmithException.class).verify();
@@ -723,18 +724,20 @@ public class ThemeServiceTest {
                 })
                 .flatMap(savedApplication -> {
                     Theme themeCustomization = new Theme();
-                    themeCustomization.setName("old name");
+                    themeCustomization.setDisplayName("old name");
                     return themeService.persistCurrentTheme(savedApplication.getId(), themeCustomization);
                 })
                 .flatMap(customizedTheme -> {
                     Theme theme = new Theme();
                     theme.setName("new name");
+                    theme.setDisplayName("new display name");
                     return themeService.updateName(customizedTheme.getId(), theme)
                             .then(themeService.getThemeById(customizedTheme.getId(), READ_THEMES));
                 });
 
         StepVerifier.create(updateThemeNameMono).assertNext(theme -> {
             assertThat(theme.getName()).isEqualTo("new name");
+            assertThat(theme.getDisplayName()).isEqualTo("new display name");
             assertThat(theme.isSystemTheme()).isFalse();
             assertThat(theme.getApplicationId()).isNotNull();
             assertThat(theme.getOrganizationId()).isEqualTo("test-org");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
@@ -529,7 +529,7 @@ public class ApplicationForkingServiceTests {
                     return applicationPageService.createApplication(application, createdOrg.getId());
                 }).flatMap(srcApplication -> {
                     Theme theme = new Theme();
-                    theme.setName("theme_" + uniqueString);
+                    theme.setDisplayName("theme_" + uniqueString);
                     return themeService.updateTheme(srcApplication.getId(), theme)
                             .then(applicationService.findById(srcApplication.getId()));
                 }).flatMap(srcApplication -> {
@@ -572,8 +572,8 @@ public class ApplicationForkingServiceTests {
             assertThat(editModeTheme.getApplicationId()).isNullOrEmpty();
 
             // forked theme should have the same name as src theme
-            assertThat(editModeTheme.getName()).isEqualTo("theme_" + uniqueString);
-            assertThat(publishedModeTheme.getName()).isEqualTo("theme_" + uniqueString);
+            assertThat(editModeTheme.getDisplayName()).isEqualTo("theme_" + uniqueString);
+            assertThat(publishedModeTheme.getDisplayName()).isEqualTo("theme_" + uniqueString);
 
             // forked application should have a new edit mode theme created, should not be same as src app theme
             assertThat(srcApp.getEditModeThemeId()).isNotEqualTo(forkedApp.getEditModeThemeId());
@@ -646,7 +646,7 @@ public class ApplicationForkingServiceTests {
                     return applicationPageService.createApplication(application, createdOrg.getId());
                 }).flatMap(srcApplication -> {
                     Theme theme = new Theme();
-                    theme.setName("theme_" + uniqueString);
+                    theme.setDisplayName("theme_" + uniqueString);
                     return themeService.updateTheme(srcApplication.getId(), theme)
                             .then(themeService.persistCurrentTheme(srcApplication.getId(), theme))
                             .then(applicationService.findById(srcApplication.getId()));
@@ -692,8 +692,8 @@ public class ApplicationForkingServiceTests {
             assertThat(editModeTheme.getApplicationId()).isNullOrEmpty();
 
             // forked theme should have the same name as src theme
-            assertThat(editModeTheme.getName()).isEqualTo("theme_" + uniqueString);
-            assertThat(publishedModeTheme.getName()).isEqualTo("theme_" + uniqueString);
+            assertThat(editModeTheme.getDisplayName()).isEqualTo("theme_" + uniqueString);
+            assertThat(publishedModeTheme.getDisplayName()).isEqualTo("theme_" + uniqueString);
 
             // forked application should have a new edit mode theme created, should not be same as src app theme
             assertThat(srcApp.getEditModeThemeId()).isNotEqualTo(forkedApp.getEditModeThemeId());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -928,12 +928,12 @@ public class ImportExportApplicationServiceTests {
                     Theme publishedTheme = tuple.getT3();
 
                     assertThat(editTheme.isSystemTheme()).isFalse();
-                    assertThat(editTheme.getName()).isEqualTo("Custom edit theme");
+                    assertThat(editTheme.getDisplayName()).isEqualTo("Custom edit theme");
                     assertThat(editTheme.getOrganizationId()).isNull();
                     assertThat(editTheme.getApplicationId()).isNull();
 
                     assertThat(publishedTheme.isSystemTheme()).isFalse();
-                    assertThat(publishedTheme.getName()).isEqualTo("Custom published theme");
+                    assertThat(publishedTheme.getDisplayName()).isEqualTo("Custom published theme");
                     assertThat(publishedTheme.getOrganizationId()).isNullOrEmpty();
                     assertThat(publishedTheme.getApplicationId()).isNullOrEmpty();
                 })

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-custom-themes.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-custom-themes.json
@@ -630,14 +630,14 @@
     ]
   },
   "editModeTheme": {
-    "name": "Custom edit theme",
+    "displayName": "Custom edit theme",
     "new": true,
     "isSystemTheme": false,
     "applicationId": "dummy-app-id",
     "organizationId": "dummy-org-id"
   },
   "publishedTheme": {
-    "name": "Custom published theme",
+    "displayName": "Custom published theme",
     "new": true,
     "isSystemTheme": false,
     "applicationId": "dummy-app-id",


### PR DESCRIPTION
## Description
Changes the name of the default theme by introducing a new theme property - display name. 

Fixes #11885

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- JUnit test
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
