### PR TITLE
fix: 12248, 12249, 12252 - issues of reconnect datasource modal

### DIFF
--- a/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
@@ -225,6 +225,7 @@ const DBFormWrapper = styled.div`
 
   div[class^="RestAPIDatasourceForm__RestApiForm-"] {
     padding-top: 0px;
+    height: 100%;
   }
 
   .t--delete-datasource {

--- a/app/client/src/pages/Editor/gitSync/components/DatasourceListItem.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/DatasourceListItem.tsx
@@ -62,7 +62,7 @@ function ListItemWrapper(props: {
           style={{ marginBottom: 2, display: "flex" }}
           type={TextType.H4}
         >
-          {plugin.name}
+          {ds.name}
           <Icon
             fillColor={ds.isConfigured ? Colors.GREEN : Colors.ERROR_RED}
             name={ds.isConfigured ? "oval-check" : "info"}
@@ -74,7 +74,7 @@ function ListItemWrapper(props: {
           color={Colors.GRAY_700}
           type={TextType.H5}
         >
-          {ds.name}
+          {plugin.name}
         </Text>
       </ListLabels>
     </ListItem>

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -158,6 +158,10 @@ export const getIsExecutingDatasourceQuery = (state: AppState): boolean => {
   return state.entities.datasources.executingDatasourceQuery;
 };
 
+export const getIsDatasourceTesting = (state: AppState): boolean => {
+  return state.entities.datasources.isTesting;
+};
+
 export const getEditorConfig = (state: AppState, pluginId: string): any[] => {
   return state.entities.plugins.editorConfigs[pluginId];
 };


### PR DESCRIPTION
## Description

> 12248 - changed datasource name on top and plugin name on bottom of datasource list
> 12249 - save button is missing on authenticated api datasource configuration panel
>  12252 - test button function of unconfigured datasource

Fixes #12248 , #12249 , #12252 

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please check linked issues and commented screenshots

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
