### PR TITLE
fix: added sanity check to avoid unexpected eval error

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -694,17 +694,19 @@ export default class DataTreeEvaluator {
                 "config",
                 "actionConfiguration",
               );
-              const validationConfig = this.allActionValidationConfig[
-                entity.actionId
-              ][configProperty];
-              this.validateActionProperty(
-                fullPropertyPath,
-                entity,
-                currentTree,
-                evalPropertyValue,
-                unEvalPropertyValue,
-                validationConfig,
-              );
+              const validationConfig =
+                !!this.allActionValidationConfig[entity.actionId] &&
+                this.allActionValidationConfig[entity.actionId][configProperty];
+              if (!!validationConfig && !_.isEmpty(validationConfig)) {
+                this.validateActionProperty(
+                  fullPropertyPath,
+                  entity,
+                  currentTree,
+                  evalPropertyValue,
+                  unEvalPropertyValue,
+                  validationConfig,
+                );
+              }
             }
             const safeEvaluatedValue = removeFunctions(evalPropertyValue);
             _.set(


### PR DESCRIPTION
## Description
There was an unexpected error during evaluation because of a missing config for APIs. Added sanity check to validate prroperty path only if it has config

Fixes #12454 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: promises-prod-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 55.72 **(0)** | 37.14 **(-0.02)** | 35.44 **(0)** | 55.98 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :red_circle: | app/client/src/workers/DataTreeEvaluator.ts | 75.81 **(-0.12)** | 56.37 **(-1.1)** | 73.86 **(0)** | 75.37 **(-0.13)**</details>