### PR TITLE
Fix log file location for MongoDB

### DIFF
--- a/deploy/docker/templates/supervisord/mongodb.conf
+++ b/deploy/docker/templates/supervisord/mongodb.conf
@@ -1,6 +1,6 @@
 [program:mongodb]
 directory=/appsmith-stacks/data/mongodb
-command=mongod --port 27017 --dbpath . --logpath log --replSet mr1 --keyFile key --bind_ip localhost
+command=mongod --port 27017 --dbpath . --logpath /appsmith-stacks/logs/%(program_name)s/db.log --replSet mr1 --keyFile key --bind_ip localhost
 priority=10
 autostart=true
 autorestart=true


### PR DESCRIPTION
MongoDB logs are currently written to `/appsmith-stacks/data/mongodb/log`, instead of using the logs folder at `/appsmeth-stacks/logs`. This PR fixes this to write these logs to the logs folder.
