### PR TITLE
fix: Fix server not starting when custom domain not set

### DIFF
--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -43,19 +43,19 @@ EOF
 
 # Check exist certificate with given custom domain
 # Heroku not support for custom domain, only generate HTTP config if deploying on Heroku
-if [[ -n $APPSMITH_CUSTOM_DOMAIN ]] && [[ -z ${DYNO-} ]]; then
-	APP_TEMPLATE="$https_conf"
+if [[ -n ${APPSMITH_CUSTOM_DOMAIN-} ]] && [[ -z ${DYNO-} ]]; then
+  APP_TEMPLATE="$https_conf"
   if ! [[ -e "/etc/letsencrypt/live/$APPSMITH_CUSTOM_DOMAIN" ]]; then
     source "/opt/appsmith/init_ssl_cert.sh"
     init_ssl_cert "$APPSMITH_CUSTOM_DOMAIN"
-		if ! init_ssl_cert "$APPSMITH_CUSTOM_DOMAIN"; then
-			echo "Status code from init_ssl_cert is $?"
-			APP_TEMPLATE="$http_conf"
-		fi
+    if ! init_ssl_cert "$APPSMITH_CUSTOM_DOMAIN"; then
+      echo "Status code from init_ssl_cert is $?"
+      APP_TEMPLATE="$http_conf"
+    fi
   fi
 fi
 
-bash "$APP_TEMPLATE" "${APPSMITH_CUSTOM_DOMAIN:-}" > /etc/nginx/sites-available/default
+bash "$APP_TEMPLATE" "${APPSMITH_CUSTOM_DOMAIN-}" > /etc/nginx/sites-available/default
 
 index_html_served=/opt/appsmith/editor/index.html
 index_html_original=/opt/appsmith/index.html.original
@@ -66,8 +66,8 @@ fi
 node -e '
 const fs = require("fs")
 const content = fs.readFileSync("'"$index_html_original"'", "utf8").replace(
-	/\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
-	(placeholder, name) => (process.env[name] || "")
+  /\b__(APPSMITH_[A-Z0-9_]+)__\b/g,
+  (placeholder, name) => (process.env[name] || "")
 )
 fs.writeFileSync("'"$index_html_served"'", content)
 '


### PR DESCRIPTION
The `run-nginx.sh` script fails to run when `APPSMITH_CUSTOM_DOMAIN` environment variable is not set. This PR fixes that problem.
