### PR TITLE
fix: editor utils moment async import

### DIFF
--- a/app/client/src/utils/EditorUtils.ts
+++ b/app/client/src/utils/EditorUtils.ts
@@ -5,6 +5,6 @@ export const editorInitializer = async () => {
   registerWidgets();
   PropertyControlRegistry.registerPropertyControlBuilders();
 
-  // const moment = await import("moment-timezone");
-  // moment.tz.setDefault(moment.tz.guess());
+  const { default: moment } = await import("moment-timezone");
+  moment.tz.setDefault(moment.tz.guess());
 };


### PR DESCRIPTION
## Description
- After the cra-5 release I noticed the moment-timezone code in `EditorUtils` is still commented. I have updated the file and changed the async import for webpack 5.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Tested manually on the canvas

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
