### PR TITLE
feat: dynamic height radio group widget standardization

### DIFF
--- a/app/client/src/widgets/RadioGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/component/index.tsx
@@ -38,7 +38,10 @@ const StyledRadioGroup = styled(RadioGroup)<StyledRadioGroupProps>`
   height: ${({ inline }) => (inline ? "32px" : "100%")};
 `;
 
-function RadioGroupComponent(props: RadioGroupComponentProps) {
+const RadioGroupComponent = React.forwardRef<
+  HTMLDivElement,
+  RadioGroupComponentProps
+>((props, ref) => {
   const {
     alignment,
     compactMode,
@@ -72,6 +75,7 @@ function RadioGroupComponent(props: RadioGroupComponentProps) {
       compactMode={compactMode}
       data-testid="radiogroup-container"
       labelPosition={labelPosition}
+      ref={ref}
     >
       {labelText && (
         <LabelWithTooltip
@@ -116,7 +120,9 @@ function RadioGroupComponent(props: RadioGroupComponentProps) {
       </StyledRadioGroup>
     </RadioGroupContainer>
   );
-}
+});
+
+RadioGroupComponent.displayName = "RadioGroupComponent";
 
 export interface RadioGroupComponentProps extends ComponentProps {
   options: RadioOption[];

--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -502,6 +502,7 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
         loading={isLoading}
         onRadioSelectionChange={this.onRadioSelectionChange}
         options={isArray(options) ? compact(options) : []}
+        ref={this.contentRef}
         selectedOptionValue={selectedOptionValue}
         widgetId={widgetId}
       />


### PR DESCRIPTION
## Description

1. Wrapped the RadioGroup default component in the React.forwardedRef so that the incoming ref from the parent widget can be hooked up to the RadioGroupContainer.
2. Hooked the BaseWIdget `contentRef` to the RadioGroupContainer component via RadioGroup Widget.

Fixes #13050  

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/dh-stdzn-radio-group-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.49 **(0.02)** | 37.98 **(0.05)** | 36.27 **(0.08)** | 56.71 **(0.01)**
 :red_circle: | app/client/src/actions/reflowActions.ts | 75 **(-10.71)** | 100 **(0)** | 20 **(-30)** | 63.64 **(-16.36)**
 :green_circle: | app/client/src/ce/constants/messages.ts | 78.05 **(0.05)** | 100 **(0)** | 35.08 **(0.14)** | 82.34 **(0.1)**
 :green_circle: | app/client/src/components/ads/Checkbox.tsx | 90.24 **(63.41)** | 56.82 **(43.18)** | 88.24 **(88.24)** | 88.89 **(58.33)**
 :green_circle: | app/client/src/pages/Editor/MainContainerLayoutControl.tsx | 88.89 **(0.25)** | 81.25 **(0)** | 80 **(0)** | 90.48 **(0.24)**
 :sparkles: :new: | **app/client/src/pages/Editor/ReflowBetaCard.tsx** | **82.86** | **68.18** | **25** | **82.86**
 :red_circle: | app/client/src/pages/Editor/Explorer/Files/index.tsx | 76.32 **(0.13)** | 33.33 **(5.55)** | 40 **(-10)** | 80.56 **(1.07)**
 :green_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 34.7 **(0.17)** | 25.77 **(0)** | 0 **(0)** | 36.02 **(0.04)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/index.tsx | 27.61 **(-0.42)** | 5.33 **(0)** | 5.26 **(-0.3)** | 29.27 **(-0.24)**
 :green_circle: | app/client/src/pages/common/CanvasArenas/hooks/useCanvasDragging.ts | 83.64 **(0.1)** | 67.05 **(0.13)** | 84.38 **(0)** | 84.19 **(0.1)**
 :green_circle: | app/client/src/reducers/uiReducers/applicationsReducer.tsx | 16 **(0.76)** | 27.27 **(7.27)** | 12.24 **(0.48)** | 14.43 **(0.57)**
 :red_circle: | app/client/src/reducers/uiReducers/reflowReducer.ts | 58.33 **(-25)** | 100 **(0)** | 25 **(-25)** | 54.55 **(-28.78)**
 :green_circle: | app/client/src/reflow/reflowHelpers.ts | 94.94 **(0.33)** | 64.77 **(5.95)** | 100 **(0)** | 95.57 **(0.54)**
 :red_circle: | app/client/src/reflow/reflowUtils.ts | 79.55 **(-0.6)** | 69.65 **(-0.8)** | 84.31 **(-0.31)** | 79.61 **(-0.69)**
 :red_circle: | app/client/src/resizable/resizenreflow/index.tsx | 53.57 **(-1.24)** | 54.46 **(-3.09)** | 40 **(0)** | 51.91 **(-1.26)**
 :red_circle: | app/client/src/sagas/ModalSagas.ts | 36.27 **(-0.34)** | 19.44 **(1.02)** | 23.08 **(0)** | 37.23 **(-1.01)**
 :sparkles: :new: | **app/client/src/sagas/ReflowSagas.ts** | **24.24** | **7.14** | **33.33** | **28.57**
 :green_circle: | app/client/src/sagas/index.tsx | 93.44 **(0.11)** | 57.14 **(0)** | 100 **(0)** | 96.49 **(0.06)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/storage.ts | 34.04 **(-0.14)** | 11.11 **(-4.68)** | 7.14 **(-2.24)** | 27.01 **(0.74)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 80 **(0.16)** | 48.94 **(0)** | 76.47 **(0)** | 79.2 **(0.17)**
 :green_circle: | app/client/src/widgets/RadioGroupWidget/component/index.tsx | 52.38 **(5.01)** | 28.57 **(0)** | 0 **(0)** | 55 **(5)**</details>