### PR TITLE
fix: allow ' quote in text widget which is inside list widget 

### DIFF
--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -104,6 +104,7 @@ export const combineDynamicBindings = (
       if (jsSnippets[index] && jsSnippets[index].length > 0) {
         return jsSnippets[index];
       } else {
+        segment = segment.replaceAll("'", "\\'");
         return `'${segment}'`;
       }
     })


### PR DESCRIPTION
## Description

single quote chars were not escaped. this will fix it.

Fixes #13211 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- tested by entering **'s** in text widget which is inside list widget 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
