### PR TITLE
fix: prevent lint warnings from blocking execution in js objects

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -1,0 +1,96 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+let guid: any, jsName: any;
+const agHelper = ObjectsRegistry.AggregateHelper,
+  ee = ObjectsRegistry.EntityExplorer,
+  dataSources = ObjectsRegistry.DataSources,
+  jsEditor = ObjectsRegistry.JSEditor,
+  table = ObjectsRegistry.Table;
+
+describe("JSObjects OnLoad Actions tests", function() {
+  before(() => {
+    ee.DragDropWidgetNVerify("tablewidget", 300, 300);
+  });
+
+  it(" Allows execution of js function when lint warnings(not errors) are present in code", function() {
+    jsEditor.CreateJSObject(
+      `export default {
+	myFun1: ()=>{
+		debugger;
+		return "yes"
+	}
+}`,
+      true,
+      true,
+      false,
+    );
+
+    // Assert that
+    jsEditor.EnableDisableOnPageLoad("getId", false, true); //Only before calling confirmation is enabled by User here
+    dataSources.NavigateToActiveDSQueryPane(guid);
+    agHelper.GetNClick(dataSources._templateMenu);
+    agHelper.RenameWithInPane("GetUser");
+    cy.get("@jsObjName").then((jsObjName) => {
+      jsName = jsObjName;
+      agHelper.EnterValue(
+        "SELECT * FROM public.users where id = {{" +
+          jsObjName +
+          ".getId.data}}",
+      );
+      ee.SelectEntityByName("Table1", "WIDGETS");
+      jsEditor.EnterJSContext("Table Data", "{{GetUser.data}}");
+      agHelper.ValidateToastMessage(
+        (("[" + jsName) as string) +
+          ".getId, GetUser] will be executed automatically on page load",
+      );
+      agHelper.DeployApp();
+      agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog"));
+      agHelper.AssertElementPresence(
+        jsEditor._dialogBody((jsName as string) + ".getId"),
+      );
+      agHelper.ClickButton("Yes");
+      agHelper.Sleep(1000);
+    });
+    agHelper.ValidateNetworkExecutionSuccess("@postExecute");
+    table.ReadTableRowColumnData(0, 0).then((cellData) => {
+      expect(cellData).to.be.equal("8");
+    });
+    agHelper.NavigateBacktoEditor();
+  });
+
+  it("3. Verify OnPage Load - auto enabeld from above case for JSOBject", function() {
+    agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog"));
+    agHelper.AssertElementPresence(
+      jsEditor._dialogBody((jsName as string) + ".getId"),
+    );
+    agHelper.ClickButton("Yes");
+    agHelper.Sleep(1000);
+    ee.SelectEntityByName(jsName as string, "QUERIES/JS");
+    jsEditor.VerifyOnPageLoadSetting("getId", true, true);
+  });
+
+  it("4. Verify Error for OnPage Load - disable & Before Function calling enabled for JSOBject", function() {
+    ee.SelectEntityByName(jsName as string, "QUERIES/JS");
+    jsEditor.EnableDisableOnPageLoad("getId", false, true);
+    agHelper.DeployApp();
+    agHelper.ValidateToastMessage('The action "GetUser" has failed');
+    agHelper.NavigateBacktoEditor();
+  });
+
+  it("5. Verify OnPage Load - Enabling back & Before Function calling disabled for JSOBject", function() {
+    ee.SelectEntityByName(jsName as string, "QUERIES/JS");
+    jsEditor.EnableDisableOnPageLoad("getId", true, false);
+    agHelper.DeployApp();
+    agHelper.AssertElementAbsence(jsEditor._dialog("Confirmation Dialog"));
+    agHelper.AssertElementAbsence(
+      jsEditor._dialogBody((jsName as string) + ".getId"),
+    );
+    // agHelper.ClickButton("Yes");
+    // agHelper.Sleep(1000)
+    agHelper.ValidateNetworkExecutionSuccess("@postExecute");
+    table.ReadTableRowColumnData(0, 0).then((cellData) => {
+      expect(cellData).to.be.equal("8");
+    });
+    agHelper.NavigateBacktoEditor();
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -1,21 +1,16 @@
 import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
-const ee = ObjectsRegistry.EntityExplorer,
-  jsEditor = ObjectsRegistry.JSEditor;
+const jsEditor = ObjectsRegistry.JSEditor;
 
 describe("JS Function Execution", function() {
-  before(() => {
-    ee.DragDropWidgetNVerify("tablewidget", 300, 300);
-  });
-
   it("Allows execution of js function when lint warnings(not errors) are present in code", function() {
     jsEditor.CreateJSObject(
       `export default {
-	myFun1: ()=>{
-		debugger;
-		return "yes"
-	}
-}`,
+  	myFun1: ()=>{
+  		debugger;
+  		return "yes"
+  	}
+  }`,
       true,
       true,
       false,
@@ -30,7 +25,7 @@ describe("JS Function Execution", function() {
 	myFun1: ()=>{
 		return "yes"
 	},
-  myFun2: ()
+  myFun2: ()==>{}
 }`,
       true,
       true,
@@ -43,7 +38,7 @@ describe("JS Function Execution", function() {
   it("Allows execution of other JS functions when lint error is present in code one JS function", function() {
     jsEditor.CreateJSObject(
       `export default {
-        myFun1:  (a ,b)=>{ 
+        myFun1:  (a ,b)=>{
         return f
         },
         myFun2 :()=>{

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -9,35 +9,57 @@ export class JSEditor {
   private _runButton = "button.run-js-action";
   private _settingsTab = ".tab-title:contains('Settings')";
   private _codeTab = ".tab-title:contains('Code')";
+  private _jsObjectParseErrorCallout = ".t--js-response-parse-error-call-out";
   private _onPageLoadRadioButton = (functionName: string, onLoad: boolean) =>
-    `.${functionName}-on-page-load-setting label:contains(${onLoad ? "Yes" : "No"
+    `.${functionName}-on-page-load-setting label:contains(${
+      onLoad ? "Yes" : "No"
     }) span.checkbox`;
-  private _onPageLoadRadioButtonStatus = (functionName: string, onLoad: boolean) =>
-    `.${functionName}-on-page-load-setting label:contains(${onLoad ? "Yes" : "No"
+  private _onPageLoadRadioButtonStatus = (
+    functionName: string,
+    onLoad: boolean,
+  ) =>
+    `.${functionName}-on-page-load-setting label:contains(${
+      onLoad ? "Yes" : "No"
     })>input`;
   private _confirmBeforeExecuteRadioButton = (
     functionName: string,
     shouldConfirm: boolean,
   ) =>
-    `.${functionName}-confirm-before-execute label:contains(${shouldConfirm ? "Yes" : "No"
+    `.${functionName}-confirm-before-execute label:contains(${
+      shouldConfirm ? "Yes" : "No"
     }) span.checkbox`;
   private _confirmBeforeExecuteRadioButtonStatus = (
     functionName: string,
     shouldConfirm: boolean,
   ) =>
-    `.${functionName}-confirm-before-execute label:contains(${shouldConfirm ? "Yes" : "No"
+    `.${functionName}-confirm-before-execute label:contains(${
+      shouldConfirm ? "Yes" : "No"
     })>input`;
   private _outputConsole = ".CodeEditorTarget";
   private _jsObjName = ".t--js-action-name-edit-field span";
   private _jsObjTxt = ".t--js-action-name-edit-field input";
-  private _newJSobj = "span:contains('New JS Object')"
-  private _bindingsClose = ".t--entity-property-close"
-  private _propertyList = ".t--entity-property"
-  private _responseTabAction = (funName: string) => "//div[@class='function-name'][text()='" + funName + "']/following-sibling::div//*[local-name()='svg']"
-  private _functionSetting = (settingTxt: string) => "//span[text()='" + settingTxt + "']/parent::div/following-sibling::input[@type='checkbox']"
-  _dialog = (dialogHeader: string) => "//div[contains(@class, 'bp3-dialog')]//h4[contains(text(), '" + dialogHeader + "')]"
-  private _closeSettings = "span[icon='small-cross']"
-  _dialogBody = (jsFuncName: string) => "//div[@class='bp3-dialog-body']//*[contains(text(), '" + Cypress.env('MESSAGES').QUERY_CONFIRMATION_MODAL_MESSAGE() + "')]//*[contains(text(),'" + jsFuncName + "')]"
+  private _newJSobj = "span:contains('New JS Object')";
+  private _bindingsClose = ".t--entity-property-close";
+  private _propertyList = ".t--entity-property";
+  private _responseTabAction = (funName: string) =>
+    "//div[@class='function-name'][text()='" +
+    funName +
+    "']/following-sibling::div//*[local-name()='svg']";
+  private _functionSetting = (settingTxt: string) =>
+    "//span[text()='" +
+    settingTxt +
+    "']/parent::div/following-sibling::input[@type='checkbox']";
+  _dialog = (dialogHeader: string) =>
+    "//div[contains(@class, 'bp3-dialog')]//h4[contains(text(), '" +
+    dialogHeader +
+    "')]";
+  private _closeSettings = "span[icon='small-cross']";
+  _dialogBody = (jsFuncName: string) =>
+    "//div[@class='bp3-dialog-body']//*[contains(text(), '" +
+    Cypress.env("MESSAGES").QUERY_CONFIRMATION_MODAL_MESSAGE() +
+    "')]//*[contains(text(),'" +
+    jsFuncName +
+    "')]";
 
   //#endregion
 
@@ -111,7 +133,7 @@ export class JSEditor {
           input.type(JSCode, {
             parseSpecialCharSequences: false,
             delay: 150,
-            force: true
+            force: true,
           });
         }
       });
@@ -178,9 +200,9 @@ export class JSEditor {
     } else {
       cy.get(
         this.locator._propertyControl +
-        endp.replace(/ +/g, "").toLowerCase() +
-        " " +
-        this.locator._codeMirrorTextArea,
+          endp.replace(/ +/g, "").toLowerCase() +
+          " " +
+          this.locator._codeMirrorTextArea,
       )
         .first()
         .then((el: any) => {
@@ -227,9 +249,9 @@ export class JSEditor {
   public RemoveText(endp: string) {
     cy.get(
       this.locator._propertyControl +
-      endp +
-      " " +
-      this.locator._codeMirrorTextArea,
+        endp +
+        " " +
+        this.locator._codeMirrorTextArea,
     )
       .first()
       .focus()
@@ -266,7 +288,7 @@ export class JSEditor {
 
   public validateDefaultJSObjProperties(jsObjName: string) {
     this.ee.ActionContextMenuByEntityName(jsObjName, "Show Bindings");
-    cy.get(this._propertyList).then(function ($lis) {
+    cy.get(this._propertyList).then(function($lis) {
       const bindingsLength = $lis.length;
       expect(bindingsLength).to.be.at.least(4);
       expect($lis.eq(0).text()).to.be.oneOf([
@@ -289,7 +311,6 @@ export class JSEditor {
     cy.get(this._bindingsClose).click({ force: true });
   }
 
-
   // public EnableDisableOnPageLoad(funName: string, onLoad: 'enable' | 'disable' | '', bfrCalling: 'enable' | 'disable' | '') {
   //   this.agHelper.GetNClick(this._responseTabAction(funName))
   //   this.agHelper.AssertElementPresence(this._dialog('Function settings'))
@@ -301,7 +322,11 @@ export class JSEditor {
   //   this.agHelper.GetNClick(this._closeSettings)
   // }
 
-  public VerifyOnPageLoadSetting(funName: string, onLoad = true, bfrCalling = true) {
+  public VerifyOnPageLoadSetting(
+    funName: string,
+    onLoad = true,
+    bfrCalling = true,
+  ) {
     // this.agHelper.GetNClick(this._responseTabAction(funName))
     // this.agHelper.AssertElementPresence(this._dialog('Function settings'))
     // this.agHelper.AssertExistingToggleState(this._functionSetting(Cypress.env("MESSAGES").JS_SETTINGS_ONPAGELOAD()), onLoad)
@@ -309,8 +334,14 @@ export class JSEditor {
     // this.agHelper.GetNClick(this._closeSettings)
 
     this.agHelper.GetNClick(this._settingsTab);
-    this.agHelper.AssertExistingToggleState(this._onPageLoadRadioButtonStatus(funName, onLoad), onLoad == true ? 'checked' : 'unchecked')
-    this.agHelper.AssertExistingToggleState(this._confirmBeforeExecuteRadioButtonStatus(funName, bfrCalling), bfrCalling == true ? 'checked' : 'unchecked')
+    this.agHelper.AssertExistingToggleState(
+      this._onPageLoadRadioButtonStatus(funName, onLoad),
+      onLoad == true ? "checked" : "unchecked",
+    );
+    this.agHelper.AssertExistingToggleState(
+      this._confirmBeforeExecuteRadioButtonStatus(funName, bfrCalling),
+      bfrCalling == true ? "checked" : "unchecked",
+    );
   }
 
   public EnableDisableOnPageLoad(
@@ -323,9 +354,23 @@ export class JSEditor {
     // Set onPageLoad
     this.agHelper.GetNClick(this._onPageLoadRadioButton(funName, onLoad));
     // Set confirmBeforeExecute
-    this.agHelper.GetNClick(this._confirmBeforeExecuteRadioButton(funName, bfrCalling));
+    this.agHelper.GetNClick(
+      this._confirmBeforeExecuteRadioButton(funName, bfrCalling),
+    );
     // Return to code tab
     this.agHelper.GetNClick(this._codeTab);
+  }
+
+  public AssertParseError(exists: boolean) {
+    const { AssertElementAbsence, AssertElementPresence } = this.agHelper;
+    // Assert presence/absence of parse error
+    if (exists) {
+      AssertElementPresence(this._jsObjectParseErrorCallout);
+      cy.get(this._runButton).should("not.be.disabled");
+    } else {
+      AssertElementAbsence(this._jsObjectParseErrorCallout);
+      cy.get(this._runButton).should("be.disabled");
+    }
   }
 
   //#endregion

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -9,7 +9,8 @@ export class JSEditor {
   private _runButton = "button.run-js-action";
   private _settingsTab = ".tab-title:contains('Settings')";
   private _codeTab = ".tab-title:contains('Code')";
-  private _jsObjectParseErrorCallout = ".t--js-response-parse-error-call-out";
+  private _jsObjectParseErrorCallout =
+    "//div[contains(@class,'t--js-response-parse-error-call-out')]";
   private _onPageLoadRadioButton = (functionName: string, onLoad: boolean) =>
     `.${functionName}-on-page-load-setting label:contains(${
       onLoad ? "Yes" : "No"
@@ -362,15 +363,10 @@ export class JSEditor {
   }
 
   public AssertParseError(exists: boolean) {
-    const { AssertElementAbsence, AssertElementPresence } = this.agHelper;
     // Assert presence/absence of parse error
-    if (exists) {
-      AssertElementPresence(this._jsObjectParseErrorCallout);
-      cy.get(this._runButton).should("not.be.disabled");
-    } else {
-      AssertElementAbsence(this._jsObjectParseErrorCallout);
-      cy.get(this._runButton).should("be.disabled");
-    }
+    cy.xpath(this._jsObjectParseErrorCallout).should(
+      exists ? "exist" : "not.exist",
+    );
   }
 
   //#endregion

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -516,8 +516,8 @@ export const JS_FUNCTION_UPDATE_SUCCESS = () =>
 export const JS_FUNCTION_DELETE_SUCCESS = () =>
   "JS function deleted successfully";
 export const JS_OBJECT_BODY_INVALID = () => "JS object could not be parsed";
-export const JS_ACTION_PARSING_ERROR = (jsFunctionName: string) =>
-  `An error occured while trying to parse code in ${jsFunctionName}, please check error logs to debug`;
+export const JS_ACTION_EXECUTION_ERROR = (jsFunctionName: string) =>
+  `An error occured while trying to execute ${jsFunctionName}, please check error logs to debug`;
 //Editor Page
 export const EDITOR_HEADER_SAVE_INDICATOR = () => "Saved";
 

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -516,7 +516,8 @@ export const JS_FUNCTION_UPDATE_SUCCESS = () =>
 export const JS_FUNCTION_DELETE_SUCCESS = () =>
   "JS function deleted successfully";
 export const JS_OBJECT_BODY_INVALID = () => "JS object could not be parsed";
-
+export const JS_ACTION_PARSING_ERROR = (jsFunctionName: string) =>
+  `An error occured while trying to parse code in ${jsFunctionName}, please check error logs to debug`;
 //Editor Page
 export const EDITOR_HEADER_SAVE_INDICATOR = () => "Saved";
 

--- a/app/client/src/components/editorComponents/CodeEditor/constants.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/constants.ts
@@ -3,6 +3,8 @@
 
 export const WARNING_LINT_ERRORS = {
   W098: "'{a}' is defined but never used.",
+  W014:
+    "Misleading line break before '{a}'; readers may interpret this as an expression boundary.",
 };
 
 export const LINT_TOOLTIP_CLASS = "CodeMirror-lint-tooltip";

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -19,6 +19,7 @@ import {
   EMPTY_RESPONSE_FIRST_HALF,
   EMPTY_JS_RESPONSE_LAST_HALF,
   NO_JS_FUNCTION_RETURN_VALUE,
+  JS_ACTION_PARSING_ERROR,
 } from "@appsmith/constants/messages";
 import { EditorTheme } from "./CodeEditor/EditorConfig";
 import DebuggerLogs from "./Debugger/DebuggerLogs";
@@ -147,6 +148,7 @@ enum JSResponseState {
 interface ReduxStateProps {
   responses: Record<string, any>;
   isExecuting: Record<string, boolean>;
+  isDirtyList: Record<string, boolean>;
 }
 
 type Props = ReduxStateProps &
@@ -165,6 +167,7 @@ function JSResponseView(props: Props) {
     currentFunction,
     disabled,
     errors,
+    isDirtyList,
     isExecuting,
     isLoading,
     jsObject,
@@ -199,6 +202,11 @@ function JSResponseView(props: Props) {
       setResponseStatus(JSResponseState.NoResponse);
     } else if (
       responses.hasOwnProperty(currentFunction.id) &&
+      isDirtyList[currentFunction.id]
+    ) {
+      setResponseStatus(JSResponseState.IsDirty);
+    } else if (
+      responses.hasOwnProperty(currentFunction.id) &&
       responses[currentFunction.id] === undefined
     ) {
       setResponseStatus(JSResponseState.NoReturnValue);
@@ -206,14 +214,14 @@ function JSResponseView(props: Props) {
       setResponseStatus(JSResponseState.ShowResponse);
     }
   }, [responses, isExecuting, currentFunction]);
-
   const tabs = [
     {
       key: "body",
       title: "Response",
       panelComponent: (
         <>
-          {errors.length > 0 && (
+          {(errors.length > 0 ||
+            responseStatus === JSResponseState.IsDirty) && (
             <HelpSection>
               <StyledCallout
                 fill
@@ -222,7 +230,14 @@ function JSResponseView(props: Props) {
                     <DebugButton onClick={onDebugClick} />
                   </FailedMessage>
                 }
-                text={createMessage(PARSING_ERROR)}
+                text={
+                  responseStatus === JSResponseState.IsDirty
+                    ? createMessage(
+                        JS_ACTION_PARSING_ERROR,
+                        `${jsObject.name}.${currentFunction?.name}`,
+                      )
+                    : createMessage(PARSING_ERROR)
+                }
                 variant={Variant.danger}
               />
             </HelpSection>
@@ -317,10 +332,12 @@ const mapStateToProps = (
       (action: JSCollectionData) => action.config.id === jsObject.id,
     );
   const responses = (seletedJsObject && seletedJsObject.data) || {};
+  const isDirtyList = (seletedJsObject && seletedJsObject.isDirty) || {};
   const isExecuting = (seletedJsObject && seletedJsObject.isExecuting) || {};
   return {
-    responses: responses,
-    isExecuting: isExecuting,
+    responses,
+    isExecuting,
+    isDirtyList,
   };
 };
 

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -19,7 +19,7 @@ import {
   EMPTY_RESPONSE_FIRST_HALF,
   EMPTY_JS_RESPONSE_LAST_HALF,
   NO_JS_FUNCTION_RETURN_VALUE,
-  JS_ACTION_PARSING_ERROR,
+  JS_ACTION_EXECUTION_ERROR,
 } from "@appsmith/constants/messages";
 import { EditorTheme } from "./CodeEditor/EditorConfig";
 import DebuggerLogs from "./Debugger/DebuggerLogs";
@@ -222,7 +222,7 @@ function JSResponseView(props: Props) {
         <>
           {(errors.length > 0 ||
             responseStatus === JSResponseState.IsDirty) && (
-            <HelpSection>
+            <HelpSection className=".t--js-response-parse-error-call-out">
               <StyledCallout
                 fill
                 label={
@@ -233,7 +233,7 @@ function JSResponseView(props: Props) {
                 text={
                   responseStatus === JSResponseState.IsDirty
                     ? createMessage(
-                        JS_ACTION_PARSING_ERROR,
+                        JS_ACTION_EXECUTION_ERROR,
                         `${jsObject.name}.${currentFunction?.name}`,
                       )
                     : createMessage(PARSING_ERROR)

--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -182,7 +182,6 @@ function JSEditorForm({ jsCollection: currentJSCollection }: Props) {
     }
     setSelectedJSActionOption(getJSActionOption(activeJSAction, jsActions));
   }, [parseErrors, jsActions, activeJSActionId]);
-
   return (
     <FormWrapper>
       <JSObjectHotKeys runActiveJSFunction={handleRunAction}>

--- a/app/client/src/reducers/entityReducers/jsActionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/jsActionsReducer.tsx
@@ -15,6 +15,8 @@ export interface JSCollectionData {
   data?: Record<string, unknown>;
   isExecuting?: Record<string, boolean>;
   activeJSActionId?: string;
+  // Existence of parse errors for each action (updates after execution)
+  isDirty?: Record<string, boolean>;
 }
 export type JSCollectionDataState = JSCollectionData[];
 export interface PartialActionData {
@@ -268,7 +270,9 @@ const jsActionsReducer = createReducer(initialState, {
     state.map((a) => {
       if (a.config.id === action.payload.collectionId) {
         const newData = { ...a.data };
+        const newIsDirty = { ...a.isDirty };
         unset(newData, action.payload.action.id);
+        unset(newIsDirty, action.payload.action.id);
         return {
           ...a,
           isExecuting: {
@@ -277,6 +281,9 @@ const jsActionsReducer = createReducer(initialState, {
           },
           data: {
             ...newData,
+          },
+          isDirty: {
+            ...newIsDirty,
           },
         };
       }
@@ -288,6 +295,7 @@ const jsActionsReducer = createReducer(initialState, {
       results: any;
       collectionId: string;
       actionId: string;
+      isDirty: boolean;
     }>,
   ): JSCollectionDataState =>
     state.map((a) => {
@@ -301,6 +309,10 @@ const jsActionsReducer = createReducer(initialState, {
           isExecuting: {
             ...a.isExecuting,
             [action.payload.actionId]: false,
+          },
+          isDirty: {
+            ...a.isDirty,
+            [action.payload.actionId]: action.payload.isDirty,
           },
         };
       }

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -26,7 +26,6 @@ import WidgetFactory, { WidgetTypeConfigMap } from "utils/WidgetFactory";
 import { GracefulWorkerService } from "utils/WorkerUtil";
 import Worker from "worker-loader!../workers/evaluation.worker";
 import {
-  EvaluationError,
   EVAL_WORKER_ACTIONS,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -323,13 +323,18 @@ export function* handleExecuteJSFunctionSaga(data: {
     }),
   );
   try {
-    const result = yield call(executeFunction, collectionName, action);
+    const { isDirty, result } = yield call(
+      executeFunction,
+      collectionName,
+      action,
+    );
     yield put({
       type: ReduxActionTypes.EXECUTE_JS_FUNCTION_SUCCESS,
       payload: {
         results: result,
         collectionId,
         actionId,
+        isDirty,
       },
     });
     AppsmithConsole.info({
@@ -342,6 +347,7 @@ export function* handleExecuteJSFunctionSaga(data: {
       state: { response: result },
     });
     appMode === APP_MODE.EDIT &&
+      !isDirty &&
       Toaster.show({
         text: createMessage(JS_EXECUTION_SUCCESS_TOASTER, action.name),
         variant: Variant.success,

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -25,12 +25,10 @@ import { ExplorerFileEntity } from "pages/Editor/Explorer/helpers";
 import { ActionValidationConfigMap } from "constants/PropertyControlConstants";
 import { selectFeatureFlags } from "./usersSelectors";
 import {
-  EvalErrorTypes,
   EvaluationError,
   EVAL_ERROR_PATH,
   PropertyEvaluationErrorType,
 } from "utils/DynamicBindingUtils";
-import { Severity } from "entities/AppsmithConsole";
 
 export const getEntities = (state: AppState): AppState["entities"] =>
   state.entities;

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -24,7 +24,12 @@ import { APP_MODE } from "entities/App";
 import { ExplorerFileEntity } from "pages/Editor/Explorer/helpers";
 import { ActionValidationConfigMap } from "constants/PropertyControlConstants";
 import { selectFeatureFlags } from "./usersSelectors";
-import { EvaluationError, EVAL_ERROR_PATH } from "utils/DynamicBindingUtils";
+import {
+  EvalErrorTypes,
+  EvaluationError,
+  EVAL_ERROR_PATH,
+  PropertyEvaluationErrorType,
+} from "utils/DynamicBindingUtils";
 import { Severity } from "entities/AppsmithConsole";
 
 export const getEntities = (state: AppState): AppState["entities"] =>
@@ -830,6 +835,6 @@ export const getJSCollectionParseErrors = (
     [],
   ) as EvaluationError[];
   return allErrors.filter((error) => {
-    return error.severity === Severity.ERROR;
+    return error.errorType === PropertyEvaluationErrorType.PARSE;
   });
 };


### PR DESCRIPTION
## Description

This PR ensures that only parse errors prevent the execution of js functions. Parse errors/ Lint errors within a function (that don't render the entire JS Object invalid) don't cause all functions to be unrunnable.

Fixes #12012 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/prevent-lint-warnings-from-blocking-execution-in-js-objects 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.58 **(-0.01)** | 38.38 **(-0.02)** | 35.83 **(-0.01)** | 56.83 **(-0.01)**
 :red_circle: | app/client/src/ce/constants/messages.ts | 77.81 **(-0.02)** | 100 **(0)** | 34.35 **(-0.05)** | 81.7 **(-0.07)**
 :red_circle: | app/client/src/components/editorComponents/JSResponseView.tsx | 51.22 **(-1.94)** | 26.51 **(-5.37)** | 8.33 **(0)** | 53.16 **(-2.1)**
 :red_circle: | app/client/src/reducers/entityReducers/jsActionsReducer.tsx | 6.54 **(-0.13)** | 0 **(0)** | 0 **(0)** | 6.67 **(-0.13)**
 :red_circle: | app/client/src/sagas/EvaluationsSaga.ts | 19.4 **(-0.08)** | 1.94 **(0)** | 7.41 **(0)** | 22.17 **(-0.11)**
 :red_circle: | app/client/src/sagas/JSPaneSagas.ts | 16.67 **(0)** | 1.02 **(-0.01)** | 4.55 **(0)** | 19.31 **(0)**
 :red_circle: | app/client/src/selectors/entitiesSelector.ts | 48.37 **(-0.11)** | 11.43 **(0)** | 23.95 **(0)** | 44.1 **(-0.16)**</details>