### PR TITLE
fix: onOptionChange event not triggering in JSON Form radio group field

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_FieldEvents_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_FieldEvents_spec.js
@@ -1,0 +1,43 @@
+/**
+ * Spec to test the events made available by each field type
+ */
+
+const dslWithoutSchema = require("../../../../../fixtures/jsonFormDslWithoutSchema.json");
+const commonlocators = require("../../../../../locators/commonlocators.json");
+
+const onSelectionChangeJSBtn =
+  ".t--property-control-onselectionchange .t--js-toggle";
+const fieldPrefix = ".t--jsonformfield";
+
+describe("JSONForm Radio Group Field", () => {
+  before(() => {
+    const schema = {
+      answer: "Y",
+    };
+    cy.addDsl(dslWithoutSchema);
+    cy.openPropertyPane("jsonformwidget");
+    cy.testJsontext("sourcedata", JSON.stringify(schema));
+    cy.openFieldConfiguration("answer");
+    cy.selectDropdownValue(commonlocators.jsonFormFieldType, "Radio Group");
+    cy.closePropertyPane();
+  });
+
+  it("shows alert on optionChange", () => {
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("answer");
+
+    // Enable JS mode for onSelectionChange
+    cy.get(onSelectionChangeJSBtn).click({ force: true });
+
+    // Add onSelectionChange action
+    cy.testJsontext("onselectionchange", "{{showAlert('Selection change')}}");
+
+    cy.get(`${fieldPrefix}-answer`)
+      .find("label")
+      .contains("No")
+      .click({ force: true });
+
+    // Check for alert
+    cy.get(commonlocators.toastmsg).contains("Selection change");
+  });
+});

--- a/app/client/src/widgets/JSONFormWidget/fields/RadioGroupField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/RadioGroupField.tsx
@@ -62,7 +62,7 @@ function RadioGroupField({
 
       if (schemaItem.onSelectionChange && executeAction) {
         executeAction({
-          triggerPropertyName: "onSelectionOptionChange",
+          triggerPropertyName: "onSelectionChange",
           dynamicString: schemaItem.onSelectionChange,
           event: {
             type: EventType.ON_OPTION_CHANGE,

--- a/app/client/src/widgets/RadioGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/component/index.tsx
@@ -64,7 +64,7 @@ function RadioGroupComponent(props: RadioGroupComponentProps) {
     (event: React.FormEvent<HTMLInputElement>) => {
       onRadioSelectionChange(event.currentTarget.value);
     },
-    [],
+    [onRadioSelectionChange],
   );
 
   return (


### PR DESCRIPTION
## Description

Fixes #13022 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual
- Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/13022-jsonform-radiogrp-event 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.48 **(-0.01)** | 37.98 **(-0.01)** | 36.27 **(0)** | 56.7 **(-0.01)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**</details>