### PR TITLE
fix: Prevent non populated labels from showing up in datasource page

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
@@ -4,6 +4,8 @@ const datasourceEditor = require("../../../../locators/DatasourcesEditor.json");
 
 describe("Authenticated API Datasource", function() {
   const URL = datasourceFormData["authenticatedApiUrl"];
+  const headers = "Headers";
+  const queryParams = "Query Params";
 
   it("1. Bug: 12045 - No Blank screen diplay after New Authentication API datasource creation", function() {
     cy.NavigateToAPI_Panel();
@@ -24,6 +26,22 @@ describe("Authenticated API Datasource", function() {
     cy.get(datasourceEditor.url).type("/users");
     cy.saveDatasource();
     cy.contains(URL + "/users");
+    cy.deleteDatasource("FakeAuthenticatedApi");
+  });
+
+  it("3. Bug: 14181 -Make sure the datasource view mode page does not contain labels with no value.", function() {
+    cy.NavigateToAPI_Panel();
+    cy.get(apiwidget.createAuthApiDatasource).click();
+    cy.wait("@createDatasource").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      201,
+    );
+    cy.renameDatasource("FakeAuthenticatedApi");
+    cy.fillAuthenticatedAPIForm();
+    cy.saveDatasource();
+    cy.contains(headers).should("not.exist");
+    cy.contains(queryParams).should("not.exist");
     cy.deleteDatasource("FakeAuthenticatedApi");
   });
 });

--- a/app/client/src/pages/Editor/DataSourceEditor/DatasourceSection.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DatasourceSection.tsx
@@ -1,6 +1,6 @@
 import { Datasource } from "entities/Datasource";
 import React from "react";
-import { map, get, isEmpty } from "lodash";
+import { map, get, isEmpty, isArray } from "lodash";
 import { Colors } from "constants/Colors";
 import styled from "styled-components";
 import { isHidden } from "components/formControls/utils";
@@ -45,6 +45,10 @@ export const renderDatasourceSection = (
             const { configProperty, controlType, label } = section;
             const reactKey = datasource.id + "_" + label;
             let value = get(datasource, configProperty);
+
+            if (!value || (isArray(value) && value.length < 1)) {
+              return;
+            }
 
             if (controlType === "KEYVALUE_ARRAY") {
               const configPropertyInfo = configProperty.split("[*].");


### PR DESCRIPTION
This prevents non-populated labels (labels with empty values) from showing up in the datasource view page

Before:
![before](https://user-images.githubusercontent.com/37867493/177208410-722d44d8-6741-4dd8-9d83-982c7031bfcb.png)



After:
<img width="1792" alt="Screenshot 2022-07-04 at 11 31 53" src="https://user-images.githubusercontent.com/37867493/177138501-ed98d9ec-2680-4a9a-b626-103d472ff237.png">


Fixes #14181 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual, Cypress

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
