### PR TITLE
remember email when invalid credentials are given

### DIFF
--- a/app/client/src/ce/pages/UserAuth/Login.tsx
+++ b/app/client/src/ce/pages/UserAuth/Login.tsx
@@ -30,6 +30,7 @@ import FormTextField from "components/ads/formFields/TextField";
 import Button, { Size } from "components/ads/Button";
 import ThirdPartyAuth from "@appsmith/pages/UserAuth/ThirdPartyAuth";
 import { ThirdPartyLoginRegistry } from "pages/UserAuth/ThirdPartyLoginRegistry";
+import localStorage from "utils/localStorage";
 import { isEmail, isEmptyString } from "utils/formhelpers";
 import { LoginFormValues } from "pages/UserAuth/helpers";
 import { withTheme } from "styled-components";
@@ -183,6 +184,7 @@ export function Login(props: LoginFormProps) {
                 disabled={!isFormValid}
                 fill
                 onClick={() => {
+                  localStorage.setItem(LOGIN_FORM_EMAIL_FIELD_NAME, email);
                   PerformanceTracker.startTracking(
                     PerformanceTransactionName.LOGIN_CLICK,
                   );
@@ -209,9 +211,22 @@ export function Login(props: LoginFormProps) {
 }
 
 const selector = formValueSelector(LOGIN_FORM_NAME);
-export default connect((state) => ({
-  emailValue: selector(state, LOGIN_FORM_EMAIL_FIELD_NAME),
-}))(
+export default connect((state) => {
+  const queryParams = new URLSearchParams(location.search);
+
+  return {
+    initialValues: {
+      /* 
+        take username(email) from local storage if error param is present in URL 
+        otherwise use empty string 
+      */
+      username: queryParams.get("error")
+        ? localStorage.getItem(LOGIN_FORM_EMAIL_FIELD_NAME) || ""
+        : "",
+    },
+    emailValue: selector(state, LOGIN_FORM_EMAIL_FIELD_NAME),
+  };
+})(
   reduxForm<LoginFormValues, { emailValue: string }>({
     validate,
     touchOnBlur: true,


### PR DESCRIPTION
## Description
stores username in localstorage & displays it when ?error=true is present in URL. otherwise it will use "" empty string.

let me know if I should proceed adding cypress test for this

Fixes #7803


## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- try to login with invalid credentials and make sure username(email) input is persisted 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
