### PR TITLE
fix: multiple storeValue action completion track

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/StoreValue_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/StoreValue_spec.ts
@@ -1,0 +1,61 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+const { AggregateHelper: agHelper, JSEditor: jsEditor } = ObjectsRegistry;
+
+describe("storeValue Action test", () => {
+  before(() => {
+    //
+  });
+
+  it("1. Running consecutive storeValue actions and await", function() {
+    const jsObjectBody = `export default {
+      myFun1: () => {
+        let values =
+          [
+            storeValue('val1', 'number 1'),
+            storeValue('val2', 'number 2'),
+            storeValue('val3', 'number 3'),
+            storeValue('val4', 'number 4')
+          ]
+        return Promise.all(values)
+          .then(() => {	
+            showAlert(JSON.stringify(appsmith.store))
+        })
+          .catch((err) => { 
+            return showAlert('Could not store values in store ' + err.toString());
+          })
+      }
+    }`;
+
+    jsEditor.CreateJSObject(jsObjectBody, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+
+    agHelper.AssertAutoSave();
+
+    jsEditor.EditJSObj(jsObjectBody);
+
+    agHelper.AssertAutoSave();
+
+    // running twice due to bug
+    Cypress._.times(2, () => {
+      cy.get(jsEditor._runButton)
+        .first()
+        .click()
+        .wait(3000);
+    });
+
+    agHelper.ValidateToastMessage(
+      JSON.stringify({
+        val1: "number 1",
+        val2: "number 2",
+        val3: "number 3",
+        val4: "number 4",
+      }),
+      2,
+    );
+  });
+});

--- a/app/client/src/actions/pageActions.tsx
+++ b/app/client/src/actions/pageActions.tsx
@@ -18,6 +18,7 @@ import { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsRe
 import { GenerateTemplatePageRequest } from "api/PageApi";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import { Replayable } from "entities/Replay/ReplayEntity/ReplayEditor";
+import { StoreValueActionDescription } from "entities/DataTree/actionTriggers";
 
 export interface FetchPageListPayload {
   applicationId: string;
@@ -314,29 +315,30 @@ export const setAppMode = (payload: APP_MODE): ReduxAction<APP_MODE> => {
   };
 };
 
+export const updateAppStoreEvaluated = (
+  storeValueAction?: StoreValueActionDescription["payload"],
+) => ({
+  type: ReduxActionTypes.UPDATE_APP_STORE_EVALUATED,
+  payload: storeValueAction,
+});
+
 export const updateAppTransientStore = (
   payload: Record<string, unknown>,
+  storeValueAction?: StoreValueActionDescription["payload"],
 ): EvaluationReduxAction<Record<string, unknown>> => ({
   type: ReduxActionTypes.UPDATE_APP_TRANSIENT_STORE,
   payload,
-  postEvalActions: [
-    {
-      type: ReduxActionTypes.UPDATE_APP_STORE_EVALUATED,
-    },
-  ],
+  postEvalActions: [updateAppStoreEvaluated(storeValueAction)],
 });
 
 export const updateAppPersistentStore = (
   payload: Record<string, unknown>,
+  storeValueAction?: StoreValueActionDescription["payload"],
 ): EvaluationReduxAction<Record<string, unknown>> => {
   return {
     type: ReduxActionTypes.UPDATE_APP_PERSISTENT_STORE,
     payload,
-    postEvalActions: [
-      {
-        type: ReduxActionTypes.UPDATE_APP_STORE_EVALUATED,
-      },
-    ],
+    postEvalActions: [updateAppStoreEvaluated(storeValueAction)],
   };
 };
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -89,6 +89,7 @@ export type StoreValueActionDescription = {
     key: string;
     value: string;
     persist: boolean;
+    uniqueRequestId: string;
   };
 };
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -89,7 +89,7 @@ export type StoreValueActionDescription = {
     key: string;
     value: string;
     persist: boolean;
-    uniqueRequestId: string;
+    uniqueActionRequestId: string;
   };
 };
 

--- a/app/client/src/sagas/ActionExecution/StoreActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/StoreActionSaga.ts
@@ -10,7 +10,7 @@ import { getAppStoreData } from "selectors/entitiesSelector";
 import { StoreValueActionDescription } from "entities/DataTree/actionTriggers";
 import { getCurrentGitBranch } from "selectors/gitSyncSelectors";
 import { getCurrentApplicationId } from "selectors/editorSelectors";
