### PR TITLE
feature: JSONForm - disable add new and remove buttons when array is disabled

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_ArrayField_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_ArrayField_spec.js
@@ -105,6 +105,52 @@ describe("JSON Form Widget Array Field", () => {
     });
   });
 
+  it("disables add new and remove buttons when array field is disabled", () => {
+    cy.closePropertyPane();
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("education");
+
+    let initialNoOfItems = 0;
+    cy.get(`${education}-item`).then(($items) => {
+      initialNoOfItems = $items.length;
+    });
+
+    // Disable -> true
+    cy.togglebar(".t--property-control-disabled input");
+    cy.get(`${education} ${addButton}`).should("have.attr", "disabled");
+    cy.get(`${education} ${addButton}`).should("have.attr", "disabled");
+
+    // Click add button
+    cy.get(`${education} ${addButton}`).click({ force: true });
+    cy.get(`${education}-item`).then(($items) => {
+      expect($items.length).equal(initialNoOfItems);
+    });
+    // Click remove button
+    cy.get(`${education} ${deleteButton}`)
+      .last()
+      .click({ force: true });
+    cy.get(`${education}-item`).then(($items) => {
+      expect($items.length).equal(initialNoOfItems);
+    });
+
+    // Disable -> false
+    cy.togglebarDisable(".t--property-control-disabled input");
+    cy.get(addButton).should("not.have.attr", "disabled");
+    cy.get(deleteButton).should("not.have.attr", "disabled");
+    // Click add button
+    cy.get(`${education} ${addButton}`).click({ force: true });
+    cy.get(`${education}-item`).then(($items) => {
+      expect($items.length).equal(initialNoOfItems + 1);
+    });
+    // Click remove button
+    cy.get(`${education} ${deleteButton}`)
+      .last()
+      .click({ force: true });
+    cy.get(`${education}-item`).then(($items) => {
+      expect($items.length).equal(initialNoOfItems);
+    });
+  });
+
   it("should not render field level default value if form level is present", () => {
     const collegeFieldDefaultValue = "College default value";
 

--- a/app/client/src/widgets/JSONFormWidget/fields/ArrayField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/ArrayField.tsx
@@ -50,6 +50,10 @@ const COMPONENT_DEFAULT_VALUES: ArrayComponentProps = {
   label: "",
 };
 
+type StyledButtonProps = {
+  disabled: boolean;
+};
+
 const ACTION_ICON_SIZE = 10;
 
 const StyledNestedFormWrapper = styled(NestedFormWrapper)`
@@ -62,7 +66,7 @@ const StyledItemWrapper = styled.div`
   flex-direction: column;
 `;
 
-const StyledButton = styled.button`
+const StyledButton = styled.button<StyledButtonProps>`
   align-items: center;
   color: ${Colors.GREEN};
   display: flex;
@@ -71,6 +75,15 @@ const StyledButton = styled.button`
   text-transform: uppercase;
   margin-top: 10px;
   width: 80px;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.3;
+
+    & * {
+      pointer-events: none;
+    }
+  }
 
   span.bp3-icon {
     margin-right: 6px;
@@ -278,7 +291,8 @@ function ArrayField({
             />
             <StyledDeleteButton
               className="t--jsonformfield-array-delete-btn"
-              onClick={() => remove(key)}
+              disabled={schemaItem.isDisabled}
+              onClick={schemaItem.isDisabled ? undefined : () => remove(key)}
               type="button"
             >
               {deleteIcon}
@@ -317,7 +331,8 @@ function ArrayField({
       {fields}
       <StyledButton
         className="t--jsonformfield-array-add-btn"
-        onClick={add}
+        disabled={schemaItem.isDisabled}
+        onClick={schemaItem.isDisabled ? undefined : add}
         type="button"
       >
         <Icon


### PR DESCRIPTION
## Description
Disable the `Add New` and `Remove` buttons when the Array Field is disabled.

Fixes #12744

## Type of change

> Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
