### PR TITLE
fix: welcome form shown for a while after signup

### DIFF
--- a/app/client/src/pages/setup/SignupSuccess.test.tsx
+++ b/app/client/src/pages/setup/SignupSuccess.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "test/testUtils";
+import React from "react";
+import "@testing-library/jest-dom";
+import { SignupSuccess } from "./SignupSuccess";
+
+const useSelector = jest.fn();
+const values = {
+  isSuperUser: true,
+};
+useSelector.mockReturnValue(values);
+
+function renderComponent() {
+  return render(<SignupSuccess />);
+}
+
+describe("SignupSuccess", () => {
+  it("If we are intending to redirect do not show the signup form", () => {
+    renderComponent();
+    expect(screen.queryByTestId("welcome-page")).toBeNull();
+  });
+});

--- a/app/client/src/pages/setup/SignupSuccess.tsx
+++ b/app/client/src/pages/setup/SignupSuccess.tsx
@@ -24,6 +24,8 @@ import PerformanceTracker, {
 import Landing from "./Welcome";
 import { error } from "loglevel";
 import { matchPath } from "react-router";
+import { Center } from "pages/setup/common";
+import { IconSize, Spinner } from "components/ads";
 
 export function SignupSuccess() {
   const dispatch = useDispatch();
@@ -108,6 +110,12 @@ export function SignupSuccess() {
     shouldEnableFirstTimeUserOnboarding !== "true"
   ) {
     redirectUsingQueryParam();
+    // Showing a loader until the redirect
+    return (
+      <Center>
+        <Spinner size={IconSize.XXXXL} />
+      </Center>
+    );
   }
   return <Landing forSuperUser={false} onGetStarted={onGetStarted} />;
 }

--- a/app/client/src/pages/setup/Welcome.tsx
+++ b/app/client/src/pages/setup/Welcome.tsx
@@ -101,6 +101,7 @@ export default memo(function LandingPage(props: LandingPageProps) {
   }, []);
   return (
     <LandingPageWrapper
+      data-testid={"welcome-page"}
       hide={!fontsInjected}
       id={WELCOME_PAGE_ANIMATION_CONTAINER}
     >

--- a/app/client/src/pages/setup/common.tsx
+++ b/app/client/src/pages/setup/common.tsx
@@ -82,6 +82,15 @@ export const DropdownWrapper = styled(StyledFormGroup)`
   }
 `;
 
+export const Center = styled.div`
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+`;
+
 export function withDropdown(options: OptionType[], width: string) {
   return function DropdownField(
     componentProps: FormTextFieldProps & {


### PR DESCRIPTION
## Description

The welcome form is shown for a while sometimes before redirecting to another screen(can be checked with invited users).
As a fix returning a loader instead of the non-super user form.

Fixes #13549 

Before

https://user-images.githubusercontent.com/67054171/165237317-0060c012-42ea-4b2d-b600-00436dae845e.mov

After fix

https://user-images.githubusercontent.com/67054171/165237426-faa34581-eb79-4cc6-974d-1f5b696af510.mov


Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/signup-invite-user-route 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.46 **(0)** | 37.93 **(-0.02)** | 36.17 **(0)** | 56.69 **(0)**
 :green_circle: | app/client/src/components/ads/Spinner.tsx | 100 **(33.33)** | 100 **(0)** | 100 **(100)** | 100 **(33.33)**
 :green_circle: | app/client/src/components/ads/index.ts | 100 **(0)** | 100 **(0)** | 7.41 **(1.85)** | 100 **(0)**
 :sparkles: :new: | **app/client/src/pages/UserAuth/requiresAuthHOC.tsx** | **45.83** | **0** | **25** | **45**
 :sparkles: :new: | **app/client/src/pages/setup/GetStarted.tsx** | **57.14** | **33.33** | **0** | **57.14**
 :sparkles: :new: | **app/client/src/pages/setup/SignupSuccess.tsx** | **69.81** | **33.33** | **75** | **72.55**
 :sparkles: :new: | **app/client/src/pages/setup/Welcome.tsx** | **38.3** | **77.78** | **0** | **40.91**
 :green_circle: | app/client/src/pages/setup/common.tsx | 90.63 **(0.31)** | 89.47 **(0.58)** | 77.78 **(0)** | 90.63 **(0.31)**
 :red_circle: | app/client/src/selectors/commentsSelectors.ts | 83.61 **(-1.64)** | 61.76 **(-2.95)** | 73.33 **(0)** | 88.24 **(-2.35)**</details>