### PR TITLE
chore: Added selected state for query/js add button in the explorer

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Entity/AddButton.tsx
+++ b/app/client/src/pages/Editor/Explorer/Entity/AddButton.tsx
@@ -15,6 +15,14 @@ const Wrapper = styled(EntityTogglesWrapper)`
       }
     }
   }
+  &.selected {
+    background: ${Colors.SHARK2} !important;
+    svg {
+      path {
+        fill: ${Colors.WHITE} !important;
+      }
+    }
+  }
 `;
 
 const PlusIcon = ControlIcons.INCREASE_CONTROL_V2;

--- a/app/client/src/pages/Editor/Explorer/Files/Submenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/Submenu.tsx
@@ -236,7 +236,10 @@ export default function ExplorerSubMenu({
         hoverOpenDelay={TOOLTIP_HOVER_ON_DELAY}
         position={Position.RIGHT}
       >
-        <EntityAddButton className={className} onClick={() => setShow(true)} />
+        <EntityAddButton
+          className={`${className} ${show ? "selected" : ""}`}
+          onClick={() => setShow(true)}
+        />
       </TooltipComponent>
     </Popover2>
   );


### PR DESCRIPTION
## Description
Adds selected state to Query/JS add button in explorer when submenu is open.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: chore/highlight-plus-icon-query-js 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/pages/Editor/Explorer/Files/Submenu.tsx | 69.77 **(0)** | 45.16 **(0.33)** | 42.11 **(0)** | 69.33 **(0)**</details>