### PR TITLE
fix: no key warning

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/Generator.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/Generator.tsx
@@ -52,6 +52,7 @@ export const generatePropertyControl = (
     } else if ((config as PropertyPaneControlConfig).controlType) {
       return (
         <Boxed
+          key={config.id + props.id}
           show={
             (config as PropertyPaneControlConfig).propertyName !==
               "tableData" && props.type === "TABLE_WIDGET"


### PR DESCRIPTION
## Description
Resolve the react error in dev mode due to no key passed in the Boxed component.

Fixes # (issue)

## Type of change


## How Has This Been Tested?



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>
No changes to code coverage between the base branch and the head branch</details>