### PR TITLE
fix: updated css clash with tree select

### DIFF
--- a/app/client/src/widgets/MultiSelectTreeWidget/component/index.styled.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/component/index.styled.tsx
@@ -380,8 +380,9 @@ border: 1px solid #E8E8E8;
     top: 7px;
     left: 3px;
     right: 3px;
-    background-color: ${Colors.WHITE};
+    background-color: ${Colors.WHITE} !important;
     position: absolute;
+    transform: unset;
   }
 }
 


### PR DESCRIPTION

## Description


> Update CSS in MultiSelectTree Widget and it fixed the issue of the Header node checkbox of a MultiTreeSelect widget does not display properly on hovering


Fixes #14026

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
