### PR TITLE
chore: Update property from property pane to use improved get strategy & BATCH_UPDATE_WIDGET_PROPERTY to be processed serially

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -110,6 +110,7 @@ import {
   getWidgetsFromIds,
   getDefaultCanvas,
   isDropTarget,
+  getValueFromTree,
 } from "./WidgetOperationUtils";
 import { getSelectedWidgets } from "selectors/ui";
 import { widgetSelectionSagas } from "./WidgetSelectionSagas";
@@ -434,7 +435,7 @@ export function getPropertiesToUpdate(
   } = getAllPathsFromPropertyConfig(widgetWithUpdates, widgetConfig, {});
 
   Object.keys(updatePaths).forEach((propertyPath) => {
-    const propertyValue = _.get(updates, propertyPath);
+    const propertyValue = getValueFromTree(updates, propertyPath);
     // only check if
     if (!_.isString(propertyValue)) {
       return;

--- a/app/client/src/sagas/WidgetOperationUtils.test.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.test.ts
@@ -18,6 +18,7 @@ import {
   getPastePositionMapFromMousePointer,
   getReflowedPositions,
   getWidgetsFromIds,
+  getValueFromTree,
 } from "./WidgetOperationUtils";
 
 describe("WidgetOperationSaga", () => {
@@ -977,5 +978,668 @@ describe("WidgetOperationSaga", () => {
         bottomRow: 70,
       },
     ]);
+  });
+});
+
+describe("getValueFromTree - ", () => {
+  it("should test that value is correctly plucked from a valid path when object keys do not have dot", () => {
+    [
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: "value",
+          },
+        },
+        path: "path1.path2",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: {
+              path3: "value",
+            },
+          },
+        },
+        path: "path1.path2",
+        output: {
+          path3: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          path1: [
+            {
+              path2: "value",
+            },
+          ],
+        },
+        path: "path1.0.path2",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          path1: [
+            {
+              path2: {
+                path3: "value",
+              },
+            },
+          ],
+        },
+        path: "path1.0.path2",
+        output: {
+          path3: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+    ].forEach((testObj: any) => {
+      expect(
+        getValueFromTree(testObj.inputObj, testObj.path, testObj.defaultValue),
+      ).toEqual(testObj.output);
+    });
+  });
+
+  it("should test that default value is returned for invalid path when object keys do not have dot", () => {
+    [
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: "value",
+          },
+        },
+        path: "path1.path4",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: {
+              path3: "value",
+            },
+          },
+        },
+        path: "path4.path2",
+        output: {
+          path3: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          path1: [
+            {
+              path2: "value",
+            },
+          ],
+        },
+        path: "path1.1.path2",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          path1: [
+            {
+              path2: {
+                path3: "value",
+              },
+            },
+          ],
+        },
+        path: "path1.1.path2",
+        output: {
+          path3: "value",
+        },
+        defaultValue: "will be returned",
+      },
+    ].forEach((testObj: any) => {
+      expect(
+        getValueFromTree(testObj.inputObj, testObj.path, testObj.defaultValue),
+      ).toEqual(testObj.defaultValue);
+    });
+  });
+
+  it("should test that value is correctly plucked from a valid path when object keys have dot", () => {
+    [
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": "value",
+        },
+        path: "path1.path2.path3",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": {
+            path3: "value",
+          },
+        },
+        path: "path1.path2.path3",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          path1: {
+            "path2.path3": "value",
+          },
+        },
+        path: "path1.path2.path3",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: {
+              "path3.path4": "value",
+            },
+          },
+        },
+        path: "path1.path2.path3.path4",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": {
+            "path3.path4": "value",
+          },
+        },
+        path: "path1.path2.path3.path4",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": {
+            path4: "value",
+          },
+        },
+        path: "path1.path2.path3",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          path1: {
+            "path2.path3": {
+              path4: "value",
+            },
+          },
+        },
+        path: "path1.path2.path3",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: {
+              "path3.path4": {
+                path5: "value",
+              },
+            },
+          },
+        },
+        path: "path1.path2.path3.path4",
+        output: {
+          path5: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: "value",
+            },
+          ],
+        },
+        path: "path1.path2.0.path3",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: {
+                path4: "value",
+              },
+            },
+          ],
+        },
+        path: "path1.path2.0.path3.path4",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              "path3.path4": "value",
+            },
+          ],
+        },
+        path: "path1.path2.0.path3.path4",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: [
+                {
+                  path4: "value",
+                },
+              ],
+            },
+          ],
+        },
+        path: "path1.path2.0.path3.0.path4",
+        output: "value",
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: {
+                path4: "value",
+              },
+            },
+          ],
+        },
+        path: "path1.path2.0.path3",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": [
+            {
+              path4: "value",
+            },
+          ],
+        },
+        path: "path1.path2.path3.0",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": [
+            {
+              path4: [
+                {
+                  path5: "value",
+                },
+              ],
+            },
+          ],
+        },
+        path: "path1.path2.path3.0.path4.0",
+        output: {
+          path5: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": [
+            {
+              "path4.path5": [
+                {
+                  path6: "value",
+                },
+              ],
+            },
+          ],
+        },
+        path: "path1.path2.path3.0.path4.path5.0",
+        output: {
+          path6: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+      {
+        inputObj: {
+          "path1.path2.path3": [
+            {
+              ".path4.path5": [
+                {
+                  path6: "value",
+                },
+              ],
+            },
+          ],
+        },
+        path: "path1.path2.path3.0..path4.path5.0",
+        output: {
+          path6: "value",
+        },
+        defaultValue: "will not be returned",
+      },
+    ].forEach((testObj: any) => {
+      expect(
+        getValueFromTree(testObj.inputObj, testObj.path, testObj.defaultValue),
+      ).toEqual(testObj.output);
+    });
+  });
+
+  it("should test that default value is returned for an invalid path when object keys have dot", () => {
+    [
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": "value",
+        },
+        path: "path1.path2.path4",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": {
+            path3: "value",
+          },
+        },
+        path: "path1.path3.path4",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          path1: {
+            "path2.path3": "value",
+          },
+        },
+        path: "path1.path2",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: {
+              "path3.path4": "value",
+            },
+          },
+        },
+        path: "path1.path2.path3",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that has a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": {
+            "path3.path4": "value",
+          },
+        },
+        path: "path1.path3.path4",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": {
+            path4: "value",
+          },
+        },
+        path: "path1.path2",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          path1: {
+            "path2.path3": {
+              path4: "value",
+            },
+          },
+        },
+        path: "path1.path2",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      //Path that has a non primitive value  as leaf node
+      {
+        inputObj: {
+          path1: {
+            path2: {
+              "path3.path4": {
+                path5: "value",
+              },
+            },
+          },
+        },
+        path: "path2.path3.path4",
+        output: {
+          path5: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: "value",
+            },
+          ],
+        },
+        path: "path1.path2.1.path3",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: {
+                path4: "value",
+              },
+            },
+          ],
+        },
+        path: "path1.path2.1.path3.path4",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              "path3.path4": "value",
+            },
+          ],
+        },
+        path: "path1.path2.1.path3.path4",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: [
+                {
+                  path4: "value",
+                },
+              ],
+            },
+          ],
+        },
+        path: "path1.path2.2.path3.0.path4",
+        output: "value",
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2": [
+            {
+              path3: {
+                path4: "value",
+              },
+            },
+          ],
+        },
+        path: "path1.0.path3",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": [
+            {
+              path4: "value",
+            },
+          ],
+        },
+        path: "path1.path2.0",
+        output: {
+          path4: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": [
+            {
+              path4: [
+                {
+                  path5: "value",
+                },
+              ],
+            },
+          ],
+        },
+        path: "path1.path2.0.path4.0",
+        output: {
+          path5: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      //Path that traverse through an array with a non primitive value as leaf node
+      {
+        inputObj: {
+          "path1.path2.path3": [
+            {
+              "path4.path5": [
+                {
+                  path6: "value",
+                },
+              ],
+            },
+          ],
+        },
+        path: "path1.path2.path3.0.path4.0",
+        output: {
+          path6: "value",
+        },
+        defaultValue: "will be returned",
+      },
+    ].forEach((testObj: any) => {
+      expect(
+        getValueFromTree(testObj.inputObj, testObj.path, testObj.defaultValue),
+      ).toEqual(testObj.defaultValue);
+    });
+  });
+
+  it("should check that invalid path strucutre should return defaultValue", () => {
+    [
+      {
+        inputObj: {
+          path1: {
+            path2: {
+              path3: "value",
+            },
+          },
+        },
+        path: "path1.path2..path3",
+        output: {
+          path6: "value",
+        },
+        defaultValue: "will be returned",
+      },
+      {
+        inputObj: {
+          path1: {
+            path2: [
+              {
+                path3: "value",
+              },
+            ],
+          },
+        },
+        path: "path1.path2.0..path3",
+        output: {
+          path6: "value",
+        },
+        defaultValue: "will be returned",
+      },
+    ].forEach((testObj: any) => {
+      expect(
+        getValueFromTree(testObj.inputObj, testObj.path, testObj.defaultValue),
+      ).toEqual(testObj.defaultValue);
+    });
   });
 });

