### PR TITLE
fix: dont show wrong msg while loading

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStructureContainer.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceStructureContainer.tsx
@@ -3,8 +3,9 @@ import {
   DatasourceTable,
 } from "entities/Datasource";
 import React, { memo, ReactElement } from "react";
+import { useSelector } from "react-redux";
+import { getIsFetchingDatasourceStructure } from "selectors/entitiesSelector";
 import EntityPlaceholder from "../Entity/Placeholder";
-import { useEntityUpdateState } from "../hooks";
 import DatasourceStructure from "./DatasourceStructure";
 
 type Props = {
@@ -14,10 +15,11 @@ type Props = {
 };
 
 const Container = (props: Props) => {
-  const isLoading = useEntityUpdateState(props.datasourceId);
   let view: ReactElement<Props> = <div />;
-
-  if (!isLoading) {
+  const isFetchingDatasourceStructure = useSelector(
+    getIsFetchingDatasourceStructure,
+  );
+  if (!isFetchingDatasourceStructure) {
     if (props.datasourceStructure?.tables?.length) {
       view = (
         <>


### PR DESCRIPTION

## Description

Fixes #13584

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- make sure `no schema` msg is not displayed when expanding datasource.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
