### PR TITLE
fix: Error message thrown on reset password from user profile screen

### DIFF
--- a/app/client/src/pages/UserProfile/General.tsx
+++ b/app/client/src/pages/UserProfile/General.tsx
@@ -25,6 +25,7 @@ import {
 } from "./StyledComponents";
 import { getCurrentUser as refreshCurrentUser } from "actions/authActions";
 import { getAppsmithConfigs } from "@appsmith/configs";
+import { ANONYMOUS_USERNAME } from "constants/userConstants";
 const { disableLoginForm } = getAppsmithConfigs();
 
 const ForgotPassword = styled.a`
@@ -72,6 +73,8 @@ function General() {
   useEffect(() => {
     dispatch(refreshCurrentUser());
   }, []);
+
+  if (user?.email === ANONYMOUS_USERNAME) return null;
 
   return (
     <Wrapper>


### PR DESCRIPTION
## Description
Fixes "There was an unexpected error" error message in reset password flow from user profile screen.

Fixes #13872 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/reset-password-error-message 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/selectors/commentsSelectors.ts | 85.25 **(1.64)** | 64.71 **(2.95)** | 73.33 **(0)** | 90.59 **(2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>