### PR TITLE
feat: make MySql plugin error messages more readable.

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -324,8 +324,9 @@ public class MySqlPlugin extends BasePlugin {
                         if (error instanceof StaleConnectionException) {
                             return Mono.error(error);
                         }
-                        else if (error instanceof R2dbcPermissionDeniedException)
+                        else if (error instanceof R2dbcPermissionDeniedException) {
                             return Mono.error(new AppsmithPluginException(error, AppsmithPluginError.PLUGIN_ERROR, error.getMessage()));
+                        }
                         ActionExecutionResult result = new ActionExecutionResult();
                         result.setIsExecutionSuccess(false);
                         result.setErrorInfo(error, mySqlErrorUtils);
@@ -588,8 +589,9 @@ public class MySqlPlugin extends BasePlugin {
 
             return (Mono<Connection>) Mono.from(ConnectionFactories.get(ob.build()).create())
                     .onErrorResume(exception -> {
-                        if (exception instanceof R2dbcPermissionDeniedException)
+                        if (exception instanceof R2dbcPermissionDeniedException) {
                             return Mono.error(new AppsmithPluginException(exception, AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR, exception));
+                        }
                         return Mono.error(new AppsmithPluginException(
                                 AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
                                 exception

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlErrorUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlErrorUtils.java
@@ -1,0 +1,74 @@
+package com.external.utils;
+
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.plugins.AppsmithPluginErrorUtils;
+import io.r2dbc.spi.R2dbcPermissionDeniedException;
+
+import java.io.Serializable;
+
+public class MySqlErrorUtils extends AppsmithPluginErrorUtils implements Serializable {
+
+    private static MySqlErrorUtils mySqlErrorUtils;
+
+    private MySqlErrorUtils () throws InstantiationException {
+        /**
+         * Prevention of creating any other new object by using constructor
+         */
+        if (mySqlErrorUtils != null)
+            throw new InstantiationException();
+    }
+
+    /**
+     * Prevention of creating any other new object by using clone
+     */
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+
+    /**
+     * Prevention of creating any other new object by using serialization
+     */
+    protected Object readResolve() throws InstantiationException {
+        return getInstance();
+    }
+
+    public static MySqlErrorUtils getInstance() throws InstantiationException {
+        if (mySqlErrorUtils == null) {
+            synchronized (MySqlErrorUtils.class) {
+                if (mySqlErrorUtils == null)
+                    mySqlErrorUtils = new MySqlErrorUtils();
+            }
+        }
+        return mySqlErrorUtils;
+    }
+
+
+    /**
+     * Extract small readable portion of error message from a larger less comprehensible error message.
+     * @param error - any error object
+     * @return readable error message
+     */
+    @Override
+    public String getReadableError(Throwable error) {
+        Throwable externalError;
+        if (error instanceof AppsmithPluginException) {
+            if (((AppsmithPluginException) error).getExternalError() == null)
+                return error.getMessage();
+            externalError = ((AppsmithPluginException) error).getExternalError();
+        }
+        else
+            externalError = error;
+        if (externalError instanceof R2dbcPermissionDeniedException) {
+            /**
+             * Extract small readable portion of error message from a larger less comprehensible error message of R2dbcPermissionDeniedException.
+             */
+            R2dbcPermissionDeniedException r2dbcPermissionDeniedException = (R2dbcPermissionDeniedException) externalError;
+            return r2dbcPermissionDeniedException
+                    .getMessage()
+                    .replaceAll("\\(|\\)", "")
+                    .trim() + ".";
+        }
+        return error.getMessage().split("\\.")[0].trim() + ".";
+    }
+}

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlErrorUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlErrorUtils.java
@@ -53,12 +53,14 @@ public class MySqlErrorUtils extends AppsmithPluginErrorUtils implements Seriali
     public String getReadableError(Throwable error) {
         Throwable externalError;
         if (error instanceof AppsmithPluginException) {
-            if (((AppsmithPluginException) error).getExternalError() == null)
+            if (((AppsmithPluginException) error).getExternalError() == null){
                 return error.getMessage();
+            }
             externalError = ((AppsmithPluginException) error).getExternalError();
         }
-        else
+        else {
             externalError = error;
+        }
         if (externalError instanceof R2dbcPermissionDeniedException) {
             /**
              * Extract small readable portion of error message from a larger less comprehensible error message of R2dbcPermissionDeniedException.

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlErrorUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlErrorUtils.java
@@ -61,6 +61,7 @@ public class MySqlErrorUtils extends AppsmithPluginErrorUtils implements Seriali
         else {
             externalError = error;
         }
+
         if (externalError instanceof R2dbcPermissionDeniedException) {
             /**
              * Extract small readable portion of error message from a larger less comprehensible error message of R2dbcPermissionDeniedException.

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/utils/MySqlErrorUtilsTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/utils/MySqlErrorUtilsTest.java
@@ -1,0 +1,25 @@
+package com.external.utils;
+
+import io.r2dbc.spi.R2dbcPermissionDeniedException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MySqlErrorUtilsTest {
+
+    private String errorMessage;
+
+    @Before
+    public void setUp() {
+        errorMessage = "Access denied for user 'mysql'@'172.17.0.1' (using password: NO)";
+    }
+
+    @Test
+    public void getReadableErrorForR2dbcPermissionDeniedException() throws InstantiationException {
+        R2dbcPermissionDeniedException r2dbcPermissionDeniedException = new R2dbcPermissionDeniedException(errorMessage);
+        String readableError = MySqlErrorUtils.getInstance().getReadableError(r2dbcPermissionDeniedException);
+        assertFalse(readableError == null);
+        assertEquals("Access denied for user 'mysql'@'172.17.0.1' using password: NO.", readableError);
+    }
+}


### PR DESCRIPTION
## Description

- Make MySql plugin's error more readable

Fixes #13977 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual
- JUnit TC

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes