### PR TITLE
fix: Canvas gets trimmed off when loading applications

### DIFF
--- a/app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx
@@ -55,6 +55,7 @@ function CanvasContainer() {
     </Centered>
   );
   let node: ReactNode;
+
   if (isFetchingPage) {
     node = pageLoading;
   }
@@ -71,7 +72,9 @@ function CanvasContainer() {
         "mt-9": shouldHaveTopMargin,
       })}
       key={currentPageId}
-      style={{ height: `calc(100% - ${shouldHaveTopMargin ? "2rem" : "0px"})` }}
+      style={{
+        height: `calc(100vh - ${shouldHaveTopMargin ? "2rem" : "0px"})`,
+      }}
     >
       {node}
     </Container>


### PR DESCRIPTION
## Description
When an app has multiple pages and multiple widgets on the canvas then the canvas only partially loads when switching pages and only half of the loading icon is visible.
Changes container height to 100vh instead of 100%

Fixes #12271 

## Type of change

- Bugfix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/canvas-cut-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.69 **(0.01)** | 37.08 **(0)** | 35.25 **(0)** | 55.95 **(0.01)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>