### PR TITLE
feat: dynamic height table widget standardisation

### DIFF
--- a/app/client/src/widgets/TableWidget/component/Table.tsx
+++ b/app/client/src/widgets/TableWidget/component/Table.tsx
@@ -93,313 +93,323 @@ function ScrollbarHorizontalThumb(props: any) {
   return <div {...props} className="thumb-horizontal" />;
 }
 
-export function Table(props: TableProps) {
-  const isResizingColumn = React.useRef(false);
+export const Table = React.forwardRef<HTMLDivElement, TableProps>(
+  (props, ref) => {
+    const isResizingColumn = React.useRef(false);
 
-  const handleResizeColumn = (columnWidths: Record<string, number>) => {
-    const columnSizeMap = {
-      ...props.columnSizeMap,
-      ...columnWidths,
+    const handleResizeColumn = (columnWidths: Record<string, number>) => {
+      const columnSizeMap = {
+        ...props.columnSizeMap,
+        ...columnWidths,
+      };
+      for (const i in columnSizeMap) {
+        if (columnSizeMap[i] < 60) {
+          columnSizeMap[i] = 60;
+        } else if (columnSizeMap[i] === undefined) {
+          const columnCounts = props.columns.filter(
+            (column) => !column.isHidden,
+          ).length;
+          columnSizeMap[i] = props.width / columnCounts;
+        }
+      }
+      props.handleResizeColumn(columnSizeMap);
     };
-    for (const i in columnSizeMap) {
-      if (columnSizeMap[i] < 60) {
-        columnSizeMap[i] = 60;
-      } else if (columnSizeMap[i] === undefined) {
-        const columnCounts = props.columns.filter((column) => !column.isHidden)
-          .length;
-        columnSizeMap[i] = props.width / columnCounts;
+    const data = React.useMemo(() => props.data, [props.data]);
+    const columnString = JSON.stringify({
+      columns: props.columns,
+      compactMode: props.compactMode,
+      columnSizeMap: props.columnSizeMap,
+    });
+    const columns = React.useMemo(() => props.columns, [columnString]);
+    const tableHeadercolumns = React.useMemo(
+      () =>
+        props.columns.filter((column: ReactTableColumnProps) => {
+          return column.accessor !== "actions";
+        }),
+      [columnString],
+    );
+    const pageCount =
+      props.serverSidePaginationEnabled && props.totalRecordsCount
+        ? Math.ceil(props.totalRecordsCount / props.pageSize)
+        : Math.ceil(props.data.length / props.pageSize);
+    const currentPageIndex = props.pageNo < pageCount ? props.pageNo : 0;
+    const {
+      getTableBodyProps,
+      getTableProps,
+      headerGroups,
+      page,
+      pageOptions,
+      prepareRow,
+      state,
+    } = useTable(
+      {
+        columns: columns,
+        data,
+        defaultColumn,
+        initialState: {
+          pageIndex: currentPageIndex,
+          pageSize: props.pageSize,
+        },
+        manualPagination: true,
+        pageCount,
+      },
+      useBlockLayout,
+      useResizeColumns,
+      usePagination,
+      useRowSelect,
+    );
+    //Set isResizingColumn as true when column is resizing using table state
+    if (state.columnResizing.isResizingColumn) {
+      isResizingColumn.current = true;
+    } else {
+      // We are updating column size since the drag is complete when we are changing value of isResizing from true to false
+      if (isResizingColumn.current) {
+        //update isResizingColumn in next event loop so that dragEnd event does not trigger click event.
+        setTimeout(function() {
+          isResizingColumn.current = false;
+          handleResizeColumn(state.columnResizing.columnWidths);
+        }, 0);
       }
     }
-    props.handleResizeColumn(columnSizeMap);
-  };
-  const data = React.useMemo(() => props.data, [props.data]);
-  const columnString = JSON.stringify({
-    columns: props.columns,
-    compactMode: props.compactMode,
-    columnSizeMap: props.columnSizeMap,
-  });
-  const columns = React.useMemo(() => props.columns, [columnString]);
-  const tableHeadercolumns = React.useMemo(
-    () =>
-      props.columns.filter((column: ReactTableColumnProps) => {
-        return column.accessor !== "actions";
-      }),
-    [columnString],
-  );
-  const pageCount =
-    props.serverSidePaginationEnabled && props.totalRecordsCount
-      ? Math.ceil(props.totalRecordsCount / props.pageSize)
-      : Math.ceil(props.data.length / props.pageSize);
-  const currentPageIndex = props.pageNo < pageCount ? props.pageNo : 0;
-  const {
-    getTableBodyProps,
-    getTableProps,
-    headerGroups,
-    page,
-    pageOptions,
-    prepareRow,
-    state,
-  } = useTable(
-    {
-      columns: columns,
-      data,
-      defaultColumn,
-      initialState: {
-        pageIndex: currentPageIndex,
-        pageSize: props.pageSize,
-      },
-      manualPagination: true,
-      pageCount,
-    },
-    useBlockLayout,
-    useResizeColumns,
-    usePagination,
-    useRowSelect,
-  );
-  //Set isResizingColumn as true when column is resizing using table state
-  if (state.columnResizing.isResizingColumn) {
-    isResizingColumn.current = true;
-  } else {
-    // We are updating column size since the drag is complete when we are changing value of isResizing from true to false
-    if (isResizingColumn.current) {
-      //update isResizingColumn in next event loop so that dragEnd event does not trigger click event.
-      setTimeout(function() {
-        isResizingColumn.current = false;
-        handleResizeColumn(state.columnResizing.columnWidths);
-      }, 0);
+    let startIndex = currentPageIndex * props.pageSize;
+    let endIndex = startIndex + props.pageSize;
+    if (props.serverSidePaginationEnabled) {
+      startIndex = 0;
+      endIndex = props.data.length;
     }
-  }
-  let startIndex = currentPageIndex * props.pageSize;
-  let endIndex = startIndex + props.pageSize;
-  if (props.serverSidePaginationEnabled) {
-    startIndex = 0;
-    endIndex = props.data.length;
-  }
-  const subPage = page.slice(startIndex, endIndex);
-  const selectedRowIndex = props.selectedRowIndex;
-  const selectedRowIndices = props.selectedRowIndices || [];
-  const tableSizes = TABLE_SIZES[props.compactMode || CompactModeTypes.DEFAULT];
-  const tableWrapperRef = useRef<HTMLDivElement | null>(null);
-  const tableBodyRef = useRef<HTMLDivElement | null>(null);
-  const tableHeaderWrapperRef = React.createRef<HTMLDivElement>();
-  const rowSelectionState = React.useMemo(() => {
-    // return : 0; no row selected | 1; all row selected | 2: some rows selected
-    if (!props.multiRowSelection) return null;
-    const selectedRowCount = reduce(
-      page,
-      (count, row) => {
-        return selectedRowIndices.includes(row.index) ? count + 1 : count;
-      },
-      0,
-    );
-    const result =
-      selectedRowCount === 0 ? 0 : selectedRowCount === page.length ? 1 : 2;
-    return result;
-  }, [selectedRowIndices, page]);
-  const handleAllRowSelectClick = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-  ) => {
-    // if all / some rows are selected we remove selection on click
-    // else select all rows
-    props.toggleAllRowSelect(!Boolean(rowSelectionState), page);
-    // loop over subPage rows and toggleRowSelected if required
-    e.stopPropagation();
-  };
-  const isHeaderVisible =
-    props.isVisibleSearch ||
-    props.isVisibleFilters ||
-    props.isVisibleDownload ||
-    props.isVisiblePagination;
+    const subPage = page.slice(startIndex, endIndex);
+    const selectedRowIndex = props.selectedRowIndex;
+    const selectedRowIndices = props.selectedRowIndices || [];
+    const tableSizes =
+      TABLE_SIZES[props.compactMode || CompactModeTypes.DEFAULT];
+    const tableWrapperRef = useRef<HTMLDivElement | null>(null);
+    const tableBodyRef = ref;
+    const tableHeaderWrapperRef = React.createRef<HTMLDivElement>();
+    const rowSelectionState = React.useMemo(() => {
+      // return : 0; no row selected | 1; all row selected | 2: some rows selected
+      if (!props.multiRowSelection) return null;
+      const selectedRowCount = reduce(
+        page,
+        (count, row) => {
+          return selectedRowIndices.includes(row.index) ? count + 1 : count;
+        },
+        0,
+      );
+      const result =
+        selectedRowCount === 0 ? 0 : selectedRowCount === page.length ? 1 : 2;
+      return result;
+    }, [selectedRowIndices, page]);
+    const handleAllRowSelectClick = (
+      e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    ) => {
+      // if all / some rows are selected we remove selection on click
+      // else select all rows
+      props.toggleAllRowSelect(!Boolean(rowSelectionState), page);
+      // loop over subPage rows and toggleRowSelected if required
+      e.stopPropagation();
+    };
+    const isHeaderVisible =
+      props.isVisibleSearch ||
+      props.isVisibleFilters ||
+      props.isVisibleDownload ||
+      props.isVisiblePagination;
 
-  return (
-    <TableWrapper
-      backgroundColor={Colors.ATHENS_GRAY_DARKER}
-      height={props.height}
-      id={`table${props.widgetId}`}
-      isHeaderVisible={isHeaderVisible}
-      tableSizes={tableSizes}
-      triggerRowSelection={props.triggerRowSelection}
-      width={props.width}
-    >
-      {isHeaderVisible && (
-        <TableHeaderWrapper
-          backgroundColor={Colors.WHITE}
-          ref={tableHeaderWrapperRef}
-          serverSidePaginationEnabled={props.serverSidePaginationEnabled}
-          tableSizes={tableSizes}
-          width={props.width}
+    return (
+      <TableWrapper
+        backgroundColor={Colors.ATHENS_GRAY_DARKER}
+        height={props.height}
+        id={`table${props.widgetId}`}
+        isHeaderVisible={isHeaderVisible}
+        tableSizes={tableSizes}
+        triggerRowSelection={props.triggerRowSelection}
+        width={props.width}
+      >
+        {isHeaderVisible && (
+          <TableHeaderWrapper
+            backgroundColor={Colors.WHITE}
+            ref={tableHeaderWrapperRef}
+            serverSidePaginationEnabled={props.serverSidePaginationEnabled}
+            tableSizes={tableSizes}
+            width={props.width}
+          >
+            <Scrollbars
+              autoHide
+              renderThumbHorizontal={ScrollbarHorizontalThumb}
+              renderThumbVertical={ScrollbarVerticalThumb}
+              style={{
+                width: props.width,
+                height: 38,
+              }}
+            >
+              <TableHeaderInnerWrapper
+                backgroundColor={Colors.WHITE}
+                serverSidePaginationEnabled={props.serverSidePaginationEnabled}
+                tableSizes={tableSizes}
+                width={props.width}
+              >
+                <TableHeader
+                  applyFilter={props.applyFilter}
+                  columns={tableHeadercolumns}
+                  currentPageIndex={currentPageIndex}
+                  delimiter={props.delimiter}
+                  filters={props.filters}
+                  isVisibleDownload={props.isVisibleDownload}
+                  isVisibleFilters={props.isVisibleFilters}
+                  isVisiblePagination={props.isVisiblePagination}
+                  isVisibleSearch={props.isVisibleSearch}
+                  nextPageClick={props.nextPageClick}
+                  pageCount={pageCount}
+                  pageNo={props.pageNo}
+                  pageOptions={pageOptions}
+                  prevPageClick={props.prevPageClick}
+                  searchKey={props.searchKey}
+                  searchTableData={props.searchTableData}
+                  serverSidePaginationEnabled={
+                    props.serverSidePaginationEnabled
+                  }
+                  tableColumns={columns}
+                  tableData={props.data}
+                  tableSizes={tableSizes}
+                  totalRecordsCount={props.totalRecordsCount}
+                  updatePageNo={props.updatePageNo}
+                  widgetId={props.widgetId}
+                  widgetName={props.widgetName}
+                />
+              </TableHeaderInnerWrapper>
+            </Scrollbars>
+          </TableHeaderWrapper>
+        )}
+        <div
+          className={props.isLoading ? Classes.SKELETON : "tableWrap"}
+          ref={tableWrapperRef}
         >
           <Scrollbars
-            autoHide
             renderThumbHorizontal={ScrollbarHorizontalThumb}
-            renderThumbVertical={ScrollbarVerticalThumb}
             style={{
               width: props.width,
-              height: 38,
+              height: isHeaderVisible ? props.height - 48 : props.height,
             }}
           >
-            <TableHeaderInnerWrapper
-              backgroundColor={Colors.WHITE}
-              serverSidePaginationEnabled={props.serverSidePaginationEnabled}
-              tableSizes={tableSizes}
-              width={props.width}
-            >
-              <TableHeader
-                applyFilter={props.applyFilter}
-                columns={tableHeadercolumns}
-                currentPageIndex={currentPageIndex}
-                delimiter={props.delimiter}
-                filters={props.filters}
-                isVisibleDownload={props.isVisibleDownload}
-                isVisibleFilters={props.isVisibleFilters}
-                isVisiblePagination={props.isVisiblePagination}
-                isVisibleSearch={props.isVisibleSearch}
-                nextPageClick={props.nextPageClick}
-                pageCount={pageCount}
-                pageNo={props.pageNo}
-                pageOptions={pageOptions}
-                prevPageClick={props.prevPageClick}
-                searchKey={props.searchKey}
-                searchTableData={props.searchTableData}
-                serverSidePaginationEnabled={props.serverSidePaginationEnabled}
-                tableColumns={columns}
-                tableData={props.data}
-                tableSizes={tableSizes}
-                totalRecordsCount={props.totalRecordsCount}
-                updatePageNo={props.updatePageNo}
-                widgetId={props.widgetId}
-                widgetName={props.widgetName}
-              />
-            </TableHeaderInnerWrapper>
-          </Scrollbars>
-        </TableHeaderWrapper>
-      )}
-      <div
-        className={props.isLoading ? Classes.SKELETON : "tableWrap"}
-        ref={tableWrapperRef}
-      >
-        <Scrollbars
-          renderThumbHorizontal={ScrollbarHorizontalThumb}
-          style={{
-            width: props.width,
-            height: isHeaderVisible ? props.height - 48 : props.height,
-          }}
-        >
-          <div {...getTableProps()} className="table">
-            <div
-              className="thead"
-              onMouseLeave={props.enableDrag}
-              onMouseOver={props.disableDrag}
-            >
-              {headerGroups.map((headerGroup: any, index: number) => {
-                const headerRowProps = {
-                  ...headerGroup.getHeaderGroupProps(),
-                  style: { display: "flex" },
-                };
-                return (
-                  <div {...headerRowProps} className="tr" key={index}>
-                    {props.multiRowSelection &&
-                      renderCheckBoxHeaderCell(
-                        handleAllRowSelectClick,
-                        rowSelectionState,
+            <div {...getTableProps()} className="table">
+              <div
+                className="thead"
+                onMouseLeave={props.enableDrag}
+                onMouseOver={props.disableDrag}
+              >
+                {headerGroups.map((headerGroup: any, index: number) => {
+                  const headerRowProps = {
+                    ...headerGroup.getHeaderGroupProps(),
+                    style: { display: "flex" },
+                  };
+                  return (
+                    <div {...headerRowProps} className="tr" key={index}>
+                      {props.multiRowSelection &&
+                        renderCheckBoxHeaderCell(
+                          handleAllRowSelectClick,
+                          rowSelectionState,
+                        )}
+                      {headerGroup.headers.map(
+                        (column: any, columnIndex: number) => {
+                          return (
+                            <TableHeaderCell
+                              column={column}
+                              columnIndex={columnIndex}
+                              columnName={column.Header}
+                              editMode={props.editMode}
+                              isAscOrder={column.isAscOrder}
+                              isHidden={column.isHidden}
+                              isResizingColumn={isResizingColumn.current}
+                              isSortable={props.isSortable}
+                              key={columnIndex}
+                              sortTableColumn={props.sortTableColumn}
+                              width={props.width}
+                            />
+                          );
+                        },
                       )}
-                    {headerGroup.headers.map(
-                      (column: any, columnIndex: number) => {
+                    </div>
+                  );
+                })}
+                {headerGroups.length === 0 &&
+                  renderEmptyRows(
+                    1,
+                    props.columns,
+                    props.width,
+                    subPage,
+                    prepareRow,
+                    props.multiRowSelection,
+                  )}
+              </div>
+              <div
+                {...getTableBodyProps()}
+                className={`tbody ${
+                  props.pageSize > subPage.length ? "no-scroll" : ""
+                }`}
+                ref={tableBodyRef}
+              >
+                {subPage.map((row, rowIndex) => {
+                  prepareRow(row);
+                  const rowProps = {
+                    ...row.getRowProps(),
+                    style: { display: "flex" },
+                  };
+                  const isRowSelected =
+                    row.index === selectedRowIndex ||
+                    selectedRowIndices.includes(row.index);
+                  return (
+                    <div
+                      {...rowProps}
+                      className={
+                        "tr" + `${isRowSelected ? " selected-row" : ""}`
+                      }
+                      key={rowIndex}
+                      onClick={(e) => {
+                        row.toggleRowSelected();
+                        props.selectTableRow(row);
+                        e.stopPropagation();
+                      }}
+                    >
+                      {props.multiRowSelection &&
+                        renderCheckBoxCell(isRowSelected)}
+                      {row.cells.map((cell, cellIndex) => {
                         return (
-                          <TableHeaderCell
-                            column={column}
-                            columnIndex={columnIndex}
-                            columnName={column.Header}
-                            editMode={props.editMode}
-                            isAscOrder={column.isAscOrder}
-                            isHidden={column.isHidden}
-                            isResizingColumn={isResizingColumn.current}
-                            isSortable={props.isSortable}
-                            key={columnIndex}
-                            sortTableColumn={props.sortTableColumn}
-                            width={props.width}
-                          />
+                          <div
+                            {...cell.getCellProps()}
+                            className="td"
+                            data-colindex={cellIndex}
+                            data-rowindex={rowIndex}
+                            key={cellIndex}
+                          >
+                            {cell.render("Cell")}
+                          </div>
                         );
-                      },
-                    )}
-                  </div>
-                );
-              })}
-              {headerGroups.length === 0 &&
-                renderEmptyRows(
-                  1,
-                  props.columns,
-                  props.width,
-                  subPage,
-                  prepareRow,
-                  props.multiRowSelection,
-                )}
+                      })}
+                    </div>
+                  );
+                })}
+                {props.pageSize > subPage.length &&
+                  renderEmptyRows(
+                    props.pageSize - subPage.length,
+                    props.columns,
+                    props.width,
+                    subPage,
+                    prepareRow,
+                    props.multiRowSelection,
+                  )}
+              </div>
             </div>
-            <div
-              {...getTableBodyProps()}
-              className={`tbody ${
-                props.pageSize > subPage.length ? "no-scroll" : ""
-              }`}
-              ref={tableBodyRef}
-            >
-              {subPage.map((row, rowIndex) => {
-                prepareRow(row);
-                const rowProps = {
-                  ...row.getRowProps(),
-                  style: { display: "flex" },
-                };
-                const isRowSelected =
-                  row.index === selectedRowIndex ||
-                  selectedRowIndices.includes(row.index);
-                return (
-                  <div
-                    {...rowProps}
-                    className={"tr" + `${isRowSelected ? " selected-row" : ""}`}
-                    key={rowIndex}
-                    onClick={(e) => {
-                      row.toggleRowSelected();
-                      props.selectTableRow(row);
-                      e.stopPropagation();
-                    }}
-                  >
-                    {props.multiRowSelection &&
-                      renderCheckBoxCell(isRowSelected)}
-                    {row.cells.map((cell, cellIndex) => {
-                      return (
-                        <div
-                          {...cell.getCellProps()}
-                          className="td"
-                          data-colindex={cellIndex}
-                          data-rowindex={rowIndex}
-                          key={cellIndex}
-                        >
-                          {cell.render("Cell")}
-                        </div>
-                      );
-                    })}
-                  </div>
-                );
-              })}
-              {props.pageSize > subPage.length &&
-                renderEmptyRows(
-                  props.pageSize - subPage.length,
-                  props.columns,
-                  props.width,
-                  subPage,
-                  prepareRow,
-                  props.multiRowSelection,
-                )}
-            </div>
-          </div>
-        </Scrollbars>
-      </div>
-      <ScrollIndicator
-        containerRef={tableBodyRef}
-        mode="LIGHT"
-        top={props.editMode ? "70px" : "73px"}
-      />
-    </TableWrapper>
-  );
-}
+          </Scrollbars>
+        </div>
+        <ScrollIndicator
+          containerRef={tableBodyRef as React.MutableRefObject<HTMLDivElement>}
+          mode="LIGHT"
+          top={props.editMode ? "70px" : "73px"}
+        />
+      </TableWrapper>
+    );
+  },
+);
+
+Table.displayName = "Table";
 
 export default Table;

--- a/app/client/src/widgets/TableWidget/component/index.tsx
+++ b/app/client/src/widgets/TableWidget/component/index.tsx
@@ -78,7 +78,10 @@ interface ReactTableComponentProps {
   isSortable?: boolean;
 }
 
-function ReactTableComponent(props: ReactTableComponentProps) {
+const ReactTableComponent = React.forwardRef<
+  HTMLDivElement,
+  ReactTableComponentProps
+>((props, ref) => {
   const {
     applyFilter,
     columns,
@@ -274,6 +277,7 @@ function ReactTableComponent(props: ReactTableComponentProps) {
       pageNo={pageNo - 1}
       pageSize={pageSize || 1}
       prevPageClick={prevPageClick}
+      ref={ref}
       searchKey={searchKey}
       searchTableData={searchTableData}
       selectTableRow={selectTableRow}
@@ -290,7 +294,9 @@ function ReactTableComponent(props: ReactTableComponentProps) {
       width={width}
     />
   );
-}
+});
+
+ReactTableComponent.displayName = "ReactTableComponent";
 
 export default React.memo(ReactTableComponent, (prev, next) => {
   return (

--- a/app/client/src/widgets/TableWidget/widget/index.tsx
+++ b/app/client/src/widgets/TableWidget/widget/index.tsx
@@ -809,6 +809,7 @@ class TableWidget extends BaseWidget<TableWidgetProps, WidgetState> {
             isVisibleHeaderOptions ? Math.max(1, pageSize) : pageSize + 1
           }
           prevPageClick={this.handlePrevPageClick}
+          ref={this.contentRef}
           searchKey={this.props.searchText}
           searchTableData={this.handleSearchTable}
           selectAllRow={this.handleAllRowSelect}


### PR DESCRIPTION
## Description

1. Wrapped the Table widget default component in the React.forwardRef so that the incoming ref from the parent widget can be hooked up to the `ReactTableComponent` component underneath.
2. Also wrapped the `Table` component inside `ReactTableComponent` in the React.forwardRef and hooked it up to `table body` div element.
3. `ScrollBar` indicators also use the table body ref, so type casted the forward ref as `React.MutableRef` while passing the prop.

Fixes #13042

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/dh-stdzn-table-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.49 **(0.03)** | 37.97 **(0.03)** | 36.27 **(0.1)** | 56.7 **(0.01)**
 :red_circle: | app/client/src/actions/reflowActions.ts | 75 **(-10.71)** | 100 **(0)** | 20 **(-30)** | 63.64 **(-16.36)**
 :green_circle: | app/client/src/ce/constants/messages.ts | 78.05 **(0.05)** | 100 **(0)** | 35.08 **(0.14)** | 82.34 **(0.1)**
 :green_circle: | app/client/src/components/ads/Checkbox.tsx | 90.24 **(63.41)** | 56.82 **(43.18)** | 88.24 **(88.24)** | 88.89 **(58.33)**
 :green_circle: | app/client/src/components/editorComponents/Debugger/index.tsx | 76.6 **(0.51)** | 26.92 **(0)** | 87.5 **(1.79)** | 78.26 **(0.48)**
 :green_circle: | app/client/src/pages/Editor/MainContainerLayoutControl.tsx | 88.89 **(0.25)** | 81.25 **(0)** | 80 **(0)** | 90.48 **(0.24)**
 :sparkles: :new: | **app/client/src/pages/Editor/ReflowBetaCard.tsx** | **82.86** | **68.18** | **25** | **82.86**
 :green_circle: | app/client/src/pages/Editor/BottomBar/ManualUpgrades.tsx | 90.32 **(0.85)** | 85 **(1.67)** | 76.92 **(1.92)** | 88.68 **(-1.12)**
 :red_circle: | app/client/src/pages/Editor/Explorer/Files/index.tsx | 76.32 **(0.13)** | 33.33 **(5.55)** | 40 **(-10)** | 80.56 **(1.07)**
 :red_circle: | app/client/src/pages/Editor/FirstTimeUserOnboarding/Checklist.tsx | 96.27 **(-0.03)** | 96.61 **(0)** | 92.68 **(-0.18)** | 96.27 **(-0.03)**
 :green_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 34.7 **(0.17)** | 25.77 **(0)** | 0 **(0)** | 36.02 **(0.04)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/index.tsx | 27.61 **(-0.42)** | 5.33 **(0)** | 5.26 **(-0.3)** | 29.27 **(-0.24)**
 :green_circle: | app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx | 62.83 **(0.33)** | 44 **(0)** | 27.59 **(2.59)** | 64.49 **(0.34)**
 :green_circle: | app/client/src/pages/common/CanvasArenas/hooks/useCanvasDragging.ts | 83.64 **(0.1)** | 67.05 **(0.13)** | 84.38 **(0)** | 84.19 **(0.1)**
 :green_circle: | app/client/src/reducers/uiReducers/applicationsReducer.tsx | 16 **(0.76)** | 27.27 **(7.27)** | 12.24 **(0.48)** | 14.43 **(0.57)**
 :red_circle: | app/client/src/reducers/uiReducers/reflowReducer.ts | 58.33 **(-25)** | 100 **(0)** | 25 **(-25)** | 54.55 **(-28.78)**
 :green_circle: | app/client/src/reflow/reflowHelpers.ts | 94.94 **(0.33)** | 64.77 **(5.95)** | 100 **(0)** | 95.57 **(0.54)**
 :red_circle: | app/client/src/reflow/reflowUtils.ts | 79.55 **(-0.6)** | 69.65 **(-0.8)** | 84.31 **(-0.31)** | 79.61 **(-0.69)**
 :red_circle: | app/client/src/resizable/resizenreflow/index.tsx | 53.57 **(-1.24)** | 54.46 **(-3.09)** | 40 **(0)** | 51.91 **(-1.26)**
 :red_circle: | app/client/src/sagas/ModalSagas.ts | 36.27 **(-0.34)** | 19.44 **(1.02)** | 23.08 **(0)** | 37.23 **(-1.01)**
 :sparkles: :new: | **app/client/src/sagas/ReflowSagas.ts** | **24.24** | **7.14** | **33.33** | **28.57**
 :green_circle: | app/client/src/sagas/index.tsx | 93.44 **(0.11)** | 57.14 **(0)** | 100 **(0)** | 96.49 **(0.06)**
 :green_circle: | app/client/src/utils/WidgetFactory.tsx | 74.47 **(8.8)** | 72.22 **(29.36)** | 64.71 **(19.26)** | 74.47 **(8.8)**
 :green_circle: | app/client/src/utils/WidgetRegisterHelpers.tsx | 100 **(3.85)** | 100 **(25)** | 100 **(0)** | 100 **(4.17)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 68.63 **(-3.92)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/utils/storage.ts | 34.04 **(-0.14)** | 11.11 **(-4.68)** | 7.14 **(-2.24)** | 27.01 **(0.74)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/utils/hooks/localstorage.tsx | 63.16 **(42.11)** | 25 **(25)** | 66.67 **(66.67)** | 58.82 **(35.29)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 80 **(0.16)** | 48.94 **(0)** | 76.47 **(0)** | 79.2 **(0.17)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/component/Form.tsx | 29.35 **(0.93)** | 20 **(0)** | 0 **(0)** | 30.68 **(1.01)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/component/index.tsx | 27.08 **(0.55)** | 33.33 **(0)** | 0 **(0)** | 27.66 **(0.58)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/widget/index.tsx | 30.1 **(0.58)** | 0 **(0)** | 21.43 **(0.74)** | 30.61 **(0.61)**
 :green_circle: | app/client/src/widgets/SingleSelectTreeWidget/component/index.tsx | 16.47 **(0.56)** | 0 **(0)** | 0 **(0)** | 18.42 **(0.7)**
 :green_circle: | app/client/src/widgets/TableWidget/component/Table.tsx | 62.07 **(0.44)** | 38.89 **(0)** | 38.89 **(0)** | 60.71 **(-0.27)**
 :green_circle: | app/client/src/widgets/TableWidget/component/index.tsx | 29.11 **(1.84)** | 2.6 **(0)** | 15.79 **(0)** | 27.63 **(1.95)**
 :x: | ~~app/client/src/utils/WidgetFactoryHelpers.ts~~ | ~~100~~ | ~~91.67~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/utils/WidgetFeatures.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~</details>