### PR TITLE
fix: react warning about trimValue in console

### DIFF
--- a/app/client/src/components/ads/TextInput.tsx
+++ b/app/client/src/components/ads/TextInput.tsx
@@ -155,6 +155,7 @@ const StyledInput = styled((props) => {
     "border",
     "asyncControl",
     "handleCopy",
+    "trimValue",
   ];
 
   const HtmlTag = props.useTextArea ? "textarea" : "input";


### PR DESCRIPTION
## Description

There was a warning about `trimValue` being present on DOM element. No such attribute exists, and thus needed change in code to remove it from the `input` element.

Fixes #10961 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

After the fix, open console to see the change. No more error.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix-trimValue-error 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.56 **(0)** | 38.55 **(0.01)** | 35.87 **(0)** | 56.8 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>