### PR TITLE
fix: JSONForm - hidden field value reflects in formData

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_HiddenFields_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_HiddenFields_spec.js
@@ -1,0 +1,223 @@
+const commonlocators = require("../../../../../locators/commonlocators.json");
+const dslWithSchema = require("../../../../../fixtures/jsonFormDslWithSchema.json");
+const widgetsPage = require("../../../../../locators/Widgets.json");
+
+const fieldPrefix = ".t--jsonformfield";
+const backBtn = ".t--property-pane-back-btn";
+
+function hideAndVerifyProperties(fieldName, fieldValue, resolveFieldValue) {
+  // Check if visible
+  cy.get(`${fieldPrefix}-${fieldName}`).should("exist");
+
+  // Hide field
+  cy.togglebarDisable(".t--property-control-visible input");
+
+  cy.wait(2000);
+
+  // Check if hidden
+  cy.get(`${fieldPrefix}-${fieldName}`).should("not.exist");
+
+  // Check if key in formData is also hidden
+  cy.get(`${widgetsPage.textWidget} .bp3-ui-text`).then(($el) => {
+    const formData = JSON.parse($el.text());
+    const formDataValue = resolveFieldValue
+      ? resolveFieldValue(formData)
+      : formData[fieldName];
+
+    cy.wrap(formDataValue).should("be.undefined");
+  });
+
+  // Show field
+  cy.togglebar(".t--property-control-visible input");
+
+  // Check if visible
+  cy.get(`${fieldPrefix}-${fieldName}`).should("exist");
+
+  cy.wait(2000);
+
+  // Check if key in formData is also hidden
+  cy.get(`${widgetsPage.textWidget} .bp3-ui-text`).then(($el) => {
+    const formData = JSON.parse($el.text());
+    const formDataValue = resolveFieldValue
+      ? resolveFieldValue(formData)
+      : formData[fieldName];
+
+    cy.wrap(formDataValue).should("deep.equal", fieldValue);
+  });
+
+  cy.closePropertyPane();
+}
+
+function changeFieldType(fieldName, fieldType) {
+  cy.openFieldConfiguration(fieldName);
+  cy.selectDropdownValue(commonlocators.jsonFormFieldType, fieldType);
+}
+
+function addCustomField(fieldType) {
+  cy.openPropertyPane("jsonformwidget");
+
+  cy.get(".t--property-pane-section-general button")
+    .contains("Add a new field")
+    .click({ force: true });
+
+  changeFieldType("customField1", fieldType);
+}
+
+function removeCustomField() {
+  cy.openPropertyPane("jsonformwidget");
+  cy.deleteField("customField1");
+}
+
+describe("JSON Form Hidden fields", () => {
+  before(() => {
+    cy.addDsl(dslWithSchema);
+    cy.openPropertyPane("textwidget");
+    cy.testJsontext("text", "{{JSON.stringify(JSONForm1.formData)}}");
+  });
+
+  it("can hide Array Field", () => {
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("education");
+    hideAndVerifyProperties("education", [
+      {
+        college: "MIT",
+        year: "20/10/2014",
+      },
+    ]);
+  });
+
+  it("can hide Array Field's inner fields", () => {
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("education");
+    cy.openFieldConfiguration("__array_item__");
+    cy.openFieldConfiguration("college");
+
+    hideAndVerifyProperties("education-0--college", "MIT", (formData) => {
+      return formData.education[0].college;
+    });
+  });
+
+  it("can hide Checkbox Field", () => {
+    // Add new custom field
+    addCustomField("Checkbox");
+
+    hideAndVerifyProperties("customField1", true);
+    // Remove custom field
+    removeCustomField();
+  });
+
+  it("can hide Currency Field", () => {
+    const defaultValue = 1000;
+    // Add new custom field
+    addCustomField("Currency Input");
+    cy.testJsontext("defaultvalue", defaultValue);
+    hideAndVerifyProperties("customField1", defaultValue);
+    removeCustomField();
+  });
+
+  it("can hide Date Field", () => {
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("dob");
+
+    hideAndVerifyProperties("dob", "10/12/1992");
+  });
+
+  it("can hide Input Field", () => {
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("name");
+
+    hideAndVerifyProperties("name", "John");
+  });
+
+  it("can hide Multiselect Field", () => {
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("hobbies");
+
+    hideAndVerifyProperties("hobbies", ["travelling", "swimming"]);
+  });
+
+  it("can hide Object Field", () => {
+    cy.openPropertyPane("jsonformwidget");
+    cy.openFieldConfiguration("address");
+
+    hideAndVerifyProperties("address", {
+      street: "Koramangala",
+      city: "Bangalore",
+    });
+  });
+
+  it("can hide Phone Number Input Field", () => {
+    const defaultValue = "1000";
+    // Add new custom field
+    addCustomField("Phone Number Input");
+
+    cy.testJsontext("defaultvalue", defaultValue);
+
+    hideAndVerifyProperties("customField1", defaultValue);
+
+    removeCustomField();
+  });
+
+  it("can hide Radio Group Field", () => {
+    const defaultValue = "Y";
+    // Add new custom field
+    addCustomField("Phone Number Input");
+
+    cy.testJsontext("defaultvalue", defaultValue);
+
+    hideAndVerifyProperties("customField1", defaultValue);
+
+    removeCustomField();
+  });
+
+  it("can hide Select Field", () => {
+    const defaultValue = "BLUE";
+    // Add new custom field
+    addCustomField(/^Select/);
+
+    cy.testJsontext("defaultvalue", defaultValue);
+
+    hideAndVerifyProperties("customField1", defaultValue);
+
+    removeCustomField();
+  });
+
+  it("can hide Switch Field", () => {
+    // Add new custom field
+    addCustomField("Switch");
+
+    hideAndVerifyProperties("customField1", true);
+
+    removeCustomField();
+  });
+
+  it("hides fields on first load", () => {
+    cy.openPropertyPane("jsonformwidget");
+
+    // hide education field
+    cy.openFieldConfiguration("education");
+    cy.togglebarDisable(".t--property-control-visible input");
+    cy.get(backBtn)
+      .click({ force: true })
+      .wait(500);
+    // hide name field
+    cy.openFieldConfiguration("name");
+    cy.togglebarDisable(".t--property-control-visible input");
+
+    // publish the app
+    cy.PublishtheApp();
+
+    // Check if name is hidden
+    cy.get(`${fieldPrefix}-name`).should("not.exist");
+    // Check if education is hidden
+    cy.get(`${fieldPrefix}-education`).should("not.exist");
+
+    // check if name and education are not present in form data
+    cy.get(".t--widget-textwidget .bp3-ui-text").then(($el) => {
+      const formData = JSON.parse($el.text());
+
+      cy.wrap(formData.name).should("deep.equal", undefined);
+      cy.wrap(formData.education).should("deep.equal", undefined);
+    });
+  });
+});

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -533,6 +533,16 @@ Cypress.Commands.add("openFieldConfiguration", (fieldIdentifier) => {
   cy.wait(1000);
 });
 
