### PR TITLE
fix: skip copying logic while grouping

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -841,6 +841,7 @@ export function calculateNewWidgetPosition(
  * @param copiedTotalWidth total width of the copied widgets
  * @param copiedTopMostRow top row of the top most copied widget
  * @param copiedLeftMostColumn left column of the left most copied widget
+ * @param shouldGroup boolean to indicate if the user is grouping instead of pasting
  * @returns
  */
 const getNewPositions = function*(
@@ -849,7 +850,11 @@ const getNewPositions = function*(
   copiedTotalWidth: number,
   copiedTopMostRow: number,
   copiedLeftMostColumn: number,
+  shouldGroup: boolean,
 ) {
+  // if it is grouping instead of pasting then skip the pasting logic
+  if (shouldGroup) return {};
+
   const selectedWidgetIDs: string[] = yield select(getSelectedWidgets);
   const canvasWidgets: CanvasWidgetsReduxState = yield select(getWidgets);
   const selectedWidgets = getWidgetsFromIds(selectedWidgetIDs, canvasWidgets);
@@ -1240,6 +1245,7 @@ function* pasteWidgetSaga(
     copiedTotalWidth,
     topMostWidget.topRow,
     leftMostWidget.leftColumn,
+    shouldGroup,
   );
 
   if (canvasId) pastingIntoWidgetId = canvasId;

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -388,7 +388,7 @@ export const checkIfPastingIntoListWidget = function(
 };
 
 /**
- * get top, left, right, bottom most widgets and and totalWidth from copied groups when pasting
+ * get top, left, right, bottom most widgets and totalWidth from copied groups when pasting
  *
  * @param copiedWidgetGroups
  * @returns


### PR DESCRIPTION
## Description

Adding check to skip pasting logic while grouping widgets

Fixes #13572 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
## How Has This Been Tested?

manual UI testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: groupingPushesBelowFix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/sagas/WidgetOperationSagas.tsx | 61.52 **(-0.05)** | 51.09 **(-0.18)** | 60.78 **(0)** | 63.37 **(0.08)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>