### PR TITLE
fix: Updating contribution guidelines for functions

### DIFF
--- a/contributions/docs/InternalFunctions.md
+++ b/contributions/docs/InternalFunctions.md
@@ -7,12 +7,10 @@ Steps to contribute:
 ## Functions docs template
 Copy paste this template in the file you are updating
 ```bash
----
-description: >-
-  Description of the function
----
 
 # Function Name
+  
+  Add the description here
 
 ## Signature
 


### PR DESCRIPTION
Removing the description box from the function doc template for contribution. The description box adds the introduction in the title description that has a character limit in Gitbook.