### PR TITLE
chore: slowed down git commit and discard progress bar

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -406,7 +406,7 @@ function Deploy() {
             <Statusbar
               completed={!commitButtonLoading}
               message={createMessage(COMMITTING_AND_PUSHING_CHANGES)}
-              period={2}
+              period={6}
             />
           </StatusbarWrapper>
         )}
@@ -415,7 +415,7 @@ function Deploy() {
             <Statusbar
               completed={!isDiscarding}
               message={createMessage(DISCARDING_AND_PULLING_CHANGES)}
-              period={5}
+              period={6}
             />
           </StatusbarWrapper>
         )}


### PR DESCRIPTION
## Description

Due to file locks commit and discard might take a while, this PR updates the progress bar progress-speed. This makes user easy as earlier progress bar was stuck at 90% and users felt that progress bar was stuck.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually.

## Before changes

https://user-images.githubusercontent.com/1573771/171134294-73da4403-59bc-4a15-b45d-5aa0219407fe.mov


## After changes

https://user-images.githubusercontent.com/1573771/171134029-707cc255-eeb1-4da7-9989-5afd74a126a3.mov



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:green_circle: Total coverage has increased</summary>


    // Code coverage diff between base branch:release and head branch: chore-make-git-progress-bar-slow 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :green_circle: | total | 56.71 **(0)** | 38.67 **(0.01)** | 36.22 **(0)** | 56.96 **(0)**
 :green_circle: | app/client/src/utils/autocomplete/TernServer.ts | 52.94 **(0.23)** | 41.67 **(0.84)** | 36.21 **(0)** | 56.99 **(0.25)**</details>