### PR TITLE
fix: Updated the condition to show expiry key

### DIFF
--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/list.json
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/resources/editor/list.json
@@ -98,7 +98,7 @@
           "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
           "initialValue": "5",
           "conditionals": {
-            "show": "{{actionConfiguration.formData.signedUrl.data === 'YES'}}"
+            "show": "{{actionConfiguration.formData.list.signedUrl.data === 'YES'}}"
           }
         },
         {


### PR DESCRIPTION
## Description

Updated the condition to show the `expiry` key for the `list files` type of s3 query

Fixes #12981

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
