### PR TITLE
fix: Fixes Mongo connection pool minimum size to 0

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -21,7 +21,6 @@ import com.appsmith.external.models.Param;
 import com.appsmith.external.models.ParsedDataType;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.RequestParamDTO;
-import com.appsmith.external.models.SSLDetails;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.external.plugins.SmartSubstitutionInterface;
@@ -30,13 +29,16 @@ import com.external.plugins.utils.MongoErrorUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.ConnectionString;
 import com.mongodb.DBObjectCodecProvider;
 import com.mongodb.DBRefCodecProvider;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoSocketWriteException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.client.gridfs.codecs.GridFSFileCodecProvider;
 import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
+import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoDatabase;
@@ -68,7 +70,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,15 +85,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.appsmith.external.constants.ActionConstants.ACTION_CONFIGURATION_BODY;
-import static com.external.plugins.constants.FieldName.NATIVE_QUERY_PATH_DATA;
-import static com.external.plugins.constants.FieldName.NATIVE_QUERY_PATH_STATUS;
-import static com.external.plugins.constants.FieldName.SUCCESS;
-import static com.external.plugins.utils.MongoPluginUtils.convertMongoFormInputToRawCommand;
-import static com.external.plugins.utils.MongoPluginUtils.generateTemplatesAndStructureForACollection;
-import static com.external.plugins.utils.MongoPluginUtils.getDatabaseName;
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromFormData;
-import static com.external.plugins.utils.MongoPluginUtils.getRawQuery;
-import static com.external.plugins.utils.MongoPluginUtils.isRawCommand;
 import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInFormData;
 import static com.appsmith.external.helpers.PluginUtils.validConfigurationPresentInFormData;
 import static com.external.plugins.constants.FieldName.AGGREGATE_PIPELINES;
@@ -104,10 +97,24 @@ import static com.external.plugins.constants.FieldName.FIND_PROJECTION;
 import static com.external.plugins.constants.FieldName.FIND_QUERY;
 import static com.external.plugins.constants.FieldName.FIND_SORT;
 import static com.external.plugins.constants.FieldName.INSERT_DOCUMENT;
+import static com.external.plugins.constants.FieldName.NATIVE_QUERY_PATH_DATA;
+import static com.external.plugins.constants.FieldName.NATIVE_QUERY_PATH_STATUS;
 import static com.external.plugins.constants.FieldName.SMART_SUBSTITUTION;
+import static com.external.plugins.constants.FieldName.SUCCESS;
 import static com.external.plugins.constants.FieldName.UPDATE_OPERATION;
 import static com.external.plugins.constants.FieldName.UPDATE_QUERY;
-import static com.external.plugins.utils.MongoPluginUtils.urlEncode;
+import static com.external.plugins.utils.DatasourceUtils.buildClientURI;
+import static com.external.plugins.utils.DatasourceUtils.buildURIFromExtractedInfo;
+import static com.external.plugins.utils.DatasourceUtils.extractInfoFromConnectionStringURI;
+import static com.external.plugins.utils.DatasourceUtils.hasNonEmptyURI;
+import static com.external.plugins.utils.DatasourceUtils.isAuthenticated;
+import static com.external.plugins.utils.DatasourceUtils.isHostStringConnectionURI;
+import static com.external.plugins.utils.DatasourceUtils.isUsingURI;
+import static com.external.plugins.utils.MongoPluginUtils.convertMongoFormInputToRawCommand;
+import static com.external.plugins.utils.MongoPluginUtils.generateTemplatesAndStructureForACollection;
+import static com.external.plugins.utils.MongoPluginUtils.getDatabaseName;
+import static com.external.plugins.utils.MongoPluginUtils.getRawQuery;
+import static com.external.plugins.utils.MongoPluginUtils.isRawCommand;
 import static java.lang.Boolean.TRUE;
 import static java.util.Arrays.asList;
 import static org.apache.logging.log4j.util.Strings.isBlank;
