### PR TITLE
fix: table Widget Multiselect Row checkbox alignment

### DIFF
--- a/app/client/src/widgets/TableWidget/component/TableStyledWrappers.tsx
+++ b/app/client/src/widgets/TableWidget/component/TableStyledWrappers.tsx
@@ -435,8 +435,12 @@ export const CellWrapper = styled.div<{
 `;
 
 export const CellCheckboxWrapper = styled(CellWrapper)<{ isChecked?: boolean }>`
-  justify-content: center;
-  width: 40px;
+  &&& {
+    justify-content: center;
+    width: 40px;
+    padding: 0px;
+    align-items: center;
+  }
   & > div {
     ${(props) =>
       props.isChecked

--- a/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
+++ b/app/client/src/widgets/TableWidget/component/TableUtilities.tsx
@@ -484,7 +484,6 @@ export const renderCheckBoxHeaderCell = (
     isChecked={!!checkState}
     onClick={onClick}
     role="columnheader"
-    style={{ padding: "0px", justifyContent: "center" }}
   >
     <CellCheckbox>
       {checkState === 1 && <CheckBoxCheckIcon className="th-svg" />}


### PR DESCRIPTION
## Description

Fix misalignment in the table widget checkbox when using multiselect Row

Fixes #12615

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Visual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/table-mutiselect-checkbox-alignment 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>