### PR TITLE
fix: Replace "klona/full" -> "klona" in JSONForm to avoid crash in dev environment

### DIFF
--- a/app/client/src/components/propertyControls/FieldConfigurationControl.tsx
+++ b/app/client/src/components/propertyControls/FieldConfigurationControl.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { isEmpty, isString, maxBy, set, sortBy } from "lodash";
 import log from "loglevel";
+import { klona } from "klona";
+import { isEmpty, isString, maxBy, set, sortBy } from "lodash";
 
 import BaseControl, { ControlProps } from "./BaseControl";
 import EmptyDataState from "components/utils/EmptyDataState";
@@ -18,8 +19,6 @@ import { DraggableListCard } from "components/ads/DraggableListCard";
 import { StyledPropertyPaneButton } from "./StyledControls";
 import { getNextEntityName } from "utils/AppsmithUtils";
 import { InputText } from "./InputTextControl";
-
-import { klona } from "klona/full";
 
 type DroppableItem = BaseItemProps & {
   index: number;

--- a/app/client/src/widgets/JSONFormWidget/component/Field.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/Field.tsx
@@ -2,12 +2,11 @@ import equal from "fast-deep-equal/es6";
 import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { ControllerProps, useFormContext } from "react-hook-form";
+import { klona } from "klona";
 
 import FieldLabel, { FieldLabelProps } from "./FieldLabel";
 import useUpdateAccessor from "../fields/useObserveAccessor";
 import { FIELD_MARGIN_BOTTOM } from "./styleConstants";
-
-import { klona } from "klona/full";
 
 type FieldProps<TValue> = React.PropsWithChildren<
   {

--- a/app/client/src/widgets/JSONFormWidget/component/Form.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/Form.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { debounce, isEmpty } from "lodash";
 import { FormProvider, useForm } from "react-hook-form";
 import { Text } from "@blueprintjs/core";
+import { klona } from "klona";
 
 import useFixedFooter from "./useFixedFooter";
 import {
@@ -15,8 +16,6 @@ import { FORM_PADDING_Y, FORM_PADDING_X } from "./styleConstants";
 import { ROOT_SCHEMA_KEY, Schema } from "../constants";
 import { convertSchemaItemToFormData, schemaItemDefaultValue } from "../helper";
 import { TEXT_SIZES } from "constants/WidgetConstants";
-
-import { klona } from "klona/full";
 
 export type FormProps<TValues = any> = PropsWithChildren<{
   backgroundColor?: string;

--- a/app/client/src/widgets/JSONFormWidget/fields/ArrayField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/ArrayField.tsx
@@ -9,6 +9,7 @@ import styled from "styled-components";
 import { ControllerRenderProps, useFormContext } from "react-hook-form";
 import { get, set } from "lodash";
 import { Icon } from "@blueprintjs/core";
+import { klona } from "klona";
 
 import Accordion from "../component/Accordion";
 import FieldLabel from "../component/FieldLabel";
@@ -29,8 +30,6 @@ import { Colors } from "constants/Colors";
 import { FIELD_MARGIN_BOTTOM } from "../component/styleConstants";
 import { generateReactKey } from "utils/generators";
 import { schemaItemDefaultValue } from "../helper";
-
-import { klona } from "klona/full";
 
 type ArrayComponentProps = FieldComponentBaseProps & {
   backgroundColor?: string;

--- a/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useRegisterFieldValidity.ts
@@ -2,11 +2,10 @@ import * as Sentry from "@sentry/react";
 import { set } from "lodash";
 import { ControllerProps, useFormContext } from "react-hook-form";
 import { useContext, useEffect } from "react";
+import { klona } from "klona";
 
 import FormContext from "../FormContext";
 import { FieldType } from "../constants";
-
-import { klona } from "klona/full";
 
 export type UseRegisterFieldValidityProps = {
   isValid: boolean;

--- a/app/client/src/widgets/JSONFormWidget/fields/useUpdateInternalMetaState.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useUpdateInternalMetaState.ts
@@ -1,10 +1,9 @@
 import { debounce, set } from "lodash";
 import { useMemo, useContext, useCallback } from "react";
+import { klona } from "klona";
 
 import { DebouncedExecuteActionPayload } from "widgets/MetaHOC";
 import FormContext from "../FormContext";
-
-import { klona } from "klona/full";
 
 export type UseUpdateInternalMetaStateProps = {
   propertyName?: string;

--- a/app/client/src/widgets/JSONFormWidget/schemaParser.test.ts
+++ b/app/client/src/widgets/JSONFormWidget/schemaParser.test.ts
@@ -1,4 +1,5 @@
 import { get, set } from "lodash";
+import { klona } from "klona";
 
 import SchemaParser, {
   applyPositions,
@@ -21,8 +22,6 @@ import {
   Schema,
   SchemaItem,
 } from "./constants";
-
-import { klona } from "klona/full";
 
 const widgetName = "JSONForm1";
 

--- a/app/client/src/widgets/JSONFormWidget/schemaParser.ts
+++ b/app/client/src/widgets/JSONFormWidget/schemaParser.ts
@@ -7,6 +7,8 @@ import {
   sortBy,
   startCase,
 } from "lodash";
+import { klona } from "klona";
+
 import { sanitizeKey } from "widgets/WidgetUtils";
 import {
   ARRAY_ITEM_KEY,
@@ -22,8 +24,6 @@ import {
   Schema,
   SchemaItem,
 } from "./constants";
-
-import { klona } from "klona/full";
 
 type Obj = Record<string, any>;
 type JSON = Obj | Obj[];

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.test.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.test.ts
@@ -1,4 +1,5 @@
 import { get, set } from "lodash";
+import { klona } from "klona";
 
 import schemaTestData from "widgets/JSONFormWidget/schemaTestData";
 import {
@@ -15,8 +16,6 @@ import {
   hiddenIfArrayItemIsObject,
   updateChildrenDisabledStateHook,
 } from "./helper";
-
-import { klona } from "klona/full";
 
 const widgetName = "JSONForm1";
 


### PR DESCRIPTION
## Description
Using "klona/full" causes crashes and unexpected behavior

Fixes #13192 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/13192-jsonform-klona 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.47 **(0.01)** | 37.92 **(0)** | 36.19 **(0.02)** | 56.69 **(0.01)**
 :green_circle: | app/client/src/components/editorComponents/Debugger/index.tsx | 76.6 **(0.51)** | 26.92 **(0)** | 87.5 **(1.79)** | 78.26 **(0.48)**
 :green_circle: | app/client/src/pages/Editor/BottomBar/ManualUpgrades.tsx | 90.32 **(0.85)** | 85 **(1.67)** | 76.92 **(1.92)** | 88.68 **(-1.12)**
 :green_circle: | app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx | 62.83 **(0.33)** | 44 **(0)** | 27.59 **(2.59)** | 64.49 **(0.34)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/utils/hooks/localstorage.tsx | 63.16 **(42.11)** | 25 **(25)** | 66.67 **(66.67)** | 58.82 **(35.29)**</details>