### PR TITLE
fix: sending query params on redirection from signup to login page

### DIFF
--- a/app/client/src/ce/pages/UserAuth/SignUp.tsx
+++ b/app/client/src/ce/pages/UserAuth/SignUp.tsx
@@ -88,11 +88,10 @@ export function SignUp(props: SignUpFormProps) {
   const history = useHistory();
   useEffect(() => {
     if (disableLoginForm) {
-      const currentURL = new URL(window.location.href);
-      const searchParams = currentURL.searchParams;
+      const search = new URL(window.location.href)?.searchParams?.toString();
       history.replace({
         pathname: AUTH_LOGIN_URL,
-        search: searchParams.toString(),
+        search,
       });
     }
   }, []);

--- a/app/client/src/ce/pages/UserAuth/SignUp.tsx
+++ b/app/client/src/ce/pages/UserAuth/SignUp.tsx
@@ -88,7 +88,12 @@ export function SignUp(props: SignUpFormProps) {
   const history = useHistory();
   useEffect(() => {
     if (disableLoginForm) {
-      history.replace(AUTH_LOGIN_URL);
+      const currentURL = new URL(window.location.href);
+      const searchParams = currentURL.searchParams;
+      history.replace({
+        pathname: AUTH_LOGIN_URL,
+        search: searchParams.toString(),
+      });
     }
   }, []);
   const { emailValue: email, error, pristine, submitting, valid } = props;


### PR DESCRIPTION
## Description

> Redirection from signup to login page doesn't include query params. This redirection happens when form login is disabled. This has been fixed in this PR.

Fixes #11932 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Checked if the redirection passes on the query parameters from signup page to login page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: hotfix/signup-redirection 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(0)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>