### PR TITLE
fix: allow camera & mic access for page in iframe

### DIFF
--- a/app/client/src/widgets/IframeWidget/component/index.tsx
+++ b/app/client/src/widgets/IframeWidget/component/index.tsx
@@ -138,9 +138,20 @@ function IframeComponent(props: IframeComponentProps) {
       {message ? (
         message
       ) : srcDoc ? (
-        <iframe ref={frameRef} src={source} srcDoc={srcDoc} title={title} />
+        <iframe
+          allow="camera; microphone"
+          ref={frameRef}
+          src={source}
+          srcDoc={srcDoc}
+          title={title}
+        />
       ) : (
-        <iframe ref={frameRef} src={source} title={title} />
+        <iframe
+          allow="camera; microphone"
+          ref={frameRef}
+          src={source}
+          title={title}
+        />
       )}
     </IframeContainer>
   );


### PR DESCRIPTION
## Description

add `allow="camera; microphone"` so it will allow camera & mic access inside iframe

Fixes #12924 
 
## Type of change
 
- Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?
- dragged iframe & set URL to https://blog.minhazav.dev/research/html5-qrcode.html
- make sure camera works

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
