### PR TITLE
Remove the click on import app button

### DIFF
--- a/app/client/perf/src/perf.js
+++ b/app/client/perf/src/perf.js
@@ -14,7 +14,6 @@ const selectors = {
   appMoreIcon: "span.t--options-icon",
   orgImportAppOption: '[data-cy*="t--org-import-app"]',
   fileInput: "#fileInput",
-  importButton: '[data-cy*="t--org-import-app-button"]',
   createNewApp: ".createnew",
 };
 module.exports = class Perf {
@@ -155,7 +154,6 @@ module.exports = class Perf {
 
     const elementHandle = await this.page.$(selectors.fileInput);
     await elementHandle.uploadFile(jsonPath);
-    await this.page.click(selectors.importButton);
 
     await this.page.waitForNavigation();
     await this.page.reload();


### PR DESCRIPTION
New import flow doesn't have the import app button after the dsl is selected. This PR address this change in perf automation.

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: perf-infra/handle-app-import-changes 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.63 **(0)** | 36.86 **(0)** | 34.94 **(0)** | 55.93 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>