### PR TITLE
fix: handled content type none in API

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_DefaultContentType_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ApiPaneTests/API_DefaultContentType_spec.js
@@ -12,12 +12,14 @@ describe("API Panel request body", function() {
     cy.contains(apiEditor.bodyTab).click({ force: true });
     cy.get(apiEditor.bodyTypeSelected).should("have.text", "NONE");
 
+    //Switch to headers tab
+    cy.contains(apiEditor.headersTab).click();
+
     // Changing method type to POST
     cy.get(apiEditor.ApiVerb).click();
     cy.xpath(appPage.selectPost).click();
 
     // Checking Header for POST Type
-    cy.contains(apiEditor.headersTab).click();
     cy.get(`${apiwidget.headerKey} .CodeMirror .CodeMirror-code`)
       .first()
       .should("have.text", "content-type");
@@ -41,10 +43,10 @@ describe("API Panel request body", function() {
     cy.contains(apiEditor.headersTab).click();
     cy.get(`${apiwidget.headerKey} .CodeMirror .CodeMirror-code`)
       .first()
-      .should("have.text", "content-type");
+      .should("not.have.text", "content-type");
     cy.get(`${apiwidget.headerValue} .CodeMirror .CodeMirror-code`)
       .first()
-      .should("have.text", "none");
+      .should("not.have.text", "application/json");
 
     cy.DeleteAPI();
   });


### PR DESCRIPTION
## Description

1. The default header (content-type:none) gets added by default in API Pane when the user switches between body and header tabs https://www.loom.com/share/0dd89cd153b54c71a11f86bc5820d968
2. The default header (content-type:none) gets added by default in API Pane when the user switches between HTTP method types


Fixes #14624 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Have updated the test case in API_DefaultContentType_spec

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
