### PR TITLE
fix: Remove postdeploy script in app.json for heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,9 +17,6 @@
     "logo": "https://raw.githubusercontent.com/appsmithorg/appsmith/master/static/logo.png",
     "success_url": "/",
     "stack": "container",
-    "scripts": {
-        "postdeploy" : "/analytics.sh"
-    },
     "env": {
       "APPSMITH_MONGODB_URI": {
         "description": "Your Mongo Database URI. Since Heroku doesn't support a managed MongoDB instance, you'll have to create a Mongo DB instance on another service such as https://cloud.mongodb.com",


### PR DESCRIPTION

## Description
- Remove postdeploy script define in app.json which is used for Heroku one click deployment
## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
