### PR TITLE
fix: api auth fails displays error on view mode now

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -42,9 +42,6 @@ import {
 } from "entities/Datasource/RestAPIForm";
 import {
   createMessage,
-  REST_API_AUTHORIZATION_APPSMITH_ERROR,
-  REST_API_AUTHORIZATION_FAILED,
-  REST_API_AUTHORIZATION_SUCCESSFUL,
   CONTEXT_DELETE,
   CONFIRM_CONTEXT_DELETE,
 } from "@appsmith/constants/messages";
@@ -173,29 +170,11 @@ class DatasourceRestAPIEditor extends React.Component<
     this.state = { confirmDelete: false };
   }
   componentDidMount() {
-    const status = this.props.responseStatus;
-
     // set replay data
     this.props.initializeReplayEntity(
       this.props.datasource.id,
       this.props.initialValues,
     );
-
-    if (status) {
-      // Set default error message
-      let message = REST_API_AUTHORIZATION_FAILED;
-      let variant = Variant.danger;
-      if (status === "success") {
-        message = REST_API_AUTHORIZATION_SUCCESSFUL;
-        variant = Variant.success;
-      } else if (status === "appsmith_error") {
-        message = REST_API_AUTHORIZATION_APPSMITH_ERROR;
-      }
-      Toaster.show({
-        text: this.props.responseMessage || createMessage(message),
-        variant,
-      });
-    }
   }
 
   componentDidUpdate() {
@@ -1150,13 +1129,6 @@ const mapStateToProps = (state: AppState, props: any) => {
   ) as Datasource;
 
   const hintMessages = datasource && datasource.messages;
-  let responseStatus = props.responseStatus;
-  let responseMessage = props.responseMessage;
-  if (props.location) {
-    const search = new URLSearchParams(props.location.search);
-    responseStatus = search.get("response_status");
-    responseMessage = search.get("display_message");
-  }
 
   return {
     initialValues: datasourceToFormValues(datasource),
@@ -1167,8 +1139,6 @@ const mapStateToProps = (state: AppState, props: any) => {
     ) as ApiDatasourceForm,
     formMeta: getFormMeta(DATASOURCE_REST_API_FORM)(state),
     messages: hintMessages,
-    responseStatus,
-    responseMessage,
   };
 };
 

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -28,6 +28,14 @@ import {
   selectURLSlugs,
 } from "selectors/editorSelectors";
 import { saasEditorDatasourceIdURL } from "RouteBuilder";
+import {
+  createMessage,
+  REST_API_AUTHORIZATION_APPSMITH_ERROR,
+  REST_API_AUTHORIZATION_FAILED,
+  REST_API_AUTHORIZATION_SUCCESSFUL,
+} from "ce/constants/messages";
+import { Toaster } from "components/ads/Toast";
+import { Variant } from "components/ads/common";
 
 interface ReduxStateProps {
   datasourceId: string;
@@ -77,6 +85,30 @@ class DataSourceEditor extends React.Component<Props> {
       this.props.pluginDatasourceForm !== "RestAPIDatasourceForm"
     ) {
       this.props.switchDatasource(this.props.datasourceId);
+    }
+
+    if (
+      this.props.pluginDatasourceForm === "RestAPIDatasourceForm" &&
+      this.props.location
+    ) {
+      const search = new URLSearchParams(this.props.location.search);
+      const responseStatus = search.get("response_status");
+      const responseMessage = search.get("display_message");
+      if (responseStatus) {
+        // Set default error message
+        let message = REST_API_AUTHORIZATION_FAILED;
+        let variant = Variant.danger;
+        if (responseStatus === "success") {
+          message = REST_API_AUTHORIZATION_SUCCESSFUL;
+          variant = Variant.success;
+        } else if (responseStatus === "appsmith_error") {
+          message = REST_API_AUTHORIZATION_APPSMITH_ERROR;
+        }
+        Toaster.show({
+          text: responseMessage || createMessage(message),
+          variant,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Earlier the API auth error redirects the url of the application with query params `response_status` and `display_message` which used to show error toast in edit mode only. But now the logic has been moved to view mode and removed from edit mode for plugin datasource `RestAPIDatasourceForm` only.

Fixes #12600 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
