### PR TITLE
fix: show js function execution errors in debugger

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -11,7 +11,7 @@ const jsEditor = ObjectsRegistry.JSEditor,
 let onPageLoadAndConfirmExecuteFunctionsLength: number,
   getJSObject: any,
   functionsLength: number,
-  jsObj: any;
+  jsObj: string;
 
 describe("JS Function Execution", function() {
   interface IFunctionSettingData {
@@ -458,7 +458,7 @@ describe("JS Function Execution", function() {
       agHelper.Sleep();
     }
 
-    ee.SelectEntityByName(jsObj as string, "QUERIES/JS");
+    ee.SelectEntityByName(jsObj, "QUERIES/JS");
 
     agHelper.GetNClick(jsEditor._settingsTab);
     assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -239,6 +239,8 @@ describe("JS Function Execution", function() {
       "TypeError: Cannot read properties of undefined (reading 'name')",
     ).should("not.exist");
 
+    // Switch back to response tab
+    agHelper.GetNClick(locator._responseTab);
     // Re-introduce parse errors
     jsEditor.EditJSObj(JS_OBJECT_WITH_PARSE_ERROR);
     agHelper.GetNClick(jsEditor._runButton);

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -242,6 +242,8 @@ describe("JS Function Execution", function() {
     // Re-introduce parse errors
     jsEditor.EditJSObj(JS_OBJECT_WITH_PARSE_ERROR);
     agHelper.GetNClick(jsEditor._runButton);
+    // Assert that there is a function execution parse error
+    jsEditor.AssertParseError(true, true);
 
     // Delete function
     jsEditor.EditJSObj(JS_OBJECT_WITH_DELETED_FUNCTION);

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -37,6 +37,7 @@ export class CommonLocators {
     _uploadBtn = "button.uppy-StatusBar-actionBtn--upload"
     _debuggerIcon = ".t--debugger svg"
     _errorTab = "[data-cy=t--tab-ERROR]"
+    _responseTab = "[data-cy=t--tab-response]"
     _debugErrorMsg = ".t--debugger-message"
     _debuggerLabel = "span.debugger-label"
     _modal = ".t--modal-widget"

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -81,6 +81,7 @@ export class JSEditor {
   _getJSFunctionSettingsId = (JSFunctionName: string) =>
     `${JSFunctionName}-settings`;
   _asyncJSFunctionSettings = `.t--async-js-function-settings`;
+  _debugCTA = `button.js-editor-debug-cta`;
   //#endregion
 
   //#region constants

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -228,7 +228,10 @@ function JSResponseView(props: Props) {
                 fill
                 label={
                   <FailedMessage>
-                    <DebugButton onClick={onDebugClick} />
+                    <DebugButton
+                      className="js-editor-debug-cta"
+                      onClick={onDebugClick}
+                    />
                   </FailedMessage>
                 }
                 text={

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -199,7 +199,6 @@ function JSResponseView(props: Props) {
     });
     dispatch(setCurrentTab(DEBUGGER_TAB_KEYS.ERROR_TAB));
   }, []);
-
   useEffect(() => {
     setResponseStatus(
       getJSResponseViewState(

--- a/app/client/src/components/editorComponents/JSResponseView.tsx
+++ b/app/client/src/components/editorComponents/JSResponseView.tsx
@@ -212,7 +212,7 @@ function JSResponseView(props: Props) {
   }, [responses, isExecuting, currentFunction, isSaving, isDirty]);
   const tabs = [
     {
-      key: "body",
+      key: "response",
       title: "Response",
       panelComponent: (
         <>

--- a/app/client/src/entities/AppsmithConsole/index.ts
+++ b/app/client/src/entities/AppsmithConsole/index.ts
@@ -11,6 +11,7 @@ export enum ENTITY_TYPE {
 
 export enum PLATFORM_ERROR {
   PLUGIN_EXECUTION = "PLUGIN_EXECUTION",
+  JS_EXECUTION = "JS_EXECUTION",
 }
 
 export type ErrorType = PropertyEvaluationErrorType | PLATFORM_ERROR;

--- a/app/client/src/entities/AppsmithConsole/index.ts
+++ b/app/client/src/entities/AppsmithConsole/index.ts
@@ -11,7 +11,7 @@ export enum ENTITY_TYPE {
 
 export enum PLATFORM_ERROR {
   PLUGIN_EXECUTION = "PLUGIN_EXECUTION",
-  JS_EXECUTION = "JS_EXECUTION",
+  JS_FUNCTION_EXECUTION = "JS_FUNCTION_EXECUTION",
 }
 
 export type ErrorType = PropertyEvaluationErrorType | PLATFORM_ERROR;

--- a/app/client/src/sagas/DebuggerSagas.ts
+++ b/app/client/src/sagas/DebuggerSagas.ts
@@ -314,6 +314,7 @@ function* logDebuggerErrorAnalyticsSaga(
         getJSCollection,
         payload.entityId,
       );
+      if (!action) return;
       const plugin: Plugin = yield select(getPlugin, action.pluginId);
       const pluginName = plugin?.name?.replace(/ /g, "");
 

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -47,6 +47,7 @@ import {
 } from "actions/evaluationActions";
 import {
   evalErrorHandler,
+  handleJSFunctionExecutionErrorLog,
   logSuccessfulBindings,
   postEvalActionDispatcher,
   updateTernDefinitions,
@@ -345,7 +346,11 @@ export function* clearEvalCache() {
   return true;
 }
 
-export function* executeFunction(collectionName: string, action: JSAction) {
+export function* executeFunction(
+  collectionName: string,
+  action: JSAction,
+  collectionId: string,
+) {
   const functionCall = `${collectionName}.${action.name}()`;
   const { isAsync } = action.actionConfiguration;
   let response: {
@@ -376,7 +381,13 @@ export function* executeFunction(collectionName: string, action: JSAction) {
   const { errors, result } = response;
   const isDirty = !!errors.length;
 
-  yield call(evalErrorHandler, errors);
+  yield call(
+    handleJSFunctionExecutionErrorLog,
+    collectionId,
+    collectionName,
+    action,
+    errors,
+  );
   return { result, isDirty };
 }
 
@@ -678,4 +689,18 @@ export default function* evaluationSagaListeners() {
       Sentry.captureException(e);
     }
   }
+}
+function* collectionId(
+  handleJSFunctionExecutionErrorLog: (
+    collectionId: string,
+    collectionName: string,
+    action: JSAction,
+    errors: any[],
+  ) => Generator<never, void, unknown>,
+  collectionId: any,
+  collectionName: string,
+  action: JSAction,
+  errors: any[],
+) {
+  throw new Error("Function not implemented.");
 }

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -690,17 +690,3 @@ export default function* evaluationSagaListeners() {
     }
   }
 }
-function* collectionId(
-  handleJSFunctionExecutionErrorLog: (
-    collectionId: string,
-    collectionName: string,
-    action: JSAction,
-    errors: any[],
-  ) => Generator<never, void, unknown>,
-  collectionId: any,
-  collectionName: string,
-  action: JSAction,
-  errors: any[],
-) {
-  throw new Error("Function not implemented.");
-}

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -272,7 +272,7 @@ function* updateJSCollection(data: {
           );
           // delete all execution error logs for deletedActions if present
           deletedActions.forEach((action) =>
-            AppsmithConsole.deleteError(`${jsCollection.id + action.id}`),
+            AppsmithConsole.deleteError(`${jsCollection.id}-${action.id}`),
           );
         }
 

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -270,6 +270,10 @@ function* updateJSCollection(data: {
             jsCollection,
             createMessage(JS_FUNCTION_DELETE_SUCCESS),
           );
+          // delete all execution error logs for deletedActions if present
+          deletedActions.forEach((action) =>
+            AppsmithConsole.deleteError(`${jsCollection.id + action.id}`),
+          );
         }
 
         yield put(

--- a/app/client/src/sagas/JSPaneSagas.ts
+++ b/app/client/src/sagas/JSPaneSagas.ts
@@ -353,6 +353,7 @@ export function* handleExecuteJSFunctionSaga(data: {
       executeFunction,
       collectionName,
       action,
+      collectionId,
     );
     yield put({
       type: ReduxActionTypes.EXECUTE_JS_FUNCTION_SUCCESS,

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -1,4 +1,9 @@
-import { ENTITY_TYPE, Log, Severity } from "entities/AppsmithConsole";
+import {
+  ENTITY_TYPE,
+  Log,
+  PLATFORM_ERROR,
+  Severity,
+} from "entities/AppsmithConsole";
 import { DataTree } from "entities/DataTree/dataTreeFactory";
 import {
   DataTreeDiff,
@@ -31,6 +36,7 @@ import {
   ERROR_EVAL_ERROR_GENERIC,
   JS_OBJECT_BODY_INVALID,
   VALUE_IS_INVALID,
+  JS_EXECUTION_FAILURE,
 } from "@appsmith/constants/messages";
 import log from "loglevel";
 import { AppState } from "reducers";
@@ -40,6 +46,7 @@ import { dataTreeTypeDefCreator } from "utils/autocomplete/dataTreeTypeDefCreato
 import TernServer from "utils/autocomplete/TernServer";
 import { selectFeatureFlags } from "selectors/usersSelectors";
 import FeatureFlags from "entities/FeatureFlags";
+import { JSAction } from "entities/JSCollection";
 
 const getDebuggerErrors = (state: AppState) => state.ui.debugger.errors;
 /**
@@ -383,4 +390,32 @@ export function* updateTernDefinitions(
     log.debug("Tern", { updates });
     log.debug("Tern definitions updated took ", (end - start).toFixed(2));
   }
+}
+
+export function* handleJSFunctionExecutionErrorLog(
+  collectionId: string,
+  collectionName: string,
+  action: JSAction,
+  errors: any[],
+) {
+  errors.length
+    ? AppsmithConsole.addError({
+        id: `${collectionId + action.id}`,
+        logType: LOG_TYPE.EVAL_ERROR,
+        text: `${createMessage(JS_EXECUTION_FAILURE)}: ${collectionName}.${
+          action.name
+        }`,
+        messages: errors.map((error) => ({
+          message: error.errorMessage || error.message,
+          type: PLATFORM_ERROR.JS_EXECUTION,
+          subType: error.errorType,
+        })),
+        source: {
+          id: action.id,
+          name: `${collectionName}.${action.name}`,
+          type: ENTITY_TYPE.JSACTION,
+          propertyPath: `${collectionName}.${action.name}`,
+        },
+      })
+    : AppsmithConsole.deleteError(`${collectionId + action.id}`);
 }

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -400,14 +400,14 @@ export function* handleJSFunctionExecutionErrorLog(
 ) {
   errors.length
     ? AppsmithConsole.addError({
-        id: `${collectionId + action.id}`,
+        id: `${collectionId}-${action.id}`,
         logType: LOG_TYPE.EVAL_ERROR,
         text: `${createMessage(JS_EXECUTION_FAILURE)}: ${collectionName}.${
           action.name
         }`,
         messages: errors.map((error) => ({
           message: error.errorMessage || error.message,
-          type: PLATFORM_ERROR.JS_EXECUTION,
+          type: PLATFORM_ERROR.JS_FUNCTION_EXECUTION,
           subType: error.errorType,
         })),
         source: {
@@ -417,5 +417,5 @@ export function* handleJSFunctionExecutionErrorLog(
           propertyPath: `${collectionName}.${action.name}`,
         },
       })
-    : AppsmithConsole.deleteError(`${collectionId + action.id}`);
+    : AppsmithConsole.deleteError(`${collectionId}-${action.id}`);
 }

--- a/app/client/src/workers/evaluate.ts
+++ b/app/client/src/workers/evaluate.ts
@@ -404,12 +404,17 @@ export function isFunctionAsync(
     });
     try {
       if (typeof userFunction === "function") {
-        const returnValue = userFunction();
-        if (!!returnValue && returnValue instanceof Promise) {
+        if (userFunction.constructor.name === "AsyncFunction") {
+          // functions declared with an async keyword
           self.IS_ASYNC = true;
-        }
-        if (self.TRIGGER_COLLECTOR.length) {
-          self.IS_ASYNC = true;
+        } else {
+          const returnValue = userFunction();
+          if (!!returnValue && returnValue instanceof Promise) {
+            self.IS_ASYNC = true;
+          }
+          if (self.TRIGGER_COLLECTOR.length) {
+            self.IS_ASYNC = true;
+          }
         }
       }
     } catch (e) {

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -66,7 +66,7 @@ function messageEventListener(
               errors: [
                 {
                   type: EvalErrorTypes.CLONE_ERROR,
-                  message: e.message,
+                  message: (e as Error)?.message,
                   context: JSON.stringify(rest),
                 },
               ],

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -66,7 +66,7 @@ function messageEventListener(
               errors: [
                 {
                   type: EvalErrorTypes.CLONE_ERROR,
-                  message: e,
+                  message: e.message,
                   context: JSON.stringify(rest),
                 },
               ],


### PR DESCRIPTION
## Description

This PR introduces js function execution errors in the debugger. These errors behave in the same way as those of Apis

They get removed when

- [x] The function gets deleted

- [x] Cause of error is fixed and function is re-run

- [x] JS Object is deleted


Fixes #14503 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Cypress tests

### Test Plan
- [x] [[Test Case]: verify, errors appears in debugger of JS editor when a JS object is in error state](https://github.com/appsmithorg/TestSmith/issues/1895)
- [ ] [[Test Case]: verify, errors appears in browser console when a JS object is in error state](https://github.com/appsmithorg/TestSmith/issues/1896) (Manual)
- [ ] [[Test Case]: verify, errors appears in debugger pane of JS editor and browser console](https://github.com/appsmithorg/TestSmith/issues/1897). (Manual)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
