### PR TITLE
feat: dynamic single tree select widget standardisation

### DIFF
--- a/app/client/src/widgets/SingleSelectTreeWidget/component/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/component/index.tsx
@@ -96,187 +96,203 @@ const switcherIcon = (treeNode: TreeNodeProps) => {
 };
 const FOCUS_TIMEOUT = 500;
 
-function SingleSelectTreeComponent({
-  allowClear,
-  compactMode,
-  disabled,
-  dropdownStyle,
-  dropDownWidth,
-  expandAll,
-  filterText,
-  isFilterable,
-  isValid,
-  labelAlignment,
-  labelPosition,
-  labelStyle,
-  labelText,
-  labelTextColor,
-  labelTextSize,
-  labelWidth,
-  loading,
-  onChange,
-  options,
-  placeholder,
-  value,
-  widgetId,
-  width,
-}: TreeSelectProps): JSX.Element {
-  const [key, setKey] = useState(Math.random());
-  const [filter, setFilter] = useState(filterText ?? "");
+const SingleSelectTreeComponent = React.forwardRef<
+  HTMLDivElement,
+  TreeSelectProps
+>(
+  (
+    {
+      allowClear,
+      compactMode,
+      disabled,
+      dropdownStyle,
+      dropDownWidth,
+      expandAll,
+      filterText,
+      isFilterable,
+      isValid,
+      labelAlignment,
+      labelPosition,
+      labelStyle,
+      labelText,
+      labelTextColor,
+      labelTextSize,
+      labelWidth,
+      loading,
+      onChange,
+      options,
+      placeholder,
+      value,
+      widgetId,
+      width,
+    },
+    ref,
+  ): JSX.Element => {
+    const [key, setKey] = useState(Math.random());
+    const [filter, setFilter] = useState(filterText ?? "");
 
-  const labelRef = useRef<HTMLDivElement>(null);
-  const _menu = useRef<HTMLElement | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
+    const labelRef = useRef<HTMLDivElement>(null);
+    const _menu = ref;
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
 
-  // treeDefaultExpandAll is uncontrolled after first render,
-  // using this to force render to respond to changes in expandAll
-  useEffect(() => {
-    setKey(Math.random());
-  }, [expandAll]);
+    // treeDefaultExpandAll is uncontrolled after first render,
+    // using this to force render to respond to changes in expandAll
+    useEffect(() => {
+      setKey(Math.random());
+    }, [expandAll]);
 
-  const getDropdownPosition = useCallback(() => {
-    const node = _menu.current;
-    if (Boolean(node?.closest(`.${MODAL_PORTAL_CLASSNAME}`))) {
-      return document.querySelector(
-        `.${MODAL_PORTAL_CLASSNAME}`,
-      ) as HTMLElement;
-    }
-    return document.querySelector(`.${CANVAS_CLASSNAME}`) as HTMLElement;
-  }, []);
-  const onClear = useCallback(() => onChange([], []), []);
-  const onOpen = useCallback((open: boolean) => {
-    if (open) {
-      setTimeout(() => inputRef.current?.focus(), FOCUS_TIMEOUT);
-    }
-  }, []);
-  const clearButton = useMemo(
-    () =>
-      filter ? (
-        <Button icon="cross" minimal onClick={() => setFilter("")} />
-      ) : null,
-    [filter],
-  );
-  const onQueryChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    event.stopPropagation();
-    setFilter(event.target.value);
-  }, []);
-
-  useEffect(() => {
-    const parentWidth = width - WidgetContainerDiff;
-    if (compactMode && labelRef.current) {
-      const labelWidth = labelRef.current.getBoundingClientRect().width;
-      const widthDiff = parentWidth - labelWidth - labelMargin;
-      setMemoDropDownWidth(
-        widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
-      );
-      return;
-    }
-    setMemoDropDownWidth(
-      parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
+    const getDropdownPosition = useCallback(() => {
+      const node = (_menu as React.MutableRefObject<HTMLDivElement>).current;
+      if (Boolean(node?.closest(`.${MODAL_PORTAL_CLASSNAME}`))) {
+        return document.querySelector(
+          `.${MODAL_PORTAL_CLASSNAME}`,
+        ) as HTMLElement;
+      }
+      return document.querySelector(`.${CANVAS_CLASSNAME}`) as HTMLElement;
+    }, []);
+    const onClear = useCallback(() => onChange([], []), []);
+    const onOpen = useCallback((open: boolean) => {
+      if (open) {
+        setTimeout(() => inputRef.current?.focus(), FOCUS_TIMEOUT);
+      }
+    }, []);
+    const clearButton = useMemo(
+      () =>
+        filter ? (
+          <Button icon="cross" minimal onClick={() => setFilter("")} />
+        ) : null,
+      [filter],
     );
-  }, [compactMode, dropDownWidth, width, labelText]);
+    const onQueryChange = useCallback(
+      (event: ChangeEvent<HTMLInputElement>) => {
+        event.stopPropagation();
+        setFilter(event.target.value);
+      },
+      [],
+    );
 
-  const dropdownRender = useCallback(
-    (
-      menu: React.ReactElement<any, string | React.JSXElementConstructor<any>>,
-    ) => (
-      <>
-        {isFilterable ? (
-          <InputGroup
-            autoFocus
-            inputRef={inputRef}
-            leftIcon="search"
-            onChange={onQueryChange}
-            onKeyDown={(e) => e.stopPropagation()}
-            placeholder="Filter..."
-            rightElement={clearButton as JSX.Element}
-            small
-            type="text"
-            value={filter}
+    useEffect(() => {
+      const parentWidth = width - WidgetContainerDiff;
+      if (compactMode && labelRef.current) {
+        const labelWidth = labelRef.current.getBoundingClientRect().width;
+        const widthDiff = parentWidth - labelWidth - labelMargin;
+        setMemoDropDownWidth(
+          widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
+        );
+        return;
+      }
+      setMemoDropDownWidth(
+        parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
+      );
+    }, [compactMode, dropDownWidth, width, labelText]);
+
+    const dropdownRender = useCallback(
+      (
+        menu: React.ReactElement<
+          any,
+          string | React.JSXElementConstructor<any>
+        >,
+      ) => (
+        <>
+          {isFilterable ? (
+            <InputGroup
+              autoFocus
+              inputRef={inputRef}
+              leftIcon="search"
+              onChange={onQueryChange}
+              onKeyDown={(e) => e.stopPropagation()}
+              placeholder="Filter..."
+              rightElement={clearButton as JSX.Element}
+              small
+              type="text"
+              value={filter}
+            />
+          ) : null}
+          <div className={`${loading ? Classes.SKELETON : ""}`}>{menu}</div>
+        </>
+      ),
+      [loading, isFilterable, filter, onQueryChange],
+    );
+
+    return (
+      <TreeSelectContainer
+        compactMode={compactMode}
+        data-testid="treeselect-container"
+        isValid={isValid}
+        labelPosition={labelPosition}
+        ref={_menu}
+      >
+        <DropdownStyles dropDownWidth={memoDropDownWidth} id={widgetId} />
+        {labelText && (
+          <LabelWithTooltip
+            alignment={labelAlignment}
+            className={`tree-select-label`}
+            color={labelTextColor}
+            compact={compactMode}
+            disabled={disabled}
+            fontSize={labelTextSize}
+            fontStyle={labelStyle}
+            loading={loading}
+            position={labelPosition}
+            ref={labelRef}
+            text={labelText}
+            width={labelWidth}
           />
-        ) : null}
-        <div className={`${loading ? Classes.SKELETON : ""}`}>{menu}</div>
-      </>
-    ),
-    [loading, isFilterable, filter, onQueryChange],
-  );
+        )}
+        <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
+          <TreeSelect
+            allowClear={allowClear}
+            animation="slide-up"
+            choiceTransitionName="rc-tree-select-selection__choice-zoom"
+            className="rc-tree-select"
+            clearIcon={
+              <Icon
+                className="clear-icon"
+                fillColor={Colors.GREY_10}
+                name="close-x"
+              />
+            }
+            disabled={disabled}
+            dropdownClassName={`tree-select-dropdown single-tree-select-dropdown treeselect-popover-width-${widgetId}`}
+            dropdownRender={dropdownRender}
+            dropdownStyle={dropdownStyle}
+            filterTreeNode
+            getPopupContainer={getDropdownPosition}
+            inputIcon={
+              <Icon
+                className="dropdown-icon"
+                fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
+                name="dropdown"
+              />
+            }
+            key={key}
+            loading={loading}
+            maxTagCount={"responsive"}
+            maxTagPlaceholder={(e) => `+${e.length} more`}
+            notFoundContent="No Results Found"
+            onChange={onChange}
+            onClear={onClear}
+            onDropdownVisibleChange={onOpen}
+            placeholder={placeholder}
+            searchValue={filter}
+            showArrow
+            showSearch={false}
+            style={{ width: "100%" }}
+            switcherIcon={switcherIcon}
+            transitionName="rc-tree-select-dropdown-slide-up"
+            treeData={options}
+            treeDefaultExpandAll={expandAll}
+            treeIcon
+            treeNodeFilterProp="label"
+            value={value}
+          />
+        </InputContainer>
+      </TreeSelectContainer>
+    );
+  },
+);
 
