### PR TITLE
fix: remove bindingPathList properties on jstoggle off.

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -331,6 +331,7 @@ function* setWidgetDynamicPropertySaga(
   const propertyValue = _.get(widget, propertyPath);
 
   let dynamicPropertyPathList = getWidgetDynamicPropertyPathList(widget);
+  let dynamicBindingPathList = getEntityDynamicBindingPathList(widget);
   if (isDynamic) {
     const keyExists =
       dynamicPropertyPathList.findIndex((path) => path.key === propertyPath) >
@@ -345,6 +346,9 @@ function* setWidgetDynamicPropertySaga(
     dynamicPropertyPathList = _.reject(dynamicPropertyPathList, {
       key: propertyPath,
     });
+    dynamicBindingPathList = _.reject(dynamicBindingPathList, {
+      key: propertyPath,
+    });
     const { parsed } = yield call(
       validateProperty,
       propertyPath,
@@ -354,7 +358,7 @@ function* setWidgetDynamicPropertySaga(
     widget = set(widget, propertyPath, parsed);
   }
   widget.dynamicPropertyPathList = dynamicPropertyPathList;
-
+  widget.dynamicBindingPathList = dynamicBindingPathList;
   const stateWidgets = yield select(getWidgets);
   const widgets = { ...stateWidgets, [widgetId]: widget };
 

--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -642,6 +642,9 @@ export const captureInvalidDynamicBindingPath = (
      * Checks if dynamicBindingPathList contains a property path that doesn't have a binding
      */
     if (!isDynamicValue(pathValue)) {
+      alert(
+        `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: ${currentDSL.widgetName}.${dBindingPath.key}`,
+      );
       Sentry.captureException(
         new Error(
           `INVALID_DynamicPathBinding_CLIENT_ERROR: Invalid dynamic path binding list: ${currentDSL.widgetName}.${dBindingPath.key}`,


### PR DESCRIPTION
## Description
- Remove `dynamicBindingPathList` when jsToggle is off.

Fixes #10037 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested Manually on the Canvas.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
