### PR TITLE
fix: Using netty dependency from server for MySQL

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/mysqlPlugin/pom.xml
@@ -30,6 +30,13 @@
     <dependencies>
 
         <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty</artifactId>
+            <version>0.9.4.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-r2dbc</artifactId>
             <version>1.1.5.RELEASE</version>


### PR DESCRIPTION
Local development fails because of the dependency being loaded by both server and plugin class loaders. This fix makes mysql use the server loaded class.