### PR TITLE
fix: Fix Node version in RTS' Dockerfile

### DIFF
--- a/app/rts/Dockerfile
+++ b/app/rts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16.14.0
 
 LABEL maintainer="tech@appsmith.com"
 


### PR DESCRIPTION
The Node version isn't inline with that in the `package.json`, which was making the Docker build fail. This PR fixes this.
