### PR TITLE
fix: getting 404 when application name conflicts with nginx prefix

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/TextUtils.java
@@ -25,6 +25,16 @@ public class TextUtils {
     private static final Pattern SEPARATORS = Pattern.compile("[\\s\\p{Punct}&&[^-]]");
 
     /**
+     * These words are used in nginx path config, we'll not allow slug names starting with these words
+     */
+    public static final String APP_SLUG_RESERVED_PREFIX_REGEX = "^api|^oauth2|^login";
+
+    private static final Pattern appSlugReservedPrefixPattern = Pattern.compile(APP_SLUG_RESERVED_PREFIX_REGEX);
+
+    // this prefix will be set to slug if it starts with reserved words from APP_SLUG_RESERVED_PREFIXES
+    public static final String APP_SLUG_PREFIX = "app-";
+
+    /**
      * Creates URL safe text aka slug from the input text. It supports english locale only.
      * See the test cases for sample conversions
      * For other languages, it'll return empty.
@@ -59,5 +69,18 @@ public class TextUtils {
         Set<String> parts = new HashSet<>(Arrays.asList(inputStringCsv.trim().split("(\\s*,\\s*)+")));
         parts.remove("");
         return parts;
+    }
+
+    /**
+     * Utility method to generate application slug. It ensures slug does not contain reserved keywords as prefix.
+     * @param applicationName Name of the application
+     * @return cleaned slug
+     */
+    public static String generateApplicationSlug(String applicationName) {
+        String slug = makeSlug(applicationName);
+        if(appSlugReservedPrefixPattern.matcher(slug).lookingAt()) {
+            slug = TextUtils.APP_SLUG_PREFIX + slug;
+        }
+        return slug;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationServiceCEImpl.java
@@ -167,7 +167,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
     @Override
     public Mono<Application> save(Application application) {
         if(!StringUtils.isEmpty(application.getName())) {
-            application.setSlug(TextUtils.makeSlug(application.getName()));
+            application.setSlug(TextUtils.generateApplicationSlug(application.getName()));
         }
 
         if(application.getApplicationVersion() != null) {
@@ -190,7 +190,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
 
     @Override
     public Mono<Application> createDefault(Application application) {
-        application.setSlug(TextUtils.makeSlug(application.getName()));
+        application.setSlug(TextUtils.generateApplicationSlug(application.getName()));
         application.setLastEditedAt(Instant.now());
         if(!StringUtils.hasLength(application.getColor())) {
             application.setColor(getRandomAppCardColor());
@@ -203,7 +203,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         application.setIsPublic(null);
         application.setLastEditedAt(Instant.now());
         if(!StringUtils.isEmpty(application.getName())) {
-            application.setSlug(TextUtils.makeSlug(application.getName()));
+            application.setSlug(TextUtils.generateApplicationSlug(application.getName()));
         }
 
         if(application.getApplicationVersion() != null) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/TextUtilsTest.java
@@ -49,4 +49,21 @@ public class TextUtilsTest {
         checkFromCsv("", 0);
         checkFromCsv(null, 0);
     }
+
+    @Test
+    public void generateApplicationSlug() {
+        assertThat(TextUtils.generateApplicationSlug("API")).isEqualTo("app-api");
+        assertThat(TextUtils.generateApplicationSlug("Api manager")).isEqualTo("app-api-manager");
+        assertThat(TextUtils.generateApplicationSlug(" API-manager")).isEqualTo("app-api-manager");
+        assertThat(TextUtils.generateApplicationSlug("APIXYZ")).isEqualTo("app-apixyz");
+        assertThat(TextUtils.generateApplicationSlug("HelloAPI")).isEqualTo("helloapi");
+
+        assertThat(TextUtils.generateApplicationSlug("Login manager")).isEqualTo("app-login-manager");
+        assertThat(TextUtils.generateApplicationSlug("LoginAndLogout")).isEqualTo("app-loginandlogout");
+        assertThat(TextUtils.generateApplicationSlug("Logout Login")).isEqualTo("logout-login");
+
+        assertThat(TextUtils.generateApplicationSlug("Oauth2 manager")).isEqualTo("app-oauth2-manager");
+        assertThat(TextUtils.generateApplicationSlug("oauth23-support-dashboard")).isEqualTo("app-oauth23-support-dashboard");
+        assertThat(TextUtils.generateApplicationSlug("Oauth manager")).isEqualTo("oauth-manager");
+    }
 }


### PR DESCRIPTION
## Description
When application name starts with `api`, `login` or `oauth2`, 404 is shown because these words conflicts with nginx configuration. As part of the clean urls project, application path starts with slug name and hence it conflicts with nginx paths. This PR appends `app-` to all old and new slug names where this is the case.

Fixes #12430

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- JUnit tests
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
