### PR TITLE
fix: Fix flickering confirmation modal

### DIFF
--- a/app/client/src/pages/Editor/RequestConfirmationModal.tsx
+++ b/app/client/src/pages/Editor/RequestConfirmationModal.tsx
@@ -77,9 +77,13 @@ class RequestConfirmationModal extends React.Component<Props> {
   render() {
     const { dispatch, modals } = this.props;
 
+    // making sure that only modals that are set to be open are eventually opened.
+    // basically filters out modals that have already been opened and prevents it from flashing after other modals have been confirmed.
+    const modalsToBeOpened = modals.filter((modal) => modal.modalOpen === true);
+
     return (
       <>
-        {modals.map((modalInfo: ModalInfo, index: number) => (
+        {modalsToBeOpened.map((modalInfo: ModalInfo, index: number) => (
           <DialogComponent
             canEscapeKeyClose
             isOpen={modalInfo?.modalOpen}


### PR DESCRIPTION
This PR fixes the quick flashing of the modals with already accepted action confirmations when a new run action confirmation has been made by the user

(Notice the quick flashing after confirmation)
[![LOOM DEMO](http://cdn.loom.com/sessions/thumbnails/7f5c93f919b149ab859a11e2233651b6-00001.gif)](https://www.loom.com/share/7f5c93f919b149ab859a11e2233651b6)

Fixes #12142 

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/flickering-confirmation-modal 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 68.63 **(-3.92)** | 100 **(0)** | 92.38 **(-0.95)**</details>