### PR TITLE
fix: Support evaluated value in nested property paths

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -329,7 +329,10 @@ const PropertyControl = memo((props: Props) => {
 
     const evaluatedValue = _.get(
       widgetProperties,
-      getEvalValuePath(dataTreePath, false, true),
+      getEvalValuePath(dataTreePath, {
+        isPopulated: true,
+        fullPath: false,
+      }),
     );
 
     const { additionalAutoComplete, ...rest } = props;

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -329,7 +329,7 @@ const PropertyControl = memo((props: Props) => {
 
     const evaluatedValue = _.get(
       widgetProperties,
-      getEvalValuePath(dataTreePath, false),
+      getEvalValuePath(dataTreePath, false, true),
     );
 
     const { additionalAutoComplete, ...rest } = props;

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -70,7 +70,10 @@ function logLatestEvalPropertyErrors(
       }
       let allEvalErrors: EvaluationError[] = get(
         entity,
-        getEvalErrorPath(evaluatedPath, false),
+        getEvalErrorPath(evaluatedPath, {
+          fullPath: false,
+          isPopulated: false,
+        }),
         [],
       );
 
@@ -84,7 +87,10 @@ function logLatestEvalPropertyErrors(
 
       const evaluatedValue = get(
         entity,
-        getEvalValuePath(evaluatedPath, false),
+        getEvalValuePath(evaluatedPath, {
+          isPopulated: false,
+          fullPath: false,
+        }),
       );
       const evalErrors: EvaluationError[] = [];
       const evalWarnings: EvaluationError[] = [];

--- a/app/client/src/utils/DynamicBindingUtils.test.ts
+++ b/app/client/src/utils/DynamicBindingUtils.test.ts
@@ -1,8 +1,10 @@
 import { Action, PluginType } from "entities/Action";
 import _ from "lodash";
 import {
+  EVAL_VALUE_PATH,
   getDynamicBindingsChangesSaga,
   getDynamicStringSegments,
+  getEvalValuePath,
   isChildPropertyPath,
 } from "./DynamicBindingUtils";
 
@@ -151,5 +153,24 @@ describe("DynamicBindingPathlist", () => {
     const actualResult = getDynamicBindingsChangesSaga(action, value, field);
 
     expect(_.isEqual(expectedResult, actualResult)).toBeTruthy();
+  });
+});
+
+describe("getNestedEvalPath", () => {
+  it("returns valid nested path", () => {
+    const actualUnpopulatedNestedPath = getEvalValuePath(
+      "Table1.primaryColumns.state",
+      true,
+      false,
+    );
+    const actualPopulatedNestedPath = getEvalValuePath(
+      "Table1.primaryColumns.state",
+      true,
+      true,
+    );
+    const expectedUnpopulatedNestedPath = `Table1.${EVAL_VALUE_PATH}.['primaryColumns.state']`;
+    const expectedPopulatedNestedPath = `Table1.${EVAL_VALUE_PATH}.primaryColumns.state`;
+    expect(actualPopulatedNestedPath).toEqual(expectedPopulatedNestedPath);
+    expect(actualUnpopulatedNestedPath).toEqual(expectedUnpopulatedNestedPath);
   });
 });

--- a/app/client/src/utils/DynamicBindingUtils.test.ts
+++ b/app/client/src/utils/DynamicBindingUtils.test.ts
@@ -160,13 +160,17 @@ describe("getNestedEvalPath", () => {
   it("returns valid nested path", () => {
     const actualUnpopulatedNestedPath = getEvalValuePath(
       "Table1.primaryColumns.state",
-      true,
-      false,
+      {
+        isPopulated: false,
+        fullPath: true,
+      },
     );
     const actualPopulatedNestedPath = getEvalValuePath(
       "Table1.primaryColumns.state",
-      true,
-      true,
+      {
+        isPopulated: true,
+        fullPath: true,
+      },
     );
     const expectedUnpopulatedNestedPath = `Table1.${EVAL_VALUE_PATH}.['primaryColumns.state']`;
     const expectedPopulatedNestedPath = `Table1.${EVAL_VALUE_PATH}.primaryColumns.state`;

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -377,27 +377,31 @@ const getNestedEvalPath = (
 
 export const getEvalErrorPath = (
   fullPropertyPath: string,
-  fullPath = true,
-  isPopulated = false,
+  options = {
+    fullPath: true,
+    isPopulated: false,
+  },
 ) => {
   return getNestedEvalPath(
     fullPropertyPath,
     EVAL_ERROR_PATH,
-    fullPath,
-    isPopulated,
+    options.fullPath,
+    options.isPopulated,
   );
 };
 
 export const getEvalValuePath = (
   fullPropertyPath: string,
-  fullPath = true,
-  isPopulated = false,
+  options = {
+    fullPath: true,
+    isPopulated: false,
+  },
 ) => {
   return getNestedEvalPath(
     fullPropertyPath,
     EVAL_VALUE_PATH,
-    fullPath,
-    isPopulated,
+    options.fullPath,
+    options.isPopulated,
   );
 };
 

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -331,27 +331,74 @@ export const EVALUATION_PATH = "__evaluation__";
 export const EVAL_ERROR_PATH = `${EVALUATION_PATH}.errors`;
 export const EVAL_VALUE_PATH = `${EVALUATION_PATH}.evaluatedValues`;
 
+/**
+ * non-populated object 
+ {
+   __evaluation__:{
+     evaluatedValues:{
+       primaryColumns: [...],
+       primaryColumns.status: {...},
+       primaryColumns.action: {...}
+     }
+   }
+ }
+
+ * Populated Object
+ {
+   __evaluation__:{
+     evaluatedValues:{
+       primaryColumns: {
+         status: [...],
+         action:[...]
+        }
+     }
+   }
+ }
+
+ */
 const getNestedEvalPath = (
   fullPropertyPath: string,
   pathType: string,
   fullPath = true,
+  isPopulated = false,
 ) => {
   const { entityName, propertyPath } = getEntityNameAndPropertyPath(
     fullPropertyPath,
   );
-  const nestedPath = `${pathType}.['${propertyPath}']`;
+  const nestedPath = isPopulated
+    ? `${pathType}.${propertyPath}`
+    : `${pathType}.['${propertyPath}']`;
+
   if (fullPath) {
     return `${entityName}.${nestedPath}`;
   }
   return nestedPath;
 };
 
-export const getEvalErrorPath = (fullPropertyPath: string, fullPath = true) => {
-  return getNestedEvalPath(fullPropertyPath, EVAL_ERROR_PATH, fullPath);
+export const getEvalErrorPath = (
+  fullPropertyPath: string,
+  fullPath = true,
+  isPopulated = false,
+) => {
+  return getNestedEvalPath(
+    fullPropertyPath,
+    EVAL_ERROR_PATH,
+    fullPath,
+    isPopulated,
+  );
 };
 
-export const getEvalValuePath = (fullPropertyPath: string, fullPath = true) => {
-  return getNestedEvalPath(fullPropertyPath, EVAL_VALUE_PATH, fullPath);
+export const getEvalValuePath = (
+  fullPropertyPath: string,
+  fullPath = true,
+  isPopulated = false,
+) => {
+  return getNestedEvalPath(
+    fullPropertyPath,
+    EVAL_VALUE_PATH,
+    fullPath,
+    isPopulated,
+  );
 };
 
 export enum PropertyEvaluationErrorType {

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -958,7 +958,10 @@ export default class DataTreeEvaluator {
     const safeEvaluatedValue = removeFunctions(evaluatedValue);
     _.set(
       widget,
-      getEvalValuePath(fullPropertyPath, false),
+      getEvalValuePath(fullPropertyPath, {
+        isPopulated: false,
+        fullPath: false,
+      }),
       safeEvaluatedValue,
     );
     if (!isValid) {

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -426,7 +426,10 @@ export function getValidatedTree(tree: DataTree) {
       const safeEvaluatedValue = removeFunctions(evaluatedValue);
       _.set(
         parsedEntity,
-        getEvalValuePath(`${entityKey}.${property}`, false),
+        getEvalValuePath(`${entityKey}.${property}`, {
+          isPopulated: false,
+          fullPath: false,
+        }),
         safeEvaluatedValue,
       );
       if (!isValid) {
@@ -440,7 +443,10 @@ export function getValidatedTree(tree: DataTree) {
         addErrorToEntityProperty(
           evalErrors,
           tree,
-          getEvalErrorPath(`${entityKey}.${property}`, false),
+          getEvalErrorPath(`${entityKey}.${property}`, {
+            isPopulated: false,
+            fullPath: false,
+          }),
         );
       }
     });


### PR DESCRIPTION
Cause of issue

The `widgetProperties` object in the property control has its evaluated values in a populated structure.  Hence, the path for retrieving values needs to change accordingly.

Populated Structure

<img width="297" alt="Screenshot 2022-03-29 at 16 31 25" src="https://user-images.githubusercontent.com/46670083/160699096-312bc504-d40c-4446-8309-ea44dcd6bd0a.png">

Unpopulated Structure

<img width="377" alt="Screenshot 2022-03-29 at 16 32 11" src="https://user-images.githubusercontent.com/46670083/160699122-924d0f5e-012a-413a-8c61-469b60ca368c.png">

## Description


Fixes #11913 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Jest

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/evaluated-value-is-undefined-for-nested-property-paths 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 55.69 **(0)** | 37.09 **(0.01)** | 35.25 **(0)** | 55.95 **(0.01)**
 :green_circle: | app/client/src/utils/DynamicBindingUtils.ts | 83.98 **(0.09)** | 70.69 **(0.15)** | 75.86 **(0)** | 83.54 **(0.31)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>