### PR TITLE
feat: dynamic height datepicker widget standardisation

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -155,71 +155,73 @@ class DatePickerComponent extends React.Component<
         ? new Date(this.state.selectedDate)
         : null;
     return (
-      <StyledControlGroup
-        compactMode={this.props.compactMode}
-        data-testid="datepicker-container"
-        fill
-        isValid={isValid}
-        labelPosition={this.props.labelPosition}
-        onClick={(e: any) => {
-          e.stopPropagation();
-        }}
-      >
-        {labelText && (
-          <LabelWithTooltip
-            alignment={labelAlignment}
-            className={`datepicker-label`}
-            color={labelTextColor}
-            compact={compactMode}
-            disabled={isDisabled}
-            fontSize={labelTextSize}
-            fontStyle={labelStyle}
-            loading={isLoading}
-            position={labelPosition}
-            text={labelText}
-            width={labelWidth}
-          />
-        )}
-        <DateInputWrapper
-          compactMode={compactMode}
-          labelPosition={labelPosition}
+      <div ref={this.props.innerRef}>
+        <StyledControlGroup
+          compactMode={this.props.compactMode}
+          data-testid="datepicker-container"
+          fill
+          isValid={isValid}
+          labelPosition={this.props.labelPosition}
+          onClick={(e: any) => {
+            e.stopPropagation();
+          }}
         >
-          <ErrorTooltip
-            isOpen={!isValid}
-            message={createMessage(DATE_WIDGET_DEFAULT_VALIDATION_ERROR)}
-          >
-            <DateInput
-              className={this.props.isLoading ? "bp3-skeleton" : ""}
-              closeOnSelection={this.props.closeOnSelection}
-              dayPickerProps={{
-                firstDayOfWeek: this.props.firstDayOfWeek || 0,
-              }}
-              disabled={this.props.isDisabled}
-              formatDate={this.formatDate}
-              inputProps={{
-                inputRef: this.props.inputRef,
-              }}
-              maxDate={maxDate}
-              minDate={minDate}
-              onChange={this.onDateSelected}
-              parseDate={this.parseDate}
-              placeholder={"Select Date"}
-              popoverProps={{
-                usePortal: !this.props.withoutPortal,
-                canEscapeKeyClose: true,
-              }}
-              shortcuts={this.props.shortcuts}
-              showActionsBar
-              timePrecision={
-                this.props.timePrecision === TimePrecision.NONE
-                  ? undefined
-                  : this.props.timePrecision
-              }
-              value={value}
+          {labelText && (
+            <LabelWithTooltip
+              alignment={labelAlignment}
+              className={`datepicker-label`}
+              color={labelTextColor}
+              compact={compactMode}
+              disabled={isDisabled}
+              fontSize={labelTextSize}
+              fontStyle={labelStyle}
+              loading={isLoading}
+              position={labelPosition}
+              text={labelText}
+              width={labelWidth}
             />
-          </ErrorTooltip>
-        </DateInputWrapper>
-      </StyledControlGroup>
+          )}
+          <DateInputWrapper
+            compactMode={compactMode}
+            labelPosition={labelPosition}
+          >
+            <ErrorTooltip
+              isOpen={!isValid}
+              message={createMessage(DATE_WIDGET_DEFAULT_VALIDATION_ERROR)}
+            >
+              <DateInput
+                className={this.props.isLoading ? "bp3-skeleton" : ""}
+                closeOnSelection={this.props.closeOnSelection}
+                dayPickerProps={{
+                  firstDayOfWeek: this.props.firstDayOfWeek || 0,
+                }}
+                disabled={this.props.isDisabled}
+                formatDate={this.formatDate}
+                inputProps={{
+                  inputRef: this.props.inputRef,
+                }}
+                maxDate={maxDate}
+                minDate={minDate}
+                onChange={this.onDateSelected}
+                parseDate={this.parseDate}
+                placeholder={"Select Date"}
+                popoverProps={{
+                  usePortal: !this.props.withoutPortal,
+                  canEscapeKeyClose: true,
+                }}
+                shortcuts={this.props.shortcuts}
+                showActionsBar
+                timePrecision={
+                  this.props.timePrecision === TimePrecision.NONE
+                    ? undefined
+                    : this.props.timePrecision
+                }
+                value={value}
+              />
+            </ErrorTooltip>
+          </DateInputWrapper>
+        </StyledControlGroup>
+      </div>
     );
   }
 
