### PR TITLE
fix: Overriding margin and padding for custom render in the dropdown component

### DIFF
--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -451,7 +451,7 @@ const SelectedDropDownHolder = styled.div`
     text-overflow: ellipsis;
   }
 
-  & > * {
+  &.custom-render-option > * {
     // below if to override any custom margin and padding added in the render option
     // because the above container already comes with a padding
     // which will result broken UI
@@ -605,7 +605,9 @@ function DefaultDropDownValueNode({
   }
 
   return (
-    <SelectedDropDownHolder>
+    <SelectedDropDownHolder
+      className={renderNode ? "custom-render-option" : ""}
+    >
       {renderNode ? (
         renderNode({
           isSelectedNode: true,

--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -249,7 +249,8 @@ const Selected = styled.div<{
         ? props.hasError
           ? Colors.FAIR_PINK
           : props.theme.colors.dropdown.hovered.bg
-        : Colors.WHITE}
+        : Colors.WHITE};
+  }
 `;
 
 export const DropdownContainer = styled.div<{ width: string; height?: string }>`
@@ -448,6 +449,14 @@ const SelectedDropDownHolder = styled.div`
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  & > * {
+    // below if to override any custom margin and padding added in the render option
+    // because the above container already comes with a padding
+    // which will result broken UI
+    margin: 0 !important;
+    padding: 0 !important;
   }
 `;
 


### PR DESCRIPTION
## Description

This PR includes the changes for overriding the margin and padding for the custom render option in Appsmith Design System dropdown component.

Fixes #12025

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Checked the dropdown which implements custom render. for eg. Generate page select datasource dropdown 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/12025-ads-select-component-selected-flag-style-fix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/components/ads/Dropdown.tsx | 84.23 **(0)** | 62.83 **(-0.08)** | 73.61 **(0)** | 83.26 **(0)**</details>