### PR TITLE
fix: dropdown showing an empty row when the options list is empty

### DIFF
--- a/app/client/src/components/ads/Dropdown.test.tsx
+++ b/app/client/src/components/ads/Dropdown.test.tsx
@@ -11,7 +11,7 @@ import Dropdown from "./Dropdown";
 import { lightTheme } from "selectors/themeSelectors";
 import userEvent from "@testing-library/user-event";
 
-const props = {
+const optionsProps: any = {
   options: [
     { label: "Primary", value: "PRIMARY" },
     { label: "Secondary", value: "SECONDARY" },
@@ -24,8 +24,13 @@ const props = {
   showLabelOnly: true,
 };
 
+const noOptionsProps = {
+  options: [],
+};
+
 const getTestComponent = (
   handleOnSelect: any = undefined,
+  props = optionsProps,
   allowDeselection?: boolean,
 ) => (
   <ThemeProvider theme={lightTheme}>
@@ -135,15 +140,15 @@ describe("<Dropdown /> - Keyboard Navigation", () => {
     userEvent.keyboard("{ArrowDown}");
     userEvent.keyboard("{Enter}");
     expect(handleOnSelect).toHaveBeenLastCalledWith(
-      props.options[1].value,
-      props.options[1],
+      optionsProps.options[1].value,
+      optionsProps.options[1],
     );
     userEvent.keyboard("{Enter}");
     userEvent.keyboard("{ArrowDown}");
     userEvent.keyboard(" ");
     expect(handleOnSelect).toHaveBeenLastCalledWith(
-      props.options[2].value,
-      props.options[2],
+      optionsProps.options[2].value,
+      optionsProps.options[2],
     );
   });
 
@@ -179,26 +184,26 @@ describe("<Dropdown /> - allowDeselection behaviour", () => {
     // click on Second Item
     fireEvent.click(screen.queryAllByRole("option")[1]);
     expect(screen.getByRole("option", { selected: true })).toHaveTextContent(
-      props.options[1].label,
+      optionsProps.options[1].label,
     );
     expect(screen.getByRole("listbox")).toHaveTextContent(
-      props.options[1].label,
+      optionsProps.options[1].label,
     );
 
     // click on Second Item Again
     fireEvent.click(screen.queryAllByRole("option")[1]);
     expect(screen.getByRole("option", { selected: true })).toHaveTextContent(
-      props.options[1].label,
+      optionsProps.options[1].label,
     );
     expect(screen.getByRole("listbox")).toHaveTextContent(
-      props.options[1].label,
+      optionsProps.options[1].label,
     );
     expect(screen.getByRole("option", { selected: true })).not.toBeNull();
   });
 
   it("Test allowDeselection = true behaviour", async () => {
     const handleOnSelect = jest.fn();
-    render(getTestComponent(handleOnSelect, true));
+    render(getTestComponent(handleOnSelect, optionsProps, true));
     expect(screen.getByRole("listbox")).toHaveTextContent("Primary");
 
     const dropdown = screen
@@ -213,14 +218,30 @@ describe("<Dropdown /> - allowDeselection behaviour", () => {
     // click on Third Item
     fireEvent.click(screen.queryAllByRole("option")[2]);
     expect(screen.getByRole("option", { selected: true })).toHaveTextContent(
-      props.options[2].label,
+      optionsProps.options[2].label,
     );
     expect(screen.getByRole("listbox")).toHaveTextContent(
-      props.options[2].label,
+      optionsProps.options[2].label,
     );
 
     // click on Third Item Again, that should unselect everything
     fireEvent.click(screen.queryAllByRole("option")[2]);
     expect(screen.queryByRole("option", { selected: true })).toBeNull();
+  });
+});
+
+describe("<Dropdown /> - when the options is an empty array", () => {
+  it("Hide options renderer when option list is empty", () => {
+    const handleOnSelect = jest.fn();
+    render(getTestComponent(handleOnSelect, noOptionsProps));
+
+    const dropdown = screen
+      .getByRole("listbox")
+      .querySelector(".bp3-popover-target");
+    expect(dropdown).not.toBeNull();
+
+    // open dropdown
+    fireEvent.click(dropdown as Element);
+    expect(screen.queryByTestId("dropdown-options-wrapper")).toBeNull();
   });
 });

--- a/app/client/src/components/ads/Dropdown.tsx
+++ b/app/client/src/components/ads/Dropdown.tsx
@@ -668,9 +668,12 @@ export function RenderDropdownOptions(props: DropdownOptionsProps) {
   };
   const theme = useTheme() as Theme;
 
+  if (!options.length) return null;
+
   return (
     <DropdownWrapper
       className="ads-dropdown-options-wrapper"
+      data-testid="dropdown-options-wrapper"
       isOpen={props.isOpen}
       width={optionWidth}
     >


### PR DESCRIPTION
## Description

Hide the empty row which appears due to the vertical padding of https://github.com/appsmithorg/appsmith/blob/release/app/client/src/components/ads/Dropdown.tsx#L672

Fixes #10329

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/crud-dropdown 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.46 **(0)** | 37.93 **(0.01)** | 36.15 **(0)** | 56.68 **(-0.01)**
 :green_circle: | app/client/src/components/ads/Dropdown.tsx | 85.88 **(0.11)** | 66.96 **(1.38)** | 77.78 **(0)** | 85 **(0.06)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>