### PR TITLE
fix: Prevent sync functions from running on pageload

### DIFF
--- a/app/client/src/utils/JSPaneUtils.test.ts
+++ b/app/client/src/utils/JSPaneUtils.test.ts
@@ -1,0 +1,644 @@
+import { PluginType } from "entities/Action";
+import { JSCollection } from "entities/JSCollection";
+import { getDifferenceInJSCollection, ParsedBody } from "./JSPaneUtils";
+
+const JSObject1: JSCollection = {
+  id: "1234",
+  applicationId: "app123",
+  organizationId: "org123",
+  name: "JSObject2",
+  pageId: "page123",
+  pluginId: "plugin123",
+  pluginType: PluginType.JS,
+  actionIds: [],
+  archivedActionIds: [],
+  actions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun1",
+      fullyQualifiedName: "JSObject2.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun1",
+    },
+  ],
+  archivedActions: [],
+  body:
+    "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const JSObject2: JSCollection = {
+  id: "1234",
+  applicationId: "app123",
+  organizationId: "org123",
+  name: "JSObject3",
+  pageId: "page123",
+  pluginId: "plugin123",
+  pluginType: PluginType.JS,
+  actionIds: [],
+  archivedActionIds: [],
+  actions: [
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun1",
+      fullyQualifiedName: "JSObject3.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject3.myFun1",
+    },
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject3.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject3.myFun2",
+    },
+  ],
+  archivedActions: [],
+  body:
+    "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const JSObject3: JSCollection = {
+  id: "12345",
+  applicationId: "app1235",
+  organizationId: "org1235",
+  name: "JSObject3",
+  pageId: "page1235",
+  pluginId: "plugin1235",
+  pluginType: PluginType.JS,
+  actionIds: [],
+  archivedActionIds: [],
+  actions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: true,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun1",
+      fullyQualifiedName: "JSObject2.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun1",
+    },
+  ],
+  archivedActions: [],
+  body:
+    "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const parsedBodyWithRenamedAction: ParsedBody = {
+  actions: [
+    {
+      name: "myFun11",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: "async () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultRenamedActions = {
+  newActions: [],
+  updateActions: [
+    {
+      id: "fun1",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun11",
+      fullyQualifiedName: "JSObject2.myFun1",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "() => {\n\t\t//write code here\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["() => {\n\t\t//write code here\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun1",
+    },
+  ],
+  deletedActions: [],
+  nameChangedActions: [
+    {
+      id: "fun1",
+      collectionId: "1234",
+      oldName: "myFun1",
+      newName: "myFun11",
+      pageId: "page123",
+    },
+  ],
+  changedVariables: [],
+};
+
+const parsedBodyWithDeletedAction: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+
+const resultDeletedActions = {
+  newActions: [],
+  updateActions: [],
+  deletedActions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: "async () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: true,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+  ],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+
+const parsedBodyWithChangedVariable: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: "async () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: true,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: "app",
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+const resultChangedVariable = {
+  newActions: [],
+  updateActions: [],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [
+    {
+      name: "myVar1",
+      value: "app",
+    },
+  ],
+};
+
+const parsedBodyWithRemovedAsyncTag: ParsedBody = {
+  actions: [
+    {
+      name: "myFun1",
+      body: "() => {\n\t\t//write code here\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+    {
+      name: "myFun2",
+      body: " () => {\n\t\t//use async-await or promises\n\t}",
+      arguments: [],
+      isAsync: false,
+    },
+  ],
+  variables: [
+    {
+      name: "myVar1",
+      value: [],
+    },
+    {
+      name: "myVar2",
+      value: {},
+    },
+  ],
+};
+const resultRemovedAsyncTag = {
+  newActions: [],
+  updateActions: [
+    {
+      id: "fun2",
+      applicationId: "app123",
+      organizationId: "org123",
+      pluginType: "JS",
+      pluginId: "plugin123",
+      name: "myFun2",
+      fullyQualifiedName: "JSObject2.myFun2",
+      datasource: {
+        userPermissions: [],
+        name: "UNUSED_DATASOURCE",
+        pluginId: "plugin123",
+        organizationId: "org123",
+        messages: [],
+        isValid: true,
+        new: true,
+      },
+      pageId: "page123",
+      collectionId: "1234",
+      actionConfiguration: {
+        timeoutInMillisecond: 10000,
+        paginationType: "NONE",
+        encodeParamsToggle: true,
+        body: " () => {\n\t\t//use async-await or promises\n\t}",
+        jsArguments: [],
+        isAsync: false,
+      },
+      executeOnLoad: false,
+      clientSideExecution: true,
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+      ],
+      isValid: true,
+      invalids: [],
+      messages: [],
+      jsonPathKeys: ["async () => {\n\t\t//use async-await or promises\n\t}"],
+      confirmBeforeExecute: false,
+      userPermissions: ["read:actions", "execute:actions", "manage:actions"],
+      validName: "JSObject2.myFun2",
+    },
+  ],
+  deletedActions: [],
+  nameChangedActions: [],
+  changedVariables: [],
+};
+
+describe("getDifferenceInJSCollection", () => {
+  it("gets name changed js action", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithRenamedAction,
+      JSObject1,
+    );
+    expect(resultRenamedActions).toStrictEqual(result);
+  });
+
+  it("gets deleted js action", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithDeletedAction,
+      JSObject1,
+    );
+    expect(resultDeletedActions).toStrictEqual(result);
+  });
+
+  it("get changed variable value in difference", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithChangedVariable,
+      JSObject2,
+    );
+    expect(resultChangedVariable).toStrictEqual(result);
+  });
+
+  it("prevents onpageload for sync function", () => {
+    const result = getDifferenceInJSCollection(
+      parsedBodyWithRemovedAsyncTag,
+      JSObject3,
+    );
+    expect(resultRemovedAsyncTag).toStrictEqual(result);
+  });
+});

