### PR TITLE
fix: multiselect default label issue

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiSelect_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiSelect_spec.js
@@ -139,9 +139,5 @@ describe("MultiSelect Widget Functionality", function() {
       .find(".rc-select-selection-item-content")
       .first()
       .should("have.text", "Green");
-    cy.get(formWidgetsPage.multiselectwidgetv2)
-      .find(".rc-select-selection-item-content")
-      .next()
-      .should("have.text", "Blue");
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiSelect_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/MultiSelect_spec.js
@@ -102,4 +102,46 @@ describe("MultiSelect Widget Functionality", function() {
       .first()
       .should("have.text", "Green");
   });
+  it("should display the right label", () => {
+    cy.openPropertyPane("multiselectwidgetv2");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": "BLUE"
+        },
+        {
+          "label": "Green",
+          "value": "GREEN"
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    cy.updateCodeInput(
+      ".t--property-control-defaultvalue",
+      `[
+      "GREEN",
+      "RED"
+    ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "not.exist",
+    );
+    cy.get(".t--property-control-defaultvalue .t--codemirror-has-error").should(
+      "not.exist",
+    );
+    cy.wait(100);
+    cy.get(formWidgetsPage.multiselectwidgetv2)
+      .find(".rc-select-selection-item-content")
+      .first()
+      .should("have.text", "Green");
+    cy.get(formWidgetsPage.multiselectwidgetv2)
+      .find(".rc-select-selection-item-content")
+      .next()
+      .should("have.text", "Blue");
+  });
 });

--- a/app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx
@@ -422,9 +422,7 @@ class MultiSelectWidget extends BaseWidget<
     const { componentWidth } = this.getComponentDimensions();
     const values: LabelValueType[] = this.props.selectedOptions
       ? this.props.selectedOptions.map((o) =>
-          isString(o) || isNumber(o)
-            ? { label: o, value: o }
-            : { label: o.label, value: o.value },
+          isString(o) || isNumber(o) ? { value: o } : { value: o.value },
         )
       : [];
     const isInvalid =


### PR DESCRIPTION

## Description
Display the right label for multi-select default values

Fixes #12020

## Type of change

- Bugfix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>