### PR TITLE
fix: Fix app crash on navigation to API and Datasource Editor

### DIFF
--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -397,7 +397,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<
 
       const evaluatedDatasourceUrl =
         "id" in datasource
-          ? datasource.datasourceConfiguration.url
+          ? datasource.datasourceConfiguration?.url
           : entity.datasourceUrl;
 
       const fullDatasourceUrlPath =

--- a/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
+++ b/app/client/src/transformers/RestAPIDatasourceFormTransformer.ts
@@ -40,10 +40,10 @@ export const datasourceToFormValues = (
     organizationId: datasource.organizationId,
     pluginId: datasource.pluginId,
     isValid: datasource.isValid,
-    url: datasource.datasourceConfiguration.url,
-    headers: cleanupProperties(datasource.datasourceConfiguration.headers),
+    url: datasource.datasourceConfiguration?.url,
+    headers: cleanupProperties(datasource.datasourceConfiguration?.headers),
     queryParameters: cleanupProperties(
-      datasource.datasourceConfiguration.queryParameters,
+      datasource.datasourceConfiguration?.queryParameters,
     ),
     isSendSessionEnabled: isSendSessionEnabled,
     sessionSignatureKey: sessionSignatureKey,


### PR DESCRIPTION
This PR fixes the way the app crashes on the API and Datasource editors due to absent datasourceConfigurations.

Fixes #12556 

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fixes-creating-api-bug 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.3 **(0)** | 37.74 **(-0.01)** | 35.92 **(0)** | 56.52 **(0)**
 :red_circle: | app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx | 28.89 **(0)** | 2.84 **(-0.08)** | 3.23 **(0)** | 30.72 **(0)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**</details>