### PR TITLE
fix: Fix wrong tooltip styling to form controls with no tooltips

### DIFF
--- a/app/client/src/pages/Editor/FormConfig.tsx
+++ b/app/client/src/pages/Editor/FormConfig.tsx
@@ -143,7 +143,7 @@ function renderFormConfigTop(props: {
                     content={tooltipText as string}
                     disabled={!tooltipText}
                     hoverOpenDelay={200}
-                    underline
+                    underline={!!tooltipText}
                   >
                     <p className="label-icon-wrapper">{label}</p>
                   </Tooltip>


### PR DESCRIPTION
Tooltip styles were being attached to Form control labels with no tooltip text assigned to them. This PR fixes that.

Fixes #14987 

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
