### PR TITLE
fix: introduce new regexp for remote url validation

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GitSync/Connection_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GitSync/Connection_spec.js
@@ -216,12 +216,7 @@ describe("Git sync modal: connect tab", function() {
       .click({ force: true })
       .type(`{selectAll}${invalidURLDetectedOnTheBackend}`);
     cy.get(gitSyncLocators.connectSubmitBtn).scrollIntoView();
-    cy.get(gitSyncLocators.connectSubmitBtn).click();
-    cy.wait("@connectGitRepo").then((interception) => {
-      const status = interception.response.body.responseMeta.status;
-      expect(status).to.be.gte(400);
-      // todo check for error msg based on the context
-    });
+    cy.get(gitSyncLocators.connectSubmitBtn).should("be.visible");
 
     cy.get(gitSyncLocators.gitRepoInput)
       .scrollIntoView()

--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
@@ -13,14 +13,14 @@ import {
   CONNECTING_REPO,
   createMessage,
   GENERATE_KEY,
+  IMPORT_BTN_LABEL,
+  IMPORT_FROM_GIT_REPOSITORY,
+  IMPORTING_APP_FROM_GIT,
   LEARN_MORE,
   PASTE_SSH_URL_INFO,
   REMOTE_URL,
   REMOTE_URL_INFO,
   REMOTE_URL_INPUT_PLACEHOLDER,
-  IMPORT_FROM_GIT_REPOSITORY,
-  IMPORT_BTN_LABEL,
-  IMPORTING_APP_FROM_GIT,
   UPDATE_CONFIG,
 } from "@appsmith/constants/messages";
 import styled from "styled-components";
@@ -54,11 +54,11 @@ import {
   getGlobalGitConfig,
   getIsFetchingGlobalGitConfig,
   getIsFetchingLocalGitConfig,
+  getIsImportingApplicationViaGit,
   getLocalGitConfig,
   getRemoteUrlDocUrl,
   getTempRemoteUrl,
   getUseGlobalProfile,
-  getIsImportingApplicationViaGit,
 } from "selectors/gitSyncSelectors";
 import Statusbar, {
   StatusbarWrapper,
@@ -141,12 +141,10 @@ const TooltipWrapper = styled.div`
 
 // v1 only support SSH
 const selectedAuthType = AUTH_TYPE_OPTIONS[0];
-const HTTP_LITERAL = "https";
 
-const SSH_INIT_FORMAT_REGEX = new RegExp(/^(ssh|.+@).*/);
+const REMOTE_URL_RE = /^((git|ssh)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)$/im;
 
-const remoteUrlIsInvalid = (value: string) =>
-  value.startsWith(HTTP_LITERAL) || !SSH_INIT_FORMAT_REGEX.test(value);
+const validRemoteURL = (value: string) => new RegExp(REMOTE_URL_RE).test(value);
 
 type AuthorInfo = {
   authorName: string;
@@ -264,7 +262,7 @@ function GitConnection({ isImport }: Props) {
   }, [authorInfo.authorEmail, authorInfo.authorName, localGitConfig]);
 
   const remoteUrlChangeHandler = (value: string) => {
-    const isInvalid = remoteUrlIsInvalid(value);
+    const isInvalid = !validRemoteURL(value);
     setIsValidRemoteUrl(isInvalid);
     setRemoteUrl(value);
     dispatch(remoteUrlInputValue({ tempRemoteUrl: value }));

--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
@@ -70,6 +70,7 @@ import Link from "../components/Link";
 import TooltipComponent from "components/ads/Tooltip";
 import Icon, { IconSize } from "components/ads/Icon";
 import AnalyticsUtil from "utils/AnalyticsUtil";
+import { isValidGitRemoteUrl } from "../utils";
 
 export const UrlOptionContainer = styled.div`
   display: flex;
@@ -141,10 +142,6 @@ const TooltipWrapper = styled.div`
 
 // v1 only support SSH
 const selectedAuthType = AUTH_TYPE_OPTIONS[0];
-
-const REMOTE_URL_RE = /^((git|ssh)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)$/im;
-
-const validRemoteURL = (value: string) => new RegExp(REMOTE_URL_RE).test(value);
 
 type AuthorInfo = {
   authorName: string;
@@ -262,7 +259,7 @@ function GitConnection({ isImport }: Props) {
   }, [authorInfo.authorEmail, authorInfo.authorName, localGitConfig]);
 
   const remoteUrlChangeHandler = (value: string) => {
-    const isInvalid = !validRemoteURL(value);
+    const isInvalid = !isValidGitRemoteUrl(value);
     setIsValidRemoteUrl(isInvalid);
     setRemoteUrl(value);
     dispatch(remoteUrlInputValue({ tempRemoteUrl: value }));

--- a/app/client/src/pages/Editor/gitSync/utils.test.ts
+++ b/app/client/src/pages/Editor/gitSync/utils.test.ts
@@ -1,0 +1,82 @@
+import { getIsStartingWithRemoteBranches, isValidGitRemoteUrl } from "./utils";
+
+const validUrls = [
+  "git@github.com:user/project.git",
+  "git://a@b:c/d.git",
+  "git@192.168.101.127:user/project.git",
+  "ssh://user@host.xz:port/path/to/repo.git",
+  "ssh://user@host.xz/path/to/repo.git",
+  "ssh://host.xz:port/path/to/repo.git",
+  "ssh://host.xz/path/to/repo.git",
+  "ssh://user@host.xz/path/to/repo.git",
+  "ssh://host.xz/path/to/repo.git",
+  "ssh://user@host.xz/~user/path/to/repo.git",
+  "ssh://host.xz/~user/path/to/repo.git",
+  "ssh://user@host.xz/~/path/to/repo.git",
+  "ssh://host.xz/~/path/to/repo.git",
+];
+
+const invalidUrls = [
+  "gitclonegit://a@b:c/d.git",
+  "https://github.com/user/project.git",
+  "http://github.com/user/project.git",
+  "https://192.168.101.127/user/project.git",
+  "http://192.168.101.127/user/project.git",
+  "ssh://user@host.xz:port/path/to/repo.git/",
+  "ssh://user@host.xz/path/to/repo.git/",
+  "ssh://host.xz:port/path/to/repo.git/",
+  "ssh://host.xz/path/to/repo.git/",
+  "ssh://user@host.xz/path/to/repo.git/",
+  "ssh://host.xz/path/to/repo.git/",
+  "ssh://user@host.xz/~user/path/to/repo.git/",
+  "ssh://host.xz/~user/path/to/repo.git/",
+  "git://host.xz/path/to/repo.git/",
+  "git://host.xz/~user/path/to/repo.git/",
+  "http://host.xz/path/to/repo.git/",
+  "https://host.xz/path/to/repo.git/",
+  "/path/to/repo.git/",
+  "path/to/repo.git/",
+  "~/path/to/repo.git",
+  "file:///path/to/repo.git/",
+  "file://~/path/to/repo.git/",
+  "user@host.xz:/path/to/repo.git/",
+  "host.xz:/path/to/repo.git/",
+  "user@host.xz:~user/path/to/repo.git/",
+  "host.xz:~user/path/to/repo.git/",
+  "user@host.xz:path/to/repo.git",
+  "host.xz:path/to/repo.git",
+  "rsync://host.xz/path/to/repo.git/",
+];
+
+describe("gitSync utils", () => {
+  describe("getIsStartingWithRemoteBranches", function() {
+    it("returns true when only remote starts with origin/", () => {
+      const actual = getIsStartingWithRemoteBranches(
+        "whatever",
+        "origin/whateverelse",
+      );
+      const expected = true;
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe("isValidGitRemoteUrl returns true for valid urls", () => {
+    validUrls.forEach((validUrl: string) => {
+      it(`${validUrl} is a valid git remote URL`, () => {
+        const actual = isValidGitRemoteUrl(validUrl);
+        const expected = true;
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+
+  describe("isValidGitRemoteUrl returns false for invalid urls", () => {
+    invalidUrls.forEach((invalidUrl: string) => {
+      it(`${invalidUrl} is a valid git remote URL`, () => {
+        const actual = isValidGitRemoteUrl(invalidUrl);
+        const expected = false;
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});

--- a/app/client/src/pages/Editor/gitSync/utils.ts
+++ b/app/client/src/pages/Editor/gitSync/utils.ts
@@ -1,10 +1,20 @@
-export const getIsStartingWithRemoteBranches = (curr: string, next: string) => {
+export const getIsStartingWithRemoteBranches = (
+  local: string,
+  remote: string,
+) => {
   const remotePrefix = "origin/";
 
   return (
-    curr &&
-    !curr.startsWith(remotePrefix) &&
-    next &&
-    next.startsWith(remotePrefix)
+    local &&
+    !local.startsWith(remotePrefix) &&
+    remote &&
+    remote.startsWith(remotePrefix)
   );
 };
+
+const GIT_REMOTE_URL_PATTERN = /^((git|ssh)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)$/im;
+
+const gitRemoteUrlRegExp = new RegExp(GIT_REMOTE_URL_PATTERN);
+
+export const isValidGitRemoteUrl = (url: string) =>
+  gitRemoteUrlRegExp.test(url);


### PR DESCRIPTION
## Description

As of today we accept almost anything in git connect modal for remote URL. The URL should be ssh/git one. This PR fixes it. 

New RE is: `/^((git|ssh)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)$/`

![Screenshot 2022-03-21 at 12 10 43 PM](https://user-images.githubusercontent.com/1573771/159215173-a574b1a9-a4be-447c-b42e-5807638be713.png)

![Screenshot 2022-03-21 at 12 05 41 PM](https://user-images.githubusercontent.com/1573771/159215181-ed18cd3b-b5c0-427d-8c6c-bf6b4487bdac.png)


Fixes #11996 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually.

## Examples of validation (post-fix):

![Screenshot 2022-03-21 at 12 07 39 PM](https://user-images.githubusercontent.com/1573771/159215085-682e4566-91f7-4cd0-8f4b-4dfdea903d55.png)
![Screenshot 2022-03-21 at 12 07 25 PM](https://user-images.githubusercontent.com/1573771/159215084-b784cd67-4997-41ea-aeff-4829305222c5.png)
![Screenshot 2022-03-21 at 12 07 02 PM](https://user-images.githubusercontent.com/1573771/159215076-3b4d3be4-fe35-4073-9960-d89b6e2ea588.png)
![Screenshot 2022-03-21 at 12 07 16 PM](https://user-images.githubusercontent.com/1573771/159215081-df0ee326-dafd-460b-b75d-6120c8fad984.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



















## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: 11996-fix-git-remote-url-validation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.25 **(0.01)** | 37.69 **(0.02)** | 35.93 **(0.02)** | 56.48 **(0.01)**
 :green_circle: | app/client/src/pages/Editor/gitSync/utils.ts | 100 **(50)** | 100 **(100)** | 100 **(100)** | 100 **(66.67)**</details>