### PR TITLE
chore: update import template response parsing

### DIFF
--- a/app/client/src/api/TemplatesApi.ts
+++ b/app/client/src/api/TemplatesApi.ts
@@ -51,7 +51,7 @@ class TemplatesAPI extends Api {
   static importTemplate(
     templateId: string,
     organizationId: string,
-  ): AxiosPromise<any> {
+  ): AxiosPromise<ImportTemplateResponse> {
     return Api.post(
       TemplatesAPI.baseUrl +
         `/app-templates/${templateId}/import/${organizationId}`,


### PR DESCRIPTION
## Description

The response meta was added as mentioned in https://github.com/appsmithorg/appsmith/issues/11661. So the response structure changed which needs an update on the frontend.

Previous response structure
```
{
  applicationId: ...
  ...
}
```
After the response meta addition from the backend
```
{
   responseMeta: {
      ...
   },
   data: {
     applicationId: ...
     ....
   }
}
```

The frontend change is to conform to this spec.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/reposnse-parsing 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.63 **(0)** | 36.88 **(0.01)** | 34.95 **(0)** | 55.94 **(0.01)**
 :red_circle: | app/client/src/sagas/TemplatesSagas.ts | 26.83 **(-2.12)** | 8.33 **(-1.67)** | 16.67 **(0)** | 32.35 **(-2.03)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>