### PR TITLE
chore: highlight name input field for newly created js objects

### DIFF
--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -45,6 +45,9 @@ export class JSEditor {
       .click({ force: true });
     cy.get(this._newJSobj).click({ force: true });
 
+     // Assert that the name of the JS Object is focused 
+     cy.get(this._jsObjTxt).should("be.focused")
+
     //cy.waitUntil(() => cy.get(this.locator._toastMsg).should('not.be.visible')) // fails sometimes
     //this.agHelper.WaitUntilEleDisappear(this.locator._toastMsg, 'created successfully')
     this.agHelper.Sleep();

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -45,8 +45,15 @@ export class JSEditor {
       .click({ force: true });
     cy.get(this._newJSobj).click({ force: true });
 
-     // Assert that the name of the JS Object is focused 
-     cy.get(this._jsObjTxt).should("be.focused")
+    // Assert that the name of the JS Object is focused when newly created
+    cy.get(this._jsObjTxt)
+      .should("be.focused")
+      .type("{enter}");
+
+    cy.wait(1000);
+
+    // Assert that the name of the JS Object is no longer in the editable form after pressing "enter"
+    cy.get(this._jsObjTxt).should("not.exist");
 
     //cy.waitUntil(() => cy.get(this.locator._toastMsg).should('not.be.visible')) // fails sometimes
     //this.agHelper.WaitUntilEleDisappear(this.locator._toastMsg, 'created successfully')

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -10,12 +10,14 @@ import { toggleShowDeviationDialog } from "actions/onboardingActions";
 import {
   getUsedActionNames,
   getSavingStatusForActionName,
+  getSavingStatusForJSObjectName,
 } from "selectors/actionSelectors";
 import {
   ACTION_INVALID_NAME_ERROR,
   ACTION_NAME_CONFLICT_ERROR,
   createMessage,
 } from "@appsmith/constants/messages";
+import { PluginType } from "entities/Action";
 
 type NameEditorProps = {
   checkForGuidedTour?: boolean;
@@ -23,6 +25,7 @@ type NameEditorProps = {
   currentActionConfig: { id: string; name: string } | undefined;
   dispatchAction: (a: any) => any;
   suffixErrorMessage?: (params?: any) => string;
+  pluginType?: PluginType;
 };
 
 /**
@@ -52,7 +55,9 @@ function NameEditor(props: NameEditorProps) {
     isSaving: boolean;
     error: boolean;
   } = useSelector((state: AppState) =>
-    getSavingStatusForActionName(state, currentActionConfig?.id || ""),
+    props.pluginType === PluginType.JS
+      ? getSavingStatusForJSObjectName(state, currentActionConfig?.id || "")
+      : getSavingStatusForActionName(state, currentActionConfig?.id || ""),
   );
 
   const conflictingNames = useSelector(

--- a/app/client/src/components/utils/NameEditorComponent.tsx
+++ b/app/client/src/components/utils/NameEditorComponent.tsx
@@ -47,7 +47,13 @@ function NameEditor(props: NameEditorProps) {
   const [forceUpdate, setForceUpdate] = useState(false);
   const dispatch = useDispatch();
   if (!currentActionConfig?.id) {
-    log.error("No correct API id or Query id found in the url.");
+    log.error(
+      `No correct ${
+        props.pluginType === PluginType.JS
+          ? "JSObject Id"
+          : "API id or Query id"
+      } found in the url.`,
+    );
   }
   const guidedTourEnabled = useSelector(inGuidedTour);
 

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -19,6 +19,7 @@ import {
   ACTION_NAME_PLACEHOLDER,
   createMessage,
 } from "@appsmith/constants/messages";
+import { PluginType } from "entities/Action";
 
 const JSObjectNameWrapper = styled.div<{ page?: string }>`
   min-width: 50%;
@@ -67,6 +68,7 @@ export function JSObjectNameEditor(props: ActionNameEditorProps) {
     <NameEditorComponent
       currentActionConfig={currentJSObjectConfig}
       dispatchAction={saveJSObjectName}
+      pluginType={PluginType.JS}
     >
       {({
         forceUpdate,

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -123,7 +123,9 @@ function* handleJSCollectionCreatedSaga(
   history.push(
     jsCollectionIdURL({
       collectionId: id,
-      params: {},
+      params: {
+        editName: true,
+      },
     }),
   );
 }

--- a/app/client/src/selectors/actionSelectors.tsx
+++ b/app/client/src/selectors/actionSelectors.tsx
@@ -4,7 +4,12 @@ import WidgetFactory from "utils/WidgetFactory";
 import { FlattenedWidgetProps } from "widgets/constants";
 import { getDataTree } from "./dataTreeSelectors";
 import { getExistingPageNames } from "./entitiesSelector";
-import { getErrorForApiName, getIsSavingForApiName } from "./ui";
+import {
+  getErrorForApiName,
+  getErrorForJSObjectName,
+  getIsSavingForApiName,
+  getIsSavingForJSObjectName,
+} from "./ui";
 import { getParentWidget } from "./widgetSelectors";
 
 /**
@@ -45,6 +50,15 @@ export const getUsedActionNames = createSelector(
 export const getSavingStatusForActionName = createSelector(
   getIsSavingForApiName,
   getErrorForApiName,
+  (isSaving: boolean, error: boolean) => ({
+    isSaving,
+    error,
+  }),
+);
+
+export const getSavingStatusForJSObjectName = createSelector(
+  getIsSavingForJSObjectName,
+  getErrorForJSObjectName,
   (isSaving: boolean, error: boolean) => ({
     isSaving,
     error,

--- a/app/client/src/selectors/ui.tsx
+++ b/app/client/src/selectors/ui.tsx
@@ -17,3 +17,15 @@ export const getIsSavingForApiName = (state: AppState, id: string) =>
  */
 export const getErrorForApiName = (state: AppState, id: string) =>
   state.ui.apiName.errors[id];
+
+/**
+ * Selector to use id and provide the status of saving a JS Object.
+ */
+export const getIsSavingForJSObjectName = (state: AppState, id: string) =>
+  state.ui.jsObjectName.isSaving[id];
+
+/**
+ * Selector to use id and provide the status of error in a JS Object.
+ */
+export const getErrorForJSObjectName = (state: AppState, id: string) =>
+  state.ui.jsObjectName.errors[id];


### PR DESCRIPTION
## Description

For newly created `JSObjects` name gets highlighted for easy editing

Fixes #13213 


## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes







## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: chore/highlight-name-for-newly-created-js-objects 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.43 **(0)** | 37.79 **(-0.01)** | 36.06 **(-0.01)** | 56.65 **(0)**
 :green_circle: | app/client/src/components/utils/NameEditorComponent.tsx | 20.41 **(1.66)** | 0 **(0)** | 0 **(0)** | 21.28 **(1.71)**
 :green_circle: | app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx | 53.57 **(1.72)** | 20 **(0)** | 0 **(0)** | 53.57 **(1.72)**
 :green_circle: | app/client/src/selectors/actionSelectors.tsx | 45 **(0.56)** | 0 **(0)** | 0 **(0)** | 45 **(0.56)**
 :red_circle: | app/client/src/selectors/ui.tsx | 77.78 **(-5.55)** | 100 **(0)** | 33.33 **(-16.67)** | 66.67 **(-8.33)**</details>