### PR TITLE
fix: disable branch dropdown until merge status returns

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/Merge.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Merge.tsx
@@ -235,6 +235,7 @@ export default function Merge() {
         <Dropdown
           className={Classes.MERGE_DROPDOWN}
           containerClassName={"t--merge-branch-dropdown-destination"}
+          disabled={isFetchingBranches || isFetchingMergeStatus || isMerging}
           dropdownMaxHeight={DROPDOWNMENU_MAXHEIGHT}
           enableSearch
           fillOptions


### PR DESCRIPTION
## Description

Disable branch drop down until mergeStatus call returns.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
