### PR TITLE
fix: Adding workspaceId when missing with organizationId present in REST API actions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -336,6 +336,12 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         Mono<Datasource> datasourceMono = Mono.just(action.getDatasource());
         if (action.getPluginType() != PluginType.JS) {
             if (action.getDatasource().getId() == null) {
+
+                // This is a nested datasource. If the action is in bad state (aka without workspace id, add the same)
+                if (action.getDatasource().getWorkspaceId() == null && action.getDatasource().getOrganizationId() != null) {
+                    action.getDatasource().setWorkspaceId(action.getDatasource().getOrganizationId());
+                }
+
                 datasourceMono = Mono.just(action.getDatasource())
                         .flatMap(datasourceService::validateDatasource);
             } else {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -2570,4 +2570,43 @@ public class ActionServiceCE_Test {
                 .verifyComplete();
     }
 
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void updateAction_withoutWorkspaceId_withOrganizationId() {
+
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        ActionDTO action = new ActionDTO();
+        action.setName("validAction_nestedDatasource");
+        action.setPageId(testPage.getId());
+        action.setExecuteOnLoad(true);
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        action.setDatasource(datasource);
+
+        Mono<ActionDTO> createActionMono = layoutActionService.createSingleAction(action).cache();
+
+
+        ActionDTO updateAction = new ActionDTO();
+        Datasource nestedDatasource = new Datasource();
+        nestedDatasource.setOrganizationId(workspaceId);
+        nestedDatasource.setName("DEFAULT_REST_DATASOURCE");
+        nestedDatasource.setPluginId(datasource.getPluginId());
+        nestedDatasource.setDatasourceConfiguration(new DatasourceConfiguration());
+
+        updateAction.setDatasource(nestedDatasource);
+        Mono<ActionDTO> actionMono = createActionMono
+                .flatMap(savedAction -> layoutActionService.updateAction(savedAction.getId(), updateAction));
+
+        StepVerifier
+                .create(actionMono)
+                .assertNext(updatedAction -> {
+                    Datasource datasource1 = updatedAction.getDatasource();
+                    assertThat(datasource1.getWorkspaceId() != null);
+                    assertThat(datasource1.getInvalids()).isEmpty();
+                })
+                .verifyComplete();
+    }
+
 }


### PR DESCRIPTION
If the client has not been refreshed and contains old copies of rest api actions (where workspaceId is absent and only orgnaizationId is present), then this PR aims to add the workspace id to such nested datasources.

Fixes #14599 