--- a/app/client/src/utils/JSPaneUtils.tsx
+++ b/app/client/src/utils/JSPaneUtils.tsx
@@ -156,15 +156,6 @@ export const getDifferenceInJSCollection = (
   } else {
     changedVariables = jsAction.variables;
   }
-  console.log(parsedBody, {
-    yes: {
-      newActions: toBeAddedActions,
-      updateActions: toBeUpdatedActions,
-      deletedActions: toBearchivedActions,
-      nameChangedActions: nameChangedActions,
-      changedVariables: changedVariables,
-    },
-  });
   return {
     newActions: toBeAddedActions,
     updateActions: toBeUpdatedActions,

--- a/app/client/src/utils/JSPaneUtils.tsx
+++ b/app/client/src/utils/JSPaneUtils.tsx
@@ -156,6 +156,15 @@ export const getDifferenceInJSCollection = (
   } else {
     changedVariables = jsAction.variables;
   }
+  console.log(parsedBody, {
+    yes: {
+      newActions: toBeAddedActions,
+      updateActions: toBeUpdatedActions,
+      deletedActions: toBearchivedActions,
+      nameChangedActions: nameChangedActions,
+      changedVariables: changedVariables,
+    },
+  });
   return {
     newActions: toBeAddedActions,
     updateActions: toBeUpdatedActions,

--- a/app/client/src/utils/JSPaneUtils.tsx
+++ b/app/client/src/utils/JSPaneUtils.tsx
@@ -51,6 +51,7 @@ export const getDifferenceInJSCollection = (
               jsArguments: action.arguments,
               isAsync: action.isAsync,
             },
+            executeOnLoad: action.isAsync ? preExisted.executeOnLoad : false,
           });
         }
       } else {


### PR DESCRIPTION
## Description

When the async keyword is removed from an async function originally set to run on page load , the corresponding sync function runs onPageLoad. 

Solution

`executeOnLoad` should always be false for a sync function.

Fixes #13197 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Jest

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/sync-function-running-on-pageload 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.56 **(0.11)** | 38.01 **(0.1)** | 36.23 **(0.06)** | 56.78 **(0.1)**
 :green_circle: | app/client/src/utils/JSPaneUtils.tsx | 84.88 **(74.41)** | 79.07 **(79.07)** | 80 **(80)** | 84.06 **(75.36)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 70.59 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**</details>