### PR TITLE
radio button value will always be string

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_RadioGroup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_RadioGroup_spec.js
@@ -1,0 +1,69 @@
+const jsonFormDslWithSchemaAndWithoutSourceData = require("../../../../../fixtures/jsonFormDslWithSchemaAndWithoutSourceData.json");
+
+const fieldPrefix = ".t--jsonformfield";
+
+function checkSelectedRadioValue(selector, value) {
+  /**
+   * This function checks if the radio button is checked.
+   * It also checks the value of the checked radio button.
+   */
+  cy.get(`${selector} input`).should("be.checked");
+  cy.get(`${selector} input:checked`).should("have.value", value);
+}
+
+describe("JSON Form radio button", () => {
+  beforeEach(() => {
+    cy.addDsl(jsonFormDslWithSchemaAndWithoutSourceData);
+  });
+
+  it("can select radio button when value is number type", () => {
+    cy.openPropertyPane("jsonformwidget");
+
+    // click on Add new Column.
+    cy.get(".t--add-column-btn").click();
+
+    //Open New Custom Column
+    cy.openFieldConfiguration("customField1");
+
+    // Change Column type to radio group
+    cy.changeFieldType("Radio Group");
+
+    // Add new radio buttons, one with number value
+    let radioButtonsSchema = [
+      {
+        label: "Yes",
+        value: "Y",
+      },
+      {
+        label: "No",
+        value: 122,
+      },
+    ];
+    cy.get(".t--property-control-options .CodeMirror")
+      .first()
+      .first()
+      .then((editor) => {
+        editor[0].CodeMirror.setValue("");
+      });
+    cy.get(".t--property-control-options .CodeMirror-code").type(
+      JSON.stringify(radioButtonsSchema).replaceAll("{", "{{}"),
+    );
+
+    // Go back to property pane
+    cy.get(".t--property-pane-back-btn").click({
+      force: true,
+    });
+
+    //ensure both radio buttons are being selected
+    let radioEl = `.t--jsonformfield-customField1`;
+    cy.get(`${radioEl} input`).check("Y", {
+      force: true,
+    });
+    checkSelectedRadioValue(radioEl, "Y");
+
+    cy.get(`${radioEl} input`).check("122", {
+      force: true,
+    });
+    checkSelectedRadioValue(radioEl, "122");
+  });
+});

--- a/app/client/cypress/locators/commonlocators.json
+++ b/app/client/cypress/locators/commonlocators.json
@@ -99,6 +99,7 @@
   "editColTitle": ".t--propery-page-title",
   "editColText": ".t--propery-page-title span",
   "changeColType": ".t--property-control-columntype .bp3-popover-target",
+  "changeFieldType": ".t--property-control-fieldtype .bp3-popover-target",
   "selectedColType": ".t--property-control-columntype button span",
   "collapsesection": ".t--property-pane-section-collapse-general .bp3-icon",
   "selectTab": ".t--tab-Tab",

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -73,6 +73,21 @@ Cypress.Commands.add("changeColumnType", (dataType) => {
         */
 });
 
+Cypress.Commands.add("changeFieldType", (dataType) => {
+  cy.get(commonlocators.changeFieldType)
+    .last()
+    .click();
+  cy.get(".t--dropdown-option")
+    .children()
+    .contains(dataType)
+    .click();
+  cy.wait("@updateLayout").should(
+    "have.nested.property",
+    "response.body.responseMeta.status",
+    200,
+  );
+});
+
 Cypress.Commands.add("switchToPaginationTab", () => {
   cy.get(apiwidget.paginationTab)
     .first()

--- a/app/client/src/widgets/RadioGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/component/index.tsx
@@ -109,7 +109,7 @@ function RadioGroupComponent(props: RadioGroupComponentProps) {
               inline={inline}
               key={optInd}
               label={option.label}
-              value={option.value}
+              value={option.value + ""}
             />
           );
         })}


### PR DESCRIPTION
## Description
issue occurs when radio button have number input. so we convert number to string before passing it as value.

Fixes #12815 


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- tested by using number value in radio box and making sure it is being selected on click.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
