### PR TITLE
fix: Updating contribution guide for widgets

### DIFF
--- a/contributions/docs/Widgets.md
+++ b/contributions/docs/Widgets.md
@@ -5,12 +5,10 @@
 ## Widget docs template
 Copy paste this template 
 ```
----
-description: >-
-  Widget Description
----
 
 # WidgetName
+
+  <Add a description here>
 
 ## Image/gif of the widget on the canvas with the icon of the widget in the sidebar
 


### PR DESCRIPTION
Removing the description box from the widget template for contribution. The description box adds the introduction in the title description  that has a character limit in Gitbook

