### PR TITLE
fix: Fix allignment issues on api response tabs

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/DebuggerLogs.tsx
+++ b/app/client/src/components/editorComponents/Debugger/DebuggerLogs.tsx
@@ -23,6 +23,7 @@ const ListWrapper = styled.div`
   overflow: auto;
   height: calc(100% - ${LIST_HEADER_HEIGHT});
   ${thinScrollbar};
+  padding-bottom: 25px;
 `;
 
 type Props = {

--- a/app/client/src/components/editorComponents/Debugger/Errors.tsx
+++ b/app/client/src/components/editorComponents/Debugger/Errors.tsx
@@ -18,6 +18,7 @@ const ListWrapper = styled.div`
   overflow: auto;
   ${thinScrollbar};
   height: 100%;
+  padding-bottom: 25px;
 `;
 
 function Errors(props: { hasShortCut?: boolean }) {


### PR DESCRIPTION
This PR resolves alignment issues on the error and log tabs in Response views.

Fixes #12314

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-response-tab-allignment 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.68 **(-0.01)** | 37.08 **(0)** | 35.25 **(0)** | 55.94 **(-0.01)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>