### PR TITLE
fix: Add fallback for responseType, in case it does not exist

### DIFF
--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -105,6 +105,8 @@ import { submitCurlImportForm } from "actions/importActions";
 import { getBasePath } from "pages/Editor/Explorer/helpers";
 import { isTrueObject } from "workers/evaluationUtils";
 import { handleExecuteJSFunctionSaga } from "sagas/JSPaneSagas";
+import { Plugin } from "api/PluginApi";
+
 enum ActionResponseDataTypes {
   BINARY = "BINARY",
 }
@@ -835,17 +837,24 @@ function* executePluginActionSaga(
         response: payload,
       }),
     );
-    let plugin;
+    let plugin: Plugin | undefined;
     if (!!pluginAction.pluginId) {
       plugin = yield select(getPlugin, pluginAction.pluginId);
     }
-    yield put(
-      setActionResponseDisplayFormat({
-        id: actionId,
-        field: "responseDisplayFormat",
-        value: plugin && plugin.responseType ? plugin.responseType : "JSON",
-      }),
-    );
+
+    if (!!plugin) {
+      const responseType = payload?.dataTypes.find(
+        (type) =>
+          plugin?.responseType && type.dataType === plugin?.responseType,
+      );
+      yield put(
+        setActionResponseDisplayFormat({
+          id: actionId,
+          field: "responseDisplayFormat",
+          value: responseType ? responseType?.dataType : "JSON",
+        }),
+      );
+    }
     return {
       payload,
       isError: isErrorResponse(response),


### PR DESCRIPTION
We add a fallback for the responseViewType in case the default responseType of the plugin is not included in the response dataTypes array.

Fixes #13310

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/response-display-format-fallback 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.46 **(0)** | 37.92 **(-0.02)** | 36.16 **(-0.01)** | 56.68 **(0)**
 :red_circle: | app/client/src/sagas/ActionExecution/PluginActionSaga.ts | 17.22 **(-0.11)** | 1.88 **(-0.23)** | 9.09 **(-0.43)** | 19.77 **(-0.15)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(3.92)** | 100 **(0)** | 93.33 **(0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>