### PR TITLE
feat: Makes the reset button keyboard accessible

### DIFF
--- a/app/client/src/components/propertyControls/StyledControls.tsx
+++ b/app/client/src/components/propertyControls/StyledControls.tsx
@@ -35,6 +35,9 @@ export const ControlWrapper = styled.div<ControlWrapperProps>`
   &&& > label {
     display: inline-block;
   }
+  &:focus-within .reset-button {
+    display: block;
+  }
 `;
 
 export const ControlPropertyLabelContainer = styled.div`

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -469,16 +469,20 @@ const PropertyControl = memo((props: Props) => {
             )}
             {isPropertyDeviatedFromTheme && (
               <>
-                <TooltipComponent content="Value deviated from theme">
+                <TooltipComponent
+                  content="Value deviated from theme"
+                  openOnTargetFocus={false}
+                >
                   <div className="w-2 h-2 rounded-full bg-primary-500" />
                 </TooltipComponent>
                 <button
-                  className="hidden ml-auto group-hover:block"
+                  className="hidden ml-auto focus:ring-2 group-hover:block reset-button"
                   onClick={resetPropertyValueToTheme}
                 >
                   <TooltipComponent
                     boundary="viewport"
                     content="Reset value"
+                    openOnTargetFocus={false}
                     position="top-right"
                   >
                     <ResetIcon className="w-5 h-5" />


### PR DESCRIPTION
## Description

The reset button made keyboard accessible by removing unwanted tab indexes and setting focus styling.

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
