### PR TITLE
fix: Kill MongoDB immediately when switching to external, or vice versa

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -306,15 +306,9 @@ public class EnvManagerCEImpl implements EnvManagerCE {
     public Mono<Void> restart() {
         return verifyCurrentUserIsSuper()
                 .flatMap(user -> {
-                    log.warn("Initiating restart via supervisor.");
+                    log.warn("Running restart script.");
                     try {
-                        Runtime.getRuntime().exec(new String[]{
-                                "supervisorctl",
-                                "restart",
-                                "backend",
-                                "editor",
-                                "rts",
-                        });
+                        Runtime.getRuntime().exec("/opt/appsmith/update-and-restart-supervisor.sh");
                     } catch (IOException e) {
                         log.error("Error invoking supervisorctl to restart.", e);
                         return Mono.error(new AppsmithException(AppsmithError.INTERNAL_SERVER_ERROR));

--- a/deploy/docker/scripts/update-and-restart-supervisor.sh
+++ b/deploy/docker/scripts/update-and-restart-supervisor.sh
@@ -6,52 +6,63 @@ set -o xtrace
 ENV_PATH="/appsmith-stacks/configuration/docker.env"
 SUPERVISORD_CONF_PATH="/opt/appsmith/templates/supervisord"
 echo 'Load environment configuration'
-set -o allexport
 . "$ENV_PATH"
-set +o allexport
 
-check_mongodb_uri() {
-  echo "Check MongoDB uri host"
-  isLocalMongo=1
-  if [[ $APPSMITH_MONGODB_URI == *"localhost"* || $APPSMITH_MONGODB_URI == *"127.0.0.1"* ]]; then
-    echo "Use local MongoDB"
-    isLocalMongo=0
-  fi
-}
-check_redis_uri() {
-  echo "Check Redis uri host"
-  isLocalRedis=1
-  if [[ $APPSMITH_REDIS_URL == *"localhost"* || $APPSMITH_REDIS_URL == *"127.0.0.1"* ]]; then
-    echo "Use local Redis"
-    isLocalRedis=0
-  fi
+is-local-uri() {
+  local uri="$1"
+  [[ $uri == *"localhost"* || $uri == *"127.0.0.1"* ]]
 }
 
-update_supervisord_mongodb_conf() {
+apply-mongodb-change() {
   echo "Update supervisord MongoDB conf"
-  if [ $isLocalMongo -eq 1 ]; then
-    echo "Disable MongoDB supervisord"
-    rm -f mongodb.conf
-  else
+  if is-local-uri "$APPSMITH_MONGODB_URI"; then
     echo "Enable MongoDB supervisord"
     cp "$SUPERVISORD_CONF_PATH/mongodb.conf" /etc/supervisor/conf.d/
+    mongodb_change=enabled
+  elif [[ -f /etc/supervisor/conf.d/mongodb.conf ]]; then
+    echo "Disable MongoDB supervisord"
+    rm -v /etc/supervisor/conf.d/mongodb.conf
+    mongodb_change=disabled
   fi
+  mongodb_change=none
 }
 
-update_supervisord_redis_conf() {
+apply-redis-change() {
   echo "Update supervisord Redis conf"
-  if [ $isLocalRedis -eq 1 ]; then
-    echo "Disable Redis supervisord"
-    rm -f redis.conf
-  else
+  if is-local-uri "$APPSMITH_REDIS_URL"; then
     echo "Enable Redis supervisord"
     cp "$SUPERVISORD_CONF_PATH/redis.conf" /etc/supervisor/conf.d/
+    redis_change=enabled
+  elif [[ -f /etc/supervisor/conf.d/redis.conf ]]; then
+    echo "Disable Redis supervisord"
+    rm -v /etc/supervisor/conf.d/redis.conf
+    redis_change=disabled
   fi
+  redis_change=none
 }
 
-check_mongodb_uri
-update_supervisord_mongodb_conf
-check_redis_uri
-update_supervisord_redis_conf
+apply-mongodb-change
+apply-redis-change
+
+# When enabling local MongoDB, `update mongodb` should happen _before_ restarting backend, so that the local MongoDB is
+# ready for the backend to connect to. But when disabling local MongoDB, `update mongodb` should happen _after_
+# restarting backend, so that supervisor doesn't kill the DB while the backend is still connected to it.
+# Same logic applies for Redis.
+
+if [[ $mongodb_change == enabled ]]; then
+  supervisorctl update mongodb
+fi
+
+if [[ $redis_change == enabled ]]; then
+  supervisorctl update redis
+fi
+
 supervisorctl restart backend editor rts
-supervisorctl update
+
+if [[ $mongodb_change == disabled ]]; then
+  supervisorctl update mongodb
+fi
+
+if [[ $redis_change == disabled ]]; then
+  supervisorctl update redis
+fi


### PR DESCRIPTION
Fixes #9967
