### PR TITLE
fix: Trigger submenu instead of omnibar when Add Query/JS" button is clicked.

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Files/Submenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/Submenu.tsx
@@ -52,11 +52,19 @@ const SubMenuContainer = styled.div`
   }
 `;
 
-type SubMenuProps = { className: string };
+type SubMenuProps = {
+  className: string;
+  openMenu: boolean;
+  onMenuClose: () => void;
+};
 
-export default function ExplorerSubMenu({ className }: SubMenuProps) {
+export default function ExplorerSubMenu({
+  className,
+  onMenuClose,
+  openMenu,
+}: SubMenuProps) {
   const [query, setQuery] = useState("");
-  const [show, setShow] = useState(false);
+  const [show, setShow] = useState(openMenu);
   const fileOperations = useFilteredFileOperations(query);
   const pageId = useSelector(getCurrentPageId);
   const applicationSlug = useSelector(selectCurrentApplicationSlug);
@@ -67,6 +75,8 @@ export default function ExplorerSubMenu({ className }: SubMenuProps) {
   });
   const pluginGroups = useMemo(() => keyBy(plugins, "id"), [plugins]);
   const [activeItemIdx, setActiveItemIdx] = useState(0);
+
+  useEffect(() => setShow(openMenu), [openMenu]);
 
   useEffect(() => {
     setQuery("");
@@ -207,7 +217,10 @@ export default function ExplorerSubMenu({ className }: SubMenuProps) {
       }
       isOpen={show}
       minimal
-      onClose={() => setShow(false)}
+      onClose={() => {
+        setShow(false);
+        onMenuClose();
+      }}
       placement="right-start"
     >
       <TooltipComponent

--- a/app/client/src/pages/Editor/Explorer/Files/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useActiveAction } from "../hooks";
 import { Entity, EntityClassNames } from "../Entity/index";
 import {
@@ -14,16 +14,10 @@ import {
 } from "selectors/editorSelectors";
 import { ExplorerActionEntity } from "../Actions/ActionEntity";
 import ExplorerJSCollectionEntity from "../JSActions/JSActionEntity";
-import { setGlobalSearchCategory } from "actions/globalSearchActions";
 import { Colors } from "constants/Colors";
-import {
-  filterCategories,
-  SEARCH_CATEGORY_ID,
-} from "components/editorComponents/GlobalSearch/utils";
 import { selectFilesForExplorer } from "selectors/entitiesSelector";
 import { getExplorerStatus, saveExplorerStatus } from "../helpers";
 import Icon from "components/ads/Icon";
-import { noop } from "lodash";
 import { AddEntity, EmptyComponent } from "../common";
 import ExplorerSubMenu from "./Submenu";
 
@@ -33,14 +27,11 @@ function Files() {
   const files = useSelector(selectFilesForExplorer);
   const dispatch = useDispatch();
   const isFilesOpen = getExplorerStatus(applicationId, "queriesAndJs");
+  const [isMenuOpen, openMenu] = useState(false);
 
   const onCreate = useCallback(() => {
-    dispatch(
-      setGlobalSearchCategory(
-        filterCategories[SEARCH_CATEGORY_ID.ACTION_OPERATION],
-      ),
-    );
-  }, [dispatch]);
+    openMenu(true);
+  }, [dispatch, openMenu]);
 
   const activeActionId = useActiveAction();
 
@@ -58,6 +49,8 @@ function Files() {
     },
     [applicationId],
   );
+
+  const onMenuClose = useCallback(() => openMenu(false), [openMenu]);
 
   const fileEntities = useMemo(
     () =>
@@ -105,12 +98,14 @@ function Files() {
       customAddButton={
         <ExplorerSubMenu
           className={`${EntityClassNames.ADD_BUTTON} group files`}
+          onMenuClose={onMenuClose}
+          openMenu={isMenuOpen}
         />
       }
       disabled={false}
       entityId={pageId + "_widgets"}
       icon={null}
-      isDefaultExpanded={isFilesOpen === null ? true : isFilesOpen}
+      isDefaultExpanded={isFilesOpen ?? true}
       isSticky
       key={pageId + "_widgets"}
       name="QUERIES/JS"
@@ -124,7 +119,7 @@ function Files() {
       ) : (
         <EmptyComponent
           addBtnText={createMessage(EMPTY_QUERY_JS_BUTTON_TEXT)}
-          addFunction={onCreate || noop}
+          addFunction={onCreate}
           mainText={createMessage(EMPTY_QUERY_JS_MAIN_TEXT)}
         />
       )}


### PR DESCRIPTION
## Description
Open explorer submenu when "Add Query/JS" button is clicked.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/trigger-submenu-new-query-btn 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.61 **(0)** | 38.55 **(0.01)** | 35.89 **(0)** | 56.86 **(0.01)**
 :green_circle: | app/client/src/pages/Editor/Explorer/Files/Submenu.tsx | 69.77 **(0.63)** | 44.83 **(0)** | 42.11 **(3.22)** | 69.33 **(0.76)**
 :red_circle: | app/client/src/pages/Editor/Explorer/Files/index.tsx | 75.56 **(-1.18)** | 33.33 **(5.55)** | 42.86 **(-7.14)** | 79.49 **(-0.51)**</details>