### PR TITLE
fix: feedbacks on label feature

### DIFF
--- a/app/client/src/widgets/BaseInputWidget/component/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/component/index.tsx
@@ -308,10 +308,9 @@ const TextInputWrapper = styled.div<{
   width: 100%;
   display: flex;
   flex: 1;
-  overflow-x: hidden;
+  min-height: 36px;
   ${({ inputHtmlType }) =>
     inputHtmlType && inputHtmlType !== InputTypes.TEXT && `&&& {flex-grow: 0;}`}
-  min-height: 36px;
 `;
 
 export type InputHTMLType = "TEXT" | "NUMBER" | "PASSWORD" | "EMAIL" | "TEL";


### PR DESCRIPTION
## Description

1. The popover for country code change on PhoneInputWidget and for currency change on CurrencyInputWidget are overlapping on the targets

Fixes #13118 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
