### PR TITLE
fix: Text overlap in slash commands

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/generateQuickCommands.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/generateQuickCommands.tsx
@@ -107,7 +107,9 @@ function Command(props: { icon: any; name: string }) {
     <div className="command-container">
       <div className="command">
         {props.icon}
-        <span className="ml-1">{props.name}</span>
+        <span className="ml-1 overflow-hidden overflow-ellipsis whitespace-nowrap">
+          {props.name}
+        </span>
       </div>
     </div>
   );

--- a/app/client/src/sagas/SnipingModeSagas.ts
+++ b/app/client/src/sagas/SnipingModeSagas.ts
@@ -87,7 +87,7 @@ export function* bindDataToWidgetSaga(
       propertyValue = `{{${currentAction.config.name}.data}}`;
       break;
     case WidgetTypes.LIST_WIDGET:
-      propertyPath = "listData";
+      propertyPath = "items";
       propertyValue = `{{${currentAction.config.name}.data}}`;
       break;
     case WidgetTypes.MAP_WIDGET:

--- a/app/client/src/sagas/SnipingModeSagas.ts
+++ b/app/client/src/sagas/SnipingModeSagas.ts
@@ -87,7 +87,7 @@ export function* bindDataToWidgetSaga(
       propertyValue = `{{${currentAction.config.name}.data}}`;
       break;
     case WidgetTypes.LIST_WIDGET:
-      propertyPath = "items";
+      propertyPath = "listData";
       propertyValue = `{{${currentAction.config.name}.data}}`;
       break;
     case WidgetTypes.MAP_WIDGET:


### PR DESCRIPTION
## Description
Fixes text overlap for datasources with longer names in slash commands.

Fixes #13868 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/13868-text-overlap-slash-commands 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 70.59 **(-1.96)** | 100 **(0)** | 93.33 **(0)**</details>