### PR TITLE
fix: don't run onClick event handler when button is disabled

### DIFF
--- a/app/client/src/components/ads/Button.test.tsx
+++ b/app/client/src/components/ads/Button.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import Button, { Size } from "./Button";
+import { create } from "react-test-renderer";
+import { lightTheme } from "../../selectors/themeSelectors";
+import { ThemeProvider } from "constants/DefaultTheme";
+
+describe("<Button /> component - render", () => {
+  it("renders the button component with text passed as input", () => {
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <Button size={Size.medium} tag="button" text="Run" />
+      </ThemeProvider>,
+    );
+    expect(screen.getByRole("button")).toHaveTextContent("Run");
+  });
+});
+
+describe("<Button /> component - loading behaviour", () => {
+  it("calls the onclick handler when not in loading state", () => {
+    const fn = jest.fn();
+    const tree = create(
+      <ThemeProvider theme={lightTheme}>
+        <Button
+          isLoading={false}
+          onClick={fn}
+          size={Size.medium}
+          tag="button"
+          text="Run"
+        />
+      </ThemeProvider>,
+    );
+    const button = tree.root.findByType("button");
+    button.props.onClick();
+    expect(fn.mock.calls.length).toBe(1);
+  });
+
+  it("does not call the onclick handler when in loading state", () => {
+    const fn = jest.fn();
+    const tree = create(
+      <ThemeProvider theme={lightTheme}>
+        <Button
+          isLoading
+          onClick={fn}
+          size={Size.medium}
+          tag="button"
+          text="Run"
+        />
+      </ThemeProvider>,
+    );
+    const button = tree.root.findByType("button");
+    button.props.onClick();
+    expect(fn.mock.calls.length).toBe(0);
+  });
+});