--- a/app/client/src/sagas/WidgetOperationUtils.test.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.test.ts
@@ -990,6 +990,7 @@ describe("getValueFromTree - ", () => {
           path1: {
             path2: "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2",
         output: "value",
@@ -1003,6 +1004,7 @@ describe("getValueFromTree - ", () => {
               path3: "value",
             },
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2",
         output: {
@@ -1018,6 +1020,7 @@ describe("getValueFromTree - ", () => {
               path2: "value",
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.0.path2",
         output: "value",
@@ -1033,6 +1036,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.0.path2",
         output: {
@@ -1055,6 +1059,7 @@ describe("getValueFromTree - ", () => {
           path1: {
             path2: "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path4",
         output: "value",
@@ -1068,6 +1073,7 @@ describe("getValueFromTree - ", () => {
               path3: "value",
             },
           },
+          someotherPath: "testValue",
         },
         path: "path4.path2",
         output: {
@@ -1081,6 +1087,7 @@ describe("getValueFromTree - ", () => {
           path1: [
             {
               path2: "value",
+              someotherPath: "testValue",
             },
           ],
         },
@@ -1098,6 +1105,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.1.path2",
         output: {
@@ -1129,6 +1137,7 @@ describe("getValueFromTree - ", () => {
           "path1.path2": {
             path3: "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3",
         output: "value",
@@ -1140,6 +1149,7 @@ describe("getValueFromTree - ", () => {
           path1: {
             "path2.path3": "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3",
         output: "value",
@@ -1153,6 +1163,7 @@ describe("getValueFromTree - ", () => {
               "path3.path4": "value",
             },
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3.path4",
         output: "value",
@@ -1164,6 +1175,7 @@ describe("getValueFromTree - ", () => {
           "path1.path2": {
             "path3.path4": "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3.path4",
         output: "value",
@@ -1175,6 +1187,7 @@ describe("getValueFromTree - ", () => {
           "path1.path2.path3": {
             path4: "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3",
         output: {
@@ -1190,6 +1203,7 @@ describe("getValueFromTree - ", () => {
               path4: "value",
             },
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3",
         output: {
@@ -1207,6 +1221,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3.path4",
         output: {
@@ -1222,6 +1237,7 @@ describe("getValueFromTree - ", () => {
               path3: "value",
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.0.path3",
         output: "value",
@@ -1237,6 +1253,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.0.path3.path4",
         output: "value",
@@ -1250,6 +1267,7 @@ describe("getValueFromTree - ", () => {
               "path3.path4": "value",
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.0.path3.path4",
         output: "value",
@@ -1267,6 +1285,7 @@ describe("getValueFromTree - ", () => {
               ],
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.0.path3.0.path4",
         output: "value",
@@ -1282,6 +1301,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.0.path3",
         output: {
@@ -1297,6 +1317,7 @@ describe("getValueFromTree - ", () => {
               path4: "value",
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3.0",
         output: {
@@ -1316,6 +1337,7 @@ describe("getValueFromTree - ", () => {
               ],
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3.0.path4.0",
         output: {
@@ -1353,6 +1375,7 @@ describe("getValueFromTree - ", () => {
               ],
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3.0..path4.path5.0",
         output: {
@@ -1373,6 +1396,7 @@ describe("getValueFromTree - ", () => {
       {
         inputObj: {
           "path1.path2.path3": "value",
+          someotherPath: "testValue",
         },
         path: "path1.path2.path4",
         output: "value",
@@ -1384,6 +1408,7 @@ describe("getValueFromTree - ", () => {
           "path1.path2": {
             path3: "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path3.path4",
         output: "value",
@@ -1395,6 +1420,7 @@ describe("getValueFromTree - ", () => {
           path1: {
             "path2.path3": "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2",
         output: "value",
@@ -1408,6 +1434,7 @@ describe("getValueFromTree - ", () => {
               "path3.path4": "value",
             },
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2.path3",
         output: "value",
@@ -1419,6 +1446,7 @@ describe("getValueFromTree - ", () => {
           "path1.path2": {
             "path3.path4": "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path3.path4",
         output: "value",
@@ -1430,6 +1458,7 @@ describe("getValueFromTree - ", () => {
           "path1.path2.path3": {
             path4: "value",
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2",
         output: {
@@ -1445,6 +1474,7 @@ describe("getValueFromTree - ", () => {
               path4: "value",
             },
           },
+          someotherPath: "testValue",
         },
         path: "path1.path2",
         output: {
@@ -1462,6 +1492,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           },
+          someotherPath: "testValue",
         },
         path: "path2.path3.path4",
         output: {
@@ -1477,6 +1508,7 @@ describe("getValueFromTree - ", () => {
               path3: "value",
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.1.path3",
         output: "value",
@@ -1492,6 +1524,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.1.path3.path4",
         output: "value",
@@ -1505,6 +1538,7 @@ describe("getValueFromTree - ", () => {
               "path3.path4": "value",
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.1.path3.path4",
         output: "value",
@@ -1522,6 +1556,7 @@ describe("getValueFromTree - ", () => {
               ],
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.path2.2.path3.0.path4",
         output: "value",
@@ -1537,6 +1572,7 @@ describe("getValueFromTree - ", () => {
               },
             },
           ],
+          someotherPath: "testValue",
         },
         path: "path1.0.path3",
         output: {

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -1389,8 +1389,8 @@ export function purgeOrphanedDynamicPaths(widget: WidgetProps) {
  * Suppose, if the path is `path1.path2.path3.path4`, this function
  * checks in following paths in the tree as well, if _.get doesn't return a value
  *  - path1.path2.path3 -> path4
- *  - path1.path2 -> path3.path4 (will recursively traversed with same logic)
- *  - path1 -> path2.path3.path4 (will recursively traversed with same logic)
+ *  - path1.path2 -> path3.path4 (will recursively traverse with same logic)
+ *  - path1 -> path2.path3.path4 (will recursively traverse with same logic)
  */
 export function getValueFromTree(
   obj: Record<string, unknown>,
@@ -1417,26 +1417,19 @@ export function getValueFromTree(
       if (obj.hasOwnProperty(currentPath)) {
         const currentValue = obj[currentPath];
 
-        if (typeof currentValue !== "object") {
-          if (!poppedPath.length) {
-            //Valid path
-            return currentValue;
-          } else {
-            //Invalid path
-            return defaultValue;
-          }
+        if (!poppedPath.length) {
+          //Valid path
+          return currentValue;
+        } else if (typeof currentValue !== "object") {
+          //Invalid path
+          return defaultValue;
         } else {
-          if (!poppedPath.length) {
-            //Valid path
-            return currentValue;
-          } else {
-            //Valid path, need to traverse recursively with same strategy
-            return getValueFromTree(
-              currentValue as Record<string, unknown>,
-              poppedPath.join("."),
-              defaultValue,
-            );
-          }
+          //Valid path, need to traverse recursively with same strategy
+          return getValueFromTree(
+            currentValue as Record<string, unknown>,
+            poppedPath.join("."),
+            defaultValue,
+          );
         }
       } else {
         // We need the popped paths to traverse recursively


### PR DESCRIPTION
## Description
- Introduced a new utility `getValueFromTree` that looks for path which
  keys have dot characters in them
- BATCH_UPDATE_WIDGET_PROPERTY updates multiple properties of a widget and updates the state.
   when two widget emits BATCH_UPDATE_WIDGET_PROPERTY parallely (happens on crud page creation),
   the state updates done by the first BATCH_UPDATE_WIDGET_PROPERTY is overwritten by the second
   BATCH_UPDATE_WIDGET_PROPERTY before it gets flushed to store, since both are processed parallel.
   So we have created an actionChannel to buffer the eventsand process them only when the previous
   event changes get flushed out to the state.

Why this was not observed previously?:
Typically when building an application, user drops one widget at a time. So we never ran into a
situation where two BATCH_UPDATE_WIDGET_PROPERTY were emitted at the same time. But now we have
modified the CRUD template to use JSON_form_widget instead of simple form_widget. So now JSON
form and the existing table widget in the template races to update the state when a CRUD page is
created. Hence we're seeing this now.

Fixes #12505
Fixes #13242

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: task/improved-get-strategy-widget-update-property 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.51 **(0.02)** | 38.01 **(0.03)** | 35.87 **(0.01)** | 56.75 **(0.02)**
 :green_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 61.94 **(0.37)** | 51.44 **(0.17)** | 61.54 **(0.76)** | 63.67 **(0.38)**
 :green_circle: | app/client/src/sagas/WidgetOperationUtils.ts | 69.08 **(0.72)** | 46.67 **(1.82)** | 67.61 **(0.47)** | 68.77 **(0.88)**
 :green_circle: | app/client/src/utils/DynamicBindingUtils.ts | 86.17 **(0.53)** | 74.79 **(1.68)** | 77.42 **(0)** | 85.8 **(0.59)**</details>