### PR TITLE
fix: Js editor inconsistency

### DIFF
--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -78,7 +78,7 @@ const TabbedViewWrapper = styled.div`
 
   &&& {
     ul.react-tabs__tab-list {
-      padding: 0px ${(props) => props.theme.spaces[12]}px;
+      padding: 0px ${(props) => props.theme.spaces[11]}px;
       height: ${TAB_MIN_HEIGHT};
     }
   }

--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -16,7 +16,6 @@ import {
   EditorTheme,
   TabBehaviour,
 } from "components/editorComponents/CodeEditor/EditorConfig";
-import FormRow from "components/editorComponents/FormRow";
 import JSObjectNameEditor from "./JSObjectNameEditor";
 import {
   setActiveJSAction,
@@ -53,9 +52,9 @@ import {
   ActionButtons,
   Form,
   FormWrapper,
-  MainConfiguration,
   NameWrapper,
   SecondaryWrapper,
+  StyledFormRow,
   TabbedViewContainer,
 } from "./styledComponents";
 
@@ -187,35 +186,33 @@ function JSEditorForm({ jsCollection: currentJSCollection }: Props) {
       <JSObjectHotKeys runActiveJSFunction={handleRunAction}>
         <CloseEditor />
         <Form>
-          <MainConfiguration>
-            <FormRow className="form-row-header">
-              <NameWrapper className="t--nameOfJSObject">
-                <JSObjectNameEditor page="JS_PANE" />
-              </NameWrapper>
-              <ActionButtons className="t--formActionButtons">
-                <MoreJSCollectionsMenu
-                  className="t--more-action-menu"
-                  id={currentJSCollection.id}
-                  name={currentJSCollection.name}
-                  pageId={pageId}
-                />
-                <SearchSnippets
-                  entityId={currentJSCollection?.id}
-                  entityType={ENTITY_TYPE.JSACTION}
-                />
-                <JSFunctionRun
-                  disabled={disableRunFunctionality}
-                  isLoading={isExecutingCurrentJSAction}
-                  jsCollection={currentJSCollection}
-                  onButtonClick={handleRunAction}
-                  onSelect={handleJSActionOptionSelection}
-                  options={convertJSActionsToDropdownOptions(jsActions)}
-                  selected={selectedJSActionOption}
-                  showTooltip={!selectedJSActionOption.data}
-                />
-              </ActionButtons>
-            </FormRow>
-          </MainConfiguration>
+          <StyledFormRow className="form-row-header">
+            <NameWrapper className="t--nameOfJSObject">
+              <JSObjectNameEditor page="JS_PANE" />
+            </NameWrapper>
+            <ActionButtons className="t--formActionButtons">
+              <MoreJSCollectionsMenu
+                className="t--more-action-menu"
+                id={currentJSCollection.id}
+                name={currentJSCollection.name}
+                pageId={pageId}
+              />
+              <SearchSnippets
+                entityId={currentJSCollection?.id}
+                entityType={ENTITY_TYPE.JSACTION}
+              />
+              <JSFunctionRun
+                disabled={disableRunFunctionality}
+                isLoading={isExecutingCurrentJSAction}
+                jsCollection={currentJSCollection}
+                onButtonClick={handleRunAction}
+                onSelect={handleJSActionOptionSelection}
+                options={convertJSActionsToDropdownOptions(jsActions)}
+                selected={selectedJSActionOption}
+                showTooltip={!selectedJSActionOption.data}
+              />
+            </ActionButtons>
+          </StyledFormRow>
           <SecondaryWrapper>
             <TabbedViewContainer isExecuting={isExecutingCurrentJSAction}>
               <TabComponent

--- a/app/client/src/pages/Editor/JSEditor/JSFunctionRun.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSFunctionRun.tsx
@@ -4,7 +4,7 @@ import Dropdown, {
   DropdownOnSelect,
   DropdownContainer,
 } from "components/ads/Dropdown";
-import Button from "components/ads/Button";
+import Button, { Size } from "components/ads/Button";
 import FlagBadge from "components/utils/FlagBadge";
 import { JSCollection } from "entities/JSCollection";
 import Tooltip from "components/ads/Tooltip";
@@ -36,9 +36,6 @@ const DropdownWithCTAWrapper = styled.div<DropdownWithCTAWrapperProps>`
   display: flex;
 
   ${StyledButton} {
-    margin-left: ${RUN_BUTTON_DEFAULTS.GAP_SIZE};
-    padding: 0px 20px;
-
     ${(props) =>
       props.isDisabled &&
       `
@@ -75,6 +72,7 @@ export function JSFunctionRun({
         selectedHighlightBg={RUN_BUTTON_DEFAULTS.DROPDOWN_HIGHLIGHT_BG}
         showLabelOnly
         truncateOption
+        width="232px"
       />
 
       <Tooltip
@@ -87,8 +85,10 @@ export function JSFunctionRun({
           height={RUN_BUTTON_DEFAULTS.HEIGHT}
           isLoading={isLoading}
           onClick={onButtonClick}
+          size={Size.medium}
           tag="button"
           text={RUN_BUTTON_DEFAULTS.CTA_TEXT}
+          type="button"
         />
       </Tooltip>
     </DropdownWithCTAWrapper>

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -3,11 +3,6 @@ import { useSelector } from "react-redux";
 
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
-// import {
-//   EditableText as NewEditableText,
-//   EditInteractionKind as NewEditInteractionKind,
-//   SavingState,
-// } from "components/ads/EditableText";
 import { removeSpecialChars } from "utils/helpers";
 import { AppState } from "reducers";
 import { JSCollection } from "entities/JSCollection";
@@ -119,7 +114,6 @@ export function JSObjectNameEditor(props: JSObjectNameEditorProps) {
               editInteractionKind={EditInteractionKind.SINGLE}
               errorTooltipClass="t--action-name-edit-error"
               forceDefault={forceUpdate}
-              hideEditIcon
               isEditingDefault={isNew}
               isInvalid={isInvalidNameForEntity}
               onTextChanged={handleNameChange}

--- a/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
+++ b/app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx
@@ -28,6 +28,7 @@ const JSObjectNameWrapper = styled.div<{ page?: string }>`
   justify-content: flex-start;
   align-content: center;
   & > div {
+    display: flex;
     max-width: 100%;
     flex: 0 1 auto;
     font-size: ${(props) => props.theme.fontSizes[5]}px;
@@ -95,11 +96,7 @@ export function JSObjectNameEditor(props: JSObjectNameEditorProps) {
         saveStatus: { isSaving: boolean; error: boolean };
       }) => (
         <JSObjectNameWrapper page={props.page}>
-          <div
-            style={{
-              display: "flex",
-            }}
-          >
+          <div>
             {currentPlugin && (
               <JSIconWrapper
                 alt={currentPlugin.name}

--- a/app/client/src/pages/Editor/JSEditor/styledComponents.ts
+++ b/app/client/src/pages/Editor/JSEditor/styledComponents.ts
@@ -105,7 +105,7 @@ export const TabbedViewContainer = styled.div<{ isExecuting: boolean }>`
   }
   &&& {
     ul.react-tabs__tab-list {
-      padding: 0px ${(props) => props.theme.spaces[12]}px;
+      padding: 0px ${(props) => props.theme.spaces[11]}px;
       background-color: ${(props) =>
         props.theme.colors.apiPane.responseBody.bg};
     }

--- a/app/client/src/pages/Editor/JSEditor/styledComponents.ts
+++ b/app/client/src/pages/Editor/JSEditor/styledComponents.ts
@@ -1,11 +1,11 @@
 import styled, { css } from "styled-components";
 import FormRow from "components/editorComponents/FormRow";
-import FormLabel from "components/editorComponents/FormLabel";
 import {
   JS_OBJECT_HOTKEYS_CLASSNAME,
   RUN_GUTTER_CLASSNAME,
   RUN_GUTTER_ID,
 } from "./constants";
+import { thinScrollbar } from "constants/DefaultTheme";
 
 export const CodeEditorWithGutterStyles = css`
   .${RUN_GUTTER_ID} {
@@ -45,23 +45,21 @@ export const Form = styled.form`
   flex-direction: column;
   height: ${({ theme }) => `calc(100% - ${theme.backBanner})`};
   overflow: hidden;
-  ${FormLabel} {
-    padding: ${(props) => props.theme.spaces[3]}px;
-  }
-  ${FormRow} {
-    ${FormLabel} {
-      padding: 0;
-      width: 100%;
-    }
-  }
   .t--no-binding-prompt {
     display: none;
   }
+  flex: 1;
+  padding: 20px 0px 0px 0px;
+`;
+
+export const StyledFormRow = styled(FormRow)`
+  padding: 0px 20px;
+  flex: 0;
 `;
 
 export const NameWrapper = styled.div`
-  width: 49%;
   display: flex;
+  justify-content: space-between;
   align-items: center;
   input {
     margin: 0;
@@ -70,12 +68,17 @@ export const NameWrapper = styled.div`
 `;
 
 export const ActionButtons = styled.div`
-  justify-self: flex-end;
   display: flex;
   align-items: center;
+  flex: 1 1 50%;
+  justify-content: flex-end;
+
+  & > div {
+    margin: 0 0 0 ${(props) => props.theme.spaces[7]}px;
+  }
 
   button:last-child {
-    margin: 0 ${(props) => props.theme.spaces[7]}px;
+    margin-left: ${(props) => props.theme.spaces[7]}px;
     height: 30px;
   }
 `;
@@ -86,17 +89,13 @@ export const SecondaryWrapper = styled.div`
   height: calc(100% - 50px);
   overflow: hidden;
 `;
-export const MainConfiguration = styled.div`
-  padding: ${(props) => props.theme.spaces[4]}px
-    ${(props) => props.theme.spaces[10]}px 0px
-    ${(props) => props.theme.spaces[10]}px;
-`;
 
 export const TabbedViewContainer = styled.div<{ isExecuting: boolean }>`
   flex: 1;
   overflow: auto;
   position: relative;
-  border-top: 2px solid ${(props) => props.theme.colors.apiPane.dividerBg};
+  border-top: 1px solid ${(props) => props.theme.colors.apiPane.dividerBg};
+  ${thinScrollbar}
   ${FormRow} {
     min-height: auto;
     padding: ${(props) => props.theme.spaces[0]}px;
@@ -112,12 +111,9 @@ export const TabbedViewContainer = styled.div<{ isExecuting: boolean }>`
     }
     .react-tabs__tab-panel {
       ${CodeEditorWithGutterStyles}
-      height: calc(100% - 36px);
-      margin-top: 2px;
+      height: calc(100% - 32px);
       background-color: ${(props) => props.theme.colors.apiPane.bg};
       .CodeEditorTarget {
-        border-bottom: 1px solid
-          ${(props) => props.theme.colors.apiPane.dividerBg};
         outline: none;
       }
       ${(props) =>

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -126,6 +126,7 @@ export const TabbedViewContainer = styled.div`
   }
   .react-tabs__tab-list {
     margin: 0px;
+   
   }
   &&& {
     ul.react-tabs__tab-list {

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -437,7 +437,6 @@ export function* initializeAppViewerSaga(
     [
       ReduxActionTypes.FETCH_ACTIONS_VIEW_MODE_SUCCESS,
       ReduxActionTypes.FETCH_JS_ACTIONS_VIEW_MODE_SUCCESS,
-      ReduxActionTypes.FETCH_PUBLISHED_PAGE_SUCCESS,
       ReduxActionTypes.FETCH_APP_THEMES_SUCCESS,
       ReduxActionTypes.FETCH_SELECTED_APP_THEME_SUCCESS,
     ],

--- a/app/client/src/sagas/InitSagas.ts
+++ b/app/client/src/sagas/InitSagas.ts
@@ -437,6 +437,7 @@ export function* initializeAppViewerSaga(
     [
       ReduxActionTypes.FETCH_ACTIONS_VIEW_MODE_SUCCESS,
       ReduxActionTypes.FETCH_JS_ACTIONS_VIEW_MODE_SUCCESS,
+      ReduxActionTypes.FETCH_PUBLISHED_PAGE_SUCCESS,
       ReduxActionTypes.FETCH_APP_THEMES_SUCCESS,
       ReduxActionTypes.FETCH_SELECTED_APP_THEME_SUCCESS,
     ],


### PR DESCRIPTION
## Description

This PR makes the JS Editor page consistent with that of the Query page

Fixes #11008 
Fixes #12303

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual (Only UI changes)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: js-editor-inconsistency 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.62 **(0.01)** | 38.54 **(-0.01)** | 35.91 **(0.01)** | 56.86 **(0)**
 :red_circle: | app/client/src/pages/Editor/JSEditor/Form.tsx | 28.77 **(-0.96)** | 0 **(0)** | 0 **(0)** | 32.81 **(-1.04)**
 :red_circle: | app/client/src/pages/Editor/JSEditor/JSObjectNameEditor.tsx | 53.13 **(-0.44)** | 20 **(0)** | 0 **(0)** | 53.13 **(-0.44)**
 :green_circle: | app/client/src/pages/Editor/JSEditor/styledComponents.ts | 50 **(7.14)** | 88.89 **(0)** | 0 **(0)** | 52.17 **(7.73)**</details>