### PR TITLE
chore: Fix perf infra data collection

### DIFF
--- a/app/client/perf/src/ci/supabase.js
+++ b/app/client/perf/src/ci/supabase.js
@@ -99,7 +99,7 @@ const saveData = async (results) => {
       row["meta"] = run_meta.id;
       const runs = results[action][metric];
       runs.forEach((value, i) => {
-        row["value"] = value;
+        row = { ...row, value };
         rows.push(row);
       });
     });


### PR DESCRIPTION
We were saving the values of the last run for all five runs of the perf test suite. This PR fixes it.
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/perf-infra-data-collection 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.48 **(0.01)** | 37.94 **(0.01)** | 36.19 **(0)** | 56.7 **(0.01)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>