### PR TITLE
fix: Proxy arguments so that they are not set when empty

### DIFF
--- a/deploy/docker/scripts/run-java.sh
+++ b/deploy/docker/scripts/run-java.sh
@@ -3,20 +3,19 @@
 set -o errexit
 set -o pipefail
 set -o nounset
+set -o noglob
 
-http_proxy_host=""
-http_proxy_port=""
-https_proxy_host=""
-https_proxy_port=""
+declare -a proxy_args
+proxy_configured=0
 
-if [[ ${HTTP_PROXY-} =~ ^http://(.*):(.*)$ ]]; then
-  http_proxy_host="${BASH_REMATCH[1]}"
-  http_proxy_port="${BASH_REMATCH[2]}"
+if [[ ${HTTP_PROXY-} =~ ^http://(.*):(.*)$ && ${BASH_REMATCH[2]} != 0 ]]; then
+  proxy_args+=(-Dhttp.proxyHost="${BASH_REMATCH[1]}" -Dhttp.proxyPort="${BASH_REMATCH[2]}")
+  proxy_configured=1
 fi
 
-if [[ ${HTTPS_PROXY-} =~ ^http://(.*):(.*)$ ]]; then
-  https_proxy_host="${BASH_REMATCH[1]}"
-  https_proxy_port="${BASH_REMATCH[2]}"
+if [[ ${HTTPS_PROXY-} =~ ^http://(.*):(.*)$ && ${BASH_REMATCH[2]} != 0 ]]; then
+  proxy_args+=(-Dhttps.proxyHost="${BASH_REMATCH[1]}" -Dhttps.proxyPort="${BASH_REMATCH[2]}")
+  proxy_configured=1
 fi
 
 if ! isset NO_PROXY; then
@@ -24,15 +23,14 @@ if ! isset NO_PROXY; then
   NO_PROXY=""
 fi
 
+if [[ $proxy_configured == 1 ]]; then
+  proxy_args+=(-Djava.net.useSystemProxies=true -Dhttp.nonProxyHosts="${NO_PROXY/,/|}")
+fi
+
 # Ref -Dlog4j2.formatMsgNoLookups=true https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot
 exec java ${APPSMITH_JAVA_ARGS:-} ${APPSMITH_JAVA_HEAP_ARG:-} \
   -Dserver.port=8080 \
   -Djava.security.egd=file:/dev/./urandom \
   -Dlog4j2.formatMsgNoLookups=true \
-  -Djava.net.useSystemProxies=true \
-  -Dhttp.proxyHost="$http_proxy_host" \
-  -Dhttp.proxyPort="$http_proxy_port" \
-  -Dhttps.proxyHost="$https_proxy_host" \
-  -Dhttps.proxyPort="$https_proxy_port" \
-  -Dhttp.nonProxyHosts="${NO_PROXY/,/|}" \
+  "${proxy_args[@]}" \
   -jar server.jar


### PR DESCRIPTION
Fixes #14391.

Fixes by ensuring that the proxy arguments are not passed to the backend server when they are empty.

To test, launch Appsmith with the following command:

```sh
docker run --name ace -p 8001:80 -d -v ~/stacks:/appsmith-stacks --pull always appsmith/appsmith-ce:release
```

Create a DynamoDB datasource and test it, ensure that it works.

As a second test, launch a proxy with `mitmweb --listen-port 9020 --web-port 9021` after installing `brew install mitmproxy`, and launch Appsmith with the following:

```sh
docker run --name ace -p 8001:80 -d -v ~/stacks:/appsmith-stacks -e HTTP_PROXY=http://host.docker.internal:9020 -e HTTPS_PROXY=https://host.docker.internal:9020 --pull always appsmith/appsmith-ce:release
```

Create a DynamoDB datasource and "Test" it. Ensure that it works. You should also see the DynamoDB requests in the proxy UI.
