### PR TITLE
fix: Fix NPE in form-data migration

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -412,6 +412,9 @@ public class DatabaseChangelog2 {
 
     private static void mapMongoToNewFormData(ActionDTO action, Map<String, Object> f) {
         final Map<String, Object> formData = action.getActionConfiguration().getFormData();
+        if (formData == null) {
+            return;
+        }
 
         final String body = action.getActionConfiguration().getBody();
         if (StringUtils.hasLength(body)) {


### PR DESCRIPTION
Staging environment issue. The `formData` is coming up as `null` in some places which is causing an NPE.

Stack trace:

```
Caused by: java.lang.NullPointerException: null
	at com.appsmith.server.migrations.DatabaseChangelog2.mapMongoToNewFormData(DatabaseChangelog2.java:422)
	at com.appsmith.server.migrations.DatabaseChangelog2.migrateMongoActionsFormData(DatabaseChangelog2.java:520)
	at com.appsmith.server.migrations.DatabaseChangelog2.updateActionFormDataPath(DatabaseChangelog2.java:146)
```