### PR TITLE
test: changed custom actions cache version to 3.0.2

### DIFF
--- a/.github/workflows/TestReuseActions.yml
+++ b/.github/workflows/TestReuseActions.yml
@@ -459,7 +459,7 @@ jobs:
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        uses: martijnhols/actions-cache@v3
+        uses: martijnhols/actions-cache@v3.0.2
         with:
           path: |
             ~/run_result

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -471,7 +471,7 @@ jobs:
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        uses: martijnhols/actions-cache@v3
+        uses: martijnhols/actions-cache@v3.0.2
         with:
           path: |
             ~/run_result
@@ -806,7 +806,7 @@ jobs:
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        uses: martijnhols/actions-cache@v3
+        uses: martijnhols/actions-cache@v3.0.2
         with:
           path: |
             ~/run_result

--- a/.github/workflows/test-build-docker-image-fat.yml
+++ b/.github/workflows/test-build-docker-image-fat.yml
@@ -446,7 +446,7 @@ jobs:
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        uses: martijnhols/actions-cache@v3
+        uses: martijnhols/actions-cache@v3.0.2
         with:
           path: |
             ~/run_result
@@ -785,7 +785,7 @@ jobs:
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        uses: martijnhols/actions-cache@v3
+        uses: martijnhols/actions-cache@v3.0.2
         with:
           path: |
             ~/run_result

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -455,7 +455,7 @@ jobs:
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        uses: martijnhols/actions-cache@v3
+        uses: martijnhols/actions-cache@v3.0.2
         with:
           path: |
             ~/run_result
@@ -829,7 +829,7 @@ jobs:
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
-        uses: martijnhols/actions-cache@v3
+        uses: martijnhols/actions-cache@v3.0.2
         with:
           path: |
             ~/run_result


### PR DESCRIPTION
## Description

Why did CI break?
- We use github actions cache to store jobstate for the previous runs. The default cache is invalidated incase the job fails. To support rerunning only failed tests, we use custom cache martijnhols/actions-cache@v3. Recently new changes into custome cache broke our workflow https://github.com/MartijnHols/actions-cache.

What is the solution?
- We are hardcoding the the version to use 3.0.2.



Fixes # (issue)



## Type of change
Why did CI break?
- We use github actions cache to store jobstate for the previous runs. The default cache is invalidated incase the job fails. To support rerunning only failed tests, we use custom cache martijnhols/actions-cache@v3. Recently new changes into custome cache broke our workflow https://github.com/MartijnHols/actions-cache.

What is the solution?
- We are hardcoding the the version to use 3.0.2.


- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

tested in fork

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
