### PR TITLE
fix: Added contains and not equals options to where clause in Google Sheets

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/ConditionalOperator.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/ConditionalOperator.java
@@ -73,4 +73,10 @@ public enum ConditionalOperator {
             return "or";
         }
     },
+    CONTAINS {
+        @Override
+        public String toString() {
+            return "like";
+        }
+    }
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -139,9 +139,14 @@ public class FilterDataServiceTest {
             Condition condition1 = new Condition("anotherKey", "GT", "15");
             conditionList.add(condition1);
 
-
             Condition condition2 = new Condition("orderStatus", "EQ", "READY");
             conditionList.add(condition2);
+
+            Condition condition3 = new Condition("productName", "CONTAINS", "Chicken");
+            conditionList.add(condition3);
+
+            Condition condition4 = new Condition("productName", "NOT_EQ", "Chicken Sub");
+            conditionList.add(condition4);
 
             ArrayNode filteredData = filterDataService.filterData(items, conditionList);
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor.json
@@ -403,12 +403,20 @@
                   "value": "EQ"
                 },
                 {
+                  "label": "!=",
+                  "value": "NOT_EQ"
+                },
+                {
                   "label": ">=",
                   "value": "GTE"
                 },
                 {
                   "label": ">",
                   "value": "GT"
+                },
+                {
+                  "label": "contains",
+                  "value": "CONTAINS"
                 },
                 {
                   "label": "in",


### PR DESCRIPTION
## Description
This PR introduce the contains and in operator in the old format of Google Sheets. The change also handles a few null scenarios for the values. This change will need to be propagated to the UQI format as well. The operators and handling have been introduced in both places, but the null handling will need to be checked since that piece of code was already missing for the newer filter format.

Fixes #11920 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Enhanced JUnit test case
- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
