### PR TITLE
fix: disable revoke button after first click

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GitSync/DisconnectGit_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/GitSync/DisconnectGit_spec.js
@@ -85,6 +85,7 @@ describe("Git disconnect modal:", function() {
     // disconnecting validation
     cy.route("POST", "api/v1/git/disconnect/*").as("disconnect");
     cy.get(gitSyncLocators.disconnectButton).click();
+    cy.get(gitSyncLocators.disconnectButton).should("be.disabled");
     cy.wait("@disconnect").should(
       "have.nested.property",
       "response.body.responseMeta.status",

--- a/app/client/src/pages/Editor/gitSync/DisconnectGitModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/DisconnectGitModal.tsx
@@ -73,16 +73,23 @@ function DisconnectGitModal() {
   const disconnectingApp = useSelector(getDisconnectingGitApplication);
   const gitDisconnectDocumentUrl = useSelector(getDisconnectDocUrl);
   const [appName, setAppName] = useState("");
-
+  const [isRevoking, setIsRevoking] = useState(false);
   const handleClose = useCallback(() => {
     dispatch(setIsDisconnectGitModalOpen(false));
   }, [dispatch, setIsDisconnectGitModalOpen]);
 
   const onDisconnectGit = useCallback(() => {
+    setIsRevoking(true);
     dispatch(disconnectGit());
   }, [dispatch, disconnectGit]);
 
   const theme = useTheme() as Theme;
+
+  const shouldDisableRevokeButton =
+    disconnectingApp.id === "" ||
+    appName !== disconnectingApp.name ||
+    isRevoking;
+
   return (
     <StyledDialog
       canEscapeKeyClose
@@ -177,9 +184,7 @@ function DisconnectGitModal() {
             <Button
               category={Category.primary}
               className="t--git-revoke-button"
-              disabled={
-                disconnectingApp.id === "" || appName !== disconnectingApp.name
-              }
+              disabled={shouldDisableRevokeButton}
               onClick={onDisconnectGit}
               size={Size.large}
               tag="button"


### PR DESCRIPTION
## Description

Revoke button can be pressed multiple times. This code change stops that.

Fixes #12164

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-12164 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.57 **(0)** | 38.35 **(0.01)** | 35.84 **(0)** | 56.82 **(0)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>