### PR TITLE
fix: delay on page load actions till all actions are retrieved

### DIFF
--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -49,11 +49,16 @@ export const fetchPage = (
   };
 };
 
-export const fetchPublishedPage = (pageId: string, bustCache = false) => ({
+export const fetchPublishedPage = (
+  pageId: string,
+  bustCache = false,
+  firstLoad = false,
+) => ({
   type: ReduxActionTypes.FETCH_PUBLISHED_PAGE_INIT,
   payload: {
     pageId,
     bustCache,
+    firstLoad,
   },
 });
 

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -21,6 +21,7 @@ import { ERROR_CODES } from "@appsmith/constants/ApiConstants";
 import {
   fetchPage,
   fetchPublishedPage,
+  fetchPublishedPageSuccess,
   resetApplicationWidgets,
   resetPageList,
   setAppMode,
@@ -427,7 +428,7 @@ export function* initializeAppViewerSaga(
     [
       fetchActionsForView({ applicationId }),
       fetchJSCollectionsForView({ applicationId }),
-      fetchPublishedPage(toLoadPageId, true),
+      fetchPublishedPage(toLoadPageId, true, true),
       fetchSelectedAppThemeAction(applicationId),
       fetchAppThemesAction(applicationId),
     ],
@@ -441,36 +442,14 @@ export function* initializeAppViewerSaga(
     [
       ReduxActionErrorTypes.FETCH_ACTIONS_VIEW_MODE_ERROR,
       ReduxActionErrorTypes.FETCH_JS_ACTIONS_VIEW_MODE_ERROR,
+      ReduxActionErrorTypes.FETCH_PUBLISHED_PAGE_ERROR,
     ],
   );
 
   if (!resultOfPrimaryCalls) return;
 
-  if (toLoadPageId) {
-    yield put(fetchPublishedPage(toLoadPageId, true));
-
-    const resultOfFetchPage: {
-      success: boolean;
-      failure: boolean;
-    } = yield race({
-      success: take(ReduxActionTypes.FETCH_PUBLISHED_PAGE_SUCCESS),
-      failure: take(ReduxActionErrorTypes.FETCH_PUBLISHED_PAGE_ERROR),
-    });
-
-    if (resultOfFetchPage.failure) {
-      yield put({
-        type: ReduxActionTypes.SAFE_CRASH_APPSMITH_REQUEST,
-        payload: {
-          code: get(
-            resultOfFetchPage,
-            "failure.payload.error.code",
-            ERROR_CODES.SERVER_ERROR,
-          ),
-        },
-      });
-      return;
-    }
-  }
+  //Delay page load actions till all actions are retrieved.
+  yield put(fetchPublishedPageSuccess([executePageLoadActions()]));
 
   yield put(fetchCommentThreadsInit());
 

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -435,7 +435,6 @@ export function* initializeAppViewerSaga(
     [
       ReduxActionTypes.FETCH_ACTIONS_VIEW_MODE_SUCCESS,
       ReduxActionTypes.FETCH_JS_ACTIONS_VIEW_MODE_SUCCESS,
-      ReduxActionTypes.FETCH_PUBLISHED_PAGE_SUCCESS,
       ReduxActionTypes.FETCH_APP_THEMES_SUCCESS,
       ReduxActionTypes.FETCH_SELECTED_APP_THEME_SUCCESS,
     ],

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -285,10 +285,14 @@ export function* fetchPageSaga(
 }
 
 export function* fetchPublishedPageSaga(
-  pageRequestAction: ReduxAction<{ pageId: string; bustCache: boolean }>,
+  pageRequestAction: ReduxAction<{
+    pageId: string;
+    bustCache: boolean;
+    firstLoad: boolean;
+  }>,
 ) {
   try {
-    const { bustCache, pageId } = pageRequestAction.payload;
+    const { bustCache, firstLoad, pageId } = pageRequestAction.payload;
     PerformanceTracker.startAsyncTracking(
       PerformanceTransactionName.FETCH_PAGE_API,
       {
@@ -316,13 +320,16 @@ export function* fetchPublishedPageSaga(
       yield put(initCanvasLayout(canvasWidgetsPayload));
       // set current page
       yield put(updateCurrentPage(pageId, response.data.slug));
-      // dispatch fetch page success
-      yield put(
-        fetchPublishedPageSuccess(
-          // Execute page load actions post published page eval
-          [executePageLoadActions()],
-        ),
-      );
+
+      if (!firstLoad) {
+        // dispatch fetch page success
+        yield put(
+          fetchPublishedPageSuccess(
+            // Execute page load actions post published page eval
+            [executePageLoadActions()],
+          ),
+        );
+      }
       PerformanceTracker.stopAsyncTracking(
         PerformanceTransactionName.FETCH_PAGE_API,
       );


### PR DESCRIPTION
## Description
As a quick fix to prevent the on-page load actions from firing before the actions are even fetched, we had reverted the changes to make fetch page DSL call parallel in [13587](https://github.com/appsmithorg/appsmith/pull/13587). Unfortunately, theming PR brought back parallelisation and the issue along with it. 

This PR ensures that the on-page-load actions are only made after actions are fetched while preserving parallelisation.

Fixes #13504 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/onload-action 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/actions/pageActions.tsx | 67.29 **(-0.63)** | 16.67 **(-8.33)** | 25 **(0)** | 56.76 **(-2.39)**
 :green_circle: | app/client/src/sagas/InitSagas.ts | 50.56 **(1.64)** | 36.67 **(2.82)** | 58.33 **(0)** | 53.95 **(2.05)**
 :red_circle: | app/client/src/sagas/PageSagas.tsx | 24.14 **(-0.07)** | 5.26 **(-0.12)** | 14.29 **(0)** | 25.67 **(-0.08)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>