### PR TITLE
fix: Hover state of renaming titles

### DIFF
--- a/app/client/src/components/editorComponents/ActionNameEditor.tsx
+++ b/app/client/src/components/editorComponents/ActionNameEditor.tsx
@@ -117,6 +117,7 @@ function ActionNameEditor(props: ActionNameEditorProps) {
               onTextChanged={handleNameChange}
               placeholder={createMessage(ACTION_NAME_PLACEHOLDER, "Api")}
               type="text"
+              underline
               updating={saveStatus.isSaving}
               valueTransform={removeSpecialChars}
             />

--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -33,6 +33,7 @@ type EditableTextProps = {
   beforeUnmount?: (value?: string) => void;
   errorTooltipClass?: string;
   maxLength?: number;
+  underline?: boolean;
 };
 
 const EditableTextWrapper = styled.div<{
@@ -71,7 +72,11 @@ const EditableTextWrapper = styled.div<{
 
 // using the !important keyword here is mandatory because a style is being applied to that element using the style attribute
 // which has higher specificity than other css selectors. It seems the overriding style is being applied by the package itself.
-const TextContainer = styled.div<{ isValid: boolean; minimal: boolean }>`
+const TextContainer = styled.div<{
+  isValid: boolean;
+  minimal: boolean;
+  underline?: boolean;
+}>`
   display: flex;
   &&&& .${Classes.EDITABLE_TEXT} {
     & .${Classes.EDITABLE_TEXT_CONTENT} {
@@ -80,7 +85,16 @@ const TextContainer = styled.div<{ isValid: boolean; minimal: boolean }>`
       }
     }
   }
-
+  &&& .${Classes.EDITABLE_TEXT_CONTENT}:hover {
+    ${(props) =>
+      props.underline
+        ? `
+        border-bottom-style: solid;
+        border-bottom-width: 1px;
+        width: fit-content;
+      `
+        : null}
+  }
   & span.bp3-editable-text-content {
     height: auto !important;
   }
@@ -186,7 +200,11 @@ export function EditableText(props: EditableTextProps) {
         isOpen={!!error}
         message={errorMessage as string}
       >
-        <TextContainer isValid={!error} minimal={!!minimal}>
+        <TextContainer
+          isValid={!error}
+          minimal={!!minimal}
+          underline={props.underline}
+        >
           <BlueprintEditableText
             className={className}
             disabled={!isEditing}

--- a/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/FormTitle.tsx
@@ -109,6 +109,7 @@ function FormTitle(props: FormTitleProps) {
         onTextChanged={handleDatasourceNameChange}
         placeholder="Datasource Name"
         type="text"
+        underline
         updating={saveStatus.isSaving}
       />
       {saveStatus.isSaving && <Spinner size={16} />}


### PR DESCRIPTION
## Description

> Added underline on hover for the titles in Queries, JS and Datasources.

Fixes #13329 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: Fix/Hover-state-of-renaming-titles 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.59 **(0)** | 38.39 **(0)** | 35.83 **(-0.01)** | 56.83 **(0)**
 :red_circle: | app/client/src/components/editorComponents/EditableText.tsx | 25 **(-0.42)** | 14.63 **(-0.75)** | 6.67 **(-0.47)** | 27.27 **(-0.51)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>