### PR TITLE
refactor: removed the duplicate style properties for the list widget

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/ListWidget/widget/propertyConfig.ts
@@ -58,59 +58,6 @@ const PropertyPaneConfig = [
     ],
   },
   {
-    sectionName: "Styles",
-    children: [
-      {
-        propertyName: "backgroundColor",
-        label: "Background Color",
-        controlType: "COLOR_PICKER",
-        isJSConvertible: true,
-        isBindProperty: true,
-        isTriggerProperty: false,
-        validation: {
-          type: ValidationTypes.TEXT,
-          params: {
-            expected: {
-              type: "Color name | hex code",
-              example: "#FFFFFF",
-              autocompleteDataType: AutocompleteDataType.STRING,
-            },
-          },
-        },
-      },
-      {
-        propertyName: "itemBackgroundColor",
-        label: "Item Background Color",
-        controlType: "COLOR_PICKER",
-        isJSConvertible: true,
-        isBindProperty: true,
-        isTriggerProperty: false,
-        defaultValue: "#FFFFFF",
-        validation: {
-          type: ValidationTypes.TEXT,
-          params: {
-            expected: {
-              type: "Color name | hex code",
-              example: "#FFFFFF",
-              autocompleteDataType: AutocompleteDataType.STRING,
-            },
-          },
-        },
-      },
-      {
-        helpText: "Spacing between items in Pixels",
-        placeholderText: "0",
-        propertyName: "gridGap",
-        label: "Item Spacing (px)",
-        controlType: "INPUT_TEXT",
-        isBindProperty: true,
-        isTriggerProperty: false,
-        inputType: "INTEGER",
-        validation: { type: ValidationTypes.NUMBER, params: { min: -8 } },
-      },
-    ],
-  },
-  {
     sectionName: "Events",
     children: [
       {
@@ -172,7 +119,7 @@ const PropertyPaneConfig = [
     children: [
       {
         propertyName: "backgroundColor",
-        label: "Background",
+        label: "Background Color",
         controlType: "COLOR_PICKER",
         isJSConvertible: true,
         isBindProperty: true,
@@ -187,6 +134,36 @@ const PropertyPaneConfig = [
             },
           },
         },
+      },
+      {
+        propertyName: "itemBackgroundColor",
+        label: "Item Background Color",
+        controlType: "COLOR_PICKER",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        defaultValue: "#FFFFFF",
+        validation: {
+          type: ValidationTypes.TEXT,
+          params: {
+            expected: {
+              type: "Color name | hex code",
+              example: "#FFFFFF",
+              autocompleteDataType: AutocompleteDataType.STRING,
+            },
+          },
+        },
+      },
+      {
+        helpText: "Spacing between items in Pixels",
+        placeholderText: "0",
+        propertyName: "gridGap",
+        label: "Item Spacing (px)",
+        controlType: "INPUT_TEXT",
+        isBindProperty: true,
+        isTriggerProperty: false,
+        inputType: "INTEGER",
+        validation: { type: ValidationTypes.NUMBER, params: { min: -8 } },
       },
       {
         propertyName: "borderRadius",


### PR DESCRIPTION
## Description
Removes duplicate style property configs found inside the property pane of the list widget

Fixes #13604 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been test manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
