### PR TITLE
fix: Using form url encoded content type for token requests

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
@@ -90,7 +90,7 @@ public class OAuth2AuthorizationCode extends APIConnection implements UpdatableC
 
     private static boolean isExpired(OAuth2 oAuth2) {
         if (oAuth2.getAuthenticationResponse().getExpiresAt() == null) {
-            return true;
+            return false;
         }
 
         OAuth2AuthorizationCode connection = new OAuth2AuthorizationCode();
@@ -102,7 +102,7 @@ public class OAuth2AuthorizationCode extends APIConnection implements UpdatableC
 
     private Mono<OAuth2> generateOAuth2Token(OAuth2 oAuth2) {
         WebClient.Builder webClientBuilder = WebClient.builder()
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .exchangeStrategies(ExchangeStrategies
                         .builder()
                         .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(MAX_IN_MEMORY_SIZE))

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -79,7 +79,7 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
     private Mono<OAuth2> generateOAuth2Token(OAuth2 oAuth2) {
         // Webclient
         WebClient webClient = WebClient.builder()
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .exchangeStrategies(ExchangeStrategies
                         .builder()
                         .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(MAX_IN_MEMORY_SIZE))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
@@ -232,8 +232,7 @@ public class AuthenticationServiceCEImpl implements AuthenticationServiceCE {
                                 if (expiresAtResponse != null) {
                                     expiresAt = Instant.ofEpochSecond(Long.valueOf((Integer) expiresAtResponse));
                                 } else if (expiresInResponse != null) {
-                                    expiresAt = issuedAt.plusSeconds(Long.valueOf((Integer) expiresInResponse));
-
+                                    expiresAt = issuedAt.plusSeconds(Long.parseLong((String) expiresInResponse));
                                 }
                                 authenticationResponse.setExpiresAt(expiresAt);
                                 // Replacing with returned scope instead

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.internal.Base64;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -197,6 +198,7 @@ public class AuthenticationServiceCEImpl implements AuthenticationServiceCE {
                     }
                     return builder.build()
                             .method(HttpMethod.POST)
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                             .body(BodyInserters.fromFormData(map))
                             .exchange()
                             .doOnError(e -> Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, e)))


### PR DESCRIPTION
## Description

OAuth2 [spec](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3) requires token requests to be form url encoded type. This change converts the content type for these requests to match.

Fixes #11952 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Tested with monday.com
- Regression tested with Auth0
- Test instance up on test.appsmith.com, being tested for NetSuite

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
