### PR TITLE
fix: made blinking cursor transparent for switch datasource

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -286,6 +286,15 @@ const DropdownSelect = styled.div`
     & > div {
       height: 100%;
     }
+
+    & .appsmith-select__input > input {
+      position: relative;
+      bottom: 4px;
+    }
+
+    & .appsmith-select__input > input[value=""] {
+      caret-color: transparent;
+    }
   }
 `;
 


### PR DESCRIPTION
## Description

Made cursor transparent when any datasource is selected in switch datasource dropdown and there is no searched input.
Cursor becomes visible when any input is typed.

Fixes #13746

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
