### PR TITLE
fix: Modified Google Sheets pagination tooltip to nudge towards binding data

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/fetch_many.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/fetch_many.json
@@ -156,8 +156,8 @@
             "offset": "0"
           },
           "tooltipText": {
-            "limit": "Fetch only the rows that can be displayed to improve performance with pagination",
-            "offset": "Skip the rows before the start of the current page"
+            "limit": "Bind to the pageSize property of your widget {{Table1.pageSize}}",
+            "offset": "Bind to the index of the first row to display {{(Table1.pageNo-1)*pageSize}}"
           }
         }
       ]


### PR DESCRIPTION
Tooltips now show a hint on how to use the fields with the table widget.