### PR TITLE
fix: wait for organisation list to be fetched before creating an application for welcome tour

### DIFF
--- a/app/client/src/sagas/OnboardingSagas.ts
+++ b/app/client/src/sagas/OnboardingSagas.ts
@@ -76,11 +76,18 @@ import { navigateToCanvas } from "pages/Editor/Explorer/Widgets/utils";
 function* createApplication() {
   // If we are starting onboarding from the editor wait for the editor to reset.
   const isEditorInitialised = yield select(getIsEditorInitialized);
+  let userOrgs: Organization[] = yield select(getOnboardingOrganisations);
   if (isEditorInitialised) {
     yield take(ReduxActionTypes.RESET_EDITOR_SUCCESS);
+
+    // If we haven't fetched the organisation list yet we wait for it to complete
+    // as we need an organisation where we create an application
+    if (!userOrgs.length) {
+      yield take(ReduxActionTypes.FETCH_USER_APPLICATIONS_ORGS_SUCCESS);
+    }
   }
 
-  const userOrgs: Organization[] = yield select(getOnboardingOrganisations);
+  userOrgs = yield select(getOnboardingOrganisations);
   const currentUser = yield select(getCurrentUser);
   const currentOrganizationId = currentUser.currentOrganizationId;
   let organization;


### PR DESCRIPTION
## Description

The onboarding test was failing sometimes as the organisation list wasn't fetched yet while try to create an app for onboarding.  So the fix is to wait for the organisation list to be fetched if it isn't fetched yet.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Has a test already

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/onboarding-test 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.87 **(0)** | 37.23 **(0)** | 35.22 **(0)** | 56.18 **(-0.01)**
 :red_circle: | app/client/src/sagas/OnboardingSagas.ts | 21.05 **(-0.57)** | 1.16 **(-0.03)** | 4.35 **(0)** | 23.88 **(-0.55)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>