### PR TITLE
chore: Adding the configuration parameter to ensure that the target branch is master for all releases are created

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,5 +25,6 @@ jobs:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           config-name: release-drafter-template.yml
           disable-autolabeler: true
+          commitish: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adding the parameter `commitish` to release-drafter to ensure that all draft releases are created on the `master` branch and not on the default `release` branch of the repo. This ensures that we don't make mistakes when tagging a release for Appsmith. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
