### PR TITLE
fix: Fix fat container not starting NGINX

### DIFF
--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -11,6 +11,8 @@ ssl_conf_path="/appsmith-stacks/data/certificate/conf"
 
 APP_TEMPLATE="$http_conf"
 
+mkdir -pv "$ssl_conf_path"
+
 cat <<EOF > "$ssl_conf_path/options-ssl-nginx.conf"
 # This file contains important security parameters. If you modify this file
 # manually, Certbot will be unable to automatically provide future security


### PR DESCRIPTION
The nginx run script is missing a `mkdir` command which is causing it to not start.
