### PR TITLE
feat: dynamic height json form widget standardisation

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/component/Form.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/Form.tsx
@@ -117,28 +117,34 @@ const StyledResetButtonWrapper = styled.div`
 
 const DEBOUNCE_TIMEOUT = 200;
 
-function Form<TValues = any>({
-  backgroundColor,
-  children,
-  disabledWhenInvalid,
-  fixedFooter,
-  getFormData,
-  hideFooter,
-  isSubmitting,
-  onSubmit,
-  registerResetObserver,
-  resetButtonLabel,
-  resetButtonStyles,
-  schema,
-  scrollContents,
-  showReset,
-  stretchBodyVertically,
-  submitButtonLabel,
-  submitButtonStyles,
-  title,
-  unregisterResetObserver,
-  updateFormData,
-}: FormProps<TValues>) {
+function Form<TValues = any>(
+  {
+    backgroundColor,
+    children,
+    disabledWhenInvalid,
+    fixedFooter,
+    getFormData,
+    hideFooter,
+    isSubmitting,
+    onSubmit,
+    registerResetObserver,
+    resetButtonLabel,
+    resetButtonStyles,
+    schema,
+    scrollContents,
+    showReset,
+    stretchBodyVertically,
+    submitButtonLabel,
+    submitButtonStyles,
+    title,
+    unregisterResetObserver,
+    updateFormData,
+  }: FormProps<TValues>,
+  ref:
+    | ((instance: HTMLDivElement | null) => void)
+    | React.MutableRefObject<HTMLDivElement | null>
+    | null,
+) {
   const valuesRef = useRef({});
   const methods = useForm();
   const { formState, reset, watch } = methods;
@@ -235,7 +241,7 @@ function Form<TValues = any>({
   return (
     <FormProvider {...methods}>
       <StyledForm ref={bodyRef} scrollContents={scrollContents}>
-        <StyledFormBody stretchBodyVertically={stretchBodyVertically}>
+        <StyledFormBody ref={ref} stretchBodyVertically={stretchBodyVertically}>
           <StyledTitle>{title}</StyledTitle>
           {children}
         </StyledFormBody>
@@ -270,4 +276,4 @@ function Form<TValues = any>({
   );
 }
 
-export default Form;
+export default React.forwardRef<HTMLDivElement, FormProps<any>>(Form);

--- a/app/client/src/widgets/JSONFormWidget/component/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/index.tsx
@@ -88,24 +88,30 @@ function InfoMessage({ children }: { children: React.ReactNode }) {
   );
 }
 
-function JSONFormComponent<TValues>({
-  backgroundColor,
-  executeAction,
-  fieldLimitExceeded,
-  getFormData,
-  isSubmitting,
-  registerResetObserver,
-  renderMode,
-  resetButtonLabel,
-  schema,
-  setMetaInternalFieldState,
-  submitButtonLabel,
-  unregisterResetObserver,
-  updateFormData,
-  updateWidgetMetaProperty,
-  updateWidgetProperty,
-  ...rest
-}: JSONFormComponentProps<TValues>) {
+function JSONFormComponent<TValues>(
+  {
+    backgroundColor,
+    executeAction,
+    fieldLimitExceeded,
+    getFormData,
+    isSubmitting,
+    registerResetObserver,
+    renderMode,
+    resetButtonLabel,
+    schema,
+    setMetaInternalFieldState,
+    submitButtonLabel,
+    unregisterResetObserver,
+    updateFormData,
+    updateWidgetMetaProperty,
+    updateWidgetProperty,
+    ...rest
+  }: JSONFormComponentProps<TValues>,
+  ref:
+    | ((instance: HTMLDivElement | null) => void)
+    | React.MutableRefObject<HTMLDivElement | null>
+    | null,
+) {
   const isSchemaEmpty = isEmpty(schema);
   const styleProps = pick(rest, [
     "borderColor",
@@ -174,6 +180,7 @@ function JSONFormComponent<TValues>({
           hideFooter={hideFooter}
           isSubmitting={isSubmitting}
           onSubmit={rest.onSubmit}
+          ref={ref}
           registerResetObserver={registerResetObserver}
           resetButtonLabel={resetButtonLabel}
           resetButtonStyles={rest.resetButtonStyles}
@@ -194,4 +201,4 @@ function JSONFormComponent<TValues>({
   );
 }
 
-export default React.memo(JSONFormComponent);
+export default React.memo(React.forwardRef(JSONFormComponent));

--- a/app/client/src/widgets/JSONFormWidget/widget/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/widget/index.tsx
@@ -304,6 +304,7 @@ class JSONFormWidget extends BaseWidget<
         getFormData={this.getFormData}
         isSubmitting={this.state.isSubmitting}
         onSubmit={this.onSubmit}
+        ref={this.contentRef}
         registerResetObserver={this.registerResetObserver}
         renderMode={this.props.renderMode}
         resetButtonLabel={this.props.resetButtonLabel}


### PR DESCRIPTION
## Description

1. Wrapped the JSONForm default component in the React.forwardRef so that the incoming ref from the parent widget can be hooked up to the Form component underneath.
2. Wrapped the Form component in the React.forwardRef and set the `ref` to the FormBody component (div).
2. Hooked the BaseWidget `contentRef` to the JSONForm component via JSONForm Widget.

Fixes #13060 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/dh-stdzn-json-form-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.47 **(0)** | 37.93 **(0)** | 36.19 **(0)** | 56.7 **(0.01)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 80 **(0.16)** | 48.94 **(0)** | 76.47 **(0)** | 79.2 **(0.17)**</details>