### PR TITLE
fix:  The reset button on properties behaves incorrect for JSONForm fields and Table primary columns

### DIFF
--- a/app/client/src/entities/AppTheming/utils.ts
+++ b/app/client/src/entities/AppTheming/utils.ts
@@ -5,10 +5,7 @@ import {
   isDynamicValue,
   THEME_BINDING_REGEX,
 } from "utils/DynamicBindingUtils";
-import {
-  getBindingTemplate,
-  ROOT_SCHEMA_KEY,
-} from "widgets/JSONFormWidget/constants";
+import { ROOT_SCHEMA_KEY } from "widgets/JSONFormWidget/constants";
 import { parseSchemaItem } from "widgets/WidgetUtils";
 import { getFieldStylesheet } from "widgets/JSONFormWidget/helper";
 import { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
@@ -107,28 +104,21 @@ export const getPropertiesToUpdateForReset = (
             `schema.${ROOT_SCHEMA_KEY}`,
             (schemaItem, propertyPath) => {
               const fieldStylesheet = getFieldStylesheet(
+                widget.widgetName,
                 schemaItem.fieldType,
                 themeStylesheet[widget.type].childStylesheet as any,
               );
 
               Object.keys(fieldStylesheet).map((fieldPropertyKey) => {
                 const fieldStylesheetValue = fieldStylesheet[fieldPropertyKey];
-                const { jsSnippets, stringSegments } = getDynamicBindings(
-                  fieldStylesheet[fieldPropertyKey],
-                );
-                const js = combineDynamicBindings(jsSnippets, stringSegments);
-                const { prefixTemplate, suffixTemplate } = getBindingTemplate(
-                  widget.widgetName,
-                );
-                const computedValue = `${prefixTemplate}${js}${suffixTemplate}`;
 
                 if (
                   isDynamicValue(fieldStylesheetValue) &&
-                  computedValue !== get(schemaItem, fieldPropertyKey)
+                  fieldStylesheetValue !== get(schemaItem, fieldPropertyKey)
                 ) {
                   modifications[
                     `${[propertyPath]}.${fieldPropertyKey}`
-                  ] = computedValue;
+                  ] = fieldStylesheetValue;
                 }
               });
             },

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -117,8 +117,6 @@ const PropertyControl = memo((props: Props) => {
     THEME_BINDING_REGEX.test(propertyStylesheetValue) &&
     propertyStylesheetValue !== propertyValue;
 
-  console.log({ propertyName: props.propertyName, propertyStylesheetValue });
-
   /**
    * resets the value of property to theme stylesheet value
    * which is a binding to theme object defined in the stylesheet

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -117,6 +117,8 @@ const PropertyControl = memo((props: Props) => {
     THEME_BINDING_REGEX.test(propertyStylesheetValue) &&
     propertyStylesheetValue !== propertyValue;
 
+  console.log({ propertyName: props.propertyName, propertyStylesheetValue });
+
   /**
    * resets the value of property to theme stylesheet value
    * which is a binding to theme object defined in the stylesheet

--- a/app/client/src/widgets/JSONFormWidget/schemaParser.ts
+++ b/app/client/src/widgets/JSONFormWidget/schemaParser.ts
@@ -492,6 +492,7 @@ class SchemaParser {
     const FieldComponent = FIELD_MAP[fieldType];
     const bindingTemplate = getBindingTemplate(widgetName);
     const fieldStylesheet = getFieldStylesheet(
+      widgetName,
       fieldType,
       fieldThemeStylesheets,
     );

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
@@ -105,15 +105,17 @@ export const getStylesheetValue = (
   propertyPath: string,
   widgetStylesheet?: AppTheme["stylesheet"][string],
 ) => {
-  return getSchemaItem(props, propertyPath).compute((schemaItem) => {
-    const fieldStylesheet = getFieldStylesheet(
-      props.widgetName,
-      schemaItem.fieldType,
-      widgetStylesheet?.childStylesheet as FieldThemeStylesheet,
-    );
+  return getSchemaItem(props, propertyPath).compute(
+    (schemaItem, propertyName) => {
+      const fieldStylesheet = getFieldStylesheet(
+        props.widgetName,
+        schemaItem.fieldType,
+        widgetStylesheet?.childStylesheet as FieldThemeStylesheet,
+      );
 
-    return fieldStylesheet || "";
-  });
+      return fieldStylesheet[propertyName] || "";
+    },
+  );
 };
 
 export const getAutocompleteProperties = (props: JSONFormWidgetProps) => {

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
@@ -10,18 +10,12 @@ import {
   HookResponse,
   FieldThemeStylesheet,
   ROOT_SCHEMA_KEY,
-  getBindingTemplate,
 } from "../../constants";
 import { getGrandParentPropertyPath, getParentPropertyPath } from "../helper";
 import { JSONFormWidgetProps } from "..";
 import { getFieldStylesheet } from "widgets/JSONFormWidget/helper";
 import { AppTheme } from "entities/AppTheming";
 import { processSchemaItemAutocomplete } from "components/propertyControls/JSONFormComputeControl";
-import {
-  combineDynamicBindings,
-  getDynamicBindings,
-  isDynamicValue,
-} from "utils/DynamicBindingUtils";
 
 export type HiddenFnParams = [JSONFormWidgetProps, string];
 
@@ -111,28 +105,15 @@ export const getStylesheetValue = (
   propertyPath: string,
   widgetStylesheet?: AppTheme["stylesheet"][string],
 ) => {
-  return getSchemaItem(props, propertyPath).compute(
-    (schemaItem, propertyName) => {
-      const fieldStylesheet = getFieldStylesheet(
-        schemaItem.fieldType,
-        widgetStylesheet?.childStylesheet as FieldThemeStylesheet,
-      );
+  return getSchemaItem(props, propertyPath).compute((schemaItem) => {
+    const fieldStylesheet = getFieldStylesheet(
+      props.widgetName,
+      schemaItem.fieldType,
+      widgetStylesheet?.childStylesheet as FieldThemeStylesheet,
+    );
 
-      if (isDynamicValue(fieldStylesheet[propertyName])) {
-        const { jsSnippets, stringSegments } = getDynamicBindings(
-          fieldStylesheet[propertyName],
-        );
-        const js = combineDynamicBindings(jsSnippets, stringSegments);
-        const { prefixTemplate, suffixTemplate } = getBindingTemplate(
-          props.widgetName,
-        );
-
-        return `${prefixTemplate}${js}${suffixTemplate}`;
-      }
-
-      return fieldStylesheet || "";
-    },
-  );
+    return fieldStylesheet || "";
+  });
 };
 
 export const getAutocompleteProperties = (props: JSONFormWidgetProps) => {

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
@@ -10,12 +10,18 @@ import {
   HookResponse,
   FieldThemeStylesheet,
   ROOT_SCHEMA_KEY,
+  getBindingTemplate,
 } from "../../constants";
 import { getGrandParentPropertyPath, getParentPropertyPath } from "../helper";
 import { JSONFormWidgetProps } from "..";
 import { getFieldStylesheet } from "widgets/JSONFormWidget/helper";
 import { AppTheme } from "entities/AppTheming";
 import { processSchemaItemAutocomplete } from "components/propertyControls/JSONFormComputeControl";
+import {
+  combineDynamicBindings,
+  getDynamicBindings,
+  isDynamicValue,
+} from "utils/DynamicBindingUtils";
 
 export type HiddenFnParams = [JSONFormWidgetProps, string];
 
@@ -112,7 +118,19 @@ export const getStylesheetValue = (
         widgetStylesheet?.childStylesheet as FieldThemeStylesheet,
       );
 
-      return fieldStylesheet[propertyName] || "";
+      if (isDynamicValue(fieldStylesheet[propertyName])) {
+        const { jsSnippets, stringSegments } = getDynamicBindings(
+          fieldStylesheet[propertyName],
+        );
+        const js = combineDynamicBindings(jsSnippets, stringSegments);
+        const { prefixTemplate, suffixTemplate } = getBindingTemplate(
+          props.widgetName,
+        );
+
+        return `${prefixTemplate}${js}${suffixTemplate}`;
+      }
+
+      return fieldStylesheet || "";
     },
   );
 };

--- a/app/client/src/widgets/TableWidget/widget/helpers.ts
+++ b/app/client/src/widgets/TableWidget/widget/helpers.ts
@@ -1,6 +1,10 @@
 import { AppTheme } from "entities/AppTheming";
 import { TableWidgetProps } from "../constants";
 import { get } from "lodash";
+import {
+  combineDynamicBindings,
+  getDynamicBindings,
+} from "utils/DynamicBindingUtils";
 
 /**
  * this is a getter function to get stylesheet value of the property from the config
@@ -20,4 +24,34 @@ export const getStylesheetValue = (
   const columnType = get(props, `primaryColumns.${columnName}.columnType`);
 
   return get(widgetStylesheet, `childStylesheet.${columnType}.${propertyName}`);
+};
+
+/**
+ * this is a getter function to get stylesheet value of the property from the config
+ *
+ * @param props
+ * @param propertyPath
+ * @param widgetStylesheet
+ * @returns
+ */
+export const getPrimaryColumnStylesheetValue = (
+  props: TableWidgetProps,
+  propertyPath: string,
+  widgetStylesheet?: AppTheme["stylesheet"][string],
+) => {
+  const propertyName = propertyPath.split(".").slice(-1)[0];
+  const columnName = propertyPath.split(".").slice(-2)[0];
+  const columnType = get(props, `primaryColumns.${columnName}.columnType`);
+  const themeStylesheetValue: any = get(
+    widgetStylesheet,
+    `childStylesheet.${columnType}.${propertyName}`,
+  );
+
+  const { jsSnippets, stringSegments } = getDynamicBindings(
+    themeStylesheetValue,
+  );
+
+  const js = combineDynamicBindings(jsSnippets, stringSegments);
+
+  return `{{${props.widgetName}.sanitizedTableData.map((currentRow) => ( ${js}))}}`;
 };

--- a/app/client/src/widgets/TableWidget/widget/propertyConfig.ts
+++ b/app/client/src/widgets/TableWidget/widget/propertyConfig.ts
@@ -23,7 +23,7 @@ import {
   TABLE_WIDGET_TOTAL_RECORD_TOOLTIP,
 } from "@appsmith/constants/messages";
 import { IconNames } from "@blueprintjs/icons";
-import { getStylesheetValue } from "./helpers";
+import { getPrimaryColumnStylesheetValue } from "./helpers";
 
 const ICON_NAMES = Object.keys(IconNames).map(
   (name: string) => IconNames[name as keyof typeof IconNames],
@@ -904,7 +904,7 @@ export default [
                 },
                 {
                   propertyName: "buttonColor",
-                  getStylesheetValue,
+                  getStylesheetValue: getPrimaryColumnStylesheetValue,
                   label: "Button Color",
                   controlType: "PRIMARY_COLUMNS_COLOR_PICKER",
                   helpText: "Changes the color of the button",
@@ -989,6 +989,7 @@ export default [
                   label: "Border Radius",
                   customJSControl: "COMPUTE_VALUE",
                   isJSConvertible: true,
+                  getStylesheetValue: getPrimaryColumnStylesheetValue,
                   helpText:
                     "Rounds the corners of the icon button's outer border edge",
                   controlType: "BORDER_RADIUS_OPTIONS",
@@ -1052,6 +1053,7 @@ export default [
                   customJSControl: "COMPUTE_VALUE",
                   isJSConvertible: true,
                   isBindProperty: true,
+                  getStylesheetValue: getPrimaryColumnStylesheetValue,
                   isTriggerProperty: false,
                   placeholderText: "#FFFFFF / Gray / rgb(255, 99, 71)",
                   validation: {


### PR DESCRIPTION
Reset value in primary columns in table widget and fields in JSONFOrm was not working as expected. This PR fixes that.

Fixes #14220

## Type of change

- Bug fix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
