### PR TITLE
fix: scroll to active entity in explorer on route change

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Modal_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/DisplayWidgets/Modal_spec.js
@@ -20,6 +20,11 @@ describe("Modal Widget Functionality", function() {
       .click();
     cy.get(".t--entity-name:contains(Modal1)").click();
     cy.get(".t--modal-widget").should("exist");
+
+    cy.CreateAPI("FirstAPI");
+
+    cy.get(".t--entity-name:contains(Modal1)").click();
+    cy.get(".t--modal-widget").should("exist");
   });
 
   it("3. Display toast on close action", () => {

--- a/app/client/src/pages/Editor/Explorer/Entity/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/index.tsx
@@ -96,6 +96,9 @@ export const EntityItem = styled.div<{
     background: ${Colors.GREY_2};
   }
 
+  scroll-margin-top: 36px;
+  scroll-snap-margin-top: 36px;
+
   & .${EntityClassNames.TOOLTIP} {
     ${entityTooltipCSS}
     .${Classes.POPOVER_TARGET} {

--- a/app/client/src/pages/Editor/Explorer/Files/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/index.tsx
@@ -48,7 +48,6 @@ function Files() {
   useEffect(() => {
     if (!activeActionId) return;
     document.getElementById(`entity-${activeActionId}`)?.scrollIntoView({
-      behavior: "smooth",
       block: "nearest",
       inline: "nearest",
     });

--- a/app/client/src/pages/Editor/Explorer/Files/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useActiveAction } from "../hooks";
 import { Entity } from "../Entity/index";
 import {
@@ -44,6 +44,15 @@ function Files() {
   }, [dispatch]);
 
   const activeActionId = useActiveAction();
+
+  useEffect(() => {
+    if (!activeActionId) return;
+    document.getElementById(`entity-${activeActionId}`)?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [activeActionId]);
 
   const onFilesToggle = useCallback(
     (isOpen: boolean) => {

--- a/app/client/src/sagas/ModalSagas.ts
+++ b/app/client/src/sagas/ModalSagas.ts
@@ -46,6 +46,8 @@ import AppsmithConsole from "utils/AppsmithConsole";
 import WidgetFactory from "utils/WidgetFactory";
 import { Toaster } from "components/ads/Toast";
 import { deselectAllInitAction } from "actions/widgetSelectionActions";
+import { navigateToCanvas } from "pages/Editor/Explorer/Widgets/utils";
+import { getCurrentPageId } from "selectors/editorSelectors";
 const WidgetTypes = WidgetFactory.widgetTypes;
 
 export function* createModalSaga(action: ReduxAction<{ modalName: string }>) {
@@ -128,6 +130,9 @@ export function* showModalSaga(action: ReduxAction<{ modalId: string }>) {
       exclude: action.payload.modalId,
     },
   });
+
+  const pageId: string = yield select(getCurrentPageId);
+  navigateToCanvas({ pageId, widgetId: action.payload.modalId });
 
   yield put({
     type: ReduxActionTypes.SELECT_WIDGET_INIT,

--- a/app/client/src/sagas/ModalSagas.ts
+++ b/app/client/src/sagas/ModalSagas.ts
@@ -48,6 +48,8 @@ import { Toaster } from "components/ads/Toast";
 import { deselectAllInitAction } from "actions/widgetSelectionActions";
 import { navigateToCanvas } from "pages/Editor/Explorer/Widgets/utils";
 import { getCurrentPageId } from "selectors/editorSelectors";
+import { APP_MODE } from "entities/App";
+import { getAppMode } from "selectors/applicationSelectors";
 const WidgetTypes = WidgetFactory.widgetTypes;
 
 export function* createModalSaga(action: ReduxAction<{ modalName: string }>) {
@@ -132,7 +134,10 @@ export function* showModalSaga(action: ReduxAction<{ modalId: string }>) {
   });
 
   const pageId: string = yield select(getCurrentPageId);
-  navigateToCanvas({ pageId, widgetId: action.payload.modalId });
+  const appMode: APP_MODE = yield select(getAppMode);
+
+  if (appMode === APP_MODE.EDIT)
+    navigateToCanvas({ pageId, widgetId: action.payload.modalId });
 
   yield put({
     type: ReduxActionTypes.SELECT_WIDGET_INIT,


### PR DESCRIPTION
## Description
Brings active JSObject, API and queries in entity explorer into viewport. 

Fixes #11937 
Fixes #10740 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Cypress

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes





## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/11937-explorer-scroll-to-active-entity 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.48 **(0)** | 37.96 **(-0.01)** | 36.27 **(0)** | 56.7 **(0)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Files/index.tsx | 76.19 **(-0.13)** | 27.78 **(-5.55)** | 50 **(10)** | 79.49 **(-1.07)**
 :green_circle: | app/client/src/sagas/ModalSagas.ts | 36.61 **(0.34)** | 18.42 **(-1.02)** | 23.08 **(0)** | 38.24 **(1.01)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**</details>