### PR TITLE
task: JSONForm footer should always stick to bottom when fixed footer enabled

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_Footer_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/FormWidgets/JSONFormWidget/JSONForm_Footer_spec.js
@@ -1,0 +1,86 @@
+const dslWithoutSchema = require("../../../../../fixtures/jsonFormDslWithoutSchema.json");
+const dslWithSchema = require("../../../../../fixtures/jsonFormDslWithSchema.json");
+
+describe("JSONForm Footer spec", () => {
+  it("sticks to the bottom when fixed footer is true and content is less", () => {
+    cy.addDsl(dslWithoutSchema);
+    // add small source data
+    const sourceData = {
+      name: "John",
+    };
+    cy.openPropertyPane("jsonformwidget");
+    cy.testJsontext("sourcedata", JSON.stringify(sourceData));
+
+    // check if fixed footer enabled
+    cy.get(".t--property-control-fixedfooter")
+      .find("label.bp3-control")
+      .should("have.class", "checked");
+
+    // Check if there is a gap between body and footer
+    cy.get(".t--jsonform-body").then(($body) => {
+      cy.get(".t--jsonform-footer").then(($footer) => {
+        const gap = $footer.prop("offsetTop") - $body.prop("scrollHeight");
+
+        expect(gap).greaterThan(0);
+      });
+    });
+  });
+
+  it("sticks to the content when fixed footer is off", () => {
+    // Disable fixed footer
+    cy.togglebarDisable(".t--property-control-fixedfooter input");
+
+    // Check if there is a gap between body and footer
+    cy.get(".t--jsonform-body").then(($body) => {
+      cy.get(".t--jsonform-footer").then(($footer) => {
+        const gap = $footer.prop("offsetTop") - $body.prop("scrollHeight");
+
+        expect(gap).equals(0);
+      });
+    });
+  });
+
+  it("floats to the bottom when fixed footer is true and content overflows", () => {
+    cy.addDsl(dslWithSchema);
+
+    cy.openPropertyPane("jsonformwidget");
+
+    // check if fixed footer enabled
+    cy.get(".t--property-control-fixedfooter")
+      .find("label.bp3-control")
+      .should("have.class", "checked");
+
+    // Check if footer is floating
+    cy.get(".t--draggable-jsonformwidget")
+      .find("form")
+      .then(($form) => {
+        cy.get(".t--jsonform-footer").then(($footer) => {
+          const gap =
+            $footer.prop("offsetTop") +
+            $footer.prop("offsetHeight") -
+            $form.prop("offsetHeight");
+
+          expect(gap).equals(0);
+        });
+      });
+  });
+
+  it("floats to the bottom when fixed footer is false and content overflows", () => {
+    // Disable fixed footer
+    cy.togglebarDisable(".t--property-control-fixedfooter input");
+
+    // Check if footer is floating
+    cy.get(".t--draggable-jsonformwidget")
+      .find("form")
+      .then(($form) => {
+        cy.get(".t--jsonform-footer").then(($footer) => {
+          const gap =
+            $footer.prop("offsetTop") +
+            $footer.prop("offsetHeight") -
+            $form.prop("scrollHeight");
+
+          expect(gap).equals(0);
+        });
+      });
+  });
+});

--- a/app/client/src/widgets/JSONFormWidget/component/Form.tsx
+++ b/app/client/src/widgets/JSONFormWidget/component/Form.tsx
@@ -42,6 +42,7 @@ export type FormProps<TValues = any> = PropsWithChildren<{
 }>;
 
 type StyledFormProps = {
+  fixedFooter: boolean;
   scrollContents: boolean;
 };
 
@@ -96,6 +97,7 @@ const StyledForm = styled.form<StyledFormProps>`
   display: flex;
   flex-direction: column;
   height: 100%;
+  justify-content: ${({ fixedFooter }) => fixedFooter && "space-between"};
   overflow-y: ${({ scrollContents }) => (scrollContents ? "auto" : "hidden")};
 `;
 
@@ -260,14 +262,22 @@ function Form<TValues = any>({
 
   return (
     <FormProvider {...methods}>
-      <StyledForm ref={bodyRef} scrollContents={scrollContents}>
-        <StyledFormBody stretchBodyVertically={stretchBodyVertically}>
+      <StyledForm
+        fixedFooter={fixedFooter}
+        ref={bodyRef}
+        scrollContents={scrollContents}
+      >
+        <StyledFormBody
+          className="t--jsonform-body"
+          stretchBodyVertically={stretchBodyVertically}
+        >
           <StyledTitle>{title}</StyledTitle>
           {children}
         </StyledFormBody>
         {!hideFooter && (
           <StyledFormFooter
             backgroundColor={backgroundColor}
+            className="t--jsonform-footer"
             fixedFooter={fixedFooter}
             ref={footerRef}
           >


### PR DESCRIPTION
## Description

SONForm submit/reset button should always be at the bottom of the form

Fixes #12599

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: task/12599-jf-sticky-button-footer 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :red_circle: | app/client/src/widgets/JSONFormWidget/component/Form.tsx | 28.28 **(-0.59)** | 18.52 **(-0.71)** | 0 **(0)** | 29.79 **(-0.32)**</details>