### PR TITLE
chore: process multiple `BATCH_UPDATE_WIDGET_PROPERTY` actions serially

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -11,8 +11,10 @@ import {
 } from "reducers/entityReducers/canvasWidgetsReducer";
 import { getWidget, getWidgets } from "./selectors";
 import {
+  actionChannel,
   all,
   call,
+  take,
   fork,
   put,
   select,
@@ -1200,10 +1202,28 @@ export function* groupWidgetsSaga() {
   }
 }
 
+function* widgetBatchUpdatePropertySaga() {
+  /*
+   * BATCH_UPDATE_WIDGET_PROPERTY should be processed serially as
+   * it updates the state. We want the state updates from previous
+   * batch update to be flushed out to the store before processing
+   * the another batch update.
+   */
+  const batchUpdateWidgetPropertyChannel = yield actionChannel(
+    ReduxActionTypes.BATCH_UPDATE_WIDGET_PROPERTY,
+  );
+
+  while (true) {
+    const action = yield take(batchUpdateWidgetPropertyChannel);
+    yield call(batchUpdateWidgetPropertySaga, action);
+  }
+}
+
 export default function* widgetOperationSagas() {
   yield fork(widgetAdditionSagas);
   yield fork(widgetDeletionSagas);
   yield fork(widgetSelectionSagas);
+  yield fork(widgetBatchUpdatePropertySaga);
   yield all([
     takeEvery(ReduxActionTypes.ADD_SUGGESTED_WIDGET, addSuggestedWidget),
     takeLatest(WidgetReduxActionTypes.WIDGET_RESIZE, resizeSaga),
@@ -1222,10 +1242,6 @@ export default function* widgetOperationSagas() {
     takeEvery(
       ReduxActionTypes.RESET_CHILDREN_WIDGET_META,
       resetChildrenMetaSaga,
-    ),
-    takeEvery(
-      ReduxActionTypes.BATCH_UPDATE_WIDGET_PROPERTY,
-      batchUpdateWidgetPropertySaga,
     ),
     takeEvery(
       ReduxActionTypes.BATCH_UPDATE_MULTIPLE_WIDGETS_PROPERTY,


### PR DESCRIPTION
## Description
BATCH_UPDATE_WIDGET_PROPERTY updates multiple properties of a widget and updates the state.
when two widgets emit BATCH_UPDATE_WIDGET_PROPERTY parallelly (happens on crud page creation),
the state updates done by the first BATCH_UPDATE_WIDGET_PROPERTY are overwritten by the second
BATCH_UPDATE_WIDGET_PROPERTY before it gets flushed to store since both are processed parallelly.
So we have created an actionChannel to buffer the events and process them only when the previous
event changes get flushed out to the state.

### Why this was not observed previously?:
Typically when building an application, the user drops one widget at a time. So we never ran into a
situation where two BATCH_UPDATE_WIDGET_PROPERTY were emitted at the same time. But now we have
modified the CRUD template to use JSON_form_widget instead of simple form_widget. So now JSON
form and the existing table widget in the template race to update the state when a CRUD page is
created. Hence we're seeing this now.

Fixes #13242

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: chore/serialize-batchupdate-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.41 **(0.01)** | 37.85 **(0.01)** | 36.02 **(0.01)** | 56.63 **(0.01)**
 :green_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 57.08 **(0.53)** | 40.58 **(0.38)** | 55.1 **(0.93)** | 58.21 **(0.53)**
 :green_circle: | app/client/src/utils/DynamicBindingUtils.ts | 85.87 **(0.54)** | 75.86 **(1.72)** | 80 **(0)** | 85.54 **(0.6)**</details>