### PR TITLE
chore: Add JS editor test cases

### DIFF
--- a/app/client/src/entities/DataTree/dataTreeJSAction.test.ts
+++ b/app/client/src/entities/DataTree/dataTreeJSAction.test.ts
@@ -189,4 +189,192 @@ describe("generateDataTreeJSAction", () => {
     const result = generateDataTreeJSAction(jsCollection);
     expect(result).toStrictEqual(expected);
   });
+  it("replaces 'this' in body with js object name", () => {
+    const jsCollection: JSCollectionData = {
+      isLoading: false,
+      config: {
+        id: "1234",
+        applicationId: "app123",
+        organizationId: "org123",
+        name: "JSObject2",
+        pageId: "page123",
+        pluginId: "plugin123",
+        pluginType: PluginType.JS,
+        actionIds: [],
+        archivedActionIds: [],
+        actions: [
+          {
+            id: "abcd",
+            applicationId: "app123",
+            organizationId: "org123",
+            pluginType: PluginType.JS,
+            pluginId: "plugin123",
+            name: "myFun2",
+            fullyQualifiedName: "JSObject2.myFun2",
+            datasource: {
+              userPermissions: [],
+              name: "UNUSED_DATASOURCE",
+              pluginId: "plugin123",
+              organizationId: "org123",
+              messages: [],
+              isValid: true,
+              new: true,
+            },
+            pageId: "page123",
+            collectionId: "1234",
+            actionConfiguration: {
+              timeoutInMillisecond: 10000,
+              paginationType: "NONE",
+              encodeParamsToggle: true,
+              body: "async () => {\n\t\t//use async-await or promises\n\t}",
+              jsArguments: [],
+              isAsync: true,
+            },
+            executeOnLoad: false,
+            dynamicBindingPathList: [
+              {
+                key: "body",
+              },
+            ],
+            isValid: true,
+            invalids: [],
+            messages: [],
+            jsonPathKeys: [
+              "async () => {\n\t\t//use async-await or promises\n\t}",
+            ],
+            confirmBeforeExecute: false,
+            userPermissions: [
+              "read:actions",
+              "execute:actions",
+              "manage:actions",
+            ],
+            validName: "JSObject2.myFun2",
+          },
+          {
+            id: "623973054d9aea1b062af87b",
+            applicationId: "app123",
+            organizationId: "org123",
+            pluginType: "JS",
+            pluginId: "plugin123",
+            name: "myFun1",
+            fullyQualifiedName: "JSObject2.myFun1",
+            datasource: {
+              userPermissions: [],
+              name: "UNUSED_DATASOURCE",
+              pluginId: "plugin123",
+              organizationId: "org123",
+              messages: [],
+              isValid: true,
+              new: true,
+            },
+            pageId: "page123",
+            collectionId: "1234",
+            actionConfiguration: {
+              timeoutInMillisecond: 10000,
+              paginationType: "NONE",
+              encodeParamsToggle: true,
+              body: "() => {\n\t\t//write code here\n\t}",
+              jsArguments: [],
+              isAsync: false,
+            },
+            executeOnLoad: false,
+            clientSideExecution: true,
+            dynamicBindingPathList: [
+              {
+                key: "body",
+              },
+            ],
+            isValid: true,
+            invalids: [],
+            messages: [],
+            jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+            confirmBeforeExecute: false,
+            userPermissions: [
+              "read:actions",
+              "execute:actions",
+              "manage:actions",
+            ],
+            validName: "JSObject2.myFun1",
+          },
+        ],
+        archivedActions: [],
+        body:
+          "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t return this.myFun2},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+        variables: [
+          {
+            name: "myVar1",
+            value: [],
+          },
+          {
+            name: "myVar2",
+            value: {},
+          },
+        ],
+      },
+      data: {
+        abcd: {
+          users: [{ id: 1, name: "John" }],
+        },
+      },
+    };
+
+    const expected = {
+      myVar1: [],
+      myVar2: {},
+      name: "JSObject2",
+      actionId: "1234",
+      pluginType: "JS",
+      ENTITY_TYPE: "JSACTION",
+      body:
+        "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t return JSObject2.myFun2},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+      meta: {
+        myFun2: {
+          arguments: [],
+          isAsync: true,
+          confirmBeforeExecute: false,
+        },
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+      },
+      bindingPaths: {
+        body: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myFun2",
+        },
+        {
+          key: "myFun1",
+        },
+      ],
+      variables: ["myVar1", "myVar2"],
+      dependencyMap: {
+        body: ["myFun2", "myFun1"],
+      },
+      myFun2: {
+        data: {
+          users: [{ id: 1, name: "John" }],
+        },
+      },
+      myFun1: {
+        data: {},
+      },
+      reactivePaths: {
+        body: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+      },
+    };
+
+    const result = generateDataTreeJSAction(jsCollection);
+    expect(result).toStrictEqual(expected);
+  });
 });

