### PR TITLE
fix: Pages tab navigation in preview mode for git apps

### DIFF
--- a/app/client/src/pages/tests/slug.test.tsx
+++ b/app/client/src/pages/tests/slug.test.tsx
@@ -5,8 +5,12 @@ import {
   getRouteBuilderParams,
   updateURLFactory,
 } from "RouteBuilder";
-import { ReduxActionTypes } from "constants/ReduxActionConstants";
-import { selectURLSlugs } from "selectors/editorSelectors";
+import { Page, ReduxActionTypes } from "constants/ReduxActionConstants";
+import {
+  getCurrentPageId,
+  getPageById,
+  selectURLSlugs,
+} from "selectors/editorSelectors";
 import store from "store";
 import { render } from "test/testUtils";
 import { getUpdatedRoute, isURLDeprecated } from "utils/helpers";
@@ -19,6 +23,9 @@ import {
 } from "./mockData";
 import ManualUpgrades from "pages/Editor/BottomBar/ManualUpgrades";
 import { updateCurrentPage } from "actions/pageActions";
+import { getCurrentApplication } from "selectors/applicationSelectors";
+import { getPageURL } from "utils/AppsmithUtils";
+import { APP_MODE } from "entities/App";
 
 describe("URL slug names", () => {
   beforeEach(async () => {
@@ -133,5 +140,26 @@ describe("URL slug names", () => {
         pageSlug: "page",
       }),
     ).toBe("/my-app/page-605c435a91dea93f0eaf91ba/edit");
+  });
+
+  it("tests getPageUrl utility method", () => {
+    const state = store.getState();
+    const currentApplication = getCurrentApplication(state);
+    const currentPageId = getCurrentPageId(state);
+    const page = getPageById(currentPageId)(state) as Page;
+
+    const editPageURL = getPageURL(page, APP_MODE.EDIT, currentApplication);
+    const viewPageURL = getPageURL(
+      page,
+      APP_MODE.PUBLISHED,
+      currentApplication,
+    );
+
+    expect(editPageURL).toBe(
+      `/${currentApplication?.slug}/${page.slug}-${page.pageId}/edit`,
+    );
+    expect(viewPageURL).toBe(
+      `/${currentApplication?.slug}/${page.slug}-${page.pageId}`,
+    );
   });
 });

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -413,11 +413,13 @@ export const getPageURL = (
     );
   }
 
-  return builderURL({
-    applicationSlug: currentApplicationDetails?.slug || PLACEHOLDER_APP_SLUG,
-    pageSlug: page.slug || PLACEHOLDER_PAGE_SLUG,
-    pageId: page.pageId,
-  });
+  return trimQueryString(
+    builderURL({
+      applicationSlug: currentApplicationDetails?.slug || PLACEHOLDER_APP_SLUG,
+      pageSlug: page.slug || PLACEHOLDER_PAGE_SLUG,
+      pageId: page.pageId,
+    }),
+  );
 };
 
 /**


### PR DESCRIPTION
## Description
fixes pages tab navigation in preview mode for git apps.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/tab-navigation-preview-mode-git-apps 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.29 **(0)** | 37.78 **(0.04)** | 35.92 **(0.04)** | 56.53 **(0.01)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :green_circle: | app/client/src/selectors/editorSelectors.tsx | 75.43 **(1.29)** | 61.74 **(0)** | 60 **(3.75)** | 73.8 **(1.07)**
 :green_circle: | app/client/src/utils/AppsmithUtils.tsx | 55.42 **(1.25)** | 38.33 **(10)** | 37.5 **(2.08)** | 50.97 **(1.46)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>