+Cypress.Commands.add("deleteField", (fieldIdentifier) => {
+  cy.get(
+    "[data-rbd-draggable-id='" + fieldIdentifier + "'] .t--delete-column-btn",
+  ).click({
+    force: true,
+  });
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(1000);
+});
+
 Cypress.Commands.add("makeColumnVisible", (colId) => {
   cy.get("[data-rbd-draggable-id='" + colId + "'] .t--show-column-btn").click({
     force: true,

--- a/app/client/src/widgets/JSONFormWidget/fields/BaseInputField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/BaseInputField.tsx
@@ -9,11 +9,11 @@ import React, {
 import styled from "styled-components";
 import { Alignment, IconName } from "@blueprintjs/core";
 import { isNil } from "lodash";
-import { useController } from "react-hook-form";
 
 import Field from "../component/Field";
 import FormContext from "../FormContext";
 import useEvents from "./useBlurAndFocusEvents";
+import useController from "./useController";
 import useRegisterFieldValidity from "./useRegisterFieldValidity";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import {

--- a/app/client/src/widgets/JSONFormWidget/fields/CheckboxField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/CheckboxField.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useContext, useMemo } from "react";
 import styled from "styled-components";
-import { useController } from "react-hook-form";
 
 import CheckboxComponent from "widgets/CheckboxWidget/component";
 import FormContext from "../FormContext";
 import Field from "../component/Field";
+import useController from "./useController";
 import useEvents from "./useBlurAndFocusEvents";
 import useRegisterFieldValidity from "./useRegisterFieldValidity";
 import { AlignWidget } from "widgets/constants";

--- a/app/client/src/widgets/JSONFormWidget/fields/DateField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/DateField.tsx
@@ -1,10 +1,10 @@
 import moment from "moment";
 import React, { useCallback, useContext, useEffect, useMemo } from "react";
-import { useController } from "react-hook-form";
 
 import DateComponent from "widgets/DatePickerWidget2/component";
 import Field from "widgets/JSONFormWidget/component/Field";
 import FormContext from "../FormContext";
+import useController from "./useController";
 import useEvents from "./useBlurAndFocusEvents";
 import useRegisterFieldValidity from "./useRegisterFieldValidity";
 import {

--- a/app/client/src/widgets/JSONFormWidget/fields/MultiSelectField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/MultiSelectField.tsx
@@ -4,12 +4,12 @@ import {
   DefaultValueType,
   LabelValueType,
 } from "rc-select/lib/interface/generator";
-import { useController } from "react-hook-form";
 import { isNil } from "lodash";
 
 import Field from "../component/Field";
 import FormContext from "../FormContext";
 import MultiSelect from "widgets/MultiSelectWidgetV2/component";
+import useController from "./useController";
 import useEvents from "./useBlurAndFocusEvents";
 import useRegisterFieldValidity from "./useRegisterFieldValidity";
 import useUpdateInternalMetaState from "./useUpdateInternalMetaState";

--- a/app/client/src/widgets/JSONFormWidget/fields/RadioGroupField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/RadioGroupField.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useContext } from "react";
 import { Alignment } from "@blueprintjs/core";
 import { isNumber } from "lodash";
-import { useController } from "react-hook-form";
 
 import FormContext from "../FormContext";
 import Field from "widgets/JSONFormWidget/component/Field";
 import RadioGroupComponent from "widgets/RadioGroupWidget/component";
+import useController from "./useController";
 import useRegisterFieldValidity from "./useRegisterFieldValidity";
 import { RadioOption } from "widgets/RadioGroupWidget/constants";
 import { BaseFieldComponentProps, FieldComponentBaseProps } from "../constants";

--- a/app/client/src/widgets/JSONFormWidget/fields/SelectField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/SelectField.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useContext, useMemo, useRef } from "react";
 import styled from "styled-components";
-import { useController } from "react-hook-form";
 
 import Field from "widgets/JSONFormWidget/component/Field";
 import FormContext from "../FormContext";
 import SelectComponent from "widgets/SelectWidget/component";
+import useController from "./useController";
 import useRegisterFieldValidity from "./useRegisterFieldValidity";
 import useUpdateInternalMetaState from "./useUpdateInternalMetaState";
 import { BaseFieldComponentProps, FieldComponentBaseProps } from "../constants";

--- a/app/client/src/widgets/JSONFormWidget/fields/SwitchField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/SwitchField.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useContext, useMemo } from "react";
-import { useController } from "react-hook-form";
 
 import FormContext from "../FormContext";
 import Field from "widgets/JSONFormWidget/component/Field";
+import useController from "./useController";
 import useEvents from "./useBlurAndFocusEvents";
 import useRegisterFieldValidity from "./useRegisterFieldValidity";
 import { AlignWidget } from "widgets/constants";

--- a/app/client/src/widgets/JSONFormWidget/fields/useController.ts
+++ b/app/client/src/widgets/JSONFormWidget/fields/useController.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import {
+  FieldPath,
+  FieldValues,
+  useController as useRHFController,
+  UseControllerProps,
+  UseControllerReturn,
+} from "react-hook-form";
+
+function useController<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>(
+  props: UseControllerProps<TFieldValues, TName>,
+): UseControllerReturn<TFieldValues, TName> {
+  const controller = useRHFController(props);
+  const {
+    field: { onChange },
+  } = controller;
+
+  useEffect(() => {
+    /**
+     * When a component is hidden, the value of it is set to null so that
+     * updating for formData is triggered and we can remove the particular field
+     * from the `formData`
+     *
+     * Alternative solution: enable `shouldUnregister` in useRHFController which will
+     * de-register in the RHF's internal formData state. There's a caveat which needs to be
+     * solved before this is enabled i.e the ArrayField does not play well with this configuration.
+     * Removing of one Array field item will reset all the items below it.
+     */
+    return () => {
+      onChange(null);
+    };
+  }, []);
+
+  return controller;
+}
+
+export default useController;

--- a/app/client/src/widgets/JSONFormWidget/helper.test.ts
+++ b/app/client/src/widgets/JSONFormWidget/helper.test.ts
@@ -22,6 +22,7 @@ describe(".schemaItemDefaultValue", () => {
       originalIdentifier: "education",
       dataType: DataType.ARRAY,
       fieldType: FieldType.ARRAY,
+      isVisible: true,
       defaultValue: [
         {
           college: "String field",
@@ -35,10 +36,12 @@ describe(".schemaItemDefaultValue", () => {
           dataType: DataType.OBJECT,
           fieldType: FieldType.OBJECT,
           defaultValue: undefined,
+          isVisible: true,
           children: {
             college: {
               label: "College",
               children: {},
+              isVisible: true,
               dataType: DataType.STRING,
               defaultValue: undefined,
               fieldType: FieldType.TEXT_INPUT,
@@ -48,6 +51,7 @@ describe(".schemaItemDefaultValue", () => {
             },
             graduationDate: {
               children: {},
+              isVisible: true,
               dataType: DataType.STRING,
               defaultValue: undefined,
               fieldType: FieldType.DATEPICKER,
@@ -79,6 +83,7 @@ describe(".schemaItemDefaultValue", () => {
       originalIdentifier: "education",
       dataType: DataType.ARRAY,
       fieldType: FieldType.ARRAY,
+      isVisible: true,
       defaultValue: [
         {
           college: "String field",
@@ -92,6 +97,7 @@ describe(".schemaItemDefaultValue", () => {
           dataType: DataType.OBJECT,
           fieldType: FieldType.OBJECT,
           defaultValue: undefined,
+          isVisible: true,
           children: {
             college: {
               label: "College",
@@ -102,6 +108,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "graduating college",
               identifier: "college",
               originalIdentifier: "college",
+              isVisible: true,
             },
             graduationDate: {
               children: {},
@@ -111,6 +118,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "graduation date",
               identifier: "graduationDate",
               originalIdentifier: "graduationDate",
+              isVisible: true,
             },
           },
         },
@@ -137,6 +145,7 @@ describe(".schemaItemDefaultValue", () => {
       originalIdentifier: "education",
       dataType: DataType.ARRAY,
       fieldType: FieldType.ARRAY,
+      isVisible: true,
       defaultValue: [
         {
           college: "String field",
@@ -154,6 +163,7 @@ describe(".schemaItemDefaultValue", () => {
             college: "String field",
             graduationDate: "10/12/2021",
           },
+          isVisible: true,
           children: {
             college: {
               label: "College",
@@ -164,6 +174,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "college",
               identifier: "college",
               originalIdentifier: "college",
+              isVisible: true,
             },
             graduationDate: {
               children: {},
@@ -173,6 +184,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "graduationDate",
               identifier: "graduationDate",
               originalIdentifier: "graduationDate",
+              isVisible: true,
             },
           },
         },
@@ -216,6 +228,7 @@ describe(".schemaItemDefaultValue", () => {
           originalIdentifier: ARRAY_ITEM_KEY,
           dataType: DataType.OBJECT,
           fieldType: FieldType.OBJECT,
+          isVisible: true,
           defaultValue: {
             college: "String field",
             graduationDate: "10/12/2021",
@@ -230,6 +243,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "college",
               identifier: "college",
               originalIdentifier: "college",
+              isVisible: true,
             },
             graduationDate: {
               children: {},
@@ -239,6 +253,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "graduationDate",
               identifier: "graduationDate",
               originalIdentifier: "graduationDate",
+              isVisible: true,
             },
           },
         },
@@ -335,6 +350,7 @@ describe(".schemaItemDefaultValue", () => {
           dataType: DataType.OBJECT,
           fieldType: FieldType.OBJECT,
           defaultValue: undefined,
+          isVisible: true,
           children: {
             graduating_college: {
               label: "College",
@@ -345,6 +361,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "college",
               identifier: "graduating_college",
               originalIdentifier: "graduating college",
+              isVisible: true,
             },
             graduation_date: {
               children: {},
@@ -354,6 +371,7 @@ describe(".schemaItemDefaultValue", () => {
               accessor: "newDate",
               identifier: "graduation_date",
               originalIdentifier: "graduation date",
+              isVisible: true,
             },
           },
         },
@@ -568,6 +586,16 @@ describe(".convertSchemaItemToFormData", () => {
           accessor: "gender",
           identifier: "customField1",
           originalIdentifier: "customField1",
+          isVisible: true,
+        },
+        customField2: {
+          children: {},
+          dataType: DataType.STRING,
+          fieldType: FieldType.TEXT_INPUT,
+          accessor: "age",
+          identifier: "customField2",
+          originalIdentifier: "customField2",
+          isVisible: false,
         },
         array: {
           children: {
@@ -579,6 +607,15 @@ describe(".convertSchemaItemToFormData", () => {
                   accessor: "firstName",
                   identifier: "name",
                   originalIdentifier: "name",
+                  isVisible: true,
+                },
+                date: {
+                  dataType: DataType.STRING,
+                  fieldType: FieldType.TEXT_INPUT,
+                  accessor: "graduationDate",
+                  identifier: "date",
+                  originalIdentifier: "date",
+                  isVisible: false,
                 },
               },
               dataType: DataType.OBJECT,
@@ -586,6 +623,7 @@ describe(".convertSchemaItemToFormData", () => {
               accessor: ARRAY_ITEM_KEY,
               identifier: ARRAY_ITEM_KEY,
               originalIdentifier: ARRAY_ITEM_KEY,
+              isVisible: true,
             },
           },
           dataType: DataType.ARRAY,
@@ -593,6 +631,87 @@ describe(".convertSchemaItemToFormData", () => {
           accessor: "students",
           identifier: "array",
           originalIdentifier: "array",
+          isVisible: true,
+        },
+        hiddenArray: {
+          children: {
+            __array_item__: {
+              children: {
+                name: {
+                  dataType: DataType.STRING,
+                  fieldType: FieldType.TEXT_INPUT,
+                  accessor: "firstName",
+                  identifier: "name",
+                  originalIdentifier: "name",
+                  isVisible: true,
+                },
+              },
+              dataType: DataType.OBJECT,
+              fieldType: FieldType.OBJECT,
+              accessor: ARRAY_ITEM_KEY,
+              identifier: ARRAY_ITEM_KEY,
+              originalIdentifier: ARRAY_ITEM_KEY,
+              isVisible: true,
+            },
+          },
+          dataType: DataType.ARRAY,
+          fieldType: FieldType.ARRAY,
+          accessor: "testHiddenArray",
+          identifier: "hiddenArray",
+          originalIdentifier: "hiddenArray",
+          isVisible: false,
+        },
+        visibleObject: {
+          children: {
+            name: {
+              dataType: DataType.STRING,
+              fieldType: FieldType.TEXT_INPUT,
+              accessor: "firstName",
+              identifier: "name",
+              originalIdentifier: "name",
+              isVisible: true,
+            },
+            date: {
+              dataType: DataType.STRING,
+              fieldType: FieldType.TEXT_INPUT,
+              accessor: "graduationDate",
+              identifier: "date",
+              originalIdentifier: "date",
+              isVisible: false,
+            },
+          },
+          dataType: DataType.OBJECT,
+          fieldType: FieldType.OBJECT,
+          accessor: "testVisibleObject",
+          identifier: "visibleObject",
+          originalIdentifier: "visibleObject",
+          isVisible: true,
+        },
+        hiddenObject: {
+          children: {
+            name: {
+              dataType: DataType.STRING,
+              fieldType: FieldType.TEXT_INPUT,
+              accessor: "firstName",
+              identifier: "name",
+              originalIdentifier: "name",
+              isVisible: true,
+            },
+            date: {
+              dataType: DataType.STRING,
+              fieldType: FieldType.TEXT_INPUT,
+              accessor: "graduationDate",
+              identifier: "date",
+              originalIdentifier: "date",
+              isVisible: false,
+            },
+          },
+          dataType: DataType.OBJECT,
+          fieldType: FieldType.OBJECT,
+          accessor: "testHiddenObject",
+          identifier: "hiddenObject",
+          originalIdentifier: "hiddenObject",
+          isVisible: false,
         },
       },
       dataType: DataType.OBJECT,
@@ -600,18 +719,27 @@ describe(".convertSchemaItemToFormData", () => {
       accessor: "",
       identifier: "",
       originalIdentifier: "",
+      isVisible: true,
     },
   } as unknown) as Schema;
 
   it("replaces data with accessor keys to identifier keys", () => {
     const formData = {
       gender: "male",
-      students: [{ firstName: "test1" }, { firstName: "test2" }],
+      age: "20",
+      students: [
+        { firstName: "test1", graduationDate: "10/12/2010" },
+        { firstName: "test2", graduationDate: "14/02/2010" },
+      ],
+      testHiddenArray: [{ firstName: "test1" }, { firstName: "test2" }],
+      testVisibleObject: { firstName: "test1", graduationDate: "10/12/2010" },
+      testHiddenObject: { firstName: "test1", graduationDate: "10/12/2010" },
     };
 
     const expectedOutput = {
       customField1: "male",
       array: [{ name: "test1" }, { name: "test2" }],
+      visibleObject: { name: "test1" },
     };
 
     const result = convertSchemaItemToFormData(
@@ -628,11 +756,15 @@ describe(".convertSchemaItemToFormData", () => {
       customField1: "male",
       customField2: "demo",
       array: [{ name: "test1" }, { name: "test2" }],
+      hiddenArray: [{ name: "test1" }, { name: "test2" }],
+      visibleObject: { name: "test1", date: "10/12/2010" },
+      hiddenObject: { name: "test1", date: "10/12/2010" },
     };
 
     const expectedOutput = {
       gender: "male",
       students: [{ firstName: "test1" }, { firstName: "test2" }],
+      testVisibleObject: { firstName: "test1" },
     };
 
     const result = convertSchemaItemToFormData(
@@ -647,11 +779,16 @@ describe(".convertSchemaItemToFormData", () => {
   it("replaces data with identifier keys to accessor keys when keys are missing", () => {
     const formData = {
       customField1: "male",
-      customField2: "demo",
+      customField2: "demo1",
+      customField3: "demo2",
+      hiddenArray: [{ name: "test1" }, { name: "test2" }],
+      visibleObject: { name: "test1", date: "10/12/2010" },
+      hiddenObject: { name: "test1", date: "10/12/2010" },
     };
 
     const expectedOutput = {
       gender: "male",
+      testVisibleObject: { firstName: "test1" },
     };
 
     const result = convertSchemaItemToFormData(
@@ -668,11 +805,15 @@ describe(".convertSchemaItemToFormData", () => {
       customField1: "male",
       customField2: "demo",
       array: [{ name: "test1" }, { name: undefined }],
+      hiddenArray: [{ name: "test1" }, { name: "test2" }],
+      visibleObject: { name: "test1", date: "10/12/2010" },
+      hiddenObject: { name: "test1", date: "10/12/2010" },
     };
 
     const expectedOutput = {
       gender: "male",
       students: [{ firstName: "test1" }, { firstName: undefined }],
+      testVisibleObject: { firstName: "test1" },
     };
 
     const result = convertSchemaItemToFormData(

--- a/app/client/src/widgets/JSONFormWidget/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/helper.ts
@@ -60,13 +60,19 @@ const convertObjectTypeToFormData = (
     const formData: Record<string, unknown> = {};
 
     Object.values(schema).forEach((schemaItem) => {
-      const value = valueLookup(
-        formValue as Record<string, unknown>,
-        schemaItem,
-        options.fromId,
-      );
-      const toKey = schemaItem[options.toId];
-      formData[toKey] = convertSchemaItemToFormData(schemaItem, value, options);
+      if (schemaItem.isVisible) {
+        const value = valueLookup(
+          formValue as Record<string, unknown>,
+          schemaItem,
+          options.fromId,
+        );
+        const toKey = schemaItem[options.toId];
+        formData[toKey] = convertSchemaItemToFormData(
+          schemaItem,
+          value,
+          options,
+        );
+      }
     });
 
     return formData;


### PR DESCRIPTION
## Description

When a field is hidden then the field's key and value reflect in `formData` which it should not as the field is hidden.

Fixes #13704 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress test:
1. The following are done for all the field types present in JSONForm
  a. Field is first tested if visible and it exists in the `formData`
  b. It is hidden and tested if the field is hidden in the form and not present in the `formData`
  c. The visibility is turned back on and tested if the field is visible and the default value is present in the `formData` for that 
        field.
2. On load hidden field visiblity
  a. A normal field and an array field is hidden and published
  b. It is tested if the field is hidden in the form and not present in the `formData`

Jest test:
Extended the existing test case for the function that converts React Hook Form's internal form data to JSONForm's `formData` so that all the variations are tested when a field is set as hidden.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
