### PR TITLE
fix: App canvas is stuck in loading state ( Desktop Layout ) 

### DIFF
--- a/app/client/src/utils/hooks/useDynamicAppLayout.tsx
+++ b/app/client/src/utils/hooks/useDynamicAppLayout.tsx
@@ -136,7 +136,7 @@ export const useDynamicAppLayout = () => {
     const calculatedWidth = calculateCanvasWidth();
     const { width: rightColumn } = mainCanvasProps || {};
 
-    if (rightColumn !== calculatedWidth) {
+    if (rightColumn !== calculatedWidth || !isCanvasInitialized) {
       dispatch(
         updateCanvasLayoutAction(calculatedWidth, mainCanvasProps?.height),
       );


### PR DESCRIPTION
this PR fixes the following bug:
> [This](https://release.app.appsmith.com/app/earworm/home-6219207a0276eb01d22fec5e/edit) app is stuck in a loading state and I'm unable to edit the app. The app can be viewed in view mode though

Fixes #14381

## Type of change
- Bug fix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
