### PR TITLE
fix: accept non-empty commit messages

### DIFF
--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -175,7 +175,7 @@ function Deploy() {
     if (currentBranch) {
       dispatch(
         commitToRepoInit({
-          commitMessage,
+          commitMessage: commitMessage.trim(),
           doPush,
         }),
       );
@@ -199,7 +199,8 @@ function Deploy() {
       dispatch(clearCommitSuccessfulState());
     };
   }, []);
-  const commitButtonDisabled = !hasChangesToCommit || !commitMessage;
+  const commitButtonDisabled =
+    !hasChangesToCommit || !commitMessage || commitMessage.trim().length < 1;
   const commitButtonLoading = isCommittingInProgress;
   const commitInputDisabled =
     !hasChangesToCommit ||


### PR DESCRIPTION
## Description

We were allowing empty commit messages, this PR doesn't allow that. We are also trimming message ourselves before sending it to backend service.

Fixes #15050 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
