### PR TITLE
fix: Disable CTRL+A to select all widgets on Api / Datasource Pane.

### DIFF
--- a/app/client/src/pages/Editor/GlobalHotKeys.tsx
+++ b/app/client/src/pages/Editor/GlobalHotKeys.tsx
@@ -40,7 +40,6 @@ import { Variant } from "components/ads/common";
 import { getAppMode } from "selectors/applicationSelectors";
 import { APP_MODE } from "entities/App";
 
-import { commentModeSelector } from "selectors/commentsSelectors";
 import {
   createMessage,
   SAVE_HOTKEY_TOASTER_MESSAGE,
@@ -51,6 +50,8 @@ import { getExplorerPinned } from "selectors/explorerSelector";
 import { setExplorerPinnedAction } from "actions/explorerActions";
 import { setIsGitSyncModalOpen } from "actions/gitSyncActions";
 import { GitSyncModalTab } from "entities/GitSync";
+import { matchBuilderPath } from "constants/routes";
+import { commentModeSelector } from "selectors/commentsSelectors";
 
 type Props = {
   copySelectedWidget: () => void;
@@ -257,8 +258,10 @@ class GlobalHotKeys extends React.Component<Props> {
           group="Canvas"
           label="Select all Widget"
           onKeyDown={(e: any) => {
-            this.props.selectAllWidgetsInit();
-            e.preventDefault();
+            if (matchBuilderPath(window.location.pathname)) {
+              this.props.selectAllWidgetsInit();
+              e.preventDefault();
+            }
           }}
         />
         <Hotkey


### PR DESCRIPTION
## Description
- Pressing CTRL + A on the `ApiPane, QueryPane, JSObjectPane, DataSources Pane` was selecting all the widgets.

Fixes #10319 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested ?

- Tested Manually on the canvas 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
