### PR TITLE
fix: prevent cyclic dependency when switching to js mode

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Switchgroup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Switchgroup_spec.js
@@ -107,10 +107,7 @@ describe("Switchgroup Widget Functionality", function() {
       .contains("Oops, Something went wrong.")
       .should("not.exist");
     cy.wait(1000);
-    // check if the evaluation is disabled
-    cy.get(".t--widget-textwidget").should(
-      "contain",
-      `{{SwitchGroup1.selectedValues[0]}}`,
-    );
+    // Assert that evaluation is not disabled
+    cy.get(".t--widget-textwidget").should("contain", `BLUE`);
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Switchgroup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Switchgroup_spec.js
@@ -100,8 +100,8 @@ describe("Switchgroup Widget Functionality", function() {
       .find(".t--js-toggle")
       .trigger("click")
       .wait(3000);
-    // wait for a cyclic dependency error to occur
-    cy.validateToastMessage("Cyclic dependency found while evaluating");
+    // verify absence of cyclic dependency error
+    cy.VerifyErrorMsgAbsence("Cyclic dependency found while evaluating");
     // check if a crash messsge is appeared
     cy.get(".t--widget-switchgroupwidget")
       .contains("Oops, Something went wrong.")

--- a/app/client/src/workers/evaluationUtils.test.ts
+++ b/app/client/src/workers/evaluationUtils.test.ts
@@ -511,6 +511,45 @@ describe("translateDiffEvent", () => {
 
     expect(expectedTranslations).toStrictEqual(actualTranslations);
   });
+
+  it("deletes member expressions when Array changes to string", () => {
+    const diffs: Diff<any, any>[] = [
+      {
+        kind: "E",
+        path: ["Api1", "data"],
+        lhs: [{ id: "{{a}}" }, { id: "{{a}}" }],
+        rhs: `{ id: "{{a}}" }, { id: "{{a}}" }`,
+      },
+    ];
+
+    const expectedTranslations: DataTreeDiff[] = [
+      {
+        payload: {
+          propertyPath: "Api1.data",
+          value: `{ id: "{{a}}" }, { id: "{{a}}" }`,
+        },
+        event: DataTreeDiffEvent.EDIT,
+      },
+      {
+        payload: {
+          propertyPath: "Api1.data[0]",
+        },
+        event: DataTreeDiffEvent.DELETE,
+      },
+      {
+        payload: {
+          propertyPath: "Api1.data[1]",
+        },
+        event: DataTreeDiffEvent.DELETE,
+      },
+    ];
+
+    const actualTranslations = flatten(
+      diffs.map((diff) => translateDiffEventToDataTreeDiffEvent(diff, {})),
+    );
+
+    expect(expectedTranslations).toEqual(actualTranslations);
+  });
 });
 
 describe("overrideWidgetProperties", () => {


### PR DESCRIPTION
## Description

When translating diffs, if an array value changes to a string, all `MemberExpressions` of the array should be removed from the dependency map.

For example.

- Previous


```
ENTITY.options = [
{
label: "name",
value: {{name}}
},
{
label: "name",
value: {{name2}}
}
]
```


- Current (after switching to js mode)


```
ENTITY.options = "[
{
label: "name",
value: {{name}}
},
{
label: "name",
value: {{name2}}
}
]"
```

ENTITY.options[0] and ENTITY.options[1] (and their child nodes eg, ENTITY.options[0].value) should be removed from the dependencyMap

Fixes #14669 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Jest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
