### PR TITLE
fix: Connection timeout for git connect when the git repo is behind a firewall

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
@@ -394,20 +394,19 @@ public class GitServiceCEImpl implements GitServiceCE {
                     // Check if the repo is public for current application and if the user have changed the access after
                     // the connection
                     final Boolean isRepoPrivate = defaultGitMetadata.getIsRepoPrivate();
-                    Mono<Application> applicationMono = Mono.just(defaultApplication);
+                    Mono<Application> applicationMono;
                     if (Boolean.FALSE.equals(isRepoPrivate)) {
-                        try {
-                            defaultGitMetadata.setIsRepoPrivate(
-                                    GitUtils.isRepoPrivate(defaultGitMetadata.getBrowserSupportedRemoteUrl())
-                            );
-                            if (!isRepoPrivate.equals(defaultGitMetadata.getIsRepoPrivate())) {
-                                applicationMono = applicationService.save(defaultApplication);
-                            } else {
-                                return applicationMono;
-                            }
-                        } catch (IOException e) {
-                            log.debug("Error while checking if the repo is private: ", e);
-                        }
+                        applicationMono = GitUtils.isRepoPrivate(defaultGitMetadata.getBrowserSupportedRemoteUrl())
+                                .flatMap(isPrivate -> {
+                                    defaultGitMetadata.setIsRepoPrivate(isPrivate);
+                                    if (!isPrivate.equals(defaultGitMetadata.getIsRepoPrivate())) {
+                                       return applicationService.save(defaultApplication);
+                                    } else {
+                                        return Mono.just(defaultApplication);
+                                    }
+                                });
+                    } else {
+                        return Mono.just(defaultApplication);
                     }
 
                     // Check if the private repo count is less than the allowed repo count
@@ -643,17 +642,13 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_CONFIGURATION, GIT_PROFILE_ERROR)));
 
         final String browserSupportedUrl = GitUtils.convertSshUrlToBrowserSupportedUrl(gitConnectDTO.getRemoteUrl());
-        boolean isRepoPrivateTemp = true;
-        try {
-            isRepoPrivateTemp = GitUtils.isRepoPrivate(browserSupportedUrl);
-        } catch (IOException e) {
-            log.debug("Error while checking if the repo is private: ", e);
-        }
 
-        final boolean isRepoPrivate = isRepoPrivateTemp;
+
         Mono<Application> connectApplicationMono =  profileMono
