### PR TITLE
feat: dynamic height input widget standardisation

### DIFF
--- a/app/client/src/widgets/BaseInputWidget/component/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/component/index.tsx
@@ -562,53 +562,55 @@ class BaseInputComponent extends React.Component<
     const showLabelHeader = label || tooltip;
 
     return (
-      <InputComponentWrapper
-        compactMode={compactMode}
-        data-testid="input-container"
-        disabled={disabled}
-        fill
-        hasError={isInvalid}
-        inputType={inputType}
-        labelPosition={labelPosition}
-        labelStyle={labelStyle}
-        labelTextColor={labelTextColor}
-        labelTextSize={labelTextSize ? TEXT_SIZES[labelTextSize] : "inherit"}
-        multiline={(!!multiline).toString()}
-        numeric={isNumberInputType(inputHTMLType)}
-      >
-        {showLabelHeader && (
-          <LabelWithTooltip
-            alignment={labelAlignment}
-            className="t--input-widget-label"
-            color={labelTextColor}
-            compact={compactMode}
-            cyHelpTextClassName="t--input-widget-tooltip"
-            disabled={disabled}
-            fontSize={labelTextSize}
-            fontStyle={labelStyle}
-            helpText={tooltip}
-            loading={isLoading}
-            position={labelPosition}
-            text={label}
-            width={labelWidth}
-          />
-        )}
-        <TextInputWrapper
-          compact={compactMode}
-          inputHtmlType={inputHTMLType}
+      <div ref={this.props.innerRef}>
+        <InputComponentWrapper
+          compactMode={compactMode}
+          data-testid="input-container"
+          disabled={disabled}
+          fill
+          hasError={isInvalid}
+          inputType={inputType}
           labelPosition={labelPosition}
+          labelStyle={labelStyle}
+          labelTextColor={labelTextColor}
+          labelTextSize={labelTextSize ? TEXT_SIZES[labelTextSize] : "inherit"}
+          multiline={(!!multiline).toString()}
+          numeric={isNumberInputType(inputHTMLType)}
         >
-          <ErrorTooltip
-            isOpen={isInvalid && showError}
-            message={
-              errorMessage ||
-              createMessage(INPUT_WIDGET_DEFAULT_VALIDATION_ERROR)
-            }
+          {showLabelHeader && (
+            <LabelWithTooltip
+              alignment={labelAlignment}
+              className="t--input-widget-label"
+              color={labelTextColor}
+              compact={compactMode}
+              cyHelpTextClassName="t--input-widget-tooltip"
+              disabled={disabled}
+              fontSize={labelTextSize}
+              fontStyle={labelStyle}
+              helpText={tooltip}
+              loading={isLoading}
+              position={labelPosition}
+              text={label}
+              width={labelWidth}
+            />
+          )}
+          <TextInputWrapper
+            compact={compactMode}
+            inputHtmlType={inputHTMLType}
+            labelPosition={labelPosition}
           >
-            {this.renderInputComponent(inputHTMLType, !!multiline)}
-          </ErrorTooltip>
-        </TextInputWrapper>
-      </InputComponentWrapper>
+            <ErrorTooltip
+              isOpen={isInvalid && showError}
+              message={
+                errorMessage ||
+                createMessage(INPUT_WIDGET_DEFAULT_VALIDATION_ERROR)
+              }
+            >
+              {this.renderInputComponent(inputHTMLType, !!multiline)}
+            </ErrorTooltip>
+          </TextInputWrapper>
+        </InputComponentWrapper>
+      </div>
     );
   }
 }
@@ -663,6 +665,14 @@ export interface BaseInputComponentProps extends ComponentProps {
   inputRef?: MutableRefObject<
     HTMLTextAreaElement | HTMLInputElement | undefined | null
   >;
+  innerRef?: React.RefObject<HTMLDivElement>;
 }
 
-export default BaseInputComponent;
+export default React.forwardRef<HTMLDivElement, BaseInputComponentProps>(
+  (props, ref) => (
+    <BaseInputComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  ),
+);

--- a/app/client/src/widgets/CurrencyInputWidget/component/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/component/index.tsx
@@ -76,6 +76,7 @@ class CurrencyInputComponent extends React.Component<
         onStep={this.props.onStep}
         onValueChange={this.props.onValueChange}
         placeholder={this.props.placeholder}
+        ref={this.props.innerRef}
         showError={this.props.showError}
         stepSize={1}
         tooltip={this.props.tooltip}
