### PR TITLE
fix: set propertyValue to default value on mount

### DIFF
--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -7,7 +7,7 @@ import { isDynamicValue } from "utils/DynamicBindingUtils";
 
 class DropDownControl extends BaseControl<DropDownControlProps> {
   componentDidMount() {
-    if (this.props.defaultValue) {
+    if (this.props.defaultValue && !this.props.propertyValue) {
       this.onItemSelect(this.props.defaultValue);
     }
   }

--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -6,6 +6,12 @@ import { isNil } from "lodash";
 import { isDynamicValue } from "utils/DynamicBindingUtils";
 
 class DropDownControl extends BaseControl<DropDownControlProps> {
+  componentDidMount() {
+    if (this.props.defaultValue) {
+      this.onItemSelect(this.props.defaultValue);
+    }
+  }
+
   render() {
     let defaultSelected: DropdownOption | DropdownOption[] = {
       label: "No selection.",


### PR DESCRIPTION
## Description
https://github.com/ganganimaulik/appsmith/blob/release/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx#L105
widgetProperties was not getting updated when drop down have defaultValue set 

so updated dropdown component to set propertyValue to defaultValue on mount by calling onItemSelect in componentDidMount


Fixes #13632

 
## Type of change
 
- Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?

- make sure selected dropdown option's value is set when switching to js enabled mode.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
