### PR TITLE
fix: take propertyValue from defaultValue if undefined

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -49,13 +49,13 @@ import { AppTheme } from "entities/AppTheming";
 type Props = PropertyPaneControlConfig & {
   panel: IPanelProps;
   theme: EditorTheme;
+  defaultValue?: string;
 };
 
 const SHOULD_NOT_REJECT_DYNAMIC_BINDING_LIST_FOR = ["COLOR_PICKER"];
 
 const PropertyControl = memo((props: Props) => {
   const dispatch = useDispatch();
-
   const propsSelector = getWidgetPropsForPropertyName(
     props.propertyName,
     props.dependencies,
@@ -102,7 +102,8 @@ const PropertyControl = memo((props: Props) => {
     return get(widgetStylesheet, props.propertyName);
   })();
 
-  const propertyValue = _.get(widgetProperties, props.propertyName);
+  const propertyValue =
+    _.get(widgetProperties, props.propertyName) || props.defaultValue;
 
   /**
    * checks if property value is deviated or not.


### PR DESCRIPTION
## Description
widgetProperties is not updated when drop down have defaultValue set so we take props.defaultValue when `_.get(widgetProperties, props.propertyName)` is undefined

Fixes #13632

 
## Type of change
 
- Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?

- make sure selected dropdown option's value is set when switching to js enabled mode.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
