### PR TITLE
fix: Remove animation in deploy button

### DIFF
--- a/app/client/src/components/designSystems/appsmith/header/DeployLinkButton.tsx
+++ b/app/client/src/components/designSystems/appsmith/header/DeployLinkButton.tsx
@@ -130,6 +130,7 @@ export const DeployLinkButton = withTheme((props: Props) => {
       modifiers={{ offset: { enabled: true, offset: "0, -3" } }}
       onClose={onClose}
       position={PopoverPosition.BOTTOM_RIGHT}
+      transitionDuration={0}
     >
       <div
         className="t--deploy-popup-option-trigger"


### PR DESCRIPTION
## Description
This PR removes the 200ms transition delays that comes by default with the blueprint popover component.
This override is only for the deploy button though.

Fixes #13927 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: fix/remove-animation-deploy-button 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>