### PR TITLE
chore: highlight matching words in JS Editor

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -18,6 +18,7 @@ import "codemirror/addon/mode/multiplex";
 import "codemirror/addon/tern/tern.css";
 import "codemirror/addon/lint/lint";
 import "codemirror/addon/lint/lint.css";
+import "codemirror/addon/search/match-highlighter.js";
 
 import { getDataTreeForAutocomplete } from "selectors/dataTreeSelectors";
 import EvaluatedValuePopup from "components/editorComponents/CodeEditor/EvaluatedValuePopup";
@@ -247,6 +248,7 @@ class CodeEditor extends Component<Props, State> {
           lintOnChange: false,
         },
         tabindex: -1,
+        highlightSelectionMatches: true,
       };
 
       const gutters = new Set<string>();

--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -304,6 +304,9 @@ export const EditorWrapper = styled.div<{
         color: ${props.isRawView ? "#000" : "#cb4b16"};
       }
     `}
+    .cm-matchhighlight{
+      background: #e3dccd;
+    }
 `;
 
 export const IconContainer = styled.div`


### PR DESCRIPTION
## Description
<img width="689" alt="Screenshot 2022-05-10 at 10 35 40" src="https://user-images.githubusercontent.com/46670083/167599037-ffb8bea0-5fc5-4b6e-a26d-b058ad49c2c0.png">

Fixes #9330 

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: chore/add-word-match-highlighting-to-js-editor 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.59 **(0)** | 38.39 **(-0.01)** | 35.84 **(0)** | 56.83 **(-0.01)**
 :green_circle: | app/client/src/components/editorComponents/CodeEditor/index.tsx | 77.03 **(0.06)** | 58.41 **(0)** | 65.22 **(0)** | 78.53 **(0.07)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>