### PR TITLE
fix: missing application id in comment threads API

### DIFF
--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -16,7 +16,6 @@ import { AppState } from "reducers";
 import {
   getCurrentApplicationId,
   getCurrentPageId,
-  getIsEditorInitialized,
   getIsPublishingApplication,
   previewModeSelector,
   selectURLSlugs,
@@ -85,7 +84,6 @@ import Boxed from "./GuidedTour/Boxed";
 import EndTour from "./GuidedTour/EndTour";
 import { GUIDED_TOUR_STEPS } from "./GuidedTour/constants";
 import { viewerURL } from "RouteBuilder";
-import { getIsInitialized } from "selectors/appViewSelectors";
 
 const HeaderWrapper = styled.div`
   width: 100%;
@@ -341,11 +339,7 @@ export function EditorHeader(props: EditorHeaderProps) {
     (user) => user.username !== props.currentUser?.username,
   );
   const { applicationSlug, pageSlug } = useSelector(selectURLSlugs);
-
-  const isEditorInitialised = useSelector(getIsEditorInitialized);
-  const isViewerInitialised = useSelector(getIsInitialized);
-  const showModes =
-    (isEditorInitialised || isViewerInitialised) && !shouldHideComments;
+  const showModes = !shouldHideComments;
 
   return (
     <ThemeProvider theme={theme}>

--- a/app/client/src/pages/Editor/ToggleModeButton.tsx
+++ b/app/client/src/pages/Editor/ToggleModeButton.tsx
@@ -45,11 +45,13 @@ import { getAppMode } from "../../selectors/applicationSelectors";
 import { setPreviewModeAction } from "actions/editorActions";
 import {
   getCurrentApplicationId,
+  getIsEditorInitialized,
   previewModeSelector,
 } from "selectors/editorSelectors";
 
 import { getCurrentGitBranch } from "selectors/gitSyncSelectors";
 import { isExploringSelector } from "selectors/onboardingSelectors";
+import { getIsInitialized } from "selectors/appViewSelectors";
 
 const ModeButton = styled.div<{
   active: boolean;
@@ -296,16 +298,20 @@ export const useHideComments = () => {
   const [shouldHide, setShouldHide] = useState(true);
   const location = useLocation();
   const currentUser = useSelector(getCurrentUser);
+  const isEditorInitialized = useSelector(getIsEditorInitialized);
+  const isViewerInitialized = useSelector(getIsInitialized);
   useEffect(() => {
     const pathName = window.location.pathname;
-    const shouldShow = matchBuilderPath(pathName) || matchViewerPath(pathName);
+    const shouldShow =
+      (matchBuilderPath(pathName) && isEditorInitialized) ||
+      (matchViewerPath(pathName) && isViewerInitialized);
     // Disable comment mode toggle for anonymous users
     setShouldHide(
       !shouldShow ||
         !currentUser ||
         currentUser.username === ANONYMOUS_USERNAME,
     );
-  }, [location, currentUser]);
+  }, [location, currentUser, isEditorInitialized, isViewerInitialized]);
 
   return shouldHide;
 };


### PR DESCRIPTION
## Description
Fixes the error toast message that says "Please enter a valid applicationId". 
This has to do with the comments component mounted and it the fetch threads API being called before the applicationId is retrieved. This PR delays the comments component mount in the application header.

Fixes #13489 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
