### PR TITLE
fix: Show signup link even if signup toggle is off

### DIFF
--- a/app/client/src/ce/pages/UserAuth/Login.tsx
+++ b/app/client/src/ce/pages/UserAuth/Login.tsx
@@ -51,7 +51,7 @@ import PerformanceTracker, {
 } from "utils/PerformanceTracker";
 import { getIsSafeRedirectURL } from "utils/helpers";
 import { getCurrentUser } from "selectors/usersSelectors";
-const { disableLoginForm, disableSignup } = getAppsmithConfigs();
+const { disableLoginForm } = getAppsmithConfigs();
 
 const validate = (values: LoginFormValues) => {
   const errors: LoginFormValues = {};
@@ -113,7 +113,7 @@ export function Login(props: LoginFormProps) {
       <AuthCardHeader>
         <h1>{createMessage(LOGIN_PAGE_TITLE)}</h1>
       </AuthCardHeader>
-      {!disableSignup && (
+      {!disableLoginForm && (
         <SignUpLinkSection>
           {createMessage(NEW_TO_APPSMITH)}
           <AuthCardNavLink

--- a/app/client/src/ce/pages/UserAuth/SignUp.tsx
+++ b/app/client/src/ce/pages/UserAuth/SignUp.tsx
@@ -61,7 +61,7 @@ declare global {
     grecaptcha: any;
   }
 }
-const { disableSignup, googleRecaptchaSiteKey } = getAppsmithConfigs();
+const { disableLoginForm, googleRecaptchaSiteKey } = getAppsmithConfigs();
 
 const validate = (values: SignupFormValues) => {
   const errors: SignupFormValues = {};
@@ -87,7 +87,7 @@ type SignUpFormProps = InjectedFormProps<
 export function SignUp(props: SignUpFormProps) {
   const history = useHistory();
   useEffect(() => {
-    if (disableSignup) {
+    if (disableLoginForm) {
       history.replace(AUTH_LOGIN_URL);
     }
   }, []);


### PR DESCRIPTION
## Description

> Fix for signup link is not visible on the login screen when signup is disabled for all users. It should work for invited users.

> If the user has disabled signup, then only invited users are allowed to signup. The user trying to signup on signup page is invited or not is decided by the backend and shows an error if not invited.

> If the user has disabled form login, then signup link on login screen is disabled. This is because users can signup using Google/Github even via Login screen Google/Github buttons.

Fixes #11919

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested by disabling signup for all users using the admin settings page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