--- a/app/client/src/components/ads/Button.tsx
+++ b/app/client/src/components/ads/Button.tsx
@@ -502,7 +502,7 @@ function ButtonComponent(props: ButtonProps) {
       data-cy={props.cypressSelector}
       {..._.omit(props, omitProps)}
       onClick={(e: React.MouseEvent<HTMLElement>) =>
-        props.onClick && props.onClick(e)
+        props.onClick && !props.isLoading && props.onClick(e)
       }
     >
       {getButtonContent(props)}

--- a/app/client/src/widgets/ButtonWidget/component/DragContainer.tsx
+++ b/app/client/src/widgets/ButtonWidget/component/DragContainer.tsx
@@ -14,9 +14,9 @@ import { buttonHoverActiveStyles } from "./utils";
 /*
   We are adding a wrapper in Canvas mode to the Button and once
   we deploy it we remove the wrapper altogether.
-  Because we are adding a wrapper we also need to duplicate any 
+  Because we are adding a wrapper we also need to duplicate any
   :hover, :active & :focus styles and pass onClick to the wrapper.
-  We could have checked for firefox browser using window.navigator 
+  We could have checked for firefox browser using window.navigator
   but we wanted our widget to be pure and have similar experience
   in all the Browsers.
 */
@@ -78,6 +78,7 @@ export function DragContainer(props: DragContainerProps) {
         loading={props.loading}
         onClick={(event) => {
           if (props.disabled) return;
+          if (props.loading) return;
           if (props.onClick) {
             props.onClick(event);
           }

--- a/app/client/src/widgets/ButtonWidget/component/index.tsx
+++ b/app/client/src/widgets/ButtonWidget/component/index.tsx
@@ -77,7 +77,7 @@ const TooltipStyles = createGlobalStyle`
 `;
 
 /*
-  Don't use buttonHoverActiveStyles in a nested function it won't work - 
+  Don't use buttonHoverActiveStyles in a nested function it won't work -
 
   const buttonHoverActiveStyles = css ``
 
@@ -114,7 +114,6 @@ const buttonBaseStyle = css<ThemeProp & ButtonStyleProps>`
           ? theme.colors.button.primary.primary.bgColor
           : "none"
       } !important;
-
 
     &:disabled, &.${Classes.DISABLED} {
       background-color: ${theme.colors.button.disabled.bgColor} !important;
@@ -306,6 +305,7 @@ function RecaptchaV2Component(
     children: any;
     isDisabled?: boolean;
     recaptchaType?: RecaptchaType;
+    isLoading: boolean;
     handleError: (event: React.MouseEvent<HTMLElement>, error: string) => void;
   } & RecaptchaProps,
 ) {
@@ -316,6 +316,7 @@ function RecaptchaV2Component(
   };
   const handleBtnClick = async (event: React.MouseEvent<HTMLElement>) => {
     if (props.isDisabled) return;
+    if (props.isLoading) return;
     if (isInvalidKey) {
       // Handle incorrent google recaptcha site key
       props.handleError(event, createMessage(GOOGLE_RECAPTCHA_KEY_ERROR));
@@ -356,6 +357,7 @@ function RecaptchaV3Component(
     children: any;
     isDisabled?: boolean;
     recaptchaType?: RecaptchaType;
+    isLoading: boolean;
     handleError: (event: React.MouseEvent<HTMLElement>, error: string) => void;
   } & RecaptchaProps,
 ) {
@@ -366,6 +368,7 @@ function RecaptchaV3Component(
 
   const handleBtnClick = (event: React.MouseEvent<HTMLElement>) => {
     if (props.isDisabled) return;
+    if (props.isLoading) return;
     if (status === ScriptStatus.READY) {
       (window as any).grecaptcha.ready(() => {
         try {
@@ -409,12 +412,21 @@ function BtnWrapper(
   props: {
     children: any;
     isDisabled?: boolean;
+    isLoading: boolean;
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   } & RecaptchaProps,
 ) {
-  if (!props.googleRecaptchaKey)
-    return <div onClick={props.onClick}>{props.children}</div>;
-  else {
+  if (!props.googleRecaptchaKey) {
+    return (
+      <div
+        onClick={(e: React.MouseEvent<HTMLElement>) =>
+          props.onClick && !props.isLoading && props.onClick(e)
+        }
+      >
+        {props.children}
+      </div>
+    );
+  } else {
     const handleError = (
       event: React.MouseEvent<HTMLElement>,
       error: string,
@@ -423,7 +435,7 @@ function BtnWrapper(
         text: error,
         variant: Variant.danger,
       });
-      props.onClick && props.onClick(event);
+      props.onClick && !props.isLoading && props.onClick(event);
     };
     if (props.recaptchaType === RecaptchaTypes.V2) {
       return <RecaptchaV2Component {...props} handleError={handleError} />;
@@ -441,6 +453,7 @@ function ButtonComponent(props: ButtonComponentProps & RecaptchaProps) {
       googleRecaptchaKey={props.googleRecaptchaKey}
       handleRecaptchaV2Loading={props.handleRecaptchaV2Loading}
       isDisabled={props.isDisabled}
+      isLoading={props.isLoading}
       onClick={props.onClick}
       recaptchaType={props.recaptchaType}
     >


### PR DESCRIPTION
## Description

When the "Run" button is clicked - it gets the disabled styles indicating a user should not be able to perform clicks while a particular query is running. But this does not prevent the operations to be performed repeatedly by clicking the button in the loading state.

This PR fixes this issue by checking if the button is not in a loading state, and only then allowing the onclick handler to be executed.

Fixes #12144

**Screenshots:**

**Before:**
https://user-images.githubusercontent.com/10229595/160589310-39e86f64-804c-4f01-9ed7-8779afb2e1d8.mov

**After fixing the issue:**
https://user-images.githubusercontent.com/10229595/160589949-12bc5c77-5898-4c9f-b269-5a2723e3012f.mov

**After fixing the issue for canvas**
https://user-images.githubusercontent.com/10229595/161064807-dc0d6f84-c99b-48b3-9043-8d47be1b62d4.mov

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Created a new API (https://swapi.dev/api/people/1) and hit the Run button. Watch the XHR/Fetch requests in the network tab of the developer tools. You will see one request going and the button in the loading state. While the button is in the loading state, click the button multiple times - there should not be additional requests being sent while the button is in the loading state.
- Checked using the same steps by connecting a Firebase data source and running a "get document" query

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes











## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/disable-onclick-in-disabled-button 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.43 **(0.01)** | 37.81 **(0)** | 36.07 **(0.05)** | 56.65 **(0.01)**
 :green_circle: | app/client/src/components/ads/Button.tsx | 92.36 **(1.39)** | 82.76 **(3.63)** | 97.78 **(2.22)** | 92.96 **(1.41)**
 :green_circle: | app/client/src/components/ads/Spinner.tsx | 100 **(33.33)** | 100 **(0)** | 100 **(100)** | 100 **(33.33)**
 :red_circle: | app/client/src/widgets/ButtonWidget/component/DragContainer.tsx | 58.82 **(-7.85)** | 42.86 **(-7.14)** | 66.67 **(0)** | 64.29 **(-4.94)**
 :red_circle: | app/client/src/widgets/ButtonWidget/component/index.tsx | 47.62 **(-2.38)** | 27.88 **(-2.33)** | 43.48 **(-1.97)** | 48.89 **(-1.68)**</details>