### PR TITLE
fix: update jest env and test-timeout

### DIFF
--- a/app/client/jest.config.js
+++ b/app/client/jest.config.js
@@ -10,6 +10,8 @@ module.exports = {
   transform: {
     "^.+\\.(png|js|ts|tsx)$": "ts-jest",
   },
+  testEnvironment: "jsdom",
+  testTimeout: 9000,
   setupFilesAfterEnv: ["<rootDir>/test/setup.ts"],
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx|ts|js)?$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node", "css"],


### PR DESCRIPTION
## Description

- Add `testEnvironment` in the jest config file to `jsdom` this is needed for the CI run on the cra-5 branch.
- Increase `testTimeout` in the jest config, from default 5000 to 9000.

## Type of change

> Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Need to run all the jest test cases on the CI and re-run the workflow multiple times to ensure all test cases pass, without timeout error
- 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: fix/jest-config-updates 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.71 **(0)** | 38.67 **(0.01)** | 36.22 **(0)** | 56.96 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(1.96)** | 100 **(0)** | 93.33 **(0.95)**</details>