### PR TITLE
feat: Handle stringified json response and fix alignment issue

### DIFF
--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -240,7 +240,7 @@ export const responseTabComponent = (
         folding
         height={"100%"}
         input={{
-          value: output ? JSON.stringify(output, null, 2) : "",
+          value: isString(output) ? output : JSON.stringify(output, null, 2),
         }}
         isReadOnly
       />
@@ -253,7 +253,7 @@ export const responseTabComponent = (
         folding
         height={"100%"}
         input={{
-          value: output ? JSON.stringify(output, null, 2) : "",
+          value: isString(output) ? output : JSON.stringify(output, null, 2),
         }}
         isRawView
         isReadOnly
@@ -390,7 +390,7 @@ function ApiResponseView(props: Props) {
               </NoResponseContainer>
             ) : (
               <ResponseBodyContainer>
-                {isString(response.body) && isHtml(response.body) && (
+                {isString(response.body) && isHtml(response.body) ? (
                   <ReadOnlyEditor
                     folding
                     height={"100%"}
@@ -399,11 +399,9 @@ function ApiResponseView(props: Props) {
                     }}
                     isReadOnly
                   />
-                )}
-                {!isString(response.body) &&
-                responseTabs &&
-                responseTabs.length > 0 &&
-                selectedTabIndex !== -1 ? (
+                ) : responseTabs &&
+                  responseTabs.length > 0 &&
+                  selectedTabIndex !== -1 ? (
                   <EntityBottomTabs
                     defaultIndex={selectedTabIndex}
                     onSelect={onResponseTabSelect}

--- a/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiRightPane.tsx
@@ -30,10 +30,12 @@ const EmptyDatasourceContainer = styled.div`
 `;
 
 const DatasourceContainer = styled.div`
-  .react-tabs__tab-list {
+  &&&&&&&&&&& .react-tabs__tab-list {
     padding: 0 16px !important;
     border-bottom: none;
     border-left: 2px solid #e8e8e8;
+    margin-left: 0px;
+    margin-right: 0px;
     .cs-icon {
       margin-right: 0;
     }


### PR DESCRIPTION
This PR handles:

1. JSON responses for content-types like application/ld+json which always return stringified json objects as a response (this is unlike content-types like application/json which return an array of objects).
2. A misalignment inconsistency in the ApiRightPane of the ApiEditor page.


Fixes #3911 and #12780

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feat/handle-stringified-json-response 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.34 **(0)** | 37.73 **(-0.01)** | 35.94 **(0)** | 56.56 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>