### PR TITLE
fix: select widget virtualization not rendering first top items

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/select_Widget_Bug_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/select_Widget_Bug_spec.js
@@ -3,6 +3,7 @@ const widgetsPage = require("../../../../locators/Widgets.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const dsl = require("../../../../fixtures/formSelectDsl.json");
+const formWidgetsPage = require("../../../../locators/FormWidgets.json");
 
 describe("Select Widget Functionality", function() {
   before(() => {
@@ -16,6 +17,139 @@ describe("Select Widget Functionality", function() {
       widgetsPage.selectwidget,
       commonlocators.selectInner,
     );
+  });
+
+  it("should check that virtualization works well", () => {
+    cy.openPropertyPane("selectwidget");
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "RANDOM",
+          "value": "RANDOM"
+        },
+        {
+          "label": "RANDOM1",
+          "value": "RANDOM1"
+        },
+        {
+          "label": "RANDOM2",
+          "value": "RANDOM2"
+        },
+        {
+          "label": "RANDOM3",
+          "value": "RANDOM3"
+        },
+        {
+          "label": "RANDOM4",
+          "value": "RANDOM4"
+        },
+        {
+          "label": "RANDOM5",
+          "value": "RANDOM5"
+        }
+      ]`,
+    );
+    cy.get(".t--property-control-options .t--codemirror-has-error").should(
+      "not.exist",
+    );
+    // Changing the option to the last item
+    cy.get(formWidgetsPage.selectWidget)
+      .find(widgetsPage.dropdownSingleSelect)
+      .click({
+        force: true,
+      });
+    cy.get(commonlocators.singleSelectWidgetMenuItem)
+      .contains("RANDOM5")
+      .click({
+        force: true,
+      });
+    cy.wait(500);
+    // Verifying the top items still renders
+    cy.get(formWidgetsPage.selectWidget)
+      .find(widgetsPage.dropdownSingleSelect)
+      .click({
+        force: true,
+      });
+    cy.get(commonlocators.singleSelectWidgetMenuItem)
+      .contains("RANDOM1")
+      .click({
+        force: true,
+      });
+    // Add a longer list of item
+    cy.updateCodeInput(
+      ".t--property-control-options",
+      `[
+        {
+          "label": "RANDOM",
+          "value": "RANDOM"
+        },
+        {
+          "label": "RANDOM1",
+          "value": "RANDOM1"
+        },
+        {
+          "label": "RANDOM2",
+          "value": "RANDOM2"
+        },
+        {
+          "label": "RANDOM3",
+          "value": "RANDOM3"
+        },
+        {
+          "label": "RANDOM4",
+          "value": "RANDOM4"
+        },
+        {
+          "label": "RANDOM5",
+          "value": "RANDOM5"
+        },
+        {
+          "label": "RANDOM6",
+          "value": "RANDOM6"
+        },
+        {
+          "label": "RANDOM7",
+          "value": "RANDOM7"
+        },
+        {
+          "label": "RANDOM8",
+          "value": "RANDOM8"
+        },
+        {
+          "label": "RANDOM9",
+          "value": "RANDOM9"
+        },
+        {
+          "label": "RANDOM10",
+          "value": "RANDOM10"
+        },
+        {
+          "label": "RANDOM11",
+          "value": "RANDOM11"
+        }
+
+      ]`,
+    );
+    cy.get(formWidgetsPage.selectWidget)
+      .find(widgetsPage.dropdownSingleSelect)
+      .click({
+        force: true,
+      });
+    cy.get(commonlocators.singleSelectWidgetMenuItem)
+      .contains("RANDOM1")
+      .click({
+        force: true,
+      });
+    cy.wait(500);
+    cy.get(formWidgetsPage.selectWidget)
+      .find(widgetsPage.dropdownSingleSelect)
+      .click({
+        force: true,
+      });
+    cy.get(commonlocators.singleSelectWidgetMenuItem)
+      .contains("RANDOM11")
+      .should("not.exist");
   });
 
   it("Disable the widget and check in publish mode", function() {

--- a/app/client/src/widgets/SelectWidget/component/index.tsx
+++ b/app/client/src/widgets/SelectWidget/component/index.tsx
@@ -192,8 +192,9 @@ class SelectComponent extends React.Component<
     renderItem: (item: any, index: number) => JSX.Element | null,
   ): JSX.Element | null => {
     // Don't scroll if the list is filtered.
+    // Also use index of 6 to show first set of items
     const scrollOffset: number =
-      !this.state.query && isNumber(activeItemIndex)
+      !this.state.query && isNumber(activeItemIndex) && activeItemIndex > 6
         ? activeItemIndex * ITEM_SIZE
         : 0;
     const RowRenderer = (itemProps: any) => (


### PR DESCRIPTION

## Description

Select widget not rendering first top items because of virtualization

Fixes #12755



## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress Test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
