### PR TITLE
fix: Fix issues in git flows when pages don't have reference in application object

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static com.appsmith.external.constants.GitConstants.NAME_SEPARATOR;
 import static com.appsmith.git.constants.GitDirectories.ACTION_COLLECTION_DIRECTORY;
 import static com.appsmith.git.constants.GitDirectories.ACTION_DIRECTORY;
 import static com.appsmith.git.constants.GitDirectories.DATASOURCE_DIRECTORY;
@@ -180,7 +181,7 @@ public class FileUtilsImpl implements FileInterface {
                         // queryName_pageName => nomenclature for the keys
                         // TODO
                         //  queryName => for app level queries, this is not implemented yet
-                        String[] names = resource.getKey().split("_");
+                        String[] names = resource.getKey().split(NAME_SEPARATOR);
                         if (names.length > 1 && StringUtils.hasLength(names[1])) {
                             // For actions, we are referring to validNames to maintain unique file names as just name
                             // field don't guarantee unique constraint for actions within JSObject
@@ -200,7 +201,7 @@ public class FileUtilsImpl implements FileInterface {
                         // JSObjectName_pageName => nomenclature for the keys
                         // TODO
                         //  JSObjectName => for app level JSObjects, this is not implemented yet
-                        String[] names = resource.getKey().split("_");
+                        String[] names = resource.getKey().split(NAME_SEPARATOR);
                         if (names.length > 1 && StringUtils.hasLength(names[1])) {
                             final String actionCollectionName = names[0];
                             final String pageName = names[1];

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/GitConstants.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/GitConstants.java
@@ -1,0 +1,7 @@
+package com.appsmith.external.constants;
+
+public class GitConstants {
+    // This will be used as a key separator for action and jsobjects name
+    // pageName{{seperator}}entityName this is needed to filter the entities to save in appropriate page directory
+    public static final String NAME_SEPARATOR = "##ENTITY_SEPARATOR##";
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -20,6 +20,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.google.gson.Gson;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.PredicateUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
@@ -40,6 +41,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static com.appsmith.external.constants.GitConstants.NAME_SEPARATOR;
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyNestedNonNullProperties;
 import static com.appsmith.external.helpers.AppsmithBeanUtils.copyProperties;
 import static com.appsmith.server.constants.FieldName.ACTION_COLLECTION_LIST;
@@ -61,7 +63,6 @@ public class GitFileUtils {
     // Only include the application helper fields in metadata object
     private static final Set<String> blockedMetadataFields
         = Set.of(EXPORTED_APPLICATION, DATASOURCE_LIST, PAGE_LIST, ACTION_LIST, ACTION_COLLECTION_LIST, DECRYPTED_FIELDS, EDIT_MODE_THEME);
-
     /**
      * This method will save the complete application in the local repo directory.
      * Path to repo will be : ./container-volumes/git-repo/organizationId/defaultApplicationId/repoName/{application_data}
@@ -134,8 +135,8 @@ public class GitFileUtils {
                         && newAction.getUnpublishedAction().getDeletedAt() == null)
                 .forEach(newAction -> {
                     String prefix = newAction.getUnpublishedAction() != null ?
-                            newAction.getUnpublishedAction().getValidName() + "_" + newAction.getUnpublishedAction().getPageId()
-                            : newAction.getPublishedAction().getValidName() + "_" + newAction.getPublishedAction().getPageId();
+                            newAction.getUnpublishedAction().getValidName() + NAME_SEPARATOR + newAction.getUnpublishedAction().getPageId()
+                            : newAction.getPublishedAction().getValidName() + NAME_SEPARATOR + newAction.getPublishedAction().getPageId();
                     removeUnwantedFieldFromAction(newAction);
                     resourceMap.put(prefix, newAction);
                 });
@@ -151,8 +152,8 @@ public class GitFileUtils {
                         && collection.getUnpublishedCollection().getDeletedAt() == null)
                 .forEach(actionCollection -> {
                     String prefix = actionCollection.getUnpublishedCollection() != null ?
-                            actionCollection.getUnpublishedCollection().getName() + "_" + actionCollection.getUnpublishedCollection().getPageId()
-                            : actionCollection.getPublishedCollection().getName() + "_" + actionCollection.getPublishedCollection().getPageId();
+                            actionCollection.getUnpublishedCollection().getName() + NAME_SEPARATOR + actionCollection.getUnpublishedCollection().getPageId()
+                            : actionCollection.getPublishedCollection().getName() + NAME_SEPARATOR + actionCollection.getPublishedCollection().getPageId();
 
                     removeUnwantedFieldFromActionCollection(actionCollection);
 
@@ -362,6 +363,7 @@ public class GitFileUtils {
         Gson gson = new Gson();
         // Extract pages
         List<NewPage> pages = getApplicationResource(applicationReference.getPages(), NewPage.class);
+        org.apache.commons.collections.CollectionUtils.filter(pages, PredicateUtils.notNullPredicate());
         pages.forEach(newPage -> {
             // As we are publishing the app and then committing to git we expect the published and unpublished PageDTO
             // will be same, so we create a deep copy for the published version for page from the unpublishedPageDTO
@@ -374,6 +376,7 @@ public class GitFileUtils {
             applicationJson.setActionList(new ArrayList<>());
         } else {
             List<NewAction> actions = getApplicationResource(applicationReference.getActions(), NewAction.class);
+            org.apache.commons.collections.CollectionUtils.filter(actions, PredicateUtils.notNullPredicate());
             actions.forEach(newAction -> {
                 // As we are publishing the app and then committing to git we expect the published and unpublished
                 // actionDTO will be same, so we create a deep copy for the published version for action from
@@ -388,6 +391,7 @@ public class GitFileUtils {
             applicationJson.setActionCollectionList(new ArrayList<>());
         } else {
             List<ActionCollection> actionCollections = getApplicationResource(applicationReference.getActionsCollections(), ActionCollection.class);
+            org.apache.commons.collections.CollectionUtils.filter(actionCollections, PredicateUtils.notNullPredicate());
             actionCollections.forEach(actionCollection -> {
                 // As we are publishing the app and then committing to git we expect the published and unpublished
                 // actionCollectionDTO will be same, so we create a deep copy for the published version for

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -105,11 +105,13 @@ public class GitFileUtils {
 
         applicationReference.setTheme(applicationJson.getEditModeTheme());
 
-        // Pass pages within the application
+        // Insert only active pages which will then be converted into individual file
         Map<String, Object> resourceMap = new HashMap<>();
         applicationJson
                 .getPageList()
                 .stream()
+                // As we are expecting the commit will happen only after the application is published, so we can safely
+                // assume if the unpublished version is deleted entity should not be committed to git
                 .filter(newPage -> newPage.getUnpublishedPage() != null
                         && newPage.getUnpublishedPage().getDeletedAt() == null)
                 .forEach(newPage -> {
@@ -124,13 +126,15 @@ public class GitFileUtils {
         applicationReference.setPages(new HashMap<>(resourceMap));
         resourceMap.clear();
 
-        // Insert actions and also assign the keys which later will be used for saving the resource in actual filepath
+        // Insert active actions and also assign the keys which later will be used for saving the resource in actual filepath
         // For actions, we are referring to validNames to maintain unique file names as just name
         // field don't guarantee unique constraint for actions within JSObject
         // queryValidName_pageName => nomenclature for the keys
         applicationJson
                 .getActionList()
                 .stream()
+                // As we are expecting the commit will happen only after the application is published, so we can safely
+                // assume if the unpublished version is deleted entity should not be committed to git
                 .filter(newAction -> newAction.getUnpublishedAction() != null
                         && newAction.getUnpublishedAction().getDeletedAt() == null)
                 .forEach(newAction -> {
@@ -148,6 +152,8 @@ public class GitFileUtils {
         applicationJson
                 .getActionCollectionList()
                 .stream()
+                // As we are expecting the commit will happen only after the application is published, so we can safely
+                // assume if the unpublished version is deleted entity should not be committed to git
                 .filter(collection -> collection.getUnpublishedCollection() != null
                         && collection.getUnpublishedCollection().getDeletedAt() == null)
                 .forEach(actionCollection -> {
@@ -363,6 +369,7 @@ public class GitFileUtils {
         Gson gson = new Gson();
         // Extract pages
         List<NewPage> pages = getApplicationResource(applicationReference.getPages(), NewPage.class);
+        // Remove null values
         org.apache.commons.collections.CollectionUtils.filter(pages, PredicateUtils.notNullPredicate());
         pages.forEach(newPage -> {
             // As we are publishing the app and then committing to git we expect the published and unpublished PageDTO
@@ -376,6 +383,7 @@ public class GitFileUtils {
             applicationJson.setActionList(new ArrayList<>());
         } else {
             List<NewAction> actions = getApplicationResource(applicationReference.getActions(), NewAction.class);
+            // Remove null values if present
             org.apache.commons.collections.CollectionUtils.filter(actions, PredicateUtils.notNullPredicate());
             actions.forEach(newAction -> {
                 // As we are publishing the app and then committing to git we expect the published and unpublished
@@ -391,6 +399,7 @@ public class GitFileUtils {
             applicationJson.setActionCollectionList(new ArrayList<>());
         } else {
             List<ActionCollection> actionCollections = getApplicationResource(applicationReference.getActionsCollections(), ActionCollection.class);
+            // Remove null values if present
             org.apache.commons.collections.CollectionUtils.filter(actionCollections, PredicateUtils.notNullPredicate());
             actionCollections.forEach(actionCollection -> {
                 // As we are publishing the app and then committing to git we expect the published and unpublished

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -80,6 +80,23 @@ public class GitFileUtils {
             2. Create application reference for appsmith-git module
             3. Save application to git repo
          */
+        ApplicationGitReference applicationReference = createApplicationReference(applicationJson);
+        // Save application to git repo
+        try {
+            return fileUtils.saveApplicationToGitRepo(baseRepoSuffix, applicationReference, branchName);
+        } catch (IOException | GitAPIException e) {
+            log.error("Error occurred while saving files to local git repo: ", e);
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    /**
+     * Method to convert application resources to the structure which can be serialised by appsmith-git module for
+     * serialisation
+     * @param applicationJson application resource including actions, jsobjects, pages
+     * @return                resource which can be saved to file system
+     */
+    public ApplicationGitReference createApplicationReference(ApplicationJson applicationJson) {
         ApplicationGitReference applicationReference = new ApplicationGitReference();
 
         Application application = applicationJson.getExportedApplication();
@@ -105,7 +122,7 @@ public class GitFileUtils {
 
         applicationReference.setTheme(applicationJson.getEditModeTheme());
 
-        // Insert only active pages which will then be converted into individual file
+        // Insert only active pages which will then be committed to repo as individual file
         Map<String, Object> resourceMap = new HashMap<>();
         applicationJson
                 .getPageList()
@@ -178,14 +195,7 @@ public class GitFileUtils {
         applicationReference.setDatasources(new HashMap<>(resourceMap));
         resourceMap.clear();
 
-
-        // Save application to git repo
-        try {
-            return fileUtils.saveApplicationToGitRepo(baseRepoSuffix, applicationReference, branchName);
-        } catch (IOException | GitAPIException e) {
-            log.error("Error occurred while saving files to local git repo: ", e);
-            throw Exceptions.propagate(e);
-        }
+        return applicationReference;
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -106,15 +106,20 @@ public class GitFileUtils {
 
         // Pass pages within the application
         Map<String, Object> resourceMap = new HashMap<>();
-        applicationJson.getPageList().forEach(newPage -> {
-            String pageName = newPage.getUnpublishedPage() != null
-                    ? newPage.getUnpublishedPage().getName()
-                    : newPage.getPublishedPage().getName();
+        applicationJson
+                .getPageList()
+                .stream()
+                .filter(newPage -> newPage.getUnpublishedPage() != null
+                        && newPage.getUnpublishedPage().getDeletedAt() == null)
+                .forEach(newPage -> {
+                    String pageName = newPage.getUnpublishedPage() != null
+                            ? newPage.getUnpublishedPage().getName()
+                            : newPage.getPublishedPage().getName();
+                    removeUnwantedFieldsFromPage(newPage);
+                    // pageName will be used for naming the json file
+                    resourceMap.put(pageName, newPage);
+                });
 
-            removeUnwantedFieldsFromPage(newPage);
-            // pageName will be used for naming the json file
-            resourceMap.put(pageName, newPage);
-        });
         applicationReference.setPages(new HashMap<>(resourceMap));
         resourceMap.clear();
 
@@ -122,36 +127,47 @@ public class GitFileUtils {
         // For actions, we are referring to validNames to maintain unique file names as just name
         // field don't guarantee unique constraint for actions within JSObject
         // queryValidName_pageName => nomenclature for the keys
-        applicationJson.getActionList().forEach(newAction -> {
-            String prefix = newAction.getUnpublishedAction() != null ?
-                    newAction.getUnpublishedAction().getValidName() + "_" + newAction.getUnpublishedAction().getPageId()
-                    : newAction.getPublishedAction().getValidName() + "_" + newAction.getPublishedAction().getPageId();
-            removeUnwantedFieldFromAction(newAction);
-            resourceMap.put(prefix, newAction);
-        });
+        applicationJson
+                .getActionList()
+                .stream()
+                .filter(newAction -> newAction.getUnpublishedAction() != null
+                        && newAction.getUnpublishedAction().getDeletedAt() == null)
+                .forEach(newAction -> {
+                    String prefix = newAction.getUnpublishedAction() != null ?
+                            newAction.getUnpublishedAction().getValidName() + "_" + newAction.getUnpublishedAction().getPageId()
+                            : newAction.getPublishedAction().getValidName() + "_" + newAction.getPublishedAction().getPageId();
+                    removeUnwantedFieldFromAction(newAction);
+                    resourceMap.put(prefix, newAction);
+                });
         applicationReference.setActions(new HashMap<>(resourceMap));
         resourceMap.clear();
 
         // Insert JSOObjects and also assign the keys which later will be used for saving the resource in actual filepath
         // JSObjectName_pageName => nomenclature for the keys
-        applicationJson.getActionCollectionList().forEach(actionCollection -> {
-            String prefix = actionCollection.getUnpublishedCollection() != null ?
-                    actionCollection.getUnpublishedCollection().getName() + "_" + actionCollection.getUnpublishedCollection().getPageId()
-                    : actionCollection.getPublishedCollection().getName() + "_" + actionCollection.getPublishedCollection().getPageId();
+        applicationJson
+                .getActionCollectionList()
+                .stream()
+                .filter(collection -> collection.getUnpublishedCollection() != null
+                        && collection.getUnpublishedCollection().getDeletedAt() == null)
+                .forEach(actionCollection -> {
+                    String prefix = actionCollection.getUnpublishedCollection() != null ?
+                            actionCollection.getUnpublishedCollection().getName() + "_" + actionCollection.getUnpublishedCollection().getPageId()
+                            : actionCollection.getPublishedCollection().getName() + "_" + actionCollection.getPublishedCollection().getPageId();
 
-            removeUnwantedFieldFromActionCollection(actionCollection);
+                    removeUnwantedFieldFromActionCollection(actionCollection);
 
-            resourceMap.put(prefix, actionCollection);
-        });
+                    resourceMap.put(prefix, actionCollection);
+                });
         applicationReference.setActionsCollections(new HashMap<>(resourceMap));
         resourceMap.clear();
 
         // Send datasources
-        applicationJson.getDatasourceList().forEach(datasource -> {
+        applicationJson
+                .getDatasourceList()
+                .forEach(datasource -> {
                     removeUnwantedFieldsFromDatasource(datasource);
                     resourceMap.put(datasource.getName(), datasource);
-                }
-        );
+                });
         applicationReference.setDatasources(new HashMap<>(resourceMap));
         resourceMap.clear();
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -1,13 +1,16 @@
 package com.appsmith.server.migrations;
 
-import com.appsmith.server.domains.Application;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.QDatasource;
+import com.appsmith.server.domains.Application;
+import com.appsmith.server.domains.ApplicationPage;
 import com.appsmith.server.domains.NewAction;
+import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.QApplication;
 import com.appsmith.server.domains.QNewAction;
+import com.appsmith.server.domains.QNewPage;
 import com.appsmith.server.domains.QPlugin;
 import com.appsmith.server.dtos.ActionDTO;
 import com.appsmith.server.exceptions.AppsmithError;
@@ -18,10 +21,12 @@ import com.github.cloudyrock.mongock.driver.mongodb.springdata.v3.decorator.impl
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -651,6 +656,60 @@ public class DatabaseChangelog2 {
                 Update.update(fieldName(QApplication.application.applicationVersion),
                         ApplicationVersion.EARLIEST_VERSION),
                 Application.class);
+    }
+
+    @ChangeSet(order = "006", id = "delete-orphan-pages", author = "")
+    public void deleteOrphanPages(MongockTemplate mongockTemplate) {
+
+        final Query validPagesQuery = query(where(fieldName(QApplication.application.deleted)).ne(true));
+        validPagesQuery.fields().include(fieldName(QApplication.application.pages));
+        validPagesQuery.fields().include(fieldName(QApplication.application.publishedPages));
+
+        final List<Application> applications = mongockTemplate.find(validPagesQuery, Application.class);
+
+        final Update deletionUpdates = new Update();
+        deletionUpdates.set(fieldName(QNewPage.newPage.deleted), true);
+        deletionUpdates.set(fieldName(QNewPage.newPage.deletedAt), Instant.now());
+
+        // Archive the pages without applicationId
+        final Query orphanPageQuery = query(where(fieldName(QNewAction.newAction.deleted)).ne(true));
+        orphanPageQuery.addCriteria(where(fieldName(QNewPage.newPage.applicationId)).exists(false));
+        orphanPageQuery.fields().include(fieldName(QNewAction.newAction.applicationId));
+        mongockTemplate.updateMulti(
+                orphanPageQuery,
+                deletionUpdates,
+                NewPage.class
+        );
+
+        // Archive the pages which have the applicationId but the connection is missing from the application object.
+        for (Application application : applications) {
+            Set<String> validPageIds = new HashSet<>();
+            if (!CollectionUtils.isEmpty(application.getPages())) {
+                for (ApplicationPage applicationPage : application.getPages()) {
+                    validPageIds.add(applicationPage.getId());
+                }
+            }
+            if (!CollectionUtils.isEmpty(application.getPublishedPages())) {
+                for (ApplicationPage applicationPublishedPage : application.getPublishedPages()) {
+                    validPageIds.add(applicationPublishedPage.getId());
+                }
+            }
+            final Query pageQuery = query(where(fieldName(QNewPage.newPage.deleted)).ne(true));
+            pageQuery.addCriteria(where(fieldName(QNewPage.newPage.applicationId)).is(application.getId()));
+            pageQuery.fields().include(fieldName(QNewPage.newPage.applicationId));
+
+            final List<NewPage> pages = mongockTemplate.find(pageQuery, NewPage.class);
+            for (NewPage newPage : pages) {
+                if (!validPageIds.contains(newPage.getId())) {
+                    log.debug("Orphan page: {}", newPage.getId());
+                    mongockTemplate.updateFirst(
+                            query(where(fieldName(QNewPage.newPage.id)).is(newPage.getId())),
+                            deletionUpdates,
+                            NewPage.class
+                    );
+                }
+            }
+        }
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -920,6 +920,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                                 // This does not apply to the traditional import via file approach
                                                 return Flux.fromIterable(invalidPageIds)
                                                         .flatMap(applicationPageService::deleteUnpublishedPage)
+                                                        .flatMap(page -> newPageService.archiveById(page.getId()))
                                                         .then()
                                                         .thenReturn(applicationPages);
                                             });


### PR DESCRIPTION
## Description

> As a part of git-directory update we have introduced a bug where if the entity names includes the `-` we were not able to filter the entities in the individual page directory. This PR introduces a new name-seperator to avoid such issues. 

> Also in the merge operation we used to delete only the unpublishedPages which resulted in stale pages, where page object had the applicationId but the same application did not had the reference of pageId in `pages` and `publishedPages` array. As a fix we are now not committing the entities in git which has non-null `deletedAt` field inside the unpublished resource as we expect commit flow will be triggered only after the publish.   

Fixes #13023 #13064 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> JUnit testcase
> Manual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
