### PR TITLE
fix: Change response tab name

### DIFF
--- a/app/client/cypress/support/ApiCommands.js
+++ b/app/client/cypress/support/ApiCommands.js
@@ -136,7 +136,7 @@ Cypress.Commands.add(
     }
     cy.get(".string-value").contains(baseurl.concat(path));
     cy.get(".string-value").contains(verb);
-    cy.get("[data-cy=t--tab-body]")
+    cy.get("[data-cy=t--tab-response]")
       .first()
       .click({ force: true });
   },

--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -345,8 +345,8 @@ function ApiResponseView(props: Props) {
 
   const tabs = [
     {
-      key: "body",
-      title: "Body",
+      key: "response",
+      title: "Response",
       panelComponent: (
         <ResponseTabWrapper>
           {Array.isArray(messages) && messages.length > 0 && (


### PR DESCRIPTION
This PR changes the response tab name from "Body" to "Response"

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/response-body-tab-name 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.49 **(0)** | 37.99 **(0.01)** | 36.28 **(0)** | 56.71 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**</details>