### PR TITLE
fix: blank screen in datasource view mode

### DIFF
--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -44,5 +44,6 @@
     "mockDatabaseName": "fakeapi",
     "mockDatabaseUsername": "fakeapi",
     "mockDatabasePassword": "LimitedAccess123#",
-    "readonly":"readonly"
+    "readonly":"readonly",
+    "authenticatedApiUrl": "https://fakeapi.com"
 }

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
@@ -1,4 +1,5 @@
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
+const datasourceFormData = require("../../../../fixtures/datasources.json");
 
 describe("Authenticated API Datasource", function() {
   it("Can create New Authentication API datasource", function() {
@@ -9,5 +10,9 @@ describe("Authenticated API Datasource", function() {
       "response.body.responseMeta.status",
       201,
     );
+    cy.fillAuthenticatedAPIForm();
+    cy.saveDatasource();
+    const URL = datasourceFormData["authenticatedApiUrl"];
+    cy.contains(URL);
   });
 });

--- a/app/client/cypress/locators/DatasourcesEditor.json
+++ b/app/client/cypress/locators/DatasourcesEditor.json
@@ -6,7 +6,7 @@
   "username": "input[name='datasourceConfiguration.authentication.username']",
   "password": "input[name='datasourceConfiguration.authentication.password']",
   "authenticationAuthtype": "[data-cy=datasourceConfiguration\\.authentication\\.authType]",
-  "url": "input[name='datasourceConfiguration.url']",
+  "url": "input[name='url']",
   "MongoDB": ".t--plugin-name:contains('MongoDB')",
   "RESTAPI": ".t--plugin-name:contains('REST API')",
   "PostgreSQL": ".t--plugin-name:contains('PostgreSQL')",

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -2306,6 +2306,11 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add("fillAuthenticatedAPIForm", () => {
+  const URL = datasourceFormData["authenticatedApiUrl"];
+  cy.get(datasourceEditor.url).type(URL);
+});
+
 Cypress.Commands.add(
   "fillPostgresDatasourceForm",
   (shouldAddTrailingSpaces = false) => {

--- a/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
@@ -89,11 +89,12 @@ class DatasourceDBEditor extends JSONtoForm<Props> {
   };
 
   render() {
-    const { formConfig } = this.props;
+    const { formConfig, viewMode } = this.props;
 
     // make sure this redux form has been initialized before rendering anything.
     // the initialized prop below comes from redux-form.
-    if (!this.props.initialized) {
+    // The viewMode condition is added to allow the conditons only run on the editMode
+    if (!this.props.initialized && !viewMode) {
       return null;
     }
 


### PR DESCRIPTION
## Description

- Upon updating an authenticated API data source it routes to a blank page

Fixes #12045

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/blank-screen-in-datasource 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.59 **(0)** | 36.79 **(0.01)** | 34.91 **(0)** | 55.9 **(0)**
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx | 49.23 **(-1.56)** | 17.14 **(-1.04)** | 9.09 **(0)** | 55.36 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>