### PR TITLE
fix: replace klona/full with klona default

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -39,7 +39,7 @@ import { entityDefinitions } from "utils/autocomplete/EntityDefinitions";
 import { escapeSpecialChars } from "../../WidgetUtils";
 import { PrivateWidgets } from "entities/DataTree/dataTreeFactory";
 
-import { klona } from "klona/full";
+import { klona } from "klona";
 
 const LIST_WIDGET_PAGINATION_HEIGHT = 36;
 


### PR DESCRIPTION
- when manipulating props, react state (immutable values) do not use `klona/default` as the non-writable property remains non-writable, and delete or update operation will crash on dev.

## Description


## Type of change

chore

## How Has This Been Tested?



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
