### PR TITLE
fix: Removed redundant init_ssl_cert function call

### DIFF
--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -47,7 +47,6 @@ if [[ -n ${APPSMITH_CUSTOM_DOMAIN-} ]] && [[ -z ${DYNO-} ]]; then
   APP_TEMPLATE="$https_conf"
   if ! [[ -e "/etc/letsencrypt/live/$APPSMITH_CUSTOM_DOMAIN" ]]; then
     source "/opt/appsmith/init_ssl_cert.sh"
-    init_ssl_cert "$APPSMITH_CUSTOM_DOMAIN"
     if ! init_ssl_cert "$APPSMITH_CUSTOM_DOMAIN"; then
       echo "Status code from init_ssl_cert is $?"
       APP_TEMPLATE="$http_conf"


### PR DESCRIPTION
## Description
The redundant `init_ssl_cert` function call was preventing the clean up of ngnix process, if the certificate provisioning had failed, and preventing falling back to using `nginx-app-http.conf`.

Fixes # [12814](https://github.com/appsmithorg/appsmith/issues/12814)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually on a sandbox instance, by setting an invalid APPSMITH_CUSTOM_DOMAIN

