### PR TITLE
feat: add smart json substitution logic for query variables in GraphQL plugin

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
@@ -316,4 +316,25 @@ public class PluginUtils {
         JSONParser parser = new JSONParser(MODE_PERMISSIVE);
         return (JSONObject) parser.parse(body);
     }
+
+    public static void setValueSafelyInPropertyList(List<Property> properties, int index, Object value) throws AppsmithPluginException {
+        if (properties == null) {
+            throw new AppsmithPluginException(
+                    AppsmithPluginError.PLUGIN_ERROR,
+                    "Appsmith server encountered an unexpected error: property list is null. Please reach out to " +
+                            "our customer support to resolve this."
+            );
+        }
+
+        if (index < 0 || index > properties.size() - 1) {
+            throw new AppsmithPluginException(
+                    AppsmithPluginError.PLUGIN_ERROR,
+                    "Appsmith server encountered an unexpected error: index value out or range: index: " + index +
+                            ", property list size: " + properties.size() + ". Please reach out to our customer " +
+                            "support to resolve this."
+            );
+        }
+
+        properties.get(index).setValue(value);
+    }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/SmartSubstitutionUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/SmartSubstitutionUtils.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SmartSubstitutionUtils {
-    public static final int SMART_JSON_SUBSTITUTION_INDEX = 0;
+    public static final int SMART_SUBSTITUTION_INDEX = 0;
 
     private static SmartSubstitutionUtils smartSubstitutionUtils;
 
@@ -21,26 +21,26 @@ public class SmartSubstitutionUtils {
         return smartSubstitutionUtils;
     }
 
-    public boolean isJsonSmartSubstitutionEnabled(List<Property> properties) {
-        boolean smartJsonSubstitution;
+    public boolean isSmartSubstitutionEnabled(List<Property> properties) {
+        boolean smartSubstitution;
         if (CollectionUtils.isEmpty(properties)) {
             // In case the smart json substitution configuration is missing, default to true
-            smartJsonSubstitution = true;
+            smartSubstitution = true;
 
             // Since properties is not empty, we are guaranteed to find the first property.
-        } else if (properties.get(SMART_JSON_SUBSTITUTION_INDEX) != null) {
-            Object ssubValue = properties.get(SMART_JSON_SUBSTITUTION_INDEX).getValue();
+        } else if (properties.get(SMART_SUBSTITUTION_INDEX) != null) {
+            Object ssubValue = properties.get(SMART_SUBSTITUTION_INDEX).getValue();
             if (ssubValue instanceof Boolean) {
-                smartJsonSubstitution = (Boolean) ssubValue;
+                smartSubstitution = (Boolean) ssubValue;
             } else if (ssubValue instanceof String) {
-                smartJsonSubstitution = Boolean.parseBoolean((String) ssubValue);
+                smartSubstitution = Boolean.parseBoolean((String) ssubValue);
             } else {
-                smartJsonSubstitution = true;
+                smartSubstitution = true;
             }
         } else {
-            smartJsonSubstitution = true;
+            smartSubstitution = true;
         }
 
-        return smartJsonSubstitution;
+        return smartSubstitution;
     }
 }

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -93,6 +93,7 @@ public class GraphQLPlugin extends BasePlugin {
                                 mustacheKeysInOrder,
                                 executeActionDTO.getParams(),
                                 parameters);
+                        setValueSafelyInPropertyList(properties, QUERY_VARIABLES_INDEX, updatedVariables);
                     } catch (AppsmithPluginException e) {
                         ActionExecutionResult errorResult = new ActionExecutionResult();
                         errorResult.setIsExecutionSuccess(false);
@@ -101,7 +102,6 @@ public class GraphQLPlugin extends BasePlugin {
                         return Mono.just(errorResult);
                     }
 
-                    setValueSafelyInPropertyList(properties, QUERY_VARIABLES_INDEX, updatedVariables);
                 }
             }
 

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -3,6 +3,8 @@ package com.external.plugins;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.helpers.DataTypeStringUtils;
+import com.appsmith.external.helpers.MustacheHelper;
 import com.appsmith.external.helpers.restApiUtils.connections.APIConnection;
 import com.appsmith.external.helpers.restApiUtils.helpers.RequestCaptureFilter;
 import com.appsmith.external.models.ActionConfiguration;
