### PR TITLE
feat: Make property title not focusable with keyboard

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertyHelpLabel.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyHelpLabel.tsx
@@ -31,6 +31,7 @@ function PropertyHelpLabel(props: Props) {
       }
       disabled={!toolTipDefined}
       hoverOpenDelay={200}
+      openOnTargetFocus={false}
       position={Position.TOP}
     >
       <div


### PR DESCRIPTION
## Description

Making the property title not focusable via keyboard improves the keyboard navigation experience.

Fixes #12412 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feat/make-property-title-not-focusible 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.72 **(0)** | 37.15 **(-0.01)** | 35.44 **(0)** | 55.98 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>