### PR TITLE
fix: Fix app crash on arrow down in where clause

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -915,7 +915,7 @@ export default function Dropdown(props: DropdownProps) {
           e.preventDefault();
           if (isOpen) {
             setSelected((prevSelected) => {
-              if (!("length" in prevSelected)) {
+              if (!(!!prevSelected && "length" in prevSelected)) {
                 let index = findIndex(props.options, prevSelected);
                 if (index === props.options.length - 1) index = 0;
                 else index++;

--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -919,7 +919,7 @@ export default function Dropdown(props: DropdownProps) {
                 let index = findIndex(props.options, prevSelected);
                 if (index === props.options.length - 1) index = 0;
                 else index++;
-                return props.options[index];
+                return prevSelected ? props.options[index] : props.options[0];
               }
               return prevSelected;
             });


### PR DESCRIPTION
This PR fixes the way the app crashes when the arrow down key is used in the where clause dropdown component.

Fixes #12706 

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/arrow-down-where-issue 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.34 **(0)** | 37.75 **(0.01)** | 35.95 **(0)** | 56.56 **(0)**
 :green_circle: | app/client/src/components/ads/Dropdown.tsx | 84.23 **(0)** | 62.91 **(0.15)** | 73.61 **(0)** | 83.26 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>