### PR TITLE
fix: switch datasource option list contains similar ds

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/SwitchDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/SwitchDatasource_spec.js
@@ -86,12 +86,17 @@ describe("Switch datasource", function() {
       .type("select * from public.users limit 10");
     cy.wait(3000);
     cy.runQuery();
+    cy.wait("@saveAction").should(
+      "have.nested.property",
+      "response.body.data.isValid",
+      true,
+    );
 
     cy.get(".t--switch-datasource").click();
     cy.contains(".t--datasource-option", postgresDatasourceNameSecond)
       .click()
       .wait(1000);
-
+    cy.runQuery();
     cy.wait("@saveAction").should(
       "have.nested.property",
       "response.body.data.isValid",
@@ -99,15 +104,16 @@ describe("Switch datasource", function() {
     );
   });
 
-  it("4. Confirm mongo datasource is not present in the switch datasources dropdown", function() {
+  it("5. Confirm mongo datasource is not present in the switch datasources dropdown", function() {
     cy.get(".t--switch-datasource").click();
     cy.get(".t--datasource-option").should("not.have", mongoDatasourceName);
   });
 
-  it("4. Delete the query and datasources", function() {
+  it("6. Delete the query and datasources", function() {
     cy.deleteQueryUsingContext();
 
     cy.deleteDatasource(postgresDatasourceName);
+    cy.deleteDatasource(postgresDatasourceNameSecond);
     cy.deleteDatasource(mongoDatasourceName);
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/SwitchDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/SwitchDatasource_spec.js
@@ -1,9 +1,9 @@
 const datasource = require("../../../../locators/DatasourcesEditor.json");
 const queryLocators = require("../../../../locators/QueryEditor.json");
-const queryEditor = require("../../../../locators/QueryEditor.json");
 
 describe("Switch datasource", function() {
   let postgresDatasourceName;
+  let postgresDatasourceNameSecond;
   let mongoDatasourceName;
 
   beforeEach(() => {
@@ -32,7 +32,29 @@ describe("Switch datasource", function() {
     cy.testSaveDatasource();
   });
 
-  it("2. Create mongo datasource", function() {
+  it("2. Create another postgres datasource", function() {
+    cy.NavigateToDatasourceEditor();
+    cy.get(datasource.PostgreSQL).click();
+    cy.generateUUID().then((uid) => {
+      postgresDatasourceNameSecond = uid;
+
+      cy.get(".t--edit-datasource-name").click();
+      cy.get(".t--edit-datasource-name input")
+        .clear()
+        .type(postgresDatasourceNameSecond, { force: true })
+        .should("have.value", postgresDatasourceNameSecond)
+        .blur();
+    });
+    cy.wait("@saveDatasource").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
+    cy.fillPostgresDatasourceForm();
+    cy.testSaveDatasource();
+  });
+
+  it("3. Create mongo datasource", function() {
     cy.NavigateToDatasourceEditor();
     cy.get(datasource.MongoDB).click();
     cy.generateUUID().then((uid) => {
@@ -55,7 +77,7 @@ describe("Switch datasource", function() {
     cy.testSaveDatasource();
   });
 
-  it("3. By switching datasources execute a query with both the datasources", function() {
+  it("4. By switching datasources execute a query with both the datasources", function() {
     cy.NavigateToActiveDSQueryPane(postgresDatasourceName);
     cy.get(queryLocators.templateMenu).click({ force: true });
     cy.get(".CodeMirror textarea")
@@ -66,7 +88,7 @@ describe("Switch datasource", function() {
     cy.runQuery();
 
     cy.get(".t--switch-datasource").click();
-    cy.contains(".t--datasource-option", mongoDatasourceName)
+    cy.contains(".t--datasource-option", postgresDatasourceNameSecond)
       .click()
       .wait(1000);
 
@@ -75,6 +97,11 @@ describe("Switch datasource", function() {
       "response.body.data.isValid",
       true,
     );
+  });
+
+  it("4. Confirm mongo datasource is not present in the switch datasources dropdown", function() {
+    cy.get(".t--switch-datasource").click();
+    cy.get(".t--datasource-option").should("not.have", mongoDatasourceName);
   });
 
   it("4. Delete the query and datasources", function() {

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -877,11 +877,26 @@ export function EditorJSONtoForm(props: Props) {
 
   const pluginImages = useSelector(getPluginImages);
 
-  const DATASOURCES_OPTIONS = dataSources.map((dataSource) => ({
-    label: dataSource.name,
-    value: dataSource.id,
-    image: pluginImages[dataSource.pluginId],
-  }));
+  type DATASOURCES_OPTIONS_TYPE = {
+    label: string;
+    value: string;
+    image: string;
+  };
+
+  // Filtering the datasources for listing the similar datasources only rather than having all the active datasources in the list, which on switching resulted in error.
+  const DATASOURCES_OPTIONS: Array<DATASOURCES_OPTIONS_TYPE> = dataSources.reduce(
+    (acc: Array<DATASOURCES_OPTIONS_TYPE>, dataSource: Datasource) => {
+      if (dataSource.pluginId === plugin?.id) {
+        acc.push({
+          label: dataSource.name,
+          value: dataSource.id,
+          image: pluginImages[dataSource.pluginId],
+        });
+      }
+      return acc;
+    },
+    [],
+  );
 
   // when switching between different redux forms, make sure this redux form has been initialized before rendering anything.
   // the initialized prop below comes from redux-form.


### PR DESCRIPTION
## Description

Switching Datasource on the query pane or api pane editor was showing non-similar datasources in dropdown. The list is now filtered using the `pluginId` of the current datasource with the other active datasources.

Fixes #13326

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Create an application
2. Add multiple datasources (some similar, some different)
3. Create a query or api for one of the above datasources
4. When the editor opens, go to switch datasource dropdown and click on it
5. You will now see a list of only similar datasources (earlier all the active datasources were listed)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
