### PR TITLE
fix: Parse nested structures as tables for action execution results

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
@@ -312,16 +312,14 @@ public class DataTypeStringUtils {
         if (data instanceof List) {
             // Check if the data is a list of simple json objects i.e. all values in the key value pairs are simple
             // objects or their wrappers.
-            return ((List)data).stream()
-                    .allMatch(item -> item instanceof Map
-                            && ((Map)item).entrySet().stream()
-                            .allMatch(e -> ((Map.Entry)e).getValue() == null ||
-                            isPrimitiveOrWrapper(((Map.Entry)e).getValue().getClass())));
+            return ((List) data).stream()
+                    .allMatch(item -> item instanceof Map);
         }
         else if (data instanceof JsonNode) {
             // Check if the data is an array of simple json objects
             try {
-                objectMapper.convertValue(data, new TypeReference<List<Map<String, String>>>() {});
+                objectMapper.convertValue(data, new TypeReference<List<Map<String, Object>>>() {
+                });
                 return true;
             } catch (IllegalArgumentException e) {
                 return false;
@@ -330,7 +328,8 @@ public class DataTypeStringUtils {
         else if (data instanceof String) {
             // Check if the data is an array of simple json objects
             try {
-                objectMapper.readValue((String)data, new TypeReference<List<Map<String, String>>>() {});
+                objectMapper.readValue((String) data, new TypeReference<List<Map<String, Object>>>() {
+                });
                 return true;
             } catch (IOException e) {
                 return false;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
@@ -310,13 +310,12 @@ public class DataTypeStringUtils {
 
     private static boolean isDisplayTypeTable(Object data) {
         if (data instanceof List) {
-            // Check if the data is a list of simple json objects i.e. all values in the key value pairs are simple
-            // objects or their wrappers.
+            // Check if the data is a list of json objects
             return ((List) data).stream()
                     .allMatch(item -> item instanceof Map);
         }
         else if (data instanceof JsonNode) {
-            // Check if the data is an array of simple json objects
+            // Check if the data is an array of json objects
             try {
                 objectMapper.convertValue(data, new TypeReference<List<Map<String, Object>>>() {
                 });
@@ -326,7 +325,7 @@ public class DataTypeStringUtils {
             }
         }
         else if (data instanceof String) {
-            // Check if the data is an array of simple json objects
+            // Check if the data is an array of json objects
             try {
                 objectMapper.readValue((String) data, new TypeReference<List<Map<String, Object>>>() {
                 });

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/DataTypeStringUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/DataTypeStringUtilsTest.java
@@ -1,8 +1,19 @@
 package com.appsmith.external.helpers;
 
 import com.appsmith.external.constants.DataType;
+import com.appsmith.external.constants.DisplayDataType;
+import com.appsmith.external.models.ParsedDataType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.appsmith.external.helpers.DataTypeStringUtils.getDisplayDataTypes;
 import static com.appsmith.external.helpers.DataTypeStringUtils.stringToKnownDataTypeConverter;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -175,5 +186,50 @@ public class DataTypeStringUtilsTest {
         assertThat(DataType.JSON_OBJECT).isEqualByComparingTo(stringToKnownDataTypeConverter("{\"a\": 0}"));
         assertThat(DataType.JSON_OBJECT).isEqualByComparingTo(stringToKnownDataTypeConverter("{\"a\": \"\"}"));
         assertThat(DataType.JSON_OBJECT).isEqualByComparingTo(stringToKnownDataTypeConverter("{\"a\": []}"));
+    }
+
+    @Test
+    public void testGetDisplayDataTypes_withNestedObjectsInList_returnsWithTable() {
+
+        final List<Object> data = new ArrayList<>();
+        final Map<String, Object> objectMap = new HashMap<>();
+        final Map<String, Object> nestedObjectMap = new HashMap<>();
+        nestedObjectMap.put("k2", "v2");
+        objectMap.put("k", nestedObjectMap);
+
+        data.add(objectMap);
+        final List<ParsedDataType> displayDataTypes = getDisplayDataTypes(data);
+
+        assertThat(displayDataTypes).anyMatch(parsedDataType -> parsedDataType.getDataType().equals(DisplayDataType.TABLE));
+    }
+
+    @Test
+    public void testGetDisplayDataTypes_withNestedObjectsInArrayNode_returnsWithTable() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ArrayNode data = objectMapper.createArrayNode();
+        final ObjectNode objectNode = objectMapper.createObjectNode();
+        final ObjectNode nestedObjectNode = objectMapper.createObjectNode();
+        nestedObjectNode.put("k2", "v2");
+        objectNode.set("k", nestedObjectNode);
+
+        data.add(objectNode);
+        final List<ParsedDataType> displayDataTypes = getDisplayDataTypes(data);
+
+        assertThat(displayDataTypes).anyMatch(parsedDataType -> parsedDataType.getDataType().equals(DisplayDataType.TABLE));
+    }
+
+    @Test
+    public void testGetDisplayDataTypes_withNestedObjectsInString_returnsWithTable() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ArrayNode data = objectMapper.createArrayNode();
+        final ObjectNode objectNode = objectMapper.createObjectNode();
+        final ObjectNode nestedObjectNode = objectMapper.createObjectNode();
+        nestedObjectNode.put("k2", "v2");
+        objectNode.set("k", nestedObjectNode);
+
+        data.add(objectNode);
+        final List<ParsedDataType> displayDataTypes = getDisplayDataTypes(data.toString());
+
+        assertThat(displayDataTypes).anyMatch(parsedDataType -> parsedDataType.getDataType().equals(DisplayDataType.TABLE));
     }
 }


### PR DESCRIPTION
## Description

We were only allowing simple data types to be parsed as a table, but most datasources allow complex nested structures within a column as well. This fix allows anything that looks like a map to be represented as a table.

Fixes #13310 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit test cases
- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
