### PR TITLE
fix: "Revert: trigger fields linting issue"

### DIFF
--- a/app/client/src/utils/WidgetFactory.tsx
+++ b/app/client/src/utils/WidgetFactory.tsx
@@ -121,7 +121,6 @@ class WidgetFactory {
     WidgetType,
     readonly PropertyPaneConfig[]
   > = new Map();
-  static loadingProperties: Map<WidgetType, Array<RegExp>> = new Map();
 
   static widgetConfigMap: Map<
     WidgetType,
@@ -135,7 +134,6 @@ class WidgetFactory {
     defaultPropertiesMap: Record<string, string>,
     metaPropertiesMap: Record<string, any>,
     propertyPaneConfig?: PropertyPaneConfig[],
-    loadingProperties?: Array<RegExp>,
   ) {
     if (!this.widgetTypes[widgetType]) {
       this.widgetTypes[widgetType] = widgetType;
@@ -143,8 +141,6 @@ class WidgetFactory {
       this.derivedPropertiesMap.set(widgetType, derivedPropertiesMap);
       this.defaultPropertiesMap.set(widgetType, defaultPropertiesMap);
       this.metaPropertiesMap.set(widgetType, metaPropertiesMap);
-      loadingProperties &&
-        this.loadingProperties.set(widgetType, loadingProperties);
 
       if (propertyPaneConfig) {
         const validatedPropertyPaneConfig = validatePropertyPaneConfig(
@@ -237,10 +233,6 @@ class WidgetFactory {
       return [];
     }
     return map;
-  }
-
-  static getLoadingProperties(type: WidgetType): Array<RegExp> | undefined {
-    return this.loadingProperties.get(type);
   }
 
   static getWidgetTypeConfigMap(): WidgetTypeConfigMap {

--- a/app/client/src/utils/WidgetLoadingStateUtils.test.ts
+++ b/app/client/src/utils/WidgetLoadingStateUtils.test.ts
@@ -7,10 +7,9 @@ import {
 } from "entities/DataTree/dataTreeFactory";
 import {
   findLoadingEntities,
-  getEntityDependantPaths,
+  getEntityDependants,
   groupAndFilterDependantsMap,
 } from "utils/WidgetLoadingStateUtils";
-import WidgetFactory from "./WidgetFactory";
 
 const JS_object_tree: DataTreeJSAction = {
   pluginType: PluginType.JS,
@@ -69,61 +68,14 @@ const Query_tree: DataTreeAction = {
   isLoading: false,
 };
 
-const Api_tree: DataTreeAction = {
-  data: {},
-  actionId: "",
-  config: {},
-  pluginType: PluginType.API,
-  pluginId: "",
-  name: "",
-  run: {},
-  clear: {},
-  dynamicBindingPathList: [],
-  bindingPaths: {},
-  ENTITY_TYPE: ENTITY_TYPE.ACTION,
-  dependencyMap: {},
-  logBlackList: {},
-  datasourceUrl: "",
-  responseMeta: {
-    isExecutionSuccess: true,
-  },
-  isLoading: false,
-};
-
-const Table_tree: DataTreeWidget = {
-  ENTITY_TYPE: ENTITY_TYPE.WIDGET,
-  bindingPaths: {},
-  triggerPaths: {},
-  validationPaths: {},
-  logBlackList: {},
-  propertyOverrideDependency: {},
-  overridingPropertyPaths: {},
-  privateWidgets: {},
-  widgetId: "",
-  type: "TABLE_WIDGET",
-  widgetName: "",
-  renderMode: "CANVAS",
-  version: 0,
-  parentColumnSpace: 0,
-  parentRowSpace: 0,
-  leftColumn: 0,
-  rightColumn: 0,
-  topRow: 0,
-  bottomRow: 0,
-  isLoading: false,
-  animateLoading: true,
-};
-
 const baseDataTree = {
   JS_file: { ...JS_object_tree, name: "JS_file" },
   Select1: { ...Select_tree, name: "Select1" },
   Select2: { ...Select_tree, name: "Select2" },
   Select3: { ...Select_tree, name: "Select3" },
-  Table1: { ...Table_tree, name: "Table1" },
   Query1: { ...Query_tree, name: "Query1" },
   Query2: { ...Query_tree, name: "Query2" },
   Query3: { ...Query_tree, name: "Query3" },
-  Api1: { ...Api_tree, name: "Api1" },
 };
 
 describe("Widget loading state utils", () => {
@@ -163,22 +115,6 @@ describe("Widget loading state utils", () => {
         "Select3",
       ],
     };
-
-    beforeAll(() => {
-      // mock WidgetFactory.getLoadingProperties
-      const loadingPropertiesMap = new Map<string, RegExp[]>();
-      loadingPropertiesMap.set("TABLE_WIDGET", [/.tableData$/]);
-
-      jest
-        .spyOn(WidgetFactory, "getLoadingProperties")
-        .mockImplementation((widgetType) =>
-          loadingPropertiesMap.get(widgetType),
-        );
-    });
-
-    afterAll(() => {
-      jest.restoreAllMocks();
-    });
 
     // Select1.options -> JS_file.func1 -> Query1.data
     it("handles linear dependencies", () => {
@@ -311,20 +247,6 @@ describe("Widget loading state utils", () => {
       });
       expect(loadingEntites).toStrictEqual(new Set(["Select2"]));
     });
-
-    it("includes loading properties", () => {
-      const loadingEntites = findLoadingEntities(["Api1"], baseDataTree, {
-        "Api1.data": ["Table1.tableData"],
-      });
-      expect(loadingEntites).toStrictEqual(new Set(["Table1"]));
-    });
-
-    it("ignores non-loading properties", () => {
-      const loadingEntites = findLoadingEntities(["Api1"], baseDataTree, {
-        "Api1.run": ["Table1.primaryColumns.action.onClick"],
-      });
-      expect(loadingEntites).toStrictEqual(new Set());
-    });
   });
 
   describe("groupAndFilterDependantsMap", () => {
@@ -405,10 +327,10 @@ describe("Widget loading state utils", () => {
     });
   });
 
-  describe("getEntityDependantPaths", () => {
+  describe("getEntityDependants", () => {
     // Select1.options -> JS_file.func1 -> Query1.data
     it("handles simple dependency", () => {
-      const dependants = getEntityDependantPaths(
+      const dependants = getEntityDependants(
         ["Query1"],
         {
           Query1: {
@@ -420,15 +342,16 @@ describe("Widget loading state utils", () => {
         },
         new Set<string>(),
       );
-      expect(dependants).toStrictEqual(
-        new Set(["JS_file.func1", "Select1.options"]),
-      );
+      expect(dependants).toStrictEqual({
+        names: new Set(["JS_file", "Select1"]),
+        fullPaths: new Set(["JS_file.func1", "Select1.options"]),
+      });
     });
 
     // Select1.options -> JS_file.func1 -> Query1.data
     // Select2.options -> JS_file.func2 -> Query1.data
     it("handles multiple dependencies", () => {
-      const dependants = getEntityDependantPaths(
+      const dependants = getEntityDependants(
         ["Query1"],
         {
           Query1: {
@@ -441,18 +364,19 @@ describe("Widget loading state utils", () => {
         },
         new Set<string>(),
       );
-      expect(dependants).toStrictEqual(
-        new Set([
+      expect(dependants).toStrictEqual({
+        names: new Set(["JS_file", "Select1", "Select2"]),
+        fullPaths: new Set([
           "JS_file.func1",
           "Select1.options",
           "JS_file.func2",
           "Select2.options",
         ]),
-      );
+      });
     });
 
     it("handles specific entity paths", () => {
-      const dependants = getEntityDependantPaths(
+      const dependants = getEntityDependants(
         ["JS_file.func2"], // specific path
         {
           Query1: {
@@ -468,12 +392,15 @@ describe("Widget loading state utils", () => {
         },
         new Set<string>(),
       );
-      expect(dependants).toStrictEqual(new Set(["Select2.options"]));
+      expect(dependants).toStrictEqual({
+        names: new Set(["Select2"]),
+        fullPaths: new Set(["Select2.options"]),
+      });
     });
 
     // Select1.options -> JS_file.func1 -> JS_file.internalFunc -> Query1.data
     it("handles JS self-dependencies", () => {
-      const dependants = getEntityDependantPaths(
+      const dependants = getEntityDependants(
         ["Query1"],
         {
           Query1: {
@@ -486,14 +413,19 @@ describe("Widget loading state utils", () => {
         },
         new Set<string>(),
       );
-      expect(dependants).toStrictEqual(
-        new Set(["JS_file.internalFunc", "JS_file.func1", "Select1.options"]),
-      );
+      expect(dependants).toStrictEqual({
+        names: new Set(["JS_file", "Select1"]),
+        fullPaths: new Set([
+          "JS_file.internalFunc",
+          "JS_file.func1",
+          "Select1.options",
+        ]),
+      });
     });
 
     // Select1.options -> JS_file.func -> JS_file.internalFunc1 -> JS_file.internalFunc2 -> Query1.data
     it("handles nested JS self-dependencies", () => {
-      const dependants = getEntityDependantPaths(
+      const dependants = getEntityDependants(
         ["Query1"],
         {
           Query1: {
@@ -507,14 +439,15 @@ describe("Widget loading state utils", () => {
         },
         new Set<string>(),
       );
-      expect(dependants).toStrictEqual(
-        new Set([
+      expect(dependants).toStrictEqual({
+        names: new Set(["JS_file", "Select1"]),
+        fullPaths: new Set([
           "JS_file.internalFunc1",
           "JS_file.internalFunc2",
           "JS_file.func",
           "Select1.options",
         ]),
-      );
+      });
     });
 
     /* Select1.options -> JS.func1 -> Query1.data,
@@ -525,7 +458,7 @@ describe("Widget loading state utils", () => {
        Only Select2 should be listed, not Select1.
     */
     it("handles selective dependencies in same JS file", () => {
-      const dependants = getEntityDependantPaths(
+      const dependants = getEntityDependants(
         ["Query2"],
         {
           Query1: {
@@ -541,9 +474,10 @@ describe("Widget loading state utils", () => {
         },
         new Set<string>(),
       );
-      expect(dependants).toStrictEqual(
-        new Set(["JS_file.func2", "Select2.options"]),
-      );
+      expect(dependants).toStrictEqual({
+        names: new Set(["JS_file", "Select2"]),
+        fullPaths: new Set(["JS_file.func2", "Select2.options"]),
+      });
     });
   });
 });

--- a/app/client/src/utils/WidgetRegisterHelpers.tsx
+++ b/app/client/src/utils/WidgetRegisterHelpers.tsx
@@ -26,7 +26,6 @@ export interface WidgetConfiguration {
     default: Record<string, string>;
     meta: Record<string, any>;
     derived: DerivedPropertiesMap;
-    loadingProperties?: Array<RegExp>;
   };
 }
 
@@ -56,7 +55,6 @@ export const registerWidget = (Widget: any, config: WidgetConfiguration) => {
     config.properties.default,
     config.properties.meta,
     config.properties.config,
-    config.properties.loadingProperties,
   );
   configureWidget(config);
 };

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -76,20 +76,6 @@ abstract class BaseWidget<
   }
 
   /**
-   * getLoadingProperties returns a list of regexp's used to specify bindingPaths,
-   * which can set the isLoading prop of the widget.
-   * When:
-   * 1. the path is bound to an action (API/Query)
-   * 2. the action is currently in-progress
-   *
-   * if undefined, all paths can set the isLoading state
-   * if empty array, no paths can set the isLoading state
-   */
-  static getLoadingProperties(): Array<RegExp> | undefined {
-    return;
-  }
-
-  /**
    *  Widget abstraction to register the widget type
    *  ```javascript
    *   getWidgetType() {

--- a/app/client/src/widgets/TableWidget/index.ts
+++ b/app/client/src/widgets/TableWidget/index.ts
@@ -180,7 +180,6 @@ export const CONFIG = {
     default: Widget.getDefaultPropertiesMap(),
     meta: Widget.getMetaPropertiesMap(),
     config: Widget.getPropertyPaneConfig(),
-    loadingProperties: Widget.getLoadingProperties(),
   },
 };
 

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -109,10 +109,6 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
     };
   }
 
-  static getLoadingProperties(): Array<RegExp> | undefined {
-    return [/.tableData$/];
-  }
-
   getTableColumns = () => {
     let columns: ReactTableColumnProps[] = [];
     const hiddenColumns: ReactTableColumnProps[] = [];

--- a/app/client/src/workers/DataTreeEvaluator.ts
+++ b/app/client/src/workers/DataTreeEvaluator.ts
@@ -521,22 +521,12 @@ export default class DataTreeEvaluator {
 
     if (isWidget(entity)) {
       // Adding the dynamic triggers in the dependency list as they need linting whenever updated
-      // To keep linting in trigger fields in sync, nodes they depend on need to be added to their dependencies
-      const dynamicTriggerPathlist = entity.dynamicTriggerPathList;
-
-      if (dynamicTriggerPathlist && dynamicTriggerPathlist.length) {
-        dynamicTriggerPathlist.forEach((dynamicPath) => {
-          const propertyPath = dynamicPath.key;
-          const unevalPropValue = _.get(entity, propertyPath);
-          const { jsSnippets } = getDynamicBindings(unevalPropValue);
-          const existingDeps =
-            dependencies[`${entityName}.${propertyPath}`] || [];
-          dependencies[`${entityName}.${propertyPath}`] = existingDeps.concat(
-            jsSnippets.filter((jsSnippet) => !!jsSnippet),
-          );
+      // we don't make it dependent on anything else
+      if (entity.dynamicTriggerPathList) {
+        Object.values(entity.dynamicTriggerPathList).forEach(({ key }) => {
+          dependencies[`${entityName}.${key}`] = [];
         });
       }
-
       const widgetDependencies = addWidgetPropertyDependencies({
         entity,
         entityName,
@@ -1346,10 +1336,7 @@ export default class DataTreeEvaluator {
                 entity,
                 entityPropertyPath,
               );
-              const isATriggerPath =
-                isWidget(entity) &&
-                isPathADynamicTrigger(entity, entityPropertyPath);
-              if (isABindingPath || isATriggerPath) {
+              if (isABindingPath) {
                 didUpdateDependencyMap = true;
 
                 const { jsSnippets } = getDynamicBindings(


### PR DESCRIPTION
Reverts appsmithorg/appsmith#11875

Reason: critical issue #12528 (cyclic dependency)

brings back linting issue #11943
## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: revert-11875-fix/onclick-linting-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.29 **(-0.01)** | 37.72 **(-0.02)** | 35.93 **(0.01)** | 56.52 **(0)**
 :green_circle: | app/client/src/utils/WidgetFactory.tsx | 74.47 **(-0.02)** | 72.22 **(-1.46)** | 64.71 **(3.6)** | 74.47 **(-0.02)**
 :red_circle: | app/client/src/utils/WidgetLoadingStateUtils.ts | 96.67 **(-0.16)** | 90 **(-2)** | 100 **(0)** | 97.96 **(-0.12)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 79.53 **(0.46)** | 44.44 **(0)** | 75.76 **(2.23)** | 78.69 **(0.46)**
 :red_circle: | app/client/src/widgets/TableWidget/widget/index.tsx | 29.74 **(-0.33)** | 9.43 **(0)** | 28.85 **(-1.34)** | 29.4 **(-0.37)**
 :green_circle: | app/client/src/workers/DataTreeEvaluator.ts | 76.47 **(0.4)** | 57.51 **(0.19)** | 75 **(0.84)** | 76.2 **(0.55)**</details>