### PR TITLE
fix: 12988 - deleting original default branch

### DIFF
--- a/app/client/src/reducers/uiReducers/applicationsReducer.tsx
+++ b/app/client/src/reducers/uiReducers/applicationsReducer.tsx
@@ -423,7 +423,26 @@ const applicationsReducer = createReducer(initialState, {
         branchName: action.payload,
       },
     },
-  }),
+  }), // updating default branch when git sync on branch list
+  [ReduxActionTypes.FETCH_BRANCHES_SUCCESS]: (
+    state: ApplicationsReduxState,
+    action: ReduxAction<any[]>,
+  ) => {
+    const defaultBranch = action.payload.find((branch: any) => branch.default);
+    if (defaultBranch) {
+      return {
+        ...state,
+        currentApplication: {
+          ...state.currentApplication,
+          gitApplicationMetadata: {
+            ...(state.currentApplication?.gitApplicationMetadata || {}),
+            defaultBranchName: defaultBranch.branchName,
+          },
+        },
+      };
+    }
+    return state;
+  },
   [ReduxActionTypes.INIT_DATASOURCE_CONNECTION_DURING_IMPORT_SUCCESS]: (
     state: ApplicationsReduxState,
   ) => ({


### PR DESCRIPTION
## Description

> When syncing git on branch list popup, default branch is updated from latest.

Fixes #12988 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please check it manually from linked issue.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/12988-delete-origin-default-branch 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.49 **(0)** | 37.98 **(-0.01)** | 36.27 **(0)** | 56.7 **(-0.01)**
 :red_circle: | app/client/src/reducers/uiReducers/applicationsReducer.tsx | 15.24 **(-0.76)** | 20 **(-7.27)** | 11.76 **(-0.48)** | 13.86 **(-0.57)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>