### PR TITLE
fix: show errors from git status

### DIFF
--- a/app/client/src/ce/constants/messages.test.ts
+++ b/app/client/src/ce/constants/messages.test.ts
@@ -24,6 +24,8 @@ import {
   DISCONNECT_EXISTING_REPOSITORIES,
   DISCONNECT_EXISTING_REPOSITORIES_INFO,
   DISCONNECT_GIT,
+  ERROR_GIT_AUTH_FAIL,
+  ERROR_GIT_INVALID_REMOTE,
   ERROR_WHILE_PULLING_CHANGES,
   ERROR_WIDGET_COPY_NOT_ALLOWED,
   FETCH_GIT_STATUS,
@@ -73,14 +75,23 @@ describe("messages", () => {
 describe("git-sync messages", () => {
   const expectedMessages = [
     { key: "COMMIT_CHANGES", value: "Commit changes" },
-    { key: "COMMIT_TO", value: "Commit to" },
+    {
+      key: "COMMIT_TO",
+      value: "Commit to",
+    },
     { key: "COMMIT_AND_PUSH", value: "Commit & push" },
-    { key: "PULL_CHANGES", value: "PULL CHANGES" },
+    {
+      key: "PULL_CHANGES",
+      value: "PULL CHANGES",
+    },
     { key: "DEPLOY_KEY_TITLE", value: "Deployed Key" },
 
     { key: "REGENERATE_SSH_KEY", value: "Regenerate SSH Key" },
     { key: "SSH_KEY", value: "SSH Key" },
-    { key: "COPY_SSH_KEY", value: "Copy SSH Key" },
+    {
+      key: "COPY_SSH_KEY",
+      value: "Copy SSH Key",
+    },
     {
       key: "REGENERATE_KEY_CONFIRM_MESSAGE",
       value:
@@ -96,11 +107,20 @@ describe("git-sync messages", () => {
       value: "COMMITTING AND PUSHING CHANGES...",
     },
     { key: "IS_MERGING", value: "MERGING CHANGES..." },
-    { key: "MERGE_CHANGES", value: "Merge changes" },
+    {
+      key: "MERGE_CHANGES",
+      value: "Merge changes",
+    },
     { key: "SELECT_BRANCH_TO_MERGE", value: "Select branch to merge" },
-    { key: "CONNECT_GIT", value: "Connect Git" },
+    {
+      key: "CONNECT_GIT",
+      value: "Connect Git",
+    },
     { key: "CONNECT_GIT_BETA", value: "Connect Git (Beta)" },
-    { key: "RETRY", value: "RETRY" },
+    {
+      key: "RETRY",
+      value: "RETRY",
+    },
     { key: "CREATE_NEW_BRANCH", value: "CREATE NEW BRANCH" },
     {
       key: "ERROR_WHILE_PULLING_CHANGES",
@@ -125,9 +145,15 @@ describe("git-sync messages", () => {
       value: "Please enter valid SSH URL of your repository",
     },
     { key: "GENERATE_KEY", value: "Generate Key" },
-    { key: "UPDATE_CONFIG", value: "UPDATE CONFIG" },
+    {
+      key: "UPDATE_CONFIG",
+      value: "UPDATE CONFIG",
+    },
     { key: "CONNECT_BTN_LABEL", value: "CONNECT" },
-    { key: "FETCH_GIT_STATUS", value: "fetching status..." },
+    {
+      key: "FETCH_GIT_STATUS",
+      value: "fetching status...",
+    },
     { key: "FETCH_MERGE_STATUS", value: "Checking mergeability..." },
     {
       key: "NO_MERGE_CONFLICT",
@@ -167,7 +193,10 @@ describe("git-sync messages", () => {
         "To make space for newer repositories you can remove existing repositories.",
     },
     { key: "CONTACT_SUPPORT", value: "Contact Support" },
-    { key: "REPOSITORY_LIMIT_REACHED", value: "Repository Limit Reached" },
+    {
+      key: "REPOSITORY_LIMIT_REACHED",
+      value: "Repository Limit Reached",
+    },
     {
       key: "REPOSITORY_LIMIT_REACHED_INFO",
       value:
@@ -187,16 +216,25 @@ describe("git-sync messages", () => {
       value: "Disconnect might cause the application to break.",
     },
     { key: "DISCONNECT_GIT", value: "Revoke access" },
-    { key: "DISCONNECT", value: "DISCONNECT" },
+    {
+      key: "DISCONNECT",
+      value: "DISCONNECT",
+    },
     { key: "GIT_DISCONNECTION_SUBMENU", value: "Git Connection > Disconnect" },
-    { key: "USE_DEFAULT_CONFIGURATION", value: "Use default configuration" },
+    {
+      key: "USE_DEFAULT_CONFIGURATION",
+      value: "Use default configuration",
+    },
     {
       key: "GIT_COMMIT_MESSAGE_PLACEHOLDER",
       value: "Your commit message here",
     },
     { key: "GIT_CONNECTION", value: "Git Connection" },
     { key: "DEPLOY", value: "Deploy" },
-    { key: "MERGE", value: "Merge" },
+    {
+      key: "MERGE",
+      value: "Merge",
+    },
     { key: "GIT_SETTINGS", value: "Git Settings" },
     { key: "CONNECT_TO_GIT", value: "Connect to git repository" },
     {
@@ -209,6 +247,15 @@ describe("git-sync messages", () => {
       value: `Create an empty git repository and paste the remote URL here.`,
     },
     { key: "REMOTE_URL_VIA", value: "Remote URL via" },
+    {
+      key: "ERROR_GIT_AUTH_FAIL",
+      value:
+        "Please make sure that regenerated SSH key is added and has write access to the repo.",
+    },
+    {
+      key: "ERROR_GIT_INVALID_REMOTE",
+      value: "Remote repo doesn't exist or is unreachable.",
+    },
   ];
   const functions = [
     CANNOT_MERGE_DUE_TO_UNCOMMITTED_CHANGES,
@@ -270,6 +317,8 @@ describe("git-sync messages", () => {
     SUBMIT,
     UPDATE_CONFIG,
     USE_DEFAULT_CONFIGURATION,
+    ERROR_GIT_AUTH_FAIL,
+    ERROR_GIT_INVALID_REMOTE,
   ];
   functions.forEach((fn: () => string) => {
     it(`${fn.name} returns expected value`, () => {

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -522,8 +522,7 @@ export const BULK_WIDGET_ADDED = (widgetName: string) =>
 export const UNSUPPORTED_PLUGIN_DIALOG_TITLE = () =>
   `Couldn't auto generate a page from this datasource.`;
 
-export const UNSUPPORTED_PLUGIN_DIALOG_SUBTITLE = () =>
-  `You can continue building your app with it using our drag & Drop
+export const UNSUPPORTED_PLUGIN_DIALOG_SUBTITLE = () => `You can continue building your app with it using our drag & Drop
   builder`;
 export const UNSUPPORTED_PLUGIN_DIALOG_MAIN_HEADING = () => `Heads up`;
 
@@ -735,6 +734,13 @@ export const CONNECTING_TO_REPO_DISABLED = () =>
   "Connecting to a git repo is disabled";
 export const DURING_ONBOARDING_TOUR = () => "during the onboarding tour";
 export const MERGED_SUCCESSFULLY = () => "Merged successfully";
+
+// GIT ERRORS begin
+export const ERROR_GIT_AUTH_FAIL = () =>
+  "Please make sure that regenerated SSH key is added and has write access to the repo.";
+export const ERROR_GIT_INVALID_REMOTE = () =>
+  "Remote repo doesn't exist or is unreachable.";
+// GIT ERRORS end
 
 // JS Snippets
 export const SNIPPET_DESCRIPTION = () =>

--- a/app/client/src/sagas/GitSyncSagas.ts
+++ b/app/client/src/sagas/GitSyncSagas.ts
@@ -56,6 +56,8 @@ import {
 import { fetchGitStatusSuccess } from "actions/gitSyncActions";
 import {
   createMessage,
+  ERROR_GIT_AUTH_FAIL,
+  ERROR_GIT_INVALID_REMOTE,
   GIT_USER_UPDATED_SUCCESSFULLY,
 } from "@appsmith/constants/messages";
 import { GitApplicationMetadata } from "../api/ApplicationApi";
@@ -65,8 +67,7 @@ import { addBranchParam, GIT_BRANCH_QUERY_KEY } from "constants/routes";
 import { MergeBranchPayload, MergeStatusPayload } from "api/GitSyncAPI";
 
 import {
-  mergeBranchSuccess,
-  // mergeBranchFailure,
+  mergeBranchSuccess, // mergeBranchFailure,
 } from "../actions/gitSyncActions";
 import {
   getCurrentGitBranch,
@@ -432,10 +433,18 @@ function* fetchGitStatusSaga() {
       yield put(fetchGitStatusSuccess(response?.data));
     }
   } catch (error) {
+    const payload = { error, show: true };
+    if (error?.message?.includes("Auth fail")) {
+      payload.error = new Error(ERROR_GIT_AUTH_FAIL());
+    } else if (error?.message?.includes("Invalid remote: origin")) {
+      payload.error = new Error(ERROR_GIT_INVALID_REMOTE());
+    }
+
     yield put({
       type: ReduxActionErrorTypes.FETCH_GIT_STATUS_ERROR,
-      payload: { error, show: false },
+      payload,
     });
+
     // non api error
     if (!response || response?.responseMeta?.success) {
       throw error;

--- a/app/client/src/sagas/GitSyncSagas.ts
+++ b/app/client/src/sagas/GitSyncSagas.ts
@@ -5,9 +5,12 @@ import {
   ReduxActionTypes,
   ReduxActionWithCallbacks,
 } from "constants/ReduxActionConstants";
-import { all, put, select, takeLatest, call } from "redux-saga/effects";
+import { all, call, put, select, takeLatest } from "redux-saga/effects";
 
-import GitSyncAPI from "api/GitSyncAPI";
+import GitSyncAPI, {
+  MergeBranchPayload,
+  MergeStatusPayload,
+} from "api/GitSyncAPI";
 import {
   getCurrentApplicationId,
   getCurrentPageId,
@@ -17,33 +20,35 @@ import {
   commitToRepoSuccess,
   fetchBranchesInit,
   fetchBranchesSuccess,
-  fetchGlobalGitConfigSuccess,
-  fetchLocalGitConfigSuccess,
-  updateLocalGitConfigSuccess,
-  fetchLocalGitConfigInit,
-  switchGitBranchInit,
-  gitPullSuccess,
-  fetchMergeStatusSuccess,
-  fetchMergeStatusFailure,
   fetchGitStatusInit,
-  setIsGitSyncModalOpen,
-  setIsGitErrorPopupVisible,
-  setIsDisconnectGitModalOpen,
-  setShowRepoLimitErrorModal,
+  fetchGitStatusSuccess,
   fetchGlobalGitConfigInit,
-  generateSSHKeyPairSuccess,
-  getSSHKeyPairSuccess,
-  getSSHKeyPairError,
+  fetchGlobalGitConfigSuccess,
+  fetchLocalGitConfigInit,
+  fetchLocalGitConfigSuccess,
+  fetchMergeStatusFailure,
+  fetchMergeStatusSuccess,
   GenerateSSHKeyPairReduxAction,
+  generateSSHKeyPairSuccess,
+  getSSHKeyPairError,
   GetSSHKeyPairReduxAction,
+  getSSHKeyPairSuccess,
+  gitPullSuccess,
   importAppViaGitSuccess,
+  setIsDisconnectGitModalOpen,
+  setIsGitErrorPopupVisible,
+  setIsGitSyncModalOpen,
+  setShowRepoLimitErrorModal,
+  switchGitBranchInit,
+  updateLocalGitConfigSuccess,
 } from "actions/gitSyncActions";
 
 import { showReconnectDatasourceModal } from "actions/applicationActions";
 
 import {
-  connectToGitSuccess,
   ConnectToGitReduxAction,
+  connectToGitSuccess,
+  mergeBranchSuccess,
 } from "../actions/gitSyncActions";
 import { ApiResponse } from "api/ApiResponses";
 import { GitConfig, GitSyncModalTab } from "entities/GitSync";
@@ -52,8 +57,8 @@ import { Variant } from "components/ads/common";
 import {
   getCurrentAppGitMetaData,
   getCurrentApplication,
+  getOrganizationIdForImport,
 } from "selectors/applicationSelectors";
-import { fetchGitStatusSuccess } from "actions/gitSyncActions";
 import {
   createMessage,
   ERROR_GIT_AUTH_FAIL,
@@ -64,18 +69,12 @@ import { GitApplicationMetadata } from "../api/ApplicationApi";
 
 import history from "utils/history";
 import { addBranchParam, GIT_BRANCH_QUERY_KEY } from "constants/routes";
-import { MergeBranchPayload, MergeStatusPayload } from "api/GitSyncAPI";
-
-import {
-  mergeBranchSuccess, // mergeBranchFailure,
-} from "../actions/gitSyncActions";
 import {
   getCurrentGitBranch,
   getDisconnectingGitApplication,
 } from "selectors/gitSyncSelectors";
 import { initEditor } from "actions/initActions";
 import { fetchPage } from "actions/pageActions";
-import { getOrganizationIdForImport } from "selectors/applicationSelectors";
 import { getLogToSentryFromResponse } from "utils/helpers";
 import { getCurrentOrg } from "selectors/organizationSelectors";
 import { Org } from "constants/orgConstants";
@@ -435,9 +434,9 @@ function* fetchGitStatusSaga() {
   } catch (error) {
     const payload = { error, show: true };
     if (error?.message?.includes("Auth fail")) {
-      payload.error = new Error(ERROR_GIT_AUTH_FAIL());
+      payload.error = new Error(createMessage(ERROR_GIT_AUTH_FAIL));
     } else if (error?.message?.includes("Invalid remote: origin")) {
-      payload.error = new Error(ERROR_GIT_INVALID_REMOTE());
+      payload.error = new Error(createMessage(ERROR_GIT_INVALID_REMOTE));
     }
 
     yield put({


### PR DESCRIPTION
## Description

We are not showing a few errors from git status API.

Fixes #12274 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: 12274-fix-show-error-notification-on-ssh-regeneration 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.18 **(0)** | 37.67 **(-0.02)** | 35.67 **(0.01)** | 56.42 **(-0.01)**
 :green_circle: | app/client/src/ce/constants/messages.ts | 77.13 **(0.06)** | 100 **(0)** | 32.2 **(0.19)** | 82.02 **(0.15)**
 :red_circle: | app/client/src/sagas/GitSyncSagas.ts | 9.15 **(-1.01)** | 0.24 **(-0.02)** | 4.35 **(0)** | 11.46 **(-1.29)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>