### PR TITLE
ci: Adding ingress.class parameter to nginx setting in helm chart docs

### DIFF
--- a/deploy/helm/Setup-https.md
+++ b/deploy/helm/Setup-https.md
@@ -86,6 +86,7 @@ The steps below explain how to use Ingress routes and cert-manager to configure 
   --set ingress.hosts[0].host=DOMAIN \
   --set ingress.certManagerTls[0].hosts[0]=DOMAIN \
   --set ingress.certManagerTls[0].secretName=letsencrypt-prod
+  --set ingress.class=nginx
   ```
 
 After the deployment completes, visit the domain in your browser and you should see the Appsmith site over a secure TLS connection with a valid Let's Encrypt certificate.

--- a/deploy/helm/Setup-https.md
+++ b/deploy/helm/Setup-https.md
@@ -86,7 +86,7 @@ The steps below explain how to use Ingress routes and cert-manager to configure 
   --set ingress.hosts[0].host=DOMAIN \
   --set ingress.certManagerTls[0].hosts[0]=DOMAIN \
   --set ingress.certManagerTls[0].secretName=letsencrypt-prod
-  --set ingress.class=nginx
+  --set ingress.className=nginx
   ```
 
 After the deployment completes, visit the domain in your browser and you should see the Appsmith site over a secure TLS connection with a valid Let's Encrypt certificate.


### PR DESCRIPTION
Specified ingress.class to nginx setting in helm chart https docs.

> While updating Appsmith with ssl using Helm, I came across an error due to ingress class of the ingress controller not matching ingress class in the ingress resource manifest(nginx), the proposed change solved the issue.
