### PR TITLE
fix: Add null checks for empty datatypes in api/query responses

### DIFF
--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -5,7 +5,6 @@ import {
   executePluginActionSuccess,
   runAction,
   updateAction,
-  setActionResponseDisplayFormat,
 } from "actions/pluginActionActions";
 import {
   ApplicationPayload,
@@ -106,6 +105,7 @@ import { getBasePath } from "pages/Editor/Explorer/helpers";
 import { isTrueObject } from "workers/evaluationUtils";
 import { handleExecuteJSFunctionSaga } from "sagas/JSPaneSagas";
 import { Plugin } from "api/PluginApi";
+import { setDefaultActionDisplayFormat } from "./PluginActionSagaUtils";
 
 enum ActionResponseDataTypes {
   BINARY = "BINARY",
@@ -842,21 +842,9 @@ function* executePluginActionSaga(
       plugin = yield select(getPlugin, pluginAction.pluginId);
     }
 
-    if (!!plugin && payload?.dataTypes?.length > 0) {
-      const responseType = payload?.dataTypes.find(
-        (type) =>
-          plugin?.responseType && type.dataType === plugin?.responseType,
-      );
-      yield put(
-        setActionResponseDisplayFormat({
-          id: actionId,
-          field: "responseDisplayFormat",
-          value: responseType
-            ? responseType?.dataType
-            : payload?.dataTypes[0]?.dataType,
-        }),
-      );
-    }
+    // sets the default display format for action response e.g Raw, Json or Table
+    yield setDefaultActionDisplayFormat(actionId, plugin, payload);
+
     return {
       payload,
       isError: isErrorResponse(response),

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -842,7 +842,7 @@ function* executePluginActionSaga(
       plugin = yield select(getPlugin, pluginAction.pluginId);
     }
 
-    if (!!plugin) {
+    if (!!plugin && payload?.dataTypes?.length > 0) {
       const responseType = payload?.dataTypes.find(
         (type) =>
           plugin?.responseType && type.dataType === plugin?.responseType,
@@ -853,7 +853,7 @@ function* executePluginActionSaga(
           field: "responseDisplayFormat",
           value: responseType
             ? responseType?.dataType
-            : payload?.dataTypes[0].dataType,
+            : payload?.dataTypes[0]?.dataType,
         }),
       );
     }

--- a/app/client/src/sagas/ActionExecution/PluginActionSagaUtils.test.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSagaUtils.test.ts
@@ -1,0 +1,66 @@
+import { put } from "redux-saga/effects";
+import { setDefaultActionDisplayFormat } from "./PluginActionSagaUtils";
+
+const actionid = "test-id";
+
+const plugin: any = {
+  id: "test-plugin",
+  name: "Test",
+  type: "API",
+  packageName: "test-package",
+  uiComponent: "ApiEditorForm",
+  datasourceComponent: "RestAPIDatasourceForm",
+  templates: {
+    test: "test",
+  },
+  responseType: "JSON",
+};
+
+describe("PluginActionSagasUtils", () => {
+  it("should set the default action display format without any bugs as long as dataTypes is there", () => {
+    const payload = {
+      body: [],
+      headers: {
+        headers: ["test-headers"],
+      },
+      statusCode: "200",
+      dataTypes: [
+        {
+          dataType: "JSON",
+        },
+      ],
+      duration: "1000",
+      size: "10kb",
+    };
+
+    const generator = setDefaultActionDisplayFormat(actionid, plugin, payload);
+
+    expect(generator.next().value).toEqual(
+      put({
+        type: "SET_ACTION_RESPONSE_DISPLAY_FORMAT",
+        payload: {
+          id: "test-id",
+          field: "responseDisplayFormat",
+          value: "JSON",
+        },
+      }),
+    );
+  });
+
+  it("If dataType is an empty array, then no action should be dispatched and no bugs should happen", () => {
+    const payload = {
+      body: [],
+      headers: {
+        headers: ["test-headers"],
+      },
+      statusCode: "200",
+      dataTypes: [],
+      duration: "1000",
+      size: "10kb",
+    };
+
+    const generator = setDefaultActionDisplayFormat(actionid, plugin, payload);
+
+    expect(generator.next().value).toBeUndefined();
+  });
+});

--- a/app/client/src/sagas/ActionExecution/PluginActionSagaUtils.test.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSagaUtils.test.ts
@@ -47,6 +47,39 @@ describe("PluginActionSagasUtils", () => {
     );
   });
 
+  it("If the response type is not present in the dataType, then it should pick the first dataType in the array", () => {
+    const payload = {
+      body: [],
+      headers: {
+        headers: ["test-headers"],
+      },
+      statusCode: "200",
+      dataTypes: [
+        {
+          dataType: "TABLE",
+        },
+        {
+          dataType: "RAW",
+        },
+      ],
+      duration: "1000",
+      size: "10kb",
+    };
+
+    const generator = setDefaultActionDisplayFormat(actionid, plugin, payload);
+
+    expect(generator.next().value).toEqual(
+      put({
+        type: "SET_ACTION_RESPONSE_DISPLAY_FORMAT",
+        payload: {
+          id: "test-id",
+          field: "responseDisplayFormat",
+          value: "TABLE",
+        },
+      }),
+    );
+  });
+
   it("If dataType is an empty array, then no action should be dispatched and no bugs should happen", () => {
     const payload = {
       body: [],

--- a/app/client/src/sagas/ActionExecution/PluginActionSagaUtils.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSagaUtils.ts
@@ -1,0 +1,25 @@
+import { put } from "redux-saga/effects";
+import { setActionResponseDisplayFormat } from "actions/pluginActionActions";
+import { ActionResponse } from "api/ActionAPI";
+import { Plugin } from "api/PluginApi";
+
+export function* setDefaultActionDisplayFormat(
+  actionId: string,
+  plugin: Plugin | undefined,
+  payload: ActionResponse,
+) {
+  if (!!plugin && payload?.dataTypes?.length > 0) {
+    const responseType = payload?.dataTypes.find(
+      (type) => plugin?.responseType && type.dataType === plugin?.responseType,
+    );
+    yield put(
+      setActionResponseDisplayFormat({
+        id: actionId,
+        field: "responseDisplayFormat",
+        value: responseType
+          ? responseType?.dataType
+          : payload?.dataTypes[0]?.dataType,
+      }),
+    );
+  }
+}


### PR DESCRIPTION
For this issue, the server returns no datatypes for an api or query response, Normally these datatypes should be returned for every API or Query, but in case they don't, we want to protect against such occurence.

Fixes #14146 

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test Plan:

Jest

PluginActionSagaUtils.test.ts

## Test coverage results :test_tube:
<details><summary>:red_circle: Total coverage has decreased</summary>


    // Code coverage diff between base branch:release and head branch: fix/fix-empty-datatype 
Status | File | % Stmts | % Branch | % Funcs | % Lines 
 -----|-----|---------|----------|---------|------ 
 :red_circle: | total | 56.71 **(0)** | 38.65 **(-0.02)** | 36.22 **(0)** | 56.96 **(0)**
 :red_circle: | app/client/src/sagas/ActionExecution/PluginActionSaga.ts | 17.22 **(0)** | 1.69 **(-0.14)** | 9.09 **(0)** | 19.77 **(0)**</details>