@@ -29,9 +31,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
+import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInPropertyList;
+import static com.external.utils.BodyUtils.QUERY_VARIABLES_INDEX;
 import static com.external.utils.BodyUtils.convertToGraphQLPOSTBodyFormat;
 import static com.external.utils.BodyUtils.getGraphQLQueryParamsForBodyAndVariables;
 import static com.external.utils.BodyUtils.validateBodyAndVariablesSyntax;
+import static java.lang.Boolean.TRUE;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class GraphQLPlugin extends BasePlugin {
 
@@ -70,6 +77,33 @@ public class GraphQLPlugin extends BasePlugin {
 
             // TODO: handle smart substitution for query body and query variables
             // TODO: handle cursor pagination
+
+            Boolean smartSubstitution = this.smartSubstitutionUtils.isSmartSubstitutionEnabled(properties);
+            if (TRUE.equals(smartSubstitution)) {
+
+                /* Apply smart JSON substitution logic to mustache binding values in query variables */
+                String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
+                if (!isEmpty(variables)) {
+                    List<String> mustacheKeysInOrder = MustacheHelper.extractMustacheKeysInOrder(variables);
+                    // Replace all the bindings with a ? as expected in a prepared statement.
+                    String updatedVariables = MustacheHelper.replaceMustacheWithPlaceholder(variables, mustacheKeysInOrder);
+
+                    try {
+                        updatedVariables = (String) smartSubstitutionOfBindings(updatedVariables,
+                                mustacheKeysInOrder,
+                                executeActionDTO.getParams(),
+                                parameters);
+                    } catch (AppsmithPluginException e) {
+                        ActionExecutionResult errorResult = new ActionExecutionResult();
+                        errorResult.setIsExecutionSuccess(false);
+                        errorResult.setErrorInfo(e);
+                        errorResult.setStatusCode(AppsmithPluginError.PLUGIN_ERROR.getAppErrorCode().toString());
+                        return Mono.just(errorResult);
+                    }
+
+                    setValueSafelyInPropertyList(properties, QUERY_VARIABLES_INDEX, updatedVariables);
+                }
+            }
 
             prepareConfigurationsForExecution(executeActionDTO, actionConfiguration, datasourceConfiguration);
 
@@ -203,6 +237,17 @@ public class GraphQLPlugin extends BasePlugin {
             return triggerUtils.triggerApiCall(client, httpMethod, uri, requestBodyObj, actionExecutionRequest,
                     objectMapper,
                     hintMessages, errorResult, requestCaptureFilter);
+        }
+
+        @Override
+        public Object substituteValueInInput(int index,
+                                             String binding,
+                                             String value,
+                                             Object input,
+                                             List<Map.Entry<String, String>> insertedParams,
+                                             Object... args) {
+            String jsonBody = (String) input;
+            return DataTypeStringUtils.jsonSmartReplacementPlaceholderWithValue(jsonBody, value, null, insertedParams, null);
         }
     }
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -73,7 +73,7 @@ public class RestApiPlugin extends BasePlugin {
             List<Map.Entry<String, String>> parameters = new ArrayList<>();
 
             // Smartly substitute in actionConfiguration.body and replace all the bindings with values.
-            Boolean smartJsonSubstitution = this.smartSubstitutionUtils.isJsonSmartSubstitutionEnabled(properties);
+            Boolean smartJsonSubstitution = this.smartSubstitutionUtils.isSmartSubstitutionEnabled(properties);
             if (TRUE.equals(smartJsonSubstitution)) {
                 // Do smart replacements in JSON body
                 if (actionConfiguration.getBody() != null) {


### PR DESCRIPTION
## Description
- Add JSON smart substitution support for GraphQL query variables section.

Fixes #12391

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual
- JUnit TC will be written as part of issue https://github.com/appsmithorg/appsmith/issues/12388 before the `feat/graphql` branch is merged to `release`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
