### PR TITLE
feat: Export App with credentials for sample apps and templates

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/SerialiseApplicationObjective.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/SerialiseApplicationObjective.java
@@ -3,5 +3,6 @@ package com.appsmith.server.constants;
 public enum SerialiseApplicationObjective {
     // For which purpose we are serialising the application from DB
     VERSION_CONTROL,
-    SHARE
+    SHARE,
+    SAMPLE_APP
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationControllerCE.java
@@ -166,10 +166,11 @@ public class ApplicationControllerCE extends BaseController<ApplicationService, 
 
     @GetMapping("/export/{id}")
     public Mono<ResponseEntity<ApplicationJson>> getApplicationFile(@PathVariable String id,
-                                                                    @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName) {
+                                                                    @RequestHeader(name = FieldName.BRANCH_NAME, required = false) String branchName,
+                                                                    @RequestParam(required = false) String isSampleApps) {
         log.debug("Going to export application with id: {}, branch: {}", id, branchName);
 
-        return importExportApplicationService.exportApplicationById(id, branchName)
+        return importExportApplicationService.exportApplicationById(id, branchName, isSampleApps)
                 .map(fetchedResource -> {
                     String applicationName = fetchedResource.getExportedApplication().getName();
                     HttpHeaders responseHeaders = new HttpHeaders();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCE.java
@@ -21,7 +21,7 @@ public interface ImportExportApplicationServiceCE {
      */
     Mono<ApplicationJson> exportApplicationById(String applicationId, SerialiseApplicationObjective serialiseFor);
 
-    Mono<ApplicationJson> exportApplicationById(String applicationId, String branchName);
+    Mono<ApplicationJson> exportApplicationById(String applicationId, String branchName, String isSampleApps);
 
     /**
      * This function will take the Json filepart and saves the application in organization

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -383,7 +383,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                         .removeIf(datasource -> !dbNamesUsedInActions.contains(datasource.getName()));
 
                                 // Save decrypted fields for datasources for internally used sample apps and templates only
-                                if(true) {
+                                if(SerialiseApplicationObjective.SAMPLE_APP.equals(serialiseFor)) {
                                     // Save decrypted fields for datasources
                                     Map<String, DecryptedSensitiveFields> decryptedFields = new HashMap<>();
                                     applicationJson.getDatasourceList().forEach(datasource -> {
@@ -455,7 +455,12 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
 
     public Mono<ApplicationJson> exportApplicationById(String applicationId, String branchName, String isSampleApp) {
         return applicationService.findBranchedApplicationId(branchName, applicationId, EXPORT_APPLICATIONS)
-                .flatMap(branchedAppId -> exportApplicationById(branchedAppId, SerialiseApplicationObjective.SHARE));
+                .flatMap(branchedAppId -> {
+                    if(StringUtils.isEmpty(isSampleApp)) {
+                        return exportApplicationById(branchedAppId, SerialiseApplicationObjective.SHARE);
+                    }
+                    return exportApplicationById(branchedAppId, SerialiseApplicationObjective.SAMPLE_APP);
+                });
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -203,7 +203,7 @@ public class ApplicationServiceTest {
                         return applicationService.save(application);
                     })
                     // Assign the branchName to all the resources connected to the application
-                    .flatMap(application -> importExportApplicationService.exportApplicationById(application.getId(), gitData.getBranchName()))
+                    .flatMap(application -> importExportApplicationService.exportApplicationById(application.getId(), gitData.getBranchName(), null))
                     .flatMap(applicationJson -> importExportApplicationService.importApplicationInOrganization(orgId, applicationJson, gitConnectedApp.getId(), gitData.getBranchName()))
                     .block();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutActionServiceTest.java
@@ -199,7 +199,7 @@ public class LayoutActionServiceTest {
                     .flatMap(application -> {
                         application.getGitApplicationMetadata().setDefaultApplicationId(application.getId());
                         return applicationService.save(application)
-                                .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName()));
+                                .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName(), null));
                     })
                     // Assign the branchName to all the resources connected to the application
                     .flatMap(tuple -> importExportApplicationService.importApplicationInOrganization(orgId, tuple.getT2(), tuple.getT1().getId(), gitData.getBranchName()))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -147,7 +147,7 @@ public class PageServiceTest {
                 .flatMap(application -> {
                     application.getGitApplicationMetadata().setDefaultApplicationId(application.getId());
                     return applicationService.save(application)
-                            .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName()));
+                            .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName(), null));
                 })
                 // Assign the branchName to all the resources connected to the application
                 .flatMap(tuple -> importExportApplicationService.importApplicationInOrganization(orgId, tuple.getT2(), tuple.getT1().getId(), gitData.getBranchName()))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -218,7 +218,7 @@ public class ActionServiceCE_Test {
                     .flatMap(application -> {
                         application.getGitApplicationMetadata().setDefaultApplicationId(application.getId());
                         return applicationService.save(application)
-                                .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName()));
+                                .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName(), null));
                     })
                     // Assign the branchName to all the resources connected to the application
                     .flatMap(tuple -> importExportApplicationService.importApplicationInOrganization(orgId, tuple.getT2(), tuple.getT1().getId(), gitData.getBranchName()))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -333,7 +333,7 @@ public class CreateDBTablePageSolutionTests {
                     application.getGitApplicationMetadata().setDefaultApplicationId(application.getId());
                     gitData.setDefaultApplicationId(application.getId());
                     return applicationService.save(application)
-                            .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName()));
+                            .zipWhen(application1 -> importExportApplicationService.exportApplicationById(application1.getId(), gitData.getBranchName(), null));
                 })
                 // Assign the branchName to all the resources connected to the application
                 .flatMap(tuple -> importExportApplicationService.importApplicationInOrganization(testOrg.getId(), tuple.getT2(), tuple.getT1().getId(), gitData.getBranchName()))


### PR DESCRIPTION
## Description

Currently the exported application does not contain datasource credentials. User need to manually set them when they import an application. This adds a manual step which breaks fork template feature. For templates, we want users to quickly see it in action. We decided to share DB credentials so that users can try them out without doing anything. For this to work, we need import with credentials. 
This PR lets the server API's to export application with credentials. 

Fixes #12296 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally
- Junit Tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