--- a/app/client/src/entities/DataTree/dataTreeJSAction.test.ts
+++ b/app/client/src/entities/DataTree/dataTreeJSAction.test.ts
@@ -1,0 +1,185 @@
+import { PluginType } from "entities/Action";
+import { generateDataTreeJSAction } from "entities/DataTree/dataTreeJSAction";
+import { JSCollectionData } from "reducers/entityReducers/jsActionsReducer";
+
+describe("generateDataTreeJSAction", () => {
+  it("generate js collection in data tree", () => {
+    const jsCollection: JSCollectionData = {
+      isLoading: false,
+      config: {
+        id: "1234",
+        applicationId: "app123",
+        organizationId: "org123",
+        name: "JSObject2",
+        pageId: "page123",
+        pluginId: "plugin123",
+        pluginType: PluginType.JS,
+        actionIds: [],
+        archivedActionIds: [],
+        actions: [
+          {
+            id: "abcd",
+            applicationId: "app123",
+            organizationId: "org123",
+            pluginType: PluginType.JS,
+            pluginId: "plugin123",
+            name: "myFun2",
+            fullyQualifiedName: "JSObject2.myFun2",
+            datasource: {
+              userPermissions: [],
+              name: "UNUSED_DATASOURCE",
+              pluginId: "plugin123",
+              organizationId: "org123",
+              messages: [],
+              isValid: true,
+              new: true,
+            },
+            pageId: "page123",
+            collectionId: "1234",
+            actionConfiguration: {
+              timeoutInMillisecond: 10000,
+              paginationType: "NONE",
+              encodeParamsToggle: true,
+              body: "async () => {\n\t\t//use async-await or promises\n\t}",
+              jsArguments: [],
+              isAsync: true,
+            },
+            executeOnLoad: false,
+            dynamicBindingPathList: [
+              {
+                key: "body",
+              },
+            ],
+            isValid: true,
+            invalids: [],
+            messages: [],
+            jsonPathKeys: [
+              "async () => {\n\t\t//use async-await or promises\n\t}",
+            ],
+            confirmBeforeExecute: false,
+            userPermissions: [
+              "read:actions",
+              "execute:actions",
+              "manage:actions",
+            ],
+            validName: "JSObject2.myFun2",
+          },
+          {
+            id: "623973054d9aea1b062af87b",
+            applicationId: "app123",
+            organizationId: "org123",
+            pluginType: "JS",
+            pluginId: "plugin123",
+            name: "myFun1",
+            fullyQualifiedName: "JSObject2.myFun1",
+            datasource: {
+              userPermissions: [],
+              name: "UNUSED_DATASOURCE",
+              pluginId: "plugin123",
+              organizationId: "org123",
+              messages: [],
+              isValid: true,
+              new: true,
+            },
+            pageId: "page123",
+            collectionId: "1234",
+            actionConfiguration: {
+              timeoutInMillisecond: 10000,
+              paginationType: "NONE",
+              encodeParamsToggle: true,
+              body: "() => {\n\t\t//write code here\n\t}",
+              jsArguments: [],
+              isAsync: false,
+            },
+            executeOnLoad: false,
+            clientSideExecution: true,
+            dynamicBindingPathList: [
+              {
+                key: "body",
+              },
+            ],
+            isValid: true,
+            invalids: [],
+            messages: [],
+            jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+            confirmBeforeExecute: false,
+            userPermissions: [
+              "read:actions",
+              "execute:actions",
+              "manage:actions",
+            ],
+            validName: "JSObject2.myFun1",
+          },
+        ],
+        archivedActions: [],
+        body:
+          "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+        variables: [
+          {
+            name: "myVar1",
+            value: [],
+          },
+          {
+            name: "myVar2",
+            value: {},
+          },
+        ],
+      },
+    };
+    const expected = {
+      myVar1: [],
+      myVar2: {},
+      name: "JSObject2",
+      actionId: "1234",
+      pluginType: "JS",
+      ENTITY_TYPE: "JSACTION",
+      body:
+        "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+      meta: {
+        myFun2: {
+          arguments: [],
+          isAsync: true,
+          confirmBeforeExecute: false,
+        },
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+      },
+      bindingPaths: {
+        body: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myFun2",
+        },
+        {
+          key: "myFun1",
+        },
+      ],
+      variables: ["myVar1", "myVar2"],
+      dependencyMap: {
+        body: ["myFun2", "myFun1"],
+      },
+      myFun2: {
+        data: {},
+      },
+      myFun1: {
+        data: {},
+      },
+      reactivePaths: {
+        body: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+      },
+    };
+    const result = generateDataTreeJSAction(jsCollection);
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/app/client/src/entities/DataTree/dataTreeJSAction.test.ts
+++ b/app/client/src/entities/DataTree/dataTreeJSAction.test.ts
@@ -125,6 +125,11 @@ describe("generateDataTreeJSAction", () => {
           },
         ],
       },