-  return (
-    <TreeSelectContainer
-      compactMode={compactMode}
-      data-testid="treeselect-container"
-      isValid={isValid}
-      labelPosition={labelPosition}
-      ref={_menu as React.RefObject<HTMLDivElement>}
-    >
-      <DropdownStyles dropDownWidth={memoDropDownWidth} id={widgetId} />
-      {labelText && (
-        <LabelWithTooltip
-          alignment={labelAlignment}
-          className={`tree-select-label`}
-          color={labelTextColor}
-          compact={compactMode}
-          disabled={disabled}
-          fontSize={labelTextSize}
-          fontStyle={labelStyle}
-          loading={loading}
-          position={labelPosition}
-          ref={labelRef}
-          text={labelText}
-          width={labelWidth}
-        />
-      )}
-      <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
-        <TreeSelect
-          allowClear={allowClear}
-          animation="slide-up"
-          choiceTransitionName="rc-tree-select-selection__choice-zoom"
-          className="rc-tree-select"
-          clearIcon={
-            <Icon
-              className="clear-icon"
-              fillColor={Colors.GREY_10}
-              name="close-x"
-            />
-          }
-          disabled={disabled}
-          dropdownClassName={`tree-select-dropdown single-tree-select-dropdown treeselect-popover-width-${widgetId}`}
-          dropdownRender={dropdownRender}
-          dropdownStyle={dropdownStyle}
-          filterTreeNode
-          getPopupContainer={getDropdownPosition}
-          inputIcon={
-            <Icon
-              className="dropdown-icon"
-              fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
-              name="dropdown"
-            />
-          }
-          key={key}
-          loading={loading}
-          maxTagCount={"responsive"}
-          maxTagPlaceholder={(e) => `+${e.length} more`}
-          notFoundContent="No Results Found"
-          onChange={onChange}
-          onClear={onClear}
-          onDropdownVisibleChange={onOpen}
-          placeholder={placeholder}
-          searchValue={filter}
-          showArrow
-          showSearch={false}
-          style={{ width: "100%" }}
-          switcherIcon={switcherIcon}
-          transitionName="rc-tree-select-dropdown-slide-up"
-          treeData={options}
-          treeDefaultExpandAll={expandAll}
-          treeIcon
-          treeNodeFilterProp="label"
-          value={value}
-        />
-      </InputContainer>
-    </TreeSelectContainer>
-  );
-}
+SingleSelectTreeComponent.displayName = "SingleSelectTreeComponent";
 
 export default SingleSelectTreeComponent;

--- a/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
@@ -441,6 +441,7 @@ class SingleSelectTreeWidget extends BaseWidget<
         onChange={this.onOptionChange}
         options={options}
         placeholder={this.props.placeholderText as string}
+        ref={this.contentRef}
         value={filteredValue}
         widgetId={this.props.widgetId}
         width={componentWidth}


### PR DESCRIPTION
## Description

1. Passed the `contentRef` to `SingleSelectTreeComponent` from `SingleSelectTreeComponent`.
2. Wrapped the `SingleSelectTreeComponent` functional, component in the React.forwardRef.
3. Set the final `ref` from React.forwardRef to `TreeSelectContainer` which is a styled `div`.

Fixes #13057

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes