### PR TITLE
fix: JSONForm Select field validate empty string as an invalid value

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/fields/SelectField.test.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/SelectField.test.tsx
@@ -1,0 +1,68 @@
+import { isValid, SelectFieldProps } from "./SelectField";
+
+describe(".isValid", () => {
+  it("returns true when isRequired is false", () => {
+    const inputs = [
+      { value: "", expectedOutput: true },
+      { value: "0", expectedOutput: true },
+      { value: "1", expectedOutput: true },
+      { value: "-1", expectedOutput: true },
+      { value: "1.2", expectedOutput: true },
+      { value: "1.200", expectedOutput: true },
+      { value: "asd", expectedOutput: true },
+      { value: "1.2.1", expectedOutput: true },
+      { value: 0, expectedOutput: true },
+      { value: 1, expectedOutput: true },
+      { value: -1, expectedOutput: true },
+      { value: null, expectedOutput: true },
+      { value: undefined, expectedOutput: true },
+    ];
+    const schemaItem = {
+      isRequired: false,
+    } as SelectFieldProps["schemaItem"];
+
+    inputs.forEach((input) => {
+      const result = isValid(schemaItem, input.value);
+      expect(result).toEqual(input.expectedOutput);
+    });
+  });
+
+  it("returns true when isRequired is true and value is valid", () => {
+    const inputs = [
+      { value: "0", expectedOutput: true },
+      { value: "1", expectedOutput: true },
+      { value: "-1", expectedOutput: true },
+      { value: "1.2", expectedOutput: true },
+      { value: "1.200", expectedOutput: true },
+      { value: "asd", expectedOutput: true },
+      { value: "1.2.1", expectedOutput: true },
+      { value: 0, expectedOutput: true },
+      { value: 1, expectedOutput: true },
+      { value: -1, expectedOutput: true },
+    ];
+    const schemaItem = {
+      isRequired: true,
+    } as SelectFieldProps["schemaItem"];
+
+    inputs.forEach((input) => {
+      const result = isValid(schemaItem, input.value);
+      expect(result).toEqual(input.expectedOutput);
+    });
+  });
+
+  it("returns false when isRequired is true and value is invalid", () => {
+    const inputs = [
+      { value: "", expectedOutput: false },
+      { value: null, expectedOutput: false },
+      { value: undefined, expectedOutput: false },
+    ];
+    const schemaItem = {
+      isRequired: true,
+    } as SelectFieldProps["schemaItem"];
+
+    inputs.forEach((input) => {
+      const result = isValid(schemaItem, input.value);
+      expect(result).toEqual(input.expectedOutput);
+    });
+  });
+});

--- a/app/client/src/widgets/JSONFormWidget/fields/SelectField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/SelectField.tsx
@@ -58,8 +58,10 @@ const StyledSelectWrapper = styled.div`
   width: 100%;
 `;
 
-const isValid = (schemaItem: SelectFieldProps["schemaItem"], value?: unknown) =>
-  !schemaItem.isRequired || !isNil(value);
+export const isValid = (
+  schemaItem: SelectFieldProps["schemaItem"],
+  value?: unknown,
+) => !schemaItem.isRequired || (value !== "" && !isNil(value));
 
 const composeDefaultValue = (
   schemaItemDefaultValue: DefaultValue,


### PR DESCRIPTION
## Description

The Select field only considers `null` and `undefined` as invalid values.
But when we consider the select widget, it considers empty string as invalid value along with `null` and `undefined`.
This PR aligns the implementation and makes the JSON Form's select field consider and empty value as an invalid value when the `Required` property is enabled.

Fixes #13981

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

 Jest Test:
The validation function is tested in 3 test cases
1. When required is enabled and the values are either valid or invalid -> It should return valid
2. When required is enabled and the values are valid -> It should return valid
3. When required is enabled and the values are invalid -> It should return invalid

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/13981-jf-select-validation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.62 **(0)** | 38.64 **(0.01)** | 35.95 **(0.01)** | 56.87 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**
 :green_circle: | app/client/src/widgets/JSONFormWidget/fields/SelectField.tsx | 37.7 **(2.7)** | 10.2 **(6.03)** | 14.29 **(14.29)** | 39.29 **(1.79)**</details>