### PR TITLE
feat: JSONFrom add isValid form level property to represent overall form validity

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_FormProperties_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_FormProperties_spec.js
@@ -1,5 +1,6 @@
 const commonlocators = require("../../../../../locators/commonlocators.json");
 const dslWithSchema = require("../../../../../fixtures/jsonFormDslWithSchema.json");
+const widgetsPage = require("../../../../../locators/Widgets.json");
 
 const backBtn = ".t--property-pane-back-btn";
 const fieldPrefix = ".t--jsonformfield";
@@ -66,5 +67,24 @@ describe("JSON Form Widget Form Bindings", () => {
       .contains("Submit")
       .parent("button")
       .should("not.have.attr", "disabled");
+  });
+
+  it("Should set isValid to false when form is invalid", () => {
+    cy.openPropertyPane("textwidget");
+    cy.testJsontext("text", "{{JSONForm1.isValid}}");
+
+    cy.get(`${widgetsPage.textWidget} .bp3-ui-text`).contains("true");
+
+    cy.get(`${fieldPrefix}-name input`)
+      .clear()
+      .wait(300);
+
+    cy.get(`${widgetsPage.textWidget} .bp3-ui-text`).contains("false");
+
+    cy.get(`${fieldPrefix}-name input`)
+      .type("JOHN")
+      .wait(300);
+
+    cy.get(`${widgetsPage.textWidget} .bp3-ui-text`).contains("true");
   });
 });

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -571,6 +571,7 @@ export const entityDefinitions: Record<string, unknown> = {
     formData: generateTypeDef(widget.formData),
     sourceData: generateTypeDef(widget.sourceData),
     fieldState: generateTypeDef(widget.fieldState),
+    isValid: "bool",
   }),
   PROGRESS_WIDGET: {
     "!doc":

--- a/app/client/src/widgets/JSONFormWidget/component/Form.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/Form.tsx
@@ -25,6 +25,7 @@ export type FormProps<TValues = any> = PropsWithChildren<{
   getFormData: () => TValues;
   hideFooter: boolean;
   isSubmitting: boolean;
+  onFormValidityUpdate: (isValid: boolean) => void;
   onSubmit: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   registerResetObserver: (callback: () => void) => void;
   resetButtonLabel: string;
@@ -125,6 +126,7 @@ function Form<TValues = any>({
   getFormData,
   hideFooter,
   isSubmitting,
+  onFormValidityUpdate,
   onSubmit,
   registerResetObserver,
   resetButtonLabel,
@@ -231,6 +233,10 @@ function Form<TValues = any>({
       bodyRef.current.scrollTo({ top: 0 });
     }
   }, [scrollContents]);
+
+  useEffect(() => {
+    onFormValidityUpdate(!isFormInValid);
+  }, [onFormValidityUpdate, isFormInValid]);
 
   return (
     <FormProvider {...methods}>

--- a/app/client/src/widgets/JSONFormWidget/component/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/index.tsx
@@ -35,14 +35,15 @@ export type JSONFormComponentProps<TValues = any> = {
   executeAction: (actionPayload: ExecuteTriggerPayload) => void;
   fieldLimitExceeded: boolean;
   fixedFooter: boolean;
+  getFormData: () => TValues;
   isSubmitting: boolean;
+  onFormValidityUpdate: (isValid: boolean) => void;
   onSubmit: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   registerResetObserver: (callback: () => void) => void;
   renderMode: RenderMode;
   resetButtonLabel: string;
   resetButtonStyles: ButtonStyleProps;
   schema: Schema;
-  getFormData: () => TValues;
   scrollContents: boolean;
   submitButtonLabel: string;
   unregisterResetObserver: () => void;
@@ -94,6 +95,7 @@ function JSONFormComponent<TValues>({
   fieldLimitExceeded,
   getFormData,
   isSubmitting,
+  onFormValidityUpdate,
   registerResetObserver,
   renderMode,
   resetButtonLabel,
@@ -173,6 +175,7 @@ function JSONFormComponent<TValues>({
           getFormData={getFormData}
           hideFooter={hideFooter}
           isSubmitting={isSubmitting}
+          onFormValidityUpdate={onFormValidityUpdate}
           onSubmit={rest.onSubmit}
           registerResetObserver={registerResetObserver}
           resetButtonLabel={resetButtonLabel}

--- a/app/client/src/widgets/JSONFormWidget/widget/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/widget/index.tsx
@@ -285,6 +285,10 @@ class JSONFormWidget extends BaseWidget<
 
   getFormData = () => this.props.formData;
 
+  onFormValidityUpdate = (isValid: boolean) => {
+    this.props.updateWidgetMetaProperty("isValid", isValid);
+  };
+
   getPageView() {
     return (
       // Warning!!! Do not ever introduce formData as a prop directly,
@@ -303,6 +307,7 @@ class JSONFormWidget extends BaseWidget<
         fixedFooter={this.props.fixedFooter}
         getFormData={this.getFormData}
         isSubmitting={this.state.isSubmitting}
+        onFormValidityUpdate={this.onFormValidityUpdate}
         onSubmit={this.onSubmit}
         registerResetObserver={this.registerResetObserver}
         renderMode={this.props.renderMode}


### PR DESCRIPTION
## Description
Adds a form level property called `isValid` which can be used to check if the current form is valid (passes all validation) or not

Fixes #12771 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: feature/jsonform-invalid-property 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.48 **(-0.01)** | 37.98 **(-0.01)** | 36.27 **(0)** | 56.7 **(-0.01)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :red_circle: | app/client/src/widgets/JSONFormWidget/component/Form.tsx | 28.42 **(-0.93)** | 20 **(0)** | 0 **(0)** | 29.67 **(-1.01)**
 :red_circle: | app/client/src/widgets/JSONFormWidget/component/index.tsx | 26.53 **(-0.55)** | 33.33 **(0)** | 0 **(0)** | 27.08 **(-0.58)**
 :red_circle: | app/client/src/widgets/JSONFormWidget/widget/index.tsx | 29.52 **(-0.58)** | 0 **(0)** | 20.69 **(-0.74)** | 30 **(-0.61)**</details>