### PR TITLE
fix: Git import error message for empty repo

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
@@ -1953,6 +1953,11 @@ public class GitServiceCEImpl implements GitServiceCE {
                                             );
                                 }
 
+                                if(Optional.ofNullable(applicationJson.getExportedApplication()).isEmpty()
+                                        || applicationJson.getPageList().isEmpty()) {
+                                    return Mono.error(new AppsmithException(AppsmithError.GIT_ACTION_FAILED, "import", "Cannot import app from an empty repo"));
+                                }
+
                                 applicationJson.getExportedApplication().setGitApplicationMetadata(gitApplicationMetadata);
                                 return importExportApplicationService
                                         .importApplicationInOrganization(organizationId, applicationJson, application.getId(), defaultBranch)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/GitServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/GitServiceTest.java
@@ -2368,6 +2368,29 @@ public class GitServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
+    public void importApplicationFromGit_emptyRepo_ThrowError() {
+        GitConnectDTO gitConnectDTO = getConnectRequest("git@github.com:test/testRepo.git", testUserProfile);
+
+        ApplicationJson applicationJson = createAppJson(filePath).block();
+        applicationJson.setExportedApplication(null);
+        applicationJson.setDatasourceList(new ArrayList<>());
+
+        Mockito.when(gitExecutor.cloneApplication(Mockito.any(Path.class), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Mono.just("defaultBranch"));
+        Mockito.when(gitFileUtils.reconstructApplicationJsonFromGitRepo(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Mono.just(applicationJson));
+
+        Mono<ApplicationImportDTO> applicationMono = gitService.importApplicationFromGit(orgId, gitConnectDTO);
+
+        StepVerifier
+                .create(applicationMono)
+                .expectErrorMatches(throwable -> throwable instanceof AppsmithException
+                        && throwable.getMessage().contains("Cannot import app from an empty repo"))
+                .verify();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
     public void importApplicationFromGit_validRequest_Success() throws GitAPIException, IOException {
         GitConnectDTO gitConnectDTO = getConnectRequest("git@github.com:test/testRepo.git", testUserProfile);
         GitAuth gitAuth = gitService.generateSSHKey().block();


### PR DESCRIPTION
## Description

> When the user tries to import an app from an empty git repo then we are just throwing the Internal Server error. But ideally we should let the user know that the failure is due to empty repo. 

Fixes #12749 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally
- JUnit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
