### PR TITLE
chore: Added analytics for manual upgrade and adds redirection

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ApplicationURL_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Applications/ApplicationURL_spec.js
@@ -134,6 +134,14 @@ describe("Slug URLs", () => {
               "contain.text",
               `/app/${application.slug}/${currentPage.slug}-${currentPage.id}/edit`,
             );
+
+            cy.visit(`/${application.slug}/${currentPage.slug}-${currentPage.id}/edit`);
+
+            cy.location().should((loc) => {
+              expect(loc.pathname).includes(
+                `/app/${application.slug}/${currentPage.slug}-${currentPage.id}/edit`,
+              );
+            });
           });
         });
       });

--- a/app/client/src/AppRouter.tsx
+++ b/app/client/src/AppRouter.tsx
@@ -24,6 +24,8 @@ import {
   BUILDER_PATH_DEPRECATED,
   VIEWER_PATH_DEPRECATED,
   TEMPLATES_PATH,
+  VIEWER_PATCH_PATH,
+  BUILDER_PATCH_PATH,
 } from "constants/routes";
 import OrganizationLoader from "pages/organization/loader";
 import ApplicationListLoader from "pages/Applications/loader";
@@ -161,6 +163,8 @@ function AppRouter(props: {
                 component={AppViewerLoader}
                 path={VIEWER_PATH_DEPRECATED}
               />
+              <Redirect from={BUILDER_PATCH_PATH} to={BUILDER_PATH} />
+              <Redirect from={VIEWER_PATCH_PATH} to={VIEWER_PATH} />
               <SentryRoute component={PageNotFound} />
             </Switch>
           </>

--- a/app/client/src/constants/routes.ts
+++ b/app/client/src/constants/routes.ts
@@ -55,6 +55,8 @@ export const BUILDER_CHECKLIST_PATH = `/checklist`;
 export const ADMIN_SETTINGS_PATH = "/settings";
 export const ADMIN_SETTINGS_CATEGORY_DEFAULT_PATH = "/settings/general";
 export const ADMIN_SETTINGS_CATEGORY_PATH = "/settings/:category/:subCategory?";
+export const BUILDER_PATCH_PATH = `/:applicationSlug/:pageSlug(.*\-):pageId/edit`;
+export const VIEWER_PATCH_PATH = `/:applicationSlug/:pageSlug(.*\-):pageId`;
 
 export const matchApplicationPath = match(APPLICATIONS_URL);
 export const matchApiBasePath = match(API_EDITOR_BASE_PATH);

--- a/app/client/src/pages/Editor/BottomBar/ManualUpgrades.tsx
+++ b/app/client/src/pages/Editor/BottomBar/ManualUpgrades.tsx
@@ -28,6 +28,7 @@ import { useLocalStorage } from "utils/hooks/localstorage";
 import { createMessage, CLEAN_URL_UPDATE } from "@appsmith/constants/messages";
 import { useLocation } from "react-router";
 import DisclaimerIcon from "remixicon-react/ErrorWarningLineIcon";
+import AnalyticsUtil from "utils/AnalyticsUtil";
 
 function RedDot() {
   return (
@@ -175,6 +176,7 @@ function UpdatesModal({
             isLoading={isLoading}
             onClick={() => {
               setIsLoading(true);
+              AnalyticsUtil.logEvent("MANUAL_UPGRADE_CLICK");
               dispatch(
                 updateApplication(
                   applicationId as string,

--- a/app/client/src/pages/common/PageNotFound.tsx
+++ b/app/client/src/pages/common/PageNotFound.tsx
@@ -10,6 +10,7 @@ import {
   createMessage,
   PAGE_NOT_FOUND,
 } from "@appsmith/constants/messages";
+import AnalyticsUtil from "utils/AnalyticsUtil";
 
 const Wrapper = styled.div`
   text-align: center;
@@ -53,7 +54,10 @@ function PageNotFound(props: Props) {
           icon="arrow-right"
           iconAlignment="right"
           intent="primary"
-          onClick={() => flushErrorsAndRedirect(APPLICATIONS_URL)}
+          onClick={() => {
+            AnalyticsUtil.logEvent("PAGE_NOT_FOUND");
+            flushErrorsAndRedirect(APPLICATIONS_URL);
+          }}
           size="small"
           text={createMessage(BACK_TO_HOMEPAGE)}
         />

--- a/app/client/src/pages/common/PageNotFound.tsx
+++ b/app/client/src/pages/common/PageNotFound.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { APPLICATIONS_URL } from "constants/routes";
@@ -34,6 +34,10 @@ interface Props {
 function PageNotFound(props: Props) {
   const { flushErrorsAndRedirect } = props;
 
+  useEffect(() => {
+    AnalyticsUtil.logEvent("PAGE_NOT_FOUND");
+  }, []);
+
   return (
     <Wrapper className="space-y-6">
       <img
@@ -54,10 +58,7 @@ function PageNotFound(props: Props) {
           icon="arrow-right"
           iconAlignment="right"
           intent="primary"
-          onClick={() => {
-            AnalyticsUtil.logEvent("PAGE_NOT_FOUND");
-            flushErrorsAndRedirect(APPLICATIONS_URL);
-          }}
+          onClick={() => flushErrorsAndRedirect(APPLICATIONS_URL)}
           size="small"
           text={createMessage(BACK_TO_HOMEPAGE)}
         />

--- a/app/client/src/utils/AnalyticsUtil.tsx
+++ b/app/client/src/utils/AnalyticsUtil.tsx
@@ -211,7 +211,9 @@ export type EventName =
   | "RECONNECTING_DATASOURCE_ITEM_CLICK"
   | "ADD_MISSING_DATASOURCE_LINK_CLICK"
   | "RECONNECTING_SKIP_TO_APPLICATION_BUTTON_CLICK"
-  | "TEMPLATE_FILTER_SELECTED";
+  | "TEMPLATE_FILTER_SELECTED"
+  | "MANUAL_UPGRADE_CLICK"
+  | "PAGE_NOT_FOUND";
 
 function getApplicationId(location: Location) {
   const pathSplit = location.pathname.split("/");


### PR DESCRIPTION
## Description
- Added analytics for manual upgrade and client side 404
- Added redirect logic to route /:applicationSlug/:pageSlug-:pageId -> /app/:applicationSlug/:pageSlug-:pageId

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Cypress

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: analytics-manual-upgrade 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/constants/routes.ts | 96.1 **(0.1)** | 100 **(0)** | 66.67 **(0)** | 95.95 **(0.12)**
 :red_circle: | app/client/src/pages/Editor/BottomBar/ManualUpgrades.tsx | 90.32 **(-1.35)** | 85 **(0)** | 76.92 **(0)** | 88.68 **(-1.52)**</details>