### PR TITLE
fix: added hover css for indeterminate checkbox

### DIFF
--- a/app/client/src/widgets/MultiSelectTreeWidget/component/index.styled.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/component/index.styled.tsx
@@ -532,6 +532,9 @@ border: 1px solid #E8E8E8;
   .rc-tree-select-tree-title {
     color: ${Colors.GREY_9};
   }
+  .rc-tree-select-tree-checkbox-indeterminate .rc-tree-select-tree-checkbox-inner {
+    background-color: ${({ accentColor }) => accentColor} !important;
+  }
   :not(.rc-tree-select-tree-treenode-checkbox-checked) .rc-tree-select-tree-checkbox-inner {
     background-color:  ${({ accentColor }) => lightenColor(accentColor)};
     border-color: ${({ accentColor }) => accentColor};


### PR DESCRIPTION

## Description


> Add hover CSS for indeterminate checkbox in MultiSelectTree widget

Fixes #14026 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