+      data: {
+        abcd: {
+          users: [{ id: 1, name: "John" }],
+        },
+      },
     };
     const expected = {
       myVar1: [],
@@ -168,7 +173,9 @@ describe("generateDataTreeJSAction", () => {
         body: ["myFun2", "myFun1"],
       },
       myFun2: {
-        data: {},
+        data: {
+          users: [{ id: 1, name: "John" }],
+        },
       },
       myFun1: {
         data: {},

--- a/app/client/src/pages/Editor/Explorer/helpers.test.ts
+++ b/app/client/src/pages/Editor/Explorer/helpers.test.ts
@@ -1,4 +1,7 @@
-import { getActionIdFromURL } from "pages/Editor/Explorer/helpers";
+import {
+  getActionIdFromURL,
+  getJSCollectionIdFromURL,
+} from "pages/Editor/Explorer/helpers";
 
 describe("getActionIdFromUrl", () => {
   it("getsApiId", () => {
@@ -28,5 +31,17 @@ describe("getActionIdFromUrl", () => {
     );
     const response = getActionIdFromURL();
     expect(response).toBe("saasActionId");
+  });
+});
+
+describe("getJSCollectionIdFromURL", () => {
+  it("getCollectionId", () => {
+    window.history.pushState(
+      {},
+      "Query",
+      "/applications/appId/pages/pageId/edit/jsObjects/collectionId",
+    );
+    const response = getJSCollectionIdFromURL();
+    expect(response).toBe("collectionId");
   });
 });

--- a/app/client/src/pages/Editor/Explorer/helpers.test.ts
+++ b/app/client/src/pages/Editor/Explorer/helpers.test.ts
@@ -35,7 +35,7 @@ describe("getActionIdFromUrl", () => {
 });
 
 describe("getJSCollectionIdFromURL", () => {
-  it("getCollectionId", () => {
+  it("returns collectionId from path", () => {
     window.history.pushState(
       {},
       "Query",
@@ -43,5 +43,15 @@ describe("getJSCollectionIdFromURL", () => {
     );
     const response = getJSCollectionIdFromURL();
     expect(response).toBe("collectionId");
+  });
+
+  it("returns undefined", () => {
+    window.history.pushState(
+      {},
+      "Query",
+      "/applications/appId/pages/pageId/edit/jsObjects",
+    );
+    const response = getJSCollectionIdFromURL();
+    expect(response).toBe(undefined);
   });
 });

--- a/app/client/src/utils/JSPaneUtils.test.ts
+++ b/app/client/src/utils/JSPaneUtils.test.ts
@@ -1,0 +1,450 @@
+import { PluginType } from "entities/Action";
+import { JSCollection } from "entities/JSCollection";
+import { getDifferenceInJSCollection, ParsedBody } from "./JSPaneUtils";
+
+const JSObject1: JSCollection = {
+  id: "1234",
+  applicationId: "app123",
+  organizationId: "org123",
+  name: "JSObject2",
+  pageId: "page123",
+  pluginId: "plugin123",
+  pluginType: PluginType.JS,
+  actionIds: [],
+  archivedActionIds: [],
+  actions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun1",
+      fullyQualifiedName: "JSObject2.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun1",
+    },
+  ],
+  archivedActions: [],
+  body:
+    "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const JSObject2: JSCollection = {
+  id: "1234",
+  applicationId: "app123",
+  organizationId: "org123",
+  name: "JSObject3",
+  pageId: "page123",
+  pluginId: "plugin123",
+  pluginType: PluginType.JS,
+  actionIds: [],
+  archivedActionIds: [],
+  actions: [
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun1",
+      fullyQualifiedName: "JSObject3.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject3.myFun1",
+    },
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject3.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject3.myFun2",
+    },
+  ],
+  archivedActions: [],
+  body:
+    "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const parsedBodyWithRenamedAction: ParsedBody = {
+  actions: [
+    {
+      name: "myFun11",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: "async () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultRenamedActions = {
+  newActions: [],
+  updateActions: [
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun11",
+      fullyQualifiedName: "JSObject2.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun1",
+    },
+  ],
+  deletedActions: [],
+  nameChangedActions: [
+    {
+      id: "fun1",
+      collectionId: "1234",
+      oldName: "myFun1",
+      newName: "myFun11",
+      pageId: "page123",
+    },
+  ],
+  changedVariables: [],
+};
+
+const parsedBodyWithDeletedAction: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultDeletedActions = {
+  newActions: [],
+  updateActions: [],
+  deletedActions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+  ],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+
+const parsedBodyWithChangedVariable: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: "async () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: "app",
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+const resultChangedVariable = {
+  newActions: [],
+  updateActions: [],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [
+    {
+      name: "myVar1",
+      value: "app",
+    },
+  ],
+};
+
+describe("get difference in updated and new js collection", () => {
+  it("get name changed js action", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithRenamedAction,
+      JSObject1,
+    );
+    expect(resultRenamedActions).toStrictEqual(result);
+  });
+
+  it("get deleted js action", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithDeletedAction,
+      JSObject1,
+    );
+    expect(resultDeletedActions).toStrictEqual(result);
+  });
+});
+
+describe("get difference for variables", () => {
+  it("get changed variable value in difference", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithChangedVariable,
+      JSObject2,
+    );
+    expect(resultChangedVariable).toStrictEqual(result);
+  });
+});

