### PR TITLE
fix: add check for disconnect button clicked once

### DIFF
--- a/app/client/cypress/fixtures/githubSource.json
+++ b/app/client/cypress/fixtures/githubSource.json
@@ -1,4 +1,0 @@
-{
-  "githubClientId": "",
-  "githubClientSecret": ""
-}

--- a/app/client/cypress/support/AdminSettingsCommands.js
+++ b/app/client/cypress/support/AdminSettingsCommands.js
@@ -7,7 +7,6 @@ require("cypress-file-upload");
 const googleForm = require("../locators/GoogleForm.json");
 const googleData = require("../fixtures/googleSource.json");
 const githubForm = require("../locators/GithubForm.json");
-const githubData = require("../fixtures/githubSource.json");
 
 Cypress.Commands.add("fillGoogleFormPartly", () => {
   cy.get(googleForm.googleClientId).type(

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -999,6 +999,9 @@ export const TEST_EMAIL_SUCCESS = (email: string) => () =>
   `Test email sent, please check the inbox of ${email}`;
 export const TEST_EMAIL_SUCCESS_TROUBLESHOOT = () => "Troubleshoot";
 export const TEST_EMAIL_FAILURE = () => "Sending Test Email Failed";
+export const DISCONNECT_AUTH_ERROR = () =>
+  "Cannot disconnect the only connected authentication method.";
+export const MANDATORY_FIELDS_ERROR = () => "Mandatory fields cannot be empty";
 //Reflow Beta Screen
 export const REFLOW_BETA_CHECKBOX_LABEL = () =>
   "Turn on new drag & drop experience";

--- a/app/client/src/pages/Settings/DisconnectService.tsx
+++ b/app/client/src/pages/Settings/DisconnectService.tsx
@@ -54,6 +54,14 @@ export function DisconnectService(props: {
   warning: string;
 }) {
   const [warnDisconnectAuth, setWarnDisconnectAuth] = useState(false);
+  const [disconnectCalled, setDisconnectCalled] = useState(false);
+
+  const callDisconnect = () => {
+    if (!disconnectCalled) {
+      setDisconnectCalled(true);
+      props.disconnect();
+    }
+  };
 
   return (
     <Container>
@@ -63,7 +71,7 @@ export function DisconnectService(props: {
       <DisconnectButton
         data-testid="disconnect-service-button"
         onClick={() =>
-          warnDisconnectAuth ? props.disconnect() : setWarnDisconnectAuth(true)
+          warnDisconnectAuth ? callDisconnect() : setWarnDisconnectAuth(true)
         }
         text={
           warnDisconnectAuth

--- a/app/client/src/pages/Settings/SettingsForm.tsx
+++ b/app/client/src/pages/Settings/SettingsForm.tsx
@@ -25,8 +25,10 @@ import {
 import { DisconnectService } from "./DisconnectService";
 import {
   createMessage,
+  DISCONNECT_AUTH_ERROR,
   DISCONNECT_SERVICE_SUBHEADER,
   DISCONNECT_SERVICE_WARNING,
+  MANDATORY_FIELDS_ERROR,
 } from "@appsmith/constants/messages";
 import { Toaster, Variant } from "components/ads";
 import {
@@ -109,7 +111,7 @@ export function SettingsForm(
       }
     } else {
       Toaster.show({
-        text: "Mandatory fields cannot be empty",
+        text: createMessage(MANDATORY_FIELDS_ERROR),
         variant: Variant.danger,
       });
     }
@@ -160,7 +162,7 @@ export function SettingsForm(
 
   const saveBlocked = () => {
     Toaster.show({
-      text: "Cannot disconnect the only connected authentication method.",
+      text: createMessage(DISCONNECT_AUTH_ERROR),
       variant: Variant.danger,
     });
   };


### PR DESCRIPTION
## Description

> Added check for disconnect button clicked once to avoid Internal server error on multiple clicks.

Fixes [#13235](https://github.com/appsmithorg/appsmith/issues/13235)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Checked if multiple clicks on Disconnect SAML button doesn't lead to Internal server error.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/disconnect-btn-check 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.46 **(0)** | 37.94 **(0)** | 36.16 **(-0.01)** | 56.68 **(0)**
 :red_circle: | app/client/src/ce/constants/messages.ts | 77.97 **(-0.03)** | 100 **(0)** | 34.85 **(-0.09)** | 82.19 **(-0.05)**
 :red_circle: | app/client/src/pages/Settings/DisconnectService.tsx | 89.29 **(-10.71)** | 81.25 **(-11.61)** | 80 **(-20)** | 87.5 **(-12.5)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>