### PR TITLE
feat: makes option control delete button keyboard accessible

### DIFF
--- a/app/client/src/components/propertyControls/KeyValueComponent.tsx
+++ b/app/client/src/components/propertyControls/KeyValueComponent.tsx
@@ -49,10 +49,8 @@ function updateOptionValue<T>(
 }
 
 const StyledDeleteIcon = styled(FormIcons.DELETE_ICON as AnyStyledComponent)`
-  padding: 0px 5px;
-  position: absolute;
-  right: 4px;
   cursor: pointer;
+
   && svg path {
     fill: ${(props) => props.theme.colors.propertyPane.deleteIconColor};
   }
@@ -64,15 +62,24 @@ const StyledDeleteIcon = styled(FormIcons.DELETE_ICON as AnyStyledComponent)`
   }
 `;
 
-const StyledOptionControlWrapper = styled(ControlWrapper)`
-  display: flex;
-  justify-content: flex-start;
-  padding-right: 16px;
-  width: calc(100% - 10px);
-`;
-
 const StyledBox = styled.div`
   width: 10px;
+`;
+
+const StyledButton = styled.button`
+  width: 28px;
+  height: 28px;
+
+  &&& svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &&:focus {
+    svg path {
+      fill: ${(props) => props.theme.colors.propertyPane.title};
+    }
+  }
 `;
 
 type UpdatePairFunction = (pair: DropdownOption[]) => any;
@@ -191,7 +198,7 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
     <>
       {renderPairs.map((pair: DropDownOptionWithKey, index) => {
         return (
-          <StyledOptionControlWrapper key={pair.key} orientation={"HORIZONTAL"}>
+          <ControlWrapper key={pair.key} orientation={"HORIZONTAL"}>
             <StyledInputGroup
               dataType={"text"}
               onBlur={onInputBlur}
@@ -213,14 +220,15 @@ export function KeyValueComponent(props: KeyValueComponentProps) {
               placeholder={"Value"}
               value={pair.value}
             />
-            <StyledDeleteIcon
-              height={24}
+            <StyledBox />
+            <StyledButton
               onClick={() => {
                 deletePair(index);
               }}
-              width={24}
-            />
-          </StyledOptionControlWrapper>
+            >
+              <StyledDeleteIcon />
+            </StyledButton>
+          </ControlWrapper>
         );
       })}
 


### PR DESCRIPTION
## Description

Change the option control delete button type from `<div>` to `<button>` so that it will be keyboard accessible.

Fixes #10615

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
