### PR TITLE
fix: Only add missing user set actions to scheduling order

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
@@ -178,14 +178,14 @@ public class PageLoadActionsUtilCEImpl implements PageLoadActionsUtilCE {
                     // If any of the explicitly set on page load actions havent been added yet, add them to the 0th set
                     // of actions set since no relationships were found with any other appsmith entity
                     if (!pageLoadActionNames.isEmpty()) {
-                        onPageLoadActionSet.addAll(explicitUserSetOnLoadActions);
+                        onPageLoadActionSet.addAll(pageLoadActionNames);
 
                         // In case there are no page load actions, initialize the 0th set of page load actions list.
                         if (onPageLoadActionsSchedulingOrder.isEmpty()) {
                             onPageLoadActionsSchedulingOrder.add(new HashSet<>());
                         }
 
-                        onPageLoadActionsSchedulingOrder.get(0).addAll(explicitUserSetOnLoadActions);
+                        onPageLoadActionsSchedulingOrder.get(0).addAll(pageLoadActionNames);
                     }
 
                     return onPageLoadActionsSchedulingOrder;


### PR DESCRIPTION
## Description
If Api1 and Api2 are marked to be run on page load manually, and only Api1 is referred to in a widget, Api1 gets added twice in the scheduling order.

This has been fixed by only adding the difference between total user set actions and already mapped user set actions to the scheduling order.

Fixes #12596

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit test case
- Manual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
