### PR TITLE
fix: Unable to use IN or ANY clause with prepared statements fix

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/QueryUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/QueryUtils.java
@@ -45,4 +45,33 @@ public class QueryUtils {
         }
         return sb.toString().trim();
     }
+
+    /**
+     * To remove Square braces if any in the query.
+     * In a scenario like Multiselect widget, the params are passed as an array which carries a square bracket.
+     * This method will fix it
+     * @param query
+     * @return
+     */
+    public static String removeSquareBraces(String query) {
+        if (query.contains("[") || query.contains("]")) {
+            query = query.replaceAll("\\[", "").replaceAll("\\]","");
+        }
+        return query;
+    }
+
+    /**
+     * Add double quotes for params missing double quotes.
+     * To handle where some widgets send data without double Quotes.
+     * @param query
+     * @return
+     */
+   public static String addDoubleQuotes(String query) {
+        String retQuery = query;
+        if (query.substring(0).equals("\"")) retQuery = query;
+
+       retQuery = "\"" + query + "\"";
+
+       return retQuery;
+    }
 }


### PR DESCRIPTION
## Unable to use IN or ANY clause with prepared statements

Resolved SQL IN clause when used with component mapping.
ANY clause works fine with SQL query, but not with data 

**Issue Resolution :**
When using a widget like Multiselect the IN clause is substituted with a array of values. This causes issues with the way prepared statement was handled earlier. Updated code by adding one method which can parse the multiple inputs and convert into multiple params.
eg:    
```
Earlier :
IN ( [1988, 1973, 1999, 2015] ) is identified with one param (?)   // Causes problem
Now :
IN ( 1988, 1973, 1999, 2015 )  with n params like (?, ?, ?, ?)   // Rest of the code can handle as before.
```



Fixes #11259

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

**Manual Tests Done**
| Test Case | Actions | Result | Status (Stmt , PreparedStmt) |
| --- | -----------| --- | :---: |
| Simple Select query| Select * from ...| As expected |  Pass, Pass |
| Simple insert query| Insert into...| As expected |  Pass, Pass |
| Simple update query| Update tabel...| As expected |  Pass, Pass |
| Qry with where condition| Params in query | As expected|  Pass, Pass |
| Qry with where condition| Params mapped from widgets | As expected|  Pass, Pass |
| Qry with where condition| Params mapped from multiple widgets | As expected|  Pass, Pass |
| Qry with IN clause| Params set in query | As expected|  Pass, Pass |
| Qry with IN clause| Params mapped from widgets | As expected|  Pass, Pass |
| Qry with IN clause| Params mapped from one multiselect widget | As expected|  Pass, Pass |
| Qry with IN clause| Params mapped from two multiselect widget | As expected|  Pass, Pass |
| Qry with IN clause| Params mapped from two multiselect widget and text widget | As expected|  Pass, Pass |
| Qry with IN clause| Params mapped from two multiselect widget and text widget and manual in query | As expected|  Pass, Pass |
| Qry with ANY clause| values set in query  | Error as expected (No support) |  Pass, Pass |
| Qry with ANY clause| Values mapped from widgets  | Error as expected (No support) |  Pass, Pass |
| Qry with ANY clause| Values from subquery  | As expected |  Pass, Pass |


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
