### PR TITLE
fix: 11141-JDBC override parameter for resolving TZ Cast Errors

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -990,7 +990,8 @@ public class PostgresPlugin extends BasePlugin {
         }
 
         /** 
-         * JDBC connection parameter to auto resolve argument type when using prepared statements. 
+         * JDBC connection parameter to auto resolve argument type when using prepared statements. Please note that this auto deduction of type happens only when 
+         * the argument is bound using `setString()` method. In our case, it means that we have identified the argument data type as String.
          * Quoting from doc: 
          * If stringtype is set to unspecified, parameters will be sent to the server as untyped values, and the server will attempt to infer an appropriate type.
          * Ref: https://jdbc.postgresql.org/documentation/83/connect.html 

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -989,7 +989,12 @@ public class PostgresPlugin extends BasePlugin {
             urlBuilder.append(authentication.getDatabaseName());
         }
 
-        //JDBC override parameter for resolving Cast Errors on PostgreSQL
+        /** 
+         * JDBC connection parameter to auto resolve argument type when using prepared statements. 
+         * Quoting from doc: 
+         * If stringtype is set to unspecified, parameters will be sent to the server as untyped values, and the server will attempt to infer an appropriate type.
+         * Ref: https://jdbc.postgresql.org/documentation/83/connect.html 
+         */
         urlBuilder.append("?stringtype=unspecified");
 
         /*

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -989,6 +989,9 @@ public class PostgresPlugin extends BasePlugin {
             urlBuilder.append(authentication.getDatabaseName());
         }
 
+        //JDBC override parameter for resolving Cast Errors on PostgreSQL
+        urlBuilder.append("?stringtype=unspecified");
+
         /*
          * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
          */

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -1315,7 +1315,7 @@ public class PostgresPluginTest {
 
         ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
         List<Param> params = new ArrayList<>();
-        params.add(new Param("createdTS", "2022-04-11 05:30:00"));
+        params.add(new Param("createdTS", "2022-04-11T05:30:00Z"));
 
         executeActionDTO.setParams(params);
 
@@ -1339,7 +1339,7 @@ public class PostgresPluginTest {
                     assertTrue(result.getIsExecutionSuccess());
 
                     final JsonNode node = ((ArrayNode) result.getBody()).get(0);
-                    assertEquals(node.get("created_on_tz").asText(), "2022-04-11T00:00:00Z"); //UTC time
+                    assertEquals(node.get("created_on_tz").asText(), "2022-04-11T05:30:00Z"); //UTC time
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -1300,6 +1300,50 @@ public class PostgresPluginTest {
 
     }
 
+    @Test
+    public void testPreparedStatementWithTimeZoneTimeStamp() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setBody("UPDATE public.\"users\" set " +
+                "created_on_tz = {{createdTS}}\n" +
+                "  where id = 3;");
+
+        List<Property> pluginSpecifiedTemplates = new ArrayList<>();
+        pluginSpecifiedTemplates.add(new Property("preparedStatement", "true"));
+        actionConfiguration.setPluginSpecifiedTemplates(pluginSpecifiedTemplates);
+
+        ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
+        List<Param> params = new ArrayList<>();
+        params.add(new Param("createdTS", "2022-04-11 05:30:00"));
+
+        executeActionDTO.setParams(params);
+
+        Mono<HikariDataSource> connectionCreateMono = pluginExecutor.datasourceCreate(dsConfig).cache();
+
+        Mono<ActionExecutionResult> resultMono = connectionCreateMono
+                .flatMap(pool -> pluginExecutor.executeParameterized(pool, executeActionDTO, dsConfig, actionConfiguration));
+
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                })
+                .verifyComplete();
+
+        actionConfiguration.setBody("SELECT * FROM public.\"users\" where id = 3;");
+        resultMono = connectionCreateMono
+                .flatMap(pool -> pluginExecutor.executeParameterized(pool, executeActionDTO, dsConfig, actionConfiguration));
+
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+
+                    final JsonNode node = ((ArrayNode) result.getBody()).get(0);
+                    assertEquals(node.get("created_on_tz").asText(), "2022-04-11T00:00:00Z"); //UTC time
+                })
+                .verifyComplete();
+    }
+
     public void testReadOnlyMode() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         dsConfig.getConnection().setMode(com.appsmith.external.models.Connection.Mode.READ_ONLY);


### PR DESCRIPTION
## Description
In Postgres CURD page, the TimeStamp with TimeZone field caused error when updating.
Resolved that issue by adding "JDBC override parameter for postgress" as per the below recommendations.
[https://support.delphix.com/Continuous_Compliance_Engine_(formerly_Masking_Engine)/Resolving_Varchar_Cast_Errors_on_PostgreSQL_(KBA6993)](https://support.delphix.com/Continuous_Compliance_Engine_(formerly_Masking_Engine)/Resolving_Varchar_Cast_Errors_on_PostgreSQL_(KBA6993))

Findings :
Part 1:
The application can work without this fix in the following way
Example of working syntax for updating TimeStampTS without this fix is : 2022-04-11 05:30:00
This is saved as UTC format in the DB, when fetching necessary conversions are required based on the fetching location and displayed in the right field in the same syntax.
So Updating again with the same syntax will work without this fix.

Part 2:
At present we are fetching and displaying in this format eg: 2022-04-11T00:00:00Z
This format although valid is creating error during update query call, so this fix is required.
In this case the TimeStampTZ value will be saved as such (like a varchar) and can be fetched back and displayed without any conversion.

However this fix work for both the above cases

Quoting from JDBC doc: 
```
stringtype = String
Specify the type to use when binding PreparedStatement parameters set via setString(). If stringtype is set to varchar (the default), such parameters will be sent to the server as varchar parameters. If stringtype is set to unspecified, parameters will be sent to the server as untyped values, and the server will attempt to infer an appropriate type. This is useful if you have an existing application that uses setString() to set parameters that are actually some other type, such as integers, and you are unable to change the application to use an appropriate method such as setInt().
```
https://jdbc.postgresql.org/documentation/83/connect.html

Fixes #11141

 
## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

Done Manually

Added Unit test

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
