### PR TITLE
fix: Allow connection without password for Postgres plugin (#14003)

### DIFF
--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -573,10 +573,6 @@ public class PostgresPlugin extends BasePlugin {
                     invalids.add("Missing username for authentication.");
                 }
 
-                if (StringUtils.isEmpty(authentication.getPassword())) {
-                    invalids.add("Missing password for authentication.");
-                }
-
                 if (StringUtils.isEmpty(authentication.getDatabaseName())) {
                     invalids.add("Missing database name.");
                 }

--- a/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-page-added.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ImportExportServiceTest/valid-application-with-page-added.json
@@ -109,8 +109,7 @@
       "pluginId": "postgres-plugin",
       "invalids": [
         "Missing endpoint.",
-        "Missing username for authentication.",
-        "Missing password for authentication."
+        "Missing username for authentication."
       ],
       "messages": [],
       "isConfigured": false,


### PR DESCRIPTION
Remove password check while validating data source
Postgres plugin: allow connection without password 

Fixes #14003

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
Add new Postgres datasource - leave password field empty - Clicking on test button works fine. (Missing password Popup not reappears).

## Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