-                .then(getApplicationById(defaultApplicationId))
-                .flatMap(application -> {
+                .then(getApplicationById(defaultApplicationId).zipWith(GitUtils.isRepoPrivate(browserSupportedUrl)))
+                .flatMap(tuple -> {
+                    Application application = tuple.getT1();
+                    boolean isRepoPrivate = tuple.getT2();
                     // Check if the repo is public
                     if(!isRepoPrivate) {
                         return Mono.just(application);
@@ -733,8 +728,10 @@ public class GitServiceCEImpl implements GitServiceCE {
                     final String applicationId = application.getId();
                     final String orgId = application.getOrganizationId();
                     try {
-                        return fileUtils.checkIfDirectoryIsEmpty(repoPath)
-                                .flatMap(isEmpty -> {
+                        return fileUtils.checkIfDirectoryIsEmpty(repoPath).zipWith(GitUtils.isRepoPrivate(browserSupportedUrl))
+                                .flatMap(objects -> {
+                                    boolean isEmpty = objects.getT1();
+                                    boolean isRepoPrivate = objects.getT2();
                                     if (!isEmpty) {
                                         return addAnalyticsForGitOperation(
                                                 AnalyticsEvents.GIT_CONNECT.getEventName(),
@@ -1825,25 +1822,20 @@ public class GitServiceCEImpl implements GitServiceCE {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "Invalid organization id"));
         }
 
-        boolean isRepoPrivateTemp;
-        try {
-            isRepoPrivateTemp = GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl(gitConnectDTO.getRemoteUrl()));
-        } catch (IOException e) {
-            log.error("Error while checking if the repo is private: ", e);
-            isRepoPrivateTemp = true;
-        }
-        final boolean isRepoPrivate = isRepoPrivateTemp;
         final String repoName = GitUtils.getRepoName(gitConnectDTO.getRemoteUrl());
         Mono<ApplicationImportDTO> importedApplicationMono = getSSHKeyForCurrentUser()
+                .zipWith(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl(gitConnectDTO.getRemoteUrl())))
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.INVALID_GIT_CONFIGURATION,
                         "Unable to find git configuration for logged-in user. Please contact Appsmith team for support")))
                 //Check the limit for number of private repo
-                .flatMap(gitAuth -> {
+                .flatMap(tuple -> {
                     // Check if the repo is public
                     Application newApplication = new Application();
                     newApplication.setName(repoName);
                     newApplication.setOrganizationId(organizationId);
                     newApplication.setGitApplicationMetadata(new GitApplicationMetadata());
+                    GitAuth gitAuth = tuple.getT1();
+                    boolean isRepoPrivate = tuple.getT2();
                     Mono<Application> applicationMono = applicationPageService
                             .createOrUpdateSuffixedApplication(newApplication, newApplication.getName(), 0);
                     if(!isRepoPrivate) {
@@ -1905,7 +1897,10 @@ public class GitServiceCEImpl implements GitServiceCE {
                     });
 
                     return defaultBranchMono
-                            .flatMap(defaultBranch -> {
+                            .zipWith(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl(gitConnectDTO.getRemoteUrl())))
+                            .flatMap(tuple2 -> {
+                                String defaultBranch = tuple2.getT1();
+                                boolean isRepoPrivate = tuple2.getT2();
                                 GitApplicationMetadata gitApplicationMetadata = new GitApplicationMetadata();
                                 gitApplicationMetadata.setGitAuth(gitAuth);
                                 gitApplicationMetadata.setDefaultApplicationId(application.getId());
@@ -2295,19 +2290,14 @@ public class GitServiceCEImpl implements GitServiceCE {
                 .flatMap(application -> {
                     GitApplicationMetadata gitData = application.getGitApplicationMetadata();
                     final Boolean isRepoPrivate = gitData.getIsRepoPrivate();
-                    try {
-                        // Check if user have altered the repo accessibility
-                        gitData.setIsRepoPrivate(
-                                GitUtils.isRepoPrivate(application.getGitApplicationMetadata().getBrowserSupportedRemoteUrl())
-                        );
-                        if (!isRepoPrivate.equals(gitData.getIsRepoPrivate())) {
-                            // Repo accessibility is changed
-                            return applicationService.save(application);
-                        }
-                    } catch (IOException e) {
-                        log.debug("Error while checking if the repo is private: ", e);
-                    }
-                    return Mono.just(application);
+                    return GitUtils.isRepoPrivate(application.getGitApplicationMetadata().getBrowserSupportedRemoteUrl())
+                            .flatMap(isPrivate -> {
+                                if (!isRepoPrivate.equals(gitData.getIsRepoPrivate())) {
+                                    // Repo accessibility is changed
+                                    return applicationService.save(application);
+                                }
+                                return Mono.just(application);
+                            });
                 })
                 .then(applicationService.getGitConnectedApplicationsCountWithPrivateRepoByOrgId(organizationId));
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import reactor.test.StepVerifier;
 
 import java.io.IOException;
 
@@ -28,15 +29,23 @@ public class GitUtilsTest {
                 .isEqualTo("https://example.test.net/user/test/tests/testRepo");
     }
     @Test
-    public void isRepoPrivate() throws IOException {
-        assertThat(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl("git@example.com:test/testRepo.git")))
-                .isEqualTo(Boolean.TRUE);
-        assertThat(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl("git@example.com:test/testRepo.git")))
-                .isEqualTo(Boolean.TRUE);
-        assertThat(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl("git@example.org:test/testRepo.git")))
-                .isEqualTo(Boolean.TRUE);
-        assertThat(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl("ssh://git@appsmith.com.git")))
-                .isEqualTo(Boolean.FALSE);
+    public void isRepoPrivate() {
+
+        StepVerifier
+                .create(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl("git@github.com:test/testRepo.git")))
+                .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.TRUE))
+                .verifyComplete();
+
+        StepVerifier
+                .create(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl("ssh://git@example.test.net:user/test/tests/testRepo.git")))
+                .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.TRUE))
+                .verifyComplete();
+
+        StepVerifier
+                .create(GitUtils.isRepoPrivate(GitUtils.convertSshUrlToBrowserSupportedUrl("git@github.com:appsmithorg/appsmith.git")))
+                .assertNext(isRepoPrivate -> assertThat(isRepoPrivate).isEqualTo(Boolean.FALSE))
+                .verifyComplete();
+
     }
 
     @Test

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/GitServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/GitServiceTest.java
@@ -731,7 +731,6 @@ public class GitServiceTest {
 
         Application application1 = this.createApplicationConnectedToGit("private_repo_1", "master", limitPrivateRepoTestOrgId);
         this.createApplicationConnectedToGit("private_repo_2", "master", limitPrivateRepoTestOrgId);
-        this.createApplicationConnectedToGit("private_repo_3", "master", limitPrivateRepoTestOrgId);
 
         Application testApplication = new Application();
         GitApplicationMetadata gitApplicationMetadata = new GitApplicationMetadata();


### PR DESCRIPTION
## Description

> It would be a good idea to set a connection timeout, because in firewall environments, there's a good chance HTTPS is blocked off without refusing the connection, which might still cause a timeout. We are currently using blocking IO call for checking the repo status which is highly undesirable in webflux environment. 
This PR fixes the above mentioned issues. 

Fixes #12721 #12407 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally
- JUnit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