-import { updateAppStoreEvaluated } from "actions/pageActions";
+import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 
 export default function* storeValueLocally(
   action: StoreValueActionDescription["payload"],
@@ -40,15 +40,18 @@ export default function* storeValueLocally(
     });
   }
   /* It is possible that user calls multiple storeValue function together, in such case we need to track completion of each action separately
-  We use uniqueRequestId to differentiate each storeValueAction here.
+  We use uniqueActionRequestId to differentiate each storeValueAction here.
   */
   while (true) {
     const returnedAction: StoreValueActionDescription = yield take(
-      updateAppStoreEvaluated().type,
+      ReduxActionTypes.UPDATE_APP_STORE_EVALUATED,
     );
-    const { uniqueRequestId } = returnedAction.payload;
+    if (!returnedAction?.payload?.uniqueActionRequestId) {
+      break;
+    }
 
-    if (uniqueRequestId === action.uniqueRequestId) {
+    const { uniqueActionRequestId } = returnedAction.payload;
+    if (uniqueActionRequestId === action.uniqueActionRequestId) {
       break;
     }
   }

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -300,9 +300,9 @@ describe("Add functions", () => {
     const key = "some";
     const value = "thing";
     const persist = false;
-    const uniqueRequestId = "kjebd";
+    const uniqueActionRequestId = "kjebd";
 
-    uniqueId.mockReturnValueOnce(uniqueRequestId);
+    uniqueId.mockReturnValueOnce(uniqueActionRequestId);
 
     expect(dataTreeWithFunctions.storeValue(key, value, persist)).resolves.toBe(
       {},
@@ -319,7 +319,7 @@ describe("Add functions", () => {
             key,
             value,
             persist,
-            uniqueRequestId,
+            uniqueActionRequestId,
           },
         },
       },

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -1,6 +1,8 @@
 import { DataTree, ENTITY_TYPE } from "entities/DataTree/dataTreeFactory";
 import { PluginType } from "entities/Action";
 import { createGlobalData } from "workers/evaluate";
+import uniqueId from "lodash/uniqueId";
+jest.mock("lodash/uniqueId");
 
 describe("Add functions", () => {
   const workerEventMock = jest.fn();
@@ -298,6 +300,9 @@ describe("Add functions", () => {
     const key = "some";
     const value = "thing";
     const persist = false;
+    const uniqueRequestId = "kjebd";
+
+    uniqueId.mockReturnValueOnce(uniqueRequestId);
 
     expect(dataTreeWithFunctions.storeValue(key, value, persist)).resolves.toBe(
       {},
@@ -314,6 +319,7 @@ describe("Add functions", () => {
             key,
             value,
             persist,
+            uniqueRequestId,
           },
         },
       },

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -9,6 +9,7 @@ import {
 import { NavigationTargetType } from "sagas/ActionExecution/NavigateActionSaga";
 import { promisifyAction } from "workers/PromisifyAction";
 import { klona } from "klona/full";
+import uniqueId from "lodash/uniqueId";
 declare global {
   interface Window {
     ALLOW_ASYNC?: boolean;
@@ -79,7 +80,12 @@ const DATA_TREE_FUNCTIONS: Record<
     _.set(self, `appsmith.store[${key}]`, value);
     return {
       type: ActionTriggerType.STORE_VALUE,
-      payload: { key, value, persist },
+      payload: {
+        key,
+        value,
+        persist,
+        uniqueRequestId: uniqueId("store_value_id_"),
+      },
       executionType: ExecutionType.PROMISE,
     };
   },

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -84,7 +84,7 @@ const DATA_TREE_FUNCTIONS: Record<
         key,
         value,
         persist,
-        uniqueRequestId: uniqueId("store_value_id_"),
+        uniqueActionRequestId: uniqueId("store_value_id_"),
       },
       executionType: ExecutionType.PROMISE,
     };


### PR DESCRIPTION
## Description


### Problem 

`yield take(ReduxActionTypes.UPDATE_APP_STORE_EVALUATED)` inside storeValueLocally saga can catch previous storeValue action and complete the latest call too.
This was not expected behaviour with promisified storeValue as we need to track completion of each storeValue action separately.


Fixes #14653


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual & Cypress

- [x] https://github.com/appsmithorg/TestSmith/issues/1893


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
