### PR TITLE
feat: dynamic height select widget standardisation

### DIFF
--- a/app/client/src/widgets/SelectWidget/component/index.tsx
+++ b/app/client/src/widgets/SelectWidget/component/index.tsx
@@ -279,6 +279,7 @@ class SelectComponent extends React.Component<
         compactMode={compactMode}
         data-testid="select-container"
         labelPosition={labelPosition}
+        ref={this.props.innerRef}
       >
         <DropdownStyles dropDownWidth={this.getDropdownWidth()} id={widgetId} />
         {labelText && (
@@ -379,6 +380,7 @@ export interface SelectComponentProps extends ComponentProps {
   options: DropdownOption[];
   isLoading: boolean;
   isFilterable: boolean;
+  innerRef?: React.RefObject<HTMLDivElement>;
   isValid: boolean;
   width: number;
   dropDownWidth: number;
@@ -391,4 +393,11 @@ export interface SelectComponentProps extends ComponentProps {
   filterText?: string;
 }
 
-export default React.memo(SelectComponent);
+export default React.memo(
+  React.forwardRef<HTMLDivElement, SelectComponentProps>((props, ref) => (
+    <SelectComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  )),
+);

--- a/app/client/src/widgets/SelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/SelectWidget/widget/index.tsx
@@ -474,6 +474,7 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
         onOptionSelected={this.onOptionSelected}
         options={options}
         placeholder={this.props.placeholderText}
+        ref={this.contentRef}
         selectedIndex={selectedIndex > -1 ? selectedIndex : undefined}
         serverSideFiltering={this.props.serverSideFiltering}
         value={this.props.selectedOptionValue}


### PR DESCRIPTION
## Description

1. Passed the `contentRef` to `SelectComponent` from `SelectWidget`.
2. Wrapped the `SelectComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to pass it to its child `DropdownContainer`.
3. Set the final `ref` to `DropdownContainer` which is a styled `div`.

Fixes #13055

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes