### PR TITLE
fix: old list widgets incorrect page size broke pagination controls

### DIFF
--- a/app/client/cypress/fixtures/listwidgetdsl.json
+++ b/app/client/cypress/fixtures/listwidgetdsl.json
@@ -172,7 +172,7 @@
               "type": "LIST_WIDGET",
               "isLoading": false,
               "parentColumnSpace": 57.875,
-              "parentRowSpace": 10,
+              "parentRowSpace": 40,
               "leftColumn": 4,
               "rightColumn": 12,
               "topRow": 2,

--- a/app/client/src/widgets/ListWidget/widget/derived.js
+++ b/app/client/src/widgets/ListWidget/widget/derived.js
@@ -113,7 +113,7 @@ export default {
 
     return updatedItems;
   },
-  //
+  // Patch #12438 - hard-coded DEFAULT_GRID_ROW_HEIGHT(parentRowSpace) for calculating template/component height. Ideally it should be dynamic based on props.
   getPageSize: (props, moment, _) => {
     const LIST_WIDGET_PAGINATION_HEIGHT = 36;
     const DEFAULT_GRID_ROW_HEIGHT = 10;
@@ -140,7 +140,7 @@ export default {
     const templateBottomRow = props.templateBottomRow;
     const templateHeight = templateBottomRow * DEFAULT_GRID_ROW_HEIGHT;
     const componentHeight =
-      (props.bottomRow - props.topRow) * props.parentRowSpace;
+      (props.bottomRow - props.topRow) * DEFAULT_GRID_ROW_HEIGHT;
 
     const spaceAvailableWithoutPaginationControls =
       componentHeight - WIDGET_PADDING * 2;


### PR DESCRIPTION
## Description

Old list widgets have a legacy parentRowSpace value `40` which lead to incorrect calculation in the pageSize which was very high than it should be. This leads to the pagination not appearing when server-side pagination is disabled. 

Note to Reviewer:
For some reason the `parentRowSpace` in the widget is `10` and in derived properties it is `40` (which is present in the DSL).
The solution for now is to hard-code the value of `parentRowSpace` as `10` in the derived properties.

Fixes #12438 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Cypress
- 
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
