### PR TITLE
feat: Add UsagePulse API, create-only

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Url.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Url.java
@@ -35,4 +35,5 @@ public interface Url {
     String GIT_URL = BASE_URL + VERSION + "/git";
     String THEME_URL = BASE_URL + VERSION + "/themes";
     String APP_TEMPLATE_URL = BASE_URL + VERSION + "/app-templates";
+    String USAGE_PULSE_URL = BASE_URL + VERSION + "/usage-pulse";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UsagePulseController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/UsagePulseController.java
@@ -1,0 +1,17 @@
+package com.appsmith.server.controllers;
+
+import com.appsmith.server.constants.Url;
+import com.appsmith.server.controllers.ce.UsagePulseControllerCE;
+import com.appsmith.server.services.UsagePulseService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(Url.USAGE_PULSE_URL)
+public class UsagePulseController extends UsagePulseControllerCE {
+
+    public UsagePulseController(UsagePulseService service) {
+        super(service);
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UsagePulseControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UsagePulseControllerCE.java
@@ -1,0 +1,23 @@
+package com.appsmith.server.controllers.ce;
+
+import com.appsmith.server.dtos.ResponseDTO;
+import com.appsmith.server.services.UsagePulseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class UsagePulseControllerCE {
+
+    private final UsagePulseService service;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<ResponseDTO<Boolean>> create() {
+        return service.createPulse()
+                .thenReturn(new ResponseDTO<>(HttpStatus.CREATED.value(), true, null));
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UsagePulse.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UsagePulse.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.Instant;
-
 @Getter
 @Setter
 @AllArgsConstructor
@@ -15,7 +13,5 @@ import java.time.Instant;
 public class UsagePulse extends BaseDomain {
 
     private String email;
-
-    private Instant time;
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UsagePulse.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UsagePulse.java
@@ -1,0 +1,21 @@
+package com.appsmith.server.domains;
+
+import com.appsmith.external.models.BaseDomain;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Document
+public class UsagePulse extends BaseDomain {
+
+    private String email;
+
+    private Instant time;
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepository.java
@@ -1,0 +1,7 @@
+package com.appsmith.server.repositories;
+
+import com.appsmith.server.repositories.ce.CustomUsagePulseRepositoryCE;
+
+public interface CustomUsagePulseRepository extends CustomUsagePulseRepositoryCE {
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomUsagePulseRepositoryImpl.java
@@ -1,0 +1,17 @@
+package com.appsmith.server.repositories;
+
+import com.appsmith.server.repositories.ce.CustomUsagePulseRepositoryCEImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CustomUsagePulseRepositoryImpl extends CustomUsagePulseRepositoryCEImpl implements CustomUsagePulseRepository {
+
+    public CustomUsagePulseRepositoryImpl(ReactiveMongoOperations mongoOperations, MongoConverter mongoConverter) {
+        super(mongoOperations, mongoConverter);
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/UsagePulseRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/UsagePulseRepository.java
@@ -1,0 +1,8 @@
+package com.appsmith.server.repositories;
+
+import com.appsmith.server.repositories.ce.UsagePulseRepositoryCE;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UsagePulseRepository extends UsagePulseRepositoryCE, CustomUsagePulseRepository {
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCE.java
@@ -1,0 +1,4 @@
+package com.appsmith.server.repositories.ce;
+
+public interface CustomUsagePulseRepositoryCE {
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUsagePulseRepositoryCEImpl.java
@@ -1,0 +1,18 @@
+package com.appsmith.server.repositories.ce;
+
+import com.appsmith.server.domains.UsagePulse;
+import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CustomUsagePulseRepositoryCEImpl extends BaseAppsmithRepositoryImpl<UsagePulse> implements CustomUsagePulseRepositoryCE {
+
+    public CustomUsagePulseRepositoryCEImpl(ReactiveMongoOperations mongoOperations, MongoConverter mongoConverter) {
+        super(mongoOperations, mongoConverter);
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/UsagePulseRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/UsagePulseRepositoryCE.java
@@ -1,0 +1,10 @@
+package com.appsmith.server.repositories.ce;
+
+import com.appsmith.server.domains.UsagePulse;
+import com.appsmith.server.repositories.BaseRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UsagePulseRepositoryCE extends BaseRepository<UsagePulse, String>, CustomUsagePulseRepositoryCE {
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UsagePulseService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UsagePulseService.java
@@ -1,0 +1,6 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.services.ce.UsagePulseServiceCE;
+
+public interface UsagePulseService extends UsagePulseServiceCE {
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UsagePulseServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UsagePulseServiceImpl.java
@@ -1,0 +1,14 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.repositories.UsagePulseRepository;
+import com.appsmith.server.services.ce.UsagePulseServiceCEImpl;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UsagePulseServiceImpl extends UsagePulseServiceCEImpl implements UsagePulseService {
+
+    public UsagePulseServiceImpl(UsagePulseRepository repository, SessionUserService sessionUserService) {
+        super(repository, sessionUserService);
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCE.java
@@ -1,0 +1,7 @@
+package com.appsmith.server.services.ce;
+
+import reactor.core.publisher.Mono;
+
+public interface UsagePulseServiceCE {
+    Mono<Void> createPulse();
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -18,6 +18,7 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
     @Override
     public Mono<Void> createPulse() {
         return sessionUserService.getCurrentUser()
+                .filter(user -> !user.isAnonymous())
                 .flatMap(user -> repository.save(new UsagePulse(user.getEmail(), Instant.now())))
                 .then();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -1,0 +1,25 @@
+package com.appsmith.server.services.ce;
+
+import com.appsmith.server.domains.UsagePulse;
+import com.appsmith.server.repositories.ce.UsagePulseRepositoryCE;
+import com.appsmith.server.services.SessionUserService;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+
+@RequiredArgsConstructor
+public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
+
+    private final UsagePulseRepositoryCE repository;
+
+    private final SessionUserService sessionUserService;
+
+    @Override
+    public Mono<Void> createPulse() {
+        return sessionUserService.getCurrentUser()
+                .flatMap(user -> repository.save(new UsagePulse(user.getEmail(), Instant.now())))
+                .then();
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -16,7 +16,6 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
     @Override
     public Mono<Void> createPulse() {
         return sessionUserService.getCurrentUser()
-                .filter(user -> !user.isAnonymous())
                 .flatMap(user -> repository.save(new UsagePulse(user.getEmail())))
                 .then();
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -6,8 +6,6 @@ import com.appsmith.server.services.SessionUserService;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
-import java.time.Instant;
-
 @RequiredArgsConstructor
 public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
 
@@ -19,7 +17,7 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
     public Mono<Void> createPulse() {
         return sessionUserService.getCurrentUser()
                 .filter(user -> !user.isAnonymous())
-                .flatMap(user -> repository.save(new UsagePulse(user.getEmail(), Instant.now())))
+                .flatMap(user -> repository.save(new UsagePulse(user.getEmail())))
                 .then();
     }
 


### PR DESCRIPTION
The usage pulse API at `/usage-pulse` only accepts `POST` requests, for only creating records. No payload body is expected either. The object saved contains the currently logged-in user, and the timestamp.
