### PR TITLE
fix: crash due to evalMetaUpdate

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -71,7 +71,7 @@ import {
   SNIPPET_EXECUTION_SUCCESS,
 } from "@appsmith/constants/messages";
 import { validate } from "workers/validations";
-import { diff, Diff } from "deep-diff";
+import { diff } from "deep-diff";
 import { REPLAY_DELAY } from "entities/Replay/replayUtils";
 import { EvaluationVersion } from "api/ApplicationApi";
 import { makeUpdateJSCollection } from "sagas/JSPaneSagas";
@@ -125,22 +125,22 @@ function* evaluateTreeSaga(
 
   const {
     dataTree,
-    dependencies = {},
-    errors = [],
+    dependencies,
+    errors,
     evalMetaUpdates = [],
-    evaluationOrder = [],
-    jsUpdates = {},
-    logs = [],
-    unEvalUpdates = [],
+    evaluationOrder,
+    jsUpdates,
+    logs,
+    unEvalUpdates,
   }: {
-    dataTree?: DataTree;
-    dependencies?: Record<string, string[]>;
-    errors?: EvalError[];
-    evalMetaUpdates?: EvalMetaUpdates;
-    evaluationOrder?: string[];
-    jsUpdates?: Record<string, JSUpdate>;
-    logs?: any[];
-    unEvalUpdates?: DataTreeDiff[];
+    dataTree: DataTree;
+    dependencies: Record<string, string[]>;
+    errors: EvalError[];
+    evalMetaUpdates: EvalMetaUpdates;
+    evaluationOrder: string[];
+    jsUpdates: Record<string, JSUpdate>;
+    logs: any[];
+    unEvalUpdates: DataTreeDiff[];
   } = workerResponse;
   PerformanceTracker.stopAsyncTracking(
     PerformanceTransactionName.DATA_TREE_EVALUATION,
@@ -148,19 +148,16 @@ function* evaluateTreeSaga(
   PerformanceTracker.startAsyncTracking(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
-  const oldDataTree: DataTree = yield select(getDataTree);
+  const oldDataTree = yield select(getDataTree);
 
-  const updates = (diff(oldDataTree, dataTree) || []) as Diff<
-    DataTree,
-    DataTree
-  >[];
+  const updates = diff(oldDataTree, dataTree) || [];
 
   yield put(setEvaluatedTree(updates));
   PerformanceTracker.stopAsyncTracking(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
   // if evalMetaUpdates are present only then dispatch updateMetaState
-  if (evalMetaUpdates && evalMetaUpdates.length) {
+  if (evalMetaUpdates.length) {
     yield put(updateMetaState(evalMetaUpdates));
   }
   log.debug({ evalMetaUpdates });

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -127,7 +127,7 @@ function* evaluateTreeSaga(
     dataTree,
     dependencies,
     errors,
-    evalMetaUpdates,
+    evalMetaUpdates = [],
     evaluationOrder,
     jsUpdates,
     logs,
@@ -136,7 +136,7 @@ function* evaluateTreeSaga(
     dataTree: DataTree;
     dependencies: Record<string, string[]>;
     errors: EvalError[];
-    evalMetaUpdates: EvalMetaUpdates;
+    evalMetaUpdates?: EvalMetaUpdates;
     evaluationOrder: string[];
     jsUpdates: Record<string, JSUpdate>;
     logs: any[];
@@ -157,7 +157,7 @@ function* evaluateTreeSaga(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
   // if evalMetaUpdates are present only then dispatch updateMetaState
-  if (evalMetaUpdates.length) {
+  if (evalMetaUpdates && evalMetaUpdates.length) {
     yield put(updateMetaState(evalMetaUpdates));
   }
   log.debug({ evalMetaUpdates });

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -71,7 +71,7 @@ import {
   SNIPPET_EXECUTION_SUCCESS,
 } from "@appsmith/constants/messages";
 import { validate } from "workers/validations";
-import { diff } from "deep-diff";
+import { diff, Diff } from "deep-diff";
 import { REPLAY_DELAY } from "entities/Replay/replayUtils";
 import { EvaluationVersion } from "api/ApplicationApi";
 import { makeUpdateJSCollection } from "sagas/JSPaneSagas";
@@ -125,22 +125,22 @@ function* evaluateTreeSaga(
 
   const {
     dataTree,
-    dependencies,
-    errors,
+    dependencies = {},
+    errors = [],
     evalMetaUpdates = [],
-    evaluationOrder,
-    jsUpdates,
-    logs,
-    unEvalUpdates,
+    evaluationOrder = [],
+    jsUpdates = {},
+    logs = [],
+    unEvalUpdates = [],
   }: {
-    dataTree: DataTree;
-    dependencies: Record<string, string[]>;
-    errors: EvalError[];
+    dataTree?: DataTree;
+    dependencies?: Record<string, string[]>;
+    errors?: EvalError[];
     evalMetaUpdates?: EvalMetaUpdates;
-    evaluationOrder: string[];
-    jsUpdates: Record<string, JSUpdate>;
-    logs: any[];
-    unEvalUpdates: DataTreeDiff[];
+    evaluationOrder?: string[];
+    jsUpdates?: Record<string, JSUpdate>;
+    logs?: any[];
+    unEvalUpdates?: DataTreeDiff[];
   } = workerResponse;
   PerformanceTracker.stopAsyncTracking(
     PerformanceTransactionName.DATA_TREE_EVALUATION,
@@ -148,9 +148,12 @@ function* evaluateTreeSaga(
   PerformanceTracker.startAsyncTracking(
     PerformanceTransactionName.SET_EVALUATED_TREE,
   );
-  const oldDataTree = yield select(getDataTree);
+  const oldDataTree: DataTree = yield select(getDataTree);
 
-  const updates = diff(oldDataTree, dataTree) || [];
+  const updates = (diff(oldDataTree, dataTree) || []) as Diff<
+    DataTree,
+    DataTree
+  >[];
 
   yield put(setEvaluatedTree(updates));
   PerformanceTracker.stopAsyncTracking(

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -149,7 +149,6 @@ ctx.addEventListener(
             evaluationOrder = dataTreeEvaluator.sortedDependencies;
             dataTree = dataTreeResponse.evalTree;
             jsUpdates = dataTreeResponse.jsUpdates;
-            evalMetaUpdates = dataTreeResponse.evalMetaUpdates;
             dataTree = dataTree && JSON.parse(JSON.stringify(dataTree));
           } else {
             if (dataTreeEvaluator && !isEmpty(allActionValidationConfig)) {

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -165,7 +165,11 @@ ctx.addEventListener(
             unEvalUpdates = updateResponse.unEvalUpdates;
             dataTree = JSON.parse(JSON.stringify(dataTreeEvaluator.evalTree));
             jsUpdates = updateResponse.jsUpdates;
-            evalMetaUpdates = updateResponse.evalMetaUpdates;
+            // evalMetaUpdates can have moment object as value which will cause DataCloneError
+            // hence, stringify and parse to avoid such errors
+            evalMetaUpdates = JSON.parse(
+              JSON.stringify(updateResponse.evalMetaUpdates),
+            );
           }
           dependencies = dataTreeEvaluator.inverseDependencyMap;
           errors = dataTreeEvaluator.errors;


### PR DESCRIPTION
## Description

### Why did we see a crash in JS?
`evalMetaUpdates` was undefined, we tried using `evalMetaUpdates.length`.  

<img width="558" alt="Screenshot 2022-06-06 at 7 07 38 PM" src="https://user-images.githubusercontent.com/23132741/172171862-0873d7a9-a752-48e6-9a95-aed5a87b62c2.png">

- It was noticed that when we have dataCloneError, in that case, workerResponse become
```
workerResponse = { errors: [{context: "someJSON", message:"error message"}]
```
Here,  `evalMetaUpdates` is undefined in `evaluateTreeSaga` and hence the crash as we use `evalMetaUpdates.length`.

## Root cause of DataCloneError

- `evalMetaUpdates` has a moment object in the given application, this leads to DataCloneError.

<img width="1237" alt="Screenshot 2022-06-06 at 9 32 09 PM" src="https://user-images.githubusercontent.com/23132741/172204052-c24d6dbe-07f8-4eb0-b333-c62c4808ddcc.png">

### Solution 

- We stringify and parse evalMetaUpdates to avoid `DataCloneError`
- We set a default value as `[]` to `evalMetaUpdates` in `evaluateTreeSaga` 


Fixes #14299


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually

### Jest
Test will be added in separate PR 
- [ ] Add evaluateTreeSaga test to handle 
      -  DataCloneError case
      -  Normal success case

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
