### PR TITLE
feat: Support getting values from secrets in helm chart configuration

### DIFF
--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -72,6 +72,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "appsmith.fullname" . }}
+            {{- if .Values.secretName }}
+            - secretRef:
+                name: {{ .Values.secretName }}
+            {{- end }}
       volumes:
   {{- if not .Values.persistence.enabled }}
       - name: data

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -239,6 +239,8 @@ autoupdate:
   ##
   scheduler: "0 * * * *"
 
+secretName: ""
+
 applicationConfig:
   APPSMITH_OAUTH2_GOOGLE_CLIENT_ID: ""
   APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET: ""


### PR DESCRIPTION
## Description
- Added a new variable `secretName` in `HELM/values.yaml` to specify the K8s Secret object that has been created by the user, outside the Appsmith helm flow.
- The secret data will be added to the deployment instance as ENV variables (overwriting the values in configMap if they have also been specified there).
- The secret resource will be of the format below, with the keys corresponding to the actual Appsmith ENV variable and the values as base64-encoded string:

```
apiVersion: v1
data:
  APPSMITH_GOOGLE_MAPS_API_KEY: bW9uZ291c2Vy
kind: Secret
metadata:
  name: appsmith-secret
type: Opaque
```
Fixes # [11752](https://github.com/appsmithorg/appsmith/issues/11752)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?
Manually on AWS EKS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
