### PR TITLE
fix: Disable uid/gid bits for fat container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN chmod 0644 /etc/cron.d/*
 RUN chmod +x entrypoint.sh renew-certificate.sh
 
 # Disable setuid/setgid bits for the files inside container.
-RUN find / \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' +
+RUN find / \( -type d -name proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true
 
 # Update path to load appsmith utils tool as default
 ENV PATH /opt/appsmith/utils/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN chmod 0644 /etc/cron.d/*
 RUN chmod +x entrypoint.sh renew-certificate.sh
 
 # Disable setuid/setgid bits for the files inside container.
-RUN find / \( -type d -name proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true
+RUN find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true
 
 # Update path to load appsmith utils tool as default
 ENV PATH /opt/appsmith/utils/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,8 @@ RUN chmod 0644 /etc/cron.d/*
 
 RUN chmod +x entrypoint.sh renew-certificate.sh
 
-# disable uid/gid bits for the user inside container
-RUN find / \( -perm -2000 -o -perm -4000 \) | xargs chmod -s
+# Disable setuid/setgid bits for the files inside container.
+RUN find / \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' +
 
 # Update path to load appsmith utils tool as default
 ENV PATH /opt/appsmith/utils/node_modules/.bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ RUN chmod 0644 /etc/cron.d/*
 
 RUN chmod +x entrypoint.sh renew-certificate.sh
 
+# disable uid/gid bits for the user inside container
+RUN find / \( -perm -2000 -o -perm -4000 \) | xargs chmod -s
+
 # Update path to load appsmith utils tool as default
 ENV PATH /opt/appsmith/utils/node_modules/.bin:$PATH
 


### PR DESCRIPTION
- Disable uid/gid bit when building docker image.
- Keep files ownership of user/group.

- Bug fix (non-breaking change which fixes an issue)


Moved from https://github.com/appsmithorg/appsmith/pull/12945 into an internal branch and internal PR.
