### PR TITLE
fix: Redirect Redis log to supervisord log

### DIFF
--- a/deploy/docker/templates/supervisord/redis.conf
+++ b/deploy/docker/templates/supervisord/redis.conf
@@ -1,8 +1,8 @@
 [program:redis]
 directory=/etc/redis
-; redirect logfile of Redis process to /dev/null
-; so that supervisord can capture and redirect to stdout_logfile
-command=redis-server redis.conf --daemonize no --logfile /dev/null
+; The empty string is used to force Redis to log to stdout
+; so that supervisor can capture it
+command=redis-server redis.conf --daemonize no --logfile ""
 priority=5
 autostart=true
 autorestart=true

--- a/deploy/docker/templates/supervisord/redis.conf
+++ b/deploy/docker/templates/supervisord/redis.conf
@@ -1,6 +1,8 @@
 [program:redis]
 directory=/etc/redis
-command=redis-server redis.conf --daemonize no
+; redirect logfile of Redis process to /dev/null
+; so that supervisord can capture and redirect to stdout_logfile
+command=redis-server redis.conf --daemonize no --logfile /dev/null
 priority=5
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Description
- Redirect default Redis log to supervisor child process log.

Fixes # (issue)
[Redis and NGINX logs aren't collected in the logs folder with fat container](https://github.com/appsmithorg/appsmith/issues/11787)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Build new image and check the log at `stacks/logs/redis/redis.log`


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
