### PR TITLE
fix: added empty stack in sppThemingReducer

### DIFF
--- a/app/client/src/reducers/uiReducers/appThemingReducer.ts
+++ b/app/client/src/reducers/uiReducers/appThemingReducer.ts
@@ -71,6 +71,7 @@ const themeReducer = createImmerReducer(initialState, {
   ) => {
     state.themesLoading = false;
     state.themes = action.payload;
+    state.stack = [];
   },
   [ReduxActionTypes.FETCH_SELECTED_APP_THEME_SUCCESS]: (
     state: AppThemingState,


### PR DESCRIPTION
## Description

**Summary of Changes**

Emptied the theming stack when REDUX Action FETCH_APP_THEMES_SUCCESS is executed.

Fixes #13836 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-reset-theme-stack 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.62 **(0.01)** | 38.56 **(0.01)** | 35.9 **(0)** | 56.86 **(0)**
 :red_circle: | app/client/src/reducers/uiReducers/appThemingReducer.ts | 28 **(-1.17)** | 100 **(0)** | 13.33 **(0)** | 28 **(-1.17)**
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>