### PR TITLE
fix: use "modified" instead of "updated" in git changes list

### DIFF
--- a/app/client/src/pages/Editor/gitSync/components/GitChangesList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/GitChangesList.tsx
@@ -83,7 +83,7 @@ const STATUS_MAP: StatusMap = {
   [Kind.PAGE]: (status: GitStatusData) => ({
     message: `${status?.modifiedPages || 0} ${
       (status?.modifiedPages || 0) <= 1 ? "page" : "pages"
-    } updated`,
+    } modified`,
     iconName: "widget",
     hasValue: (status?.modifiedPages || 0) > 0,
   }),


### PR DESCRIPTION
## Description

We are using "updated" and "modified" in git changes list. We should be using "modified" consistently, this PR fixes that.

Fixes #13652 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually.

## Before changes (bug)

<img width="550" alt="Screenshot 2022-05-07 at 7 48 18 AM" src="https://user-images.githubusercontent.com/1573771/167235018-6a8b62a2-4185-46af-a906-73bbc76183b2.png">

## After changes (fix)

<img width="553" alt="Screenshot 2022-05-07 at 8 09 59 AM" src="https://user-images.githubusercontent.com/1573771/167235034-db4e9dff-3d54-4edd-a592-aea547eb3cc0.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix-13652 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.57 **(-0.01)** | 38.36 **(-0.01)** | 35.84 **(0)** | 56.82 **(0)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**</details>