### PR TITLE
feat: dynamic height datepicker widget standardisation

### DIFF
--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -165,80 +165,82 @@ class DatePickerComponent extends React.Component<
         ? new Date(this.state.selectedDate)
         : null;
     return (
-      <StyledControlGroup
-        accentColor={this.props.accentColor}
-        borderRadius={this.props.borderRadius}
-        boxShadow={this.props.boxShadow}
-        compactMode={this.props.compactMode}
-        data-testid="datepicker-container"
-        fill
-        isValid={isValid}
-        labelPosition={this.props.labelPosition}
-        onClick={(e: any) => {
-          e.stopPropagation();
-        }}
-      >
-        {labelText && (
-          <LabelWithTooltip
-            alignment={labelAlignment}
-            className={`datepicker-label`}
-            color={labelTextColor}
-            compact={compactMode}
-            disabled={isDisabled}
-            fontSize={labelTextSize}
-            fontStyle={labelStyle}
-            loading={isLoading}
-            position={labelPosition}
-            text={labelText}
-            width={labelWidth}
-          />
-        )}
-        <DateInputWrapper
-          compactMode={compactMode}
-          labelPosition={labelPosition}
-        >
-          <ErrorTooltip
-            isOpen={!isValid}
-            message={createMessage(DATE_WIDGET_DEFAULT_VALIDATION_ERROR)}
-          >
-            <DateInput
-              className={this.props.isLoading ? "bp3-skeleton" : ""}
-              closeOnSelection={this.props.closeOnSelection}
-              dayPickerProps={{
-                firstDayOfWeek: this.props.firstDayOfWeek || 0,
-              }}
-              disabled={this.props.isDisabled}
-              formatDate={this.formatDate}
-              inputProps={{
-                inputRef: this.props.inputRef,
-              }}
-              maxDate={maxDate}
-              minDate={minDate}
-              onChange={this.onDateSelected}
-              parseDate={this.parseDate}
-              placeholder={"Select Date"}
-              popoverProps={{
-                usePortal: !this.props.withoutPortal,
-                canEscapeKeyClose: true,
-                portalClassName: `${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`,
-              }}
-              shortcuts={this.props.shortcuts}
-              showActionsBar
-              timePrecision={
-                this.props.timePrecision === TimePrecision.NONE
-                  ? undefined
-                  : this.props.timePrecision
-              }
-              value={value}
-            />
-          </ErrorTooltip>
-        </DateInputWrapper>
-        <PopoverStyles
+      <div ref={this.props.innerRef}>
+        <StyledControlGroup
           accentColor={this.props.accentColor}
           borderRadius={this.props.borderRadius}
-          portalClassName={`${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`}
-        />
-      </StyledControlGroup>
+          boxShadow={this.props.boxShadow}
+          compactMode={this.props.compactMode}
+          data-testid="datepicker-container"
+          fill
+          isValid={isValid}
+          labelPosition={this.props.labelPosition}
+          onClick={(e: any) => {
+            e.stopPropagation();
+          }}
+        >
+          {labelText && (
+            <LabelWithTooltip
+              alignment={labelAlignment}
+              className={`datepicker-label`}
+              color={labelTextColor}
+              compact={compactMode}
+              disabled={isDisabled}
+              fontSize={labelTextSize}
+              fontStyle={labelStyle}
+              loading={isLoading}
+              position={labelPosition}
+              text={labelText}
+              width={labelWidth}
+            />
+          )}
+          <DateInputWrapper
+            compactMode={compactMode}
+            labelPosition={labelPosition}
+          >
+            <ErrorTooltip
+              isOpen={!isValid}
+              message={createMessage(DATE_WIDGET_DEFAULT_VALIDATION_ERROR)}
+            >
+              <DateInput
+                className={this.props.isLoading ? "bp3-skeleton" : ""}
+                closeOnSelection={this.props.closeOnSelection}
+                dayPickerProps={{
+                  firstDayOfWeek: this.props.firstDayOfWeek || 0,
+                }}
+                disabled={this.props.isDisabled}
+                formatDate={this.formatDate}
+                inputProps={{
+                  inputRef: this.props.inputRef,
+                }}
+                maxDate={maxDate}
+                minDate={minDate}
+                onChange={this.onDateSelected}
+                parseDate={this.parseDate}
+                placeholder={"Select Date"}
+                popoverProps={{
+                  usePortal: !this.props.withoutPortal,
+                  canEscapeKeyClose: true,
+                  portalClassName: `${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`,
+                }}
+                shortcuts={this.props.shortcuts}
+                showActionsBar
+                timePrecision={
+                  this.props.timePrecision === TimePrecision.NONE
+                    ? undefined
+                    : this.props.timePrecision
+                }
+                value={value}
+              />
+            </ErrorTooltip>
+          </DateInputWrapper>
+          <PopoverStyles
+            accentColor={this.props.accentColor}
+            borderRadius={this.props.borderRadius}
+            portalClassName={`${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`}
+          />
+        </StyledControlGroup>
+      </div>
     );
   }
 
@@ -330,6 +332,7 @@ interface DatePickerComponentProps extends ComponentProps {
   shortcuts: boolean;
   firstDayOfWeek?: number;
   timePrecision: TimePrecision;
+  innerRef?: React.RefObject<HTMLDivElement>;
   inputRef?: IRef<HTMLInputElement>;
   borderRadius: string;
   boxShadow?: string;
@@ -340,4 +343,11 @@ interface DatePickerComponentState {
   selectedDate?: string;
 }
 
-export default DatePickerComponent;
+export default React.forwardRef<HTMLDivElement, DatePickerComponentProps>(
+  (props, ref) => (
+    <DatePickerComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  ),
+);

--- a/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
@@ -460,6 +460,7 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
         maxDate={this.props.maxDate}
         minDate={this.props.minDate}
         onDateSelected={this.onDateSelected}
+        ref={this.contentRef}
         selectedDate={this.props.value}
         shortcuts={this.props.shortcuts}
         timePrecision={this.props.timePrecision}


### PR DESCRIPTION
## Description

**Created again because of merge conflicts.**

1. Passed the `contentRef` to `DatePickerComponent` from `DatePickerWidgetV2`.
2. Wrapped the `DatePickerComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to pass it to its child `StyledControlGroup`.
4. `StyledControlGroup` is a styled component on top of `ControlGroup` and there is no way to hook it up the ref dom element, so wrapped `StyledControlGroup` in a `div`.

Fixes #13059

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes