### PR TITLE
fix: Redis installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,15 @@ RUN apt-get update \
     supervisor curl cron certbot nginx gnupg wget netcat openssh-client \
     software-properties-common gettext openjdk-11-jre \
     python3-pip python-setuptools git \
-  && add-apt-repository ppa:redislabs/redis \
   && pip install --no-cache-dir git+https://github.com/coderanger/supervisor-stdout@973ba19967cdaf46d9c1634d1675fc65b9574f6e \
-  && apt-get remove -y git python3-pip \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get remove -y git python3-pip
 
 # Install MongoDB v4.0.5, Redis, NodeJS - Service Layer
 RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
 RUN echo "deb [ arch=amd64,arm64 ]http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list \
   && apt-get remove wget -y
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-  && apt-get -y install --no-install-recommends -y mongodb-org=4.4.6 nodejs redis build-essential \
+  && apt-get install --no-install-recommends -y mongodb-org=4.4.6 nodejs redis build-essential \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -89,7 +86,7 @@ RUN chmod 0644 /etc/cron.d/*
 RUN chmod +x entrypoint.sh renew-certificate.sh
 
 # Disable setuid/setgid bits for the files inside container.
-#RUN find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true
+RUN find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true
 
 # Update path to load appsmith utils tool as default
 ENV PATH /opt/appsmith/utils/node_modules/.bin:$PATH


### PR DESCRIPTION

## Description

Fix fat image not building in CI on release branch. This PR changes the Redis version in the fat container to v5, where it was v6 in the past. The PPA we were relying on to get v6 has upgrade to v7 and doesn't have the v6 packages anymore. But the v7 package's dependencies appear to be broken so we get the following error when installing from the PPA:

```
redis : Depends: redis-server (< 6:6.2.6-2rl1~focal1.1~) but 6:7.0.0-1rl1~focal1 is to be installed
```

PPA: https://launchpad.net/~redislabs/+archive/ubuntu/redis?field.series_filter=focal#packages

## Type of change

- Bug fix (non-breaking change which fixes an issue)