@@ -91,9 +92,17 @@ export interface CurrencyInputComponentProps extends BaseInputComponentProps {
   noOfDecimals?: number;
   allowCurrencyChange?: boolean;
   decimals?: number;
+  innerRef?: React.RefObject<HTMLDivElement>;
   onCurrencyTypeChange: (code?: string) => void;
   onStep: (direction: number) => void;
   renderMode: string;
 }
 
-export default CurrencyInputComponent;
+export default React.forwardRef<HTMLDivElement, CurrencyInputComponentProps>(
+  (props, ref) => (
+    <CurrencyInputComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  ),
+);

--- a/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
@@ -378,6 +378,7 @@ class CurrencyInputWidget extends BaseInputWidget<
         onStep={this.onStep}
         onValueChange={this.onValueChange}
         placeholder={this.props.placeholderText}
+        ref={this.contentRef}
         renderMode={this.props.renderMode}
         showError={!!this.props.isFocused}
         tooltip={this.props.tooltip}

--- a/app/client/src/widgets/InputWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/component/index.tsx
@@ -70,6 +70,7 @@ class InputComponent extends React.Component<InputComponentProps> {
         onKeyDown={this.props.onKeyDown}
         onValueChange={this.props.onValueChange}
         placeholder={this.props.placeholder}
+        ref={this.props.innerRef}
         showError={this.props.showError}
         spellCheck={this.props.spellCheck}
         stepSize={1}
@@ -81,6 +82,7 @@ class InputComponent extends React.Component<InputComponentProps> {
   }
 }
 export interface InputComponentProps extends BaseInputComponentProps {
+  innerRef?: React.RefObject<HTMLDivElement>;
   inputType: InputTypes;
   maxChars?: number;
   spellCheck?: boolean;
@@ -88,4 +90,11 @@ export interface InputComponentProps extends BaseInputComponentProps {
   minNum?: number;
 }
 
-export default InputComponent;
+export default React.forwardRef<HTMLDivElement, InputComponentProps>(
+  (props, ref) => (
+    <InputComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  ),
+);

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -498,6 +498,7 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
         onKeyDown={this.handleKeyDown}
         onValueChange={this.onValueChange}
         placeholder={this.props.placeholderText}
+        ref={this.contentRef}
         showError={!!this.props.isFocused}
         spellCheck={!!this.props.isSpellCheck}
         stepSize={1}

--- a/app/client/src/widgets/PhoneInputWidget/component/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/component/index.tsx
@@ -77,6 +77,7 @@ class PhoneInputComponent extends React.Component<PhoneInputComponentProps> {
         onKeyDown={this.onKeyDown}
         onValueChange={this.props.onValueChange}
         placeholder={this.props.placeholder}
+        ref={this.props.innerRef}
         showError={this.props.showError}
         tooltip={this.props.tooltip}
         value={this.props.value}
@@ -91,6 +92,14 @@ export interface PhoneInputComponentProps extends BaseInputComponentProps {
   countryCode?: CountryCode;
   onISDCodeChange: (code?: string) => void;
   allowDialCodeChange: boolean;
+  innerRef?: React.RefObject<HTMLDivElement>;
 }
 
-export default PhoneInputComponent;
+export default React.forwardRef<HTMLDivElement, PhoneInputComponentProps>(
+  (props, ref) => (
+    <PhoneInputComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  ),
+);

--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -320,6 +320,7 @@ class PhoneInputWidget extends BaseInputWidget<
         onKeyDown={this.handleKeyDown}
         onValueChange={this.onValueChange}
         placeholder={this.props.placeholderText}
+        ref={this.contentRef}
         showError={!!this.props.isFocused}
         tooltip={this.props.tooltip}
         value={value}


### PR DESCRIPTION
## Description

1. Passed the `contentRef` to `InputComponent` from `InputWidgetV2`.
2. Passed the `contentRef` to `PhoneInputComponent` from `PhoneInputWidget`.
3. Passed the `contentRef` to `CurrencyInputComponent` from `CurrencyInputWidget`.

1. Wrapped the `InputComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to 
pass it to its child `BaseInputComponent`.
2. Wrapped the `PhoneInputComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to pass it to its child `BaseInputComponent`.
3. Wrapped the `CurrencyInputComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to pass it to its child `BaseInputComponent`.

1. Wrapped the `BaseInputComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to pass it to its child `InputComponentWrapper`.
2. `InputComponentWrapper` is a styled component on top of `ControlGroup` and there is no way to hook it up the ref dom element, so wrapped `InputComponentWrapper` in a `div`.
3. This standardization applies to Input, InputCurrency and InputPhone widgets.

Fixes #13052 
Fixes #13053
Fixes #13054

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes