### PR TITLE
feat: Expose window.postMessage as a global function

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -232,6 +232,7 @@ export const ActionType = {
   getGeolocation: "appsmith.geolocation.getCurrentPosition",
   watchGeolocation: "appsmith.geolocation.watchPosition",
   stopWatchGeolocation: "appsmith.geolocation.clearWatch",
+  postMessage: "postWindowMessage",
 };
 type ActionType = typeof ActionType[keyof typeof ActionType];
 
@@ -407,6 +408,9 @@ const fieldConfigs: FieldConfigs = {
           break;
         case ActionType.resetWidget:
           defaultParams = `"",true`;
+          break;
+        case ActionType.postMessage:
+          defaultParams = `"", '*'`;
           break;
         default:
           break;

--- a/app/client/src/components/editorComponents/ActionCreator/index.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/index.tsx
@@ -373,6 +373,18 @@ function getFieldFromValue(
       field: FieldType.CALLBACK_FUNCTION_FIELD,
     });
   }
+
+  if (value.indexOf("postWindowMessage") !== -1) {
+    fields.push(
+      {
+        field: FieldType.MESSAGE_FIELD,
+      },
+      {
+        field: FieldType.TARGET_ORIGIN_FIELD,
+      },
+    );
+  }
+
   return fields;
 }
 

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -37,6 +37,7 @@ export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
   [ActionTriggerType.WATCH_CURRENT_LOCATION]: "watchLocation",
   [ActionTriggerType.STOP_WATCHING_CURRENT_LOCATION]: "stopWatch",
   [ActionTriggerType.CONFIRMATION_MODAL]: "ConfirmationModal",
+  [ActionTriggerType.POST_MESSAGE]: "postWindowMessage",
 };
 
 export type RunPluginActionDescription = {

--- a/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PostMessageSaga.ts
@@ -1,0 +1,35 @@
+import { spawn } from "redux-saga/effects";
+import { PostMessageDescription } from "../../entities/DataTree/actionTriggers";
+import {
+  logActionExecutionError,
+  TriggerFailureError,
+} from "sagas/ActionExecution/errorUtils";
+import { TriggerMeta } from "./ActionExecutionSagas";
+import { isEmpty } from "lodash";
+
+export function* postMessageSaga(
+  payload: PostMessageDescription["payload"],
+  triggerMeta: TriggerMeta,
+) {
+  yield spawn(executePostMessage, payload, triggerMeta);
+}
+
+export function* executePostMessage(
+  payload: PostMessageDescription["payload"],
+  triggerMeta: TriggerMeta,
+) {
+  const { message, targetOrigin } = payload;
+  try {
+    if (isEmpty(targetOrigin)) {
+      throw new TriggerFailureError("Please enter a target origin URL.");
+    } else {
+      window.parent.postMessage(message, targetOrigin, undefined);
+    }
+  } catch (error) {
+    logActionExecutionError(
+      (error as Error).message,
+      triggerMeta.source,
+      triggerMeta.triggerPropertyName,
+    );
+  }
+}

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -670,6 +670,11 @@ export const GLOBAL_FUNCTIONS = {
     "!doc": "Stop executing a setInterval with id",
     "!type": "fn(id: string) -> void",
   },
+  postWindowMessage: {
+    "!doc":
+      "Establish cross-origin communication between Window objects/page and iframes",
+    "!type": "fn(message: unknown, targetOrigin: string)",
+  },
 };
 
 export const getPropsForJSActionEntity = ({

--- a/app/client/src/workers/Actions.test.ts
+++ b/app/client/src/workers/Actions.test.ts
@@ -433,4 +433,162 @@ describe("Add functions", () => {
       ]),
     );
   });
+
+  describe("Post message to target window works", () => {
+    const targetOrigin = "https://dev.appsmith.com/";
+
+    it("Post message with first argument (message) as a string", () => {
+      const message = "Hello world!";
+
+      expect(
+        dataTreeWithFunctions.postWindowMessage(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: "Hello world!",
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as undefined", () => {
+      const message = undefined;
+
+      expect(
+        dataTreeWithFunctions.postWindowMessage(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: undefined,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as null", () => {
+      const message = null;
+
+      expect(
+        dataTreeWithFunctions.postWindowMessage(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: null,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as a number", () => {
+      const message = 1826;
+
+      expect(
+        dataTreeWithFunctions.postWindowMessage(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: 1826,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as a boolean", () => {
+      const message = true;
+
+      expect(
+        dataTreeWithFunctions.postWindowMessage(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: true,
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as an array", () => {
+      const message = [1, 2, 3, [1, 2, 3, [1, 2, 3]]];
+
+      expect(
+        dataTreeWithFunctions.postWindowMessage(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: [1, 2, 3, [1, 2, 3, [1, 2, 3]]],
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+
+    it("Post message with first argument (message) as an object", () => {
+      const message = {
+        key: 1,
+        status: "active",
+        person: {
+          name: "timothee chalamet",
+        },
+        randomArr: [1, 2, 3],
+      };
+
+      expect(
+        dataTreeWithFunctions.postWindowMessage(message, targetOrigin),
+      ).toBe(undefined);
+
+      expect(self.TRIGGER_COLLECTOR).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            payload: {
+              message: {
+                key: 1,
+                status: "active",
+                person: {
+                  name: "timothee chalamet",
+                },
+                randomArr: [1, 2, 3],
+              },
+              targetOrigin: "https://dev.appsmith.com/",
+            },
+            type: "POST_MESSAGE",
+          }),
+        ]),
+      );
+    });
+  });
 });

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,6 +261,16 @@ const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
+  postWindowMessage: function(message: unknown, targetOrigin: string) {
+    return {
+      type: ActionTriggerType.POST_MESSAGE,
+      payload: {
+        message,
+        targetOrigin,
+      },
+      executionType: ExecutionType.TRIGGER,
+    };
+  },
 };
 
 export const enhanceDataTreeWithFunctions = (


### PR DESCRIPTION
## Description

This pull request exposes `window.postMessage()` as a global function in the Appsmith platform.

Post message safely enables cross-origin communication between window objects.
**Example use-case** - Appsmith page embedded within an iframe which communicates with the container website

**More on post message here** - https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage

**References used for this PR:**
1. Geolocation APIs - https://github.com/appsmithorg/appsmith/pull/9295
2. setInterval and clearInterval support - https://github.com/appsmithorg/appsmith/pull/8158

**Fixes** #7241 

**Screen recording** - 

https://user-images.githubusercontent.com/10229595/163362579-18b5a26c-5ae5-40da-a4ff-3335ee024da5.mov


## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test plan 
- **Manual**: Created an app with different buttons holding different types of data and embedded it in a code sandbox within an iframe. Also removed the target origin which throws an error (App link - https://dev.appsmith.com/app/untitled-application-1/page1-624c1af4d8e632741017682e, Codesandbox link - https://codesandbox.io/s/compassionate-tdd-6dnzzd?file=/src/index.js)
- Added Jest tests
- https://github.com/appsmithorg/TestSmith/issues/1892

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes




    