### PR TITLE
fix: Added routing for admin settings page in App Header

### DIFF
--- a/app/client/src/pages/common/AppHeader.tsx
+++ b/app/client/src/pages/common/AppHeader.tsx
@@ -12,6 +12,7 @@ import {
   USER_AUTH_URL,
   BUILDER_PATH_DEPRECATED,
   VIEWER_PATH_DEPRECATED,
+  ADMIN_SETTINGS_CATEGORY_PATH,
 } from "constants/routes";
 import { withRouter, RouteComponentProps } from "react-router";
 import AppViewerHeader from "pages/AppViewer/viewer/AppViewerHeader";
@@ -33,6 +34,7 @@ class AppHeader extends React.Component<Props, any> {
   get header() {
     return (
       <Switch>
+        <Route component={PageHeader} path={ADMIN_SETTINGS_CATEGORY_PATH} />
         <Route component={AppEditorHeader} path={BUILDER_PATH} />
         <Route component={AppEditorHeader} path={BUILDER_PATH_DEPRECATED} />
         <Route component={AppViewerHeader} exact path={VIEWER_PATH} />

--- a/app/client/src/pages/common/AppHeader.tsx
+++ b/app/client/src/pages/common/AppHeader.tsx
@@ -35,6 +35,9 @@ class AppHeader extends React.Component<Props, any> {
     return (
       <Switch>
         <Route component={PageHeader} path={ADMIN_SETTINGS_CATEGORY_PATH} />
+        <Route component={LoginHeader} path={USER_AUTH_URL} />
+        <Route path={SETUP} />
+        <Route path={SIGNUP_SUCCESS_URL} />
         <Route component={AppEditorHeader} path={BUILDER_PATH} />
         <Route component={AppEditorHeader} path={BUILDER_PATH_DEPRECATED} />
         <Route component={AppViewerHeader} exact path={VIEWER_PATH} />
@@ -43,9 +46,6 @@ class AppHeader extends React.Component<Props, any> {
           exact
           path={VIEWER_PATH_DEPRECATED}
         />
-        <Route component={LoginHeader} path={USER_AUTH_URL} />
-        <Route path={SETUP} />
-        <Route path={SIGNUP_SUCCESS_URL} />
         <Route component={PageHeader} path={BASE_URL} />
       </Switch>
     );


### PR DESCRIPTION
## Description

> App Editor Header was being seen on some of the Admin settings pages. Fixed it in this PR by adding a separate route for the Admin settings page in the App Header component. 

Fixes #12261 

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested all pages of admin settings to see if it all has the same app header -> page header

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: hotfix/header-admin-settings 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>