### PR TITLE
fix: Conversion logic for expires in field

### DIFF
--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2AuthorizationCode.java
@@ -142,9 +142,9 @@ public class OAuth2AuthorizationCode extends APIConnection implements UpdatableC
                     Object expiresInResponse = mappedResponse.get(Authentication.EXPIRES_IN);
                     Instant expiresAt = null;
                     if (expiresAtResponse != null) {
-                        expiresAt = Instant.ofEpochSecond(Long.valueOf((Integer) expiresAtResponse));
+                        expiresAt = Instant.ofEpochSecond(Long.parseLong(String.valueOf(expiresAtResponse)));
                     } else if (expiresInResponse != null) {
-                        expiresAt = issuedAt.plusSeconds(Long.valueOf((Integer) expiresInResponse));
+                        expiresAt = issuedAt.plusSeconds(Long.parseLong(String.valueOf(expiresInResponse)));
                     }
                     authenticationResponse.setExpiresAt(expiresAt);
                     authenticationResponse.setIssuedAt(issuedAt);

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/connections/OAuth2ClientCredentials.java
@@ -111,9 +111,9 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
                     Object expiresInResponse = mappedResponse.get(Authentication.EXPIRES_IN);
                     Instant expiresAt = null;
                     if (expiresAtResponse != null) {
-                        expiresAt = Instant.ofEpochSecond(Long.parseLong((String) expiresAtResponse));
+                        expiresAt = Instant.ofEpochSecond(Long.parseLong(String.valueOf(expiresAtResponse)));
                     } else if (expiresInResponse != null) {
-                        expiresAt = issuedAt.plusSeconds(Long.valueOf((Integer) expiresInResponse));
+                        expiresAt = issuedAt.plusSeconds(Long.parseLong(String.valueOf(expiresInResponse)));
                     }
                     authenticationResponse.setExpiresAt(expiresAt);
                     authenticationResponse.setIssuedAt(issuedAt);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
@@ -230,9 +230,9 @@ public class AuthenticationServiceCEImpl implements AuthenticationServiceCE {
                                 Object expiresInResponse = response.get(Authentication.EXPIRES_IN);
                                 Instant expiresAt = null;
                                 if (expiresAtResponse != null) {
-                                    expiresAt = Instant.ofEpochSecond(Long.valueOf((Integer) expiresAtResponse));
+                                    expiresAt = Instant.ofEpochSecond(Long.parseLong(String.valueOf(expiresAtResponse)));
                                 } else if (expiresInResponse != null) {
-                                    expiresAt = issuedAt.plusSeconds(Long.parseLong((String) expiresInResponse));
+                                    expiresAt = issuedAt.plusSeconds(Long.parseLong(String.valueOf(expiresInResponse)));
                                 }
                                 authenticationResponse.setExpiresAt(expiresAt);
                                 // Replacing with returned scope instead


### PR DESCRIPTION
Fixes #11952

The conversion logic needs to handle both numeric and string return types since different providers seem to follow different norms.

We do not have the ability to test for this fix right now. However, monday.com and Dropbox are two providers that have been identified with having this difference and tested for. We should add these providers in our manual test suite.