### PR TITLE
fix: Fix issue with oauth2 save and authorize button

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -534,21 +534,29 @@ class DatasourceRestAPIEditor extends React.Component<
         </FormInputContainer>
         {this.renderAuthFields()}
         {this.renderSelfSignedCertificateFields()}
-        <FormInputContainer>
-          <AuthorizeButton
-            disabled={this.disableSave()}
-            filled
-            intent="primary"
-            loading={isSaving}
-            onClick={() =>
-              this.save(
-                redirectAuthorizationCode(pageId, datasourceId, PluginType.API),
-              )
-            }
-            size="small"
-            text={isAuthorized ? "Save and Re-Authorize" : "Save and Authorize"}
-          />
-        </FormInputContainer>
+        {formData.authType && formData.authType === AuthType.OAuth2 && (
+          <FormInputContainer>
+            <AuthorizeButton
+              disabled={this.disableSave()}
+              filled
+              intent="primary"
+              loading={isSaving}
+              onClick={() =>
+                this.save(
+                  redirectAuthorizationCode(
+                    pageId,
+                    datasourceId,
+                    PluginType.API,
+                  ),
+                )
+              }
+              size="small"
+              text={
+                isAuthorized ? "Save and Re-Authorize" : "Save and Authorize"
+              }
+            />
+          </FormInputContainer>
+        )}
       </>
     );
   };


### PR DESCRIPTION
This PR ensures the Save and Authorize button only shows when user has chosen the OAuth2 authentication type for rest api datasource forms.

Fixes #12437

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/remove-save-and-authorize-button 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx | 23.48 **(0)** | 12.2 **(-0.22)** | 2.44 **(0)** | 24.54 **(0)**</details>