### PR TITLE
fix: Minor UI changes in page properties screen.

### DIFF
--- a/app/client/src/pages/Editor/PagesEditor/PageListItem.tsx
+++ b/app/client/src/pages/Editor/PagesEditor/PageListItem.tsx
@@ -30,6 +30,7 @@ import { TOOLTIP_HOVER_ON_DELAY } from "constants/AppConstants";
 import { Position } from "@blueprintjs/core";
 
 import { getCurrentApplicationId } from "selectors/editorSelectors";
+import classNames from "classnames";
 
 export const Container = styled.div`
   display: flex;
@@ -70,6 +71,10 @@ export const Action = styled.button`
 
   &:focus {
     outline: none;
+  }
+
+  &:hover:not(.noHover) {
+    background: ${Colors.GREY_5};
   }
 `;
 
@@ -158,8 +163,12 @@ function PageListItem(props: PageListItemProps) {
               hoverOpenDelay={TOOLTIP_HOVER_ON_DELAY}
               position={Position.BOTTOM}
             >
-              <Action>
-                <DefaultPageIcon color={Colors.GREEN} height={16} width={16} />
+              <Action className="noHover">
+                <DefaultPageIcon
+                  color={Colors.MINE_SHAFT_2}
+                  height={16}
+                  width={16}
+                />
               </Action>
             </TooltipComponent>
           )}
@@ -200,7 +209,10 @@ function PageListItem(props: PageListItemProps) {
             hoverOpenDelay={TOOLTIP_HOVER_ON_DELAY}
             position={Position.BOTTOM}
           >
-            <Action type="button">
+            <Action
+              className={classNames({ noHover: item.isDefault })}
+              type="button"
+            >
               <DeleteIcon
                 color={
                   item.isDefault


### PR DESCRIPTION
## Description
Changed default page colour from a shade of green to gray.
Added hovers state to actionable page icons.

Fixes #13109 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/page-properties-ui 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.43 **(0)** | 37.81 **(0.01)** | 36.07 **(0)** | 56.65 **(0)**
 :green_circle: | app/client/src/pages/Editor/PagesEditor/PageListItem.tsx | 65.91 **(0.79)** | 57.14 **(0)** | 0 **(0)** | 65.91 **(0.79)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>