### PR TITLE
fix: remove extra key value pair for DataSource

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
@@ -91,6 +91,12 @@ class DatasourceDBEditor extends JSONtoForm<Props> {
   render() {
     const { formConfig } = this.props;
 
+    // make sure this redux form has been initialized before rendering anything.
+    // the initialized prop below comes from redux-form.
+    if (!this.props.initialized) {
+      return null;
+    }
+
     const content = this.renderDataSourceConfigForm(formConfig);
     return this.renderForm(content);
   }


### PR DESCRIPTION
## Description

The extra Host and port Input boxes displayed when the user click to edit a Datasource is removed


Fixes #9664


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/extra-key-value-datasource 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.65 **(0)** | 36.9 **(-0.01)** | 34.96 **(0)** | 55.96 **(0)**
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx | 50.79 **(-1.67)** | 18.18 **(-1.17)** | 9.09 **(0)** | 55.36 **(-2.05)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>