### PR TITLE
fix: Changes git import modal text

### DIFF
--- a/app/client/src/ce/constants/messages.test.ts
+++ b/app/client/src/ce/constants/messages.test.ts
@@ -247,7 +247,7 @@ describe("git-sync messages", () => {
     { key: "REMOTE_URL", value: "Remote URL" },
     {
       key: "REMOTE_URL_INFO",
-      value: `Create an empty git repository and paste the remote URL here.`,
+      value: `Paste the remote url here.`,
     },
     { key: "REMOTE_URL_VIA", value: "Remote URL via" },
     {

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -594,8 +594,7 @@ export const CONNECT_TO_GIT = () => "Connect to git repository";
 export const CONNECT_TO_GIT_SUBTITLE = () =>
   "Checkout branches, make commits, and deploy your application";
 export const REMOTE_URL = () => "Remote URL";
-export const REMOTE_URL_INFO = () =>
-  `Create an empty git repository and paste the remote URL here.`;
+export const REMOTE_URL_INFO = () => "Paste the remote url here.";
 export const REMOTE_URL_VIA = () => "Remote URL via";
 
 export const USER_PROFILE_SETTINGS_TITLE = () => "User settings";


### PR DESCRIPTION
Discussed in #12603

## Description
The git import modal text says to create an empty git repository and link it, however the linked repo shouldn't be empty.

Fixes #12603 (issue)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Shouldn't require testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
