### PR TITLE
fix: 10114 MongoDB Fetch with DBRef - fix  with codec

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -356,6 +356,11 @@ public class MongoPlugin extends BasePlugin {
                     )
                     .flatMap(mongoOutput -> {
                         try {
+                            /*
+                             * Added Custom codec for JSON conversion since MongoDB Reactive API does not support
+                             * processing of DbRef Object.
+                             * https://github.com/spring-projects/spring-data-mongodb/issues/3015 : Mark Paluch commented
+                             */
                             DocumentCodec documentCodec = new DocumentCodec(
                                     DEFAULT_REGISTRY,
                                     DEFAULT_BSON_TYPE_CLASS_MAP

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -30,14 +30,25 @@ import com.external.plugins.utils.MongoErrorUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.DBObjectCodecProvider;
+import com.mongodb.DBRefCodecProvider;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoSocketWriteException;
 import com.mongodb.MongoTimeoutException;
+import com.mongodb.client.gridfs.codecs.GridFSFileCodecProvider;
+import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
+import org.bson.codecs.BsonTypeClassMap;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -98,6 +109,7 @@ import static com.external.plugins.constants.FieldName.UPDATE_OPERATION;
 import static com.external.plugins.constants.FieldName.UPDATE_QUERY;
 import static com.external.plugins.utils.MongoPluginUtils.urlEncode;
 import static java.lang.Boolean.TRUE;
+import static java.util.Arrays.asList;
 import static org.apache.logging.log4j.util.Strings.isBlank;
 
 public class MongoPlugin extends BasePlugin {
@@ -178,7 +190,7 @@ public class MongoPlugin extends BasePlugin {
 
     private static final Integer MONGO_COMMAND_EXCEPTION_UNAUTHORIZED_ERROR_CODE = 13;
 
-    private static final Set<String> bsonFields = new HashSet<>(Arrays.asList(
+    private static final Set<String> bsonFields = new HashSet<>(asList(
             AGGREGATE_PIPELINES,
             COUNT_QUERY,
             DELETE_QUERY,
@@ -192,6 +204,18 @@ public class MongoPlugin extends BasePlugin {
     ));
 
     private static final MongoErrorUtils mongoErrorUtils = MongoErrorUtils.getInstance();
+
+    private static final CodecRegistry DEFAULT_REGISTRY = CodecRegistries.fromProviders(
+            asList(new ValueCodecProvider(),
+                    new BsonValueCodecProvider(),
+                    new DocumentCodecProvider(),
+                    new DBRefCodecProvider(),
+                    new DBObjectCodecProvider(),
+                    new BsonValueCodecProvider(),
+                    new GeoJsonCodecProvider(),
+                    new GridFSFileCodecProvider()));
+
+    private static final BsonTypeClassMap DEFAULT_BSON_TYPE_CLASS_MAP = new org.bson.codecs.BsonTypeClassMap();
 
     public MongoPlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -332,7 +356,12 @@ public class MongoPlugin extends BasePlugin {
                     )
                     .flatMap(mongoOutput -> {
                         try {
-                            JSONObject outputJson = new JSONObject(mongoOutput.toJson());
+                            DocumentCodec documentCodec = new DocumentCodec(
+                                    DEFAULT_REGISTRY,
+                                    DEFAULT_BSON_TYPE_CLASS_MAP
+                            );
+
+                            JSONObject outputJson = new JSONObject(mongoOutput.toJson(documentCodec));
 
                             //The output json contains the key "ok". This is the status of the command
                             BigInteger status = outputJson.getBigInteger("ok");


### PR DESCRIPTION
## Description

- Reactive MongoDB driver does not support fetching DBRef directly.
- Applied Codec so that fetching happens.
- TBD: JUnit TC will be added later due to some issue with my local setup environment. Tracking it here: https://github.com/appsmithorg/appsmith/issues/12591


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Manual**
Input:
```
{
_id:61d2afdc27368d17882c8636
inventory:DBRef(stores, 1, testdb)
}
```
Output
 ```
 {
    "_id": "61d2afdc27368d17882c8636",
    "inventory": {
      "$db": "testdb",
      "$ref": "stores",
      "$id": 1
   }
```
**Unit Test**
Some issues found, created a issue to create unit test
[https://github.com/appsmithorg/appsmith/issues/12591](https://github.com/appsmithorg/appsmith/issues/12591)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
