### PR TITLE
fix: Redirection after login does not work for Google and Github

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
@@ -181,7 +181,7 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
         ServerWebExchange exchange = webFilterExchange.getExchange();
         String state = exchange.getRequest().getQueryParams().getFirst(Security.QUERY_PARAMETER_STATE);
         String redirectUrl = RedirectHelper.DEFAULT_REDIRECT_URL;
-        String prefix = Security.STATE_PARAMETER_ORIGIN + "=";
+        String prefix = Security.STATE_PARAMETER_ORIGIN;
         if (state != null && !state.isEmpty()) {
             String[] stateArray = state.split(",");
             for (String stateVar : stateArray) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
@@ -181,11 +181,10 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
         ServerWebExchange exchange = webFilterExchange.getExchange();
         String state = exchange.getRequest().getQueryParams().getFirst(Security.QUERY_PARAMETER_STATE);
         String redirectUrl = RedirectHelper.DEFAULT_REDIRECT_URL;
-        String prefix = Security.STATE_PARAMETER_ORIGIN;
         if (state != null && !state.isEmpty()) {
             String[] stateArray = state.split(",");
             for (String stateVar : stateArray) {
-                if (stateVar != null && stateVar.startsWith(prefix)) {
+                if (stateVar != null && stateVar.startsWith(Security.STATE_PARAMETER_ORIGIN)) {
                     // This is the origin of the request that we want to redirect to
                     redirectUrl = stateVar.split("=", 2)[1];
                 }


### PR DESCRIPTION
Security.STATE_PARAMETER_ORIGIN is already set to "origin="

## Description

When we open a private application url in incognito window ( where appsmith is not logged in) and log in via any Ouath (github/google)  mechanism, after successful authentication we will be redirected to Default "/applications" page instead of actual application 
## Fixes #9819

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

   Manually 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
