### PR TITLE
fix: Fix google sheets datasource options

### DIFF
--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -163,6 +163,10 @@ const HelpSection = styled.div`
   padding-top: 10px;
 `;
 
+const ResponseBodyContainer = styled.div`
+  padding-bottom: 5px;
+`;
+
 interface ReduxStateProps {
   responses: Record<string, ActionResponse | undefined>;
   isRunning: Record<string, boolean>;
@@ -385,7 +389,7 @@ function ApiResponseView(props: Props) {
                 </Text>
               </NoResponseContainer>
             ) : (
-              <>
+              <ResponseBodyContainer>
                 {isString(response.body) && isHtml(response.body) && (
                   <ReadOnlyEditor
                     folding
@@ -408,7 +412,7 @@ function ApiResponseView(props: Props) {
                     tabs={responseTabs}
                   />
                 ) : null}
-              </>
+              </ResponseBodyContainer>
             )}
           </ResponseDataContainer>
         </ResponseTabWrapper>

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -680,8 +680,6 @@ export function EditorJSONtoForm(props: Props) {
         section.controlType === "SECTION" &&
         section.hasOwnProperty("children")
       ) {
-        // eslint-disable-next-line no-debugger
-        debugger;
         return section.children.map((section: any, idx: number) => {
           return renderEachConfigV2(formName, section, idx);
         });

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -27,7 +27,7 @@ import {
   getPluginImages,
   getAction,
   getActionResponses,
-  getDBAndRemoteDatasources,
+  getDBAndRemoteAndSaasDatasources,
 } from "selectors/entitiesSelector";
 import { PLUGIN_PACKAGE_DBS } from "constants/QueryEditorConstants";
 import { QueryAction, QueryActionConfig, SaaSAction } from "entities/Action";
@@ -346,7 +346,7 @@ const mapStateToProps = (state: AppState, props: any): ReduxStateProps => {
     plugins: allPlugins,
     runErrorMessage,
     pluginIds: getPluginIdsOfPackageNames(state, PLUGIN_PACKAGE_DBS),
-    dataSources: getDBAndRemoteDatasources(state),
+    dataSources: getDBAndRemoteAndSaasDatasources(state),
     responses: getActionResponses(state),
     isRunning: state.ui.queryPane.isRunning[actionId],
     isDeleting: state.ui.queryPane.isDeleting[actionId],

--- a/app/client/src/pages/Editor/QueryEditor/index.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/index.tsx
@@ -27,7 +27,8 @@ import {
   getPluginImages,
   getAction,
   getActionResponses,
-  getDBAndRemoteAndSaasDatasources,
+  getDatasourceByPluginId,
+  getDBAndRemoteDatasources,
 } from "selectors/entitiesSelector";
 import { PLUGIN_PACKAGE_DBS } from "constants/QueryEditorConstants";
 import { QueryAction, QueryActionConfig, SaaSAction } from "entities/Action";
@@ -346,7 +347,9 @@ const mapStateToProps = (state: AppState, props: any): ReduxStateProps => {
     plugins: allPlugins,
     runErrorMessage,
     pluginIds: getPluginIdsOfPackageNames(state, PLUGIN_PACKAGE_DBS),
-    dataSources: getDBAndRemoteAndSaasDatasources(state),
+    dataSources: !!apiId
+      ? getDatasourceByPluginId(state, action?.pluginId)
+      : getDBAndRemoteDatasources(state),
     responses: getActionResponses(state),
     isRunning: state.ui.queryPane.isRunning[actionId],
     isDeleting: state.ui.queryPane.isDeleting[actionId],

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -233,17 +233,6 @@ export const getDBAndRemotePlugins = createSelector(getPlugins, (plugins) =>
   ),
 );
 
-export const getDBAndRemoteAndSaasPlugins = createSelector(
-  getPlugins,
-  (plugins) =>
-    plugins.filter(
-      (plugin) =>
-        plugin.type === PluginType.DB ||
-        plugin.type === PluginType.REMOTE ||
-        plugin.type === PluginType.SAAS,
-    ),
-);
-
 export const getUnconfiguredDatasources = (state: AppState) =>
   state.entities.datasources.unconfiguredList ?? [];
 
@@ -265,19 +254,6 @@ export const getDBDatasources = createSelector(
 
 export const getDBAndRemoteDatasources = createSelector(
   getDBAndRemotePlugins,
-  getEntities,
-  (plugins, entities) => {
-    const datasources = entities.datasources.list;
-    const pluginIds = plugins.map((plugin) => plugin.id);
-
-    return datasources.filter((datasource) =>
-      pluginIds.includes(datasource.pluginId),
-    );
-  },
-);
-
-export const getDBAndRemoteAndSaasDatasources = createSelector(
-  getDBAndRemoteAndSaasPlugins,
   getEntities,
   (plugins, entities) => {
     const datasources = entities.datasources.list;

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -233,6 +233,17 @@ export const getDBAndRemotePlugins = createSelector(getPlugins, (plugins) =>
   ),
 );
 
+export const getDBAndRemoteAndSaasPlugins = createSelector(
+  getPlugins,
+  (plugins) =>
+    plugins.filter(
+      (plugin) =>
+        plugin.type === PluginType.DB ||
+        plugin.type === PluginType.REMOTE ||
+        plugin.type === PluginType.SAAS,
+    ),
+);
+
 export const getUnconfiguredDatasources = (state: AppState) =>
   state.entities.datasources.unconfiguredList ?? [];
 
@@ -254,6 +265,19 @@ export const getDBDatasources = createSelector(
 
 export const getDBAndRemoteDatasources = createSelector(
   getDBAndRemotePlugins,
+  getEntities,
+  (plugins, entities) => {
+    const datasources = entities.datasources.list;
+    const pluginIds = plugins.map((plugin) => plugin.id);
+
+    return datasources.filter((datasource) =>
+      pluginIds.includes(datasource.pluginId),
+    );
+  },
+);
+
+export const getDBAndRemoteAndSaasDatasources = createSelector(
+  getDBAndRemoteAndSaasPlugins,
   getEntities,
   (plugins, entities) => {
     const datasources = entities.datasources.list;


### PR DESCRIPTION
This PR fixes google sheets datasources from not appearing in the datasource options dropdown. and it also addresses some misalignment issues in the response body tab.

Fixes #12762

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/saas-datasource-name-in-dropdown 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.34 **(0)** | 37.75 **(0.01)** | 35.95 **(0)** | 56.57 **(0.01)**
 :green_circle: | app/client/src/components/editorComponents/ApiResponseView.tsx | 49.52 **(0.48)** | 30.48 **(1.35)** | 0 **(0)** | 51 **(0.49)**
 :green_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 34.7 **(0.15)** | 25.77 **(0)** | 0 **(0)** | 36.02 **(0.17)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/index.tsx | 27.61 **(0)** | 5.33 **(-0.47)** | 5.26 **(0)** | 29.27 **(0)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**</details>