### PR TITLE
feat: dynamic height RateWidget standardisation

### DIFF
--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -58,6 +58,7 @@ abstract class BaseWidget<
   K extends WidgetState
 > extends Component<T, K> {
   static contextType = EditorContext;
+  contentRef = React.createRef();
 
   static getPropertyPaneConfig(): PropertyPaneConfig[] {
     return [];

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -58,7 +58,7 @@ abstract class BaseWidget<
   K extends WidgetState
 > extends Component<T, K> {
   static contextType = EditorContext;
-  contentRef = React.createRef();
+  contentRef = React.createRef<HTMLDivElement>();
 
   static getPropertyPaneConfig(): PropertyPaneConfig[] {
     return [];

--- a/app/client/src/widgets/RateWidget/component/index.tsx
+++ b/app/client/src/widgets/RateWidget/component/index.tsx
@@ -95,61 +95,65 @@ function renderStarsWithTooltip(props: RateComponentProps) {
   return _.concat(starWithTooltip, starWithoutTooltip);
 }
 
-function RateComponent(props: RateComponentProps) {
-  const rateContainerRef = React.createRef<HTMLDivElement>();
+const RateComponent = React.forwardRef<HTMLDivElement, RateComponentProps>(
+  (props, ref) => {
+    const rateContainerRef = ref as React.MutableRefObject<HTMLDivElement>;
 
-  const {
-    bottomRow,
-    inactiveColor,
-    isAllowHalf,
-    isDisabled,
-    leftColumn,
-    maxCount,
-    onValueChanged,
-    readonly,
-    rightColumn,
-    size,
-    topRow,
-    value,
-  } = props;
+    const {
+      bottomRow,
+      inactiveColor,
+      isAllowHalf,
+      isDisabled,
+      leftColumn,
+      maxCount,
+      onValueChanged,
+      readonly,
+      rightColumn,
+      size,
+      topRow,
+      value,
+    } = props;
 
-  const [scrollable, setScrollable] = useState(false);
+    const [scrollable, setScrollable] = useState(false);
 
-  useEffect(() => {
-    const rateContainerElement = rateContainerRef.current;
-    if (
-      rateContainerElement &&
-      rateContainerElement.scrollHeight > rateContainerElement.clientHeight
-    ) {
-      setScrollable(true);
-    } else {
-      setScrollable(false);
-    }
-  }, [leftColumn, rightColumn, topRow, bottomRow, maxCount, size]);
+    useEffect(() => {
+      const rateContainerElement = rateContainerRef.current;
+      if (
+        rateContainerElement &&
+        rateContainerElement.scrollHeight > rateContainerElement.clientHeight
+      ) {
+        setScrollable(true);
+      } else {
+        setScrollable(false);
+      }
+    }, [leftColumn, rightColumn, topRow, bottomRow, maxCount, size]);
 
-  return (
-    <RateContainer
-      isDisabled={Boolean(isDisabled)}
-      ref={rateContainerRef}
-      scrollable={scrollable}
-    >
-      <Rating
-        emptySymbol={
-          <Star
-            color={inactiveColor || Colors.ALTO_3}
-            icon={IconNames.STAR}
-            iconSize={RATE_SIZES[size]}
-          />
-        }
-        fractions={isAllowHalf ? 2 : 1}
-        fullSymbol={renderStarsWithTooltip(props)}
-        initialRating={value}
-        onChange={onValueChanged}
-        readonly={readonly}
-        stop={maxCount}
-      />
-    </RateContainer>
-  );
-}
+    return (
+      <RateContainer
+        isDisabled={Boolean(isDisabled)}
+        ref={rateContainerRef}
+        scrollable={scrollable}
+      >
+        <Rating
+          emptySymbol={
+            <Star
+              color={inactiveColor || Colors.ALTO_3}
+              icon={IconNames.STAR}
+              iconSize={RATE_SIZES[size]}
+            />
+          }
+          fractions={isAllowHalf ? 2 : 1}
+          fullSymbol={renderStarsWithTooltip(props)}
+          initialRating={value}
+          onChange={onValueChanged}
+          readonly={readonly}
+          stop={maxCount}
+        />
+      </RateContainer>
+    );
+  },
+);
+
+RateComponent.displayName = "RateComponent";
 
 export default RateComponent;

--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -257,6 +257,7 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
           maxCount={this.props.maxCount}
           onValueChanged={this.valueChangedHandler}
           readonly={this.props.isDisabled}
+          ref={this.contentRef}
           rightColumn={this.props.rightColumn}
           size={this.props.size}
           tooltips={this.props.tooltips}


### PR DESCRIPTION
## Description

1. Wrapped the RateWidget default component in the React.forwardRef so that the incoming ref from the parent widget can be hooked up to the `RateComponent` component underneath.
2. Wrapped the `RateComponent` component in the React.forwardRef and set the ref to the `RateContainer` component (div).
3. Hooked the BaseWidget contentRef to the JSONForm component via JSONForm Widget.
4. `RateComponent` uses the ref to `RateContainer` so type casted it `React.MutableRef`.



Fixes #

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes