### PR TITLE
fix: Handle JSON schema migration for CRUD page generation JSON template

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaMigration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaMigration.java
@@ -3,6 +3,7 @@ package com.appsmith.server.migrations;
 import com.appsmith.server.domains.ApplicationJson;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
+import com.appsmith.server.helpers.CollectionUtils;
 
 public class JsonSchemaMigration {
     private static boolean checkCompatibility(ApplicationJson applicationJson) {
@@ -38,7 +39,9 @@ public class JsonSchemaMigration {
 
             case 1:
                 // Migration for deprecating archivedAt field in ActionDTO
-                HelperMethods.updateArchivedAtByDeletedATForActions(applicationJson.getActionList());
+                if (!CollectionUtils.isNullOrEmpty(applicationJson.getActionList())) {
+                    HelperMethods.updateArchivedAtByDeletedATForActions(applicationJson.getActionList());
+                }
                 applicationJson.setServerSchemaVersion(2);
             case 2:
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaMigration.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/JsonSchemaMigration.java
@@ -31,13 +31,15 @@ public class JsonSchemaMigration {
             return applicationJson;
         }
         // Run migration linearly
+        // Updating the schema version after each migration is not required as we are not exiting by breaking the switch
+        // cases, but this keeps the version number and the migration in sync
         switch (applicationJson.getServerSchemaVersion()) {
             case 0:
 
             case 1:
                 // Migration for deprecating archivedAt field in ActionDTO
                 HelperMethods.updateArchivedAtByDeletedATForActions(applicationJson.getActionList());
-
+                applicationJson.setServerSchemaVersion(2);
             case 2:
 
             default:

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -26,6 +26,7 @@ import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.migrations.JsonSchemaMigration;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.ApplicationPageService;
 import com.appsmith.server.services.ApplicationService;
@@ -483,7 +484,8 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
         Gson gson = gsonBuilder.registerTypeAdapter(DatasourceStructure.Key.class, new DatasourceStructure.KeyInstanceCreator())
                 .create();
 
-        return gson.fromJson(jsonContent, ApplicationJson.class);
+        ApplicationJson applicationJson = gson.fromJson(jsonContent, ApplicationJson.class);
+        return JsonSchemaMigration.migrateApplicationToLatestSchema(applicationJson);
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -1,11 +1,11 @@
 package com.appsmith.server.solutions;
 
+import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.InvisibleActionFields;
-import com.appsmith.external.models.DecryptedSensitiveFields;
 import com.appsmith.external.models.Policy;
 import com.appsmith.external.models.Property;
 import com.appsmith.server.constants.FieldName;
@@ -30,6 +30,7 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.migrations.JsonSchemaMigration;
 import com.appsmith.server.migrations.JsonSchemaVersions;
 import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.NewPageRepository;
@@ -95,7 +96,6 @@ import static com.appsmith.server.acl.AclPermission.MANAGE_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_DATASOURCES;
 import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
-import static com.appsmith.server.acl.AclPermission.MANAGE_THEMES;
 import static com.appsmith.server.acl.AclPermission.READ_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.READ_PAGES;
@@ -1871,6 +1871,34 @@ public class ImportExportApplicationServiceTests {
                     assertThat(actionCollectionNames).contains(deletedActionCollectionNames);
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void applySchemaMigration_jsonFileWithFirstVersion_migratedToLatestVersionSuccess() {
+        Mono<ApplicationJson> v1ApplicationMono = createAppJson("test_assets/ImportExportServiceTest/file-with-v1.json").cache();
+        Mono<ApplicationJson> migratedApplicationMono = v1ApplicationMono
+                .map(applicationJson -> {
+                    ApplicationJson applicationJson1 = new ApplicationJson();
+                    AppsmithBeanUtils.copyNestedNonNullProperties(applicationJson, applicationJson1);
+                    return JsonSchemaMigration.migrateApplicationToLatestSchema(applicationJson1);
+                });
+
+        StepVerifier
+                .create(Mono.zip(v1ApplicationMono, migratedApplicationMono))
+                .assertNext(tuple -> {
+                    ApplicationJson v1ApplicationJson = tuple.getT1();
+                    ApplicationJson latestApplicationJson = tuple.getT2();
+
+                    assertThat(v1ApplicationJson.getServerSchemaVersion()).isEqualTo(1);
+                    assertThat(v1ApplicationJson.getClientSchemaVersion()).isEqualTo(1);
+
+                    assertThat(latestApplicationJson.getServerSchemaVersion()).isEqualTo(JsonSchemaVersions.serverVersion);
+                    assertThat(latestApplicationJson.getClientSchemaVersion()).isEqualTo(JsonSchemaVersions.clientVersion);
+                })
+                .verifyComplete();
+
+
     }
     
 }

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/file-with-v1.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/file-with-v1.json
@@ -1,0 +1,4 @@
+{
+  "serverSchemaVersion" : 1,
+  "clientSchemaVersion" : 1
+}


### PR DESCRIPTION
## Description

> When we run the schema updates we specify the JSON migration to keep the change backward compatible for already exported files. This check was missing for the template which we use for CRUD page generation. This PR introduces the migration for stored JSON file used for CRUD page.  

Fixes https://github.com/appsmithorg/appsmith/issues/11867

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Manual test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
