### PR TITLE
fix: JSONForm - Generate Form button apply theme on new fields

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/widget/helper.test.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/helper.test.ts
@@ -1,6 +1,7 @@
 import {
   ARRAY_ITEM_KEY,
   DataType,
+  FieldThemeStylesheet,
   FieldType,
   ROOT_SCHEMA_KEY,
   Schema,
@@ -540,6 +541,7 @@ describe(".computeSchema", () => {
     const response = computeSchema({
       currSourceData: sourceData,
       widgetName: "JSONForm1",
+      fieldThemeStylesheets: {} as FieldThemeStylesheet,
     });
 
     expect(response.status).toEqual(ComputedSchemaStatus.LIMIT_EXCEEDED);
@@ -554,6 +556,7 @@ describe(".computeSchema", () => {
       const response = computeSchema({
         currSourceData: sourceData,
         widgetName: "JSONForm1",
+        fieldThemeStylesheets: {} as FieldThemeStylesheet,
       });
 
       expect(response.status).toEqual(ComputedSchemaStatus.UNCHANGED);
@@ -583,6 +586,7 @@ describe(".computeSchema", () => {
       currSourceData,
       prevSourceData,
       widgetName: "JSONForm1",
+      fieldThemeStylesheets: {} as FieldThemeStylesheet,
     });
 
     expect(response.status).toEqual(ComputedSchemaStatus.UNCHANGED);

--- a/app/client/src/widgets/JSONFormWidget/widget/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/helper.ts
@@ -42,7 +42,7 @@ type ComputeSchemaProps = {
   prevSchema?: Schema;
   widgetName: string;
   currentDynamicPropertyPathList?: PathList;
-  fieldThemeStylesheets?: FieldThemeStylesheet;
+  fieldThemeStylesheets: FieldThemeStylesheet;
 };
 
 export enum ComputedSchemaStatus {

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.test.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.test.ts
@@ -1,3 +1,9 @@
+import { OnButtonClickProps } from "components/propertyControls/ButtonControl";
+import { set } from "lodash";
+import { EVALUATION_PATH } from "utils/DynamicBindingUtils";
+
+import schemaTestData from "../schemaTestData";
+import { onGenerateFormClick } from "./propertyConfig";
 import generatePanelPropertyConfig from "./propertyConfig/generatePanelPropertyConfig";
 
 describe(".generatePanelPropertyConfig", () => {
@@ -28,5 +34,134 @@ describe(".generatePanelPropertyConfig", () => {
     });
 
     done();
+  });
+});
+
+describe(".onGenerateFormClick", () => {
+  it("calls batchUpdateProperties with new schema when prevSchema is not provided", () => {
+    const mockBatchUpdateProperties = jest.fn();
+    const widgetProperties = {
+      autoGenerateForm: false,
+      widgetName: "JSONForm1",
+      childStylesheet: schemaTestData.fieldThemeStylesheets,
+    };
+
+    set(
+      widgetProperties,
+      `${EVALUATION_PATH}.evaluatedValues.sourceData`,
+      schemaTestData.initialDataset.dataSource,
+    );
+
+    const params = ({
+      batchUpdateProperties: mockBatchUpdateProperties,
+      props: {
+        widgetProperties,
+      },
+    } as unknown) as OnButtonClickProps;
+
+    onGenerateFormClick(params);
+
+    const expectedDynamicPropertyPathList = [
+      { key: "schema.__root_schema__.children.dob.defaultValue" },
+      { key: "schema.__root_schema__.children.boolean.defaultValue" },
+    ];
+
+    expect(mockBatchUpdateProperties.mock.calls.length).toBe(1);
+    const response = mockBatchUpdateProperties.mock.calls[0][0];
+    expect(response.fieldLimitExceeded).toEqual(false);
+    expect(response.dynamicPropertyPathList).toEqual(
+      expectedDynamicPropertyPathList,
+    );
+    expect(response.schema).toEqual(schemaTestData.initialDataset.schemaOutput);
+  });
+
+  it("calls batchUpdateProperties with retained existing dynamicBindingPropertyPathList", () => {
+    const existingDynamicBindingPropertyPathList = [
+      { key: "dummy.path1" },
+      { key: "dummy.path2" },
+    ];
+
+    const mockBatchUpdateProperties = jest.fn();
+    const widgetProperties = {
+      autoGenerateForm: false,
+      widgetName: "JSONForm1",
+      childStylesheet: schemaTestData.fieldThemeStylesheets,
+      dynamicPropertyPathList: existingDynamicBindingPropertyPathList,
+    };
+
+    set(
+      widgetProperties,
+      `${EVALUATION_PATH}.evaluatedValues.sourceData`,
+      schemaTestData.initialDataset.dataSource,
+    );
+
+    const params = ({
+      batchUpdateProperties: mockBatchUpdateProperties,
+      props: {
+        widgetProperties,
+      },
+    } as unknown) as OnButtonClickProps;
+
+    onGenerateFormClick(params);
+
+    const expectedDynamicPropertyPathList = [
+      ...existingDynamicBindingPropertyPathList,
+      { key: "schema.__root_schema__.children.dob.defaultValue" },
+      { key: "schema.__root_schema__.children.boolean.defaultValue" },
+    ];
+
+    expect(mockBatchUpdateProperties.mock.calls.length).toBe(1);
+    const response = mockBatchUpdateProperties.mock.calls[0][0];
+    expect(response.fieldLimitExceeded).toEqual(false);
+    expect(response.dynamicPropertyPathList).toEqual(
+      expectedDynamicPropertyPathList,
+    );
+    expect(response.schema).toEqual(schemaTestData.initialDataset.schemaOutput);
+  });
+
+  it("calls batchUpdateProperties with updated schema when new key added to existing data source", () => {
+    const existingDynamicBindingPropertyPathList = [
+      { key: "dummy.path1" },
+      { key: "dummy.path2" },
+    ];
+
+    const mockBatchUpdateProperties = jest.fn();
+    const widgetProperties = {
+      autoGenerateForm: false,
+      widgetName: "JSONForm1",
+      childStylesheet: schemaTestData.fieldThemeStylesheets,
+      dynamicPropertyPathList: existingDynamicBindingPropertyPathList,
+      schema: schemaTestData.initialDataset.schemaOutput,
+    };
+
+    set(
+      widgetProperties,
+      `${EVALUATION_PATH}.evaluatedValues.sourceData`,
+      schemaTestData.withRemovedAddedKeyToInitialDataset.dataSource,
+    );
+
+    const params = ({
+      batchUpdateProperties: mockBatchUpdateProperties,
+      props: {
+        widgetProperties,
+      },
+    } as unknown) as OnButtonClickProps;
+
+    onGenerateFormClick(params);
+
+    const expectedDynamicPropertyPathList = [
+      ...existingDynamicBindingPropertyPathList,
+      { key: "schema.__root_schema__.children.dob.defaultValue" },
+    ];
+
+    expect(mockBatchUpdateProperties.mock.calls.length).toBe(1);
+    const response = mockBatchUpdateProperties.mock.calls[0][0];
+    expect(response.fieldLimitExceeded).toEqual(false);
+    expect(response.dynamicPropertyPathList).toEqual(
+      expectedDynamicPropertyPathList,
+    );
+    expect(response.schema).toEqual(
+      schemaTestData.withRemovedAddedKeyToInitialDataset.schemaOutput,
+    );
   });
 });

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig.ts
@@ -57,7 +57,7 @@ export const sourceDataValidationFn = (
   }
 };
 
-const onGenerateFormClick = ({
+export const onGenerateFormClick = ({
   batchUpdateProperties,
   props,
 }: OnButtonClickProps) => {
@@ -73,6 +73,7 @@ const onGenerateFormClick = ({
   const { dynamicPropertyPathList, schema, status } = computeSchema({
     currentDynamicPropertyPathList: widgetProperties.dynamicPropertyPathList,
     currSourceData,
+    fieldThemeStylesheets: widgetProperties.childStylesheet,
     prevSchema: widgetProperties.schema,
     prevSourceData,
     widgetName: widgetProperties.widgetName,
@@ -314,7 +315,12 @@ export default [
         onClick: onGenerateFormClick,
         isDisabled: generateFormCTADisabled,
         isTriggerProperty: false,
-        dependencies: ["autoGenerateForm", "schema", "fieldLimitExceeded"],
+        dependencies: [
+          "autoGenerateForm",
+          "schema",
+          "fieldLimitExceeded",
+          "childStylesheet",
+        ],
         evaluatedDependencies: ["sourceData"],
       },
       {


### PR DESCRIPTION
## Description

When the JSONForm auto-generate option is disabled, new source data is added and the `GENERATE FORM` button is clicked; the newly generated fields do not get current theme applied.

Reason:
In the property config, the function that gets called when the `GENERATE FORM` button is clicked, the function does not use the `childStylesheet` property present in the widget props.

Solution:
Passing of the `childStylesheet` to the appropriate function makes the theme config available to the schema parser to generate the new field with the theme config.

Fixes #14677 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual -
The steps to reproduce the issue was followed and made sure the theme gets applied correctly.

Jest -
The function that gets called when the `GENERATE FORM` is pressed is tested with 3 scenarios and the output is cross-verified
1. When a fresh form is generated with the auto-generate is disabled and the button is pressed, the schema for the fields are generated with theme config.
2. When certain new dynamicPropertyPaths are introduced, the source data remains the same and the button is pressed, the form schema/config should remain unchanged.
3. When few properties from the source data is removed and some new are added, the appropriated changes reflect in the output schema/config with the theme config.

Cypress -
None

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
