### PR TITLE
added bugfix for date parsing in datepicker widget 2

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2/component/Date.test.ts
+++ b/app/client/src/widgets/DatePickerWidget2/component/Date.test.ts
@@ -1,0 +1,16 @@
+import moment from "moment-timezone";
+import { DateFormatOptions } from "./constants";
+import { parseDate } from "./utils";
+
+describe("DatePickerWidget", () => {
+  it("should parse date strings correctly according to date formats", () => {
+    DateFormatOptions.forEach((format) => {
+      const testDate = new Date(2000000000000); // let's enter into the future
+      const testDateStr = moment(testDate).format(format.value);
+      const parsedDate = parseDate(testDateStr, format.value);
+      expect(parsedDate.getFullYear()).toBe(testDate.getFullYear());
+      expect(parsedDate.getUTCMonth()).toBe(testDate.getUTCMonth());
+      expect(parsedDate.getDate()).toBe(testDate.getDate());
+    });
+  });
+});

--- a/app/client/src/widgets/DatePickerWidget2/component/constants.ts
+++ b/app/client/src/widgets/DatePickerWidget2/component/constants.ts
@@ -1,0 +1,84 @@
+import moment from "moment";
+
+export const DateFormatOptions = [
+  {
+    label: moment().format("YYYY-MM-DDTHH:mm:ss.sssZ"),
+    subText: "ISO 8601",
+    value: "YYYY-MM-DDTHH:mm:ss.sssZ",
+  },
+  {
+    label: moment().format("LLL"),
+    subText: "LLL",
+    value: "LLL",
+  },
+  {
+    label: moment().format("LL"),
+    subText: "LL",
+    value: "LL",
+  },
+  {
+    label: moment().format("YYYY-MM-DD HH:mm"),
+    subText: "YYYY-MM-DD HH:mm",
+    value: "YYYY-MM-DD HH:mm",
+  },
+  {
+    label: moment().format("YYYY-MM-DDTHH:mm:ss"),
+    subText: "YYYY-MM-DDTHH:mm:ss",
+    value: "YYYY-MM-DDTHH:mm:ss",
+  },
+  {
+    label: moment().format("YYYY-MM-DD hh:mm:ss A"),
+    subText: "YYYY-MM-DD hh:mm:ss A",
+    value: "YYYY-MM-DD hh:mm:ss A",
+  },
+  {
+    label: moment().format("DD/MM/YYYY HH:mm"),
+    subText: "DD/MM/YYYY HH:mm",
+    value: "DD/MM/YYYY HH:mm",
+  },
+  {
+    label: moment().format("D MMMM, YYYY"),
+    subText: "D MMMM, YYYY",
+    value: "D MMMM, YYYY",
+  },
+  {
+    label: moment().format("H:mm A D MMMM, YYYY"),
+    subText: "H:mm A D MMMM, YYYY",
+    value: "H:mm A D MMMM, YYYY",
+  },
+  {
+    label: moment().format("YYYY-MM-DD"),
+    subText: "YYYY-MM-DD",
+    value: "YYYY-MM-DD",
+  },
+  {
+    label: moment().format("MM-DD-YYYY"),
+    subText: "MM-DD-YYYY",
+    value: "MM-DD-YYYY",
+  },
+  {
+    label: moment().format("DD-MM-YYYY"),
+    subText: "DD-MM-YYYY",
+    value: "DD-MM-YYYY",
+  },
+  {
+    label: moment().format("MM/DD/YYYY"),
+    subText: "MM/DD/YYYY",
+    value: "MM/DD/YYYY",
+  },
+  {
+    label: moment().format("DD/MM/YYYY"),
+    subText: "DD/MM/YYYY",
+    value: "DD/MM/YYYY",
+  },
+  {
+    label: moment().format("DD/MM/YY"),
+    subText: "DD/MM/YY",
+    value: "DD/MM/YY",
+  },
+  {
+    label: moment().format("MM/DD/YY"),
+    subText: "MM/DD/YY",
+    value: "MM/DD/YY",
+  },
+];

--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -19,6 +19,7 @@ import {
   createMessage,
   DATE_WIDGET_DEFAULT_VALIDATION_ERROR,
 } from "@appsmith/constants/messages";
