### PR TITLE
fix: prevent multiple execution of pageload actions when generating page from template

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GenerateCRUD/Mongo_Spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GenerateCRUD/Mongo_Spec.js
@@ -2,6 +2,7 @@ const pages = require("../../../../locators/Pages.json");
 const generatePage = require("../../../../locators/GeneratePage.json");
 import homePage from "../../../../locators/HomePage";
 const datasource = require("../../../../locators/DatasourcesEditor.json");
+const commonlocators = require("../../../../locators/commonlocators.json");
 
 describe("Generate New CRUD Page Inside from Mongo as Data Source", function() {
   let datasourceName;
@@ -91,6 +92,9 @@ describe("Generate New CRUD Page Inside from Mongo as Data Source", function() {
       "response.body.responseMeta.status",
       200,
     );
+    cy.get(commonlocators.toastAction)
+      .should("have.length", 1)
+      .should("have.text", "Successfully generated a page");
     cy.get("span:contains('GOT IT')").click();
   });
 

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -976,6 +976,7 @@ export function* generateTemplatePageSaga(
           responseMeta: response.responseMeta,
         },
         pageId,
+        isFirstLoad: true,
       });
 
       // TODO : Add this to onSuccess (Redux Action)


### PR DESCRIPTION
## Description


Fixes #13013 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/prevent-dual-execution-of-pageload-action-when-generating-page-from-templates 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.46 **(0)** | 37.92 **(0.01)** | 36.15 **(0)** | 56.69 **(0.01)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>