### PR TITLE
fix: list copy - update dynamic trigger path list names

### DIFF
--- a/app/client/src/sagas/WidgetOperationUtils.test.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.test.ts
@@ -222,6 +222,57 @@ describe("WidgetOperationSaga", () => {
     );
   });
 
+  it("handleSpecificCasesWhilePasting should rename dynamicTriggerPathList template keys for a copied list widget", async () => {
+    const result = handleSpecificCasesWhilePasting(
+      {
+        widgetId: "list2",
+        type: "LIST_WIDGET",
+        widgetName: "List2",
+        parentId: "0",
+        renderMode: "CANVAS",
+        parentColumnSpace: 2,
+        parentRowSpace: 3,
+        leftColumn: 2,
+        rightColumn: 3,
+        topRow: 1,
+        bottomRow: 3,
+        isLoading: false,
+        listData: [],
+        version: 16,
+        disablePropertyPane: false,
+        template: {
+          Image1: {
+            widgetId: "image1",
+            type: "Image_WIDGET",
+            widgetName: "Image1",
+            parentId: "list2",
+            renderMode: "CANVAS",
+            parentColumnSpace: 2,
+            parentRowSpace: 3,
+            leftColumn: 2,
+            rightColumn: 3,
+            topRow: 1,
+            bottomRow: 3,
+            isLoading: false,
+            listData: [],
+            version: 16,
+            disablePropertyPane: false,
+            dynamicTriggerPathList: [{ key: "onClick" }],
+          },
+        },
+        dynamicTriggerPathList: [{ key: "template.Image1.onClick" }],
+      },
+      {},
+      {
+        Image1: "Image1Copy",
+      },
+      [],
+    );
+    expect(get(result, "list2.dynamicTriggerPathList.0.key")).toStrictEqual(
+      "template.Image1Copy.onClick",
+    );
+  });
+
   it("should return correct close modal reference name after executing handleSpecificCasesWhilePasting", async () => {
     const result = handleSpecificCasesWhilePasting(
       {

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -223,6 +223,22 @@ export const handleSpecificCasesWhilePasting = (
           return path;
         },
       );
+
+      // updating dynamicTriggerPath in copied widget if the copied widge thas reference to oldWidgetNames
+      widget.dynamicTriggerPathList = (widget.dynamicTriggerPathList || []).map(
+        (path: any) => {
+          if (path.key.startsWith(`template.${oldWidgetName}`)) {
+            return {
+              key: path.key.replace(
+                `template.${oldWidgetName}`,
+                `template.${newWidgetName}`,
+              ),
+            };
+          }
+
+          return path;
+        },
+      );
     });
 
     widgets[widget.widgetId] = widget;

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -208,7 +208,7 @@ export const handleSpecificCasesWhilePasting = (
         }
       }
 
-      // updating dynamicBindingPath in copied widget if the copied widge thas reference to oldWidgetNames
+      // updating dynamicBindingPath in copied widget if the copied widget thas reference to oldWidgetNames
       widget.dynamicBindingPathList = (widget.dynamicBindingPathList || []).map(
         (path: any) => {
           if (path.key.startsWith(`template.${oldWidgetName}`)) {
@@ -224,7 +224,7 @@ export const handleSpecificCasesWhilePasting = (
         },
       );
 
-      // updating dynamicTriggerPath in copied widget if the copied widge thas reference to oldWidgetNames
+      // updating dynamicTriggerPath in copied widget if the copied widget thas reference to oldWidgetNames
       widget.dynamicTriggerPathList = (widget.dynamicTriggerPathList || []).map(
         (path: any) => {
           if (path.key.startsWith(`template.${oldWidgetName}`)) {


### PR DESCRIPTION
## Description
List widget:
Update `dynamicTriggerPathList` with new widget names upon copying.

Fixes #14028

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Unit test
- [Repro steps](https://github.com/appsmithorg/appsmith/issues/14028#issuecomment-1147268849) manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
