### PR TITLE
feat: dynamic height json form widget standardisation

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/component/Form.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/Form.tsx
@@ -120,30 +120,36 @@ const RESET_OPTIONS = {
   keepErrors: true,
 };
 
-function Form<TValues = any>({
-  backgroundColor,
-  children,
-  disabledWhenInvalid,
-  fixedFooter,
-  getFormData,
-  hideFooter,
-  isSubmitting,
-  isWidgetMounting,
-  onFormValidityUpdate,
-  onSubmit,
-  registerResetObserver,
-  resetButtonLabel,
-  resetButtonStyles,
-  schema,
-  scrollContents,
-  showReset,
-  stretchBodyVertically,
-  submitButtonLabel,
-  submitButtonStyles,
-  title,
-  unregisterResetObserver,
-  updateFormData,
-}: FormProps<TValues>) {
+function Form<TValues = any>(
+  {
+    backgroundColor,
+    children,
+    disabledWhenInvalid,
+    fixedFooter,
+    getFormData,
+    hideFooter,
+    isSubmitting,
+    isWidgetMounting,
+    onFormValidityUpdate,
+    onSubmit,
+    registerResetObserver,
+    resetButtonLabel,
+    resetButtonStyles,
+    schema,
+    scrollContents,
+    showReset,
+    stretchBodyVertically,
+    submitButtonLabel,
+    submitButtonStyles,
+    title,
+    unregisterResetObserver,
+    updateFormData,
+  }: FormProps<TValues>,
+  ref:
+    | ((instance: HTMLDivElement | null) => void)
+    | React.MutableRefObject<HTMLDivElement | null>
+    | null,
+) {
   const valuesRef = useRef({});
   const methods = useForm();
   const { formState, reset, watch } = methods;
@@ -261,7 +267,7 @@ function Form<TValues = any>({
   return (
     <FormProvider {...methods}>
       <StyledForm ref={bodyRef} scrollContents={scrollContents}>
-        <StyledFormBody stretchBodyVertically={stretchBodyVertically}>
+        <StyledFormBody ref={ref} stretchBodyVertically={stretchBodyVertically}>
           <StyledTitle>{title}</StyledTitle>
           {children}
         </StyledFormBody>
@@ -296,4 +302,4 @@ function Form<TValues = any>({
   );
 }
 
-export default Form;
+export default React.forwardRef<HTMLDivElement, FormProps<any>>(Form);

--- a/app/client/src/widgets/JSONFormWidget/component/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/index.tsx
@@ -90,26 +90,32 @@ function InfoMessage({ children }: { children: React.ReactNode }) {
   );
 }
 
-function JSONFormComponent<TValues>({
-  backgroundColor,
-  executeAction,
-  fieldLimitExceeded,
-  getFormData,
-  isSubmitting,
-  isWidgetMounting,
-  onFormValidityUpdate,
-  registerResetObserver,
-  renderMode,
-  resetButtonLabel,
-  schema,
-  setMetaInternalFieldState,
-  submitButtonLabel,
-  unregisterResetObserver,
-  updateFormData,
-  updateWidgetMetaProperty,
-  updateWidgetProperty,
-  ...rest
-}: JSONFormComponentProps<TValues>) {
+function JSONFormComponent<TValues>(
+  {
+    backgroundColor,
+    executeAction,
+    fieldLimitExceeded,
+    getFormData,
+    isSubmitting,
+    isWidgetMounting,
+    onFormValidityUpdate,
+    registerResetObserver,
+    renderMode,
+    resetButtonLabel,
+    schema,
+    setMetaInternalFieldState,
+    submitButtonLabel,
+    unregisterResetObserver,
+    updateFormData,
+    updateWidgetMetaProperty,
+    updateWidgetProperty,
+    ...rest
+  }: JSONFormComponentProps<TValues>,
+  ref:
+    | ((instance: HTMLDivElement | null) => void)
+    | React.MutableRefObject<HTMLDivElement | null>
+    | null,
+) {
   const isSchemaEmpty = isEmpty(schema);
   const styleProps = pick(rest, [
     "borderColor",
@@ -180,6 +186,7 @@ function JSONFormComponent<TValues>({
           isWidgetMounting={isWidgetMounting}
           onFormValidityUpdate={onFormValidityUpdate}
           onSubmit={rest.onSubmit}
+          ref={ref}
           registerResetObserver={registerResetObserver}
           resetButtonLabel={resetButtonLabel}
           resetButtonStyles={rest.resetButtonStyles}
@@ -200,4 +207,4 @@ function JSONFormComponent<TValues>({
   );
 }
 
-export default React.memo(JSONFormComponent);
+export default React.memo(React.forwardRef(JSONFormComponent));

--- a/app/client/src/widgets/JSONFormWidget/widget/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/widget/index.tsx
@@ -365,6 +365,7 @@ class JSONFormWidget extends BaseWidget<
         isWidgetMounting={this.isWidgetMounting}
         onFormValidityUpdate={this.onFormValidityUpdate}
         onSubmit={this.onSubmit}
+        ref={this.contentRef}
         registerResetObserver={this.registerResetObserver}
         renderMode={this.props.renderMode}
         resetButtonLabel={this.props.resetButtonLabel}


### PR DESCRIPTION
## Description

**Created again because of merge conflicts.**

1. Wrapped the JSONForm default component in the React.forwardRef so that the incoming ref from the parent widget can be hooked up to the Form component underneath.
2. Wrapped the Form component in the React.forwardRef and set the `ref` to the FormBody component (div).
2. Hooked the BaseWidget `contentRef` to the JSONForm component via JSONForm Widget.

Fixes #13060 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes