### PR TITLE
fix: Removes transition animation on tooltip component

### DIFF
--- a/app/client/src/components/ads/Tooltip.tsx
+++ b/app/client/src/components/ads/Tooltip.tsx
@@ -25,6 +25,7 @@ export type TooltipProps = CommonComponentProps & {
   onOpening?: typeof noop;
   popoverClassName?: string;
   donotUsePortal?: boolean;
+  transitionDuration?: number;
 };
 
 const portalContainer = document.getElementById("tooltip-root");
@@ -50,6 +51,7 @@ function TooltipComponent(props: TooltipProps) {
         ""}`}
       portalContainer={portalContainer as HTMLDivElement}
       position={props.position}
+      transitionDuration={props.transitionDuration || 0}
       usePortal={!props.donotUsePortal}
     >
       {props.children}

--- a/app/client/src/pages/Editor/Explorer/Files/Submenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/Submenu.tsx
@@ -222,6 +222,7 @@ export default function ExplorerSubMenu({
         onMenuClose();
       }}
       placement="right-start"
+      transitionDuration={0}
     >
       <TooltipComponent
         boundary="viewport"

--- a/app/client/src/pages/common/SharedUserList.tsx
+++ b/app/client/src/pages/common/SharedUserList.tsx
@@ -87,6 +87,7 @@ export default function SharedUserList(props: any) {
           interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
           key={el.username}
           position={Position.BOTTOM}
+          transitionDuration={0}
           usePortal={false}
         >
           <ProfileImage
@@ -105,6 +106,7 @@ export default function SharedUserList(props: any) {
           hoverCloseDelay={0}
           interactionKind={PopoverInteractionKind.CLICK}
           position={Position.BOTTOM}
+          transitionDuration={0}
           usePortal={false}
         >
           <ProfileImageMore


### PR DESCRIPTION
## Description
Sets the default transition duration on tooltip component to 0.

Fixes #13926 
Fixes #13923 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- UX change

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/remove-tooltip-animation 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.62 **(0)** | 38.64 **(0.01)** | 35.94 **(0)** | 56.87 **(0)**
 :green_circle: | app/client/src/components/ads/Tooltip.tsx | 100 **(0)** | 87.5 **(4.17)** | 100 **(0)** | 100 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>