### PR TITLE
fix: dont show import modal unexpectedly

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/GitConnection.tsx
@@ -385,6 +385,7 @@ function GitConnection({ isImport }: Props) {
     return () => {
       dispatch(remoteUrlInputValue({ tempRemoteUrl: "" }));
       dispatch(resetSSHKeys());
+      dispatch(setIsGitSyncModalOpen({ isOpen: false }));
     };
   }, []);
 


### PR DESCRIPTION
## Description

Fixes the reported issue. One reset call was missing from git connection component.

Fixes #14507 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
