### PR TITLE
fix: Property pane - Hidden sections icon select popover not opening properly

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_FormProperties_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_FormProperties_spec.js
@@ -7,6 +7,8 @@ const publishPage = require("../../../../../locators/publishWidgetspage.json");
 const backBtn = ".t--property-pane-back-btn";
 const fieldPrefix = ".t--jsonformfield";
 const propertyControlPrefix = ".t--property-control";
+const submitButtonStylesSection =
+  ".t--property-pane-section-submitbuttonstyles";
 
 describe("JSON Form Widget Form Bindings", () => {
   before(() => {
@@ -88,6 +90,31 @@ describe("JSON Form Widget Form Bindings", () => {
       .wait(300);
 
     cy.get(`${widgetsPage.textWidget} .bp3-ui-text`).contains("true");
+  });
+
+  it("show show icon select when a collapsed section is opened", () => {
+    cy.openPropertyPane("jsonformwidget");
+
+    // Check Submit Button Styles hidden
+    cy.get(submitButtonStylesSection).should("not.be.visible");
+    // .parent()
+    // .should("have.attr", "aria-hidden", "true");
+
+    // Open Submit Button Section
+    cy.get(".t--property-pane-section-collapse-submitbuttonstyles").click({
+      force: true,
+    });
+
+    // Click Icon property
+    cy.get(submitButtonStylesSection)
+      .contains("(none)")
+      .parent()
+      .click({
+        force: true,
+      });
+
+    // Check if icon selector opened
+    cy.get(".bp3-select-popover .virtuoso-grid-item").should("be.visible");
   });
 
   it("Should set isValid to false on first load when form is invalid", () => {

--- a/app/client/src/components/propertyControls/IconSelectControl.tsx
+++ b/app/client/src/components/propertyControls/IconSelectControl.tsx
@@ -14,18 +14,22 @@ import TooltipComponent from "components/ads/Tooltip";
 import { Colors } from "constants/Colors";
 import { replayHighlightClass } from "globalStyles/portals";
 import _ from "lodash";
+import { generateReactKey } from "utils/generators";
 
 const IconSelectContainerStyles = createGlobalStyle<{
   targetWidth: number | undefined;
+  id: string;
 }>`
-  .bp3-select-popover {
-    width: ${({ targetWidth }) => targetWidth}px;
-    background: white;
+  ${({ id, targetWidth }) => `
+    .icon-select-popover-${id} {
+      width: ${targetWidth}px;
+      background: white;
 
-    .bp3-input-group {
-      margin: 5px !important;
+      .bp3-input-group {
+        margin: 5px !important;
+      }
     }
-  }
+  `}
 `;
 
 const StyledButton = styled(Button)`
@@ -114,6 +118,7 @@ class IconSelectControl extends BaseControl<
   private initialItemIndex: number;
   private filteredItems: Array<IconType>;
   private searchInput: React.RefObject<HTMLInputElement>;
+  id: string = generateReactKey();
 
   constructor(props: IconSelectControlProps) {
     super(props);
@@ -168,7 +173,7 @@ class IconSelectControl extends BaseControl<
 
     return (
       <>
-        <IconSelectContainerStyles targetWidth={containerWidth} />
+        <IconSelectContainerStyles id={this.id} targetWidth={containerWidth} />
         <TypedSelect
           activeItem={activeIcon || defaultIconName || NONE}
           className="icon-select-container"
@@ -185,6 +190,7 @@ class IconSelectControl extends BaseControl<
             enforceFocus: false,
             minimal: true,
             isOpen: this.state.isOpen,
+            popoverClassName: `icon-select-popover-${this.id}`,
             onInteraction: (state) => {
               if (this.state.isOpen !== state)
                 this.debouncedSetState({ isOpen: state });


### PR DESCRIPTION
## Description

In the property pane of the JSON Form widget; were 2 icon selectors both of them in a different collapsed section. As the popover width was being set by targeting the class .bp3-select-popover, the first was getting overridden by the second instance of the popover and thus getting the width of 0 (because of the hidden state of 2nd icon selector).

They now have separate class names based on id.

Fixes #13879 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/13879-collapsed-section-icon 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.56 **(0)** | 38.54 **(-0.01)** | 35.87 **(0)** | 56.8 **(0)**
 :green_circle: | app/client/src/components/propertyControls/IconSelectControl.tsx | 91.49 **(0.19)** | 76.11 **(0)** | 95.83 **(0)** | 91.47 **(0.13)**
 :red_circle: | app/client/src/utils/WorkerUtil.ts | 88.98 **(-0.78)** | 70.59 **(-1.96)** | 100 **(0)** | 92.38 **(-0.95)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>