### PR TITLE
fix: align Table widget URL Column type

### DIFF
--- a/app/client/src/widgets/TableWidget/component/AutoToolTipComponent.tsx
+++ b/app/client/src/widgets/TableWidget/component/AutoToolTipComponent.tsx
@@ -12,7 +12,8 @@ const TooltipContentWrapper = styled.div<{ width: number }>`
 
 export const OpenNewTabIconWrapper = styled.div`
   left: 4px;
-  top: 2px;
+  height: 28px;
+  align-items: center;
   position: relative;
 `;
 

--- a/app/client/src/widgets/TableWidget/component/AutoToolTipComponent.tsx
+++ b/app/client/src/widgets/TableWidget/component/AutoToolTipComponent.tsx
@@ -44,6 +44,7 @@ function LinkWrapper(props: Props) {
       isCellVisible={props.isCellVisible}
       isHidden={props.isHidden}
       isHyperLink
+      isPadding
       isTextType
       onClick={() => {
         window.open(props.title, "_blank");

--- a/app/client/src/widgets/TableWidget/component/TableStyledWrappers.tsx
+++ b/app/client/src/widgets/TableWidget/component/TableStyledWrappers.tsx
@@ -422,7 +422,7 @@ export const CellWrapper = styled.div<{
   }
   &:hover {
     .hidden-icon {
-      display: inline;
+      display: flex;
     }
   }
 `;


### PR DESCRIPTION

## Description

Fix URL column type on table widget by adding padding to the cell

Fixes #12130


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Visual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/Align-Table-widget-URL-Column-type 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.24 **(0)** | 37.67 **(-0.01)** | 35.92 **(0)** | 56.47 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>