--- a/app/client/src/utils/JSPaneUtils.test.ts
+++ b/app/client/src/utils/JSPaneUtils.test.ts
@@ -117,7 +117,7 @@ const JSObject2: JSCollection = {
   id: "1234",
   applicationId: "app123",
   organizationId: "org123",
-  name: "JSObject3",
+  name: "JSObject2",
   pageId: "page123",
   pluginId: "plugin123",
   pluginType: PluginType.JS,
@@ -131,7 +131,7 @@ const JSObject2: JSCollection = {
       pluginType: "JS",
       pluginId: "plugin123",
       name: "myFun1",
-      fullyQualifiedName: "JSObject3.myFun1",
+      fullyQualifiedName: "JSObject2.myFun1",
       datasource: {
         userPermissions: [],
         name: "UNUSED_DATASOURCE",
@@ -164,7 +164,7 @@ const JSObject2: JSCollection = {
       jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
       confirmBeforeExecute: false,
       userPermissions: ["read:actions", "execute:actions", "manage:actions"],
-      validName: "JSObject3.myFun1",
+      validName: "JSObject2.myFun1",
     },
     {
       id: "fun2",
@@ -173,7 +173,7 @@ const JSObject2: JSCollection = {
       pluginType: "JS",
       pluginId: "plugin123",
       name: "myFun2",
-      fullyQualifiedName: "JSObject3.myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
       datasource: {
         userPermissions: [],
         name: "UNUSED_DATASOURCE",
@@ -206,7 +206,7 @@ const JSObject2: JSCollection = {
       jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
       confirmBeforeExecute: false,
       userPermissions: ["read:actions", "execute:actions", "manage:actions"],
-      validName: "JSObject3.myFun2",
+      validName: "JSObject2.myFun2",
     },
   ],
   archivedActions: [],
@@ -421,8 +421,382 @@ const resultChangedVariable = {
   ],
 };
 
-describe("get difference in updated and new js collection", () => {
-  it("get name changed js action", () => {
+const parsedBodyWithChangeInBody: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body:
+        "async () => {\n\t\t//use async-await or promises\n\tconsole.log('content changed')}",
+      arguments: [],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultChangedBody = {
+  newActions: [],
+  updateActions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body:
+          "async () => {\n\t\t//use async-await or promises\n\tconsole.log('content changed')}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+  ],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+const parsedBodyWithChangedParameters: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: "async (a,b) => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [
+        { name: "a", value: undefined },
+        { name: "b", value: undefined },
+      ],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultChangedParameters = {
+  newActions: [],
+  updateActions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async (a,b) => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [
+          { name: "a", value: undefined },
+          { name: "b", value: undefined },
+        ],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+  ],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+
+const parsedBodyWithRemovedAsync: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: "() => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultRemovedAsync = {
+  newActions: [],
+  updateActions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+  ],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+
+const parsedBodyWithAddedAsync: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "async () => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+    {
+      name: "myFun2",
+      body: "async () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultAddedAsync = {
+  newActions: [],
+  updateActions: [
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun1",
+      fullyQualifiedName: "JSObject2.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun1",
+    },
+  ],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+
+const parsedBodyWithAddedAction: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: "async () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+    {
+      name: "myFun3",
+      body: "async () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultAddedAction = {
+  newActions: [
+    {
+      name: "myFun3",
+      executeOnLoad: false,
+      pageId: "page123",
+      collectionId: "1234",
+      organizationId: "org123",
+      actionConfiguration: {
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        isAsync: true,
+        timeoutInMillisecond: 0,
+        jsArguments: [],
+      },
+    },
+  ],
+  updateActions: [],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+
+describe("getDifferenceInJSCollection", () => {
+  it("gets name changed js action", () => {
     const result = getDifferenceInJSCollection(
       parsedBodyWithRenamedAction,
       JSObject1,
@@ -430,21 +804,58 @@ describe("get difference in updated and new js collection", () => {
     expect(resultRenamedActions).toStrictEqual(result);
   });
 
-  it("get deleted js action", () => {
+  it("gets deleted js action", () => {
     const result = getDifferenceInJSCollection(
       parsedBodyWithDeletedAction,
       JSObject1,
     );
     expect(resultDeletedActions).toStrictEqual(result);
   });
-});
 
-describe("get difference for variables", () => {
-  it("get changed variable value in difference", () => {
+  it("gets added js action ", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithAddedAction,
+      JSObject2,
+    );
+    expect(resultAddedAction).toStrictEqual(result);
+  });
+
+  it("gets changed variable value in difference", () => {
     const result = getDifferenceInJSCollection(
       parsedBodyWithChangedVariable,
       JSObject2,
     );
     expect(resultChangedVariable).toStrictEqual(result);
+  });
+
+  it("gets updated body value in difference", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithChangeInBody,
+      JSObject2,
+    );
+    expect(resultChangedBody).toStrictEqual(result);
+  });
+
+  it("gets updated params value in difference", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithChangedParameters,
+      JSObject2,
+    );
+    expect(resultChangedParameters).toStrictEqual(result);
+  });
+  it("gets removed async tag in difference", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithRemovedAsync,
+      JSObject2,
+    );
+    expect(resultRemovedAsync).toStrictEqual(result);
+  });
+
+  it("gets added async tag value in difference", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithAddedAsync,
+      JSObject2,
+    );
+    expect(resultAddedAsync).toStrictEqual(result);
   });
 });

--- a/app/client/src/utils/autocomplete/EntityDefinitions.test.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.test.ts
@@ -1,4 +1,9 @@
-import { entityDefinitions } from "utils/autocomplete/EntityDefinitions";
+import { PluginType } from "entities/Action";
+import { JSCollectionData } from "reducers/entityReducers/jsActionsReducer";
+import {
+  entityDefinitions,
+  getPropsForJSActionEntity,
+} from "utils/autocomplete/EntityDefinitions";
 
 describe("EntityDefinitions", () => {
   it("it tests list widget selectRow", () => {
@@ -48,5 +53,133 @@ describe("EntityDefinitions", () => {
     };
 
     expect(listWidgetEntityDefinitions).toStrictEqual(output);
+  });
+});
+
+const jsObject: JSCollectionData = {
+  isLoading: false,
+  config: {
+    id: "1234",
+    applicationId: "app123",
+    organizationId: "org123",
+    name: "JSObject3",
+    pageId: "page123",
+    pluginId: "plugin123",
+    pluginType: PluginType.JS,
+    actionIds: [],
+    archivedActionIds: [],
+    actions: [
+      {
+        id: "fun1",
+        applicationId: "app123",
+        organizationId: "org123",
+        pluginType: "JS",
+        pluginId: "plugin123",
+        name: "myFun1",
+        fullyQualifiedName: "JSObject3.myFun1",
+        datasource: {
+          userPermissions: [],
+          name: "UNUSED_DATASOURCE",
+          pluginId: "plugin123",
+          organizationId: "org123",
+          messages: [],
+          isValid: true,
+          new: true,
+        },
+        pageId: "page123",
+        collectionId: "1234",
+        actionConfiguration: {
+          timeoutInMillisecond: 10000,
+          paginationType: "NONE",
+          encodeParamsToggle: true,
+          body: "() => {\n\t\t//write code here\n\t}",
+          jsArguments: [],
+          isAsync: false,
+        },
+        executeOnLoad: false,
+        clientSideExecution: true,
+        dynamicBindingPathList: [
+          {
+            key: "body",
+          },
+        ],
+        isValid: true,
+        invalids: [],
+        messages: [],
+        jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+        confirmBeforeExecute: false,
+        userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+        validName: "JSObject3.myFun1",
+      },
+      {
+        id: "fun2",
+        applicationId: "app123",
+        organizationId: "org123",
+        pluginType: PluginType.JS,
+        pluginId: "plugin123",
+        name: "myFun2",
+        fullyQualifiedName: "JSObject3.myFun2",
+        datasource: {
+          userPermissions: [],
+          name: "UNUSED_DATASOURCE",
+          pluginId: "plugin123",
+          organizationId: "org123",
+          messages: [],
+          isValid: true,
+          new: true,
+        },
+        pageId: "page123",
+        collectionId: "1234",
+        actionConfiguration: {
+          timeoutInMillisecond: 10000,
+          encodeParamsToggle: true,
+          body: "async () => {\n\t\t//use async-await or promises\n\t}",
+          jsArguments: [],
+          isAsync: true,
+        },
+        executeOnLoad: false,
+        clientSideExecution: true,
+        dynamicBindingPathList: [
+          {
+            key: "body",
+          },
+        ],
+        isValid: true,
+        invalids: [],
+        messages: [],
+        jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+        confirmBeforeExecute: false,
+        userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+        validName: "JSObject3.myFun2",
+      },
+    ],
+    archivedActions: [],
+    body:
+      "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+    variables: [
+      {
+        name: "myVar1",
+        value: [],
+      },
+      {
+        name: "myVar2",
+        value: {},
+      },
+    ],
+  },
+  data: {},
+  isExecuting: {},
+};
+
+describe("getPropsForJSActionEntity", () => {
+  it("get properties from js collection to show bindings", () => {
+    const expectedProperties = {
+      "myFun1()": "Function",
+      "myFun2()": "Function",
+      myVar1: [],
+      myVar2: {},
+    };
+    const result = getPropsForJSActionEntity(jsObject);
+    expect(expectedProperties).toStrictEqual(result);
   });
 });

--- a/app/client/src/utils/autocomplete/EntityDefinitions.test.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.test.ts
@@ -167,7 +167,10 @@ const jsObject: JSCollectionData = {
       },
     ],
   },
-  data: {},
+  data: {
+    fun1: {},
+    fun2: [],
+  },
   isExecuting: {},
 };
 
@@ -178,6 +181,8 @@ describe("getPropsForJSActionEntity", () => {
       "myFun2()": "Function",
       myVar1: [],
       myVar2: {},
+      "myFun1.data": {},
+      "myFun2.data": [],
     };
     const result = getPropsForJSActionEntity(jsObject);
     expect(expectedProperties).toStrictEqual(result);


### PR DESCRIPTION

## Description


Fixes #10581

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Jest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: chore/js-editor-tests 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.62 **(0.2)** | 37.99 **(0.19)** | 36.11 **(0.09)** | 56.83 **(0.19)**
 :green_circle: | app/client/src/entities/DataTree/dataTreeJSAction.ts | 100 **(85.29)** | 71.43 **(71.43)** | 100 **(100)** | 100 **(87.1)**
 :green_circle: | app/client/src/pages/Editor/Explorer/helpers.tsx | 84.06 **(7.25)** | 58.51 **(18.08)** | 100 **(14.29)** | 84.21 **(8.77)**
 :green_circle: | app/client/src/utils/JSPaneUtils.tsx | 90.7 **(80.23)** | 82.93 **(82.93)** | 80 **(80)** | 89.86 **(81.16)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 70.59 **(0)** | 100 **(0)** | 93.33 **(0.95)**
 :green_circle: | app/client/src/utils/autocomplete/EntityDefinitions.ts | 66.67 **(42.86)** | 50 **(50)** | 25 **(12.5)** | 64.1 **(41.02)**</details>