### PR TITLE
Fix: JSON.parse fail in list widget when options have an apostrophe

### DIFF
--- a/app/client/src/widgets/WidgetUtils.test.ts
+++ b/app/client/src/widgets/WidgetUtils.test.ts
@@ -164,6 +164,16 @@ hello! how are you?
     expect(result).toStrictEqual(expectedResult);
   });
 
+  it.only("validate escaping apostrophe", () => {
+    const testData = "Drop a t'able"; // having single quote in value
+    const expectedTestData = "Drop a t&apos;able";
+    const testString = JSON.stringify(testData);
+    const result = escapeSpecialChars(testString);
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult).toStrictEqual(expectedTestData);
+  });
+
   it("Check if the color is lightened with lightenColor utility", () => {
     /**
      * Colors with :

--- a/app/client/src/widgets/WidgetUtils.ts
+++ b/app/client/src/widgets/WidgetUtils.ts
@@ -184,12 +184,13 @@ export const getAlignText = (isRightAlign: boolean, iconName?: IconName) =>
     : Alignment.CENTER;
 export const escapeSpecialChars = (stringifiedJSONObject: string) => {
   return stringifiedJSONObject
+    .replace(/[\/\(\)\']/g, "&apos;") // apostrophe
     .replace(/\\n/g, "\\\\n") // new line char
-    .replace(/\\b/g, "\\\\b") //
+    .replace(/\\b/g, "\\\\b") // backspace
     .replace(/\\t/g, "\\\\t") // tab
-    .replace(/\\f/g, "\\\\f") //
-    .replace(/\\/g, "\\\\") //
-    .replace(/\\r/g, "\\\\r"); //
+    .replace(/\\f/g, "\\\\f") // form feed
+    .replace(/\\/g, "\\\\") // backslash
+    .replace(/\\r/g, "\\\\r"); // carriage return
 };
 
 /**


### PR DESCRIPTION
## Description

**Issue faced** - If the list widget has an apostrophe within its options, `currentItem` related code does not work due to JSON.parse failing

**Solution** - Escape the apostrophe jo JSON.parse can work as expected

**Screen recording of fix** - 

https://user-images.githubusercontent.com/10229595/167590471-2fd6733e-2644-497f-979f-ccf1e2216a64.mov


Fixes #9872

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


- **Manually** - Steps To Reproduce and verify bug doesn't occur
1. Add list widget to canvas and add a button to the item.
```
[
  {
    "step": "#1",
    "task": "Drop a t'able",
    "status": "✅",
    "action": "'"
  },
  {
    "step": "#2",
    "task": "Create a query fetch_users with the Mock DB",
    "status": "--",
    "action": ""
  },
  {
    "step": "#3",
    "task": "Bind the query using => fetch_users.data",
    "status": "--",
    "action": ""
  }
]
```
2. Add onClick of button {{navigateTo(currentItem.task, {})}}
3. Click on button and check if the issue has been resolved
- **Added unit test**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/json-parse-fail-list-widget 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.53 **(-0.06)** | 38.3 **(-0.09)** | 35.78 **(-0.06)** | 56.77 **(-0.06)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/widgets/WidgetUtils.ts | 62.5 **(-20.31)** | 32.17 **(-30.44)** | 43.33 **(-23.34)** | 55.7 **(-23.41)**</details>