+import { parseDate } from "./utils";
 
 const StyledControlGroup = styled(ControlGroup)<{ isValid: boolean }>`
   &&& {
@@ -224,10 +225,8 @@ class DatePickerComponent extends React.Component<
     if (!dateStr) {
       return null;
     } else {
-      const date = moment(dateStr);
       const dateFormat = this.props.dateFormat || ISO_DATE_FORMAT;
-      if (date.isValid()) return moment(dateStr, dateFormat).toDate();
-      else return moment().toDate();
+      return parseDate(dateStr, dateFormat);
     }
   };
 

--- a/app/client/src/widgets/DatePickerWidget2/component/utils.ts
+++ b/app/client/src/widgets/DatePickerWidget2/component/utils.ts
@@ -1,0 +1,7 @@
+import moment from "moment-timezone";
+
+export const parseDate = (dateStr: string, dateFormat: string): Date => {
+  const date = moment(dateStr, dateFormat);
+  if (date.isValid()) return date.toDate();
+  else return moment().toDate();
+};

--- a/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
@@ -8,9 +8,9 @@ import { ValidationTypes } from "constants/WidgetValidation";
 import { DerivedPropertiesMap } from "utils/WidgetFactory";
 import { AutocompleteDataType } from "utils/autocomplete/TernServer";
 
-import moment from "moment";
 import derivedProperties from "./parseDerivedProperties";
 import { DatePickerType, TimePrecision } from "../constants";
+import { DateFormatOptions } from "../component/constants";
 
 function allowedRange(value: any) {
   const allowedValues = [0, 1, 2, 3, 4, 5, 6];
@@ -47,88 +47,7 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
             controlType: "DROP_DOWN",
             isJSConvertible: true,
             optionWidth: "340px",
-            options: [
-              {
-                label: moment().format("YYYY-MM-DDTHH:mm:ss.sssZ"),
-                subText: "ISO 8601",
-                value: "YYYY-MM-DDTHH:mm:ss.sssZ",
-              },
-              {
-                label: moment().format("LLL"),
-                subText: "LLL",
-                value: "LLL",
-              },
-              {
-                label: moment().format("LL"),
-                subText: "LL",
-                value: "LL",
-              },
-              {
-                label: moment().format("YYYY-MM-DD HH:mm"),
-                subText: "YYYY-MM-DD HH:mm",
-                value: "YYYY-MM-DD HH:mm",
-              },
-              {
-                label: moment().format("YYYY-MM-DDTHH:mm:ss"),
-                subText: "YYYY-MM-DDTHH:mm:ss",
-                value: "YYYY-MM-DDTHH:mm:ss",
-              },
-              {
-                label: moment().format("YYYY-MM-DD hh:mm:ss A"),
-                subText: "YYYY-MM-DD hh:mm:ss A",
-                value: "YYYY-MM-DD hh:mm:ss A",
-              },
-              {
-                label: moment().format("DD/MM/YYYY HH:mm"),
-                subText: "DD/MM/YYYY HH:mm",
-                value: "DD/MM/YYYY HH:mm",
-              },
-              {
-                label: moment().format("D MMMM, YYYY"),
-                subText: "D MMMM, YYYY",
-                value: "D MMMM, YYYY",
-              },
-              {
-                label: moment().format("H:mm A D MMMM, YYYY"),
-                subText: "H:mm A D MMMM, YYYY",
-                value: "H:mm A D MMMM, YYYY",
-              },
-              {
-                label: moment().format("YYYY-MM-DD"),
-                subText: "YYYY-MM-DD",
-                value: "YYYY-MM-DD",
-              },
-              {
-                label: moment().format("MM-DD-YYYY"),
-                subText: "MM-DD-YYYY",
-                value: "MM-DD-YYYY",
-              },
-              {
-                label: moment().format("DD-MM-YYYY"),
-                subText: "DD-MM-YYYY",
-                value: "DD-MM-YYYY",
-              },
-              {
-                label: moment().format("MM/DD/YYYY"),
-                subText: "MM/DD/YYYY",
-                value: "MM/DD/YYYY",
-              },
-              {
-                label: moment().format("DD/MM/YYYY"),
-                subText: "DD/MM/YYYY",
-                value: "DD/MM/YYYY",
-              },
-              {
-                label: moment().format("DD/MM/YY"),
-                subText: "DD/MM/YY",
-                value: "DD/MM/YY",
-              },
-              {
-                label: moment().format("MM/DD/YY"),
-                subText: "MM/DD/YY",
-                value: "MM/DD/YY",
-              },
-            ],
+            options: DateFormatOptions,
             isBindProperty: true,
             isTriggerProperty: false,
             validation: { type: ValidationTypes.TEXT },


### PR DESCRIPTION
## Description

There was a bug in the parseDate method of the Datepicker widget component where we were not passing the date format correctly, which resulted in resetting of date values to today's date whenever the user types in the date input.

Fixes #11837 

## Type of change

- Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added a unit test for parseDate function
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
