### PR TITLE
feature: GraphQL pagination server side support

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
@@ -9,9 +9,10 @@ import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.Property;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import net.minidev.json.JSONObject;
+import org.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
+import org.json.JSONException;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -312,9 +313,8 @@ public class PluginUtils {
         return getValueSafelyFromPropertyList(properties, index, Object.class);
     }
 
-    public static JSONObject parseStringIntoJSONObject(String body) throws ParseException {
-        JSONParser parser = new JSONParser(MODE_PERMISSIVE);
-        return parser.parse(body, JSONObject.class);
+    public static JSONObject parseStringIntoJSONObject(String body) throws JSONException {
+        return new JSONObject(body);
     }
 
     public static void setValueSafelyInPropertyList(List<Property> properties, int index, Object value) throws AppsmithPluginException {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
@@ -314,7 +314,7 @@ public class PluginUtils {
 
     public static JSONObject parseStringIntoJSONObject(String body) throws ParseException {
         JSONParser parser = new JSONParser(MODE_PERMISSIVE);
-        return (JSONObject) parser.parse(body);
+        return parser.parse(body, JSONObject.class);
     }
 
     public static void setValueSafelyInPropertyList(List<Property> properties, int index, Object value) throws AppsmithPluginException {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -46,7 +46,6 @@ public class DataUtils {
 
     public  static String FIELD_API_CONTENT_TYPE = "apiContentType";
 
-    private static DataUtils dataUtils;
     private final ObjectMapper objectMapper;
 
     public enum MultipartFormDataType {
@@ -55,16 +54,9 @@ public class DataUtils {
         ARRAY,
     }
 
-    private DataUtils() {
+    public DataUtils() {
         this.objectMapper = new ObjectMapper();
         this.objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-    }
-
-    public static DataUtils getInstance() {
-        if (dataUtils == null) {
-            dataUtils = new DataUtils();
-        }
-        return dataUtils;
     }
 
     public BodyInserter<?, ?> buildBodyInserter(Object body, String contentType, Boolean encodeParamsToggle) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -319,7 +319,7 @@ public class DataUtils {
             requestBodyObj = actionConfiguration.getBodyFormData();
         }
 
-        requestBodyObj = dataUtils.buildBodyInserter(requestBodyObj, reqContentType, encodeParamsToggle);
+        requestBodyObj = this.buildBodyInserter(requestBodyObj, reqContentType, encodeParamsToggle);
 
         return requestBodyObj;
     }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
@@ -11,19 +11,10 @@ import org.springframework.util.CollectionUtils;
 import java.util.HashSet;
 import java.util.Set;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class DatasourceUtils {
 
-    protected static HeaderUtils headerUtils = HeaderUtils.getInstance();
-
-    protected static DatasourceUtils datasourceUtils;
-    public static DatasourceUtils getInstance() {
-        if (datasourceUtils == null) {
-            datasourceUtils = new DatasourceUtils();
-        }
-
-        return datasourceUtils;
-    }
+    protected static HeaderUtils headerUtils = new HeaderUtils();
 
     public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
         /**

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/HeaderUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/HeaderUtils.java
@@ -16,19 +16,10 @@ import org.springframework.util.CollectionUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class HeaderUtils {
     public static final String IS_SEND_SESSION_ENABLED_KEY = "isSendSessionEnabled";
     public static final String SESSION_SIGNATURE_KEY_KEY = "sessionSignatureKey";
-
-    protected static HeaderUtils headerUtils;
-    public static HeaderUtils getInstance() {
-        if (headerUtils == null) {
-            headerUtils = new HeaderUtils();
-        }
-
-        return headerUtils;
-    }
 
     public boolean isEncodeParamsToggleEnabled(ActionConfiguration actionConfiguration) {
         /**

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/HintMessageUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/HintMessageUtils.java
@@ -34,7 +34,7 @@ import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtil
 import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils.DUPLICATE_ATTRIBUTE_LOCATION.DATASOURCE_AND_ACTION_CONFIG;
 import static com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils.DUPLICATE_ATTRIBUTE_LOCATION.DATASOURCE_CONFIG_ONLY;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class HintMessageUtils {
 
     public enum DUPLICATE_ATTRIBUTE_LOCATION {
@@ -46,15 +46,6 @@ public class HintMessageUtils {
     protected enum ATTRIBUTE {
         HEADER,
         PARAM
-    }
-
-    protected static HintMessageUtils hintMessageUtils;
-    public static HintMessageUtils getInstance() {
-        if (hintMessageUtils == null) {
-            hintMessageUtils = new HintMessageUtils();
-        }
-
-        return hintMessageUtils;
     }
 
     protected static String HINT_MESSAGE_FOR_DUPLICATE_ATTRIBUTE_IN_DATASOURCE_CONFIG = "API queries linked to this " +
@@ -75,7 +66,7 @@ public class HintMessageUtils {
                     "remove the duplicate definition(s) from the ''{2}'' section of either the API query or the " +
                     "datasource. Please note that some of the authentication mechanisms also implicitly define a " +
                     "{0}.";
-    
+
     public Set<String> getDatasourceHintMessages(DatasourceConfiguration datasourceConfiguration) {
         Set<String> datasourceHintMessages = new HashSet<>();
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/InitUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/InitUtils.java
@@ -7,17 +7,8 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class InitUtils {
-
-    protected static InitUtils initUtils;
-    public static InitUtils getInstance() {
-        if (initUtils == null) {
-            initUtils = new InitUtils();
-        }
-
-        return initUtils;
-    }
 
     public String initializeRequestUrl(ActionConfiguration actionConfiguration,
                                             DatasourceConfiguration datasourceConfiguration ) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/SmartSubstitutionUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/SmartSubstitutionUtils.java
@@ -7,19 +7,9 @@ import org.apache.commons.collections.CollectionUtils;
 
 import java.util.List;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class SmartSubstitutionUtils {
     public static final int SMART_SUBSTITUTION_INDEX = 0;
-
-    private static SmartSubstitutionUtils smartSubstitutionUtils;
-
-    public static SmartSubstitutionUtils getInstance() {
-        if (smartSubstitutionUtils == null) {
-            smartSubstitutionUtils = new SmartSubstitutionUtils();
-        }
-
-        return smartSubstitutionUtils;
-    }
 
     public boolean isSmartSubstitutionEnabled(List<Property> properties) {
         boolean smartSubstitution;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/TriggerUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/TriggerUtils.java
@@ -53,7 +53,7 @@ import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class TriggerUtils {
 
     public static String SIGNATURE_HEADER_NAME = "X-APPSMITH-SIGNATURE";
@@ -65,18 +65,7 @@ public class TriggerUtils {
             "application/pkcs8",
             "application/x-binary");
 
-    public static HeaderUtils headerUtils = HeaderUtils.getInstance();
-
-    protected static TriggerUtils triggerUtils;
-    public static TriggerUtils getInstance() {
-        if (triggerUtils == null) {
-            triggerUtils = new TriggerUtils();
-        }
-
-        return triggerUtils;
-    }
-
-
+    public static HeaderUtils headerUtils = new HeaderUtils();
 
     public Mono<ActionExecutionResult> triggerApiCall(WebClient client, HttpMethod httpMethod, URI uri,
                                                              Object requestBody,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/URIUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/URIUtils.java
@@ -21,21 +21,12 @@ import java.util.Set;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class URIUtils {
     public static final Set<String> DISALLOWED_HOSTS = Set.of(
             "169.254.169.254",
             "metadata.google.internal"
     );
-
-    protected static URIUtils uriUtils;
-    public static URIUtils getInstance() {
-        if (uriUtils == null) {
-            uriUtils = new URIUtils();
-        }
-
-        return uriUtils;
-    }
 
     public URI createUriWithQueryParams(ActionConfiguration actionConfiguration,
                                         DatasourceConfiguration datasourceConfiguration, String url,

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
@@ -54,6 +54,14 @@ public class ActionConfiguration implements AppsmithDomain {
     String next;
     String prev;
 
+    /**
+     * This field is supposed to contain all action config data that may contain valid references to itself. This
+     * field has been excluded from dynamic binding path map computation in PageLoadActionUtilCEImpl.java so that any
+     * self referencing binding in this data path will not cause a cyclic dependency error. This field should ideally
+     * replace the usage of `next` and `prev` fields defined above. 
+     */
+    Object selfReferencingData;
+
     // DB action fields
 
     // JS action fields

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ActionConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpMethod;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.appsmith.external.constants.ActionConstants.DEFAULT_ACTION_EXECUTION_TIMEOUT_MS;
 
@@ -55,12 +56,13 @@ public class ActionConfiguration implements AppsmithDomain {
     String prev;
 
     /**
-     * This field is supposed to contain all action config data that may contain valid references to itself. This
-     * field has been excluded from dynamic binding path map computation in PageLoadActionUtilCEImpl.java so that any
-     * self referencing binding in this data path will not cause a cyclic dependency error. This field should ideally
-     * replace the usage of `next` and `prev` fields defined above. 
+     * This field is supposed to hold a set of paths that are expected to contain bindings that refer to the same action
+     * object i.e. a cyclic reference. e.g. A GraphQL API response can contain pagination cursors that are required
+     * to be configured in the pagination tab of the same API. We don't want to treat these cyclic references as
+     * cyclic dependency errors.
      */
-    Object selfReferencingData;
+    @Transient
+    Set<String> selfReferencingDataPaths;
 
     // DB action fields
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PaginationType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PaginationType.java
@@ -1,5 +1,5 @@
 package com.appsmith.external.models;
 
 public enum PaginationType {
-    NONE, PAGE_NO, URL
+    NONE, PAGE_NO, URL, CURSOR
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PaginationType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PaginationType.java
@@ -1,5 +1,5 @@
 package com.appsmith.external.models;
 
 public enum PaginationType {
-    NONE, PAGE_NO, URL, LIMIT, CURSOR
+    NONE, PAGE_NO, URL, CURSOR
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PaginationType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/PaginationType.java
@@ -1,5 +1,5 @@
 package com.appsmith.external.models;
 
 public enum PaginationType {
-    NONE, PAGE_NO, URL, CURSOR
+    NONE, PAGE_NO, URL, LIMIT, CURSOR
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
@@ -22,11 +22,12 @@ public class Property {
         this.value = value;
     }
 
-    @Transient
+    // TODO: remove it.
+    /*@Transient
     Object limit;
     public void setLimit(Object val) {
         this.value = val;
-    }
+    }*/
 
     String key;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.annotation.Transient;
 
 @Getter
 @Setter
@@ -19,6 +20,12 @@ public class Property {
     public Property(String key, Object value) {
         this.key = key;
         this.value = value;
+    }
+
+    @Transient
+    Object limit;
+    public void setLimit(Object val) {
+        this.value = val;
     }
 
     String key;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/Property.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.Transient;
 
 @Getter
 @Setter
@@ -21,13 +20,6 @@ public class Property {
         this.key = key;
         this.value = value;
     }
-
-    // TODO: remove it.
-    /*@Transient
-    Object limit;
-    public void setLimit(Object val) {
-        this.value = val;
-    }*/
 
     String key;
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BasePlugin.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class BasePlugin extends Plugin {
 
     protected static final ObjectMapper objectMapper = new ObjectMapper();

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
@@ -48,14 +48,14 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
 
     protected BaseRestApiPluginExecutor(SharedConfig sharedConfig) {
         this.sharedConfig = sharedConfig;
-        this.dataUtils = DataUtils.getInstance();
-        this.smartSubstitutionUtils = SmartSubstitutionUtils.getInstance();
-        this.uriUtils = URIUtils.getInstance();
-        this.triggerUtils = TriggerUtils.getInstance();
-        this.initUtils = InitUtils.getInstance();
-        this.headerUtils = HeaderUtils.getInstance();
-        this.datasourceUtils = DatasourceUtils.getInstance();
-        this.hintMessageUtils = new HintMessageUtils(); // TODO: do the same for all other classes
+        this.dataUtils = new DataUtils();
+        this.smartSubstitutionUtils = new SmartSubstitutionUtils();
+        this.uriUtils = new URIUtils();
+        this.triggerUtils = new TriggerUtils();
+        this.initUtils = new InitUtils();
+        this.headerUtils = new HeaderUtils();
+        this.datasourceUtils = new DatasourceUtils();
+        this.hintMessageUtils = new HintMessageUtils();
         this.EXCHANGE_STRATEGIES = ExchangeStrategies
                 .builder()
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(sharedConfig.getCodecSize()))

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
@@ -17,6 +17,7 @@ import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.services.SharedConfig;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.pf4j.Extension;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -25,19 +26,20 @@ import reactor.util.function.Tuple2;
 
 import java.util.Set;
 
+@Setter
 @Slf4j
 @Extension
 public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>, SmartSubstitutionInterface {
 
-    protected final SharedConfig sharedConfig;
-    protected final DataUtils dataUtils;
-    protected final SmartSubstitutionUtils smartSubstitutionUtils;
-    protected final URIUtils uriUtils;
-    protected final DatasourceUtils datasourceUtils;
-    protected final TriggerUtils triggerUtils;
-    protected final InitUtils initUtils;
-    protected final HeaderUtils headerUtils;
-    protected final HintMessageUtils hintMessageUtils;
+    protected SharedConfig sharedConfig;
+    protected DataUtils dataUtils;
+    protected SmartSubstitutionUtils smartSubstitutionUtils;
+    protected URIUtils uriUtils;
+    protected DatasourceUtils datasourceUtils;
+    protected TriggerUtils triggerUtils;
+    protected InitUtils initUtils;
+    protected HeaderUtils headerUtils;
+    protected HintMessageUtils hintMessageUtils;
 
 
     // Setting max content length. This would've been coming from `spring.codec.max-in-memory-size` property if the
@@ -53,7 +55,7 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
         this.initUtils = InitUtils.getInstance();
         this.headerUtils = HeaderUtils.getInstance();
         this.datasourceUtils = DatasourceUtils.getInstance();
-        this.hintMessageUtils = HintMessageUtils.getInstance();
+        this.hintMessageUtils = new HintMessageUtils(); // TODO: do the same for all other classes
         this.EXCHANGE_STRATEGIES = ExchangeStrategies
                 .builder()
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(sharedConfig.getCodecSize()))

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -222,4 +222,14 @@ public interface PluginExecutor<C> extends ExtensionPoint {
     default ActionConfiguration extractAndSetNativeQueryFromFormData(ActionConfiguration actionConfiguration) {
         return actionConfiguration;
     }
+
+    /**
+     * This method returns a set of paths that are expected to contain bindings that refer to the same action
+     * object i.e. a cyclic reference. e.g. A REST API response can contain pagination related URL that would
+     * have to be configured in the pagination tab of the same API. We don't want to treat these cyclic
+     * references as cyclic dependency errors.
+     */
+    default Set<String> getSelfReferencingDataPaths() {
+        return Set.of("prev", "next");
+    }
 }

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -81,7 +81,6 @@ public class GraphQLPlugin extends BasePlugin {
             List<Map.Entry<String, String>> parameters = new ArrayList<>();
 
             // TODO: handle smart substitution for query body and query variables
-            // TODO: handle cursor pagination
 
             Boolean smartSubstitution = this.smartSubstitutionUtils.isSmartSubstitutionEnabled(properties);
             if (TRUE.equals(smartSubstitution)) {

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -11,6 +11,7 @@ import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionRequest;
 import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.PaginationType;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.BaseRestApiPluginExecutor;
@@ -34,6 +35,7 @@ import java.util.Set;
 
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
 import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInPropertyList;
+import static com.external.utils.GraphQLBodyUtils.PAGINATION_DATA_INDEX;
 import static com.external.utils.GraphQLPaginationUtils.updateVariablesWithPaginationValues;
 import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
 import static com.external.utils.GraphQLBodyUtils.convertToGraphQLPOSTBodyFormat;
@@ -121,7 +123,7 @@ public class GraphQLPlugin extends BasePlugin {
             }
 
             Set<String> hintMessages = new HashSet<String>();
-            if (actionConfiguration.getPaginationType() != null) {
+            if (actionConfiguration.getPaginationType() != null && !PaginationType.NONE.equals(actionConfiguration.getPaginationType())) {
                 updateVariablesWithPaginationValues(actionConfiguration, executeActionDTO, hintMessages);
             }
 

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -17,6 +17,8 @@ import com.appsmith.external.plugins.BaseRestApiPluginExecutor;
 import com.appsmith.external.services.SharedConfig;
 import com.external.utils.GraphQLHintMessageUtils;
 import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.ParseException;
 import org.pf4j.Extension;
 import org.pf4j.PluginWrapper;
 import org.springframework.http.HttpMethod;
@@ -33,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
+import static com.appsmith.external.helpers.PluginUtils.parseStringIntoJSONObject;
 import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInPropertyList;
 import static com.external.utils.GraphQLPaginationUtils.updateVariablesWithPaginationValues;
 import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
@@ -79,6 +82,18 @@ public class GraphQLPlugin extends BasePlugin {
 
             final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
             List<Map.Entry<String, String>> parameters = new ArrayList<>();
+
+            // TODO: remove it.
+            // For test only
+            String paginationString = "{\"limit\": {\"name\": \"limit\", \"value\":2}, \"offset\": {\"name\": " +
+                    "\"offset\", \"value\":0}}";
+            JSONObject limitPagination = null;
+            try {
+                limitPagination = parseStringIntoJSONObject(paginationString);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+            actionConfiguration.getPluginSpecifiedTemplates().get(2).setValue(limitPagination);
 
             // TODO: handle smart substitution for query body and query variables
 

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -261,5 +261,16 @@ public class GraphQLPlugin extends BasePlugin {
             String jsonBody = (String) input;
             return DataTypeStringUtils.jsonSmartReplacementPlaceholderWithValue(jsonBody, value, null, insertedParams, null);
         }
+
+        /**
+         * This method returns a set of paths that are expected to contain bindings that refer to the
+         * same action object i.e. a cyclic reference. e.g. A GraphQL API response can contain pagination
+         * cursors that are required to be configured in the pagination tab of the same API. We don't want to treat
+         * these cyclic references as cyclic dependency errors.
+         */
+        @Override
+        public Set<String> getSelfReferencingDataPaths() {
+            return Set.of("pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value");
+        }
     }
 }

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
@@ -16,7 +16,7 @@ import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromProper
 import static com.appsmith.external.helpers.PluginUtils.parseStringIntoJSONObject;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-public class BodyUtils {
+public class GraphQLBodyUtils {
     public static final int QUERY_VARIABLES_INDEX = 1;
     public static final String QUERY_KEY = "query";
     public static final String VARIABLES_KEY = "variables";
@@ -68,7 +68,9 @@ public class BodyUtils {
 
         final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
         String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
-        queryParams.add(new Property(VARIABLES_KEY, variables));
+        if (!isEmpty(variables)) {
+            queryParams.add(new Property(VARIABLES_KEY, variables));
+        }
 
         return queryParams;
     }

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
 import static com.appsmith.external.helpers.PluginUtils.parseStringIntoJSONObject;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class GraphQLBodyUtils {
@@ -27,12 +28,14 @@ public class GraphQLBodyUtils {
 
         final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
         String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
-        try {
-            JSONObject json = parseStringIntoJSONObject(variables);
-            query.put(VARIABLES_KEY, json);
-        } catch (ParseException e) {
-            throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "GraphQL query " +
-                    "variables are not in proper JSON format: " + e.getMessage());
+        if (!isBlank(variables)) {
+            try {
+                JSONObject json = parseStringIntoJSONObject(variables);
+                query.put(VARIABLES_KEY, json);
+            } catch (ParseException | ClassCastException e) {
+                throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "GraphQL query " +
+                        "variables are not in proper JSON format: " + e.getMessage());
+            }
         }
 
         return query.toString();
@@ -68,7 +71,7 @@ public class GraphQLBodyUtils {
 
         final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
         String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
-        if (!isEmpty(variables)) {
+        if (!isBlank(variables)) {
             queryParams.add(new Property(VARIABLES_KEY, variables));
         }
 

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
@@ -6,8 +6,9 @@ import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.Property;
 import graphql.parser.InvalidSyntaxException;
 import graphql.parser.Parser;
-import net.minidev.json.JSONObject;
+import org.json.JSONObject;
 import net.minidev.json.parser.ParseException;
+import org.json.JSONException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class GraphQLBodyUtils {
     public static final int QUERY_VARIABLES_INDEX = 1;
+    public static final int PAGINATION_DATA_INDEX = 2;
     public static final String QUERY_KEY = "query";
     public static final String VARIABLES_KEY = "variables";
 
@@ -32,7 +34,7 @@ public class GraphQLBodyUtils {
             try {
                 JSONObject json = parseStringIntoJSONObject(variables);
                 query.put(VARIABLES_KEY, json);
-            } catch (ParseException | ClassCastException e) {
+            } catch (JSONException | ClassCastException e) {
                 throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "GraphQL query " +
                         "variables are not in proper JSON format: " + e.getMessage());
             }
@@ -56,7 +58,7 @@ public class GraphQLBodyUtils {
         if (!isEmpty(variables)) {
             try {
                 parseStringIntoJSONObject(variables);
-            } catch (ParseException e) {
+            } catch (JSONException e) {
                 throw new AppsmithPluginException(
                         AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
                         "GraphQL query variables are not in proper JSON format: " + e.getMessage()

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLBodyUtils.java
@@ -7,7 +7,6 @@ import com.appsmith.external.models.Property;
 import graphql.parser.InvalidSyntaxException;
 import graphql.parser.Parser;
 import org.json.JSONObject;
-import net.minidev.json.parser.ParseException;
 import org.json.JSONException;
 
 import java.util.ArrayList;
@@ -52,7 +51,6 @@ public class GraphQLBodyUtils {
                     AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
                     "Invalid GraphQL body: " + e.getMessage());
         }
-
         final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
         String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
         if (!isEmpty(variables)) {

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLConstants.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLConstants.java
@@ -8,7 +8,18 @@ public class GraphQLConstants {
     public static final String OFFSET = "offset";
     public static final String NAME = "name";
     public static final String VALUE = "value";
-
+    public static final String PREV_LIMIT_VARIABLE_NAME = "prevLimitVariableName";
+    public static final String PREV_LIMIT_VAL = "prevLimitValue";
+    public static final String PREV_CURSOR_VARIABLE_NAME = "prevCursorVariableName";
+    public static final String PREV_CURSOR_VAL = "prevCursorValue";
+    public static final String NEXT_LIMIT_VARIABLE_NAME = "nextLimitVariableName";
+    public static final String NEXT_LIMIT_VAL = "nextLimitValue";
+    public static final String NEXT_CURSOR_VARIABLE_NAME = "nextCursorVariableName";
+    public static final String NEXT_CURSOR_VAL = "nextCursorValue";
+    public static final String LIMIT_VARIABLE_NAME = "limitVariableName";
+    public static final String LIMIT_VAL = "limitValue";
+    public static final String OFFSET_VARIABLE_NAME = "offsetVariableName";
+    public static final String OFFSET_VAL = "offsetValue";
     protected static String HINT_MESSAGE_FOR_DUPLICATE_VARIABLE_DEFINITION = "Your GraphQL query may not run as " +
             "expected because it has duplicate definition for variable(s): {0}. Please remove one of the definitions " +
             "- either in the query variables section or the pagination tab to resolve this issue.";

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLConstants.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLConstants.java
@@ -1,0 +1,15 @@
+package com.external.utils;
+
+public class GraphQLConstants {
+    public static final String PREV = "previous";
+    public static final String NEXT = "next";
+    public static final String CURSOR = "cursor";
+    public static final String LIMIT = "limit";
+    public static final String OFFSET = "offset";
+    public static final String NAME = "name";
+    public static final String VALUE = "value";
+
+    protected static String HINT_MESSAGE_FOR_DUPLICATE_VARIABLE_DEFINITION = "Your GraphQL query may not run as " +
+            "expected because it has duplicate definition for variable(s): {0}. Please remove one of the definitions " +
+            "- either in the query variables section or the pagination tab to resolve this issue.";
+}

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
@@ -1,0 +1,131 @@
+package com.external.utils;
+
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils;
+import com.appsmith.external.models.ActionConfiguration;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.PaginationType;
+import com.appsmith.external.models.Property;
+import lombok.NoArgsConstructor;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.ParseException;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
+import static com.appsmith.external.helpers.PluginUtils.parseStringIntoJSONObject;
+import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
+import static com.external.utils.GraphQLConstants.CURSOR;
+import static com.external.utils.GraphQLConstants.HINT_MESSAGE_FOR_DUPLICATE_VARIABLE_DEFINITION;
+import static com.external.utils.GraphQLConstants.LIMIT;
+import static com.external.utils.GraphQLConstants.NAME;
+import static com.external.utils.GraphQLConstants.NEXT;
+import static com.external.utils.GraphQLConstants.OFFSET;
+import static com.external.utils.GraphQLConstants.PREV;
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
+@NoArgsConstructor
+public class GraphQLHintMessageUtils extends HintMessageUtils {
+
+    // TODO: add comments
+    public static Set<String> getHintMessagesForDuplicatesInQueryVariables(ActionConfiguration actionConfiguration) throws AppsmithPluginException {
+        Set<String> hintMessages = new HashSet<String>();
+
+        if (actionConfiguration.getPaginationType() != null) {
+            final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
+            String paginationData = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
+            JSONObject paginationDataJson;
+            try {
+                paginationDataJson = parseStringIntoJSONObject(paginationData);
+            } catch (ParseException e) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_ERROR,
+                        "Appsmith server encountered an unexpected error: failed to parse pagination data into JSON. " +
+                                "Please reach out to our customer support to resolve this."
+                );
+            }
+
+            String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
+            JSONObject queryVariablesJson = new JSONObject();
+            try {
+                queryVariablesJson = parseStringIntoJSONObject(variables);
+            } catch (ParseException e) {
+            /* Not returning an exception here since the user is still editing the query variables and hence it is
+            expected that the query variables would not be parseable till the final edit. */
+            }
+
+            List<String> duplicateVariables = new ArrayList<String>();
+            if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
+                String limitVarName = ((JSONObject)paginationDataJson.get(LIMIT)).getAsString(NAME);
+                String offsetVarName = ((JSONObject)paginationDataJson.get(OFFSET)).getAsString(NAME);
+
+                if (queryVariablesJson.containsKey(limitVarName)) {
+                    duplicateVariables.add(limitVarName);
+                }
+
+                if (queryVariablesJson.containsKey(offsetVarName)) {
+                    duplicateVariables.add(offsetVarName);
+                }
+            }
+            else if (PaginationType.CURSOR.equals(actionConfiguration.getPaginationType())) {
+                // TODO: remove duplication
+                String prevLimitVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(LIMIT)).getAsString(NAME));
+                String prevCursorVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(CURSOR)).getAsString(NAME));
+                String nextLimitVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(LIMIT)).getAsString(NAME));
+                String nextCursorVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(CURSOR)).getAsString(NAME));
+
+                if (queryVariablesJson.containsKey(prevLimitVarName)) {
+                    duplicateVariables.add(prevLimitVarName);
+                }
+
+                if (queryVariablesJson.containsKey(prevCursorVarName)) {
+                    duplicateVariables.add(prevCursorVarName);
+                }
+
+                if (queryVariablesJson.containsKey(nextLimitVarName)) {
+                    duplicateVariables.add(nextLimitVarName);
+                }
+
+                if (queryVariablesJson.containsKey(nextCursorVarName)) {
+                    duplicateVariables.add(nextCursorVarName);
+                }
+            }
+            else {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_ERROR,
+                        "Appsmith server encountered an unexpected error: unrecognized pagination type: " + actionConfiguration.getPaginationType() +
+                                ". Please reach out to our customer support to resolve this."
+                );
+            }
+
+            if (!isEmpty(duplicateVariables)) {
+                String message = MessageFormat.format(HINT_MESSAGE_FOR_DUPLICATE_VARIABLE_DEFINITION,
+                        duplicateVariables.toString());
+                hintMessages.add(message);
+            }
+        }
+
+        return hintMessages;
+    }
+
+    @Override
+    public Set<String> getActionHintMessages(ActionConfiguration actionConfiguration,
+                                             DatasourceConfiguration datasourceConfiguration) {
+
+        Set<String> actionHintMessages = super.getActionHintMessages(actionConfiguration, datasourceConfiguration);
+
+        // TODO: add comments
+        actionHintMessages.addAll(getHintMessagesForDuplicatesInQueryVariables(actionConfiguration));
+
+        return actionHintMessages;
+    }
+}

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
@@ -42,21 +42,31 @@ public class GraphQLHintMessageUtils extends HintMessageUtils {
 
     // TODO: add comments
     public static Set<String> getHintMessagesForDuplicatesInQueryVariables(ActionConfiguration actionConfiguration) throws AppsmithPluginException {
+        if (actionConfiguration == null) {
+            return new HashSet<>();
+        }
+
         Set<String> hintMessages = new HashSet<String>();
         List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
         String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
         JSONObject queryVariablesJson = new JSONObject();
         try {
             queryVariablesJson = parseStringIntoJSONObject(variables);
-        } catch (ParseException e) {
+        } catch (ParseException | ClassCastException e) {
             /* Not returning an exception here since the user is still editing the query variables and hence it is
 -            expected that the query variables would not be parseable till the final edit. */
         }
 
-        if (actionConfiguration.getPaginationType() != null) {
-            Map<String, Object> paginationDataMap = getPaginationData(actionConfiguration);
+        if (!PaginationType.NONE.equals(actionConfiguration.getPaginationType())) {
+            Map<String, Object> paginationDataMap = null;
+            try {
+                paginationDataMap = getPaginationData(actionConfiguration);
+            } catch (AppsmithPluginException e) {
+                // TODO: add comment
+                return new HashSet<>();
+            }
             List<String> duplicateVariables = new ArrayList<String>();
-            if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
+            if (PaginationType.LIMIT.equals(actionConfiguration.getPaginationType())) {
                 String limitVarName = (String) paginationDataMap.get(LIMIT_VARIABLE_NAME);
                 String offsetVarName = (String) paginationDataMap.get(OFFSET_VARIABLE_NAME);
 

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
@@ -8,8 +8,9 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.PaginationType;
 import com.appsmith.external.models.Property;
 import lombok.NoArgsConstructor;
-import net.minidev.json.JSONObject;
+import org.json.JSONObject;
 import net.minidev.json.parser.ParseException;
+import org.json.JSONException;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -52,29 +53,23 @@ public class GraphQLHintMessageUtils extends HintMessageUtils {
         JSONObject queryVariablesJson = new JSONObject();
         try {
             queryVariablesJson = parseStringIntoJSONObject(variables);
-        } catch (ParseException | ClassCastException e) {
+        } catch (JSONException | ClassCastException e) {
             /* Not returning an exception here since the user is still editing the query variables and hence it is
 -            expected that the query variables would not be parseable till the final edit. */
         }
 
-        if (!PaginationType.NONE.equals(actionConfiguration.getPaginationType())) {
-            Map<String, Object> paginationDataMap = null;
-            try {
-                paginationDataMap = getPaginationData(actionConfiguration);
-            } catch (AppsmithPluginException e) {
-                // TODO: add comment
-                return new HashSet<>();
-            }
+        Map<String, Object> paginationDataMap =  getPaginationData(actionConfiguration);
+        if (!PaginationType.NONE.equals(actionConfiguration.getPaginationType()) && !isEmpty(paginationDataMap)) {
             List<String> duplicateVariables = new ArrayList<String>();
-            if (PaginationType.LIMIT.equals(actionConfiguration.getPaginationType())) {
+            if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
                 String limitVarName = (String) paginationDataMap.get(LIMIT_VARIABLE_NAME);
                 String offsetVarName = (String) paginationDataMap.get(OFFSET_VARIABLE_NAME);
 
-                if (queryVariablesJson.containsKey(limitVarName)) {
+                if (queryVariablesJson.has(limitVarName)) {
                     duplicateVariables.add(limitVarName);
                 }
 
-                if (queryVariablesJson.containsKey(offsetVarName)) {
+                if (queryVariablesJson.has(offsetVarName)) {
                     duplicateVariables.add(offsetVarName);
                 }
             }
@@ -84,19 +79,19 @@ public class GraphQLHintMessageUtils extends HintMessageUtils {
                 String nextLimitVarName = (String) paginationDataMap.get(NEXT_LIMIT_VARIABLE_NAME);
                 String nextCursorVarName = (String) paginationDataMap.get(NEXT_CURSOR_VARIABLE_NAME);
 
-                if (queryVariablesJson.containsKey(prevLimitVarName)) {
+                if (queryVariablesJson.has(prevLimitVarName)) {
                     duplicateVariables.add(prevLimitVarName);
                 }
 
-                if (queryVariablesJson.containsKey(prevCursorVarName)) {
+                if (queryVariablesJson.has(prevCursorVarName)) {
                     duplicateVariables.add(prevCursorVarName);
                 }
 
-                if (queryVariablesJson.containsKey(nextLimitVarName)) {
+                if (queryVariablesJson.has(nextLimitVarName)) {
                     duplicateVariables.add(nextLimitVarName);
                 }
 
-                if (queryVariablesJson.containsKey(nextCursorVarName)) {
+                if (queryVariablesJson.has(nextCursorVarName)) {
                     duplicateVariables.add(nextCursorVarName);
                 }
             }

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLHintMessageUtils.java
@@ -41,7 +41,10 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 @NoArgsConstructor
 public class GraphQLHintMessageUtils extends HintMessageUtils {
 
-    // TODO: add comments
+    /**
+     * This method checks if the user has defined a query variable in both the places - pagination tab and the query
+     * variables editor section. If so, then a warning message is returned informing user of the same.
+     */
     public static Set<String> getHintMessagesForDuplicatesInQueryVariables(ActionConfiguration actionConfiguration) throws AppsmithPluginException {
         if (actionConfiguration == null) {
             return new HashSet<>();
@@ -119,7 +122,6 @@ public class GraphQLHintMessageUtils extends HintMessageUtils {
 
         Set<String> actionHintMessages = super.getActionHintMessages(actionConfiguration, datasourceConfiguration);
 
-        // TODO: add comments
         actionHintMessages.addAll(getHintMessagesForDuplicatesInQueryVariables(actionConfiguration));
 
         return actionHintMessages;

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -19,10 +19,22 @@ import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromProper
 import static com.appsmith.external.helpers.PluginUtils.parseStringIntoJSONObject;
 import static com.external.utils.GraphQLConstants.CURSOR;
 import static com.external.utils.GraphQLConstants.LIMIT;
+import static com.external.utils.GraphQLConstants.LIMIT_VAL;
+import static com.external.utils.GraphQLConstants.LIMIT_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.NAME;
 import static com.external.utils.GraphQLConstants.NEXT;
+import static com.external.utils.GraphQLConstants.NEXT_CURSOR_VAL;
+import static com.external.utils.GraphQLConstants.NEXT_CURSOR_VARIABLE_NAME;
+import static com.external.utils.GraphQLConstants.NEXT_LIMIT_VAL;
+import static com.external.utils.GraphQLConstants.NEXT_LIMIT_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.OFFSET;
+import static com.external.utils.GraphQLConstants.OFFSET_VAL;
+import static com.external.utils.GraphQLConstants.OFFSET_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.PREV;
+import static com.external.utils.GraphQLConstants.PREV_CURSOR_VAL;
+import static com.external.utils.GraphQLConstants.PREV_CURSOR_VARIABLE_NAME;
+import static com.external.utils.GraphQLConstants.PREV_LIMIT_VAL;
+import static com.external.utils.GraphQLConstants.PREV_LIMIT_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.VALUE;
 import static com.external.utils.GraphQLHintMessageUtils.getHintMessagesForDuplicatesInQueryVariables;
 import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
@@ -70,9 +82,59 @@ public class GraphQLPaginationUtils {
             }
 
             paginationDataMap.put(LIMIT_VARIABLE_NAME, limitVarName);
-            paginationDataMap.put(LIMIT_VARIABLE_VAL, limitValue);
+            paginationDataMap.put(LIMIT_VAL, limitValue);
             paginationDataMap.put(OFFSET_VARIABLE_NAME, offsetVarName);
-            paginationDataMap.put(OFFSET_VARIABLE_VAL, offsetValue);
+            paginationDataMap.put(OFFSET_VAL, offsetValue);
+        }
+        else if (PaginationType.CURSOR.equals(actionConfiguration.getPaginationType())) {
+            String prevLimitVarName =
+                    (((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(LIMIT)).getAsString(NAME));
+            int prevLimitValue;
+            try {
+                prevLimitValue =
+                        ((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(LIMIT)).getAsNumber(VALUE).intValue();
+            } catch (NumberFormatException e) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                        "Please provide a valid number for variable '" + prevLimitVarName + "' in the pagination " +
+                                "tab."
+                );
+            }
+
+            String prevCursorVarName =
+                    (((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(CURSOR)).getAsString(NAME));
+            String prevCursorValue =
+                    ((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(CURSOR)).getAsString(VALUE);
+
+
+            String nextLimitVarName =
+                    (((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(LIMIT)).getAsString(NAME));
+            int nextLimitValue;
+            try {
+                nextLimitValue =
+                        ((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(LIMIT)).getAsNumber(VALUE).intValue();
+            } catch (NumberFormatException e) {
+                throw new AppsmithPluginException(
+                        AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                        "Please provide a valid number for variable '" + nextLimitVarName + "' in the pagination " +
+                                "tab."
+                );
+            }
+
+            String nextCursorVarName =
+                    (((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(CURSOR)).getAsString(NAME));
+            String nextCursorValue =
+                    ((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(CURSOR)).getAsString(VALUE);
+
+
+            paginationDataMap.put(PREV_LIMIT_VARIABLE_NAME, prevLimitVarName);
+            paginationDataMap.put(PREV_LIMIT_VAL, prevLimitValue);
+            paginationDataMap.put(PREV_CURSOR_VARIABLE_NAME, prevCursorVarName);
+            paginationDataMap.put(PREV_CURSOR_VAL, prevCursorValue);
+            paginationDataMap.put(NEXT_LIMIT_VARIABLE_NAME, nextLimitVarName);
+            paginationDataMap.put(NEXT_LIMIT_VAL, nextLimitValue);
+            paginationDataMap.put(NEXT_CURSOR_VARIABLE_NAME, nextCursorVarName);
+            paginationDataMap.put(NEXT_CURSOR_VAL, nextCursorValue);
         }
 
         return paginationDataMap;

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -1,0 +1,136 @@
+package com.external.utils;
+
+import com.appsmith.external.dtos.ExecuteActionDTO;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.models.ActionConfiguration;
+import com.appsmith.external.models.PaginationField;
+import com.appsmith.external.models.PaginationType;
+import com.appsmith.external.models.Property;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.ParseException;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
+import static com.appsmith.external.helpers.PluginUtils.parseStringIntoJSONObject;
+import static com.external.utils.GraphQLConstants.CURSOR;
+import static com.external.utils.GraphQLConstants.LIMIT;
+import static com.external.utils.GraphQLConstants.NAME;
+import static com.external.utils.GraphQLConstants.NEXT;
+import static com.external.utils.GraphQLConstants.OFFSET;
+import static com.external.utils.GraphQLConstants.PREV;
+import static com.external.utils.GraphQLConstants.VALUE;
+import static com.external.utils.GraphQLHintMessageUtils.getHintMessagesForDuplicatesInQueryVariables;
+import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class GraphQLPaginationUtils {
+    public static void updateVariablesWithPaginationValues(ActionConfiguration actionConfiguration,
+                                                           ExecuteActionDTO executeActionDTO,
+                                                           Set<String> hintMessages) throws AppsmithPluginException {
+        hintMessages.addAll(getHintMessagesForDuplicatesInQueryVariables(actionConfiguration));
+
+        final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
+        String paginationData = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
+        JSONObject paginationDataJson;
+        try {
+            paginationDataJson = parseStringIntoJSONObject(paginationData);
+        } catch (ParseException e) {
+            throw new AppsmithPluginException(
+                    AppsmithPluginError.PLUGIN_ERROR,
+                    "Appsmith server encountered an unexpected error: failed to parse pagination data into JSON. " +
+                            "Please reach out to our customer support to resolve this."
+            );
+        }
+
+        String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
+        JSONObject queryVariablesJson = new JSONObject();
+        try {
+            queryVariablesJson = parseStringIntoJSONObject(variables);
+        } catch (ParseException e) {
+            // TODO: add comment
+            throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "GraphQL query " +
+                    "variables are not in proper JSON format: " + e.getMessage());
+        }
+
+        // TODO: refactor to remove dup code
+        if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
+            String limitVarName = ((JSONObject)paginationDataJson.get(LIMIT)).getAsString(NAME);
+            int limitValue = ((JSONObject)paginationDataJson.get(LIMIT)).getAsNumber(VALUE).intValue();
+            String offsetVarName = ((JSONObject)paginationDataJson.get(OFFSET)).getAsString(NAME);
+            int offsetValue = ((JSONObject)paginationDataJson.get(OFFSET)).getAsNumber(VALUE).intValue();
+
+            queryVariablesJson.put(limitVarName, limitValue);
+            queryVariablesJson.put(offsetVarName, offsetValue);
+        }
+        else if (PaginationType.CURSOR.equals(actionConfiguration.getPaginationType())) {
+            if (PaginationField.PREV.equals(executeActionDTO.getPaginationField())) {
+                String prevLimitVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(LIMIT)).getAsString(NAME));
+                int prevLimitValue = 0;
+                try {
+                    prevLimitValue = (((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(LIMIT)).getAsNumber(NAME)).intValue();
+                } catch (NumberFormatException e) {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Please provide a valid number for variable '" + prevLimitVarName + "' in the pagination " +
+                                    "tab."
+                    );
+                }
+
+                String prevCursorVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(CURSOR)).getAsString(NAME));
+                String prevCursorValue =
+                        ((JSONObject)((JSONObject)paginationDataJson.get(PREV)).get(CURSOR)).getAsString(NAME);
+                if (isBlank(prevCursorValue)) {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Please provide a non empty value for variable '" + prevCursorVarName + "' in the " +
+                                    "pagination tab."
+                    );
+                }
+
+                queryVariablesJson.put(prevLimitVarName, prevLimitValue);
+                queryVariablesJson.put(prevCursorVarName, prevCursorValue);
+            }
+            else if (PaginationField.NEXT.equals(executeActionDTO.getPaginationField())) {
+                String nextLimitVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(LIMIT)).getAsString(NAME));
+                int nextLimitValue = 0;
+                try {
+                    nextLimitValue = (((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(LIMIT)).getAsNumber(NAME)).intValue();
+                } catch (NumberFormatException e) {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Please provide a valid number for variable '" + nextLimitVarName + "' in the pagination" +
+                                    " tab."
+                    );
+                }
+
+                String nextCursorVarName =
+                        (((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(CURSOR)).getAsString(NAME));
+                String nextCursorValue =
+                        ((JSONObject)((JSONObject)paginationDataJson.get(NEXT)).get(CURSOR)).getAsString(NAME);
+                if (isBlank(nextCursorValue)) {
+                    throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR,
+                            "Please provide a non empty value for variable '" + nextCursorVarName + "' in the " +
+                                    "pagination tab."
+                    );
+                }
+
+                queryVariablesJson.put(nextLimitVarName, nextLimitValue);
+                queryVariablesJson.put(nextCursorVarName, nextCursorValue);
+            }
+        }
+        else {
+            throw new AppsmithPluginException(
+                    AppsmithPluginError.PLUGIN_ERROR,
+                    "Appsmith server encountered an unexpected error: unrecognized pagination type: " + actionConfiguration.getPaginationType() +
+                            ". Please reach out to our customer support to resolve this."
+            );
+        }
+    }
+}

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -114,6 +114,12 @@ public class GraphQLPaginationUtils {
         }
 
         Map<String, String> paginationDataMap = getPaginationData(actionConfiguration);
+        if (isEmpty(paginationDataMap)) {
+            throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "Appsmith " +
+                    "server could not find any GraphQL pagination data even though pagination is toggled on. Please " +
+                    "provide pagination data by editing relevant fields in the pagination tab.");
+        }
+
         if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
             String limitVarName = paginationDataMap.get(LIMIT_VARIABLE_NAME);
             String limitValueString = paginationDataMap.get(LIMIT_VAL);

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -48,9 +48,16 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class GraphQLPaginationUtils {
     public static Map getPaginationData(ActionConfiguration actionConfiguration) throws AppsmithPluginException {
-        final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
-        Map<String, Object> paginationData =
-                getValueSafelyFromPropertyList(properties, PAGINATION_DATA_INDEX, Map.class);
+        Map<String, Object> paginationData = null;
+        if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
+            paginationData = getValueSafelyFromFormData((Map) actionConfiguration.getSelfReferencingData(),
+                    "paginationData.limitBased", Map.class, null);
+        }
+        else if (PaginationType.CURSOR.equals(actionConfiguration.getPaginationType())) {
+            paginationData = getValueSafelyFromFormData((Map) actionConfiguration.getSelfReferencingData(),
+                    "paginationData.cursorBased", Map.class, null);
+        }
+
         if (isEmpty(paginationData)) {
             return paginationData;
         }

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -48,7 +48,7 @@ public class GraphQLPaginationUtils {
         JSONObject paginationDataJson;
         try {
             paginationDataJson = parseStringIntoJSONObject(paginationData);
-        } catch (ParseException e) {
+        } catch (ParseException | ClassCastException e) {
             throw new AppsmithPluginException(
                     AppsmithPluginError.PLUGIN_ERROR,
                     "Appsmith server encountered an unexpected error: failed to parse pagination data into JSON. " +
@@ -57,7 +57,7 @@ public class GraphQLPaginationUtils {
         }
 
         HashMap<String, Object> paginationDataMap = new HashMap<String, Object>();
-        if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
+        if (PaginationType.LIMIT.equals(actionConfiguration.getPaginationType())) {
             String limitVarName = ((JSONObject) paginationDataJson.get(LIMIT)).getAsString(NAME);
             int limitValue;
             try {
@@ -157,7 +157,7 @@ public class GraphQLPaginationUtils {
         }
 
         Map<String, Object> paginationDataMap = getPaginationData(actionConfiguration);
-        if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
+        if (PaginationType.LIMIT.equals(actionConfiguration.getPaginationType())) {
             String limitVarName = (String) paginationDataMap.get(LIMIT_VARIABLE_NAME);
             int limitValue = (int) paginationDataMap.get(LIMIT_VAL);
             String offsetVarName = (String) paginationDataMap.get(OFFSET_VARIABLE_NAME);

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -8,7 +8,6 @@ import com.appsmith.external.models.PaginationField;
 import com.appsmith.external.models.PaginationType;
 import com.appsmith.external.models.Property;
 import org.json.JSONObject;
-import net.minidev.json.parser.ParseException;
 import org.json.JSONException;
 
 import java.util.HashMap;
@@ -19,28 +18,20 @@ import java.util.Set;
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromFormData;
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
 import static com.appsmith.external.helpers.PluginUtils.parseStringIntoJSONObject;
-import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInFormData;
 import static com.appsmith.external.helpers.PluginUtils.setValueSafelyInPropertyList;
 import static com.external.utils.GraphQLBodyUtils.PAGINATION_DATA_INDEX;
-import static com.external.utils.GraphQLConstants.CURSOR;
-import static com.external.utils.GraphQLConstants.LIMIT;
 import static com.external.utils.GraphQLConstants.LIMIT_VAL;
 import static com.external.utils.GraphQLConstants.LIMIT_VARIABLE_NAME;
-import static com.external.utils.GraphQLConstants.NAME;
-import static com.external.utils.GraphQLConstants.NEXT;
 import static com.external.utils.GraphQLConstants.NEXT_CURSOR_VAL;
 import static com.external.utils.GraphQLConstants.NEXT_CURSOR_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.NEXT_LIMIT_VAL;
 import static com.external.utils.GraphQLConstants.NEXT_LIMIT_VARIABLE_NAME;
-import static com.external.utils.GraphQLConstants.OFFSET;
 import static com.external.utils.GraphQLConstants.OFFSET_VAL;
 import static com.external.utils.GraphQLConstants.OFFSET_VARIABLE_NAME;
-import static com.external.utils.GraphQLConstants.PREV;
 import static com.external.utils.GraphQLConstants.PREV_CURSOR_VAL;
 import static com.external.utils.GraphQLConstants.PREV_CURSOR_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.PREV_LIMIT_VAL;
 import static com.external.utils.GraphQLConstants.PREV_LIMIT_VARIABLE_NAME;
-import static com.external.utils.GraphQLConstants.VALUE;
 import static com.external.utils.GraphQLHintMessageUtils.getHintMessagesForDuplicatesInQueryVariables;
 import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
@@ -48,14 +39,21 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class GraphQLPaginationUtils {
     public static Map getPaginationData(ActionConfiguration actionConfiguration) throws AppsmithPluginException {
+        List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
+        if (properties.size() < PAGINATION_DATA_INDEX + 1) {
+            return null;
+        }
+
         Map<String, Object> paginationData = null;
         if (PaginationType.PAGE_NO.equals(actionConfiguration.getPaginationType())) {
-            paginationData = getValueSafelyFromFormData((Map) actionConfiguration.getSelfReferencingData(),
-                    "paginationData.limitBased", Map.class, null);
+            paginationData =
+                    getValueSafelyFromFormData((Map) properties.get(PAGINATION_DATA_INDEX).getValue(),
+                    "limitBased", Map.class, null);
         }
         else if (PaginationType.CURSOR.equals(actionConfiguration.getPaginationType())) {
-            paginationData = getValueSafelyFromFormData((Map) actionConfiguration.getSelfReferencingData(),
-                    "paginationData.cursorBased", Map.class, null);
+            paginationData =
+                    getValueSafelyFromFormData((Map) properties.get(PAGINATION_DATA_INDEX).getValue(),
+                    "cursorBased", Map.class, null);
         }
 
         if (isEmpty(paginationData)) {

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/helpers/DataUtilsTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/helpers/DataUtilsTest.java
@@ -83,7 +83,7 @@ public class DataUtilsTest {
 
     @Before
     public void setUp() {
-        dataUtils = DataUtils.getInstance();
+        dataUtils = new DataUtils();
     }
 
     @Test

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -82,7 +82,7 @@ public class RestApiPluginTest {
 
     @Before
     public void setUp() {
-        hintMessageUtils = HintMessageUtils.getInstance();
+        hintMessageUtils = new HintMessageUtils();
     }
 
     @Test

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCE.java
@@ -100,4 +100,6 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
     Mono<String> findBranchedIdByBranchNameAndDefaultActionId(String branchName, String defaultActionId, AclPermission permission);
 
     public Mono<NewAction> sanitizeAction(NewAction action);
+
+    Mono<ActionDTO> fillSelfReferencingDataPaths(ActionDTO actionDTO);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -1405,6 +1405,18 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         return actionMono;
     }
 
+    @Override
+    public Mono<ActionDTO> fillSelfReferencingDataPaths(ActionDTO actionDTO) {
+        Mono<Plugin> pluginMono = pluginService.getById(actionDTO.getPluginId());
+        Mono<PluginExecutor> pluginExecutorMono = pluginExecutorHelper.getPluginExecutor(pluginMono);
+
+        return pluginExecutorMono
+                .map(pluginExecutor -> {
+                    actionDTO.getActionConfiguration().setSelfReferencingDataPaths(pluginExecutor.getSelfReferencingDataPaths());
+                    return actionDTO;
+                });
+    }
+
     private boolean isPluginTypeOrPluginIdMissing(NewAction action) {
         return action.getPluginId() == null || action.getPluginType() == null;
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
@@ -790,7 +790,8 @@ public class PageLoadActionsUtilCEImpl implements PageLoadActionsUtilCE {
                 final String fieldPath = String.valueOf(x.getKey());
 
                 // Ignore pagination configuration since pagination technically does not belong to dynamic binding list.
-                if (fieldPath.equals("prev") || fieldPath.equals("next")) {
+                if (fieldPath.equals("prev") || fieldPath.equals("next") || fieldPath.matches("selfReferencingData\\." +
+                        ".*")) {
                     continue;
                 }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/PageLoadActionsUtilCEImpl.java
@@ -330,6 +330,7 @@ public class PageLoadActionsUtilCEImpl implements PageLoadActionsUtilCE {
                 })
                 .flatMapMany(possibleEntityNamesInDsl -> newActionService.findUnpublishedActionsInPageByNames(possibleEntityNamesInDsl, pageId))
                 .flatMap(newAction -> newActionService.generateActionByViewMode(newAction, false))
+                .flatMap(newActionService::fillSelfReferencingDataPaths)
                 // Add dependencies of the actions found in the DSL in the graph.
                 .map(action -> {
                     // This action is directly referenced in the DSL. This action is an ideal candidate for on page load
@@ -588,6 +589,7 @@ public class PageLoadActionsUtilCEImpl implements PageLoadActionsUtilCE {
         // First fetch all the actions in the page whose name matches the words found in all the dynamic bindings
         Mono<List<ActionDTO>> findAndAddActionsInBindingsMono = newActionService.findUnpublishedActionsInPageByNames(possibleActionNames, pageId)
                 .flatMap(newAction -> newActionService.generateActionByViewMode(newAction, false))
+                .flatMap(newActionService::fillSelfReferencingDataPaths)
                 .map(action -> {
 
                     extractAndSetActionBindingsInGraphEdges(edges, action, newBindings, actionsFoundDuringWalk);
@@ -631,6 +633,7 @@ public class PageLoadActionsUtilCEImpl implements PageLoadActionsUtilCE {
         //First fetch all the actions which have been tagged as on load by the user explicitly.
         return newActionService.findUnpublishedOnLoadActionsExplicitSetByUserInPage(pageId)
                 .flatMap(newAction -> newActionService.generateActionByViewMode(newAction, false))
+                .flatMap(newActionService::fillSelfReferencingDataPaths)
                 // Add the vertices and edges to the graph for these actions
                 .map(actionDTO -> {
                     extractAndSetActionBindingsInGraphEdges(edges, actionDTO, bindingsFromActions, actionsFoundDuringWalk);
@@ -783,15 +786,19 @@ public class PageLoadActionsUtilCEImpl implements PageLoadActionsUtilCE {
         Map<String, Set<String>> completePathToDynamicBindingMap = new HashMap<>();
 
         Map<String, Object> configurationObj = objectMapper.convertValue(action.getActionConfiguration(), Map.class);
-
+        Set<String> selfReferencingDataPaths = action.getActionConfiguration().getSelfReferencingDataPaths();
         if (dynamicBindingPathList != null) {
             // Each of these might have nested structures, so we iterate through them to find the leaf node for each
             for (Property x : dynamicBindingPathList) {
                 final String fieldPath = String.valueOf(x.getKey());
 
-                // Ignore pagination configuration since pagination technically does not belong to dynamic binding list.
-                if (fieldPath.equals("prev") || fieldPath.equals("next") || fieldPath.matches("selfReferencingData\\." +
-                        ".*")) {
+                /**
+                 * selfReferencingDataPaths is a set of paths that are expected to contain bindings that refer to the
+                 * same action object i.e. a cyclic reference. e.g. A GraphQL API response can contain pagination
+                 * cursors that are required to be configured in the pagination tab of the same API. We don't want to
+                 * treat these cyclic references as cyclic dependency errors.
+                 */
+                if (selfReferencingDataPaths.contains(fieldPath)) {
                     continue;
                 }
 


### PR DESCRIPTION
## Description
- This PR provides server-side support for pagination feature of GraphQL plugin. Two types of pagination is supported: limit offset based and cursor based. 
- In case a user has configured a query variable in both the query variables editor box and the pagination tab then a warning / hint message is returned to the client. Hint message is computed and returned at the time of query edit and at the time of query execution.
- Minor refactor: Some singleton pattern helper classes have been modified to allow for inheritance and extension. This was also suggested as a feedback on one of the earlier PRs. 

Fixes #13830 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual
- TBD: JUnit TC will be added as part of a different PR.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
