### PR TITLE
fix: Even disabled button tooltip should show

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Button_tooltip_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/Button_tooltip_spec.js
@@ -7,30 +7,51 @@ describe("Button Widget Functionality - Validate tooltip visibility", function()
     cy.addDsl(dsl);
   });
 
-  it("Validate show tooltip on button hover", function() {
+  it("Validate show/hide tooltip feature on normal button", function() {
     cy.openPropertyPane("buttonwidget");
-    // add tooltip
+    // Add tooltip
     cy.testJsontext(
       "tooltip",
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
     );
+    // Hover in
     cy.get(widgetsPage.buttonWidget).trigger("mouseover");
-    // tooltip should show on hover
+    // Check if a tooltip is displayed
     cy.get(".bp3-popover2-content").should(
       "have.text",
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
     );
+    // Hover out
+    cy.get(widgetsPage.buttonWidget).trigger("mouseout");
+    // Check if the tooltip is disappeared
+    cy.get(".bp3-popover2-content")
+      .contains(
+        "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
+      )
+      .should("not.exist");
   });
 
-  it("Validate tooltip hidden for disabled button", function() {
-    // first disable button
+  it("Validate show/hide tooltip feature for a disabled button", function() {
+    // Disable the button
     cy.get(".t--property-control-disabled .bp3-switch").click({ force: true });
     cy.validateDisableWidget(
       widgetsPage.buttonWidget,
       commonlocators.disabledField,
     );
-    // hover on button and check tooltip should not show
+    // Hover in
     cy.get(widgetsPage.buttonWidget).trigger("mouseover");
-    cy.get(".bp3-popover2-content").should("not.exist");
+    // Check if a tooltip is displayed
+    cy.get(".bp3-popover2-content").should(
+      "have.text",
+      "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
+    );
+    // Hover out
+    cy.get(widgetsPage.buttonWidget).trigger("mouseout");
+    // Check if the tooltip is disappeared
+    cy.get(".bp3-popover2-content")
+      .contains(
+        "Lorem Ipsum is simply dummy text of the printing and typesetting industry",
+      )
+      .should("not.exist");
   });
 });

--- a/app/client/src/widgets/ButtonWidget/component/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/component/index.tsx
@@ -469,7 +469,6 @@ function ButtonComponent(props: ButtonComponentProps & RecaptchaProps) {
         <Popover2
           autoFocus={false}
           content={<Interweave content={props.tooltip} />}
-          disabled={props.isDisabled}
           hoverOpenDelay={200}
           interactionKind="hover"
           portalClassName="btnTooltipContainer"


### PR DESCRIPTION
## Description
> What should be done:
- [ ] The tooltip should be visible on the button upon hover even if the button is disabled. 
- [ ] The tooltip should not be visible if the cursor is not focusing on the button.

> What has been done:
- Remove disable popover prop

Fixes #7554 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/7554-disabled-button-enable-tooltip 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.59 **(0)** | 36.78 **(-0.01)** | 34.91 **(0)** | 55.9 **(-0.01)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>