### PR TITLE
fix: Fix okhttp dependency

### DIFF
--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <scope>test</scope>
+            <version>3.14.9</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
Fix release server image not coming up due to the following error:

```
java.lang.ClassNotFoundException: okhttp3.OkHttpClient$Builder
```
