### PR TITLE
feat: Add a field for the post message api exposure

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -430,6 +430,7 @@ export const CLEAR_INTERVAL = () => `Clear interval`;
 export const GET_GEO_LOCATION = () => `Get Geolocation`;
 export const WATCH_GEO_LOCATION = () => `Watch Geolocation`;
 export const STOP_WATCH_GEO_LOCATION = () => `Stop watching Geolocation`;
+export const POST_MESSAGE = () => `Post message`;
 
 //js actions
 export const JS_ACTION_COPY_SUCCESS = (actionName: string, pageName: string) =>

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -430,7 +430,7 @@ export const CLEAR_INTERVAL = () => `Clear interval`;
 export const GET_GEO_LOCATION = () => `Get Geolocation`;
 export const WATCH_GEO_LOCATION = () => `Watch Geolocation`;
 export const STOP_WATCH_GEO_LOCATION = () => `Stop watching Geolocation`;
-export const POST_MESSAGE = () => `Post message`;
+export const POST_MESSAGE = () => `Post message to a target window`;
 
 //js actions
 export const JS_ACTION_COPY_SUCCESS = (actionName: string, pageName: string) =>

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -232,6 +232,7 @@ export const ActionType = {
   getGeolocation: "appsmith.geolocation.getCurrentPosition",
   watchGeolocation: "appsmith.geolocation.watchPosition",
   stopWatchGeolocation: "appsmith.geolocation.clearWatch",
+  postMessage: "postMessage",
 };
 type ActionType = typeof ActionType[keyof typeof ActionType];
 
