### PR TITLE
chore: Run perf tests only on buildjet machine

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -1302,11 +1302,7 @@ jobs:
     needs: [build, server-build]
     # Only run if the build step is successful
     if: success()
-    strategy:
-      fail-fast: false
-      matrix:
-        machine: [ubuntu-latest,buildjet-4vcpu-ubuntu-2004]
-    runs-on: ${{ matrix.machine }}
+    runs-on: buildjet-4vcpu-ubuntu-2004
     defaults:
       run:
         working-directory: app/client


### PR DESCRIPTION
## Description
We ran performance tests on machine provided by github and buldjet machine for a while to see how they perform. 

We have seen a lot of deviation in runs done on github making the data useless. With this PR we no longer run the tests on github machine.

Fixes #14301

## Type of change
CI related, no impact on users.

## How Has This Been Tested?

Will be tested after merge.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
