### PR TITLE
fix: disable uid/gid bits for fat container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ RUN chmod 0644 /etc/cron.d/*
 
 RUN chmod +x entrypoint.sh renew-certificate.sh
 
+# disable uid/gid bits for the user inside container
+RUN find / \( -perm -2000 -o -perm -4000 \) | xargs chmod -s
+
 # Update path to load appsmith utils tool as default
 ENV PATH /opt/appsmith/utils/node_modules/.bin:$PATH
 


### PR DESCRIPTION
## Description
- Disable uid/gid bit when building docker image.
- Keep files ownership of user/group.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested?
- Build the image and run app to make sure it's functional normally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