@@ -355,6 +356,7 @@ export enum FieldType {
   DELAY_FIELD = "DELAY_FIELD",
   ID_FIELD = "ID_FIELD",
   CLEAR_INTERVAL_ID_FIELD = "CLEAR_INTERVAL_ID_FIELD",
+  // TODO - see if post message needs to accept any arguments and add them here
 }
 
 type FieldConfig = {
@@ -407,6 +409,9 @@ const fieldConfigs: FieldConfigs = {
           break;
         case ActionType.resetWidget:
           defaultParams = `"",true`;
+          break;
+        case ActionType.postMessage:
+          defaultParams = "() => { \n\t // add code here \n}";
           break;
         default:
           break;

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -358,7 +358,6 @@ export enum FieldType {
   CLEAR_INTERVAL_ID_FIELD = "CLEAR_INTERVAL_ID_FIELD",
   MESSAGE_FIELD = "MESSAGE_FIELD",
   TARGET_ORIGIN_FIELD = "TARGET_ORIGIN_FIELD",
-  TRANSFER_ARRAY_FIELD = "TRANSFER_ARRAY_FIELD",
 }
 
 type FieldConfig = {
@@ -649,15 +648,6 @@ const fieldConfigs: FieldConfigs = {
     },
     view: ViewTypes.TEXT_VIEW,
   },
-  [FieldType.TRANSFER_ARRAY_FIELD]: {
-    getter: (value: string) => {
-      return textGetter(value, 2);
-    },
-    setter: (value: string, currentValue: string) => {
-      return textSetter(value, currentValue, 2);
-    },
-    view: ViewTypes.TEXT_VIEW,
-  },
 };
 
 function renderField(props: {
@@ -831,7 +821,6 @@ function renderField(props: {
     case FieldType.CLEAR_INTERVAL_ID_FIELD:
     case FieldType.MESSAGE_FIELD:
     case FieldType.TARGET_ORIGIN_FIELD:
-    case FieldType.TRANSFER_ARRAY_FIELD:
       let fieldLabel = "";
       if (fieldType === FieldType.ALERT_TEXT_FIELD) {
         fieldLabel = "Message";
@@ -861,8 +850,6 @@ function renderField(props: {
         fieldLabel = "Message";
       } else if (fieldType === FieldType.TARGET_ORIGIN_FIELD) {
         fieldLabel = "Target origin";
-      } else if (fieldType === FieldType.TRANSFER_ARRAY_FIELD) {
-        fieldLabel = "Transfer array (optional)";
       }
       viewElement = (view as (props: TextViewProps) => JSX.Element)({
         label: fieldLabel,

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -356,7 +356,9 @@ export enum FieldType {
   DELAY_FIELD = "DELAY_FIELD",
   ID_FIELD = "ID_FIELD",
   CLEAR_INTERVAL_ID_FIELD = "CLEAR_INTERVAL_ID_FIELD",
-  // TODO - see if post message needs to accept any arguments and add them here
+  MESSAGE_FIELD = "MESSAGE_FIELD",
+  TARGET_ORIGIN_FIELD = "TARGET_ORIGIN_FIELD",
+  TRANSFER_ARRAY_FIELD = "TRANSFER_ARRAY_FIELD",
 }
 
 type FieldConfig = {
@@ -411,7 +413,7 @@ const fieldConfigs: FieldConfigs = {
           defaultParams = `"",true`;
           break;
         case ActionType.postMessage:
-          defaultParams = "() => { \n\t // add code here \n}";
+          defaultParams = `"",*,undefined`;
           break;
         default:
           break;
@@ -627,6 +629,33 @@ const fieldConfigs: FieldConfigs = {
     },
     view: ViewTypes.TEXT_VIEW,
   },
+  [FieldType.MESSAGE_FIELD]: {
+    getter: (value: string) => {
+      return textGetter(value, 0);
+    },
+    setter: (value: string, currentValue: string) => {
+      return textSetter(value, currentValue, 0);
+    },
+    view: ViewTypes.TEXT_VIEW,
+  },
+  [FieldType.TARGET_ORIGIN_FIELD]: {
+    getter: (value: string) => {
+      return textGetter(value, 1);
+    },
+    setter: (value: string, currentValue: string) => {
+      return textSetter(value, currentValue, 1);
+    },
+    view: ViewTypes.TEXT_VIEW,
+  },
+  [FieldType.TRANSFER_ARRAY_FIELD]: {
+    getter: (value: string) => {
+      return textGetter(value, 2);
+    },
+    setter: (value: string, currentValue: string) => {
+      return textSetter(value, currentValue, 2);
+    },
+    view: ViewTypes.TEXT_VIEW,
+  },
 };
 
 function renderField(props: {
@@ -798,6 +827,9 @@ function renderField(props: {
     case FieldType.DELAY_FIELD:
     case FieldType.ID_FIELD:
     case FieldType.CLEAR_INTERVAL_ID_FIELD:
+    case FieldType.MESSAGE_FIELD:
+    case FieldType.TARGET_ORIGIN_FIELD:
+    case FieldType.TRANSFER_ARRAY_FIELD:
       let fieldLabel = "";
       if (fieldType === FieldType.ALERT_TEXT_FIELD) {
         fieldLabel = "Message";
@@ -823,6 +855,12 @@ function renderField(props: {
         fieldLabel = "Id";
       } else if (fieldType === FieldType.CLEAR_INTERVAL_ID_FIELD) {
         fieldLabel = "Id";
+      } else if (fieldType === FieldType.MESSAGE_FIELD) {
+        fieldLabel = "Message";
+      } else if (fieldType === FieldType.TARGET_ORIGIN_FIELD) {
+        fieldLabel = "Target origin";
+      } else if (fieldType === FieldType.TRANSFER_ARRAY_FIELD) {
+        fieldLabel = "Transfer array (optional)";
       }
       viewElement = (view as (props: TextViewProps) => JSX.Element)({
         label: fieldLabel,

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -413,7 +413,7 @@ const fieldConfigs: FieldConfigs = {
           defaultParams = `"",true`;
           break;
         case ActionType.postMessage:
-          defaultParams = `"",*,undefined`;
+          defaultParams = `,'*'`;
           break;
         default:
           break;

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -412,8 +412,10 @@ const fieldConfigs: FieldConfigs = {
         case ActionType.resetWidget:
           defaultParams = `"",true`;
           break;
+        // add example website so that users don't leave it empty or use '*' raising security issues
+        // https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns
         case ActionType.postMessageToTargetWindow:
-          defaultParams = `,'*'`;
+          defaultParams = `,'https://www.example.com'`;
           break;
         default:
           break;

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -232,7 +232,7 @@ export const ActionType = {
   getGeolocation: "appsmith.geolocation.getCurrentPosition",
   watchGeolocation: "appsmith.geolocation.watchPosition",
   stopWatchGeolocation: "appsmith.geolocation.clearWatch",
-  postMessageToTargetWindow: "postMessageToTargetWindow",
+  postMessage: "postMessageToTargetWindow",
 };
 type ActionType = typeof ActionType[keyof typeof ActionType];
 
@@ -413,7 +413,7 @@ const fieldConfigs: FieldConfigs = {
           break;
         // add example website so that users don't leave it empty or use '*' raising security issues
         // https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns
-        case ActionType.postMessageToTargetWindow:
+        case ActionType.postMessage:
           defaultParams = `,'https://www.example.com'`;
           break;
         default:

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -411,11 +411,6 @@ const fieldConfigs: FieldConfigs = {
         case ActionType.resetWidget:
           defaultParams = `"",true`;
           break;
-        // add example website so that users don't leave it empty or use '*' raising security issues
-        // https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns
-        case ActionType.postMessage:
-          defaultParams = `,'https://www.example.com'`;
-          break;
         default:
           break;
       }

--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -232,7 +232,7 @@ export const ActionType = {
   getGeolocation: "appsmith.geolocation.getCurrentPosition",
   watchGeolocation: "appsmith.geolocation.watchPosition",
   stopWatchGeolocation: "appsmith.geolocation.clearWatch",
-  postMessage: "postMessage",
+  postMessageToTargetWindow: "postMessageToTargetWindow",
 };
 type ActionType = typeof ActionType[keyof typeof ActionType];
 
@@ -412,7 +412,7 @@ const fieldConfigs: FieldConfigs = {
         case ActionType.resetWidget:
           defaultParams = `"",true`;
           break;
-        case ActionType.postMessage:
+        case ActionType.postMessageToTargetWindow:
           defaultParams = `,'*'`;
           break;
         default:

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -49,6 +49,7 @@ import {
   NAVIGATE_TO,
   NO_ACTION,
   OPEN_MODAL,
+  POST_MESSAGE,
   RESET_WIDGET,
   SET_INTERVAL,
   SHOW_MESSAGE,
@@ -124,6 +125,10 @@ const baseOptions: { label: string; value: string }[] = [
   {
     label: createMessage(STOP_WATCH_GEO_LOCATION),
     value: ActionType.stopWatchGeolocation,
+  },
+  {
+    label: createMessage(POST_MESSAGE),
+    value: ActionType.postMessage,
   },
 ];
 
@@ -373,6 +378,13 @@ function getFieldFromValue(
       field: FieldType.CALLBACK_FUNCTION_FIELD,
     });
   }
+
+  if (value.indexOf("postMessage") !== -1) {
+    fields.push({
+      field: FieldType.CALLBACK_FUNCTION_FIELD,
+    });
+  }
+
   return fields;
 }
 

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -128,7 +128,7 @@ const baseOptions: { label: string; value: string }[] = [
   },
   {
     label: createMessage(POST_MESSAGE),
-    value: ActionType.postMessage,
+    value: ActionType.postMessageToTargetWindow,
   },
 ];
 
@@ -379,7 +379,7 @@ function getFieldFromValue(
     });
   }
 
-  if (value.indexOf("postMessage") !== -1) {
+  if (value.indexOf("postMessageToTargetWindow") !== -1) {
     fields.push(
       {
         field: FieldType.MESSAGE_FIELD,

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -387,9 +387,6 @@ function getFieldFromValue(
       {
         field: FieldType.TARGET_ORIGIN_FIELD,
       },
-      {
-        field: FieldType.TRANSFER_ARRAY_FIELD,
-      },
     );
   }
 

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -380,9 +380,17 @@ function getFieldFromValue(
   }
 
   if (value.indexOf("postMessage") !== -1) {
-    fields.push({
-      field: FieldType.CALLBACK_FUNCTION_FIELD,
-    });
+    fields.push(
+      {
+        field: FieldType.MESSAGE_FIELD,
+      },
+      {
+        field: FieldType.TARGET_ORIGIN_FIELD,
+      },
+      {
+        field: FieldType.TRANSFER_ARRAY_FIELD,
+      },
+    );
   }
 
   return fields;

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -128,7 +128,7 @@ const baseOptions: { label: string; value: string }[] = [
   },
   {
     label: createMessage(POST_MESSAGE),
-    value: ActionType.postMessageToTargetWindow,
+    value: ActionType.postMessage,
   },
 ];
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -173,7 +173,7 @@ export type PostMessageDescription = {
   payload: {
     message: any;
     targetOrigin: any;
-    transfer?: any;
+    transfer?: [any];
   };
 };
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -18,6 +18,7 @@ export enum ActionTriggerType {
   WATCH_CURRENT_LOCATION = "WATCH_CURRENT_LOCATION",
   STOP_WATCHING_CURRENT_LOCATION = "STOP_WATCHING_CURRENT_LOCATION",
   CONFIRMATION_MODAL = "CONFIRMATION_MODAL",
+  POST_MESSAGE = "POST_MESSAGE",
 }
 
 export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
@@ -37,6 +38,7 @@ export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
   [ActionTriggerType.WATCH_CURRENT_LOCATION]: "watchLocation",
   [ActionTriggerType.STOP_WATCHING_CURRENT_LOCATION]: "stopWatch",
   [ActionTriggerType.CONFIRMATION_MODAL]: "ConfirmationModal",
+  [ActionTriggerType.POST_MESSAGE]: "postMessage",
 };
 
 export type RunPluginActionDescription = {
@@ -166,6 +168,13 @@ export type ConfirmationModal = {
   payload?: Record<string, any>;
 };
 
+export type PostMessageDescription = {
+  type: ActionTriggerType.POST_MESSAGE;
+  payload: {
+    callback: string;
+  };
+};
+
 export type ActionDescription =
   | RunPluginActionDescription
   | ClearPluginActionDescription
@@ -182,4 +191,5 @@ export type ActionDescription =
   | GetCurrentLocationDescription
   | WatchCurrentLocationDescription
   | StopWatchingCurrentLocationDescription
-  | ConfirmationModal;
+  | ConfirmationModal
+  | PostMessageDescription;

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -172,8 +172,8 @@ export type PostMessageDescription = {
   type: ActionTriggerType.POST_MESSAGE;
   payload: {
     message: any;
-    targetOrigin: any;
-    transfer?: [any];
+    targetOrigin: string;
+    transfer?: any[];
   };
 };
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -171,7 +171,9 @@ export type ConfirmationModal = {
 export type PostMessageDescription = {
   type: ActionTriggerType.POST_MESSAGE;
   payload: {
-    callback: string;
+    message: any;
+    targetOrigin: any;
+    transfer?: any;
   };
 };
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -38,7 +38,7 @@ export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
   [ActionTriggerType.WATCH_CURRENT_LOCATION]: "watchLocation",
   [ActionTriggerType.STOP_WATCHING_CURRENT_LOCATION]: "stopWatch",
   [ActionTriggerType.CONFIRMATION_MODAL]: "ConfirmationModal",
-  [ActionTriggerType.POST_MESSAGE]: "postMessage",
+  [ActionTriggerType.POST_MESSAGE]: "postMessageToTargetWindow",
 };
 
 export type RunPluginActionDescription = {

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -173,7 +173,6 @@ export type PostMessageDescription = {
   payload: {
     message: any;
     targetOrigin: string;
-    transfer?: any[];
   };
 };
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -171,7 +171,7 @@ export type ConfirmationModal = {
 export type PostMessageDescription = {
   type: ActionTriggerType.POST_MESSAGE;
   payload: {
-    message: any;
+    message: unknown;
     targetOrigin: string;
   };
 };

--- a/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
@@ -10,8 +10,8 @@ import {
 import * as log from "loglevel";
 import { all, call, put, takeEvery, takeLatest } from "redux-saga/effects";
 import {
-  evaluateArgumentSaga,
   evaluateAndExecuteDynamicTrigger,
+  evaluateArgumentSaga,
   evaluateSnippetSaga,
   setAppVersionOnWorkerSaga,
 } from "sagas/EvaluationsSaga";
@@ -36,12 +36,12 @@ import {
   logActionExecutionError,
   TriggerFailureError,
   UncaughtPromiseError,
+  UserCancelledActionExecutionError,
 } from "sagas/ActionExecution/errorUtils";
 import {
   clearIntervalSaga,
   setIntervalSaga,
 } from "sagas/ActionExecution/SetIntervalSaga";
-import { UserCancelledActionExecutionError } from "sagas/ActionExecution/errorUtils";
 import {
   getCurrentLocationSaga,
   stopWatchCurrentLocation,
@@ -49,6 +49,7 @@ import {
 } from "sagas/ActionExecution/GetCurrentLocationSaga";
 import { requestModalConfirmationSaga } from "sagas/UtilSagas";
 import { ModalType } from "reducers/uiReducers/modalActionReducer";
+import { postMessageSaga } from "./PostMessageSaga";
 
 export type TriggerMeta = {
   source?: TriggerSource;
@@ -141,6 +142,9 @@ export function* executeActionTriggers(
       if (!flag) {
         throw new UserCancelledActionExecutionError();
       }
+      break;
+    case ActionTriggerType.POST_MESSAGE:
+      yield call(postMessageSaga, trigger.payload);
       break;
     default:
       log.error("Trigger type unknown", trigger);

--- a/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
@@ -144,7 +144,7 @@ export function* executeActionTriggers(
       }
       break;
     case ActionTriggerType.POST_MESSAGE:
-      yield call(postMessageSaga, trigger.payload);
+      yield call(postMessageSaga, trigger.payload, triggerMeta);
       break;
     default:
       log.error("Trigger type unknown", trigger);

--- a/app/client/src/sagas/ActionExecution/PostMessage.test.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessage.test.ts
@@ -34,6 +34,8 @@ describe("PostMessageSaga", () => {
     it("calls window.parent with message and target origin", () => {
       const dispatched: any[] = [];
 
+      const postMessage = jest.spyOn(window.parent, "postMessage");
+
       runSaga(
         {
           dispatch: (action) => dispatched.push(action),
@@ -46,13 +48,13 @@ describe("PostMessageSaga", () => {
         {},
       );
 
-      expect(window.parent.postMessage).toHaveBeenCalledWith(
+      expect(postMessage).toHaveBeenCalledWith(
         "hello world",
         "https://dev.appsmith.com",
-        {},
+        undefined,
       );
 
-      expect(dispatched).toEqual(undefined);
+      expect(dispatched).toEqual([]);
     });
   });
 });

--- a/app/client/src/sagas/ActionExecution/PostMessage.test.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessage.test.ts
@@ -1,0 +1,58 @@
+import { postMessageSaga, executePostMessage } from "./PostMessageSaga";
+import { spawn } from "redux-saga/effects";
+import { runSaga } from "redux-saga";
+
+describe("PostMessageSaga", () => {
+  describe("postMessageSaga function", () => {
+    const generator = postMessageSaga(
+      {
+        message: "hello world",
+        targetOrigin: "https://dev.appsmith.com",
+      },
+      {},
+    );
+
+    it("executes postMessageSaga with the payload and trigger meta", () => {
+      expect(generator.next().value).toStrictEqual(
+        spawn(
+          executePostMessage,
+          {
+            message: "hello world",
+            targetOrigin: "https://dev.appsmith.com",
+          },
+          {},
+        ),
+      );
+    });
+
+    it("should be done on next iteration", () => {
+      expect(generator.next().done).toBeTruthy();
+    });
+  });
+
+  describe("executePostMessage function", () => {
+    it("calls window.parent with message and target origin", () => {
+      const dispatched: any[] = [];
+
+      runSaga(
+        {
+          dispatch: (action) => dispatched.push(action),
+        },
+        executePostMessage,
+        {
+          message: "hello world",
+          targetOrigin: "https://dev.appsmith.com",
+        },
+        {},
+      );
+
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        "hello world",
+        "https://dev.appsmith.com",
+        {},
+      );
+
+      expect(dispatched).toEqual(undefined);
+    });
+  });
+});

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -9,11 +9,7 @@ export function* postMessageSaga(payload: PostMessageDescription["payload"]) {
 function* executePostMessage(payload: PostMessageDescription["payload"]) {
   const { message, targetOrigin, transfer } = payload;
   try {
-    window.parent.postMessage(
-      message,
-      targetOrigin || "*",
-      transfer || undefined,
-    );
+    window.parent.postMessage(message, targetOrigin, transfer || undefined);
   } catch (error) {
     throw new TriggerFailureError(error.message);
   }

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -9,7 +9,7 @@ export function* postMessageSaga(payload: PostMessageDescription["payload"]) {
 function* executePostMessage(payload: PostMessageDescription["payload"]) {
   const { message, targetOrigin, transfer } = payload;
   try {
-    postMessage(message, targetOrigin || "*", transfer || undefined);
+    window.postMessage(message, targetOrigin || "*", transfer || undefined);
   } catch (error) {
     throw new TriggerFailureError(error.message);
   }

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -31,7 +31,7 @@ export function* executePostMessage(
     }
   } catch (error) {
     logActionExecutionError(
-      error.message,
+      (error as Error).message,
       triggerMeta.source,
       triggerMeta.triggerPropertyName,
     );

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -5,6 +5,7 @@ import {
   TriggerFailureError,
 } from "sagas/ActionExecution/errorUtils";
 import { TriggerMeta } from "./ActionExecutionSagas";
+import { isEmpty } from "lodash";
 
 export function* postMessageSaga(
   payload: PostMessageDescription["payload"],
@@ -23,8 +24,10 @@ export function* executePostMessage(
       throw new TriggerFailureError(
         "Please enter a valid url as targetOrigin. Failing to provide a specific target discloses the data you send to any interested malicious site.",
       );
-    } else if (!message) {
+    } else if (isEmpty(message)) {
       throw new TriggerFailureError("Please enter a message.");
+    } else if (isEmpty(targetOrigin)) {
+      throw new TriggerFailureError("Please enter a target origin URL.");
     } else {
       window.parent.postMessage(message, targetOrigin, undefined);
     }

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -10,7 +10,7 @@ export function* postMessageSaga(
   yield spawn(executePostMessage, payload, triggerMeta);
 }
 
-function* executePostMessage(
+export function* executePostMessage(
   payload: PostMessageDescription["payload"],
   triggerMeta: TriggerMeta,
 ) {

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -1,0 +1,16 @@
+import { spawn } from "redux-saga/effects";
+import { PostMessageDescription } from "../../entities/DataTree/actionTriggers";
+import { TriggerFailureError } from "sagas/ActionExecution/errorUtils";
+
+export function* postMessageSaga(payload: PostMessageDescription["payload"]) {
+  yield spawn(executePostMessage, payload);
+}
+
+function* executePostMessage(payload: PostMessageDescription["payload"]) {
+  const { message, targetOrigin, transfer } = payload;
+  try {
+    postMessage(message, targetOrigin || "*", transfer || undefined);
+  } catch (error) {
+    throw new TriggerFailureError(error.message);
+  }
+}

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -1,6 +1,9 @@
 import { spawn } from "redux-saga/effects";
 import { PostMessageDescription } from "../../entities/DataTree/actionTriggers";
-import { logActionExecutionError } from "sagas/ActionExecution/errorUtils";
+import {
+  logActionExecutionError,
+  TriggerFailureError,
+} from "sagas/ActionExecution/errorUtils";
 import { TriggerMeta } from "./ActionExecutionSagas";
 
 export function* postMessageSaga(
@@ -16,7 +19,15 @@ export function* executePostMessage(
 ) {
   const { message, targetOrigin } = payload;
   try {
-    window.parent.postMessage(message, targetOrigin, undefined);
+    if (targetOrigin === "*") {
+      throw new TriggerFailureError(
+        "Please enter a valid url as targetOrigin. Failing to provide a specific target discloses the data you send to any interested malicious site.",
+      );
+    } else if (!message) {
+      throw new TriggerFailureError("Please enter a message.");
+    } else {
+      window.parent.postMessage(message, targetOrigin, undefined);
+    }
   } catch (error) {
     logActionExecutionError(
       error.message,

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -1,16 +1,27 @@
 import { spawn } from "redux-saga/effects";
 import { PostMessageDescription } from "../../entities/DataTree/actionTriggers";
-import { TriggerFailureError } from "sagas/ActionExecution/errorUtils";
+import { logActionExecutionError } from "sagas/ActionExecution/errorUtils";
+import { TriggerMeta } from "./ActionExecutionSagas";
 
-export function* postMessageSaga(payload: PostMessageDescription["payload"]) {
-  yield spawn(executePostMessage, payload);
+export function* postMessageSaga(
+  payload: PostMessageDescription["payload"],
+  triggerMeta: TriggerMeta,
+) {
+  yield spawn(executePostMessage, payload, triggerMeta);
 }
 
-function* executePostMessage(payload: PostMessageDescription["payload"]) {
-  const { message, targetOrigin, transfer } = payload;
+function* executePostMessage(
+  payload: PostMessageDescription["payload"],
+  triggerMeta: TriggerMeta,
+) {
+  const { message, targetOrigin } = payload;
   try {
-    window.parent.postMessage(message, targetOrigin, transfer || undefined);
+    window.parent.postMessage(message, targetOrigin, undefined);
   } catch (error) {
-    throw new TriggerFailureError(error.message);
+    logActionExecutionError(
+      error.message,
+      triggerMeta.source,
+      triggerMeta.triggerPropertyName,
+    );
   }
 }

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -24,8 +24,6 @@ export function* executePostMessage(
       throw new TriggerFailureError(
         "Please enter a valid url as targetOrigin. Failing to provide a specific target discloses the data you send to any interested malicious site.",
       );
-    } else if (isEmpty(message)) {
-      throw new TriggerFailureError("Please enter a message.");
     } else if (isEmpty(targetOrigin)) {
       throw new TriggerFailureError("Please enter a target origin URL.");
     } else {

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -9,7 +9,11 @@ export function* postMessageSaga(payload: PostMessageDescription["payload"]) {
 function* executePostMessage(payload: PostMessageDescription["payload"]) {
   const { message, targetOrigin, transfer } = payload;
   try {
-    window.postMessage(message, targetOrigin || "*", transfer || undefined);
+    window.parent.postMessage(
+      message,
+      targetOrigin || "*",
+      transfer || undefined,
+    );
   } catch (error) {
     throw new TriggerFailureError(error.message);
   }

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -673,7 +673,7 @@ export const GLOBAL_FUNCTIONS = {
   postMessageToTargetWindow: {
     "!doc":
       "Establish cross-origin communication between Window objects/page and iframes",
-    "!type": "fn(message: unknown, targetOrigin: string, transfer: [any])",
+    "!type": "fn(message: unknown, targetOrigin: string)",
   },
 };
 

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -670,6 +670,11 @@ export const GLOBAL_FUNCTIONS = {
     "!doc": "Stop executing a setInterval with id",
     "!type": "fn(id: string) -> void",
   },
+  postMessage: {
+    "!doc":
+      "Establish cross-origin communication between Window objects/page and iframes",
+    "!type": "fn(message: any, targetOrigin: any, transfer: [any])",
+  },
 };
 
 export const getPropsForJSActionEntity = ({

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -670,7 +670,7 @@ export const GLOBAL_FUNCTIONS = {
     "!doc": "Stop executing a setInterval with id",
     "!type": "fn(id: string) -> void",
   },
-  postMessage: {
+  postMessageToTargetWindow: {
     "!doc":
       "Establish cross-origin communication between Window objects/page and iframes",
     "!type": "fn(message: any, targetOrigin: any, transfer: [any])",

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -673,7 +673,7 @@ export const GLOBAL_FUNCTIONS = {
   postMessageToTargetWindow: {
     "!doc":
       "Establish cross-origin communication between Window objects/page and iframes",
-    "!type": "fn(message: any, targetOrigin: any, transfer: [any])",
+    "!type": "fn(message: any, targetOrigin: string, transfer: [any])",
   },
 };
 

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -673,7 +673,7 @@ export const GLOBAL_FUNCTIONS = {
   postMessageToTargetWindow: {
     "!doc":
       "Establish cross-origin communication between Window objects/page and iframes",
-    "!type": "fn(message: any, targetOrigin: string, transfer: [any])",
+    "!type": "fn(message: unknown, targetOrigin: string, transfer: [any])",
   },
 };
 

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -435,24 +435,161 @@ describe("Add functions", () => {
     );
   });
 
-  it("post message to target window works", () => {
-    const message = "Hello world!";
+  describe("Post message to target window works", () => {
     const targetOrigin = "https://dev.appsmith.com/";
 
-    expect(
-      dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
-    ).toBe(undefined);
+    it("Post message with first argument (message) as a string", () => {
+      const message = "Hello world!";
 
-    expect(self.TRIGGER_COLLECTOR).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          payload: {
-            message: "Hello world!",
-            targetOrigin: "https://dev.appsmith.com/",
-          },
-          type: "POST_MESSAGE",
-        }),
-      ]),
-    );
+      expect(
+        dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: "Hello world!",
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as undefined", () => {
+      const message = undefined;
+
+      expect(
+        dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: undefined,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as null", () => {
+      const message = null;
+
+      expect(
+        dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: null,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as a number", () => {
+      const message = 1826;
+
+      expect(
+        dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: 1826,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as a boolean", () => {
+      const message = true;
+
+      expect(
+        dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: true,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as an array", () => {
+      const message = [1, 2, 3, [1, 2, 3, [1, 2, 3]]];
+
+      expect(
+        dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: [1, 2, 3, [1, 2, 3, [1, 2, 3]]],
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as an object", () => {
+      const message = {
+        key: 1,
+        status: "active",
+        person: {
+          name: "timothee chalamet",
+        },
+        randomArr: [1, 2, 3],
+      };
+
+      expect(
+        dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: {
+                key: 1,
+                status: "active",
+                person: {
+                  name: "timothee chalamet",
+                },
+                randomArr: [1, 2, 3],
+              },
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
   });
 });

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -16,7 +16,6 @@ describe("Add functions", () => {
       config: {},
       datasourceUrl: "",
       pluginType: PluginType.API,
-      pluginId: "",
       dynamicBindingPathList: [],
       name: "action1",
       bindingPaths: {},

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -16,6 +16,7 @@ describe("Add functions", () => {
       config: {},
       datasourceUrl: "",
       pluginType: PluginType.API,
+      pluginId: "",
       dynamicBindingPathList: [],
       name: "action1",
       bindingPaths: {},
@@ -429,6 +430,27 @@ describe("Add functions", () => {
             id: "myInterval",
           },
           type: "CLEAR_INTERVAL",
+        }),
+      ]),
+    );
+  });
+
+  it("post message to target window works", () => {
+    const message = "Hello world!";
+    const targetOrigin = "https://dev.appsmith.com/";
+
+    expect(
+      dataTreeWithFunctions.postMessageToTargetWindow(message, targetOrigin),
+    ).toBe(undefined);
+
+    expect(self.TRIGGER_COLLECTOR).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          payload: {
+            message: "Hello world!",
+            targetOrigin: "https://dev.appsmith.com/",
+          },
+          type: "POST_MESSAGE",
         }),
       ]),
     );

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,7 +261,7 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
-  postMessage: function(message: any, targetOrigin: any, transfer?: [any]) {
+  postMessage: function(message: any, targetOrigin: string, transfer?: any[]) {
     return {
       type: ActionTriggerType.POST_MESSAGE,
       payload: {

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,7 +261,7 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
-  postMessage: function(message: any, targetOrigin: any, transfer?: any) {
+  postMessage: function(message: any, targetOrigin: any, transfer?: [any]) {
     return {
       type: ActionTriggerType.POST_MESSAGE,
       payload: {

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,7 +261,11 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
-  postMessage: function(message: any, targetOrigin: string, transfer?: any[]) {
+  postMessageToTargetWindow: function(
+    message: any,
+    targetOrigin: string,
+    transfer?: any[],
+  ) {
     return {
       type: ActionTriggerType.POST_MESSAGE,
       payload: {

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,7 +261,7 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
-  postMessageToTargetWindow: function(message: any, targetOrigin: string) {
+  postMessageToTargetWindow: function(message: unknown, targetOrigin: string) {
     return {
       type: ActionTriggerType.POST_MESSAGE,
       payload: {

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,11 +261,13 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
-  postMessage: function(callback) {
+  postMessage: function(message: any, targetOrigin: any, transfer?: any) {
     return {
       type: ActionTriggerType.POST_MESSAGE,
       payload: {
-        callback: callback.toString(),
+        message,
+        targetOrigin,
+        transfer,
       },
       executionType: ExecutionType.TRIGGER,
     };

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,17 +261,12 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
-  postMessageToTargetWindow: function(
-    message: any,
-    targetOrigin: string,
-    transfer?: any[],
-  ) {
+  postMessageToTargetWindow: function(message: any, targetOrigin: string) {
     return {
       type: ActionTriggerType.POST_MESSAGE,
       payload: {
         message,
         targetOrigin,
-        transfer,
       },
       executionType: ExecutionType.TRIGGER,
     };

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,6 +261,15 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
+  postMessage: function(callback) {
+    return {
+      type: ActionTriggerType.POST_MESSAGE,
+      payload: {
+        callback: callback.toString(),
+      },
+      executionType: ExecutionType.TRIGGER,
+    };
+  },
 };
 
 export const enhanceDataTreeWithFunctions = (


### PR DESCRIPTION
## Description

This pull request exposes `window.postMessage()` as a global function in the Appsmith platform.

Post message safely enables cross-origin communication between window objects.
**Example use-case** - Appsmith page embedded within an iframe which communicates with the container website

**More on post message here** - https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage

**References used for this PR:**
1. Geolocation APIs - https://github.com/appsmithorg/appsmith/pull/9295
2. setInterval and clearInterval support - https://github.com/appsmithorg/appsmith/pull/8158

**Fixes** #7241 

**Screen recording** - 

https://user-images.githubusercontent.com/10229595/163362579-18b5a26c-5ae5-40da-a4ff-3335ee024da5.mov


## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test plan 
- **Manual**: Created an app with different buttons holding different types of data and embedded it in a code sandbox within an iframe. Also removed the target origin which throws an error (App link - https://dev.appsmith.com/app/untitled-application-1/page1-624c1af4d8e632741017682e, Codesandbox link - https://codesandbox.io/s/compassionate-tdd-6dnzzd?file=/src/index.js)
- Added Jest tests
- https://github.com/appsmithorg/TestSmith/issues/1892

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes










## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feature/expose-post-message 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.57 **(0)** | 38.35 **(-0.01)** | 35.85 **(0.01)** | 56.82 **(0)**
 :green_circle: | app/client/src/ce/constants/messages.ts | 77.86 **(0.03)** | 100 **(0)** | 34.49 **(0.09)** | 81.78 **(0.01)**
 :red_circle: | app/client/src/components/editorComponents/ActionCreator/Fields.tsx | 34.87 **(-0.44)** | 24.46 **(-0.82)** | 9.88 **(-0.51)** | 34.22 **(-0.43)**
 :red_circle: | app/client/src/components/editorComponents/ActionCreator/index.tsx | 38.29 **(-0.44)** | 6.96 **(-0.12)** | 43.48 **(0)** | 38.15 **(-0.45)**
 :red_circle: | app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts | 24.04 **(-0.71)** | 1.69 **(-0.06)** | 25 **(0)** | 25.25 **(-0.79)**
 :sparkles: :new: | **app/client/src/sagas/ActionExecution/PostMessageSaga.ts** | **75** | **57.14** | **100** | **75**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :green_circle: | app/client/src/workers/Actions.ts | 91.78 **(0.11)** | 68.85 **(0)** | 80.65 **(0.65)** | 90.77 **(0.14)**</details>