### PR TITLE
feat: dynamic height checkbox group standardization

### DIFF
--- a/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
@@ -134,7 +134,10 @@ export interface CheckboxGroupComponentProps extends ComponentProps {
   labelStyle?: string;
   labelWidth?: number;
 }
-function CheckboxGroupComponent(props: CheckboxGroupComponentProps) {
+const CheckboxGroupComponent = React.forwardRef<
+  HTMLDivElement,
+  CheckboxGroupComponentProps
+>((props, ref) => {
   const {
     compactMode,
     isDisabled,
@@ -175,6 +178,7 @@ function CheckboxGroupComponent(props: CheckboxGroupComponentProps) {
       compactMode={compactMode}
       data-testid="checkboxgroup-container"
       labelPosition={labelPosition}
+      ref={ref}
     >
       {labelText && (
         <LabelWithTooltip
@@ -226,6 +230,8 @@ function CheckboxGroupComponent(props: CheckboxGroupComponentProps) {
       </InputContainer>
     </CheckboxGroupContainer>
   );
-}
+});
+
+CheckboxGroupComponent.displayName = "CheckboxGroupComponent";
 
 export default CheckboxGroupComponent;

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -492,6 +492,7 @@ class CheckboxGroupWidget extends BaseWidget<
         onSelectAllChange={this.handleSelectAllChange}
         optionAlignment={this.props.optionAlignment}
         options={compact(this.props.options)}
+        ref={this.contentRef as React.RefObject<HTMLDivElement>}
         rowSpace={this.props.parentRowSpace}
         selectedValues={this.props.selectedValues}
         widgetId={this.props.widgetId}

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -492,7 +492,7 @@ class CheckboxGroupWidget extends BaseWidget<
         onSelectAllChange={this.handleSelectAllChange}
         optionAlignment={this.props.optionAlignment}
         options={compact(this.props.options)}
-        ref={this.contentRef as React.RefObject<HTMLDivElement>}
+        ref={this.contentRef}
         rowSpace={this.props.parentRowSpace}
         selectedValues={this.props.selectedValues}
         widgetId={this.props.widgetId}


### PR DESCRIPTION
## Description

1. Wrapped the CheckboxGroup default component in the React.forwardedRef so that the incoming ref from the parent widget can be hooked up with the CheckboxGroupContainer.
2. Hooked the BaseWIdget `contentRef` to the CheckboxGroupContainer component via CheckboxGroup Widget.

Fixes #13049 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feature/dh-stdzn-checkbox-group 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 80 **(0.16)** | 48.94 **(0)** | 76.47 **(0)** | 79.2 **(0.17)**
 :green_circle: | app/client/src/widgets/CheckboxGroupWidget/component/index.tsx | 35 **(3.42)** | 8.89 **(0)** | 0 **(0)** | 41.18 **(3.68)**</details>