### PR TITLE
fix: Handle string datatype in api response

### DIFF
--- a/app/client/src/components/editorComponents/ApiResponseView.tsx
+++ b/app/client/src/components/editorComponents/ApiResponseView.tsx
@@ -340,7 +340,7 @@ function ApiResponseView(props: Props) {
         title: dataType.title,
         panelComponent: responseTabComponent(
           dataType.key,
-          response.body,
+          response?.body,
           tableBodyHeight,
         ),
       };
@@ -407,12 +407,12 @@ function ApiResponseView(props: Props) {
               </NoResponseContainer>
             ) : (
               <ResponseBodyContainer>
-                {isString(response.body) && isHtml(response.body) ? (
+                {isString(response?.body) && isHtml(response?.body) ? (
                   <ReadOnlyEditor
                     folding
                     height={"100%"}
                     input={{
-                      value: response.body,
+                      value: response?.body,
                     }}
                     isReadOnly
                   />
@@ -475,7 +475,7 @@ function ApiResponseView(props: Props) {
                 folding
                 height={"100%"}
                 input={{
-                  value: response.body
+                  value: response?.body
                     ? JSON.stringify(responseHeaders, null, 2)
                     : "",
                 }}
@@ -547,12 +547,12 @@ function ApiResponseView(props: Props) {
                   </Text>
                 </Flex>
               )}
-              {!isEmpty(response.body) && Array.isArray(response.body) && (
+              {!isEmpty(response?.body) && Array.isArray(response?.body) && (
                 <Flex>
                   <Text type={TextType.P3}>Result: </Text>
                   <Text type={TextType.H5}>
-                    {`${response.body.length} Record${
-                      response.body.length > 1 ? "s" : ""
+                    {`${response?.body.length} Record${
+                      response?.body.length > 1 ? "s" : ""
                     }`}
                   </Text>
                 </Flex>

--- a/app/client/src/pages/Editor/QueryEditor/Table.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/Table.tsx
@@ -13,7 +13,7 @@ import ErrorBoundary from "components/editorComponents/ErrorBoundry";
 import { CellWrapper } from "widgets/TableWidget/component/TableStyledWrappers";
 import AutoToolTipComponent from "widgets/TableWidget/component/AutoToolTipComponent";
 import { Theme } from "constants/DefaultTheme";
-import { uniqueId } from "lodash";
+import { isArray, uniqueId } from "lodash";
 
 interface TableProps {
   data: Record<string, any>[];
@@ -28,6 +28,10 @@ const TABLE_SIZES = {
   ROW_FONT_SIZE: 14,
   SCROLL_SIZE: 20,
 };
+
+const NoDataMessage = styled.span`
+  margin-left: 24px;
+`;
 
 export const TableWrapper = styled.div`
   width: 100%;
@@ -198,7 +202,7 @@ function Table(props: TableProps) {
   const data = React.useMemo(() => {
     const emptyString = "";
     /* Check for length greater than 0 of rows returned from the query for mappings keys */
-    if (props.data?.length > 0) {
+    if (isArray(props.data)) {
       const keys = Object.keys(props.data[0]);
       keys.forEach((key) => {
         if (key === emptyString) {
@@ -286,7 +290,11 @@ function Table(props: TableProps) {
   );
 
   if (rows.length === 0 || headerGroups.length === 0)
-    return <span>No data records to show</span>;
+    return (
+      <NoDataMessage data-testid="no-data-table-message">
+        No data records to show
+      </NoDataMessage>
+    );
 
   return (
     <ErrorBoundary>


### PR DESCRIPTION
## Description

> When a response to an API is string for TABLE datatype, app crashes. 


Fixes #14242

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
