### PR TITLE
chore: rename variable

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -130,18 +130,18 @@ public class FirestorePlugin extends BasePlugin {
                 ActionConfiguration actionConfiguration) {
 
             Object smartSubstitutionObject = actionConfiguration.getFormData().getOrDefault(SMART_SUBSTITUTION, TRUE);
-            Boolean smartBsonSubstitution = TRUE;
+            Boolean smartJsonSubstitution = TRUE;
             if (smartSubstitutionObject instanceof Boolean) {
-                smartBsonSubstitution = (Boolean) smartSubstitutionObject;
+                smartJsonSubstitution = (Boolean) smartSubstitutionObject;
             } else if (smartSubstitutionObject instanceof String) {
                 // Older UI configuration used to set this value as a string which may/may not be castable to a boolean
                 // directly. This is to ensure we are backward compatible
-                smartBsonSubstitution = Boolean.parseBoolean((String) smartSubstitutionObject);
+                smartJsonSubstitution = Boolean.parseBoolean((String) smartSubstitutionObject);
             }
 
             // Smartly substitute in actionConfiguration.body and replace all the bindings with values.
             List<Map.Entry<String, String>> parameters = new ArrayList<>();
-            if (TRUE.equals(smartBsonSubstitution)) {
+            if (TRUE.equals(smartJsonSubstitution)) {
                 String query = getValueSafelyFromFormData(actionConfiguration.getFormData(), BODY, String.class);
                 if (query != null) {
 


### PR DESCRIPTION
## Description
- Rename `smartBsonSubstitution` to `smartJsonSubstitution` for Firestore plugin variable, since `Bson` word would be misleading. 
- Addresses review comment on https://github.com/appsmithorg/appsmith/pull/10572 

Fixes #7110 

## Type of change
- internal: variable rename

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
