### PR TITLE
fix: Fix `isset` command not found

### DIFF
--- a/deploy/docker/scripts/run-java.sh
+++ b/deploy/docker/scripts/run-java.sh
@@ -18,8 +18,9 @@ if [[ ${HTTPS_PROXY-} =~ ^https?://(.*):(.*)$ && ${BASH_REMATCH[2]} != 0 ]]; the
   proxy_configured=1
 fi
 
-if ! isset NO_PROXY; then
+if [[ -z "${NO_PROXY-}" ]]; then
   # A default for this value is set in entrypoint.sh script.
+  # If this variable is not set, just set it to empty string.
   NO_PROXY=""
 fi
 


### PR DESCRIPTION
It appears we see the following error when starting a fat container instance:

```
/opt/appsmith/run-java.sh: line 21: isset: command not found
```

Although it doesn't affect the functionality of Appsmith today, it may if the `NO_PROXY` is set to a non-empty value in the future. This PR fixes the error for good.

First seen at: https://app.intercom.com/a/apps/y10e7138/inbox/inbox/conversation/164629100136239#part_id=comment-164629100136239-15602739687

## Type of change

- Bug fix (non-breaking change which fixes an issue)
