### PR TITLE
fix: stop showing errored widget labels prmanently and show them only on hover or when selected

### DIFF
--- a/app/client/src/components/editorComponents/WidgetNameComponent/index.tsx
+++ b/app/client/src/components/editorComponents/WidgetNameComponent/index.tsx
@@ -140,8 +140,7 @@ export function WidgetNameComponent(props: WidgetNameComponentProps) {
         : props.showControls ||
           ((focusedWidget === props.widgetId || showAsSelected) &&
             !isDragging &&
-            !isResizing) ||
-          (!!props.errorCount && !shouldHideErrors))
+            !isResizing))
     );
   };
 


### PR DESCRIPTION
## Description

Changed the condition to display errored widgetLabel only when focused or selected and not permanently.

Fixes #13873 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual UI verification

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: widgetLabelErrorFix 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/components/editorComponents/WidgetNameComponent/index.tsx | 96.97 **(0)** | 84.91 **(1.27)** | 100 **(0)** | 96.88 **(0)**</details>