### PR TITLE
fix: Switch group widget is crashed when selectedValues is undefined

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Switchgroup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Switchgroup_spec.js
@@ -6,10 +6,18 @@ describe("Switchgroup Widget Functionality", function() {
     cy.addDsl(dsl);
   });
 
-  it("Add new widget", () => {
+  it("Add a new switch group widget with others", () => {
     cy.get(explorer.addWidget).click();
     cy.dragAndDropToCanvas("switchgroupwidget", { x: 300, y: 300 });
     cy.get(".t--widget-switchgroupwidget").should("exist");
+    cy.dragAndDropToCanvas("checkboxgroupwidget", { x: 300, y: 500 });
+    cy.get(".t--widget-checkboxgroupwidget").should("exist");
+    cy.dragAndDropToCanvas("textwidget", { x: 300, y: 700 });
+    cy.get(".t--widget-textwidget").should("exist");
+    cy.updateCodeInput(
+      ".t--property-control-text",
+      `{{SwitchGroup1.selectedValues}}`,
+    );
   });
 
   it("should check that empty value is allowed in options", () => {
@@ -57,6 +65,49 @@ describe("Switchgroup Widget Functionality", function() {
     );
     cy.get(".t--property-control-options .t--codemirror-has-error").should(
       "exist",
+    );
+  });
+
+  it("setting selectedValues to undefined does not crash the app", () => {
+    // Reset options for switch group
+    cy.openPropertyPane("switchgroupwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "Blue",
+          "value": "BLUE"
+        },
+        {
+          "label": "Green",
+          "value": "GREEN"
+        },
+        {
+          "label": "Red",
+          "value": "RED"
+        }
+      ]`,
+    );
+    // throw a cyclic dependency error from checkbox group
+    cy.openPropertyPane("checkboxgroupwidget");
+    cy.get(".t--property-control-options input")
+      .eq(1)
+      .click({ force: true })
+      .type("{{BLUE}}", { parseSpecialCharSequences: false });
+
+    cy.get(".t--property-control-options")
+      .find(".t--js-toggle")
+      .click();
+    // wait for a cyclic dependency error to occur
+    cy.wait(2000);
+    // check if a crash messsge is appeared
+    cy.get(".t--widget-switchgroupwidget")
+      .contains("Oops, Something went wrong.")
+      .should("not.exist");
+    // check if the evaluation is disabled
+    cy.get(".t--widget-textwidget").should(
+      "contain",
+      `{{SwitchGroup1.selectedValues}}`,
     );
   });
 });

--- a/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
@@ -101,7 +101,7 @@ function SwitchGroupComponent(props: SwitchGroupComponentProps) {
         options.map((option: OptionProps) => (
           <StyledSwitch
             alignIndicator={alignment}
-            checked={selected.includes(option.value)}
+            checked={(selected || []).includes(option.value)}
             disabled={disabled}
             inline={inline}
             key={option.value}


### PR DESCRIPTION

## Description
- When selectedValues is undefined, the app is crashed
- Make selected prop for the component to return empty array if its value is falsy

Fixes #12078 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/12078-switchgroup-selected-undefined 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/widgets/SwitchGroupWidget/component/index.tsx | 26.67 **(0)** | 11.76 **(-0.74)** | 0 **(0)** | 36.36 **(0)**</details>