### PR TITLE
ci: Revert "ci: Use buildjet runners for Cypress tests, and fewer of them"

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -761,7 +761,7 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       github.event.pull_request.head.repo.full_name == github.repository))
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: app/client
@@ -778,6 +778,23 @@ jobs:
             4,
             5,
             6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
           ]
 
     # Service containers to run with this job. Required for running tests


### PR DESCRIPTION
Reverts appsmithorg/appsmith#14636

Reverting this change for now because there is an issue when re-running the failed specs. The action is unable to find the correct directory. 

Check error at: https://github.com/appsmithorg/appsmith/runs/6987190225?check_suite_focus=true#step:9:9