### PR TITLE
fix: pass remote url to ConflictInfo component

### DIFF
--- a/app/client/src/pages/Editor/gitSync/components/GitErrorPopup.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/GitErrorPopup.tsx
@@ -18,6 +18,7 @@ import { Colors } from "constants/Colors";
 import { get } from "lodash";
 
 import ConflictInfo from "../components/ConflictInfo";
+import { getCurrentAppGitMetaData } from "selectors/applicationSelectors";
 
 const StyledGitErrorPopup = styled.div`
   & {
@@ -81,7 +82,9 @@ function GitErrorPopup() {
   };
 
   const gitConflictDocumentUrl = useSelector(getConflictFoundDocUrlDeploy);
-
+  const gitMetaData = useSelector(getCurrentAppGitMetaData);
+  const browserSupportedRemoteUrl =
+    gitMetaData?.browserSupportedRemoteUrl || "";
   const isConflicting = true; // refactored
 
   return (
@@ -99,7 +102,7 @@ function GitErrorPopup() {
             <Space size={2} />
             {isConflicting && (
               <ConflictInfo
-                browserSupportedRemoteUrl={""}
+                browserSupportedRemoteUrl={browserSupportedRemoteUrl}
                 learnMoreLink={gitConflictDocumentUrl}
               />
             )}


### PR DESCRIPTION
## Description

During a refatoring, one of the location where the ConflictInfo component is invoked from was getting an empty string; that was making current app open up in new tab instead of git repo.

Fixes #14674 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
