### PR TITLE
fix: Fix validation check that is blocking input from changing

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/ElasticSearchDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/ElasticSearchDatasource_spec.js
@@ -1,0 +1,35 @@
+const datasource = require("../../../../locators/DatasourcesEditor.json");
+const queryLocators = require("../../../../locators/QueryEditor.json");
+const queryEditor = require("../../../../locators/QueryEditor.json");
+
+let elasticSearchName;
+
+describe("Elastic search datasource tests", function() {
+  beforeEach(() => {
+    cy.startRoutesForDatasource();
+  });
+
+  it("1. Create elastic search datasource", function() {
+    cy.NavigateToDatasourceEditor();
+    cy.get(datasource.ElasticSearch).click();
+    cy.generateUUID().then((uid) => {
+      elasticSearchName = uid;
+
+      cy.get(".t--edit-datasource-name").click();
+      cy.get(".t--edit-datasource-name input")
+        .clear()
+        .type(elasticSearchName, { force: true })
+        .should("have.value", elasticSearchName)
+        .blur();
+    });
+    cy.wait("@saveDatasource").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
+    cy.fillElasticDatasourceForm();
+
+    //once we have test values for elastic search we can test and save the datasources.
+    // cy.testSaveDatasource();
+  });
+});

--- a/app/client/cypress/locators/DatasourcesEditor.json
+++ b/app/client/cypress/locators/DatasourcesEditor.json
@@ -30,7 +30,7 @@
   "selConnectionType": "[data-cy='datasourceConfiguration.connection.type']",
   "scope":"[data-cy='datasourceConfiguration.authentication.scopeString']",
   "Mysql": ".t--plugin-name:contains('Mysql')",
-  "ElasticSearch": ".t--plugin-name:contains('ElasticSearch')",
+  "ElasticSearch": ".t--plugin-name:contains('Elasticsearch')",
   "DynamoDB": ".t--plugin-name:contains('DynamoDB')",
   "Redis": ".t--plugin-name:contains('Redis')",
   "MsSQL": ".t--plugin-name:contains('Microsoft SQL Server')",

--- a/app/client/cypress/locators/DatasourcesEditor.json
+++ b/app/client/cypress/locators/DatasourcesEditor.json
@@ -5,6 +5,7 @@
   "databaseName": "input[name='datasourceConfiguration.authentication.databaseName']",
   "username": "input[name='datasourceConfiguration.authentication.username']",
   "password": "input[name='datasourceConfiguration.authentication.password']",
+  "headers": "input[name='datasourceConfiguration.headers[0]']",
   "authenticationAuthtype": "[data-cy=datasourceConfiguration\\.authentication\\.authType]",
   "url": "input[name='url']",
   "MongoDB": ".t--plugin-name:contains('MongoDB')",

--- a/app/client/cypress/support/dataSourceCommands.js
+++ b/app/client/cypress/support/dataSourceCommands.js
@@ -162,6 +162,25 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  "fillElasticDatasourceForm",
+  (shouldAddTrailingSpaces = false) => {
+    // we are using postgresql data for elastic search,
+    // in the future, this should be changed, just for testing purposes
+    const hostAddress = "https://localhost";
+
+    cy.get(datasourceEditor.host).type(hostAddress);
+    cy.get(datasourceEditor.port).type(datasourceFormData["postgres-port"]);
+    cy.get(datasourceEditor.sectionAuthentication).click();
+    cy.get(datasourceEditor.username).type(
+      datasourceFormData["postgres-username"],
+    );
+    cy.get(datasourceEditor.password).type(
+      datasourceFormData["postgres-password"],
+    );
+  },
+);
+
+Cypress.Commands.add(
   "fillMySQLDatasourceForm",
   (shouldAddTrailingSpaces = false) => {
     const hostAddress = shouldAddTrailingSpaces

--- a/app/client/cypress/support/dataSourceCommands.js
+++ b/app/client/cypress/support/dataSourceCommands.js
@@ -167,6 +167,7 @@ Cypress.Commands.add(
     // we are using postgresql data for elastic search,
     // in the future, this should be changed, just for testing purposes
     const hostAddress = "https://localhost";
+    const headerValue = "Bearer Token";
 
     cy.get(datasourceEditor.host).type(hostAddress);
     cy.get(datasourceEditor.port).type(datasourceFormData["postgres-port"]);
@@ -177,6 +178,7 @@ Cypress.Commands.add(
     cy.get(datasourceEditor.password).type(
       datasourceFormData["postgres-password"],
     );
+    cy.get(datasourceEditor.headers).type(headerValue);
   },
 );
 

--- a/app/client/src/components/ads/TextInput.tsx
+++ b/app/client/src/components/ads/TextInput.tsx
@@ -340,11 +340,7 @@ const TextInput = forwardRef(
         if (inputValueValidation) {
           props.validator && setValidation(inputValueValidation);
 
-          return (
-            inputValueValidation.isValid &&
-            props.onChange &&
-            props.onChange(inputValue)
-          );
+          return props.onChange && props.onChange(inputValue);
         } else {
           return props.onChange && props.onChange(inputValue);
         }

--- a/app/client/src/components/ads/TextInput.tsx
+++ b/app/client/src/components/ads/TextInput.tsx
@@ -339,11 +339,9 @@ const TextInput = forwardRef(
           props.validator && props.validator(inputValue);
         if (inputValueValidation) {
           props.validator && setValidation(inputValueValidation);
-
-          return props.onChange && props.onChange(inputValue);
-        } else {
-          return props.onChange && props.onChange(inputValue);
         }
+
+        return props.onChange && props.onChange(inputValue);
       },
       [props.onChange, setValidation, trimValue],
     );

--- a/app/client/src/components/formControls/KeyValueArrayControl.tsx
+++ b/app/client/src/components/formControls/KeyValueArrayControl.tsx
@@ -80,10 +80,10 @@ function KeyValueRow(
 
         return regex.test(value)
           ? { isValid: true }
-          : keyFieldProps.validationMessage;
+          : { isValid: false, message: keyFieldProps.validationMessage };
       }
 
-      return { isValid: true };
+      return undefined;
     },
     [keyFieldProps?.validationRegex, keyFieldProps?.validationMessage],
   );

--- a/app/client/src/components/formControls/KeyValueArrayControl.tsx
+++ b/app/client/src/components/formControls/KeyValueArrayControl.tsx
@@ -78,10 +78,12 @@ function KeyValueRow(
       if (value && keyFieldProps?.validationRegex) {
         const regex = new RegExp(keyFieldProps?.validationRegex);
 
-        return regex.test(value) ? undefined : keyFieldProps.validationMessage;
+        return regex.test(value)
+          ? { isValid: true }
+          : keyFieldProps.validationMessage;
       }
 
-      return undefined;
+      return { isValid: true };
     },
     [keyFieldProps?.validationRegex, keyFieldProps?.validationMessage],
   );


### PR DESCRIPTION
Fixes validation regex checks blocking onChange function from firing in KeyValue array form input.

Fixes #13919

> if no issue exists, please create an issue and ask the maintainers about this first

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes




## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-key-value-validation-check 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.65 **(0.01)** | 38.62 **(0.01)** | 35.97 **(0)** | 56.9 **(0.01)**
 :green_circle: | app/client/src/components/ads/TextInput.tsx | 79.84 **(0.61)** | 63.89 **(1.3)** | 87.5 **(0)** | 78.63 **(0.66)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>