### PR TITLE
fix: page launch error from dashboard

### DIFF
--- a/app/client/src/api/ApiUtils.ts
+++ b/app/client/src/api/ApiUtils.ts
@@ -16,7 +16,6 @@ import store from "store";
 import { logoutUser } from "actions/userActions";
 import { AUTH_LOGIN_URL } from "constants/routes";
 import { getCurrentGitBranch } from "selectors/gitSyncSelectors";
-import getQueryParamsObject from "utils/getQueryParamsObject";
 
 const executeActionRegex = /actions\/execute/;
 const timeoutErrorRegex = /timeout of (\d+)ms exceeded/;

--- a/app/client/src/api/ApiUtils.ts
+++ b/app/client/src/api/ApiUtils.ts
@@ -39,8 +39,7 @@ const is404orAuthPath = () => {
 // this will be used to calculate the time taken for an action
 // execution request
 export const apiRequestInterceptor = (config: AxiosRequestConfig) => {
-  const branch =
-    getCurrentGitBranch(store.getState()) || getQueryParamsObject().branch;
+  const branch = getCurrentGitBranch(store.getState());
   if (branch) {
     config.headers.branchName = branch;
   }

--- a/app/client/src/pages/tests/mockData.ts
+++ b/app/client/src/pages/tests/mockData.ts
@@ -43,6 +43,12 @@ export const fetchApplicationMockResponse: FetchApplicationResponse = {
         isDefault: true,
         slug: "page-1",
       },
+      {
+        id: "605c435a91dea93f0eaf91bc",
+        name: "Page2",
+        isDefault: false,
+        slug: "page-2",
+      },
     ],
     organizationId: "",
   },
@@ -66,4 +72,22 @@ export const setMockApplication = () => {
       pages: fetchApplicationMockResponse.data.pages,
     },
   });
+};
+
+export const updatedApplicationPayload = {
+  id: "605c435a91dea93f0eaf91b8",
+  name: "Renamed application",
+  slug: "renamed-application",
+  organizationId: "",
+  evaluationVersion: 1,
+  appIsExample: false,
+  gitApplicationMetadata: undefined,
+  applicationVersion: 2,
+};
+
+export const updatedPagePayload = {
+  id: "605c435a91dea93f0eaf91bc",
+  name: "My Page 2",
+  isDefault: false,
+  slug: "my-page-2",
 };

--- a/app/client/src/pages/tests/slug.test.tsx
+++ b/app/client/src/pages/tests/slug.test.tsx
@@ -11,6 +11,7 @@ import store from "store";
 import { render } from "test/testUtils";
 import { getUpdatedRoute, isURLDeprecated } from "utils/helpers";
 import {
+  fetchApplicationMockResponse,
   setMockApplication,
   setMockPageList,
   updatedApplicationPayload,
@@ -85,8 +86,11 @@ describe("URL slug names", () => {
 
   it("tests the manual upgrade option", () => {
     store.dispatch({
-      type: ReduxActionTypes.UPDATE_APPLICATION_SUCCESS,
-      payload: { applicationVersion: 1 },
+      type: ReduxActionTypes.FETCH_APPLICATION_SUCCESS,
+      payload: {
+        ...fetchApplicationMockResponse.data.application,
+        applicationVersion: 1,
+      },
     });
     const component = render(<ManualUpgrades />);
     expect(component.getByTestId("update-indicator")).toBeDefined();

--- a/app/client/src/reducers/uiReducers/applicationsReducer.tsx
+++ b/app/client/src/reducers/uiReducers/applicationsReducer.tsx
@@ -380,10 +380,6 @@ const applicationsReducer = createReducer(initialState, {
     return {
       ...state,
       userOrgs: _organizations,
-      currentApplication: {
-        ...state.currentApplication,
-        applicationVersion: action.payload.applicationVersion,
-      },
       isSavingAppName: false,
       isErrorSavingAppName: false,
     };

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -361,7 +361,7 @@ export function* initializeAppViewerSaga(
     PerformanceTransactionName.INIT_VIEW_APP,
   );
 
-  if (branch) yield put(updateBranchLocally(branch));
+  yield put(updateBranchLocally(branch || ""));
 
   yield put(setAppMode(APP_MODE.PUBLISHED));
 

--- a/app/client/src/store.ts
+++ b/app/client/src/store.ts
@@ -48,17 +48,23 @@ const routeParamsMiddleware: Middleware = () => (next: any) => (
       });
       break;
     }
-    case ReduxActionTypes.SWITCH_CURRENT_PAGE_ID:
+    case ReduxActionTypes.SWITCH_CURRENT_PAGE_ID: {
+      const id = action.payload.id;
+      const slug = action.payload.slug;
+      updateURLFactory({ pageId: id, pageSlug: slug });
+      break;
+    }
     case ReduxActionTypes.UPDATE_PAGE_SUCCESS: {
       const id = action.payload.id;
       const slug = action.payload.slug;
       const { pageId } = getRouteBuilderParams();
-      // Update page slug in URL only if the current page is renamed
-      if (pageId === id)
+      // Update route params and page slug in URL only if the current page is updated
+      if (pageId === id) {
+        updateURLFactory({ pageId: id, pageSlug: slug });
         updateSlugNamesInURL({
           pageSlug: slug,
         });
-      updateURLFactory({ pageId: id, pageSlug: slug });
+      }
       break;
     }
     case ReduxActionTypes.UPDATE_APPLICATION_SUCCESS:

--- a/app/client/src/store.ts
+++ b/app/client/src/store.ts
@@ -60,7 +60,7 @@ const routeParamsMiddleware: Middleware = () => (next: any) => (
       const { pageId } = getRouteBuilderParams();
       // Update route params and page slug in URL only if the current page is updated
       if (pageId === id) {
-        updateURLFactory({ pageId: id, pageSlug: slug });
+        updateURLFactory({ pageSlug: slug });
         updateSlugNamesInURL({
           pageSlug: slug,
         });


### PR DESCRIPTION
## Description
Fixes page launch 404 when launching an application(not git synced) right after visiting a git synced application on the same tab.
Should have been introduced because of the client side routing changes done on the /applications pages

Fixes #12558 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/page-launch-error-from-dashboard 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.28 **(0.02)** | 37.74 **(0.01)** | 35.88 **(0.04)** | 56.52 **(0.03)**
 :green_circle: | app/client/src/store.ts | 90.38 **(4.96)** | 58.33 **(0)** | 80 **(0)** | 89.13 **(5.8)**
 :red_circle: | app/client/src/api/ApiUtils.ts | 61.02 **(-0.65)** | 43.18 **(-2.47)** | 80 **(0)** | 58.18 **(-0.75)**
 :green_circle: | app/client/src/reducers/entityReducers/pageListReducer.tsx | 27.45 **(9.8)** | 30 **(5)** | 25 **(10)** | 30.43 **(10.86)**
 :green_circle: | app/client/src/reducers/uiReducers/applicationsReducer.tsx | 16 **(1)** | 27.27 **(0)** | 12.24 **(2.04)** | 14.43 **(1.03)**
 :green_circle: | app/client/src/reducers/uiReducers/editorReducer.tsx | 27.78 **(2.78)** | 50 **(50)** | 33.33 **(3.7)** | 27.78 **(2.78)**
 :green_circle: | app/client/src/reducers/uiReducers/explorerReducer.ts | 56 **(4)** | 0 **(0)** | 30 **(10)** | 56 **(4)**
 :green_circle: | app/client/src/sagas/InitSagas.ts | 41.4 **(0.22)** | 18.03 **(0.29)** | 50 **(0)** | 45.16 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>