### PR TITLE
fix: Organization name can be empty

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
@@ -13,7 +13,6 @@ public class FieldName {
     public static final String COLLECTION_ID = "collectionId";
     public static final String ACTION_ID = "actionId";
     public static String ORGANIZATION = "organization";
-    public static String ORGANIZATION_NAME = "organizationName";
     public static String ID = "id";
     public static final String NAME = "name";
     public static String PAGE_ID = "pageId";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/FieldName.java
@@ -13,6 +13,7 @@ public class FieldName {
     public static final String COLLECTION_ID = "collectionId";
     public static final String ACTION_ID = "actionId";
     public static String ORGANIZATION = "organization";
+    public static String ORGANIZATION_NAME = "organizationName";
     public static String ID = "id";
     public static final String NAME = "name";
     public static String PAGE_ID = "pageId";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -216,9 +216,11 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
 
     @Override
     public Mono<Organization> update(String id, Organization resource) {
+        // Organization name should not be empty
         if (resource.getName().isEmpty()) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ORGANIZATION_NAME));
         }
+
         return repository.updateById(id, resource, MANAGE_ORGANIZATIONS)
                 .flatMap(analyticsService::sendUpdateEvent);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/OrganizationServiceCEImpl.java
@@ -216,6 +216,9 @@ public class OrganizationServiceCEImpl extends BaseService<OrganizationRepositor
 
     @Override
     public Mono<Organization> update(String id, Organization resource) {
+        if (resource.getName().isEmpty()) {
+            return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.ORGANIZATION_NAME));
+        }
         return repository.updateById(id, resource, MANAGE_ORGANIZATIONS)
                 .flatMap(analyticsService::sendUpdateEvent);
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/OrganizationServiceTest.java
@@ -262,12 +262,11 @@ public class OrganizationServiceTest {
 
         Mono<Organization> createOrganization = organizationService.create(organization);
         Mono<Organization> updateOrganization = createOrganization
-                .map(t -> {
-                    t.setDomain("abc.com");
-                    return t;
-                })
-                .flatMap(t -> organizationService.update(t.getId(), t))
-                .flatMap(t -> organizationService.getById(t.getId()));
+                .flatMap(t -> {
+                    Organization newOrganization = new Organization();
+                    newOrganization.setDomain("abc.com");
+                    return organizationService.update(t.getId(), newOrganization);
+                });
 
         StepVerifier.create(updateOrganization)
                 .assertNext(t -> {
@@ -302,16 +301,15 @@ public class OrganizationServiceTest {
         organization.setSlug("test-update-name");
         Mono<Organization> createOrganization = organizationService.create(organization);
         Mono<Organization> updateOrganization = createOrganization
-                .map(t -> {
-                    t.setName("");
-                    return t;
-                })
-                .flatMap(t -> organizationService.update(t.getId(), t))
-                .flatMap(t -> organizationService.getById(t.getId()));
+                .flatMap(t -> {
+                    Organization newOrganization = new Organization();
+                    newOrganization.setName("");
+                    return organizationService.update(t.getId(), newOrganization);
+                });
 
         StepVerifier.create(updateOrganization)
                 .expectErrorMatches(throwable -> throwable instanceof AppsmithException &&
-                        throwable.getMessage().equals(AppsmithError.INVALID_PARAMETER.getMessage(FieldName.ORGANIZATION_NAME)))
+                        throwable.getMessage().equals(AppsmithError.INVALID_PARAMETER.getMessage(FieldName.NAME)))
                 .verify();
     }
 


### PR DESCRIPTION
## Description

From the general settings page, if you try to update the organization name, it can be left empty. 

[![Reported Issue](https://cdn.loom.com/sessions/thumbnails/8562f9ae102746fa9f94c1e3f3fef8e3-with-play.gif)](https://loom.com/embed/45f0b5c1570c4337b248fc3989306c57 "Issue video")

This PR fixes that on the backend and throws an invalid parameter exception.

Fixes #[12301](https://github.com/appsmithorg/appsmith/issues/12301)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested on local app
[![Test Video](https://cdn.loom.com/sessions/thumbnails/8562f9ae102746fa9f94c1e3f3fef8e3-with-play.gif)](https://www.loom.com/embed/8562f9ae102746fa9f94c1e3f3fef8e3 "Test Video")
- Verified the added test case for this.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