@@ -124,8 +131,6 @@ public class MongoPlugin extends BasePlugin {
             .map(String::valueOf)
             .collect(Collectors.joining(", "));
 
-    private static final int DEFAULT_PORT = 27017;
-
     public static final String N_MODIFIED = "nModified";
 
     private static final String VALUE = "value";
@@ -140,7 +145,7 @@ public class MongoPlugin extends BasePlugin {
      *   - mongodb://user:pass@some-url:port,some-url:port,.../some-db...
      * - It has been grouped like this: (mongodb+srv://)(user):(pass)@(some-url)/(some-db...)?(params...)
      */
-    private static final String MONGO_URI_REGEX = "^(mongodb(?:\\+srv)?:\\/\\/)(?:(.+):(.+)@)?([^\\/\\?]+)\\/?([^\\?]+)?\\??(.+)?$";
+    private static final String MONGO_URI_REGEX = "^(mongodb(?:\\+srv)?://)(?:(.+):(.+)@)?([^/?]+)/?([^?]+)?\\??(.+)?$";
 
     /**
      * We use this regex to find usage of special Mongo data types like ObjectId(...) wrapped inside double quotes
@@ -158,33 +163,11 @@ public class MongoPlugin extends BasePlugin {
      */
     private static final String MONGODB_SPECIAL_TYPE_INSIDE_QUOTES_REGEX_TEMPLATE = "(\\\"(E\\((.*?((\\w|-|:|\\.|,|\\s)+).*?)?\\))\\\")";
 
-    private static final int REGEX_GROUP_HEAD = 1;
-
-    private static final int REGEX_GROUP_USERNAME = 2;
-
-    private static final int REGEX_GROUP_PASSWORD = 3;
-
-    private static final int REGEX_HOST_PORT = 4;
-
-    private static final int REGEX_GROUP_DBNAME = 5;
-
-    private static final int REGEX_GROUP_TAIL = 6;
-
     private static final String KEY_USERNAME = "username";
 
     private static final String KEY_PASSWORD = "password";
 
-    private static final String KEY_HOST_PORT = "hostPort";
-
-    private static final String KEY_URI_HEAD = "uriHead";
-
-    private static final String KEY_URI_TAIL = "uriTail";
-
     private static final String KEY_URI_DBNAME = "dbName";
-
-    private static final String YES = "Yes";
-
-    private static final int DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX = 0;
 
     private static final int DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX = 1;
 
@@ -237,7 +220,6 @@ public class MongoPlugin extends BasePlugin {
          *                                which would be used for substitution
          * @param datasourceConfiguration : These are the configurations which have been used to create a Datasource from a Plugin
          * @param actionConfiguration     : These are the configurations which have been used to create an Action from a Datasource.
-         * @return
          */
         @Override
         public Mono<ActionExecutionResult> executeParameterized(MongoClient mongoClient,
@@ -379,10 +361,10 @@ public class MongoPlugin extends BasePlugin {
                                         new ParsedDataType(DisplayDataType.RAW)
                                 ));
 
-                                /**
-                                 * For the `findAndModify` command, we don't get the count of modifications made. Instead,
-                                 * we either get the modified new value or the pre-modified old value (depending on the
-                                 * `new` field in the command. Let's return that value to the user.
+                                /*
+                                  For the `findAndModify` command, we don't get the count of modifications made. Instead,
+                                  we either get the modified new value or the pre-modified old value (depending on the
+                                  `new` field in the command. Let's return that value to the user.
                                  */
                                 if (outputJson.has(VALUE)) {
                                     result.setBody(objectMapper.readTree(
@@ -390,9 +372,9 @@ public class MongoPlugin extends BasePlugin {
                                     ));
                                 }
 
-                                /**
-                                 * The json contains key "cursor" when find command was issued and there are 1 or more
-                                 * results. In case there are no results for find, this key is not present in the result json.
+                                /*
+                                  The json contains key "cursor" when find command was issued and there are 1 or more
+                                  results. In case there are no results for find, this key is not present in the result json.
                                  */
                                 if (outputJson.has("cursor")) {
                                     JSONArray outputResult = (JSONArray) cleanUp(
@@ -400,10 +382,10 @@ public class MongoPlugin extends BasePlugin {
                                     result.setBody(objectMapper.readTree(outputResult.toString()));
                                 }
 
-                                /**
-                                 * The json contains key "n" when insert/update command is issued. "n" for update
-                                 * signifies the no of documents selected for update. "n" in case of insert signifies the
-                                 * number of documents inserted.
+                                /*
+                                  The json contains key "n" when insert/update command is issued. "n" for update
+                                  signifies the no of documents selected for update. "n" in case of insert signifies the
+                                  number of documents inserted.
                                  */
                                 if (outputJson.has("n")) {
                                     JSONObject body = new JSONObject().put("n", outputJson.getBigInteger("n"));
@@ -411,9 +393,9 @@ public class MongoPlugin extends BasePlugin {
                                     headerArray.put(body);
                                 }
 
-                                /**
-                                 * The json key contains key "nModified" in case of update command. This signifies the no of
-                                 * documents updated.
+                                /*
+                                  The json key contains key "nModified" in case of update command. This signifies the no of
+                                  documents updated.
                                  */
                                 if (outputJson.has(N_MODIFIED)) {
                                     JSONObject body = new JSONObject().put(N_MODIFIED, outputJson.getBigInteger(N_MODIFIED));
@@ -421,8 +403,8 @@ public class MongoPlugin extends BasePlugin {
                                     headerArray.put(body);
                                 }
 
-                                /**
-                                 * The json contains key "values" when distinct command is used.
+                                /*
+                                  The json contains key "values" when distinct command is used.
                                  */
                                 if (outputJson.has(VALUES)) {
                                     JSONArray outputResult = (JSONArray) cleanUp(
@@ -439,9 +421,9 @@ public class MongoPlugin extends BasePlugin {
                                     result.setBody(objectMapper.readTree(resultNode.toString()));
                                 }
 
-                                /** TODO
-                                 * Go through all the possible fields that are returned in the output JSON and add all the fields
-                                 * that are important to the headerArray.
+                                /*
+                                TODO Go through all the possible fields that are returned in the output JSON and add all the fields
+                                 that are important to the headerArray.
                                  */
                             }
 
@@ -485,7 +467,7 @@ public class MongoPlugin extends BasePlugin {
          * happens as part of smart substitution process.
          *
          * @param replacementValue - value to be substituted
-         * @param dataType
+         * @param dataType         - the expected datatype of the value
          * @return - updated replacement value
          */
         @Override
@@ -493,13 +475,13 @@ public class MongoPlugin extends BasePlugin {
             replacementValue = removeOrAddQuotesAroundMongoDBSpecialTypes(replacementValue);
 
             if (DataType.BSON_SPECIAL_DATA_TYPES.equals(dataType)) {
-                /**
-                 * For all other data types the replacementValue is prepared for replacement (by using Matcher
-                 * .quoteReplacement(...)) during the common handling of data types in
-                 * `jsonSmartReplacementPlaceholderWithValue(...)` method before reaching this program point. For
-                 * BSON_SPECIAL_DATA_TYPES it is skipped in the common handling flow because we want to modify
-                 * (removeOrAddQuotesAroundMongoDBSpecialTypes(...)) the replacement value further before the final
-                 * replacement happens.
+                /*
+                  For all other data types the replacementValue is prepared for replacement (by using Matcher
+                  .quoteReplacement(...)) during the common handling of data types in
+                  `jsonSmartReplacementPlaceholderWithValue(...)` method before reaching this program point. For
+                  BSON_SPECIAL_DATA_TYPES it is skipped in the common handling flow because we want to modify
+                  (removeOrAddQuotesAroundMongoDBSpecialTypes(...)) the replacement value further before the final
+                  replacement happens.
                  */
                 replacementValue = Matcher.quoteReplacement(replacementValue);
             }
@@ -527,13 +509,13 @@ public class MongoPlugin extends BasePlugin {
                 Pattern pattern = Pattern.compile(regex);
                 Matcher matcher = pattern.matcher(query);
                 while (matcher.find()) {
-                    /**
-                     * `If` branch will match when any special data type is found wrapped within double quotes e.g.
-                     * "ObjectId('someId')":
-                     *   o Group 1 = "ObjectId('someId')"
-                     *   o Group 2 = ObjectId(someId)
-                     *   o Group 3 = 'someId'
-                     *   o Group 4 = someId
+                    /*
+                      `If` branch will match when any special data type is found wrapped within double quotes e.g.
+                      "ObjectId('someId')":
+                        o Group 1 = "ObjectId('someId')"
+                        o Group 2 = ObjectId(someId)
+                        o Group 3 = 'someId'
+                        o Group 4 = someId
                      */
                     if (matcher.group(1) != null) {
                         String objectIdWithQuotes = matcher.group(1);
@@ -587,10 +569,6 @@ public class MongoPlugin extends BasePlugin {
          * !!!WARNING!!! : formData gets updated as part of this flow (and hence is not being returned)
          * This function replaces the mustache variables using smart substitution and updates the existing formData
          * with the values post substitution
-         * @param formData
-         * @param params
-         * @param parameters
-         * @throws AppsmithPluginException
          */
         private void smartSubstituteFormCommand(Map<String, Object> formData,
                                                 List<Param> params,
@@ -607,10 +585,10 @@ public class MongoPlugin extends BasePlugin {
 
         @Override
         public Mono<MongoClient> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
-            /**
-             * TODO: ReadOnly seems to be not supported at the driver level. The recommendation is to connect with a
-             * user that doesn't have write permissions on the database.
-             * Ref: https://api.mongodb.com/java/2.13/com/mongodb/DB.html#setReadOnly-java.lang.Boolean-
+            /*
+              TODO: ReadOnly seems to be not supported at the driver level. The recommendation is to connect with
+               a user that doesn't have write permissions on the database.
+               Ref: https://api.mongodb.com/java/2.13/com/mongodb/DB.html#setReadOnly-java.lang.Boolean-
              */
 
             return Mono.just(datasourceConfiguration)
@@ -621,7 +599,13 @@ public class MongoPlugin extends BasePlugin {
                             return Mono.error(e);
                         }
                     })
-                    .map(MongoClients::create)
+                    .map(uriString -> MongoClients.create(
+                            MongoClientSettings
+                                    .builder()
+                                    .applyToConnectionPoolSettings(t -> t.applySettings(ConnectionPoolSettings.builder().minSize(0).build()))
+                                    .applyConnectionString(new ConnectionString(uriString))
+                                    .build()
+                    ))
                     .onErrorMap(
                             IllegalArgumentException.class,
                             error ->
@@ -640,206 +624,7 @@ public class MongoPlugin extends BasePlugin {
                     .subscribeOn(scheduler);
         }
 
-        private boolean isUsingURI(DatasourceConfiguration datasourceConfiguration) {
-            List<Property> properties = datasourceConfiguration.getProperties();
-            if (properties != null && properties.size() > DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX
-                    && properties.get(DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX) != null
-                    && YES.equals(properties.get(DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX).getValue())) {
-                return true;
-            }
 
-            return false;
-        }
-
-        private boolean hasNonEmptyURI(DatasourceConfiguration datasourceConfiguration) {
-            List<Property> properties = datasourceConfiguration.getProperties();
-            if (properties != null && properties.size() > DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX
-                    && properties.get(DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX) != null
-                    && !StringUtils.isEmpty(properties.get(DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX).getValue())) {
-                return true;
-            }
-
-            return false;
-        }
-
-        private Map extractInfoFromConnectionStringURI(String uri, String regex) {
-            if (uri.matches(regex)) {
-                Pattern pattern = Pattern.compile(regex);
-                Matcher matcher = pattern.matcher(uri);
-                if (matcher.find()) {
-                    Map extractedInfoMap = new HashMap();
-                    extractedInfoMap.put(KEY_URI_HEAD, matcher.group(REGEX_GROUP_HEAD));
-                    extractedInfoMap.put(KEY_USERNAME, matcher.group(REGEX_GROUP_USERNAME));
-                    extractedInfoMap.put(KEY_PASSWORD, matcher.group(REGEX_GROUP_PASSWORD));
-                    extractedInfoMap.put(KEY_HOST_PORT, matcher.group(REGEX_HOST_PORT));
-                    extractedInfoMap.put(KEY_URI_DBNAME, matcher.group(REGEX_GROUP_DBNAME));
-                    extractedInfoMap.put(KEY_URI_TAIL, matcher.group(REGEX_GROUP_TAIL));
-                    return extractedInfoMap;
-                }
-            }
-
-            return null;
-        }
-
-        private String buildURIFromExtractedInfo(Map extractedInfo, String password) {
-            String userInfo = "";
-            if (extractedInfo.get(KEY_USERNAME) != null) {
-                userInfo += extractedInfo.get(KEY_USERNAME) + ":";
-                if (password != null) {
-                    userInfo += password;
-                }
-                userInfo += "@";
-            }
-
-            final String dbInfo = "/" + (extractedInfo.get(KEY_URI_DBNAME) == null ? "" : extractedInfo.get(KEY_URI_DBNAME));
-
-            String tailInfo = (String) (extractedInfo.get(KEY_URI_TAIL) == null ? "" : extractedInfo.get(KEY_URI_TAIL));
-            if (StringUtils.hasLength(tailInfo)) {
-                if (!tailInfo.contains("authSource")) {
-                    tailInfo = "?" + tailInfo + "&authSource=admin";
-                } else {
-                    tailInfo = "?" + tailInfo;
-                }
-            } else {
-                tailInfo = "?authSource=admin";
-            }
-
-            return extractedInfo.get(KEY_URI_HEAD)
-                    + userInfo
-                    + extractedInfo.get(KEY_HOST_PORT)
-                    + dbInfo
-                    + tailInfo;
-        }
-
-        public String buildClientURI(DatasourceConfiguration datasourceConfiguration) throws AppsmithPluginException {
-            List<Property> properties = datasourceConfiguration.getProperties();
-            if (isUsingURI(datasourceConfiguration)) {
-                if (hasNonEmptyURI(datasourceConfiguration)) {
-                    String uriWithHiddenPassword =
-                            (String) properties.get(DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX).getValue();
-                    Map extractedInfo = extractInfoFromConnectionStringURI(uriWithHiddenPassword, MONGO_URI_REGEX);
-                    if (extractedInfo != null) {
-                        String password = ((DBAuth) datasourceConfiguration.getAuthentication()).getPassword();
-                        return buildURIFromExtractedInfo(extractedInfo, password);
-                    } else {
-                        throw new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
-                                "Appsmith server has failed to parse the Mongo connection string URI. Please check " +
-                                        "if the URI has the correct format."
-                        );
-                    }
-                } else {
-                    throw new AppsmithPluginException(
-                            AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
-                            "Could not find any Mongo connection string URI. Please edit the 'Mongo Connection String" +
-                                    " URI' field to provide the URI to connect to."
-                    );
-                }
-            }
-
-            StringBuilder builder = new StringBuilder();
-            final Connection connection = datasourceConfiguration.getConnection();
-            final List<Endpoint> endpoints = datasourceConfiguration.getEndpoints();
-
-            // Use SRV mode if using REPLICA_SET, AND a port is not specified in the first endpoint. In SRV mode, the
-            // host and port details of individual shards will be obtained from the TXT records of the first endpoint.
-            boolean isSrv = Connection.Type.REPLICA_SET.equals(connection.getType())
-                    && endpoints.get(0).getPort() == null;
-
-            if (isSrv) {
-                builder.append("mongodb+srv://");
-            } else {
-                builder.append("mongodb://");
-            }
-
-            boolean hasUsername = false;
-            DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
-            if (authentication != null) {
-                hasUsername = StringUtils.hasText(authentication.getUsername());
-                final boolean hasPassword = StringUtils.hasText(authentication.getPassword());
-                if (hasUsername) {
-                    builder.append(urlEncode(authentication.getUsername()));
-                }
-                if (hasPassword) {
-                    builder.append(':').append(urlEncode(authentication.getPassword()));
-                }
-                if (hasUsername || hasPassword) {
-                    builder.append('@');
-                }
-            }
-
-            for (Endpoint endpoint : endpoints) {
-                builder.append(endpoint.getHost());
-                if (endpoint.getPort() != null) {
-                    builder.append(':').append(endpoint.getPort());
-                } else if (!isSrv) {
-                    // Connections with +srv should NOT have a port.
-                    builder.append(':').append(DEFAULT_PORT);
-                }
-                builder.append(',');
-            }
-
-            // Delete the trailing comma.
-            builder.deleteCharAt(builder.length() - 1);
-
-            final String authenticationDatabaseName = authentication == null ? null : authentication.getDatabaseName();
-            builder.append('/').append(authenticationDatabaseName);
-
-            List<String> queryParams = new ArrayList<>();
-
-            /*
-             * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
-             */
-            if (datasourceConfiguration.getConnection() == null
-                    || datasourceConfiguration.getConnection().getSsl() == null
-                    || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
-                throw new AppsmithPluginException(
-                        AppsmithPluginError.PLUGIN_ERROR,
-                        "Appsmith server has failed to fetch SSL configuration from datasource configuration form. " +
-                                "Please reach out to Appsmith customer support to resolve this."
-                );
-            }
-
-            /*
-             * - By default, the driver configures SSL in the preferred mode.
-             */
-            SSLDetails.AuthType sslAuthType = datasourceConfiguration.getConnection().getSsl().getAuthType();
-            switch (sslAuthType) {
-                case ENABLED:
-                    queryParams.add("ssl=true");
-
-                    break;
-                case DISABLED:
-                    queryParams.add("ssl=false");
-
-                    break;
-                case DEFAULT:
-                    /* do nothing - accept default driver setting */
-
-                    break;
-                default:
-                    throw new AppsmithPluginException(
-                            AppsmithPluginError.PLUGIN_ERROR,
-                            "Appsmith server has found an unexpected SSL option: " + sslAuthType + ". Please reach out to" +
-                                    " Appsmith customer support to resolve this."
-                    );
-            }
-
-            if (hasUsername && authentication.getAuthType() != null) {
-                queryParams.add("authMechanism=" + authentication.getAuthType().name().replace('_', '-'));
-            }
-
-            if (!queryParams.isEmpty()) {
-                builder.append('?');
-                for (String param : queryParams) {
-                    builder.append(param).append('&');
-                }
-                // Delete the trailing ampersand.
-                builder.deleteCharAt(builder.length() - 1);
-            }
-
-            return builder.toString();
-        }
 
         @Override
         public void datasourceDestroy(MongoClient mongoClient) {
@@ -848,21 +633,6 @@ public class MongoPlugin extends BasePlugin {
             }
         }
 
-        private boolean hostStringHasConnectionURIHead(String host) {
-            if (!StringUtils.isEmpty(host) && (host.contains("mongodb://") || host.contains("mongodb+srv"))) {
-                return true;
-            }
-
-            return false;
-        }
-
-        private boolean isHostStringConnectionURI(Endpoint endpoint) {
-            if (endpoint != null && hostStringHasConnectionURIHead(endpoint.getHost())) {
-                return true;
-            }
-
-            return false;
-        }
 
         @Override
         public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
@@ -934,14 +704,14 @@ public class MongoPlugin extends BasePlugin {
                         invalids.add("Invalid authType. Must be one of " + VALID_AUTH_TYPES_STR);
                     }
 
-                    if (StringUtils.isEmpty(authentication.getDatabaseName())) {
+                    if (!StringUtils.hasLength(authentication.getDatabaseName())) {
                         invalids.add("Missing database name.");
                     }
 
                 }
 
                 /*
-                 * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
+                 * Ideally, it is never expected to be null because the SSL dropdown is set to an initial value.
                  */
                 if (datasourceConfiguration.getConnection() == null
                         || datasourceConfiguration.getConnection().getSsl() == null
@@ -1104,7 +874,6 @@ public class MongoPlugin extends BasePlugin {
          * This method coverts Mongo plugin's form data to Mongo's native query. Currently, it is meant to help users
          * switch easily from form based input to raw input mode by providing a readily available translation of the
          * form data to raw query.
-         * @param actionConfiguration
          * @return Mongo's native/raw query set at path `formData.formToNativeQuery.data`
          */
         @Override
@@ -1114,9 +883,9 @@ public class MongoPlugin extends BasePlugin {
                 /* If it is not raw command, then it must be one of the mongo form commands */
                 if (!isRawCommand(formData)) {
 
-                    /**
-                     * This translation must happen only if the user has not edited the raw mode. Hence, check that
-                     * user has not provided any raw query.
+                    /*
+                      This translation must happen only if the user has not edited the raw mode. Hence, check that
+                      user has not provided any raw query.
                      */
                     if (isBlank(getValueSafelyFromFormData(formData, BODY, String.class))) {
                         try {
@@ -1179,12 +948,4 @@ public class MongoPlugin extends BasePlugin {
         return object;
     }
 
-    private static boolean isAuthenticated(DBAuth authentication, String mongoUri) {
-        if (authentication != null && authentication.getUsername() != null
-                && authentication.getPassword() != null && mongoUri.contains("****")) {
-
-            return true;
-        }
-        return false;
-    }
 }

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/DatasourceUtils.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/DatasourceUtils.java
@@ -1,0 +1,313 @@
+package com.external.plugins.utils;
+
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.models.Connection;
+import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.Endpoint;
+import com.appsmith.external.models.Property;
+import com.appsmith.external.models.SSLDetails;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.external.plugins.utils.MongoPluginUtils.urlEncode;
+
+public class DatasourceUtils {
+
+    private static final int DEFAULT_PORT = 27017;
+
+    /*
+     * - The regex matches the following two pattern types:
+     *   - mongodb+srv://user:pass@some-url/some-db...
+     *   - mongodb://user:pass@some-url:port,some-url:port,.../some-db...
+     * - It has been grouped like this: (mongodb+srv://)(user):(pass)@(some-url)/(some-db...)?(params...)
+     */
+    private static final String MONGO_URI_REGEX = "^(mongodb(?:\\+srv)?:\\/\\/)(?:(.+):(.+)@)?([^\\/\\?]+)\\/?([^\\?]+)?\\??(.+)?$";
+
+    private static final int REGEX_GROUP_HEAD = 1;
+
+    private static final int REGEX_GROUP_USERNAME = 2;
+
+    private static final int REGEX_GROUP_PASSWORD = 3;
+
+    private static final int REGEX_HOST_PORT = 4;
+
+    private static final int REGEX_GROUP_DBNAME = 5;
+
+    private static final int REGEX_GROUP_TAIL = 6;
+
+    private static final String KEY_USERNAME = "username";
+
+    private static final String KEY_PASSWORD = "password";
+
+    private static final String KEY_HOST_PORT = "hostPort";
+
+    private static final String KEY_URI_HEAD = "uriHead";
+
+    private static final String KEY_URI_TAIL = "uriTail";
+
+    private static final String KEY_URI_DBNAME = "dbName";
+
+    private static final String YES = "Yes";
+
+    private static final int DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX = 0;
+
+    private static final int DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX = 1;
+
+    public static boolean isUsingURI(DatasourceConfiguration datasourceConfiguration) {
+        List<Property> properties = datasourceConfiguration.getProperties();
+        if (properties != null && properties.size() > DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX
+                && properties.get(DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX) != null
+                && YES.equals(properties.get(DATASOURCE_CONFIG_USE_MONGO_URI_PROPERTY_INDEX).getValue())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static boolean hasNonEmptyURI(DatasourceConfiguration datasourceConfiguration) {
+        List<Property> properties = datasourceConfiguration.getProperties();
+        if (properties != null && properties.size() > DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX
+                && properties.get(DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX) != null
+                && !StringUtils.isEmpty(properties.get(DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX).getValue())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static Map extractInfoFromConnectionStringURI(String uri, String regex) {
+        if (uri.matches(regex)) {
+            Pattern pattern = Pattern.compile(regex);
+            Matcher matcher = pattern.matcher(uri);
+            if (matcher.find()) {
+                Map extractedInfoMap = new HashMap();
+                extractedInfoMap.put(KEY_URI_HEAD, matcher.group(REGEX_GROUP_HEAD));
+                extractedInfoMap.put(KEY_USERNAME, matcher.group(REGEX_GROUP_USERNAME));
+                extractedInfoMap.put(KEY_PASSWORD, matcher.group(REGEX_GROUP_PASSWORD));
+                extractedInfoMap.put(KEY_HOST_PORT, matcher.group(REGEX_HOST_PORT));
+                extractedInfoMap.put(KEY_URI_DBNAME, matcher.group(REGEX_GROUP_DBNAME));
+                extractedInfoMap.put(KEY_URI_TAIL, matcher.group(REGEX_GROUP_TAIL));
+                return extractedInfoMap;
+            }
+        }
+
+        return null;
+    }
+
+    public static String buildURIFromExtractedInfo(Map extractedInfo, String password) {
+        String userInfo = "";
+        if (extractedInfo.get(KEY_USERNAME) != null) {
+            userInfo += extractedInfo.get(KEY_USERNAME) + ":";
+            if (password != null) {
+                userInfo += password;
+            }
+            userInfo += "@";
+        }
+
+        final String dbInfo = "/" + (extractedInfo.get(KEY_URI_DBNAME) == null ? "" : extractedInfo.get(KEY_URI_DBNAME));
+
+        String tailInfo = (String) (extractedInfo.get(KEY_URI_TAIL) == null ? "" : extractedInfo.get(KEY_URI_TAIL));
+        tailInfo = "?" + buildURITail(tailInfo);
+
+        return extractedInfo.get(KEY_URI_HEAD)
+                + userInfo
+                + extractedInfo.get(KEY_HOST_PORT)
+                + dbInfo
+                + tailInfo;
+    }
+
+    private static String buildURITail(String tailInfo) {
+        Map<String, String> optionsMap = new HashMap<>();
+
+        for (final String part : tailInfo.split("[&;]")) {
+            if (part.length() == 0) {
+                continue;
+            }
+            int idx = part.indexOf("=");
+            if (idx >= 0) {
+                String key = part.substring(0, idx).toLowerCase();
+                String value = part.substring(idx + 1);
+                optionsMap.put(key, value);
+            } else {
+                optionsMap.put(part.toLowerCase(), "");
+            }
+        }
+        optionsMap.putIfAbsent("authsource", "admin");
+        optionsMap.put("minpoolsize", "0");
+        return optionsMap
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    if (StringUtils.hasLength(entry.getValue())) {
+                        return entry.getKey() + "=" + entry.getValue();
+                    } else {
+                        return entry.getKey();
+                    }
+                })
+                .collect(Collectors.joining("&"));
+    }
+
+    public static String buildClientURI(DatasourceConfiguration datasourceConfiguration) throws AppsmithPluginException {
+        List<Property> properties = datasourceConfiguration.getProperties();
+        if (isUsingURI(datasourceConfiguration)) {
+            if (hasNonEmptyURI(datasourceConfiguration)) {
+                String uriWithHiddenPassword =
+                        (String) properties.get(DATASOURCE_CONFIG_MONGO_URI_PROPERTY_INDEX).getValue();
+                Map extractedInfo = extractInfoFromConnectionStringURI(uriWithHiddenPassword, MONGO_URI_REGEX);
+                if (extractedInfo != null) {
+                    String password = ((DBAuth) datasourceConfiguration.getAuthentication()).getPassword();
+                    return buildURIFromExtractedInfo(extractedInfo, password);
+                } else {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
+                            "Appsmith server has failed to parse the Mongo connection string URI. Please check " +
+                                    "if the URI has the correct format."
+                    );
+                }
+            } else {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
+                        "Could not find any Mongo connection string URI. Please edit the 'Mongo Connection String" +
+                                " URI' field to provide the URI to connect to."
+                );
+            }
+        }
+
+        StringBuilder builder = new StringBuilder();
+        final Connection connection = datasourceConfiguration.getConnection();
+        final List<Endpoint> endpoints = datasourceConfiguration.getEndpoints();
+
+        // Use SRV mode if using REPLICA_SET, AND a port is not specified in the first endpoint. In SRV mode, the
+        // host and port details of individual shards will be obtained from the TXT records of the first endpoint.
+        boolean isSrv = Connection.Type.REPLICA_SET.equals(connection.getType())
+                && endpoints.get(0).getPort() == null;
+
+        if (isSrv) {
+            builder.append("mongodb+srv://");
+        } else {
+            builder.append("mongodb://");
+        }
+
+        boolean hasUsername = false;
+        DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
+        if (authentication != null) {
+            hasUsername = StringUtils.hasText(authentication.getUsername());
+            final boolean hasPassword = StringUtils.hasText(authentication.getPassword());
+            if (hasUsername) {
+                builder.append(urlEncode(authentication.getUsername()));
+            }
+            if (hasPassword) {
+                builder.append(':').append(urlEncode(authentication.getPassword()));
+            }
+            if (hasUsername || hasPassword) {
+                builder.append('@');
+            }
+        }
+
+        for (Endpoint endpoint : endpoints) {
+            builder.append(endpoint.getHost());
+            if (endpoint.getPort() != null) {
+                builder.append(':').append(endpoint.getPort());
+            } else if (!isSrv) {
+                // Connections with +srv should NOT have a port.
+                builder.append(':').append(DEFAULT_PORT);
+            }
+            builder.append(',');
+        }
+
+        // Delete the trailing comma.
+        builder.deleteCharAt(builder.length() - 1);
+
+        final String authenticationDatabaseName = authentication == null ? null : authentication.getDatabaseName();
+        builder.append('/').append(authenticationDatabaseName);
+
+        List<String> queryParams = new ArrayList<>();
+
+        /*
+         * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
+         */
+        if (datasourceConfiguration.getConnection() == null
+                || datasourceConfiguration.getConnection().getSsl() == null
+                || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
+            throw new AppsmithPluginException(
+                    AppsmithPluginError.PLUGIN_ERROR,
+                    "Appsmith server has failed to fetch SSL configuration from datasource configuration form. " +
+                            "Please reach out to Appsmith customer support to resolve this."
+            );
+        }
+
+        /*
+         * - By default, the driver configures SSL in the preferred mode.
+         */
+        SSLDetails.AuthType sslAuthType = datasourceConfiguration.getConnection().getSsl().getAuthType();
+        switch (sslAuthType) {
+            case ENABLED:
+                queryParams.add("ssl=true");
+
+                break;
+            case DISABLED:
+                queryParams.add("ssl=false");
+
+                break;
+            case DEFAULT:
+                /* do nothing - accept default driver setting */
+
+                break;
+            default:
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_ERROR,
+                        "Appsmith server has found an unexpected SSL option: " + sslAuthType + ". Please reach out to" +
+                                " Appsmith customer support to resolve this."
+                );
+        }
+
+        if (hasUsername && authentication.getAuthType() != null) {
+            queryParams.add("authMechanism=" + authentication.getAuthType().name().replace('_', '-'));
+        }
+
+        if (!queryParams.isEmpty()) {
+            builder.append('?');
+            for (String param : queryParams) {
+                builder.append(param).append('&');
+            }
+            // Delete the trailing ampersand.
+            builder.deleteCharAt(builder.length() - 1);
+        }
+
+        return builder.toString();
+    }
+
+    private static boolean hostStringHasConnectionURIHead(String host) {
+        if (!StringUtils.isEmpty(host) && (host.contains("mongodb://") || host.contains("mongodb+srv"))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static boolean isHostStringConnectionURI(Endpoint endpoint) {
+        if (endpoint != null && hostStringHasConnectionURIHead(endpoint.getHost())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static boolean isAuthenticated(DBAuth authentication, String mongoUri) {
+        if (authentication != null && authentication.getUsername() != null
+                && authentication.getPassword() != null && mongoUri.contains("****")) {
+
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.DBRef;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
-import com.mongodb.DBRef;
 import org.bson.Document;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Decimal128;
@@ -75,6 +75,7 @@ import static com.external.plugins.constants.FieldName.SMART_SUBSTITUTION;
 import static com.external.plugins.constants.FieldName.UPDATE_LIMIT;
 import static com.external.plugins.constants.FieldName.UPDATE_OPERATION;
 import static com.external.plugins.constants.FieldName.UPDATE_QUERY;
+import static com.external.plugins.utils.DatasourceUtils.buildClientURI;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2432,59 +2433,6 @@ public class MongoPluginTest {
                     assertEquals(value.asInt(), 3);
                 })
                 .verifyComplete();
-    }
-
-    @Test
-    public void testBuildClientURI_withoutUserInfoAndAuthSource() {
-
-        final String testUri = "mongodb://host:port/db?param";
-        final String resultUri = "mongodb://host:port/db?param&authSource=admin";
-
-        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
-        final DBAuth dbAuth = new DBAuth();
-        datasourceConfiguration.setAuthentication(dbAuth);
-        datasourceConfiguration.setProperties(List.of(
-                new Property("0", "Yes"),
-                new Property("1", testUri)
-        ));
-        final String clientURI = pluginExecutor.buildClientURI(datasourceConfiguration);
-        assertEquals(resultUri, clientURI);
-    }
-
-    @Test
-    public void testBuildClientURI_withUserInfoAndAuthSource() {
-
-        final String testUri = "mongodb://user:pass@host:port/db?param&authSource=notAdmin";
-        final String resultUri = "mongodb://user:newPass@host:port/db?param&authSource=notAdmin";
-
-        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
-        final DBAuth dbAuth = new DBAuth();
-        dbAuth.setPassword("newPass");
-        datasourceConfiguration.setAuthentication(dbAuth);
-        datasourceConfiguration.setProperties(List.of(
-                new Property("0", "Yes"),
-                new Property("1", testUri)
-        ));
-        final String clientURI = pluginExecutor.buildClientURI(datasourceConfiguration);
-        assertEquals(resultUri, clientURI);
-    }
-
-    @Test
-    public void testBuildClientURI_withoutDbInfoAndPortsAndParams() {
-
-        final String testUri = "mongodb://user:pass@host";
-        final String resultUri = "mongodb://user:newPass@host/?authSource=admin";
-
-        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
-        final DBAuth dbAuth = new DBAuth();
-        dbAuth.setPassword("newPass");
-        datasourceConfiguration.setAuthentication(dbAuth);
-        datasourceConfiguration.setProperties(List.of(
-                new Property("0", "Yes"),
-                new Property("1", testUri)
-        ));
-        final String clientURI = pluginExecutor.buildClientURI(datasourceConfiguration);
-        assertEquals(resultUri, clientURI);
     }
 
     @Test

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/utils/DatasourceUtilsTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/utils/DatasourceUtilsTest.java
@@ -1,0 +1,69 @@
+package com.external.plugins.utils;
+
+import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.Property;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.external.plugins.utils.DatasourceUtils.buildClientURI;
+import static org.junit.Assert.assertEquals;
+
+public class DatasourceUtilsTest {
+
+    @Test
+    public void testBuildClientURI_withoutDbInfoAndPortsAndParams() {
+
+        final String testUri = "mongodb://user:pass@host";
+        final String resultUri = "mongodb://user:newPass@host/?authsource=admin&minpoolsize=0";
+
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        final DBAuth dbAuth = new DBAuth();
+        dbAuth.setPassword("newPass");
+        datasourceConfiguration.setAuthentication(dbAuth);
+        datasourceConfiguration.setProperties(List.of(
+                new Property("0", "Yes"),
+                new Property("1", testUri)
+        ));
+        final String clientURI = buildClientURI(datasourceConfiguration);
+        assertEquals(resultUri, clientURI);
+    }
+
+
+    @Test
+    public void testBuildClientURI_withoutUserInfoAndAuthSource() {
+
+        final String testUri = "mongodb://host:port/db?param";
+        final String resultUri = "mongodb://host:port/db?param&authsource=admin&minpoolsize=0";
+
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        final DBAuth dbAuth = new DBAuth();
+        datasourceConfiguration.setAuthentication(dbAuth);
+        datasourceConfiguration.setProperties(List.of(
+                new Property("0", "Yes"),
+                new Property("1", testUri)
+        ));
+        final String clientURI = buildClientURI(datasourceConfiguration);
+        assertEquals(resultUri, clientURI);
+    }
+
+    @Test
+    public void testBuildClientURI_withUserInfoAndAuthSource() {
+
+        final String testUri = "mongodb://user:pass@host:port/db?param&authSource=notAdmin";
+        final String resultUri = "mongodb://user:newPass@host:port/db?param&authsource=notAdmin&minpoolsize=0";
+
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        final DBAuth dbAuth = new DBAuth();
+        dbAuth.setPassword("newPass");
+        datasourceConfiguration.setAuthentication(dbAuth);
+        datasourceConfiguration.setProperties(List.of(
+                new Property("0", "Yes"),
+                new Property("1", testUri)
+        ));
+        final String clientURI = buildClientURI(datasourceConfiguration);
+        assertEquals(resultUri, clientURI);
+    }
+
+}


### PR DESCRIPTION
The mongo plugin retries creating connections passively in the pool all the time right now because the pool is initialized with a setting to always have at least one connection open. This fix forces all datasources to allow 0 connections as well. This will allow incorrect datasource configurations to not keep attempting the connection. 

Also contains refactoring since the logic for URIs was crowding the `MongoPluginExecutor` class.

Do we also need to be checking for the duration of time that each connection is held on to even when idle?

Fixes #4142

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit tests for parameter additions
- Manually tested for connection recreation attempts

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
