### PR TITLE
fix: added a null check for datasourceConfiguration to refer url key

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
@@ -263,7 +263,7 @@ function ApiRightPane(props: any) {
                             </IconContainer>
                           </DataSourceNameContainer>
                           <DatasourceURL>
-                            {d.datasourceConfiguration.url}
+                            {d.datasourceConfiguration?.url}
                           </DatasourceURL>
                           {dataSourceInfo && (
                             <>


### PR DESCRIPTION
## Description

Added a null check for `datasourceConfiguration` which was referring to `url` key and application was breaking if `datasourceConfiguration` becomes undefined.

Fixes #12513 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/12513-datasourceConfig-null-check 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.24 **(-0.01)** | 37.68 **(-0.01)** | 35.91 **(0)** | 56.47 **(0)**
 :red_circle: | app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx | 43.28 **(0)** | 40.74 **(-3.26)** | 0 **(0)** | 46.67 **(0)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 68.63 **(-3.92)** | 100 **(0)** | 92.38 **(-0.95)**</details>