### PR TITLE
fix:added fixActionPayloadForMongoQuery

### DIFF
--- a/app/client/src/components/formControls/utils.ts
+++ b/app/client/src/components/formControls/utils.ts
@@ -1,5 +1,8 @@
 import { isBoolean, get, set } from "lodash";
 import { HiddenType } from "./BaseControl";
+import { diff, Diff } from "deep-diff";
+import { MongoDefaultActionConfig } from "constants/DatasourceEditorConstants";
+import { Action } from "@sentry/react/dist/types";
 
 export const evaluateCondtionWithType = (
   conditions: Array<boolean> | undefined,
@@ -278,3 +281,52 @@ export enum WhereClauseSubComponent {
 }
 
 export const allowedControlTypes = ["DROP_DOWN", "QUERY_DYNAMIC_INPUT_TEXT"];
+
+export function fixActionPayloadForMongoQuery(
+  action?: Action,
+): Action | undefined {
+  if (!action) return action;
+
+  /* eslint-disable */
+  //@ts-nocheck
+  try {
+    let actionObjectDiff: undefined | Diff<any, any>[] = diff(
+      action,
+      MongoDefaultActionConfig,
+    );
+    if (actionObjectDiff) {
+      actionObjectDiff = actionObjectDiff.filter((diff) => diff.kind === "N");
+      for (let i = 0; i < actionObjectDiff.length; i++) {
+        let path = "";
+        let value = "";
+        //kind = N indicates a newly added property/element
+        //This property is present in initialValues but not in action object
+        if (
+          actionObjectDiff &&
+          actionObjectDiff[i].hasOwnProperty("kind") &&
+          actionObjectDiff[i].path &&
+          Array.isArray(actionObjectDiff[i].path) &&
+          actionObjectDiff[i]?.path?.length &&
+          actionObjectDiff[i]?.kind === "N"
+        ) {
+          // Calculate path from path[] in diff
+          //@ts-ignore
+          if (typeof actionObjectDiff[i]?.path[0] === "string") {
+            //@ts-ignore
+            path = actionObjectDiff[i]?.path?.join(".");
+          }
+          // get value from diff object
+          //@ts-ignore
+          value = actionObjectDiff[i]?.rhs;
+          //@ts-ignore
+          set(action, path, value);
+        }
+      }
+    }
+    return action;
+    //@ts-check
+  } catch (error) {
+    console.error("Error adding default paths in Mongo query");
+    return action;
+  }
+}

--- a/app/client/src/constants/DatasourceEditorConstants.ts
+++ b/app/client/src/constants/DatasourceEditorConstants.ts
@@ -1,5 +1,81 @@
 export const DATASOURCE_CONSTANT = "DATASOURCE";
 export const APPSMITH_IP_ADDRESSES = ["18.223.74.85", "3.131.104.27"];
-
 export const PRIMARY_KEY = "primary key";
 export const FOREIGN_KEY = "foreign key";
+
+/* NOTE: This is a default formData value, 
+required to fix the missing config for an existing mongo query */
+export const MongoDefaultActionConfig = {
+  actionConfiguration: {
+    formData: {
+      aggregate: {
+        limit: {
+          data: "10",
+        },
+        arrayPipelines: {
+          data: "",
+        },
+      },
+      delete: {
+        limit: {
+          data: "SINGLE",
+        },
+        query: {
+          data: "",
+        },
+      },
+      updateMany: {
+        limit: {
+          data: "SINGLE",
+        },
+        query: {
+          data: "",
+        },
+        update: {
+          data: "",
+        },
+      },
+      smartSubstitution: {
+        data: true,
+      },
+      collection: {
+        data: "",
+      },
+      find: {
+        skip: {
+          data: "",
+        },
+        query: {
+          data: "",
+        },
+        sort: {
+          data: "",
+        },
+        limit: {
+          data: "",
+        },
+        projection: {
+          data: "",
+        },
+      },
+      insert: {
+        documents: {
+          data: "",
+        },
+      },
+      count: {
+        query: {
+          data: "",
+        },
+      },
+      distinct: {
+        query: {
+          data: "",
+        },
+        key: {
+          data: "",
+        },
+      },
+    },
+  },
+};

--- a/app/client/src/sagas/ActionSagas.ts
+++ b/app/client/src/sagas/ActionSagas.ts
@@ -82,7 +82,10 @@ import {
   ERROR_ACTION_RENAME_FAIL,
 } from "@appsmith/constants/messages";
 import { merge, get } from "lodash";
-import { getConfigInitialValues } from "components/formControls/utils";
+import {
+  fixActionPayloadForMongoQuery,
+  getConfigInitialValues,
+} from "components/formControls/utils";
 import AppsmithConsole from "utils/AppsmithConsole";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import LOG_TYPE from "entities/AppsmithConsole/logtype";
@@ -117,6 +120,7 @@ import {
   queryEditorIdURL,
   saasEditorApiIdURL,
 } from "RouteBuilder";
+import { PLUGIN_PACKAGE_MONGO } from "constants/QueryEditorConstants";
 
 export function* createActionSaga(
   actionPayload: ReduxAction<
@@ -316,7 +320,16 @@ export function* updateActionSaga(
       action = transformRestAction(action);
     }
 
+    /* NOTE: This  is fix for a missing command config */
+    const plugin = yield select(getPlugin, action.pluginId);
+    if (action && plugin.packageName === PLUGIN_PACKAGE_MONGO) {
+      /* eslint-disable-next-line */
+      //@ts-ignore
+      action = fixActionPayloadForMongoQuery(action);
+    }
     const response: GenericApiResponse<Action> = yield ActionAPI.updateAction(
+      /* eslint-disable-next-line */
+      //@ts-ignore
       action,
     );
     const isValidResponse = yield validateResponse(response);
@@ -326,18 +339,18 @@ export function* updateActionSaga(
         response.data.id,
       );
 
-      if (action.pluginType === PluginType.DB) {
+      if (action?.pluginType === PluginType.DB) {
         AnalyticsUtil.logEvent("SAVE_QUERY", {
           queryName: action.name,
           pageName,
         });
-      } else if (action.pluginType === PluginType.API) {
+      } else if (action?.pluginType === PluginType.API) {
         AnalyticsUtil.logEvent("SAVE_API", {
           apiId: response.data.id,
           apiName: response.data.name,
           pageName: pageName,
         });
-      } else if (action.pluginType === PluginType.SAAS) {
+      } else if (action?.pluginType === PluginType.SAAS) {
         AnalyticsUtil.logEvent("SAVE_SAAS", {
           apiId: response.data.id,
           apiName: response.data.name,


### PR DESCRIPTION
## Description

Added a function to fix the corrupt state of mongo query. Function adds the missing config for all the commands in mongo query.

Fixes #13228 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/mongo-query-payload 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.43 **(-0.01)** | 37.81 **(-0.05)** | 36.02 **(-0.01)** | 56.64 **(-0.01)**
 :red_circle: | app/client/src/components/formControls/utils.ts | 65.58 **(-8.66)** | 42.14 **(-18.06)** | 80.95 **(-8.52)** | 65 **(-7.73)**
 :green_circle: | app/client/src/sagas/ActionSagas.ts | 12.67 **(0.1)** | 1.34 **(-0.16)** | 8 **(0)** | 15.46 **(0.13)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>