### PR TITLE
fix: Canvas jitters on page refresh on an application where widgets don't occupy the entire width of the canvas

### DIFF
--- a/app/client/src/pages/Editor/MainContainer.test.tsx
+++ b/app/client/src/pages/Editor/MainContainer.test.tsx
@@ -20,6 +20,7 @@ import { getAbsolutePixels } from "utils/helpers";
 import { UpdatedMainContainer } from "test/testMockedWidgets";
 import { AppState } from "reducers";
 import { generateReactKey } from "utils/generators";
+import * as useDynamicAppLayoutHook from "utils/hooks/useDynamicAppLayout";
 
 const renderNestedComponent = () => {
   const initialState = (store.getState() as unknown) as Partial<AppState>;
@@ -88,6 +89,9 @@ const renderNestedComponent = () => {
 describe("Drag and Drop widgets into Main container", () => {
   const mockGetIsFetchingPage = jest.spyOn(utilities, "getIsFetchingPage");
   const spyGetCanvasWidgetDsl = jest.spyOn(utilities, "getCanvasWidgetDsl");
+  jest
+    .spyOn(useDynamicAppLayoutHook, "useDynamicAppLayout")
+    .mockImplementation(() => [true, jest.fn()]);
 
   const pushState = jest.spyOn(window.history, "pushState");
   pushState.mockImplementation((state: any, title: any, url: any) => {

--- a/app/client/src/pages/Editor/MainContainer.tsx
+++ b/app/client/src/pages/Editor/MainContainer.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import * as Sentry from "@sentry/react";
 import { useDispatch, useSelector } from "react-redux";
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback } from "react";
 import { Route, Switch } from "react-router";
 
 import EditorsRouter from "./routes";

--- a/app/client/src/pages/Editor/MainContainer.tsx
+++ b/app/client/src/pages/Editor/MainContainer.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import * as Sentry from "@sentry/react";
 import { useDispatch, useSelector } from "react-redux";
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { Route, Switch } from "react-router";
 
 import EditorsRouter from "./routes";
@@ -47,6 +47,11 @@ function MainContainer() {
   const onLeftSidebarDragEnd = useCallback(() => {
     dispatch(updateExplorerWidthAction(sidebarWidth));
   }, [sidebarWidth]);
+
+  // save the entity explorer width in redux
+  useEffect(() => {
+    dispatch(updateExplorerWidthAction(DEFAULT_ENTITY_EXPLORER_WIDTH));
+  }, []);
 
   const isPreviewMode = useSelector(previewModeSelector);
 

--- a/app/client/src/pages/Editor/MainContainer.tsx
+++ b/app/client/src/pages/Editor/MainContainer.tsx
@@ -48,11 +48,6 @@ function MainContainer() {
     dispatch(updateExplorerWidthAction(sidebarWidth));
   }, [sidebarWidth]);
 
-  // save the entity explorer width in redux
-  useEffect(() => {
-    dispatch(updateExplorerWidthAction(DEFAULT_ENTITY_EXPLORER_WIDTH));
-  }, []);
-
   const isPreviewMode = useSelector(previewModeSelector);
 
   return (

--- a/app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx
@@ -23,6 +23,7 @@ import {
 import Spinner from "components/ads/Spinner";
 import useGoogleFont from "utils/hooks/useGoogleFont";
 import { IconSize } from "components/ads/Icon";
+import { useDynamicAppLayout } from "utils/hooks/useDynamicAppLayout";
 import { getCurrentThemeDetails } from "selectors/themeSelectors";
 
 const Container = styled.section<{
@@ -56,6 +57,9 @@ function CanvasContainer() {
   const shouldHaveTopMargin = !isPreviewMode || pages.length > 1;
   const isAppThemeChanging = useSelector(getAppThemeIsChanging);
 
+  const isLayoutingInitialized = useDynamicAppLayout();
+  const isPageInitializing = isFetchingPage || !isLayoutingInitialized;
+
   useEffect(() => {
     return () => {
       dispatch(forceOpenWidgetPanel(false));
@@ -71,11 +75,11 @@ function CanvasContainer() {
   );
   let node: ReactNode;
 
-  if (isFetchingPage) {
+  if (isPageInitializing) {
     node = pageLoading;
   }
 
-  if (!isFetchingPage && widgets) {
+  if (!isPageInitializing && widgets) {
     node = <Canvas dsl={widgets} pageId={params.pageId} />;
   }
   // calculating exact height to not allow scroll at this component,

--- a/app/client/src/pages/Editor/WidgetsEditor/index.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/index.tsx
@@ -17,7 +17,6 @@ import Debugger from "components/editorComponents/Debugger";
 import OnboardingTasks from "../FirstTimeUserOnboarding/Tasks";
 import CrudInfoModal from "../GeneratePage/components/CrudInfoModal";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
-import { useDynamicAppLayout } from "utils/hooks/useDynamicAppLayout";
 import { getCurrentApplication } from "selectors/applicationSelectors";
 import { setCanvasSelectionFromEditor } from "actions/canvasSelectionActions";
 import { closePropertyPane, closeTableFilterPane } from "actions/widgetActions";
@@ -50,7 +49,6 @@ function WidgetsEditor() {
     getIsOnboardingWidgetSelection,
   );
   const guidedTourEnabled = useSelector(inGuidedTour);
-  useDynamicAppLayout();
   useEffect(() => {
     PerformanceTracker.stopTracking(PerformanceTransactionName.CLOSE_SIDE_PANE);
   });

--- a/app/client/src/reducers/uiReducers/mainCanvasReducer.ts
+++ b/app/client/src/reducers/uiReducers/mainCanvasReducer.ts
@@ -8,6 +8,7 @@ import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { UpdateCanvasLayoutPayload } from "actions/controlActions";
 
 const initialState: MainCanvasReduxState = {
+  initialized: false,
   width: 0,
   height: 0,
 };
@@ -30,12 +31,14 @@ const mainCanvasReducer = createImmerReducer(initialState, {
   ) => {
     state.width = action.payload.width || state.width;
     state.height = action.payload.height || state.height;
+    state.initialized = true;
   },
 });
 
 export interface MainCanvasReduxState {
   width: number;
   height: number;
+  initialized: boolean;
 }
 
 export default mainCanvasReducer;

--- a/app/client/src/selectors/mainCanvasSelectors.tsx
+++ b/app/client/src/selectors/mainCanvasSelectors.tsx
@@ -1,0 +1,5 @@
+import { AppState } from "reducers";
+
+export const getIsCanvasInitialized = (state: AppState) => {
+  return state.ui.mainCanvas.initialized;
+};

--- a/app/client/src/utils/hooks/useDynamicAppLayout.tsx
+++ b/app/client/src/utils/hooks/useDynamicAppLayout.tsx
@@ -136,7 +136,6 @@ export const useDynamicAppLayout = () => {
     const calculatedWidth = calculateCanvasWidth();
     const { width: rightColumn } = mainCanvasProps || {};
 
-    // making sure entity explorer is rendered
     if (rightColumn !== calculatedWidth) {
       dispatch(
         updateCanvasLayoutAction(calculatedWidth, mainCanvasProps?.height),

--- a/app/client/src/utils/hooks/useDynamicAppLayout.tsx
+++ b/app/client/src/utils/hooks/useDynamicAppLayout.tsx
@@ -181,13 +181,25 @@ export const useDynamicAppLayout = () => {
     isPreviewMode,
     explorerWidth,
     isExplorerPinned,
-    initialized,
   ]);
 
   /**
    * calling the setInitialized here so that property pane width is initialized
    */
   useEffect(() => {
-    setInitialized(true);
+    const observer = new MutationObserver((mutations, obs) => {
+      if (domEntityExplorer && domPropertyPane) {
+        setInitialized(true);
+        obs.disconnect();
+        return;
+      }
+    });
+
+    observer.observe(document, {
+      childList: true,
+      subtree: true,
+    });
   });
+
+  return initialized;
 };

--- a/app/client/src/utils/hooks/useDynamicAppLayout.tsx
+++ b/app/client/src/utils/hooks/useDynamicAppLayout.tsx
@@ -159,7 +159,7 @@ export const useDynamicAppLayout = () => {
   }, [screenHeight, mainCanvasProps?.height]);
 
   useEffect(() => {
-    debouncedResize();
+    if (initialized) debouncedResize();
   }, [screenWidth]);
 
   /**
@@ -173,7 +173,7 @@ export const useDynamicAppLayout = () => {
    *  - theme mode is turned on
    */
   useEffect(() => {
-    resizeToLayout();
+    if (initialized) resizeToLayout();
   }, [
     appLayout,
     currentPageId,
@@ -187,10 +187,11 @@ export const useDynamicAppLayout = () => {
    * calling the setInitialized here so that property pane width is initialized
    */
   useEffect(() => {
-    const observer = new MutationObserver((mutations, obs) => {
+    const observer = new MutationObserver(() => {
       if (domEntityExplorer && domPropertyPane) {
         setInitialized(true);
-        obs.disconnect();
+        resizeToLayout();
+        observer.disconnect();
         return;
       }
     });
@@ -199,7 +200,13 @@ export const useDynamicAppLayout = () => {
       childList: true,
       subtree: true,
     });
-  });
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+  }, [setInitialized, resizeToLayout]);
 
   return initialized;
 };


### PR DESCRIPTION
When there are widgets on the canvas, on refresh the width of the widget flickers due to a bug in dynamic app layout logic. This PR fixes that

Fixes #12292

## Type of chang

- Bug fix

## How Has This Been Tested?

- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/flickering-of-canvas-width 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.64 **(0)** | 38.61 **(0.01)** | 35.96 **(0)** | 56.9 **(0.01)**
 :green_circle: | app/client/src/pages/Editor/WidgetsEditor/CanvasContainer.tsx | 100 **(2.38)** | 77.78 **(15.28)** | 100 **(0)** | 100 **(2.44)**
 :red_circle: | app/client/src/pages/Editor/WidgetsEditor/index.tsx | 93.55 **(-0.2)** | 60 **(0)** | 100 **(0)** | 93.22 **(-0.22)**
 :green_circle: | app/client/src/reducers/uiReducers/mainCanvasReducer.ts | 75 **(2.27)** | 22.22 **(0)** | 50 **(0)** | 75 **(2.27)**
 :sparkles: :new: | **app/client/src/selectors/mainCanvasSelectors.tsx** | **100** | **100** | **100** | **100**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0)**
 :red_circle: | app/client/src/utils/hooks/useDynamicAppLayout.tsx | 86.84 **(-1.47)** | 62.5 **(-3.21)** | 100 **(0)** | 90 **(0)**</details>