### PR TITLE
fix: Page order sequence for git import

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
@@ -35,6 +35,8 @@ public class ApplicationJson {
 
     List<NewPage> pageList;
 
+    List<String> pageOrder;
+
     String publishedDefaultPageName;
     
     String unpublishedDefaultPageName;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ApplicationJson.java
@@ -37,6 +37,8 @@ public class ApplicationJson {
 
     List<String> pageOrder;
 
+    List<String> publishedPageOrder;
+
     String publishedDefaultPageName;
     
     String unpublishedDefaultPageName;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -77,6 +77,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -861,7 +862,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                             .map(newPageList -> {
                                 // Check if the pages order match with json file
                                 List<String> pageOrderList;
-                                if(applicationJson.getPageOrder().isEmpty()) {
+                                if(Optional.ofNullable(applicationJson.getPageOrder()).isEmpty()) {
                                     pageOrderList = importedNewPageList.stream().map(newPage -> newPage.getUnpublishedPage().getName()).collect(Collectors.toList());
                                 } else {
                                     pageOrderList = applicationJson.getPageOrder();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -258,7 +258,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 Collections.sort(newPages, Comparator.comparing(newPage -> publishedPageOrderList.indexOf(newPage.getId())));
                                 pageOrder = new ArrayList<>();
                                 for (NewPage page: newPages) {
-                                    pageOrder.add(page.getUnpublishedPage().getName());
+                                    pageOrder.add(page.getPublishedPage().getName());
                                 }
                                 applicationJson.setPublishedPageOrder(pageOrder);
                                 return Mono.just(newPages);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -860,8 +860,12 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                     ).collectList()
                             .map(newPageList -> {
                                 // Check if the pages order match with json file
-                                List<String> pageOrderList = applicationJson.getPageOrder();
-                                // Add null check
+                                List<String> pageOrderList;
+                                if(applicationJson.getPageOrder().isEmpty()) {
+                                    pageOrderList = importedNewPageList.stream().map(newPage -> newPage.getUnpublishedPage().getName()).collect(Collectors.toList());
+                                } else {
+                                    pageOrderList = applicationJson.getPageOrder();
+                                }
                                 Collections.sort(newPageList,
                                         Comparator.comparing(newPage -> pageOrderList.indexOf(newPage.getUnpublishedPage().getName())));
                                 for (NewPage newPage : newPageList) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -899,10 +899,15 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 // Sort the published pages based on the json file order only
                                 List<String> publishedPageOrderList;
                                 if(Optional.ofNullable(applicationJson.getPublishedPageOrder()).isEmpty()) {
-                                    publishedPageOrderList = importedNewPageList.stream().map(newPage -> newPage.getPublishedPage().getName()).collect(Collectors.toList());
+                                    publishedPageOrderList = importedNewPageList.stream()
+                                            .filter(newPage -> !Optional.ofNullable(newPage.getPublishedPage()).isEmpty())
+                                            .map(newPage -> newPage.getPublishedPage().getName()).collect(Collectors.toList());
                                 } else {
                                     publishedPageOrderList = applicationJson.getPublishedPageOrder();
                                 }
+
+                                // When there is difference in number of pages between edit and view mode
+                                newPageList = newPageList.stream().filter(newPage -> !Optional.ofNullable(newPage.getPublishedPage()).isEmpty()).collect(Collectors.toList());
                                 Collections.sort(newPageList,
                                         Comparator.comparing(newPage -> publishedPageOrderList.indexOf(newPage.getPublishedPage().getName())));
                                 for (NewPage newPage : newPageList) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -901,7 +901,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 if(Optional.ofNullable(applicationJson.getPublishedPageOrder()).isEmpty()) {
                                     publishedPageOrderList = importedNewPageList.stream().map(newPage -> newPage.getPublishedPage().getName()).collect(Collectors.toList());
                                 } else {
-                                    publishedPageOrderList = applicationJson.getPublishedPageOrder();;
+                                    publishedPageOrderList = applicationJson.getPublishedPageOrder();
                                 }
                                 Collections.sort(newPageList,
                                         Comparator.comparing(newPage -> publishedPageOrderList.indexOf(newPage.getPublishedPage().getName())));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -255,9 +255,12 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                                 }
                                 applicationJson.setPageOrder(pageOrder);
 
-                                Collections.sort(newPages, Comparator.comparing(newPage -> publishedPageOrderList.indexOf(newPage.getId())));
+                                List<NewPage> newPageList = newPages;
+                                // When there is difference in number of pages between edit and view mode
+                                newPageList = newPageList.stream().filter(newPage -> !Optional.ofNullable(newPage.getPublishedPage()).isEmpty()).collect(Collectors.toList());
+                                Collections.sort(newPageList, Comparator.comparing(newPage -> publishedPageOrderList.indexOf(newPage.getId())));
                                 pageOrder = new ArrayList<>();
-                                for (NewPage page: newPages) {
+                                for (NewPage page: newPageList) {
                                     pageOrder.add(page.getPublishedPage().getName());
                                 }
                                 applicationJson.setPublishedPageOrder(pageOrder);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -2336,7 +2336,7 @@ public class ImportExportApplicationServiceTests {
     
     @Test
     @WithUserDetails(value = "api_user")
-    public void exportAndImportApplication_withMultiplePages_PagesOrderIsMaintained() {
+    public void exportAndImportApplication_withMultiplePagesOrderSameInDeployAndEditMode_PagesOrderIsMaintainedInEditAndViewMode() {
         Organization newOrganization = new Organization();
         newOrganization.setName("template-org-with-ds");
 
@@ -2359,22 +2359,30 @@ public class ImportExportApplicationServiceTests {
         // Set order for the newly created pages
         applicationPageService.reorderPage(testApplication.getId(), page1.getId(), 0, null).block();
         applicationPageService.reorderPage(testApplication.getId(), page2.getId(), 1, null).block();
+        // Deploy the current application
+        applicationPageService.publish(testApplication.getId(), true).block();
 
         Mono<ApplicationJson> applicationJsonMono = importExportApplicationService.exportApplicationById(testApplication.getId(), "");
 
         StepVerifier
                 .create(applicationJsonMono)
                 .assertNext(applicationJson -> {
-                    List<NewPage> pageList = applicationJson.getPageList();
-                    assertThat(pageList.get(0).getUnpublishedPage().getName()).isEqualTo("123");
-                    assertThat(pageList.get(1).getUnpublishedPage().getName()).isEqualTo("abc");
-                    assertThat(pageList.get(2).getUnpublishedPage().getName()).isEqualTo("Page1");
+                    List<String> pageList = applicationJson.getPageOrder();
+                    assertThat(pageList.get(0)).isEqualTo("123");
+                    assertThat(pageList.get(1)).isEqualTo("abc");
+                    assertThat(pageList.get(2)).isEqualTo("Page1");
+
+                    List<String> publishedPageList = applicationJson.getPageOrder();
+                    assertThat(publishedPageList.get(0)).isEqualTo("123");
+                    assertThat(publishedPageList.get(1)).isEqualTo("abc");
+                    assertThat(publishedPageList.get(2)).isEqualTo("Page1");
                 })
                 .verifyComplete();
 
         ApplicationJson applicationJson = importExportApplicationService.exportApplicationById(testApplication.getId(), "").block();
         Application application = importExportApplicationService.importApplicationInOrganization(orgId, applicationJson).block();
 
+        // Get the unpublished pages and verify the order
         List<ApplicationPage> pageDTOS = application.getPages();
         Mono<NewPage> newPageMono1 = newPageService.findById(pageDTOS.get(0).getId(), MANAGE_PAGES);
         Mono<NewPage> newPageMono2 = newPageService.findById(pageDTOS.get(1).getId(), MANAGE_PAGES);
@@ -2393,6 +2401,124 @@ public class ImportExportApplicationServiceTests {
                     assertThat(newPage1.getId()).isEqualTo(pageDTOS.get(0).getId());
                     assertThat(newPage2.getId()).isEqualTo(pageDTOS.get(1).getId());
                     assertThat(newPage3.getId()).isEqualTo(pageDTOS.get(2).getId());
+                })
+                .verifyComplete();
+
+        // Get the published pages
+        List<ApplicationPage> publishedPageDTOs = application.getPublishedPages();
+        Mono<NewPage> newPublishedPageMono1 = newPageService.findById(publishedPageDTOs.get(0).getId(), MANAGE_PAGES);
+        Mono<NewPage> newPublishedPageMono2 = newPageService.findById(publishedPageDTOs.get(1).getId(), MANAGE_PAGES);
+        Mono<NewPage> newPublishedPageMono3 = newPageService.findById(publishedPageDTOs.get(2).getId(), MANAGE_PAGES);
+
+        StepVerifier
+                .create(Mono.zip(newPublishedPageMono1, newPublishedPageMono2, newPublishedPageMono3))
+                .assertNext(objects -> {
+                    NewPage newPage1 = objects.getT1();
+                    NewPage newPage2 = objects.getT2();
+                    NewPage newPage3 = objects.getT3();
+                    assertThat(newPage1.getPublishedPage().getName()).isEqualTo("123");
+                    assertThat(newPage2.getPublishedPage().getName()).isEqualTo("abc");
+                    assertThat(newPage3.getPublishedPage().getName()).isEqualTo("Page1");
+
+                    assertThat(newPage1.getId()).isEqualTo(publishedPageDTOs.get(0).getId());
+                    assertThat(newPage2.getId()).isEqualTo(publishedPageDTOs.get(1).getId());
+                    assertThat(newPage3.getId()).isEqualTo(publishedPageDTOs.get(2).getId());
+                })
+                .verifyComplete();
+
+    }
+
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void exportAndImportApplication_withMultiplePagesOrderDifferentInDeployAndEditMode_PagesOrderIsMaintainedInEditAndViewMode() {
+        Organization newOrganization = new Organization();
+        newOrganization.setName("template-org-with-ds");
+
+        Application testApplication = new Application();
+        testApplication.setName("exportApplication_withMultiplePages_PagesOrderIsMaintainedINExportedAppJson");
+        testApplication.setExportWithConfiguration(true);
+        testApplication = applicationPageService.createApplication(testApplication, orgId).block();
+        assert testApplication != null;
+
+        PageDTO testPage = new PageDTO();
+        testPage.setName("123");
+        testPage.setApplicationId(testApplication.getId());
+        PageDTO page1 = applicationPageService.createPage(testPage).block();
+
+        testPage = new PageDTO();
+        testPage.setName("abc");
+        testPage.setApplicationId(testApplication.getId());
+        PageDTO page2 = applicationPageService.createPage(testPage).block();
+
+        // Deploy the current application so that edit and view mode will have different page order
+        applicationPageService.publish(testApplication.getId(), true).block();
+
+        // Set order for the newly created pages
+        applicationPageService.reorderPage(testApplication.getId(), page1.getId(), 0, null).block();
+        applicationPageService.reorderPage(testApplication.getId(), page2.getId(), 1, null).block();
+
+        Mono<ApplicationJson> applicationJsonMono = importExportApplicationService.exportApplicationById(testApplication.getId(), "");
+
+        StepVerifier
+                .create(applicationJsonMono)
+                .assertNext(applicationJson -> {
+                    List<String> pageList = applicationJson.getPageOrder();
+                    assertThat(pageList.get(0)).isEqualTo("123");
+                    assertThat(pageList.get(1)).isEqualTo("abc");
+                    assertThat(pageList.get(2)).isEqualTo("Page1");
+
+                    List<String> publishedPageList = applicationJson.getPageOrder();
+                    assertThat(publishedPageList.get(0)).isEqualTo("123");
+                    assertThat(publishedPageList.get(1)).isEqualTo("abc");
+                    assertThat(publishedPageList.get(2)).isEqualTo("Page1");
+                })
+                .verifyComplete();
+
+        ApplicationJson applicationJson = importExportApplicationService.exportApplicationById(testApplication.getId(), "").block();
+        Application application = importExportApplicationService.importApplicationInOrganization(orgId, applicationJson).block();
+
+        // Get the unpublished pages and verify the order
+        List<ApplicationPage> pageDTOS = application.getPages();
+        Mono<NewPage> newPageMono1 = newPageService.findById(pageDTOS.get(0).getId(), MANAGE_PAGES);
+        Mono<NewPage> newPageMono2 = newPageService.findById(pageDTOS.get(1).getId(), MANAGE_PAGES);
+        Mono<NewPage> newPageMono3 = newPageService.findById(pageDTOS.get(2).getId(), MANAGE_PAGES);
+
+        StepVerifier
+                .create(Mono.zip(newPageMono1, newPageMono2, newPageMono3))
+                .assertNext(objects -> {
+                    NewPage newPage1 = objects.getT1();
+                    NewPage newPage2 = objects.getT2();
+                    NewPage newPage3 = objects.getT3();
+                    assertThat(newPage1.getUnpublishedPage().getName()).isEqualTo("123");
+                    assertThat(newPage2.getUnpublishedPage().getName()).isEqualTo("abc");
+                    assertThat(newPage3.getUnpublishedPage().getName()).isEqualTo("Page1");
+
+                    assertThat(newPage1.getId()).isEqualTo(pageDTOS.get(0).getId());
+                    assertThat(newPage2.getId()).isEqualTo(pageDTOS.get(1).getId());
+                    assertThat(newPage3.getId()).isEqualTo(pageDTOS.get(2).getId());
+                })
+                .verifyComplete();
+
+        // Get the published pages
+        List<ApplicationPage> publishedPageDTOs = application.getPublishedPages();
+        Mono<NewPage> newPublishedPageMono1 = newPageService.findById(publishedPageDTOs.get(0).getId(), MANAGE_PAGES);
+        Mono<NewPage> newPublishedPageMono2 = newPageService.findById(publishedPageDTOs.get(1).getId(), MANAGE_PAGES);
+        Mono<NewPage> newPublishedPageMono3 = newPageService.findById(publishedPageDTOs.get(2).getId(), MANAGE_PAGES);
+
+        StepVerifier
+                .create(Mono.zip(newPublishedPageMono1, newPublishedPageMono2, newPublishedPageMono3))
+                .assertNext(objects -> {
+                    NewPage newPage1 = objects.getT1();
+                    NewPage newPage2 = objects.getT2();
+                    NewPage newPage3 = objects.getT3();
+                    assertThat(newPage1.getPublishedPage().getName()).isEqualTo("Page1");
+                    assertThat(newPage2.getPublishedPage().getName()).isEqualTo("123");
+                    assertThat(newPage3.getPublishedPage().getName()).isEqualTo("abc");
+
+                    assertThat(newPage1.getId()).isEqualTo(publishedPageDTOs.get(0).getId());
+                    assertThat(newPage2.getId()).isEqualTo(publishedPageDTOs.get(1).getId());
+                    assertThat(newPage3.getId()).isEqualTo(publishedPageDTOs.get(2).getId());
                 })
                 .verifyComplete();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -2468,10 +2468,10 @@ public class ImportExportApplicationServiceTests {
                     assertThat(pageList.get(1)).isEqualTo("abc");
                     assertThat(pageList.get(2)).isEqualTo("Page1");
 
-                    List<String> publishedPageList = applicationJson.getPageOrder();
-                    assertThat(publishedPageList.get(0)).isEqualTo("123");
-                    assertThat(publishedPageList.get(1)).isEqualTo("abc");
-                    assertThat(publishedPageList.get(2)).isEqualTo("Page1");
+                    List<String> publishedPageOrder = applicationJson.getPageOrder();
+                    assertThat(publishedPageOrder.get(0)).isEqualTo("123");
+                    assertThat(publishedPageOrder.get(1)).isEqualTo("abc");
+                    assertThat(publishedPageOrder.get(2)).isEqualTo("Page1");
                 })
                 .verifyComplete();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -2341,7 +2341,7 @@ public class ImportExportApplicationServiceTests {
         newOrganization.setName("template-org-with-ds");
 
         Application testApplication = new Application();
-        testApplication.setName("exportApplication_withMultiplePages_PagesOrderIsMaintainedINExportedAppJson");
+        testApplication.setName("exportAndImportApplication_withMultiplePagesOrderSameInDeployAndEditMode_PagesOrderIsMaintainedInEditAndViewMode");
         testApplication.setExportWithConfiguration(true);
         testApplication = applicationPageService.createApplication(testApplication, orgId).block();
         assert testApplication != null;
@@ -2436,7 +2436,7 @@ public class ImportExportApplicationServiceTests {
         newOrganization.setName("template-org-with-ds");
 
         Application testApplication = new Application();
-        testApplication.setName("exportApplication_withMultiplePages_PagesOrderIsMaintainedINExportedAppJson");
+        testApplication.setName("exportAndImportApplication_withMultiplePagesOrderDifferentInDeployAndEditMode_PagesOrderIsMaintainedInEditAndViewMode");
         testApplication.setExportWithConfiguration(true);
         testApplication = applicationPageService.createApplication(testApplication, orgId).block();
         assert testApplication != null;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -2372,7 +2372,7 @@ public class ImportExportApplicationServiceTests {
                     assertThat(pageList.get(1)).isEqualTo("abc");
                     assertThat(pageList.get(2)).isEqualTo("Page1");
 
-                    List<String> publishedPageList = applicationJson.getPageOrder();
+                    List<String> publishedPageList = applicationJson.getPublishedPageOrder();
                     assertThat(publishedPageList.get(0)).isEqualTo("123");
                     assertThat(publishedPageList.get(1)).isEqualTo("abc");
                     assertThat(publishedPageList.get(2)).isEqualTo("Page1");

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/invalid-application-without-pageId-action-collection.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/invalid-application-without-pageId-action-collection.json
@@ -380,6 +380,10 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "Page1",
+    "Page2"
+  ],
   "actionList": [
     {
       "id": "60aca092136c4b7178f6790a",

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-custom-themes.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-custom-themes.json
@@ -421,6 +421,10 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "Page1",
+    "Page2"
+  ],
   "actionList": [
     {
       "id": "60aca092136c4b7178f6790a",

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-page-added.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-page-added.json
@@ -541,6 +541,11 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "Page1",
+    "Page2",
+    "Page3"
+  ],
   "publishedDefaultPageName": "Page1",
   "unpublishedDefaultPageName": "Page1",
   "actionList": [

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-page-removed.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-page-removed.json
@@ -253,6 +253,9 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "importedPage"
+  ],
   "publishedDefaultPageName": "importedPage",
   "unpublishedDefaultPageName": "importedPage",
   "actionList": [],

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-un-configured-datasource.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-un-configured-datasource.json
@@ -280,6 +280,9 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "Page1"
+  ],
   "publishedDefaultPageName": "Page1",
   "unpublishedDefaultPageName": "Page1",
   "actionList": [

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-without-action-collection.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-without-action-collection.json
@@ -421,6 +421,10 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "Page1",
+    "Page2"
+  ],
   "actionList": [
     {
       "id": "60aca092136c4b7178f6790a",

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-without-theme.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-without-theme.json
@@ -421,6 +421,10 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "Page1",
+    "Page2"
+  ],
   "actionList": [
     {
       "id": "60aca092136c4b7178f6790a",

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application.json
@@ -421,6 +421,10 @@
       "new": true
     }
   ],
+  "pageOrder": [
+    "Page1",
+    "Page2"
+  ],
   "actionList": [
     {
       "id": "60aca092136c4b7178f6790a",


### PR DESCRIPTION
## Description

> Page order sequence gets messed up when we do git import. The reason is because of the parallel execution of task by stream API, which is used to process page from the application json file. We don't have control over this. So we have decided to add the page order to the metadata of json file which is exported. This list is then referred while importing application into the org. 

Fixes #12944 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally 
- Junit Tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
