### PR TITLE
fix:only show js successful execution toast message in edit mode

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/LayoutOnLoadActions/JSOnLoadActions_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/LayoutOnLoadActions/JSOnLoadActions_Spec.ts
@@ -5,14 +5,15 @@ const agHelper = ObjectsRegistry.AggregateHelper,
   ee = ObjectsRegistry.EntityExplorer,
   dataSources = ObjectsRegistry.DataSources,
   jsEditor = ObjectsRegistry.JSEditor,
-  table = ObjectsRegistry.Table;
+  table = ObjectsRegistry.Table,
+  locator = ObjectsRegistry.CommonLocators;
 
-describe("JSObjects OnLoad Actions tests", function () {
+describe("JSObjects OnLoad Actions tests", function() {
   before(() => {
     ee.DragDropWidgetNVerify("tablewidget", 300, 300);
   });
 
-  it("1. Create Postgress DS & the query", function () {
+  it("1. Create Postgress DS & the query", function() {
     ee.NavigateToSwitcher("explorer");
     agHelper.GenerateUUID();
     cy.get("@guid").then((uid) => {
@@ -25,7 +26,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     });
   });
 
-  it("2. Verify User enables only 'Before Function calling' & OnPage Load is Automatically enable after mapping done on JSOBject", function () {
+  it("2. Verify User enables only 'Before Function calling' & OnPage Load is Automatically enable after mapping done on JSOBject", function() {
     jsEditor.CreateJSObject(
       `export default {
       getId: async () => {
@@ -43,16 +44,23 @@ describe("JSObjects OnLoad Actions tests", function () {
     cy.get("@jsObjName").then((jsObjName) => {
       jsName = jsObjName;
       agHelper.EnterValue(
-        "SELECT * FROM public.users where id = {{" + jsObjName + ".getId.data}}",
+        "SELECT * FROM public.users where id = {{" +
+          jsObjName +
+          ".getId.data}}",
       );
-      ee.SelectEntityByName("Table1", 'WIDGETS');
+      ee.SelectEntityByName("Table1", "WIDGETS");
       jsEditor.EnterJSContext("Table Data", "{{GetUser.data}}");
-      agHelper.ValidateToastMessage("[" + jsName as string + ".getId, GetUser] will be executed automatically on page load")
+      agHelper.ValidateToastMessage(
+        (("[" + jsName) as string) +
+          ".getId, GetUser] will be executed automatically on page load",
+      );
       agHelper.DeployApp();
       agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog"));
-      agHelper.AssertElementPresence(jsEditor._dialogBody(jsName as string + ".getId"))
+      agHelper.AssertElementPresence(
+        jsEditor._dialogBody((jsName as string) + ".getId"),
+      );
       agHelper.ClickButton("Yes");
-      agHelper.Sleep(1000)
+      agHelper.Sleep(1000);
     });
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0).then((cellData) => {
@@ -61,29 +69,35 @@ describe("JSObjects OnLoad Actions tests", function () {
     agHelper.NavigateBacktoEditor();
   });
 
-  it("3. Verify OnPage Load - auto enabeld from above case for JSOBject", function () {
+  it("3. Verify OnPage Load - auto enabled from above case for JSOBject", function() {
     agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog"));
-    agHelper.AssertElementPresence(jsEditor._dialogBody(jsName as string + ".getId"))
+    agHelper.AssertElementPresence(
+      jsEditor._dialogBody((jsName as string) + ".getId"),
+    );
     agHelper.ClickButton("Yes");
-    agHelper.Sleep(1000)
-    ee.SelectEntityByName(jsName as string, 'QUERIES/JS')
-    jsEditor.VerifyOnPageLoadSetting('getId', true, true)
+    agHelper.Sleep(1000);
+    ee.SelectEntityByName(jsName as string, "QUERIES/JS");
+    jsEditor.VerifyOnPageLoadSetting("getId", true, true);
   });
 
-  it("4. Verify Error for OnPage Load - disable & Before Function calling enabled for JSOBject", function () {
-    ee.SelectEntityByName(jsName as string, 'QUERIES/JS')
+  it("4. Verify Error for OnPage Load - disable & Before Function calling enabled for JSOBject", function() {
+    ee.SelectEntityByName(jsName as string, "QUERIES/JS");
     jsEditor.EnableDisableOnPageLoad("getId", false, true);
     agHelper.DeployApp();
-    agHelper.ValidateToastMessage("The action \"GetUser\" has failed")
+    agHelper.ValidateToastMessage('The action "GetUser" has failed');
     agHelper.NavigateBacktoEditor();
   });
 
-  it("5. Verify OnPage Load - Enabling back & Before Function calling disabled for JSOBject", function () {
-    ee.SelectEntityByName(jsName as string, 'QUERIES/JS')
+  it("5. Verify OnPage Load - Enabling back & Before Function calling disabled for JSOBject", function() {
+    ee.SelectEntityByName(jsName as string, "QUERIES/JS");
     jsEditor.EnableDisableOnPageLoad("getId", true, false);
     agHelper.DeployApp();
     agHelper.AssertElementAbsence(jsEditor._dialog("Confirmation Dialog"));
-    agHelper.AssertElementAbsence(jsEditor._dialogBody(jsName as string + ".getId"))
+    agHelper.AssertElementAbsence(
+      jsEditor._dialogBody((jsName as string) + ".getId"),
+    );
+    // assert that on view mode, we don't get "successful run" toast message for onpageload actions
+    agHelper.AssertElementAbsence(locator._toastMsg);
     // agHelper.ClickButton("Yes");
     // agHelper.Sleep(1000)
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -72,6 +72,8 @@ import { jsCollectionIdURL } from "RouteBuilder";
 import { ModalType } from "reducers/uiReducers/modalActionReducer";
 import { requestModalConfirmationSaga } from "sagas/UtilSagas";
 import { UserCancelledActionExecutionError } from "sagas/ActionExecution/errorUtils";
+import { APP_MODE } from "entities/App";
+import { getAppMode } from "selectors/applicationSelectors";
 
 function* handleCreateNewJsActionSaga(action: ReduxAction<{ pageId: string }>) {
   const organizationId: string = yield select(getCurrentOrgId);
@@ -312,6 +314,7 @@ export function* handleExecuteJSFunctionSaga(data: {
 }): any {
   const { action, collectionId, collectionName } = data;
   const actionId = action.id;
+  const appMode: APP_MODE = yield select(getAppMode);
   yield put(
     executeJSFunctionInit({
       collectionName,
@@ -338,10 +341,11 @@ export function* handleExecuteJSFunctionSaga(data: {
       },
       state: { response: result },
     });
-    Toaster.show({
-      text: createMessage(JS_EXECUTION_SUCCESS_TOASTER, action.name),
-      variant: Variant.success,
-    });
+    appMode === APP_MODE.EDIT &&
+      Toaster.show({
+        text: createMessage(JS_EXECUTION_SUCCESS_TOASTER, action.name),
+        variant: Variant.success,
+      });
   } catch (e) {
     AppsmithConsole.addError({
       id: actionId,


### PR DESCRIPTION
## Description
This PR prevents the "successful execution" toast message that shows up on page load in view mode.

Fixes #13581

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/show-js-execution-successful-toast-on-edit-mode 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.58 **(0)** | 38.36 **(-0.01)** | 35.84 **(0)** | 56.82 **(0)**
 :green_circle: | app/client/src/sagas/JSPaneSagas.ts | 16.67 **(0.58)** | 1.03 **(-0.02)** | 4.55 **(0)** | 19.31 **(0.72)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>