### PR TITLE
fix: old list widgets incorrect page size (#12443)

### DIFF
--- a/app/client/cypress/fixtures/listwidgetdsl.json
+++ b/app/client/cypress/fixtures/listwidgetdsl.json
@@ -172,7 +172,7 @@
               "type": "LIST_WIDGET",
               "isLoading": false,
               "parentColumnSpace": 57.875,
-              "parentRowSpace": 10,
+              "parentRowSpace": 40,
               "leftColumn": 4,
               "rightColumn": 12,
               "topRow": 2,

--- a/app/client/src/widgets/ListWidget/widget/derived.js
+++ b/app/client/src/widgets/ListWidget/widget/derived.js
@@ -113,7 +113,7 @@ export default {
 
     return updatedItems;
   },
-  //
+  // Patch #12438 - hard-coded DEFAULT_GRID_ROW_HEIGHT(parentRowSpace) for calculating template/component height. Ideally it should be dynamic based on props.
   getPageSize: (props, moment, _) => {
     const LIST_WIDGET_PAGINATION_HEIGHT = 36;
     const DEFAULT_GRID_ROW_HEIGHT = 10;
@@ -140,7 +140,7 @@ export default {
     const templateBottomRow = props.templateBottomRow;
     const templateHeight = templateBottomRow * DEFAULT_GRID_ROW_HEIGHT;
     const componentHeight =
-      (props.bottomRow - props.topRow) * props.parentRowSpace;
+      (props.bottomRow - props.topRow) * DEFAULT_GRID_ROW_HEIGHT;
 
     const spaceAvailableWithoutPaginationControls =
       componentHeight - WIDGET_PADDING * 2;


### PR DESCRIPTION
## Description
hotfix: #12438 (cherry picked from commit [50efc6](https://github.com/appsmithorg/appsmith/commit/50efc68fd36c5b9f13292568286bee430afcfeff))

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:master and head branch: hotfix/12438-list-pagination 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**</details>