### PR TITLE
chore: throttle git apis

### DIFF
--- a/app/client/src/sagas/GitSyncSagas.ts
+++ b/app/client/src/sagas/GitSyncSagas.ts
@@ -5,7 +5,14 @@ import {
   ReduxActionTypes,
   ReduxActionWithCallbacks,
 } from "@appsmith/constants/ReduxActionConstants";
-import { all, call, put, select, takeLatest } from "redux-saga/effects";
+import {
+  all,
+  call,
+  put,
+  select,
+  takeLatest,
+  throttle,
+} from "redux-saga/effects";
 import GitSyncAPI, {
   MergeBranchPayload,
   MergeStatusPayload,
@@ -848,7 +855,7 @@ export default function* gitSyncSagas() {
       updateGlobalGitConfig,
     ),
     takeLatest(ReduxActionTypes.SWITCH_GIT_BRANCH_INIT, switchBranch),
-    takeLatest(ReduxActionTypes.FETCH_BRANCHES_INIT, fetchBranches),
+    throttle(5 * 1000, ReduxActionTypes.FETCH_BRANCHES_INIT, fetchBranches),
     takeLatest(ReduxActionTypes.CREATE_NEW_BRANCH_INIT, createNewBranch),
     takeLatest(
       ReduxActionTypes.FETCH_LOCAL_GIT_CONFIG_INIT,
@@ -860,7 +867,11 @@ export default function* gitSyncSagas() {
     ),
     takeLatest(ReduxActionTypes.FETCH_GIT_STATUS_INIT, fetchGitStatusSaga),
     takeLatest(ReduxActionTypes.MERGE_BRANCH_INIT, mergeBranchSaga),
-    takeLatest(ReduxActionTypes.FETCH_MERGE_STATUS_INIT, fetchMergeStatusSaga),
+    throttle(
+      5 * 1000,
+      ReduxActionTypes.FETCH_MERGE_STATUS_INIT,
+      fetchMergeStatusSaga,
+    ),
     takeLatest(ReduxActionTypes.GIT_PULL_INIT, gitPullSaga),
     takeLatest(ReduxActionTypes.SHOW_CONNECT_GIT_MODAL, showConnectGitModal),
     takeLatest(ReduxActionTypes.DISCONNECT_GIT, disconnectGitSaga),


### PR DESCRIPTION
## Description

As of today, we can click sync-branches button and open merge tab multiple times in quick sessions, that causes api call to be made for every such interaction. This PR throttles those api calls.

Related: #14619 

Fixes #14638 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
