### PR TITLE
fix: undefined check added for plugin

### DIFF
--- a/app/client/src/sagas/DebuggerSagas.ts
+++ b/app/client/src/sagas/DebuggerSagas.ts
@@ -314,7 +314,7 @@ function* logDebuggerErrorAnalyticsSaga(
         payload.entityId,
       );
       const plugin: Plugin = yield select(getPlugin, action.pluginId);
-      const pluginName = plugin.name.replace(/ /g, "");
+      const pluginName = plugin?.name?.replace(/ /g, "");
 
       // Sending plugin name for actions
       AnalyticsUtil.logEvent(payload.eventName, {


### PR DESCRIPTION
## Description

Getting plugin from the redux store was turning out to be undefined. `Name` property was be referred to using this object. So undefined check was needed in `DebuggerSagas` 

Fixes #13594 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
