### PR TITLE
fix: update check for GSheet where condition

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Condition.java
@@ -18,12 +18,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.helpers.DataTypeStringUtils.stringToKnownDataTypeConverter;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Condition {
+
+    public static final String PATH_KEY = "path";
+    public static final String OPERATOR_KEY = "operator";
 
     String path;
 
@@ -103,7 +107,7 @@ public class Condition {
             if (condition.entrySet().isEmpty()) {
                 // Its an empty object set by the client for UX. Ignore the same
                 continue;
-            } else if (!condition.keySet().containsAll(Set.of("path", "operator"))) {
+            } else if (isColumnOrOperatorEmpty(condition)) {
                 throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "Filtering Condition not configured properly");
             }
             conditionList.add(new Condition(
@@ -114,5 +118,9 @@ public class Condition {
         }
 
         return conditionList;
+    }
+
+    private static boolean isColumnOrOperatorEmpty(Map<String, String> condition) {
+        return isBlank(condition.get(PATH_KEY)) || isBlank(condition.get(OPERATOR_KEY));
     }
 }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/MethodConfigTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/MethodConfigTest.java
@@ -1,11 +1,18 @@
 package com.external.config;
 
 
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.models.Condition;
 import com.appsmith.external.models.Property;
 import com.external.config.MethodConfig;
 import org.junit.Assert;
 import org.junit.Test;
 import java.util.*;
+
+import static com.external.config.MethodConfig.OPERATOR_KEY;
+import static com.external.config.MethodConfig.PATH_KEY;
+import static com.external.config.MethodConfig.VALUE_KEY;
+import static org.junit.Assert.assertEquals;
 
 public class MethodConfigTest {
 
@@ -41,24 +48,61 @@ public class MethodConfigTest {
 
                 switch (testPropKeys[i]){
                     case "range":
-                        Assert.assertEquals(methodConfig.getSpreadsheetRange(), e.getKey());
+                        assertEquals(methodConfig.getSpreadsheetRange(), e.getKey());
                         break;
                     case "tableHeaderIndex":
-                        Assert.assertEquals(methodConfig.getTableHeaderIndex(), e.getKey());
+                        assertEquals(methodConfig.getTableHeaderIndex(), e.getKey());
                         break;
                     case "rowLimit":
-                        Assert.assertEquals(methodConfig.getRowLimit(), e.getKey());
+                        assertEquals(methodConfig.getRowLimit(), e.getKey());
                         break;
                     case "rowOffset":
-                        Assert.assertEquals(methodConfig.getRowOffset(), e.getKey());
+                        assertEquals(methodConfig.getRowOffset(), e.getKey());
                         break;
                     case "rowIndex":
-                        Assert.assertEquals(methodConfig.getRowIndex(), e.getKey());
+                        assertEquals(methodConfig.getRowIndex(), e.getKey());
                         break;
                 }
 
             }
         }
+    }
+
+    @Test
+    public void testInitialEmptyWhereCondition() {
+        Map condition = new LinkedHashMap();
+        condition.put(PATH_KEY, "");
+        condition.put(VALUE_KEY, "");
+
+        List<Map> listOfConditions = new ArrayList<>();
+        listOfConditions.add(condition);
+
+        Property property = new Property("where", listOfConditions);
+        List<Property> propertyList = new ArrayList();
+        propertyList.add(property);
+
+        MethodConfig methodConfig = new MethodConfig(propertyList);
+        List<Condition> parsedWhereConditions = methodConfig.getWhereConditions();
+        assertEquals(0, parsedWhereConditions.size());
+    }
+
+    @Test(expected = AppsmithPluginException.class)
+    public void testNonEmptyOperatorWithEmptyColumnWhereCondition() {
+        Map condition = new LinkedHashMap();
+        condition.put(PATH_KEY, "");
+        condition.put(OPERATOR_KEY, "EQ");
+        condition.put(VALUE_KEY, "");
+
+        List<Map> listOfConditions = new ArrayList<>();
+        listOfConditions.add(condition);
+
+        Property property = new Property("where", listOfConditions);
+        List<Property> propertyList = new ArrayList();
+        propertyList.add(property);
+
+        MethodConfig methodConfig = new MethodConfig(propertyList);
+        List<Condition> parsedWhereConditions = methodConfig.getWhereConditions();
+        assertEquals(0, parsedWhereConditions.size());
     }
 }
 


### PR DESCRIPTION
## Description
- Earlier GSheet plugin had check based on null value that would ignore empty where conditions. However, due to a recent change the client has now started to return empty string instead of null value against empty input fields of where clause. This PR updates the previous check to now rely on the following condition to ignore where condition: (1) all column names are empty (2) all operators are empty. In case both the conditons are not met simultaneously then an error is shown to the user if the configuration is found to have missing column name or operator.

Fixes #12701 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
