### PR TITLE
fix: JSONForm currency and phone input dropdown not working in Array Field

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_ArrayField_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_ArrayField_spec.js
@@ -140,4 +140,77 @@ describe("JSON Form Widget Array Field", () => {
         cy.get(`${education}-1--year input`).should("have.value", "");
       });
   });
+
+  it("phone input dropdown should update the selected value", () => {
+    cy.closePropertyPane();
+    cy.openPropertyPane("jsonformwidget");
+
+    cy.openFieldConfiguration("education");
+    cy.openFieldConfiguration("__array_item__");
+
+    // Add new custom field
+    cy.get(".t--property-pane-section-general button")
+      .contains("Add a new field")
+      .click({ force: true });
+
+    cy.openFieldConfiguration("customField1");
+    cy.selectDropdownValue(
+      commonlocators.jsonFormFieldType,
+      /^Phone Number Input/,
+    );
+
+    // Enable Allow Country Code Change
+    cy.togglebar(
+      ".t--property-control-allowcountrycodechange input[type='checkbox']",
+    );
+    // Change the label of the field to Phone Number
+    cy.testJsontext("label", "Phone Number");
+
+    // Open country code dropdown and select +91
+    cy.get(".t--input-country-code-change")
+      .first()
+      .click();
+    cy.get(".t--search-input input").type("+91");
+    cy.wait(500);
+    cy.get(".t--dropdown-option")
+      .last()
+      .click();
+
+    cy.get(".t--input-country-code-change").should("contain", "🇮🇳+91");
+  });
+
+  it("currency input dropdown should update the selected value", () => {
+    cy.closePropertyPane();
+    cy.openPropertyPane("jsonformwidget");
+
+    cy.openFieldConfiguration("education");
+    cy.openFieldConfiguration("__array_item__");
+
+    // Add new custom field
+    cy.get(".t--property-pane-section-general button")
+      .contains("Add a new field")
+      .click({ force: true });
+
+    cy.openFieldConfiguration("customField1");
+    cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Currency Input/);
+
+    // Enable Allow Country Code Change
+    cy.togglebar(
+      ".t--property-control-allowcurrencychange input[type='checkbox']",
+    );
+    // Change the label of the field to Phone Number
+    cy.testJsontext("label", "Currency");
+
+    // Open country code dropdown and select gbp
+    cy.get(".t--input-currency-change")
+      .first()
+      .click();
+    cy.get(".t--search-input input").type("gbp");
+    cy.wait(500);
+    cy.get(".t--dropdown-option")
+      .first()
+      .click();
+
+    cy.get(".t--input-currency-change").should("contain", "£");
+  });
 });

--- a/app/client/src/widgets/JSONFormWidget/fields/ArrayField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/ArrayField.tsx
@@ -134,8 +134,6 @@ function ArrayField({
 
   const { setMetaInternalFieldState } = useContext(FormContext);
 
-  const basePropertyPath = `${propertyPath}.children.${ARRAY_ITEM_KEY}`;
-
   const add = () => {
     let values = klona(getValues(name));
     if (values && values.length) {
@@ -255,9 +253,10 @@ function ArrayField({
   const fields = useMemo(() => {
     const arrayItemSchema = schemaItem.children[ARRAY_ITEM_KEY];
 
+    const fieldPropertyPath = `${propertyPath}.children.${ARRAY_ITEM_KEY}`;
+
     return itemKeys.map((key, index) => {
       const fieldName = `${name}[${index}]` as ControllerRenderProps["name"];
-      const fieldPropertyPath = `${basePropertyPath}.children.${arrayItemSchema.identifier}`;
 
       return (
         <Accordion
@@ -289,13 +288,13 @@ function ArrayField({
       );
     });
   }, [
-    schemaItem,
-    basePropertyPath,
-    name,
-    remove,
-    itemKeys,
-    fieldClassName,
     cachedDefaultValue,
+    fieldClassName,
+    itemKeys,
+    name,
+    propertyPath,
+    remove,
+    schemaItem,
   ]);
 
   if (!schemaItem.isVisible) {


### PR DESCRIPTION
## Description
When `Allow currency change` in Currency Input and `Allow country code change`  in Phone Number Input are enabled for the fields in an Array Field type, the dropdowns enabled to change the `Country Code` and `Currency Code` does not update when selected.

Solution - 
The propertyPath which is used to update the particular field's configuration in the schema was incorrect. `__array_item__.children` was being appended twice before passing it down to the children.

Fixes #13270 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
-Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/13270-jsonform-currencycode 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 70.59 **(0)** | 100 **(0)** | 93.33 **(0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/fields/ArrayField.tsx | 26.27 **(0.22)** | 21.74 **(0)** | 0 **(0)** | 27.93 **(0.25)**</details>