@@ -311,6 +313,7 @@ interface DatePickerComponentProps extends ComponentProps {
   shortcuts: boolean;
   firstDayOfWeek?: number;
   timePrecision: TimePrecision;
+  innerRef?: React.RefObject<HTMLDivElement>;
   inputRef?: IRef<HTMLInputElement>;
 }
 
@@ -318,4 +321,11 @@ interface DatePickerComponentState {
   selectedDate?: string;
 }
 
-export default DatePickerComponent;
+export default React.forwardRef<HTMLDivElement, DatePickerComponentProps>(
+  (props, ref) => (
+    <DatePickerComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  ),
+);

--- a/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
@@ -416,6 +416,7 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
         maxDate={this.props.maxDate}
         minDate={this.props.minDate}
         onDateSelected={this.onDateSelected}
+        ref={this.contentRef}
         selectedDate={this.props.value}
         shortcuts={this.props.shortcuts}
         timePrecision={this.props.timePrecision}


### PR DESCRIPTION
## Description

1. Passed the `contentRef` to `DatePickerComponent` from `DatePickerWidgetV2`.
2. Wrapped the `DatePickerComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to pass it to its child `StyledControlGroup`.
4. `StyledControlGroup` is a styled component on top of `ControlGroup` and there is no way to hook it up the ref dom element, so wrapped `StyledControlGroup` in a `div`.

Fixes #13059

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: feature/dh-stdzn-datepicker-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.48 **(0.06)** | 37.98 **(0.18)** | 36.27 **(0.25)** | 56.7 **(0.06)**
 :red_circle: | app/client/src/actions/jsPaneActions.ts | 65.63 **(-0.08)** | 0 **(0)** | 0 **(0)** | 50 **(0)**
 :red_circle: | app/client/src/actions/reflowActions.ts | 75 **(-10.71)** | 100 **(0)** | 20 **(-30)** | 63.64 **(-16.36)**
 :green_circle: | app/client/src/ce/constants/messages.ts | 78.05 **(0.21)** | 100 **(0)** | 35.08 **(0.61)** | 82.34 **(0.58)**
 :green_circle: | app/client/src/components/ads/Checkbox.tsx | 90.24 **(63.41)** | 56.82 **(43.18)** | 88.24 **(88.24)** | 88.89 **(58.33)**
 :green_circle: | app/client/src/components/ads/DialogComponent.tsx | 87.18 **(0.69)** | 59.38 **(0)** | 85 **(1.67)** | 86.49 **(0.78)**
 :green_circle: | app/client/src/components/ads/DraggableListCard.tsx | 13.46 **(0.5)** | 3.17 **(0)** | 0 **(0)** | 15.56 **(0.67)**
 :red_circle: | app/client/src/components/ads/Dropdown.tsx | 85.77 **(-0.16)** | 65.58 **(-1.28)** | 77.78 **(-0.3)** | 84.94 **(-0.12)**
 :red_circle: | app/client/src/components/ads/LabelWithTooltip.tsx | 71.58 **(-2.33)** | 53.54 **(-1.67)** | 58.33 **(-5.31)** | 73.85 **(-2.34)**
 :green_circle: | app/client/src/components/ads/Radio.tsx | 14.63 **(0)** | 10 **(0.48)** | 0 **(0)** | 15.38 **(0)**
 :green_circle: | app/client/src/components/ads/Tabs.tsx | 22.41 **(0.9)** | 12.12 **(2.69)** | 0 **(0)** | 23.21 **(0.59)**
 :red_circle: | app/client/src/components/ads/index.ts | 100 **(0)** | 100 **(0)** | 5.56 **(-1.85)** | 100 **(0)**
 :red_circle: | app/client/src/components/editorComponents/EntityBottomTabs.tsx | 27.59 **(-2.71)** | 0 **(0)** | 0 **(0)** | 30.77 **(-1.37)**
 :red_circle: | app/client/src/components/editorComponents/JSResponseView.tsx | 45.65 **(-7.51)** | 21.98 **(-9.9)** | 0 **(-8.33)** | 49.41 **(-5.85)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 78.51 **(1.54)** | 60.48 **(2.07)** | 64.44 **(-0.78)** | 80.13 **(1.67)**
 :green_circle: | app/client/src/components/editorComponents/Debugger/index.tsx | 76.6 **(0.51)** | 26.92 **(0)** | 87.5 **(1.79)** | 78.26 **(0.48)**
 :green_circle: | app/client/src/components/formControls/utils.ts | 74.24 **(8.66)** | 60.2 **(18.06)** | 89.47 **(8.52)** | 72.73 **(7.73)**
 :green_circle: | app/client/src/pages/Editor/MainContainerLayoutControl.tsx | 88.89 **(0.25)** | 81.25 **(0)** | 80 **(0)** | 90.48 **(0.24)**
 :sparkles: :new: | **app/client/src/pages/Editor/ReflowBetaCard.tsx** | **82.86** | **68.18** | **25** | **82.86**
 :green_circle: | app/client/src/pages/Editor/BottomBar/ManualUpgrades.tsx | 90.32 **(0.85)** | 85 **(1.67)** | 76.92 **(1.92)** | 88.68 **(-1.12)**
 :red_circle: | app/client/src/pages/Editor/Explorer/Files/index.tsx | 76.32 **(0.13)** | 33.33 **(5.55)** | 40 **(-10)** | 80.56 **(1.07)**
 :red_circle: | app/client/src/pages/Editor/FirstTimeUserOnboarding/Checklist.tsx | 96.27 **(-0.03)** | 96.61 **(0)** | 92.68 **(-0.18)** | 96.27 **(-0.03)**
 :green_circle: | app/client/src/pages/Editor/JSEditor/Form.tsx | 50 **(20.27)** | 66.67 **(66.67)** | 0 **(0)** | 52 **(18.15)**
 :green_circle: | app/client/src/pages/Editor/JSEditor/JSFunctionSettings.tsx | 52.94 **(26.02)** | 100 **(60)** | 0 **(0)** | 52.94 **(21.83)**
 :red_circle: | app/client/src/pages/Editor/JSEditor/index.tsx | 54.84 **(-2.85)** | 33.33 **(0)** | 33.33 **(0)** | 59.26 **(-1.61)**
 :green_circle: | app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx | 34.7 **(0.47)** | 25.77 **(0.77)** | 0 **(0)** | 36.02 **(0.34)**
 :red_circle: | app/client/src/pages/Editor/QueryEditor/index.tsx | 27.61 **(-0.42)** | 5.33 **(0)** | 5.26 **(-0.3)** | 29.27 **(-0.24)**
 :red_circle: | app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx | 96.77 **(-0.29)** | 66.67 **(0)** | 100 **(0)** | 96.77 **(-0.29)**
 :green_circle: | app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx | 62.83 **(0.33)** | 44 **(0)** | 27.59 **(2.59)** | 64.49 **(0.34)**
 :green_circle: | app/client/src/pages/Settings/DisconnectService.tsx | 100 **(10.71)** | 92.86 **(11.61)** | 100 **(20)** | 100 **(12.5)**
 :green_circle: | app/client/src/pages/Settings/FormGroup/group.tsx | 100 **(2.13)** | 68.66 **(6.5)** | 100 **(0)** | 100 **(2.17)**
 :green_circle: | app/client/src/pages/common/CanvasArenas/hooks/useCanvasDragging.ts | 83.64 **(0.1)** | 67.05 **(0.13)** | 84.38 **(0)** | 84.19 **(0.1)**
 :red_circle: | app/client/src/pages/organization/OrgInviteUsersForm.tsx | 41.44 **(-1.15)** | 26.92 **(0)** | 0 **(0)** | 42.99 **(-1.24)**
 :green_circle: | app/client/src/reducers/entityReducers/jsActionsReducer.tsx | 7.07 **(0.4)** | 0 **(0)** | 0 **(0)** | 7.22 **(0.42)**
 :green_circle: | app/client/src/reducers/uiReducers/applicationsReducer.tsx | 16 **(0.76)** | 27.27 **(7.27)** | 12.24 **(0.48)** | 14.43 **(0.57)**
 :red_circle: | app/client/src/reducers/uiReducers/reflowReducer.ts | 58.33 **(-25)** | 100 **(0)** | 25 **(-25)** | 54.55 **(-28.78)**
 :green_circle: | app/client/src/reflow/reflowHelpers.ts | 94.94 **(0.33)** | 64.77 **(5.95)** | 100 **(0)** | 95.57 **(0.54)**
 :red_circle: | app/client/src/reflow/reflowUtils.ts | 79.55 **(-0.6)** | 69.65 **(-0.8)** | 84.31 **(-0.31)** | 79.61 **(-0.69)**
 :red_circle: | app/client/src/resizable/resizenreflow/index.tsx | 53.57 **(-1.24)** | 54.46 **(-3.09)** | 40 **(0)** | 51.91 **(-1.26)**
 :red_circle: | app/client/src/sagas/ActionSagas.ts | 12.57 **(-0.1)** | 1.5 **(0.16)** | 8 **(0)** | 15.33 **(-0.13)**
 :green_circle: | app/client/src/sagas/JSPaneSagas.ts | 16.16 **(0.07)** | 1.05 **(0)** | 4.55 **(0)** | 18.69 **(0.1)**
 :red_circle: | app/client/src/sagas/ModalSagas.ts | 36.27 **(-0.34)** | 19.44 **(1.02)** | 23.08 **(0)** | 37.23 **(-1.01)**
 :sparkles: :new: | **app/client/src/sagas/ReflowSagas.ts** | **24.24** | **7.14** | **33.33** | **28.57**
 :green_circle: | app/client/src/sagas/index.tsx | 93.44 **(0.11)** | 57.14 **(0)** | 100 **(0)** | 96.49 **(0.06)**
 :green_circle: | app/client/src/sagas/ActionExecution/PluginActionSaga.ts | 17.33 **(0.11)** | 2.11 **(0.23)** | 9.52 **(0.43)** | 19.92 **(0.15)**
 :green_circle: | app/client/src/selectors/entitiesSelector.ts | 48.97 **(0.49)** | 13.25 **(1.82)** | 25.16 **(1.21)** | 45.24 **(0.98)**
 :red_circle: | app/client/src/selectors/onboardingSelectors.tsx | 42.42 **(-0.35)** | 1.43 **(0)** | 21.57 **(0)** | 36.62 **(-0.44)**
 :green_circle: | app/client/src/utils/WidgetFactory.tsx | 74.47 **(8.8)** | 72.22 **(29.36)** | 64.71 **(19.26)** | 74.47 **(8.8)**
 :green_circle: | app/client/src/utils/WidgetRegisterHelpers.tsx | 100 **(3.85)** | 100 **(25)** | 100 **(0)** | 100 **(4.17)**
 :red_circle: | app/client/src/utils/storage.ts | 34.04 **(-0.14)** | 11.11 **(-4.68)** | 7.14 **(-2.24)** | 27.01 **(0.74)**
 :green_circle: | app/client/src/utils/hooks/localstorage.tsx | 63.16 **(42.11)** | 25 **(25)** | 66.67 **(66.67)** | 58.82 **(35.29)**
 :green_circle: | app/client/src/widgets/BaseWidget.tsx | 80 **(0.16)** | 48.94 **(0)** | 76.47 **(0)** | 79.2 **(0.17)**
 :red_circle: | app/client/src/widgets/DatePickerWidget2/component/index.tsx | 26.44 **(-0.39)** | 5.71 **(-0.26)** | 5.56 **(-0.69)** | 25.88 **(-0.05)**
 :green_circle: | app/client/src/widgets/DropdownWidget/component/index.tsx | 83.33 **(0.9)** | 53.13 **(2.31)** | 64.71 **(2.21)** | 81.94 **(0.78)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/component/Form.tsx | 29.35 **(0.93)** | 20 **(0)** | 0 **(0)** | 30.68 **(1.01)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/component/index.tsx | 27.08 **(0.55)** | 33.33 **(0)** | 0 **(0)** | 27.66 **(0.58)**
 :red_circle: | app/client/src/widgets/JSONFormWidget/widget/helper.ts | 98.92 **(-0.03)** | 90.91 **(0)** | 100 **(0)** | 98.82 **(-0.03)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/widget/index.tsx | 30.1 **(0.58)** | 0 **(0)** | 21.43 **(0.74)** | 30.61 **(0.61)**
 :red_circle: | app/client/src/widgets/SelectWidget/component/index.styled.tsx | 53.57 **(-6.43)** | 48 **(-6.55)** | 0 **(0)** | 60 **(-5.22)**
 :red_circle: | app/client/src/widgets/SingleSelectTreeWidget/component/index.styled.tsx | 52.63 **(-4.51)** | 48.28 **(-5.57)** | 0 **(0)** | 58.06 **(-4.01)**
 :green_circle: | app/client/src/widgets/SingleSelectTreeWidget/component/index.tsx | 16.47 **(0.56)** | 0 **(0)** | 0 **(0)** | 18.42 **(0.7)**
 :green_circle: | app/client/src/widgets/TableWidget/component/TableHeader.tsx | 50 **(0)** | 53.06 **(4)** | 30 **(0)** | 47.37 **(0)**
 :green_circle: | app/client/src/widgets/TextWidget/widget/index.tsx | 100 **(0)** | 75 **(11.36)** | 100 **(0)** | 100 **(0)**
 :green_circle: | app/client/src/workers/ast.ts | 92.78 **(0.23)** | 78.57 **(1.07)** | 90.91 **(0)** | 94.51 **(0.39)**
 :sparkles: :new: | **app/client/src/workers/constants.ts** | **100** | **100** | **100** | **100**
 :red_circle: | app/client/src/workers/helpers.ts | 41.94 **(-41.93)** | 12.5 **(-31.25)** | 50 **(-50)** | 36 **(-52)**
 :x: | ~~app/client/src/components/ads/formFields/SelectField.tsx~~ | ~~31.58~~ | ~~0~~ | ~~0~~ | ~~35.29~~
 :x: | ~~app/client/src/constants/ast.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/pages/Editor/JSEditor/JSFunctionRun.tsx~~ | ~~52.17~~ | ~~33.33~~ | ~~0~~ | ~~52.17~~
 :x: | ~~app/client/src/pages/Editor/JSEditor/JSObjectHotKeys.tsx~~ | ~~84.62~~ | ~~100~~ | ~~33.33~~ | ~~81.82~~
 :x: | ~~app/client/src/pages/Editor/JSEditor/constants.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/pages/Editor/JSEditor/styledComponents.ts~~ | ~~42.86~~ | ~~88.89~~ | ~~0~~ | ~~44.44~~
 :x: | ~~app/client/src/pages/Editor/JSEditor/utils.ts~~ | ~~61.76~~ | ~~48.48~~ | ~~41.18~~ | ~~59.65~~
 :x: | ~~app/client/src/pages/Settings/FormGroup/Dropdown.tsx~~ | ~~66.67~~ | ~~0~~ | ~~0~~ | ~~66.67~~
 :x: | ~~app/client/src/utils/WidgetFactoryHelpers.ts~~ | ~~100~~ | ~~91.67~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/utils/WidgetFeatures.ts~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~
 :x: | ~~app/client/src/utils/hooks/useResizeObserver.tsx~~ | ~~36.36~~ | ~~0~~ | ~~0~~ | ~~40~~</details>