### PR TITLE
fix: Check Redis URL for `localhost` as well

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -162,7 +162,7 @@ configure_supervisord() {
   if [[ $isUriLocal -eq 0 ]]; then
     cp "$SUPERVISORD_CONF_PATH/mongodb.conf" /etc/supervisor/conf.d/
   fi
-  if [[ "$APPSMITH_REDIS_URL" = "redis://127.0.0.1:6379" ]]; then
+  if [[ $APPSMITH_REDIS_URL == *"localhost"* || $APPSMITH_REDIS_URL == *"127.0.0.1"* ]]; then
     cp "$SUPERVISORD_CONF_PATH/redis.conf" /etc/supervisor/conf.d/
     # Enable saving Redis session data to disk more often, so recent sessions aren't cleared on restart.
     sed -i 's/^# save 60 10000$/save 60 1/g' /etc/redis/redis.conf


### PR DESCRIPTION
Currently, to check if Redis URI is local or not, we only check for `127.0.0.1` and not for `localhost`, and we also check for the port to be 6379, which doesn't actually have to be.

This change is actually copied from line 71, where we perform a similar check for MongoDB URI.
