### PR TITLE
fix: checkbox-group widget breaking UI issue

### DIFF
--- a/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
@@ -69,6 +69,15 @@ export interface CheckboxGroupContainerProps {
 
 export const CheckboxGroupContainer = styled.div<CheckboxGroupContainerProps>`
   ${labelLayoutStyles}
+   justify-content: ${({ compactMode, labelPosition }) => {
+     if (
+       labelPosition &&
+       labelPosition !== LabelPosition.Left &&
+       !compactMode
+     ) {
+       return "flex-start";
+     }
+   }};
   & .${LABEL_CONTAINER_CLASS} {
     ${({ labelPosition }) =>
       labelPosition === LabelPosition.Left && "min-height: 30px"};

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -165,9 +165,29 @@ class CheckboxGroupWidget extends BaseWidget<
             isJSConvertible: true,
             isBindProperty: true,
             isTriggerProperty: false,
+            updateHook: (
+              props: CheckboxGroupWidgetProps,
+              propertyPath: string,
+              propertyValue: string,
+            ) => {
+              const propertiesToUpdate = [{ propertyPath, propertyValue }];
+              const isOffInline =
+                typeof propertyValue === "string"
+                  ? !(propertyValue === "true")
+                  : !propertyValue;
+
+              if (isOffInline) {
+                propertiesToUpdate.push({
+                  propertyPath: "optionAlignment",
+                  propertyValue: CheckboxGroupAlignmentTypes.NONE,
+                });
+              }
+              return propertiesToUpdate;
+            },
             validation: {
               type: ValidationTypes.BOOLEAN,
             },
+            dependencies: ["isInline"],
           },
           {
             propertyName: "isSelectAll",
@@ -315,6 +335,12 @@ class CheckboxGroupWidget extends BaseWidget<
                 ],
               },
             },
+            hidden: (props: CheckboxGroupWidgetProps) => {
+              return typeof props.isInline === "string"
+                ? !(props.isInline === "true")
+                : !props.isInline;
+            },
+            dependencies: ["isInline"],
           },
           {
             propertyName: "labelTextColor",


### PR DESCRIPTION
## Description

> Checkbox-group widget breaking UI issue due to the inline and style alignment.

Fixes #14327  

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Steps you can reproduce:

> For Test 1:

- Drag and drop a checkbox group widget
- Add around 3 or 4 more options.
- Set the inline property to off, and label position to top or auto
- Set Style Alignment to either - End/Center/Around.

> For Test 2:

- Drag and drop a checkbox group widget
- Add around 3 or 4 more options.
- Set the inline property to on, and label position to top or auto
- Then stretch the bottom border of the widget.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
