### PR TITLE
fix: added healthcheck for editor with https

### DIFF
--- a/app/client/Dockerfile
+++ b/app/client/Dockerfile
@@ -17,5 +17,5 @@ COPY ./docker/templates/nginx-app-https.conf.template /nginx-app-https.conf.temp
 
 # This is the script that is used to start Nginx when the Docker container starts
 COPY ./docker/start-nginx.sh /start-nginx.sh
-HEALTHCHECK --interval=15s --timeout=15s --start-period=15s --retries=3 CMD curl -f http://localhost/ || curl -fk https://localhost/ || exit 1
+HEALTHCHECK --interval=15s --timeout=15s --start-period=15s --retries=3 CMD curl -Lfk http://localhost/ || exit 1
 CMD ["/start-nginx.sh"]

--- a/app/client/Dockerfile
+++ b/app/client/Dockerfile
@@ -1,3 +1,4 @@
+
 FROM nginx:1.20-alpine
 
 COPY ./build /var/www/appsmith
@@ -16,5 +17,5 @@ COPY ./docker/templates/nginx-app-https.conf.template /nginx-app-https.conf.temp
 
 # This is the script that is used to start Nginx when the Docker container starts
 COPY ./docker/start-nginx.sh /start-nginx.sh
-HEALTHCHECK --interval=15s --timeout=15s --start-period=15s --retries=3 CMD curl -f http://localhost:80/ || exit 1
+HEALTHCHECK --interval=15s --timeout=15s --start-period=15s --retries=3 CMD curl -f http://localhost/ || curl -fk https://localhost/ || exit 1
 CMD ["/start-nginx.sh"]

--- a/deploy/docker/scripts/healthcheck.sh
+++ b/deploy/docker/scripts/healthcheck.sh
@@ -11,9 +11,11 @@ while read -r line
     else
       echo "PROCESS: $process - STATUS: $status"
       if [[ "$process" == 'editor' ]]; then
-        if [[ $(curl -s -w "%{http_code}\n" http://localhost:80/ -o /dev/null) -ne 200 ]]; then
+        if [[ $(curl -s -w "%{http_code}\n" http://localhost/ -o /dev/null) -ne 200 ]]; then
+          if [[ $(curl -k -s -w "%{http_code}\n" https://localhost/ -o /dev/null) -ne 200 ]]; then
            echo 'ERROR: Editor is down';
            healthy=false
+          fi
         fi
       elif [[ "$process" == "server" ]]; then
         if [[ $(curl -s -w "%{http_code}\n" http://localhost:8080/api/v1/users/me/ -o /dev/null) -ne 200 ]]; then

--- a/deploy/docker/scripts/healthcheck.sh
+++ b/deploy/docker/scripts/healthcheck.sh
@@ -11,11 +11,9 @@ while read -r line
     else
       echo "PROCESS: $process - STATUS: $status"
       if [[ "$process" == 'editor' ]]; then
-        if [[ $(curl -s -w "%{http_code}\n" http://localhost/ -o /dev/null) -ne 200 ]]; then
-          if [[ $(curl -k -s -w "%{http_code}\n" https://localhost/ -o /dev/null) -ne 200 ]]; then
-           echo 'ERROR: Editor is down';
-           healthy=false
-          fi
+        if [[ $(curl -Lfk -s -w "%{http_code}\n" http://localhost/ -o /dev/null) -ne 200 ]]; then
+          echo 'ERROR: Editor is down';
+          healthy=false
         fi
       elif [[ "$process" == "server" ]]; then
         if [[ $(curl -s -w "%{http_code}\n" http://localhost:8080/api/v1/users/me/ -o /dev/null) -ne 200 ]]; then


### PR DESCRIPTION
## Description
Added a fix for the docker health check on editor with ssl enabled for `appsmith-ce` fat container and the slim client `appsmith-editor`




## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: FIX/health-check-https 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>