### PR TITLE
fix: Fix replicaset checking with limited permissions

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -129,7 +129,6 @@ init_replica_set() {
 
     if appsmithctl check_replica_set; then
       echo "Mongodb cloud Replica Set is enabled"
-      mongo "$APPSMITH_MONGODB_URI" --eval 'rs.initiate()'
     else
       echo -e "\033[0;31m********************************************************************\033[0m"
       echo -e "\033[0;31m*          MongoDB Replica Set is not enabled                      *\033[0m"

--- a/deploy/docker/utils/bin/check_replica_set.js
+++ b/deploy/docker/utils/bin/check_replica_set.js
@@ -6,12 +6,12 @@ async function exec() {
     useUnifiedTopology: true,
   });
 
-  let isReplicaSetEnabled = false
+  let isReplicaSetEnabled = false;
 
   try {
     isReplicaSetEnabled = await checkReplicaSet(client);
   } catch (err) {
-    console.error("Error trying to check replicaset", err)
+    console.error("Error trying to check replicaset", err);
   } finally {
     client.close();
   }
@@ -29,7 +29,7 @@ async function checkReplicaSet(client) {
         .watch()
         .on("change", (change) => console.log(change))
         .on("error", (err) => {
-          console.error("Error even from changeStream", err)
+          console.error("Error even from changeStream", err);
           resolve(false);
         });
 

--- a/deploy/docker/utils/bin/check_replica_set.js
+++ b/deploy/docker/utils/bin/check_replica_set.js
@@ -5,25 +5,18 @@ async function exec() {
     useNewUrlParser: true,
     useUnifiedTopology: true,
   });
-  checkReplicaSet(client)
-    .then((res) => {
-      // support replica set
-      if (res === 0) {
-        client.close();
-        process.exit(0);
-      }
 
-      // not support replica set
-      if (res === 1) {
-        client.close();
-        process.exit(1);
-      }
-    })
-    .catch((err) => {
-      // exit 1 for any other error
-      client.close();
-      process.exit(1);
-    });
+  let isReplicaSetEnabled = false
+
+  try {
+    isReplicaSetEnabled = await checkReplicaSet(client);
+  } catch (err) {
+    console.error("Error trying to check replicaset", err)
+  } finally {
+    client.close();
+  }
+
+  process.exit(isReplicaSetEnabled ? 0 : 1);
 }
 
 async function checkReplicaSet(client) {
@@ -31,17 +24,22 @@ async function checkReplicaSet(client) {
   return await new Promise((resolve) => {
     try {
       client
+        .db()
+        .collection("user")
         .watch()
         .on("change", (change) => console.log(change))
-        .on("error", () => resolve(1));
+        .on("error", (err) => {
+          console.error("Error even from changeStream", err)
+          resolve(false);
+        });
 
       // setTimeout so the error event can kick-in first
       setTimeout(() => {
-        resolve(0);
+        resolve(true);
       }, 1000);
     } catch (err) {
-      console.log(err.stack);
-      resolve(1);
+      console.error("Error thrown when checking replicaset", err);
+      resolve(false);
     }
   });
 }


### PR DESCRIPTION
When running the fat container, with an external MongoDB, where the user only has the following permission:

```js
            {
                "role" : "readWrite",
                "db" : "appsmith"
            }
```

The container fails to start. Although this permission is sufficient to work with `changeStream`s, we get the following error instead:

```
Checking Replica Set of external MongoDB
********************************************************************
*          MongoDB Replica Set is not enabled                      *
********************************************************************
```

This PR fixes the problem by checking for `changeStream` only in the DB that we have access to, and only on a specific collection, the `user` collection. This way, even if the user doesn't have permissions on the whole database, we can still work with it.
