### PR TITLE
fix: git remote SSH url for Azure | FE

### DIFF
--- a/app/client/src/pages/Editor/gitSync/utils.test.ts
+++ b/app/client/src/pages/Editor/gitSync/utils.test.ts
@@ -14,9 +14,12 @@ const validUrls = [
   "ssh://host.xz/~user/path/to/repo.git",
   "ssh://user@host.xz/~/path/to/repo.git",
   "ssh://host.xz/~/path/to/repo.git",
+  "git@ssh.dev.azure.com:v3/something/other/thing",
+  "git@ssh.dev.azure.com:v3/something/other/thing.git",
 ];
 
 const invalidUrls = [
+  "git@ssh.dev.azure.com:v3/something/other/thing/",
   "gitclonegit://a@b:c/d.git",
   "https://github.com/user/project.git",
   "http://github.com/user/project.git",

--- a/app/client/src/pages/Editor/gitSync/utils.ts
+++ b/app/client/src/pages/Editor/gitSync/utils.ts
@@ -12,7 +12,7 @@ export const getIsStartingWithRemoteBranches = (
   );
 };
 
-const GIT_REMOTE_URL_PATTERN = /^((git|ssh)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)$/im;
+const GIT_REMOTE_URL_PATTERN = /^((git|ssh)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)[^\/]$/im;
 
 const gitRemoteUrlRegExp = new RegExp(GIT_REMOTE_URL_PATTERN);
 


### PR DESCRIPTION
## Description

Azure SSH url was not getting accepted by FE code while connecting an application to git.

Fixes #12891 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests

## After change

<img width="967" alt="Screenshot 2022-04-13 at 3 13 26 PM" src="https://user-images.githubusercontent.com/1573771/163152221-d11fa888-c1ab-4728-b734-4e63f4c0dea3.png">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>