### PR TITLE
feat: dynamic height text widget standardisation

### DIFF
--- a/app/client/src/widgets/TextWidget/component/FontLoader.tsx
+++ b/app/client/src/widgets/TextWidget/component/FontLoader.tsx
@@ -6,10 +6,16 @@ interface Props {
   children?: React.ReactNode;
 }
 
-function FontLoader(props: Props) {
+const FontLoader = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
   const fontFamily = useGoogleFont(props.fontFamily);
 
-  return <div style={{ fontFamily, height: "100%" }}>{props.children}</div>;
-}
+  return (
+    <div ref={ref} style={{ fontFamily, height: "100%" }}>
+      {props.children}
+    </div>
+  );
+});
+
+FontLoader.displayName = "FontLoader";
 
 export default FontLoader;

--- a/app/client/src/widgets/TextWidget/component/index.tsx
+++ b/app/client/src/widgets/TextWidget/component/index.tsx
@@ -207,6 +207,7 @@ export interface TextComponentProps extends ComponentProps {
   leftColumn?: number;
   rightColumn?: number;
   topRow?: number;
+  innerRef?: React.RefObject<HTMLDivElement>;
 }
 
 type State = {
@@ -282,7 +283,10 @@ class TextComponent extends React.Component<TextComponentProps, State> {
 
     return (
       <>
-        <FontLoader fontFamily={this.props.fontFamily}>
+        <FontLoader
+          fontFamily={this.props.fontFamily}
+          ref={this.props.innerRef}
+        >
           <TextContainer>
             <StyledText
               backgroundColor={backgroundColor}
@@ -362,4 +366,11 @@ class TextComponent extends React.Component<TextComponentProps, State> {
   }
 }
 
-export default TextComponent;
+export default React.forwardRef<HTMLDivElement, TextComponentProps>(
+  (props, ref) => (
+    <TextComponent
+      {...props}
+      innerRef={ref as React.RefObject<HTMLDivElement>}
+    />
+  ),
+);

--- a/app/client/src/widgets/TextWidget/widget/index.tsx
+++ b/app/client/src/widgets/TextWidget/widget/index.tsx
@@ -347,6 +347,7 @@ class TextWidget extends BaseWidget<TextWidgetProps, WidgetState> {
           key={this.props.widgetId}
           leftColumn={this.props.leftColumn}
           overflow={this.props.overflow}
+          ref={this.contentRef}
           rightColumn={this.props.rightColumn}
           text={this.props.text}
           textAlign={this.props.textAlign ? this.props.textAlign : "LEFT"}


### PR DESCRIPTION
## Description

**Created it again because of some CSS issues.**

1. Passed the `contentRef` to `TextComponent` from `InputWidgetV2`.
2. Wrapped the `TextComponent` class component in the React.forwardRef, and added a new optional prop `innerRef` to 
pass it to its child.
3. Wrapped the `FontLoader` functional component in a React.forwardedRef.
4. Passed the final ref to the FontLoader child div.

Fixes #13043

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes