### PR TITLE
Added HA and PV

### DIFF
--- a/deploy/helm/templates/autoupdate.yaml
+++ b/deploy/helm/templates/autoupdate.yaml
@@ -53,6 +53,7 @@ rules:
       - get
       - list
       - update
+      - restart
   - apiGroups:
       - ""
       - apps

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: {{ if .Values.useStatefulSet }}StatefulSet{{- else }}Deployment{{- end }}
+metadata:
+  name: {{ include "appsmith.fullname" . }}
+  namespace: {{ include "appsmith.namespace" . }}
+  labels:
+    {{- include "appsmith.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: 3
+  {{- end }}
+  {{- if .Values.useStatefulSet }}
+  serviceName: {{ include "appsmith.fullname" . }}
+  updateStrategy:
+  {{- else }}
+  strategy:
+  {{- end }}
+    type: {{ .Values.strategyType }}
+    {{- if or (and (not .Values.useStatefulSet) (eq "Recreate" .Values.strategyType)) (and .Values.useStatefulSet (eq "OnDelete" .Values.strategyType))  }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "appsmith.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "appsmith.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
+      serviceAccountName: {{ template "appsmith.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.containerName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            - name: supervisord
+              containerPort: 9001
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: "25m"
+            limits:
+              memory: 128Mi
+              cpu: "50m"
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /appsmith-data
+          envFrom:
+            - configMapRef:
+                name: {{ include "appsmith.fullname" . }}
+      volumes:
+  {{- if not .Values.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+  {{- else if not .Values.useStatefulSet }}
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ template "appsmith.fullname" . }}
+  {{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        {{- if .Values.persistence.annotations }}
+        annotations: {{- include "tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- if .Values.persistence.volumeClaimTemplates.selector }}
+        selector: {{- include "tplvalues.render" (dict "value" .Values.persistence.volumeClaimTemplates.selector "context" $) | nindent 10 }}
+        {{- end }}
+        {{ include "storage.class" (dict "persistence" .Values.persistence "global" .Values.global) }}
+  {{- end }}

--- a/deploy/helm/templates/hpa.yml
+++ b/deploy/helm/templates/hpa.yml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "appsmith.fullname" . }}
+  labels:
+    {{- include "appsmith.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "appsmith.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -1,14 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "appsmith.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,27 +9,17 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ include "appsmith.namespace" . }}
   labels:
     {{- include "appsmith.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-    {{- if .Values.ingress.certManager }}
-    kubernetes.io/tls-acme: "true"
-    {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.secrets }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-    {{- range .Values.ingress.certManagerTls }}
+    {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -45,38 +28,15 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- if not .Values.ingress.hosts }}
-    - host:
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-    {{- end }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-              {{- end }}
+          {{- end }}
     {{- end }}
-{{- end }}
+  {{- end }}

--- a/deploy/helm/templates/persistentVolume.yaml
+++ b/deploy/helm/templates/persistentVolume.yaml
@@ -12,8 +12,11 @@ spec:
   {{- range .Values.persistence.accessModes }}
     - {{ . | quote }}
   {{- end }}
-  persistentVolumeReclaimPolicy: Delete
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-pv
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: fs-090c491a0740aa9e3
   local:
     path: {{ .Values.persistence.storagePath }} # Path to the directory this PV refers to.
   nodeAffinity: # nodeAffinity is required when using local volumes.

--- a/deploy/helm/templates/persistentVolumeClaim.yaml
+++ b/deploy/helm/templates/persistentVolumeClaim.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.persistence.enabled ( not .Values.useStatefulSet) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "appsmith.fullname" . }}
+  namespace: {{ include "appsmith.namespace" . }}
+spec:
+  accessModes:
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  storageClassName: efs-pv
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/deploy/helm/templates/storageClass.yaml
+++ b/deploy/helm/templates/storageClass.yaml
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.persistence.storageClass }}  
-provisioner: kubernetes.io/no-provisioner
+provisioner: efs.csi.aws.com
 volumeBindingMode: WaitForFirstConsumer
 ---
 {{- else if .Values.storageClass.enabled }}
@@ -26,6 +26,12 @@ allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 {{- if .Values.storageClass.parameters }}
 parameters:
+  provisioningMode: efs-ap
+  fileSystemId: "fs-090c491a0740aa9e3"
+  directoryPerms: "700"
+  basePath: "/appsmith-data"
+
+
 {{- range $key, $value := .Values.storageClass.parameters }}
   {{ $key }}: {{ $value }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,43 +1,20 @@
-## @section Global parameters
-## Global Docker image parameters
-## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
-##
 
-## @param global.storageClass Global StorageClass for Persistent Volume(s)
-## @param global.namespaceOverride Override the namespace for resource deployed by the chart, but can itself be overridden by the local namespaceOverride
-##
-global:
-  storageClass: ""
-  namespaceOverride: ""
-## @param fullnameOverride String to fully override appsmith.fullname template
-##
-fullnameOverride: ""
-## @param containerName specify running container name in a pod
-##
 containerName: "appsmith"
-## @param commonLabels Labels to add to all deployed objects
-##
-commonLabels: {}
-## @param commonAnnotations Common annotations to add to all Appsmith resources (sub-charts are not considered). Evaluated as a template
-##
-commonAnnotations: {}
-## @param schedulerName Name of the scheduler (other than default) to dispatch pods
-## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-##
-schedulerName: ""
-## @param strategyType StrategyType for Appsmith&reg; statefulset
-## It can be set to RollingUpdate or Recreate by default.
-##
+
+useStatefulSet: false
+
 strategyType: RollingUpdate
-## Image
-##
+
 image:
   registry: index.docker.io
   repository: appsmith/appsmith-ce
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "release"
+## Namespace
+##
+namespace:
+  create: true
 ## ServiceAccount
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
@@ -99,17 +76,19 @@ service:
 ingress:
   ## @param ingress.enabled Enable ingress record generation for Ghost
   ##
-  enabled: false
+  enabled: true
   ## @param ingress.annotations Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
+  ingressClassName: nginx
+  #kubernetes.io/ingress.class: "nginx"
     # cert-manager.io/cluster-issuer: "letsencrypt-prod"
     # nginx.ingress.kubernetes.io/ssl-redirect: "true"
     # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-  hosts: []
-    # - host: appsmith-domain.me
+  hosts:
+    - host: "a9175efee4fac4960bd75ea99b3d000b-08abe2a45de00e2c.elb.ap-south-1.amazonaws.com"
+      paths:
+      - path: "/"
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hosts` parameter
   ## You can:
   ##   - Use the `ingress.secrets` parameter to create this TLS secret
@@ -151,7 +130,7 @@ ingress:
   ## e.g:
   ## className: "nginx"
   ##
-  className: ""
+  className: "nginx"
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -161,11 +140,18 @@ resources:
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+
   limits: {}
-  requests: {}
+ # requests:
+  #   cpu: 100m
+   #  memory: 202Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 5
+  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 
@@ -179,7 +165,9 @@ persistence:
   enabled: true
   ## @param persistence.storageClass PVC Storage Class
   ##
-  storageClass: ""
+  storageClass: efs-pv
+
+
   ## @param persistence.annotations Additional custom annotations for the PVC
   ##
   annotations: {}
@@ -188,27 +176,41 @@ persistence:
   localStorage: false
   ## @param persistence.storagePath - local storage path
   ##
-  storagePath: /tmp/hostpath_pv
+  storagePath:
   ## @param persistence.localCluster
   ##
-  localCluster:
-    - minikube
+  localCluster: false
   ## @param persistence.accessModes PV Access Mode
   ##
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   ## @param persistence.size PVC Storage Request
   ##
   size: 10Gi
+  ## Fine tuning for volumeClaimTemplates
+  ##
+  volumeClaimTemplates:
+    ## @param persistence.volumeClaimTemplates.selector A label query over volumes to consider for binding (e.g. when using local volumes)
+    ## A label query over volumes to consider for binding (e.g. when using local volumes)
+    ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta for more details
+    ##
+    selector: {}
+    ## @param persistence.volumeClaimTemplates.requests Custom PVC requests attributes
+    ## Sometime cloud providers use additional requests attributes to provision custom storage instance
+    ## See https://cloud.ibm.com/docs/containers?topic=containers-file_storage#file_dynamic_statefulset
+    ##
+    requests: {}
+    ## @param persistence.volumeClaimTemplates.dataSource Add dataSource to the VolumeClaimTemplate
+    ##
+    dataSource: {}
 # tags:
 #   install-ingress-nginx: true
 storageClass:
   ## @param storageClass.enabled - Enable config storage class
   ##
-  enabled: false
+  enabled: true
   ## @param storageClass.bindingMode - the binding mode for PVCs using this storage class
   ##
-  bindingMode: Immediate
   ## @param storageClass.defaultClass - boolean to set annotation designating this object as the default storage class
   ##
   defaultClass: false
@@ -220,7 +222,7 @@ storageClass:
   reclaimPolicy: Delete
   ## @param storageClass.provisioner - storage class parameters used for volumes created with this storage class
   ##
-  provisioner: ""
+  provisioner: efs.csi.aws.com
   ## @param storageClass.annotations - annotations in yaml map format to be added to the object
   ##
   annotations: {}
@@ -229,17 +231,17 @@ storageClass:
   mountOptions: {}
   ## @param storageClass.parameters - storage class parameters used for volumes created with this storage class
   ##
-  parameters: {}
+  parameters: 
+    provisioningMode: efs-ap
+   
 
 autoupdate:
   ## @param autoupdate.enabled - Enable config autoupdate
   ##
-  enabled: false
+  enabled: true
   ## @param autoupdate.scheduler - Schedule cron job to check & update Helm image
   ##
   scheduler: "0 * * * *"
-
-secretName: ""
 
 applicationConfig:
   APPSMITH_OAUTH2_GOOGLE_CLIENT_ID: ""
@@ -263,8 +265,10 @@ applicationConfig:
   APPSMITH_RECAPTCHA_SITE_KEY: ""
   APPSMITH_RECAPTCHA_SECRET_KEY: ""
   APPSMITH_RECAPTCHA_ENABLED: ""
-  APPSMITH_MONGODB_URI: ""
-  APPSMITH_REDIS_URL: ""
+  APPSMITH_MONGODB_URI: "mongodb+srv://appsmith:appsmith@appsmith.yj62f.mongodb.net/newappsmith12"
+  APPSMITH_REDIS_URL: "redis://subin-test-001.ihh5sj.0001.aps1.cache.amazonaws.com:6379"
   APPSMITH_ENCRYPTION_PASSWORD: ""
   APPSMITH_ENCRYPTION_SALT: ""
   APPSMITH_CUSTOM_DOMAIN: ""
+  APPSMITH_CLOUD_SERVICES_BASE_URL: ""
+


### PR DESCRIPTION


## Description
The main changes bought here are to implement a Horizontal POD Auto Scaler and the Persistent Volume.

-  Added hpa.yaml 
-   To enable autoscaling we have changed stateful set to deployment 
-  The Persistent volume has been added in the /appsmith-data path so now will be available on every pods
- the hpa uses metrics Server which needs to be setup
-  an efs-csi driver is used to setup the persistent  volume

### Setup metrics server run below 
`kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml '

###  To setup aws-efs-csi-driver

`helm repo add aws-efs-csi-driver https://kubernetes-sigs.github.io/aws-efs-csi-driver/
`

` helm upgrade --install aws-efs-csi-driver --namespace kube-system aws-efs-csi-driver/aws-efs-csi-driver -f efs/values.yaml `

Ref: [
](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/charts/aws-efs-csi-driver/values.yaml)
 Add the IAM role under the annotations of values.yaml 

Detailed Steps for aws-efs-csi-driver can be found in the [link](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html)



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
