### PR TITLE
chore: Migrating Github release workflow to use Buildjet for client build

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -44,7 +44,7 @@ jobs:
     needs:
       - prelude
 
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2004
 
     defaults:
       run:


### PR DESCRIPTION
The Github release workflow takes a lot of time for client build step. Moving to Buildjet to speed this CI workflow.