### PR TITLE
feat: dynamic height switch group widget standardization

### DIFF
--- a/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
@@ -50,7 +50,10 @@ export interface OptionProps {
   value: string;
 }
 
-function SwitchGroupComponent(props: SwitchGroupComponentProps) {
+const SwitchGroupComponent = React.forwardRef<
+  HTMLDivElement,
+  React.PropsWithChildren<SwitchGroupComponentProps>
+>((props, ref) => {
   const {
     alignment,
     compactMode,
@@ -77,6 +80,7 @@ function SwitchGroupComponent(props: SwitchGroupComponentProps) {
       compactMode={compactMode}
       data-testid="switchgroup-container"
       labelPosition={labelPosition}
+      ref={ref}
     >
       {labelText && (
         <LabelWithTooltip
@@ -119,7 +123,7 @@ function SwitchGroupComponent(props: SwitchGroupComponentProps) {
       </InputContainer>
     </SwitchGroupContainer>
   );
-}
+});
 
 export interface SwitchGroupComponentProps {
   alignment: Alignment;
@@ -141,5 +145,7 @@ export interface SwitchGroupComponentProps {
   widgetId: string;
   height: number;
 }
+
+SwitchGroupComponent.displayName = "SwitchGroupComponent";
 
 export default SwitchGroupComponent;

--- a/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
@@ -400,6 +400,7 @@ class SwitchGroupWidget extends BaseWidget<
         labelWidth={this.getLabelWidth()}
         onChange={this.handleSwitchStateChange}
         options={options}
+        ref={this.contentRef}
         required={isRequired}
         selected={selectedValues}
         valid={isValid}


### PR DESCRIPTION
## Description

1. Wrapped the SwitchGroup default component in the React.forwardedRef so that the incoming ref from the parent widget can be hooked up to the SwitchGroupContainer.
2. Hooked the BaseWIdget `contentRef` to the SwitchGroupContainer component via SwitchGroup Widget.

Fixes #13051 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: feature/dh-stdzn-switch-group-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 80 **(0.16)** | 48.94 **(0)** | 76.47 **(0)** | 79.2 **(0.17)**
 :green_circle: | app/client/src/widgets/SwitchGroupWidget/component/index.tsx | 50 **(5)** | 21.05 **(0)** | 0 **(0)** | 55 **(5)**</details>