### PR TITLE
fix: prioritize parse errors in debugger callout

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_MultiPart_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_MultiPart_Spec.ts
@@ -1,142 +1,174 @@
-import { ObjectsRegistry } from "../../../../support/Objects/Registry"
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
 let agHelper = ObjectsRegistry.AggregateHelper,
-    ee = ObjectsRegistry.EntityExplorer,
-    jsEditor = ObjectsRegistry.JSEditor,
-    apiPage = ObjectsRegistry.ApiPage,
-    locator = ObjectsRegistry.CommonLocators;
+  ee = ObjectsRegistry.EntityExplorer,
+  jsEditor = ObjectsRegistry.JSEditor,
+  apiPage = ObjectsRegistry.ApiPage,
+  locator = ObjectsRegistry.CommonLocators;
 
 describe("Validate API request body panel", () => {
-    it("1. Check whether input and type dropdown selector exist when multi-part is selected", () => {
-        apiPage.CreateApi("FirstAPI", 'POST');
-        apiPage.SelectPaneTab('Body')
-        apiPage.SelectSubTab('FORM_URLENCODED')
-        agHelper.AssertElementPresence(apiPage._bodyKey(0))
-        agHelper.AssertElementPresence(apiPage._bodyValue(0))
-        apiPage.SelectSubTab('MULTIPART_FORM_DATA')
-        agHelper.AssertElementPresence(apiPage._bodyKey(0))
-        agHelper.AssertElementPresence(apiPage._bodyTypeDropdown)
-        agHelper.AssertElementPresence(apiPage._bodyValue(0))
-        agHelper.ActionContextMenuWithInPane('Delete')
+  it("1. Check whether input and type dropdown selector exist when multi-part is selected", () => {
+    apiPage.CreateApi("FirstAPI", "POST");
+    apiPage.SelectPaneTab("Body");
+    apiPage.SelectSubTab("FORM_URLENCODED");
+    agHelper.AssertElementPresence(apiPage._bodyKey(0));
+    agHelper.AssertElementPresence(apiPage._bodyValue(0));
+    apiPage.SelectSubTab("MULTIPART_FORM_DATA");
+    agHelper.AssertElementPresence(apiPage._bodyKey(0));
+    agHelper.AssertElementPresence(apiPage._bodyTypeDropdown);
+    agHelper.AssertElementPresence(apiPage._bodyValue(0));
+    agHelper.ActionContextMenuWithInPane("Delete");
+  });
+
+  it("2. Checks whether No body error message is shown when None API body content type is selected", function() {
+    apiPage.CreateApi("FirstAPI", "GET");
+    apiPage.SelectPaneTab("Body");
+    apiPage.SelectSubTab("NONE");
+    cy.get(apiPage._noBodyMessageDiv).contains(apiPage._noBodyMessage);
+    agHelper.ActionContextMenuWithInPane("Delete");
+  });
+
+  it("3. Checks whether header content type is being changed when FORM_URLENCODED API body content type is selected", function() {
+    apiPage.CreateApi("FirstAPI", "POST");
+    apiPage.ValidateHeaderParams({
+      key: "content-type",
+      value: "application/json",
+    });
+    apiPage.SelectPaneTab("Body");
+    apiPage.SelectSubTab("FORM_URLENCODED");
+    apiPage.ValidateHeaderParams({
+      key: "content-type",
+      value: "application/x-www-form-urlencoded",
+    });
+    agHelper.ActionContextMenuWithInPane("Delete");
+  });
+
+  it("4. Checks whether header content type is being changed when MULTIPART_FORM_DATA API body content type is selected", function() {
+    apiPage.CreateApi("FirstAPI", "POST");
+    apiPage.ValidateHeaderParams({
+      key: "content-type",
+      value: "application/json",
+    });
+    apiPage.SelectPaneTab("Body");
+    apiPage.SelectSubTab("MULTIPART_FORM_DATA");
+    apiPage.ValidateHeaderParams({
+      key: "content-type",
+      value: "multipart/form-data",
+    });
+    agHelper.ActionContextMenuWithInPane("Delete");
+  });
+
+  it("5. Checks whether content type 'FORM_URLENCODED' is preserved when user selects None API body content type", function() {
+    apiPage.CreateApi("FirstAPI", "POST");
+    apiPage.SelectPaneTab("Body");
+    apiPage.SelectSubTab("FORM_URLENCODED");
+    apiPage.SelectSubTab("NONE");
+    apiPage.ValidateHeaderParams({
+      key: "content-type",
+      value: "application/x-www-form-urlencoded",
+    });
+    agHelper.ActionContextMenuWithInPane("Delete");
+  });
+
+  it("6. Checks whether content type 'MULTIPART_FORM_DATA' is preserved when user selects None API body content type", function() {
+    apiPage.CreateApi("FirstAPI", "POST");
+    apiPage.SelectPaneTab("Body");
+    apiPage.SelectSubTab("MULTIPART_FORM_DATA");
+    apiPage.SelectSubTab("NONE");
+    apiPage.ValidateHeaderParams({
+      key: "content-type",
+      value: "multipart/form-data",
+    });
+    agHelper.ActionContextMenuWithInPane("Delete");
+  });
+
+  it("7. Checks MultiPart form data for a File Type upload + Bug 12476", () => {
+    let imageNameToUpload = "ConcreteHouse.jpg";
+    cy.fixture("multiPartFormDataDsl").then((val: any) => {
+      agHelper.AddDsl(val);
     });
 
-    it("2. Checks whether No body error message is shown when None API body content type is selected", function () {
-        apiPage.CreateApi("FirstAPI", 'GET');
-        apiPage.SelectPaneTab('Body')
-        apiPage.SelectSubTab('NONE')
-        cy.get(apiPage._noBodyMessageDiv).contains(apiPage._noBodyMessage);
-        agHelper.ActionContextMenuWithInPane('Delete')
-    });
+    apiPage.CreateAndFillApi(
+      "https://api.cloudinary.com/v1_1/appsmithautomationcloud/image/upload?upload_preset=fbbhg4xu",
+      "CloudinaryUploadApi",
+      "POST",
+    );
+    apiPage.EnterBodyFormData(
+      "MULTIPART_FORM_DATA",
+      "file",
+      "{{FilePicker1.files[0]}}",
+      "File",
+    );
 
-    it("3. Checks whether header content type is being changed when FORM_URLENCODED API body content type is selected", function () {
-        apiPage.CreateApi("FirstAPI", 'POST');
-        apiPage.ValidateHeaderParams({
-            key: "content-type",
-            value: "application/json",
-        });
-        apiPage.SelectPaneTab('Body')
-        apiPage.SelectSubTab('FORM_URLENCODED')
-        apiPage.ValidateHeaderParams({
-            key: "content-type",
-            value: "application/x-www-form-urlencoded",
-        });
-        agHelper.ActionContextMenuWithInPane('Delete')
-    });
-
-    it("4. Checks whether header content type is being changed when MULTIPART_FORM_DATA API body content type is selected", function () {
-        apiPage.CreateApi("FirstAPI", 'POST');
-        apiPage.ValidateHeaderParams({
-            key: "content-type",
-            value: "application/json",
-        });
-        apiPage.SelectPaneTab('Body')
-        apiPage.SelectSubTab('MULTIPART_FORM_DATA')
-        apiPage.ValidateHeaderParams({
-            key: "content-type",
-            value: "multipart/form-data",
-        });
-        agHelper.ActionContextMenuWithInPane('Delete')
-    });
-
-    it("5. Checks whether content type 'FORM_URLENCODED' is preserved when user selects None API body content type", function () {
-        apiPage.CreateApi("FirstAPI", 'POST');
-        apiPage.SelectPaneTab('Body')
-        apiPage.SelectSubTab('FORM_URLENCODED')
-        apiPage.SelectSubTab('NONE')
-        apiPage.ValidateHeaderParams({
-            key: "content-type",
-            value: "application/x-www-form-urlencoded",
-        });
-        agHelper.ActionContextMenuWithInPane('Delete')
-    });
-
-    it("6. Checks whether content type 'MULTIPART_FORM_DATA' is preserved when user selects None API body content type", function () {
-        apiPage.CreateApi("FirstAPI", 'POST');
-        apiPage.SelectPaneTab('Body')
-        apiPage.SelectSubTab('MULTIPART_FORM_DATA')
-        apiPage.SelectSubTab('NONE')
-        apiPage.ValidateHeaderParams({
-            key: "content-type",
-            value: "multipart/form-data",
-        });
-        agHelper.ActionContextMenuWithInPane('Delete')
-    });
-
-    it("7. Checks MultiPart form data for a File Type upload + Bug 12476", () => {
-        let imageNameToUpload = "ConcreteHouse.jpg";
-        cy.fixture('multiPartFormDataDsl').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-
-        apiPage.CreateAndFillApi('https://api.cloudinary.com/v1_1/appsmithautomationcloud/image/upload?upload_preset=fbbhg4xu', 'CloudinaryUploadApi', 'POST')
-        apiPage.EnterBodyFormData('MULTIPART_FORM_DATA', 'file', '{{FilePicker1.files[0]}}', 'File')
-
-        jsEditor.CreateJSObject(`export default {
+    jsEditor.CreateJSObject(
+      `export default {
             myVar1: [],
             myVar2: {},
             upload: async () => {
                 await CloudinaryUploadApi.run().then(()=> showAlert('Image uploaded to Cloudinary successfully', 'success')).catch(err => showAlert(err.message, 'error'));
                 await resetWidget('FilePicker1', true);
             }
-        }`, true, true, false);
+        }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldNavigate: true,
+      },
+    );
 
-        ee.SelectEntityByName("FilePicker1", 'WIDGETS');
-        jsEditor.EnterJSContext('onFilesSelected', `{{JSObject1.upload()}}`, true, true);
+    ee.SelectEntityByName("FilePicker1", "WIDGETS");
+    jsEditor.EnterJSContext(
+      "onFilesSelected",
+      `{{JSObject1.upload()}}`,
+      true,
+      true,
+    );
 
-        ee.SelectEntityByName("Image1");
-        jsEditor.EnterJSContext('Image', '{{CloudinaryUploadApi.data.url}}')
+    ee.SelectEntityByName("Image1");
+    jsEditor.EnterJSContext("Image", "{{CloudinaryUploadApi.data.url}}");
 
-        ee.SelectEntityByName("CloudinaryUploadApi", 'QUERIES/JS');
+    ee.SelectEntityByName("CloudinaryUploadApi", "QUERIES/JS");
 
-        apiPage.OnPageLoadRun(false)//Bug 12476
-        ee.SelectEntityByName("Page1");
-        agHelper.DeployApp(locator._spanButton('Select Files'))
-        agHelper.ClickButton('Select Files');
-        agHelper.UploadFile(imageNameToUpload)
-        agHelper.ValidateToastMessage("Image uploaded to Cloudinary successfully")
-        agHelper.Sleep()
-        cy.xpath(apiPage._imageSrc).find('img')
-            .invoke('attr', 'src').then($src => {
-                expect($src).not.eq("https://assets.appsmith.com/widgets/default.png")
-            })
-        agHelper.AssertElementPresence(locator._spanButton('Select Files'))//verifying if reset!
-        agHelper.NavigateBacktoEditor()
-    });
+    apiPage.OnPageLoadRun(false); //Bug 12476
+    ee.SelectEntityByName("Page1");
+    agHelper.DeployApp(locator._spanButton("Select Files"));
+    agHelper.ClickButton("Select Files");
+    agHelper.UploadFile(imageNameToUpload);
+    agHelper.ValidateToastMessage("Image uploaded to Cloudinary successfully");
+    agHelper.Sleep();
+    cy.xpath(apiPage._imageSrc)
+      .find("img")
+      .invoke("attr", "src")
+      .then(($src) => {
+        expect($src).not.eq("https://assets.appsmith.com/widgets/default.png");
+      });
+    agHelper.AssertElementPresence(locator._spanButton("Select Files")); //verifying if reset!
+    agHelper.NavigateBacktoEditor();
+  });
 
-    it("8. Checks MultiPart form data for a Array Type upload results in API error", () => {
-        let imageNameToUpload = "AAAFlowerVase.jpeg";
-        ee.SelectEntityByName("CloudinaryUploadApi", 'QUERIES/JS');
-        apiPage.EnterBodyFormData('MULTIPART_FORM_DATA', 'file', '{{FilePicker1.files[0]}}', 'Array', true)
-        ee.SelectEntityByName("FilePicker1", 'WIDGETS');
-        agHelper.ClickButton('Select Files');
-        agHelper.UploadFile(imageNameToUpload, false)
-        agHelper.AssertDebugError("Execution failed with status 400 BAD_REQUEST", '{"error":{"message":"Unsupported source URL: {\\"type\\":\\"image/jpeg\\"')
+  it("8. Checks MultiPart form data for a Array Type upload results in API error", () => {
+    let imageNameToUpload = "AAAFlowerVase.jpeg";
+    ee.SelectEntityByName("CloudinaryUploadApi", "QUERIES/JS");
+    apiPage.EnterBodyFormData(
+      "MULTIPART_FORM_DATA",
+      "file",
+      "{{FilePicker1.files[0]}}",
+      "Array",
+      true,
+    );
+    ee.SelectEntityByName("FilePicker1", "WIDGETS");
+    agHelper.ClickButton("Select Files");
+    agHelper.UploadFile(imageNameToUpload, false);
+    agHelper.AssertDebugError(
+      "Execution failed with status 400 BAD_REQUEST",
+      '{"error":{"message":"Unsupported source URL: {\\"type\\":\\"image/jpeg\\"',
+    );
 
-        agHelper.DeployApp(locator._spanButton('Select Files'))
-        agHelper.ClickButton('Select Files');
-        agHelper.UploadFile(imageNameToUpload, false)
-        agHelper.ValidateToastMessage("CloudinaryUploadApi failed to execute")
-        agHelper.AssertElementPresence(locator._spanButton('Select Files'))//verifying if reset in case of failure!
-    });
-
+    agHelper.DeployApp(locator._spanButton("Select Files"));
+    agHelper.ClickButton("Select Files");
+    agHelper.UploadFile(imageNameToUpload, false);
+    agHelper.ValidateToastMessage("CloudinaryUploadApi failed to execute");
+    agHelper.AssertElementPresence(locator._spanButton("Select Files")); //verifying if reset in case of failure!
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/JSObjectToInput_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/JSObjectToInput_Spec.ts
@@ -1,4 +1,4 @@
-import { ObjectsRegistry } from "../../../../support/Objects/Registry"
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
 let agHelper = ObjectsRegistry.AggregateHelper,
   ee = ObjectsRegistry.EntityExplorer,
@@ -7,28 +7,43 @@ let agHelper = ObjectsRegistry.AggregateHelper,
 
 describe("Validate JSObjects binding to Input widget", () => {
   before(() => {
-    cy.fixture('formInputTableDsl').then((val: any) => {
-      agHelper.AddDsl(val)
+    cy.fixture("formInputTableDsl").then((val: any) => {
+      agHelper.AddDsl(val);
     });
   });
 
   let jsOjbNameReceived: any;
 
-  it("1. Bind Input widget with JSObject", function () {
-    jsEditor.CreateJSObject('return "Success";', false);
-    ee.expandCollapseEntity("WIDGETS")//to expand widgets
-    ee.expandCollapseEntity("Form1")
-    ee.SelectEntityByName("Input2")
-    cy.get(locator._inputWidget).last().invoke("attr", "value").should("equal", 'Hello');//Before mapping JSObject value of input
+  it("1. Bind Input widget with JSObject", function() {
+    jsEditor.CreateJSObject('return "Success";', {
+      paste: false,
+      completeReplace: false,
+      toRun: true,
+      shouldNavigate: true,
+    });
+    ee.expandCollapseEntity("WIDGETS"); //to expand widgets
+    ee.expandCollapseEntity("Form1");
+    ee.SelectEntityByName("Input2");
+    cy.get(locator._inputWidget)
+      .last()
+      .invoke("attr", "value")
+      .should("equal", "Hello"); //Before mapping JSObject value of input
     cy.get("@jsObjName").then((jsObjName) => {
       jsOjbNameReceived = jsObjName;
-      jsEditor.EnterJSContext("Default Text", "{{" + jsObjName + ".myFun1()}}")
+      jsEditor.EnterJSContext("Default Text", "{{" + jsObjName + ".myFun1()}}");
     });
-    cy.get(locator._inputWidget).last().invoke("attr", "value").should("equal", 'Success');//After mapping JSObject value of input
-    agHelper.DeployApp(locator._inputWidgetInDeployed)
-    cy.get(locator._inputWidgetInDeployed).first().should('have.value', 'Hello')
-    cy.get(locator._inputWidgetInDeployed).last().should('have.value', 'Success')
-    agHelper.NavigateBacktoEditor()
+    cy.get(locator._inputWidget)
+      .last()
+      .invoke("attr", "value")
+      .should("equal", "Success"); //After mapping JSObject value of input
+    agHelper.DeployApp(locator._inputWidgetInDeployed);
+    cy.get(locator._inputWidgetInDeployed)
+      .first()
+      .should("have.value", "Hello");
+    cy.get(locator._inputWidgetInDeployed)
+      .last()
+      .should("have.value", "Success");
+    agHelper.NavigateBacktoEditor();
 
     // cy.get(locator._inputWidget)
     //   .last()
@@ -39,9 +54,9 @@ describe("Validate JSObjects binding to Input widget", () => {
     //   });
   });
 
-  it.skip("2. Bug 10284, 11529 - Verify autosave while editing JSObj & reference changes when JSObj is mapped", function () {
-    ee.SelectEntityByName(jsOjbNameReceived as string, 'QUERIES/JS')
-    jsEditor.EditJSObj("myFun1", "newName")
+  it.skip("2. Bug 10284, 11529 - Verify autosave while editing JSObj & reference changes when JSObj is mapped", function() {
+    ee.SelectEntityByName(jsOjbNameReceived as string, "QUERIES/JS");
+    jsEditor.EditJSObj("myFun1", "newName");
 
     //jsEditor.CreateJSObject('return "Success";', true);
     // ee.expandCollapseEntity("Form1")
@@ -59,5 +74,4 @@ describe("Validate JSObjects binding to Input widget", () => {
     // cy.get(locator._inputWidgetInDeployed).first().should('have.value', 'Hello')
     // cy.get(locator._inputWidgetInDeployed).last().should('have.value', 'Success')
   });
-
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/JSObjectToListWidget_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/JSObjectToListWidget_Spec.ts
@@ -1,102 +1,110 @@
-import { ObjectsRegistry } from "../../../../support/Objects/Registry"
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
 let dataSet: any, valueToTest: any, jsName: any;
 let agHelper = ObjectsRegistry.AggregateHelper,
-    ee = ObjectsRegistry.EntityExplorer,
-    jsEditor = ObjectsRegistry.JSEditor,
-    locator = ObjectsRegistry.CommonLocators,
-    apiPage = ObjectsRegistry.ApiPage,
-    table = ObjectsRegistry.Table;
-
+  ee = ObjectsRegistry.EntityExplorer,
+  jsEditor = ObjectsRegistry.JSEditor,
+  locator = ObjectsRegistry.CommonLocators,
+  apiPage = ObjectsRegistry.ApiPage,
+  table = ObjectsRegistry.Table;
 
 describe("Validate JSObj binding to Table widget", () => {
-    before(() => {
-        cy.fixture('listwidgetdsl').then((val: any) => {
-            agHelper.AddDsl(val)
-        });
-
-        cy.fixture("example").then(function (data: any) {
-            dataSet = data;
-        });
+  before(() => {
+    cy.fixture("listwidgetdsl").then((val: any) => {
+      agHelper.AddDsl(val);
     });
 
-    it("1. Add users api and bind to JSObject", () => {
-        apiPage.CreateAndFillApi(dataSet.userApi + "/users")
-        apiPage.RunAPI()
-        apiPage.ReadApiResponsebyKey("name");
-        cy.get("@apiResp").then((value) => {
-            valueToTest = value;
-            cy.log("valueToTest to test returned is :" + valueToTest)
-            //cy.log("value to test returned is :" + value)
-        })
-        jsEditor.CreateJSObject("return Api1.data.users;", false);
-        cy.get("@jsObjName").then((jsObj) => {
-            jsName = jsObj;
-            cy.log("jsName returned is :" + jsName)
-        })
+    cy.fixture("example").then(function(data: any) {
+      dataSet = data;
     });
+  });
 
-    it("2. Validate the Api data is updated on List widget + Bug 12438", function () {
-        ee.SelectEntityByName("List1", 'WIDGETS');
-        jsEditor.EnterJSContext("Items", "{{" + jsName as string + ".myFun1()}}")
-        cy.get(locator._textWidget).should("have.length", 8);
-        agHelper.DeployApp(locator._textWidgetInDeployed);
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 8)
-        cy.get(locator._textWidgetInDeployed)
-            .first()
-            .invoke("text")
-            .then((text) => {
-                expect(text).to.equal((valueToTest as string).trimEnd());
-            });
-
-        table.AssertPageNumber_List(1)
-        table.NavigateToNextPage_List()
-        table.AssertPageNumber_List(2)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 8)
-        table.NavigateToNextPage_List()
-        table.AssertPageNumber_List(3, true)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 4)
-        table.NavigateToPreviousPage_List()
-        table.AssertPageNumber_List(2)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 8)
-        table.NavigateToPreviousPage_List()
-        table.AssertPageNumber_List(1)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 8)
-        agHelper.NavigateBacktoEditor()
+  it("1. Add users api and bind to JSObject", () => {
+    apiPage.CreateAndFillApi(dataSet.userApi + "/users");
+    apiPage.RunAPI();
+    apiPage.ReadApiResponsebyKey("name");
+    cy.get("@apiResp").then((value) => {
+      valueToTest = value;
+      cy.log("valueToTest to test returned is :" + valueToTest);
+      //cy.log("value to test returned is :" + value)
     });
-
-    it("3. Validate the List widget + Bug 12438 ", function () {
-        ee.SelectEntityByName("List1", 'WIDGETS');
-        jsEditor.EnterJSContext("Item Spacing (px)", "50")
-        cy.get(locator._textWidget).should("have.length", 6);
-        agHelper.DeployApp(locator._textWidgetInDeployed);
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 6)
-        cy.get(locator._textWidgetInDeployed).first()
-            .invoke("text")
-            .then((text) => {
-                expect(text).to.equal((valueToTest as string).trimEnd());
-            });
-
-        table.AssertPageNumber_List(1)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 6)
-        table.NavigateToNextPage_List()
-        table.AssertPageNumber_List(2)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 6)
-        table.NavigateToNextPage_List()
-        table.AssertPageNumber_List(3)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 6)
-        table.NavigateToNextPage_List()
-        table.AssertPageNumber_List(4, true)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 2)
-        table.NavigateToPreviousPage_List()
-        table.AssertPageNumber_List(3)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 6)
-        table.NavigateToPreviousPage_List()
-        table.AssertPageNumber_List(2)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 6)
-        table.NavigateToPreviousPage_List()
-        table.AssertPageNumber_List(1)
-        agHelper.AssertElementLength(locator._textWidgetInDeployed, 6)
-        //agHelper.NavigateBacktoEditor()
+    jsEditor.CreateJSObject("return Api1.data.users;", {
+      paste: false,
+      completeReplace: false,
+      toRun: true,
+      shouldNavigate: true,
     });
+    cy.get("@jsObjName").then((jsObj) => {
+      jsName = jsObj;
+      cy.log("jsName returned is :" + jsName);
+    });
+  });
+
+  it("2. Validate the Api data is updated on List widget + Bug 12438", function() {
+    ee.SelectEntityByName("List1", "WIDGETS");
+    jsEditor.EnterJSContext(
+      "Items",
+      (("{{" + jsName) as string) + ".myFun1()}}",
+    );
+    cy.get(locator._textWidget).should("have.length", 8);
+    agHelper.DeployApp(locator._textWidgetInDeployed);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 8);
+    cy.get(locator._textWidgetInDeployed)
+      .first()
+      .invoke("text")
+      .then((text) => {
+        expect(text).to.equal((valueToTest as string).trimEnd());
+      });
+
+    table.AssertPageNumber_List(1);
+    table.NavigateToNextPage_List();
+    table.AssertPageNumber_List(2);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 8);
+    table.NavigateToNextPage_List();
+    table.AssertPageNumber_List(3, true);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 4);
+    table.NavigateToPreviousPage_List();
+    table.AssertPageNumber_List(2);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 8);
+    table.NavigateToPreviousPage_List();
+    table.AssertPageNumber_List(1);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 8);
+    agHelper.NavigateBacktoEditor();
+  });
+
+  it("3. Validate the List widget + Bug 12438 ", function() {
+    ee.SelectEntityByName("List1", "WIDGETS");
+    jsEditor.EnterJSContext("Item Spacing (px)", "50");
+    cy.get(locator._textWidget).should("have.length", 6);
+    agHelper.DeployApp(locator._textWidgetInDeployed);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 6);
+    cy.get(locator._textWidgetInDeployed)
+      .first()
+      .invoke("text")
+      .then((text) => {
+        expect(text).to.equal((valueToTest as string).trimEnd());
+      });
+
+    table.AssertPageNumber_List(1);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 6);
+    table.NavigateToNextPage_List();
+    table.AssertPageNumber_List(2);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 6);
+    table.NavigateToNextPage_List();
+    table.AssertPageNumber_List(3);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 6);
+    table.NavigateToNextPage_List();
+    table.AssertPageNumber_List(4, true);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 2);
+    table.NavigateToPreviousPage_List();
+    table.AssertPageNumber_List(3);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 6);
+    table.NavigateToPreviousPage_List();
+    table.AssertPageNumber_List(2);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 6);
+    table.NavigateToPreviousPage_List();
+    table.AssertPageNumber_List(1);
+    agHelper.AssertElementLength(locator._textWidgetInDeployed, 6);
+    //agHelper.NavigateBacktoEditor()
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Promises_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Promises_Spec.ts
@@ -1,4 +1,4 @@
-import { ObjectsRegistry } from "../../../../support/Objects/Registry"
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
 let agHelper = ObjectsRegistry.AggregateHelper,
   ee = ObjectsRegistry.EntityExplorer,
@@ -7,25 +7,29 @@ let agHelper = ObjectsRegistry.AggregateHelper,
   apiPage = ObjectsRegistry.ApiPage;
 
 describe("Validate basic Promises", () => {
-
   it("1. Verify storeValue via .then via direct Promises", () => {
     let date = new Date().toDateString();
-    cy.fixture('promisesBtnDsl').then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'))
+    cy.fixture("promisesBtnDsl").then((val: any) => {
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
-    ee.SelectEntityByName("Button1", 'WIDGETS');
-    jsEditor.EnterJSContext('onClick', "{{storeValue('date', Date()).then(() => showAlert(appsmith.store.date))}}", true, true);
-    agHelper.DeployApp()
-    agHelper.ClickButton('Submit')
-    agHelper.ValidateToastMessage(date)
-    agHelper.NavigateBacktoEditor()
+    ee.SelectEntityByName("Button1", "WIDGETS");
+    jsEditor.EnterJSContext(
+      "onClick",
+      "{{storeValue('date', Date()).then(() => showAlert(appsmith.store.date))}}",
+      true,
+      true,
+    );
+    agHelper.DeployApp();
+    agHelper.ClickButton("Submit");
+    agHelper.ValidateToastMessage(date);
+    agHelper.NavigateBacktoEditor();
   });
 
   it("2. Verify resolve & chaining via direct Promises", () => {
     cy.fixture("promisesBtnDsl").then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'));
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    ee.SelectEntityByName("Button1", "WIDGETS");
     jsEditor.EnterJSContext(
       "onClick",
       `{{
@@ -36,16 +40,19 @@ describe("Validate basic Promises", () => {
           }).then((res) => {
             showAlert(res, 'success')
           }).catch(err => { showAlert(err, 'error') });
-        }}`, true, true);
-    agHelper.DeployApp()
-    agHelper.ClickButton('Submit')
-    agHelper.ValidateToastMessage('We are on planet Earth')
-    agHelper.NavigateBacktoEditor()
+        }}`,
+      true,
+      true,
+    );
+    agHelper.DeployApp();
+    agHelper.ClickButton("Submit");
+    agHelper.ValidateToastMessage("We are on planet Earth");
+    agHelper.NavigateBacktoEditor();
   });
 
   it("3. Verify Async Await in direct Promises", () => {
     cy.fixture("promisesBtnDsl").then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'));
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
     apiPage.CreateAndFillApi("https://randomuser.me/api/", "RandomUser");
     apiPage.CreateAndFillApi(
@@ -56,7 +63,7 @@ describe("Validate basic Promises", () => {
       key: "name",
       value: "{{this.params.country}}",
     }); // verifies Bug 10055
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    ee.SelectEntityByName("Button1", "WIDGETS");
     jsEditor.EnterJSContext(
       "onClick",
       `{{(async function(){
@@ -69,7 +76,7 @@ describe("Validate basic Promises", () => {
       true,
       true,
     );
-    agHelper.DeployApp()
+    agHelper.DeployApp();
     agHelper.ClickButton("Submit");
     cy.get(locator._toastMsg).should("have.length", 2);
     cy.get(locator._toastMsg)
@@ -78,18 +85,18 @@ describe("Validate basic Promises", () => {
     cy.get(locator._toastMsg)
       .last()
       .contains(/male|female|null/g);
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
   it("4. Verify .then & .catch via direct Promises", () => {
     cy.fixture("promisesBtnImgDsl").then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'));
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
     apiPage.CreateAndFillApi(
       "https://source.unsplash.com/collection/8439505",
       "Christmas",
     );
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    ee.SelectEntityByName("Button1", "WIDGETS");
     jsEditor.EnterJSContext(
       "onClick",
       `{{
@@ -104,56 +111,78 @@ describe("Validate basic Promises", () => {
     );
     ee.SelectEntityByName("Image1");
     jsEditor.EnterJSContext("Image", `{{Christmas.data}}`, true);
-    agHelper.ValidateToastMessage('will be executed automatically on page load')
-    agHelper.DeployApp()
+    agHelper.ValidateToastMessage(
+      "will be executed automatically on page load",
+    );
+    agHelper.DeployApp();
     agHelper.ClickButton("Submit");
     cy.get(locator._toastMsg)
       .should("have.length", 1)
       .contains(/You have a beautiful picture|Oops!/g);
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
   it("5. Verify .then & .catch via JS Objects in Promises", () => {
     cy.fixture("promisesBtnDsl").then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'));
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
     apiPage.CreateAndFillApi("https://favqs.com/api/qotd", "InspiringQuotes");
     jsEditor.CreateJSObject(`const user = 'You';
 return InspiringQuotes.run().then((res) => { showAlert("Today's quote for " + user + " is " + JSON.stringify(res.quote.body), 'success') }).catch(() => showAlert("Unable to fetch quote for " + user, 'warning'))`);
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    ee.SelectEntityByName("Button1", "WIDGETS");
     cy.get("@jsObjName").then((jsObjName) => {
-      jsEditor.EnterJSContext('onClick', "{{" + jsObjName + ".myFun1()}}", true, true);
-    })
-    agHelper.DeployApp()
+      jsEditor.EnterJSContext(
+        "onClick",
+        "{{" + jsObjName + ".myFun1()}}",
+        true,
+        true,
+      );
+    });
+    agHelper.DeployApp();
     agHelper.ClickButton("Submit");
     //agHelper.ValidateToastMessage("Today's quote for You")
-    cy.get(locator._toastMsg).should("have.length", 1).contains(/Today's quote for You|Unable to fetch quote for/g)
-    agHelper.NavigateBacktoEditor()
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .contains(/Today's quote for You|Unable to fetch quote for/g);
+    agHelper.NavigateBacktoEditor();
   });
 
   it("6. Verify Promise.race via direct Promises", () => {
-    cy.fixture('promisesBtnDsl').then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'))
+    cy.fixture("promisesBtnDsl").then((val: any) => {
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
-    apiPage.CreateAndFillApi("https://api.agify.io?name={{this.params.person}}", "Agify")
-    apiPage.ValidateQueryParams({ key: "name", value: "{{this.params.person}}" }); // verifies Bug 10055
-    ee.SelectEntityByName("Button1", 'WIDGETS');
-    jsEditor.EnterJSContext('onClick', `{{ Promise.race([Agify.run({ person: 'Melinda' }), Agify.run({ person: 'Trump' })]).then((res) => { showAlert('Winner is ' + JSON.stringify(res.name), 'success') }) }} `, true, true);
-    agHelper.DeployApp()
-    agHelper.ClickButton('Submit')
-    cy.get(locator._toastMsg).should("have.length", 1).contains(/Melinda|Trump/g)
-    agHelper.NavigateBacktoEditor()
-  })
+    apiPage.CreateAndFillApi(
+      "https://api.agify.io?name={{this.params.person}}",
+      "Agify",
+    );
+    apiPage.ValidateQueryParams({
+      key: "name",
+      value: "{{this.params.person}}",
+    }); // verifies Bug 10055
+    ee.SelectEntityByName("Button1", "WIDGETS");
+    jsEditor.EnterJSContext(
+      "onClick",
+      `{{ Promise.race([Agify.run({ person: 'Melinda' }), Agify.run({ person: 'Trump' })]).then((res) => { showAlert('Winner is ' + JSON.stringify(res.name), 'success') }) }} `,
+      true,
+      true,
+    );
+    agHelper.DeployApp();
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg)
+      .should("have.length", 1)
+      .contains(/Melinda|Trump/g);
+    agHelper.NavigateBacktoEditor();
+  });
 
   it("7. Verify maintaining context via direct Promises", () => {
     cy.fixture("promisesBtnListDsl").then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'));
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
     apiPage.CreateAndFillApi(
       "https://api.jikan.moe/v3/search/anime?q={{this.params.name}}",
       "GetAnime",
     );
-    ee.SelectEntityByName("List1", 'WIDGETS');
+    ee.SelectEntityByName("List1", "WIDGETS");
     jsEditor.EnterJSContext(
       "Items",
       `[{
@@ -173,7 +202,9 @@ return InspiringQuotes.run().then((res) => { showAlert("Today's quote for " + us
 }]`,
       true,
     );
-    agHelper.ValidateToastMessage('will be executed automatically on page load')//Validating 'Run API on Page Load' is set once api response is mapped
+    agHelper.ValidateToastMessage(
+      "will be executed automatically on page load",
+    ); //Validating 'Run API on Page Load' is set once api response is mapped
     ee.SelectEntityByName("Button1");
     jsEditor.EnterJSContext(
       "onClick",
@@ -187,21 +218,23 @@ return InspiringQuotes.run().then((res) => { showAlert("Today's quote for " + us
       true,
       true,
     );
-    agHelper.DeployApp()
+    agHelper.DeployApp();
     agHelper.ClickButton("Submit");
-    agHelper.WaitUntilEleAppear(locator._toastMsg)
+    agHelper.WaitUntilEleAppear(locator._toastMsg);
     cy.get(locator._toastMsg)
       //.should("have.length", 1)//covered in WaitUntilEleAppear()
       .should("have.text", "Showing results for : fruits basket : the final");
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
   it("8: Verify Promise.all via direct Promises", () => {
-    cy.fixture('promisesBtnDsl').then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'))
+    cy.fixture("promisesBtnDsl").then((val: any) => {
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
-    ee.SelectEntityByName("Button1", 'WIDGETS');
-    jsEditor.EnterJSContext('onClick', `{{
+    ee.SelectEntityByName("Button1", "WIDGETS");
+    jsEditor.EnterJSContext(
+      "onClick",
+      `{{
     (function () {
       let agifyy = [];
       let animals = ['cat', 'dog', 'camel', 'rabbit', 'rat'];
@@ -211,17 +244,20 @@ return InspiringQuotes.run().then((res) => { showAlert("Today's quote for " + us
       return Promise.all(agifyy)
         .then((responses) => showAlert(responses.map((res) => res.name).join(',')))
     })()
-  }} `, true, true);
-    agHelper.DeployApp()
-    agHelper.ClickButton('Submit')
-    agHelper.ValidateToastMessage("cat,dog,camel,rabbit,rat")
-    agHelper.NavigateBacktoEditor()
+  }} `,
+      true,
+      true,
+    );
+    agHelper.DeployApp();
+    agHelper.ClickButton("Submit");
+    agHelper.ValidateToastMessage("cat,dog,camel,rabbit,rat");
+    agHelper.NavigateBacktoEditor();
   });
 
   it("9. Bug 10150: Verify Promise.all via JSObjects", () => {
     let date = new Date().toDateString();
-    cy.fixture('promisesBtnDsl').then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'))
+    cy.fixture("promisesBtnDsl").then((val: any) => {
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
     jsEditor.CreateJSObject(`let allFuncs = [Genderize.run({ country: 'India' }),
 RandomUser.run(),
@@ -232,28 +268,42 @@ Christmas.run()
 ]
 showAlert("Running all api's", "warning");
 return Promise.all(allFuncs).then(() =>
-showAlert("Wonderful! all apis executed", "success")).catch(() => showAlert("Please check your api's again", "error")); `)
+showAlert("Wonderful! all apis executed", "success")).catch(() => showAlert("Please check your api's again", "error")); `);
 
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    ee.SelectEntityByName("Button1", "WIDGETS");
     cy.get("@jsObjName").then((jsObjName) => {
-      jsEditor.EnterJSContext('onClick', "{{storeValue('date', Date()).then(() => { showAlert(appsmith.store.date, 'success'); return " + jsObjName + ".myFun1()})}}", true, true);
+      jsEditor.EnterJSContext(
+        "onClick",
+        "{{storeValue('date', Date()).then(() => { showAlert(appsmith.store.date, 'success'); return " +
+          jsObjName +
+          ".myFun1()})}}",
+        true,
+        true,
+      );
     });
-    agHelper.DeployApp()
-    agHelper.ClickButton('Submit')
+    agHelper.DeployApp();
+    agHelper.ClickButton("Submit");
     //agHelper.WaitUntilEleAppear(locator._toastMsg)
-    cy.get(locator._toastMsg).should("have.length", 3)
-    cy.get(locator._toastMsg).eq(0).should('contain.text', date)
-    cy.get(locator._toastMsg).eq(1).contains("Running all api's")
-    agHelper.WaitUntilEleAppear(locator._toastMsg)
-    cy.get(locator._toastMsg).last().contains(/Wonderful|Please check/g)
-    agHelper.NavigateBacktoEditor()
+    cy.get(locator._toastMsg).should("have.length", 3);
+    cy.get(locator._toastMsg)
+      .eq(0)
+      .should("contain.text", date);
+    cy.get(locator._toastMsg)
+      .eq(1)
+      .contains("Running all api's");
+    agHelper.WaitUntilEleAppear(locator._toastMsg);
+    cy.get(locator._toastMsg)
+      .last()
+      .contains(/Wonderful|Please check/g);
+    agHelper.NavigateBacktoEditor();
   });
 
   it("10. Verify Promises.any via direct JSObjects", () => {
-    cy.fixture('promisesBtnDsl').then((val: any) => {
-      agHelper.AddDsl(val, locator._spanButton('Submit'))
+    cy.fixture("promisesBtnDsl").then((val: any) => {
+      agHelper.AddDsl(val, locator._spanButton("Submit"));
     });
-    jsEditor.CreateJSObject(`export default {
+    jsEditor.CreateJSObject(
+      `export default {
       func2: async () => {
      return Promise.reject(new Error('fail')).then(showAlert("Promises reject from func2"));
     },
@@ -268,25 +318,35 @@ showAlert("Wonderful! all apis executed", "success")).catch(() => showAlert("Ple
     runAny: async () => {
       return Promise.any([this.func2(), this.func3(), this.func1()]).then((value) => showAlert("Resolved promise is:" + value))
     }
-    }`, true, true)
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    }`,
+      { paste: true, completeReplace: true, toRun: true, shouldNavigate: true },
+    );
+    ee.SelectEntityByName("Button1", "WIDGETS");
     cy.get("@jsObjName").then((jsObjName) => {
-      jsEditor.EnterJSContext('onClick', "{{" + jsObjName + ".runAny()}}", true, true);
+      jsEditor.EnterJSContext(
+        "onClick",
+        "{{" + jsObjName + ".runAny()}}",
+        true,
+        true,
+      );
     });
-    agHelper.DeployApp()
-    agHelper.ClickButton('Submit')
+    agHelper.DeployApp();
+    agHelper.ClickButton("Submit");
+    cy.get(locator._toastMsg).should("have.length", 4);
     cy.get(locator._toastMsg)
-      .should("have.length", 4)
-    cy.get(locator._toastMsg).eq(0).contains('Promises reject from func2')
-    cy.get(locator._toastMsg).last().contains('Resolved promise is:func3')
-    agHelper.NavigateBacktoEditor()
+      .eq(0)
+      .contains("Promises reject from func2");
+    cy.get(locator._toastMsg)
+      .last()
+      .contains("Resolved promise is:func3");
+    agHelper.NavigateBacktoEditor();
   });
 
   it("11. Bug : 11110 - Verify resetWidget via .then direct Promises", () => {
     cy.fixture("promisesBtnDsl").then((dsl: any) => {
-      agHelper.AddDsl(dsl, locator._spanButton('Submit'));
+      agHelper.AddDsl(dsl, locator._spanButton("Submit"));
     });
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    ee.SelectEntityByName("Button1", "WIDGETS");
     jsEditor.EnterJSContext(
       "onClick",
       "{{resetWidget('Input1').then(() => showAlert(Input1.text))}}",
@@ -296,25 +356,27 @@ showAlert("Wonderful! all apis executed", "success")).catch(() => showAlert("Ple
     agHelper.DeployApp(locator._inputWidgetInDeployed);
     cy.get(locator._inputWidgetInDeployed).type("Update value");
     agHelper.ClickButton("Submit");
-    agHelper.ValidateToastMessage("Test")
-    agHelper.NavigateBacktoEditor()
-  })
+    agHelper.ValidateToastMessage("Test");
+    agHelper.NavigateBacktoEditor();
+  });
 
   //Skipping until this bug this is addressed!
   it.skip("12. Bug 9782: Verify .then & .catch (show alert should trigger) via JS Objects without return keyword", () => {
-    cy.fixture('promisesBtnDsl').then((val: any) => {
-      agHelper.AddDsl(val)
+    cy.fixture("promisesBtnDsl").then((val: any) => {
+      agHelper.AddDsl(val);
     });
     jsEditor.CreateJSObject(`const user = 'You';
 InspiringQuotes.run().then((res) => { showAlert("Today's quote for " + user + " is " + JSON.stringify(res.quote.body), 'success') }).catch(() => showAlert("Unable to fetch quote for " + user, 'warning'))`);
     ee.SelectEntityByName("Button1");
     cy.get("@jsObjName").then((jsObjName) => {
-      jsEditor.EnterJSContext('onClick', "{{" + jsObjName + ".myFun1()}}", true, true);
+      jsEditor.EnterJSContext(
+        "onClick",
+        "{{" + jsObjName + ".myFun1()}}",
+        true,
+        true,
+      );
     });
-    agHelper.ClickButton('Submit')
-    agHelper.ValidateToastMessage("Today's quote for You")
+    agHelper.ClickButton("Submit");
+    agHelper.ValidateToastMessage("Today's quote for You");
   });
-
-})
-
-
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -1,14 +1,13 @@
 import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
-const jsEditor = ObjectsRegistry.JSEditor,
-  locator = ObjectsRegistry.CommonLocators;
+const jsEditor = ObjectsRegistry.JSEditor;
 
 describe("JS Function Execution", function() {
   it("1. Allows execution of js function when lint warnings(not errors) are present in code", function() {
     jsEditor.CreateJSObject(
       `export default {
   	myFun1: ()=>{
-  		debugger;
+  		f;
   		return "yes"
   	}
   }`,
@@ -23,10 +22,9 @@ describe("JS Function Execution", function() {
   it("2. Prevents execution of js function when parse errors are present in code", function() {
     jsEditor.CreateJSObject(
       `export default {
-  	myFun1: ()=>{
+  	myFun1: ()=>>{
   		return "yes"
-  	},
-    myFun2: ()==>{}
+  	}
   }`,
       true,
       true,
@@ -36,40 +34,16 @@ describe("JS Function Execution", function() {
     jsEditor.AssertParseError(true, false);
   });
 
-  it("3. Allows execution of other JS functions when lint error is present in code one JS function", function() {
-    jsEditor.CreateJSObject(
-      `export default {
-          myFun1:  (a ,b)=>{
-          return f
-          },
-          myFun2 :()=>{
-            return "yes"
-          }
-        }`,
-      true,
-      true,
-      false,
-    );
-
-    jsEditor.AssertParseError(false, false);
-  });
-
-  it("4. Prioritizes parse errors that render JS Object invalid over function execution parse errors in debugger callouts", function() {
-    const JSObjectWithFunctionExecutionParseErrors = `export default {
-      myFun1:  (a ,b)=>{
-      return f
-      },
-      myFun2 :()=>{
-        return "yes"
+  it("3. Prioritizes parse errors that render JS Object invalid over function execution parse errors in debugger callouts", function() {
+    const JSObjectWithFunctionExecutionParseErrors = `export default {  
+      myFun1 :()=>{  
+        return f
       }
     }`;
 
     const JSObjectWithParseErrors = `export default {
       myFun1:  (a ,b)=>>{
-      return f
-      },
-      myFun2 :()=>{
-        return "yes"
+      return "yes"
       }
     }`;
 
@@ -79,28 +53,15 @@ describe("JS Function Execution", function() {
       true,
       true,
       true,
+      true,
     );
 
     // Assert presence of function execution parse error callout
     jsEditor.AssertParseError(true, true);
-    // clear code
-    cy.get(locator._codeMirrorTextArea)
-      .first()
-      .focus()
-      .type(
-        "{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}",
-      )
-      .type(
-        "{shift}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}",
-        { force: true },
-      )
-      .type("{backspace}", { force: true })
-      // Add parse error that renders JS Object invalid in code
-      .type(JSObjectWithParseErrors, {
-        parseSpecialCharSequences: false,
-        delay: 150,
-        force: true,
-      });
+
+    // Add parse error that renders JS Object invalid in code
+    jsEditor.CreateJSObject(JSObjectWithParseErrors, true, true, false, false);
+
     // Assert presence of parse error callout (entire JS Object is invalid)
     jsEditor.AssertParseError(true, false);
   });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -1,9 +1,10 @@
 import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
-const jsEditor = ObjectsRegistry.JSEditor;
+const jsEditor = ObjectsRegistry.JSEditor,
+  locator = ObjectsRegistry.CommonLocators;
 
 describe("JS Function Execution", function() {
-  it("Allows execution of js function when lint warnings(not errors) are present in code", function() {
+  it("1. Allows execution of js function when lint warnings(not errors) are present in code", function() {
     jsEditor.CreateJSObject(
       `export default {
   	myFun1: ()=>{
@@ -16,40 +17,98 @@ describe("JS Function Execution", function() {
       false,
     );
 
-    jsEditor.AssertParseError(false);
+    jsEditor.AssertParseError(false, false);
   });
 
-  it("Prevents execution of js function when parse errors are present in code", function() {
+  it("2. Prevents execution of js function when parse errors are present in code", function() {
     jsEditor.CreateJSObject(
       `export default {
-	myFun1: ()=>{
-		return "yes"
-	},
-  myFun2: ()==>{}
-}`,
+  	myFun1: ()=>{
+  		return "yes"
+  	},
+    myFun2: ()==>{}
+  }`,
       true,
       true,
       false,
     );
 
-    jsEditor.AssertParseError(true);
+    jsEditor.AssertParseError(true, false);
   });
 
-  it("Allows execution of other JS functions when lint error is present in code one JS function", function() {
+  it("3. Allows execution of other JS functions when lint error is present in code one JS function", function() {
     jsEditor.CreateJSObject(
       `export default {
-        myFun1:  (a ,b)=>{
-        return f
-        },
-        myFun2 :()=>{
-          return "yes"
-        }
-      }`,
+          myFun1:  (a ,b)=>{
+          return f
+          },
+          myFun2 :()=>{
+            return "yes"
+          }
+        }`,
       true,
       true,
       false,
     );
 
-    jsEditor.AssertParseError(false);
+    jsEditor.AssertParseError(false, false);
+  });
+
+  it("4. Prioritizes parse errors that render JS Object invalid over function execution parse errors in debugger callouts", function() {
+    const JSObjectWithFunctionExecutionParseErrors = `export default {
+      myFun1:  (a ,b)=>{
+      return f
+      },
+      myFun2 :()=>{
+        return "yes"
+      }
+    }`;
+
+    const JSObjectWithParseErrors = `export default {
+      myFun1:  (a ,b)=>>{
+      return f
+      },
+      myFun2 :()=>{
+        return "yes"
+      }
+    }`;
+
+    // create jsObject with parse error (that doesn't render JS Object invalid)
+    jsEditor.CreateJSObject(
+      JSObjectWithFunctionExecutionParseErrors,
+      true,
+      true,
+      true,
+    );
+
+    // Assert presence of function execution parse error callout
+    jsEditor.AssertParseError(true, true);
+    // clear code
+    cy.get(locator._codeMirrorTextArea)
+      .first()
+      .focus()
+      .type(
+        "{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}",
+      )
+      .type(
+        "{shift}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}",
+        { force: true },
+      )
+      .type("{backspace}", { force: true });
+
+    // Add parse error that renders JS Object invalid in code
+    cy.get(locator._codeMirrorTextArea)
+      .first()
+      .then((el: any) => {
+        const input = cy.get(el);
+        input.type(JSObjectWithParseErrors, {
+          parseSpecialCharSequences: false,
+          delay: 150,
+          force: true,
+        });
+      });
+
+    // Assert presence of parse error callout (entire JS Object is invalid)
+    jsEditor.AssertParseError(true, false);
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -11,9 +11,12 @@ describe("JS Function Execution", function() {
   		return "yes"
   	}
   }`,
-      true,
-      true,
-      false,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldNavigate: true,
+      },
     );
 
     jsEditor.AssertParseError(false, false);
@@ -26,9 +29,12 @@ describe("JS Function Execution", function() {
   		return "yes"
   	}
   }`,
-      true,
-      true,
-      false,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldNavigate: true,
+      },
     );
 
     jsEditor.AssertParseError(true, false);
@@ -48,19 +54,23 @@ describe("JS Function Execution", function() {
     }`;
 
     // create jsObject with parse error (that doesn't render JS Object invalid)
-    jsEditor.CreateJSObject(
-      JSObjectWithFunctionExecutionParseErrors,
-      true,
-      true,
-      true,
-      true,
-    );
+    jsEditor.CreateJSObject(JSObjectWithFunctionExecutionParseErrors, {
+      paste: true,
+      completeReplace: true,
+      toRun: true,
+      shouldNavigate: true,
+    });
 
     // Assert presence of function execution parse error callout
     jsEditor.AssertParseError(true, true);
 
     // Add parse error that renders JS Object invalid in code
-    jsEditor.CreateJSObject(JSObjectWithParseErrors, true, true, false, false);
+    jsEditor.CreateJSObject(JSObjectWithParseErrors, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldNavigate: false,
+    });
 
     // Assert presence of parse error callout (entire JS Object is invalid)
     jsEditor.AssertParseError(true, false);

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -94,20 +94,13 @@ describe("JS Function Execution", function() {
         "{shift}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}",
         { force: true },
       )
-      .type("{backspace}", { force: true });
-
-    // Add parse error that renders JS Object invalid in code
-    cy.get(locator._codeMirrorTextArea)
-      .first()
-      .then((el: any) => {
-        const input = cy.get(el);
-        input.type(JSObjectWithParseErrors, {
-          parseSpecialCharSequences: false,
-          delay: 150,
-          force: true,
-        });
+      .type("{backspace}", { force: true })
+      // Add parse error that renders JS Object invalid in code
+      .type(JSObjectWithParseErrors, {
+        parseSpecialCharSequences: false,
+        delay: 150,
+        force: true,
       });
-
     // Assert presence of parse error callout (entire JS Object is invalid)
     jsEditor.AssertParseError(true, false);
   });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad_Spec.ts
@@ -35,9 +35,12 @@ describe("JSObjects OnLoad Actions tests", function() {
         return 8;
       }
     }`,
-      true,
-      true,
-      false,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldNavigate: true,
+      },
     );
     jsEditor.EnableDisableAsyncFuncSettings("getId", false, true); //Only before calling confirmation is enabled by User here
     dataSources.NavigateToActiveDSQueryPane(guid);
@@ -182,9 +185,12 @@ describe("JSObjects OnLoad Actions tests", function() {
         myFun6: async () => {	},
         myFun7: () => {	},
       }`,
-      true,
-      true,
-      false,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldNavigate: true,
+      },
     );
 
     jsEditor.VerifyAsyncFuncSettings("myFun2", false, false);
@@ -241,9 +247,12 @@ describe("JSObjects OnLoad Actions tests", function() {
         callQuotes: () => {
           return Quotes.run().then(()=> Quotes.data.quoteText);}
       }`,
-      true,
-      true,
-      false,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldNavigate: true,
+      },
     );
 
     cy.get("@jsObjName").then((jsObjName) => {
@@ -320,7 +329,7 @@ describe("JSObjects OnLoad Actions tests", function() {
       agHelper.AssertElementPresence(jsEditor._dialogBody("WhatTrumpThinks")); //Since JS call is Yes, dependent confirmation should appear aswell!
       agHelper.ClickButton("Yes");
 
-      agHelper.Sleep(2000)//to let the api's call be finished & populate the text fields before validation!
+      agHelper.Sleep(2000); //to let the api's call be finished & populate the text fields before validation!
       agHelper
         .GetText(locator._textAreainputWidgetv2InDeployed, "text", 1)
         .then(($quote) => cy.wrap($quote).should("not.be.empty"));
@@ -427,9 +436,12 @@ describe("JSObjects OnLoad Actions tests", function() {
         //callCountry:() => {      //Commentning until Bug 13826 fixed
          //return getCountry.run(); }
       }`,
-      true,
-      true,
-      false,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldNavigate: true,
+      },
     );
 
     jsEditor.EnableDisableAsyncFuncSettings("getId", false, true);
@@ -532,11 +544,18 @@ describe("JSObjects OnLoad Actions tests", function() {
     agHelper.ClickButton("No");
     agHelper.ValidateToastMessage('The action "getBooks" has failed');
 
-
     ee.SelectEntityByName(jsName as string, "QUERIES/JS");
-    ee.ActionContextMenuByEntityName("getCitiesList", "Delete", "Are you sure?");
+    ee.ActionContextMenuByEntityName(
+      "getCitiesList",
+      "Delete",
+      "Are you sure?",
+    );
     ee.ActionContextMenuByEntityName("getBooks", "Delete", "Are you sure?");
-    ee.ActionContextMenuByEntityName(jsName as string, "Delete", "Are you sure?");
+    ee.ActionContextMenuByEntityName(
+      jsName as string,
+      "Delete",
+      "Are you sure?",
+    );
   });
 
   it.skip("13. Tc # 57 - Multiple functions set to true for OnPageLoad & Confirmation before running", () => {});

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Params/PassingParams_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Params/PassingParams_Spec.ts
@@ -1,4 +1,4 @@
-import { ObjectsRegistry } from "../../../../support/Objects/Registry"
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
 let guid: any, jsName: any;
 let agHelper = ObjectsRegistry.AggregateHelper,
@@ -16,7 +16,7 @@ describe("[Bug] - 10784 - Passing params from JS to SQL query should not break",
     });
   });
 
-  it("1. With Optional chaining : {{ this?.params?.condition }}", function () {
+  it("1. With Optional chaining : {{ this?.params?.condition }}", function() {
     dataSources.NavigateToDSCreateNew();
     dataSources.CreatePlugIn("PostgreSQL");
     dataSources.FillPostgresDSForm();
@@ -33,10 +33,16 @@ describe("[Bug] - 10784 - Passing params from JS to SQL query should not break",
         "SELECT * FROM public.users where id = {{this?.params?.condition || '1=1'}} order by id",
       );
       jsEditor.CreateJSObject(
-        'ParamsTest.run(() => {},() => {},{"condition": selRecordFilter.selectedOptionValue})', true, false, false
+        'ParamsTest.run(() => {},() => {},{"condition": selRecordFilter.selectedOptionValue})',
+        {
+          paste: true,
+          completeReplace: false,
+          toRun: false,
+          shouldNavigate: true,
+        },
       );
     });
-    ee.SelectEntityByName("Button1", 'WIDGETS');
+    ee.SelectEntityByName("Button1", "WIDGETS");
     cy.get("@jsObjName").then((jsObjName) => {
       jsName = jsObjName;
       jsEditor.EnterJSContext(
@@ -49,10 +55,10 @@ describe("[Bug] - 10784 - Passing params from JS to SQL query should not break",
     ee.SelectEntityByName("Table1");
     jsEditor.EnterJSContext("Table Data", "{{ParamsTest.data}}");
 
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
-    apiPage.OnPageLoadRun(false)//Bug 12476
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
+    apiPage.OnPageLoadRun(false); //Bug 12476
 
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("7");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
@@ -60,169 +66,172 @@ describe("[Bug] - 10784 - Passing params from JS to SQL query should not break",
       expect(cellData).to.be.equal("7");
     });
 
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("2. With Optional chaining : {{ (function() { return this?.params?.condition })() }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("2. With Optional chaining : {{ (function() { return this?.params?.condition })() }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(function() { return this?.params?.condition })() || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("9");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("9");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("3. With Optional chaining : {{ (() => { return this?.params?.condition })() }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("3. With Optional chaining : {{ (() => { return this?.params?.condition })() }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(() => { return this?.params?.condition })() || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("7");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("7");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("4. With Optional chaining : {{ this?.params.condition }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("4. With Optional chaining : {{ this?.params.condition }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{this?.params.condition || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("9");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("9");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("5. With Optional chaining : {{ (function() { return this?.params.condition })() }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("5. With Optional chaining : {{ (function() { return this?.params.condition })() }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(function() { return this?.params.condition })() || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("7");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("7");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("6. With Optional chaining : {{ (() => { return this?.params.condition })() }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("6. With Optional chaining : {{ (() => { return this?.params.condition })() }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(() => { return this?.params.condition })() || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("9");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("9");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("7. With No Optional chaining : {{ this.params.condition }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("7. With No Optional chaining : {{ this.params.condition }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{this.params.condition || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("7");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("7");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("8. With No Optional chaining : {{ (function() { return this.params.condition })() }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("8. With No Optional chaining : {{ (function() { return this.params.condition })() }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(function() { return this.params.condition })() || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("8");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("8");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("9. With No Optional chaining : {{ (() => { return this.params.condition })() }}", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("9. With No Optional chaining : {{ (() => { return this.params.condition })() }}", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(() => { return this.params.condition })() || '1=1'}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.SelectDropDown("9");
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("9");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("10. With Optional chaining : {{ this.params.condition }} && direct paramter passed", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("10. With Optional chaining : {{ this.params.condition }} && direct paramter passed", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(() => { return this.params.condition })() || '7'}} order by id",
     );
 
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     //Verifh when No selected option passed
-    cy.xpath(locator._selectWidgetDropdownInDeployed("selectwidget")).within(() =>
-      cy.get(locator._crossBtn).click(),
-    );
+    cy.xpath(
+      locator._selectWidgetDropdownInDeployed("selectwidget"),
+    ).within(() => cy.get(locator._crossBtn).click());
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("7");
     });
-    agHelper.NavigateBacktoEditor()
-
+    agHelper.NavigateBacktoEditor();
   });
 
-  it("11. With Optional chaining : {{ this.params.condition }} && no optional paramter passed", function () {
-    ee.SelectEntityByName("ParamsTest", 'QUERIES/JS');
+  it("11. With Optional chaining : {{ this.params.condition }} && no optional paramter passed", function() {
+    ee.SelectEntityByName("ParamsTest", "QUERIES/JS");
     agHelper.EnterValue(
       "SELECT * FROM public.users where id = {{(() => { return this.params.condition })()}} order by id",
     );
-    agHelper.DeployApp(locator._spanButton('Submit'))
+    agHelper.DeployApp(locator._spanButton("Submit"));
     agHelper.ClickButton("Submit");
     agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
       expect(cellData).to.be.equal("8");
     });
-    agHelper.NavigateBacktoEditor()
+    agHelper.NavigateBacktoEditor();
   });
 
   it("12. Delete all entities - Query, JSObjects, Datasource + Bug 12532", () => {
-    ee.expandCollapseEntity('QUERIES/JS')
-    ee.ActionContextMenuByEntityName('ParamsTest', 'Delete', 'Are you sure?')
-    agHelper.ValidateNetworkStatus("@deleteAction", 200)
-    ee.ActionContextMenuByEntityName(jsName as string, 'Delete', 'Are you sure?')
-    agHelper.ValidateNetworkStatus("@deleteJSCollection", 200)
+    ee.expandCollapseEntity("QUERIES/JS");
+    ee.ActionContextMenuByEntityName("ParamsTest", "Delete", "Are you sure?");
+    agHelper.ValidateNetworkStatus("@deleteAction", 200);
+    ee.ActionContextMenuByEntityName(
+      jsName as string,
+      "Delete",
+      "Are you sure?",
+    );
+    agHelper.ValidateNetworkStatus("@deleteJSCollection", 200);
     // //Bug 12532
     // ee.expandCollapseEntity('DATASOURCES')
     // ee.ActionContextMenuByEntityName(guid, 'Delete', 'Are you sure?')

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -25,7 +25,7 @@ export class CommonLocators {
     _imageWidget = ".t--draggable-imagewidget"
     _backToEditor = ".t--back-to-editor"
     _newPage = ".pages .t--entity-add-btn"
-    _toastMsg = ".t--toast-action"
+    _toastMsg = "div.t--toast-action"
     _empty = "span[name='no-response']"
     _contextMenuInPane = "span[name='context-menu']"
     _visibleTextDiv = (divText: string) => "//div[text()='" + divText + "']"

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -1,5 +1,18 @@
 import { ObjectsRegistry } from "../Objects/Registry";
 
+export interface ICreateJSObjectOptions {
+  paste: boolean;
+  completeReplace: boolean;
+  toRun: boolean;
+  shouldNavigate: boolean;
+}
+const DEFAULT_CREATE_JS_OBJECT_OPTIONS = {
+  paste: true,
+  completeReplace: false,
+  toRun: true,
+  shouldNavigate: true,
+};
+
 export class JSEditor {
   public agHelper = ObjectsRegistry.AggregateHelper;
   public locator = ObjectsRegistry.CommonLocators;
@@ -92,13 +105,11 @@ export class JSEditor {
 
   public CreateJSObject(
     JSCode: string,
-    paste = true,
-    completeReplace = false,
-    toRun = true,
-    shouldNavigate = true,
+    options: ICreateJSObjectOptions = DEFAULT_CREATE_JS_OBJECT_OPTIONS,
   ) {
-    shouldNavigate && this.NavigateToJSEditor();
+    const { completeReplace, paste, shouldNavigate, toRun } = options;
 
+    shouldNavigate && this.NavigateToJSEditor();
     if (!completeReplace) {
       cy.get(this.locator._codeMirrorTextArea)
         .first()

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -10,9 +10,9 @@ export class JSEditor {
   private _settingsTab = ".tab-title:contains('Settings')";
   private _codeTab = ".tab-title:contains('Code')";
   private _jsObjectParseErrorCallout =
-    "//div[contains(@class,'t--js-response-parse-error-call-out')]";
+    "div.t--js-response-parse-error-call-out";
   private _jsFunctionExecutionParseErrorCallout =
-    "//div[contains(@class,'t--function-execution-parse-error-call-out')]";
+    "div.t--function-execution-parse-error-call-out";
   private _onPageLoadRadioButton = (functionName: string, onLoad: boolean) =>
     `.${functionName}-on-page-load-setting label:contains(${
       onLoad ? "Yes" : "No"
@@ -95,8 +95,9 @@ export class JSEditor {
     paste = true,
     completeReplace = false,
     toRun = true,
+    shouldNavigate = true,
   ) {
-    this.NavigateToJSEditor();
+    shouldNavigate && this.NavigateToJSEditor();
 
     if (!completeReplace) {
       cy.get(this.locator._codeMirrorTextArea)
@@ -155,7 +156,6 @@ export class JSEditor {
           .wait(3000);
       });
       cy.get(this.locator._empty).should("not.exist");
-      cy.get(this.locator._toastMsg).should("have.length", 0);
     }
     this.GetJSObjectName();
   }
@@ -375,11 +375,15 @@ export class JSEditor {
     exists: boolean,
     isFunctionExecutionParseError: boolean,
   ) {
+    const {
+      _jsFunctionExecutionParseErrorCallout,
+      _jsObjectParseErrorCallout,
+    } = this;
     // Assert presence/absence of parse error
-    cy.xpath(
+    cy.get(
       isFunctionExecutionParseError
-        ? this._jsFunctionExecutionParseErrorCallout
-        : this._jsObjectParseErrorCallout,
+        ? _jsFunctionExecutionParseErrorCallout
+        : _jsObjectParseErrorCallout,
     ).should(exists ? "exist" : "not.exist");
   }
 

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -11,6 +11,8 @@ export class JSEditor {
   private _codeTab = ".tab-title:contains('Code')";
   private _jsObjectParseErrorCallout =
     "//div[contains(@class,'t--js-response-parse-error-call-out')]";
+  private _jsFunctionExecutionParseErrorCallout =
+    "//div[contains(@class,'t--function-execution-parse-error-call-out')]";
   private _onPageLoadRadioButton = (functionName: string, onLoad: boolean) =>
     `.${functionName}-on-page-load-setting label:contains(${
       onLoad ? "Yes" : "No"
@@ -363,12 +365,22 @@ export class JSEditor {
     // Return to code tab
     this.agHelper.GetNClick(this._codeTab);
   }
-
-  public AssertParseError(exists: boolean) {
+  /**
+ * 
+  There are two types of parse errors in the JS Editor
+  1. Parse errors that render the JS Object invalid and all functions unrunnable
+  2. Parse errors within functions that throw errors when executing those functions
+ */
+  public AssertParseError(
+    exists: boolean,
+    isFunctionExecutionParseError: boolean,
+  ) {
     // Assert presence/absence of parse error
-    cy.xpath(this._jsObjectParseErrorCallout).should(
-      exists ? "exist" : "not.exist",
-    );
+    cy.xpath(
+      isFunctionExecutionParseError
+        ? this._jsFunctionExecutionParseErrorCallout
+        : this._jsObjectParseErrorCallout,
+    ).should(exists ? "exist" : "not.exist");
   }
 
   //#endregion

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -222,7 +222,13 @@ function JSResponseView(props: Props) {
         <>
           {(errors.length > 0 ||
             responseStatus === JSResponseState.IsDirty) && (
-            <HelpSection className=".t--js-response-parse-error-call-out">
+            <HelpSection
+              className={`.${
+                errors.length > 0
+                  ? "t--js-response-parse-error-call-out"
+                  : "t--function-execution-parse-error-call-out"
+              }`}
+            >
               <StyledCallout
                 fill
                 label={

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -183,6 +183,10 @@ function JSResponseView(props: Props) {
     currentFunction && currentFunction.id && currentFunction.id in responses
       ? responses[currentFunction.id]
       : "";
+  // parse error found while trying to execute function
+  const hasExecutionParseErrors = responseStatus === JSResponseState.IsDirty;
+  // error found while trying to parse JS Object
+  const hasJSObjectParseError = errors.length > 0;
 
   const onDebugClick = useCallback(() => {
     AnalyticsUtil.logEvent("OPEN_DEBUGGER", {
@@ -220,8 +224,7 @@ function JSResponseView(props: Props) {
       title: "Response",
       panelComponent: (
         <>
-          {(errors.length > 0 ||
-            responseStatus === JSResponseState.IsDirty) && (
+          {(hasExecutionParseErrors || hasJSObjectParseError) && (
             <HelpSection
               className={`.${
                 errors.length > 0
@@ -237,7 +240,7 @@ function JSResponseView(props: Props) {
                   </FailedMessage>
                 }
                 text={
-                  errors.length > 0
+                  hasJSObjectParseError
                     ? createMessage(PARSING_ERROR)
                     : createMessage(
                         JS_ACTION_EXECUTION_ERROR,

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -226,8 +226,8 @@ function JSResponseView(props: Props) {
         <>
           {(hasExecutionParseErrors || hasJSObjectParseError) && (
             <HelpSection
-              className={`.${
-                errors.length > 0
+              className={`${
+                hasJSObjectParseError
                   ? "t--js-response-parse-error-call-out"
                   : "t--function-execution-parse-error-call-out"
               }`}

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -231,12 +231,12 @@ function JSResponseView(props: Props) {
                   </FailedMessage>
                 }
                 text={
-                  responseStatus === JSResponseState.IsDirty
-                    ? createMessage(
+                  errors.length > 0
+                    ? createMessage(PARSING_ERROR)
+                    : createMessage(
                         JS_ACTION_EXECUTION_ERROR,
                         `${jsObject.name}.${currentFunction?.name}`,
                       )
-                    : createMessage(PARSING_ERROR)
                 }
                 variant={Variant.danger}
               />


### PR DESCRIPTION
## Description 

Fixes #13764



## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Cypress

- [x] Assert presence of function 'execution parse error' callout when function with error is executed
<img width="1270" alt="Screenshot 2022-05-14 at 20 51 29" src="https://user-images.githubusercontent.com/46670083/168446403-c1854b19-2ae1-490a-8ccf-8588b7b4f99f.png">

- [x] Assert parse error callout when JS Object is invalid
<img width="1281" alt="Screenshot 2022-05-14 at 20 50 54" src="https://user-images.githubusercontent.com/46670083/168446407-09df5073-1aaa-444a-99b4-7e8d9ba086ad.png">

- [x] Assert that when JS Object becomes invalid after function with error is executed, parse error callout is shown

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes






## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: chore/prioritize-parse-errors-in-debugger-callout 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.64 **(0)** | 38.6 **(-0.01)** | 35.96 **(0)** | 56.89 **(0)**
 :red_circle: | app/client/src/components/editorComponents/JSResponseView.tsx | 50 **(-1.22)** | 25.88 **(-0.63)** | 8.33 **(0)** | 51.85 **(-1.31)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**</details>