### PR TITLE
fix: name not getting focused on adding new modal widget

### DIFF
--- a/app/client/src/widgets/ModalWidget/component/index.tsx
+++ b/app/client/src/widgets/ModalWidget/component/index.tsx
@@ -176,6 +176,19 @@ export default function ModalComponent(props: ModalComponentProps) {
   }, []);
 
   useEffect(() => {
+    window.addEventListener("keydown", handleKeydown);
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  });
+
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      if (props.canEscapeKeyClose) props.onClose(e);
+    }
+  };
+
+  useEffect(() => {
     if (!props.scrollContents) {
       modalContentRef.current?.scrollTo({ top: 0, behavior: "smooth" });
     }
@@ -236,6 +249,7 @@ export default function ModalComponent(props: ModalComponentProps) {
   const getEditorView = () => {
     return (
       <Overlay
+        autoFocus={false}
         canEscapeKeyClose={false}
         canOutsideClickClose={false}
         enforceFocus={false}
@@ -261,6 +275,7 @@ export default function ModalComponent(props: ModalComponentProps) {
           }
         >
           <Overlay
+            autoFocus={false}
             canEscapeKeyClose={props.canEscapeKeyClose}
             canOutsideClickClose={props.canOutsideClickClose}
             className={props.overlayClassName}


### PR DESCRIPTION
## Description

The modal widget's name was not getting focused on adding a new modal widget. This was happening since the autofocus is happening on the modal's Overlay component.
This PR disables the autofocus on the modal overlay.

Fixes #14204

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/modal-autofocus 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.7 **(-0.01)** | 38.66 **(0)** | 36.21 **(-0.01)** | 56.96 **(0)**
 :green_circle: | app/client/src/utils/WorkerUtil.ts | 89.76 **(0.78)** | 72.55 **(3.92)** | 100 **(0)** | 93.33 **(0.95)**
 :red_circle: | app/client/src/widgets/ModalWidget/component/index.tsx | 19.1 **(-1.89)** | 11.32 **(-0.92)** | 0 **(0)** | 20.73 **(-1.94)**</details>