### PR TITLE
chore: Focus search input box when widgets library is opened

### DIFF
--- a/app/client/src/pages/Editor/WidgetSidebar.tsx
+++ b/app/client/src/pages/Editor/WidgetSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import WidgetCard from "./WidgetCard";
 import { getWidgetCards } from "selectors/editorSelectors";
@@ -27,6 +27,10 @@ function WidgetSidebar({ isActive }: { isActive: boolean }) {
     }
     setFilteredCards(filteredCards);
   };
+
+  useEffect(() => {
+    if (isActive) searchInputRef.current?.focus();
+  }, [isActive]);
 
   /**
    * filter widgets


### PR DESCRIPTION
## Description
Auto-focus search input box when widgets library is open in explorer

Fixes #13929 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:white_circle: Total coverage has not changed</summary>


    // Code coverage diff between base branch:release and head branch: chore/focus-widget-search-input 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | app/client/src/pages/Editor/WidgetSidebar.tsx | 66.67 **(3.03)** | 38.89 **(22.22)** | 37.5 **(8.93)** | 63.64 **(2.35)**
 :red_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.71 **(-0.23)** | 40.83 **(-0.84)** | 36.21 **(0)** | 56.74 **(-0.25)**</details>