### PR TITLE
fix: JsObject parsing

### DIFF
--- a/app/client/src/constants/ast.ts
+++ b/app/client/src/constants/ast.ts
@@ -12,14 +12,19 @@ export enum SourceType {
 // what all properties can the node have.
 // We will just define the ones we are working with
 export enum NodeTypes {
-  MemberExpression = "MemberExpression",
   Identifier = "Identifier",
-  VariableDeclarator = "VariableDeclarator",
-  FunctionDeclaration = "FunctionDeclaration",
-  FunctionExpression = "FunctionExpression",
   AssignmentPattern = "AssignmentPattern",
   Literal = "Literal",
-  ExportDefaultDeclaration = "ExportDefaultDeclaration",
   Property = "Property",
+  // Declaration - https://github.com/estree/estree/blob/master/es5.md#declarations
+  FunctionDeclaration = "FunctionDeclaration",
+  ExportDefaultDeclaration = "ExportDefaultDeclaration",
+  VariableDeclarator = "VariableDeclarator",
+  // Expression - https://github.com/estree/estree/blob/master/es5.md#expressions
+  MemberExpression = "MemberExpression",
+  FunctionExpression = "FunctionExpression",
   ArrowFunctionExpression = "ArrowFunctionExpression",
+  ObjectExpression = "ObjectExpression",
+  ArrayExpression = "ArrayExpression",
+  ThisExpression = "ThisExpression",
 }

--- a/app/client/src/workers/ast.test.ts
+++ b/app/client/src/workers/ast.test.ts
@@ -308,7 +308,6 @@ describe("parseJSObjectWithAST", () => {
       },
     ];
     const resultParsedObject = parseJSObjectWithAST(body);
-    console.log(resultParsedObject, parsedObject);
     expect(resultParsedObject).toStrictEqual(parsedObject);
   });
 });

--- a/app/client/src/workers/ast.test.ts
+++ b/app/client/src/workers/ast.test.ts
@@ -310,4 +310,40 @@ describe("parseJSObjectWithAST", () => {
     const resultParsedObject = parseJSObjectWithAST(body);
     expect(resultParsedObject).toStrictEqual(parsedObject);
   });
+  it("parse js object with variable declaration inside function", () => {
+    const body = `{
+      myFun1: () => {
+        const a = {
+          conditions: [],
+          requires: 1,
+          testFunc: () => {},
+          testFunc2: function(){}
+        };
+      },
+      myFun2: async () => {
+        //use async-await or promises
+      }
+    }`;
+    const parsedObject = [
+      {
+        key: "myFun1",
+        value: `() => {
+  const a = {
+    conditions: [],
+    requires: 1,
+    testFunc: () => {},
+    testFunc2: function () {}
+  };
+}`,
+        type: "ArrowFunctionExpression",
+      },
+      {
+        key: "myFun2",
+        value: "async () => {}",
+        type: "ArrowFunctionExpression",
+      },
+    ];
+    const resultParsedObject = parseJSObjectWithAST(body);
+    expect(resultParsedObject).toStrictEqual(parsedObject);
+  });
 });

--- a/app/client/src/workers/ast.test.ts
+++ b/app/client/src/workers/ast.test.ts
@@ -285,12 +285,6 @@ describe("parseJSObjectWithAST", () => {
         value: "[]",
         type: "ArrayExpression",
       },
-      // "a" shouldn't be considered as jsObject's property as it is value of myVar2
-      // {
-      //   key: '"a"',
-      //   value: '"app"',
-      //   type: "Literal",
-      // },
       {
         key: "myVar2",
         value: '{\n  "a": "app"\n}',

--- a/app/client/src/workers/ast.test.ts
+++ b/app/client/src/workers/ast.test.ts
@@ -285,11 +285,12 @@ describe("parseJSObjectWithAST", () => {
         value: "[]",
         type: "ArrayExpression",
       },
-      {
-        key: '"a"',
-        value: '"app"',
-        type: "Literal",
-      },
+      // "a" shouldn't be considered as jsObject's property as it is value of myVar2
+      // {
+      //   key: '"a"',
+      //   value: '"app"',
+      //   type: "Literal",
+      // },
       {
         key: "myVar2",
         value: '{\n  "a": "app"\n}',
@@ -307,6 +308,7 @@ describe("parseJSObjectWithAST", () => {
       },
     ];
     const resultParsedObject = parseJSObjectWithAST(body);
+    console.log(resultParsedObject, parsedObject);
     expect(resultParsedObject).toStrictEqual(parsedObject);
   });
 });

--- a/app/client/src/workers/ast.ts
+++ b/app/client/src/workers/ast.ts
@@ -300,6 +300,7 @@ const getPropertyAccessor = (propertyNode: IdentifierNode | LiteralNode) => {
   }
 };
 
+// https://github.com/estree/estree/blob/master/es5.md#objectexpression
 interface ObjectNode extends Node {
   id: {
     end: number;
@@ -309,7 +310,7 @@ interface ObjectNode extends Node {
   };
   init: {
     end: number;
-    properties: Array<Node>;
+    properties: Array<PropertyNode>;
     start: number;
     type: string;
   };


### PR DESCRIPTION
## Description

When JSObject function has code for variable declaration like below. In such cases, those properties also gets added as JSObject property which is not expected.  

```
newConfig.runners[0].issue.labels[edit_name.text] = {
				conditions: [],
				requires: 1,
                                 testFunc: () => { 
					console.log()
				}
			}
```

We will need to make sure to only parse JSobject's properties and not internal object property or function, this PR changes logic to do so.

<img width="1271" alt="Screenshot 2022-06-27 at 6 45 37 PM" src="https://user-images.githubusercontent.com/23132741/175950510-616e2423-03b9-4818-8398-5284f1c7d0f8.png">

### Solution

- Change the parsing logic to track variableDeclarator and check for JSObject being declared and find its properties using the AST Node.
- As we are exactly checking JSobject Node we won't have any incorrect properties defined or any property missed.

Fixes https://github.com/appsmithorg/appsmith/issues/14836

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

#### Jest test
- [x] Add variable declaration inside JSObject's function and verify AST parsing

#### Cypress test
- [ ] Add variable declaration inside JSObject's function and verify async function list
- [ ] [Nested async code in an array should not appear on the settings tab of a JS object](https://github.com/appsmithorg/TestSmith/issues/1919)
- [ ] [Nested async code in an object should not appear on the settings tab of a JS object](https://github.com/appsmithorg/TestSmith/issues/1918)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
