### PR TITLE
fix: Toast shows wrong theme name when changing themes

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/CRUD_JSONForm/Postgres_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/CRUD_JSONForm/Postgres_Spec.ts
@@ -456,7 +456,7 @@ describe("Validate Postgres Generate CRUD with JSON Form", () => {
     agHelper.GetNClick(dataSources._refreshIcon);
 
     //Store Address deletion remains
-    table.ReadTableRowColumnData(7, 3, 200).then(($cellData) => {
+    table.ReadTableRowColumnData(7, 3, 2000).then(($cellData) => {
       expect($cellData).to.eq("");
     });
     table.ReadTableRowColumnData(7, 4, 200).then(($cellData) => {

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -69,11 +69,11 @@ export class PropertyPane {
   public ChangeTheme(newTheme: string) {
     this.agHelper.GetNClick(this._changeThemeBtn, 0, true);
     this.agHelper.GetNClick(this._themeCard(newTheme));
-    this.agHelper.ValidateToastMessage("Theme " + (newTheme == "Modern" ? "Default" : newTheme) + " Applied");
+    this.agHelper.ValidateToastMessage("Theme " + newTheme + " Applied");
   }
 
   public GetJSONFormConfigurationFileds() {
-    let fieldNames: string[] = [];
+    const fieldNames: string[] = [];
     let fieldInvokeValue: string;
     cy.xpath(this._jsonFieldConfigList).each(function($item) {
       cy.wrap($item)

--- a/app/client/src/sagas/AppThemingSaga.tsx
+++ b/app/client/src/sagas/AppThemingSaga.tsx
@@ -167,7 +167,7 @@ export function* changeSelectedTheme(
 
     // shows toast
     Toaster.show({
-      text: createMessage(CHANGE_APP_THEME, theme.name),
+      text: createMessage(CHANGE_APP_THEME, theme.displayName),
       variant: Variant.success,
       actionElement: (
         <span onClick={() => store.dispatch(undoAction())}>Undo</span>


### PR DESCRIPTION

## Description
When we change to modern, the toast shows Theme default applied.. It should have been Theme Modern applied. This PR fixes this.

Fixes #14487 

## Type of change
- Bug fix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
