### PR TITLE
test: cypress test in twilio establish connection

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceBehavior_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceBehavior_spec.js
@@ -1,0 +1,72 @@
+const pages = require("../../../../locators/Pages.json");
+const queryLocators = require("../../../../locators/QueryEditor.json");
+import ApiEditor from "../../../../locators/ApiEditor";
+
+describe("Tests on active datasource behaviour ", function() {
+  before(() => {
+    localStorage.setItem("ApiPaneV2", "ApiPaneV2");
+    cy.NavigateToApiEditor();
+    cy.get(pages.integrationCreateNew)
+      .should("be.visible")
+      .click({ force: true });
+    cy.get(".tab-title").contains("Active");
+    cy.get(".tab-title:contains('Active')").click();
+  });
+
+  it("1. Test to check that the saved Twilio is displayed under the Active tab section", function() {
+    cy.contains(".t--datasource-name", "Test Airtable1.2");
+    cy.get(".t--datasource-name:contains('Test Airtable1.2')").should("exist");
+  });
+
+  it("2. Test that buttons displayed in for Twilio", function() {
+    /* 1 - Generate CURD (Inactive)
+       2 - New Query
+       3 - Action Icon
+           a) Edit b) Delete
+    */
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(queryLocators.createQuery)
+      .should("be.visible");
+
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(".t--datasource-menu-option")
+      .click();
+
+    cy.get(".t--datasource-option-edit").should("exist");
+    cy.get(".t--datasource-option-delete").should("exist");
+  });
+
+  it("3. Test clicking on New Query user must be navigated to Query Pane", function() {
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(queryLocators.createQuery)
+      .click();
+
+    cy.contains(".tab-title", "Query").should("exist");
+  });
+
+  it("5/6. Test ensure that the existing Query must not be deleted", function() {
+    cy.get(ApiEditor.backBtn).click();
+
+    cy.contains(".t--datasource-name", "Test Airtable1.2").click();
+    cy.get(".t--delete-datasource").click();
+    cy.get(".t--delete-datasource")
+      .contains("Are you sure?")
+      .click();
+    cy.wait("@deleteDatasource").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      409,
+    );
+  });
+
+  it("7. Test clicking on Edit option of the action icon it is observed that the user is navigated into Datasource pane", function() {
+    cy.get(ApiEditor.backBtn).click();
+
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(".t--datasource-menu-option")
+      .click();
+
+    cy.get(".t--datasource-option-edit").click();
+    cy.get(".t--json-to-form-wrapper").should("be.visible");
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceBehavior_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceBehavior_spec.js
@@ -14,8 +14,8 @@ describe("Tests on active datasource behaviour ", function() {
   });
 
   it("1. Test to check that the saved Twilio is displayed under the Active tab section", function() {
-    cy.contains(".t--datasource-name", "Test Airtable1.2");
-    cy.get(".t--datasource-name:contains('Test Airtable1.2')").should("exist");
+    cy.contains(".t--datasource-name", "Test Twilio");
+    cy.get(".t--datasource-name:contains('Test Twilio')").should("exist");
   });
 
   it("2. Test that buttons displayed in for Twilio", function() {
@@ -24,11 +24,11 @@ describe("Tests on active datasource behaviour ", function() {
        3 - Action Icon
            a) Edit b) Delete
     */
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(queryLocators.createQuery)
       .should("be.visible");
 
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(".t--datasource-menu-option")
       .click();
 
@@ -37,7 +37,7 @@ describe("Tests on active datasource behaviour ", function() {
   });
 
   it("3. Test clicking on New Query user must be navigated to Query Pane", function() {
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(queryLocators.createQuery)
       .click();
 
@@ -47,7 +47,7 @@ describe("Tests on active datasource behaviour ", function() {
   it("5/6. Test ensure that the existing Query must not be deleted", function() {
     cy.get(ApiEditor.backBtn).click();
 
-    cy.contains(".t--datasource-name", "Test Airtable1.2").click();
+    cy.contains(".t--datasource-name", "Test Twilio").click();
     cy.get(".t--delete-datasource").click();
     cy.get(".t--delete-datasource")
       .contains("Are you sure?")
@@ -62,7 +62,7 @@ describe("Tests on active datasource behaviour ", function() {
   it("7. Test clicking on Edit option of the action icon it is observed that the user is navigated into Datasource pane", function() {
     cy.get(ApiEditor.backBtn).click();
 
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(".t--datasource-menu-option")
       .click();
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
@@ -1,0 +1,149 @@
+const pages = require("../../../../locators/Pages.json");
+const queryLocators = require("../../../../locators/QueryEditor.json");
+import ApiEditor from "../../../../locators/ApiEditor";
+
+/* TO-DO
+    6. Ensure the user is able to Name conventions that are appropriate when moved/Copied
+    7. Ensure the user is able to delete the query from the Entity explorer
+    8. Ensure the user is able to add special characters as names and is reflected into the
+    9. Ensure the user is able to copy the binding from the entity explorer and bind to a widget
+    10.Ensure the user is able to click Show BIndings and added binding are displayed to the user
+    11.Ensure the user is able to copy the binding from the entity explorer
+    12.Ensure the user is able to close the binding option by clicking on the cross mark
+    13.Ensure to add a longer query name and observe the behavior of the entity explorer
+    14.Ensure to add a longer query name and observe if it is truncated in the entity explorer
+*/
+
+describe("Test ideas Entity Explorer", function() {
+  before(() => {
+    localStorage.setItem("ApiPaneV2", "ApiPaneV2");
+    cy.NavigateToApiEditor();
+    cy.get(pages.integrationCreateNew)
+      .should("be.visible")
+      .click({ force: true });
+    cy.get(".tab-title").contains("Active");
+    cy.get(".tab-title:contains('Active')").click();
+  });
+
+  it("1. Test user is able to see the query in the entity explorer", function() {
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(queryLocators.createQuery)
+      .click();
+
+    cy.get(queryLocators.queryNameField).type("Test");
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        )
+          .trigger("click", { multiple: true, force: true })
+          .wait(1000);
+      });
+
+    cy.contains(".t--entity-item", "Test").should("exist");
+  });
+
+  it("2. Test the user is able to change the name from the Entity explorer", function() {
+    cy.contains(".t--entity-item", "Test")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Edit Name");
+
+    cy.contains(".t--entity-item", "Test").type("CREATE_MESSAGE_TEST1");
+
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
+  });
+
+  it("3. Test the user is able to COPY query into the same page from entity explorer", function() {
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Copy to page");
+    cy.selectAction("Page1");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy").should("exist");
+  });
+
+  it("4. Test the user is able to COPY query into the Different page from entity explorer", function() {
+    cy.Createpage("Page2");
+    cy.contains(".t--entity-name", "Page1").click();
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        )
+          .trigger("click", { multiple: true, force: true })
+          .wait(1000);
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Copy to page");
+    cy.selectAction("Page2");
+
+    cy.contains(".t--entity-name", "Page2").click();
+    cy.wait(1000);
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
+  });
+
+  it("5. Test the user is able to MOVE query into the Different page from entity explorer", function() {
+    cy.contains(".t--entity-name", "Page1").click();
+    cy.wait(1000);
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Move to page");
+    cy.selectAction("Page2");
+
+    cy.contains(".t--entity-name", "Page2").click();
+    cy.wait(1000);
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy").should("exist");
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
@@ -1,15 +1,13 @@
 const pages = require("../../../../locators/Pages.json");
 const queryLocators = require("../../../../locators/QueryEditor.json");
 import ApiEditor from "../../../../locators/ApiEditor";
+const dsl = require("../../../../fixtures/formInputTableDsl.json");
 
 /* TO-DO
     6. Ensure the user is able to Name conventions that are appropriate when moved/Copied
-    7. Ensure the user is able to delete the query from the Entity explorer
     8. Ensure the user is able to add special characters as names and is reflected into the
     9. Ensure the user is able to copy the binding from the entity explorer and bind to a widget
-    10.Ensure the user is able to click Show BIndings and added binding are displayed to the user
     11.Ensure the user is able to copy the binding from the entity explorer
-    12.Ensure the user is able to close the binding option by clicking on the cross mark
     13.Ensure to add a longer query name and observe the behavior of the entity explorer
     14.Ensure to add a longer query name and observe if it is truncated in the entity explorer
 */
@@ -145,5 +143,122 @@ describe("Test ideas Entity Explorer", function() {
       });
 
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy").should("exist");
+  });
+
+  it("7. Test the user is able to delete the query from the Entity explorer", function() {
+    cy.contains(".t--entity-name", "Page2").click();
+    cy.wait(1000);
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Delete");
+    cy.selectAction("Are you sure?");
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+
+    cy.get(".t--entity-item:contains('CREATE_MESSAGE_TEST1')").should(
+      "not.exist",
+    );
+  });
+
+  /*it("9.Test the user is able to copy the binding from the entity explorer and bind to a widget", function() {
+    cy.addDsl(dsl);
+
+    cy.SearchEntityandOpen("Input1");
+    cy.testJsontext("defaulttext", "Copy data");
+
+    cy.wait("@updateLayout").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
+  });*/
+
+  it("10. Test the user is able to click Show BIndings and added binding are displayed to the user", function() {
+    cy.contains(".t--entity-name", "Page1").click();
+    cy.wait(1000);
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Show Bindings");
+
+    cy.contains(".sticky", "BINDINGS").should("exist");
+    cy.contains(
+      ".language-appsmith-binding",
+      "{{CREATE_MESSAGE_TEST1.isLoading}}",
+    ).should("exist");
+  });
+
+  it("11.Test the user is able to copy the binding from the entity explorer", function() {
+    cy.contains(
+      ".language-appsmith-binding",
+      "{{CREATE_MESSAGE_TEST1.isLoading}}",
+    ).click();
+  });
+
+  it("12.Test the user is able to close the binding option by clicking on the cross mark", function() {
+    cy.get(".t--entity-property-close").should("exist");
+    cy.get(".t--entity-property-close").click();
+  });
+
+  it("13.Test add a longer query name and observe the behavior of the entity explorer", function() {
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Edit Name");
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").type(
+      "CREATE MESSAGE TEST LONG NAME MORE MORE MORE LONGER",
+    );
+
+    cy.get("[alt='entityIcon']").click(); //Only to save the query name
+
+    cy.contains(
+      ".t--entity-item",
+      "CREATE_MESSAGE_TEST_LONG_NAME_MORE_MORE_MORE_LONGER",
+    ).should("not.exist");
+  });
+
+  it("14.Test add a longer query name and observe if it is truncated in the entity explorer", function() {
+    cy.contains(
+      ".t--entity-item",
+      "CREATE_MESSAGE_TEST_LONG_NAME_MORE_MORE_MORE_LONGER",
+    ).should("not.exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST_LONG_NAME_").should(
+      "exist",
+    );
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
@@ -4,7 +4,6 @@ import ApiEditor from "../../../../locators/ApiEditor";
 const dsl = require("../../../../fixtures/formInputTableDsl.json");
 
 /* TO-DO
-    6. Ensure the user is able to Name conventions that are appropriate when moved/Copied
     8. Ensure the user is able to add special characters as names and is reflected into the
     9. Ensure the user is able to copy the binding from the entity explorer and bind to a widget
     11.Ensure the user is able to copy the binding from the entity explorer
@@ -31,17 +30,8 @@ describe("Test Entity Explorer", function() {
     cy.get(queryLocators.queryNameField).type("Test");
     cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        )
-          .trigger("click", { multiple: true, force: true })
-          .wait(1000);
-      });
+    cy.openDropdown("QUERIES/JS");
+    cy.wait(1000);
 
     cy.contains(".t--entity-item", "Test").should("exist");
   });
@@ -53,130 +43,94 @@ describe("Test Entity Explorer", function() {
 
     cy.selectAction("Edit Name");
 
-    cy.contains(".t--entity-item", "Test").type("CREATE_MESSAGE_TEST1");
+    cy.contains(".t--entity-item", "Test").type("CREATE_MESSAGE_TEST");
 
     cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
 
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
   });
 
   it("3. Test the user is able to COPY query into the same page from entity explorer", function() {
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
-      .find(".entity-context-menu-icon")
-      .click({ force: true });
+    cy.copyQuery("CREATE_MESSAGE_TEST", "Page1", "Copy to page");
 
-    cy.selectAction("Copy to page");
-    cy.selectAction("Page1");
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy").should("exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy").should("exist");
   });
 
   it("4. Test the user is able to COPY query into the Different page from entity explorer", function() {
     cy.Createpage("Page2");
     cy.contains(".t--entity-name", "Page1").click();
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        )
-          .trigger("click", { multiple: true, force: true })
-          .wait(1000);
-      });
+    cy.openDropdown("QUERIES/JS");
+    cy.wait(1000);
 
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
-      .find(".entity-context-menu-icon")
-      .click({ force: true });
-
-    cy.selectAction("Copy to page");
-    cy.selectAction("Page2");
+    cy.copyQuery("CREATE_MESSAGE_TEST", "Page2", "Copy to page");
 
     cy.contains(".t--entity-name", "Page2").click();
     cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
+    cy.openDropdown("QUERIES/JS");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
   });
 
   it("5. Test the user is able to MOVE query into the Different page from entity explorer", function() {
     cy.contains(".t--entity-name", "Page1").click();
     cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
+    cy.openDropdown("QUERIES/JS");
 
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy")
-      .find(".entity-context-menu-icon")
-      .click({ force: true });
-
-    cy.selectAction("Move to page");
-    cy.selectAction("Page2");
+    cy.copyQuery("CREATE_MESSAGE_TESTCopy", "Page2", "Move to page");
 
     cy.contains(".t--entity-name", "Page2").click();
     cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
+    cy.openDropdown("QUERIES/JS");
 
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy").should("exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy").should("exist");
+  });
+
+  it("6. Test the user is able to Name conventions that are appropriate when moved/Copied.", function() {
+    cy.contains(".t--entity-name", "Page1").click();
+    cy.wait(1000);
+
+    cy.openDropdown("QUERIES/JS");
+
+    cy.copyQuery("CREATE_MESSAGE_TEST", "Page1", "Copy to page");
+    cy.copyQuery("CREATE_MESSAGE_TEST", "Page1", "Copy to page");
+    cy.copyQuery("CREATE_MESSAGE_TEST", "Page1", "Copy to page");
+    cy.copyQuery("CREATE_MESSAGE_TESTCopy", "Page1", "Copy to page");
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy1").should("exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy2").should("exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopyCopy").should(
+      "exist",
+    );
+
+    cy.copyQuery("CREATE_MESSAGE_TEST", "Page2", "Move to page");
+
+    cy.contains(".t--entity-name", "Page2").click();
+    cy.wait(1000);
+
+    cy.openDropdown("QUERIES/JS");
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
   });
 
   it("7. Test the user is able to delete the query from the Entity explorer", function() {
     cy.contains(".t--entity-name", "Page2").click();
     cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
+    cy.openDropdown("QUERIES/JS");
 
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1Copy")
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy")
       .find(".entity-context-menu-icon")
       .click({ force: true });
 
     cy.selectAction("Delete");
     cy.selectAction("Are you sure?");
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
+    cy.openDropdown("QUERIES/JS");
 
-    cy.get(".t--entity-item:contains('CREATE_MESSAGE_TEST1')").should(
+    cy.get(".t--entity-item:contains('CREATE_MESSAGE_TEST')").should(
       "not.exist",
     );
   });
@@ -196,19 +150,8 @@ describe("Test Entity Explorer", function() {
 
   it("10. Test the user is able to click Show BIndings and added binding are displayed to the user", function() {
     cy.contains(".t--entity-name", "Page1").click();
-    cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
-
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy")
       .find(".entity-context-menu-icon")
       .click({ force: true });
 
@@ -217,14 +160,14 @@ describe("Test Entity Explorer", function() {
     cy.contains(".sticky", "BINDINGS").should("exist");
     cy.contains(
       ".language-appsmith-binding",
-      "{{CREATE_MESSAGE_TEST1.isLoading}}",
+      "{{CREATE_MESSAGE_TESTCopy.isLoading}}",
     ).should("exist");
   });
 
   it("11.Test the user is able to copy the binding from the entity explorer", function() {
     cy.contains(
       ".language-appsmith-binding",
-      "{{CREATE_MESSAGE_TEST1.isLoading}}",
+      "{{CREATE_MESSAGE_TESTCopy.isLoading}}",
     ).click();
   });
 
@@ -234,17 +177,19 @@ describe("Test Entity Explorer", function() {
   });
 
   it("13.Test add a longer query name and observe the behavior of the entity explorer", function() {
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy1")
       .find(".entity-context-menu-icon")
       .click({ force: true });
 
     cy.selectAction("Edit Name");
 
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").type(
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy1").type(
       "CREATE MESSAGE TEST LONG NAME MORE MORE MORE LONGER",
     );
 
-    cy.get("[alt='entityIcon']").click(); //Only to save the query name
+    cy.get("[alt='entityIcon']").click({ multiple: true }); //Only to save the query name
+
+    cy.wait(3000);
 
     cy.contains(
       ".t--entity-item",
@@ -261,4 +206,15 @@ describe("Test Entity Explorer", function() {
       "exist",
     );
   });
+});
+
+Cypress.Commands.add("copyQuery", (query, page, type) => {
+  cy.contains(".t--entity-item", query)
+    .find(".entity-context-menu-icon")
+    .click({ force: true });
+
+  cy.selectAction(type);
+  cy.selectAction(page);
+
+  cy.wait(1000);
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceEntityExplorer_spec.js
@@ -12,7 +12,7 @@ const dsl = require("../../../../fixtures/formInputTableDsl.json");
     14.Ensure to add a longer query name and observe if it is truncated in the entity explorer
 */
 
-describe("Test ideas Entity Explorer", function() {
+describe("Test Entity Explorer", function() {
   before(() => {
     localStorage.setItem("ApiPaneV2", "ApiPaneV2");
     cy.NavigateToApiEditor();
@@ -24,12 +24,12 @@ describe("Test ideas Entity Explorer", function() {
   });
 
   it("1. Test user is able to see the query in the entity explorer", function() {
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(queryLocators.createQuery)
       .click();
 
     cy.get(queryLocators.queryNameField).type("Test");
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
 
     cy.xpath(
       "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
@@ -55,7 +55,7 @@ describe("Test ideas Entity Explorer", function() {
 
     cy.contains(".t--entity-item", "Test").type("CREATE_MESSAGE_TEST1");
 
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
 
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
   });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
@@ -7,8 +7,6 @@ import ApiEditor from "../../../../locators/ApiEditor";
     5. Ensure Long body form is added
     6. Ensure use the method from the drop-down
     9. Ensure user is able to add special characters to the name from Pane
-    10. Ensure user is able to save the queries
-    12. Ensure user is able to edit the query pane and the changes get saved
     16. Ensure user is able to Name conventions that are appropriate when moved/Copied
 */
 
@@ -109,11 +107,11 @@ describe("Test ideas Query Pane  ", function() {
 
     cy.selectAction("Edit Name");
 
-    cy.contains(".t--entity-item", "CREATE").type("CREATE MESSAGE TEST");
+    cy.contains(".t--entity-item", "CREATE").type("CREATE MESSAGE TEST1");
 
     cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
 
-    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
   });
 
   it("10. Test user is able to save the queries", function() {
@@ -121,6 +119,20 @@ describe("Test ideas Query Pane  ", function() {
     //cy.contains(".t--entity action .ContextMenu", "New Query Test").should("exist");
     //cy.get(".whitespace-nowrap:contains('New Query Test')").should("exist");
     //cy.get(".t--entity-name:contains('New Query Test')").should("exist");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Edit Name");
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").type(
+      "CREATE MESSAGE TEST",
+    );
+
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
+    cy.wait(2000);
   });
 
   it("11. Test user is able to reopen the query pane", function() {
@@ -130,7 +142,37 @@ describe("Test ideas Query Pane  ", function() {
     cy.contains(".bp3-editable-text-content", "CREATE_MESSAGE_TEST");
   });
 
+  it("12. Test user is able to edit the query pane and the changes get saved", function() {
+    cy.get(".Datasources__ShowAll-g3whk1-0").click(); //Show all datasources
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(queryLocators.createQuery)
+      .click();
+
+    cy.get(queryLocators.queryNameField).type("Test");
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.dropdownTypeAuth).click();
+    cy.contains(ApiEditor.dropdownOption, "List Records").click();
+    cy.get(
+      ':nth-child(2) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines',
+    ).type("1234");
+    cy.get(
+      ':nth-child(3) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines > [style="position: relative; outline: none;"] > .CodeMirror-code > .CodeMirror-line',
+    ).type("Project");
+    cy.get(ApiEditor.backBtn).click();
+
+    cy.contains(".t--entity-item", "Test").click();
+    cy.contains(
+      ':nth-child(2) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines',
+      "1234",
+    ).should("exist");
+    cy.contains(
+      ':nth-child(3) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines > [style="position: relative; outline: none;"] > .CodeMirror-code > .CodeMirror-line',
+      "Project",
+    ).should("exist");
+  });
+
   it("13. Test user is able to COPY query into the same page from Query Pane", function() {
+    cy.get(ApiEditor.backBtn).click();
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
     cy.get(".t--more-action-menu").should("exist");
     cy.get(".t--more-action-menu").click({ multiple: true });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
@@ -1,0 +1,163 @@
+const pages = require("../../../../locators/Pages.json");
+const queryLocators = require("../../../../locators/QueryEditor.json");
+import ApiEditor from "../../../../locators/ApiEditor";
+
+/* TO-DO
+    4. Ensure the user is displayed appropriate error messages on the wrong field data
+    5. Ensure Long body form is added
+    6. Ensure use the method from the drop-down
+    9. Ensure user is able to add special characters to the name from Pane
+    10. Ensure user is able to save the queries
+    12. Ensure user is able to edit the query pane and the changes get saved
+
+    14. Ensure user is able to COPY query into the Different page from Query Pane
+    15. Ensure user is able to MOVE query into the Different page from Query Pane
+    16. Ensure user is able to Name conventions that are appropriate when moved/Copied
+*/
+describe("Test ideas Query Pane  ", function() {
+  before(() => {
+    localStorage.setItem("ApiPaneV2", "ApiPaneV2");
+    cy.NavigateToApiEditor();
+    cy.get(pages.integrationCreateNew)
+      .should("be.visible")
+      .click({ force: true });
+    cy.get(".tab-title").contains("Active");
+    cy.get(".tab-title:contains('Active')").click();
+  });
+
+  it("1. Test user is displayed with following command", function() {
+    /*
+       1) Create Message    2) Delete Message
+       3) Fetch Message     4) List Messages
+       5) Schedule Message  6) Update Message
+   */
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(queryLocators.createQuery)
+      .click();
+
+    cy.get(queryLocators.queryNameField).type("Test");
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.dropdownTypeAuth).click();
+    cy.contains(ApiEditor.dropdownOption, "List Records").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Create Records").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Delete A Record").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Retrieve A Record").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Update Records").should("exist");
+
+    /*Twilio
+    cy.contains(ApiEditor.dropdownOption, "Create Message").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Delete Message").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Fetch Message").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "List Messages").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Schedule Message").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Update Message").should("exist");
+    */
+  });
+
+  it("2. Test user is able to select Create message cmd and the following fields are displayed to the user", function() {
+    /*
+        1) Twilio Account SID     2) To 
+        3) From                   4) Body
+    */
+
+    /*Twilio
+    
+    cy.contains(ApiEditor.dropdownOption, "Create Message").click();
+    cy.get(ApiEditor.labelAuth).contains("Twilio Account SID").should("exist");
+    cy.get(ApiEditor.labelAuth).contains("To").should("exist");
+    cy.get(ApiEditor.labelAuth).contains("From").should("exist");
+    cy.get(ApiEditor.labelAuth).contains("Body").should("exist");
+
+    */
+    cy.contains(ApiEditor.dropdownOption, "List Records").click();
+    cy.get(ApiEditor.labelAuth)
+      .contains("Base ID")
+      .should("exist");
+  });
+
+  it("3. Test mandatory Fields are added in Created", function() {
+    //cy.contains(ApiEditor.dropdownOption, "Create Records").click();
+    cy.get(ApiEditor.labelAuth)
+      .contains("Base ID")
+      .should("exist");
+    cy.get(".label-icon-wrapper:contains('Base ID')").contains("*");
+
+    /*
+    cy.get(".label-icon-wrapper:contains('Twilio Account SID')").contains("*");
+    cy.get(".label-icon-wrapper:contains('To')").contains("*");
+    cy.get(".label-icon-wrapper:contains('From')").contains("*");
+    cy.get(".label-icon-wrapper:contains('Body')").contains("*");
+    */
+  });
+
+  it("7. Test user is able to change the name from the pane", function() {
+    cy.contains(".t--entity-item", "Test")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Edit Name");
+
+    cy.contains(".t--entity-item", "Test").type("CREATE");
+
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+
+    cy.contains(".t--entity-item", "CREATE").should("exist");
+  });
+
+  it("8. Test user is able to add longer name", function() {
+    cy.contains(".t--entity-item", "CREATE")
+      .find(".entity-context-menu-icon")
+      .click({ force: true });
+
+    cy.selectAction("Edit Name");
+
+    cy.contains(".t--entity-item", "CREATE").type("CREATE MESSAGE TEST");
+
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
+  });
+
+  it("10. Test user is able to save the queries", function() {
+    //cy.get(ApiEditor.backBtn).click();
+    //cy.contains(".t--entity action .ContextMenu", "New Query Test").should("exist");
+    //cy.get(".whitespace-nowrap:contains('New Query Test')").should("exist");
+    //cy.get(".t--entity-name:contains('New Query Test')").should("exist");
+  });
+
+  it("11. Test user is able to reopen the query pane", function() {
+    cy.get(ApiEditor.backBtn).click();
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
+    cy.get(ApiEditor.airtableImage).should("exist");
+    cy.contains(".bp3-editable-text-content", "CREATE_MESSAGE_TEST");
+  });
+
+  it("13. Test user is able to COPY query into the same page from Query Pane", function() {
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
+    cy.get(".t--more-action-menu").should("exist");
+    cy.get(".t--more-action-menu").click({ multiple: true });
+    cy.selectAction("Copy to page");
+    cy.selectAction("Page1");
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy").should("exist");
+  });
+
+  it("14. Test user is able to COPY query into the Different page from Query Pane", function() {
+    cy.Createpage("Page2");
+    /*cy.contains(".t--entity-name", "Page1").click();
+      cy.get(".t--entity-collapse-toggle").click({ multiple: true });
+      cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
+
+      cy.get(".t--more-action-menu").should("exist");
+      cy.get(".t--more-action-menu").click({ multiple: true });
+      cy.selectAction("Copy to page");
+      cy.selectAction("Page2");
+      cy.contains(".t--entity-name", "Page2").click();
+      
+    
+      cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy").should("exist");*/
+  });
+
+  /*
+    it("15. Test user is able to MOVE query into the Different page from Query Pane", function() {
+    });*/
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
@@ -9,11 +9,9 @@ import ApiEditor from "../../../../locators/ApiEditor";
     9. Ensure user is able to add special characters to the name from Pane
     10. Ensure user is able to save the queries
     12. Ensure user is able to edit the query pane and the changes get saved
-
-    14. Ensure user is able to COPY query into the Different page from Query Pane
-    15. Ensure user is able to MOVE query into the Different page from Query Pane
     16. Ensure user is able to Name conventions that are appropriate when moved/Copied
 */
+
 describe("Test ideas Query Pane  ", function() {
   before(() => {
     localStorage.setItem("ApiPaneV2", "ApiPaneV2");
@@ -143,21 +141,75 @@ describe("Test ideas Query Pane  ", function() {
 
   it("14. Test user is able to COPY query into the Different page from Query Pane", function() {
     cy.Createpage("Page2");
-    /*cy.contains(".t--entity-name", "Page1").click();
-      cy.get(".t--entity-collapse-toggle").click({ multiple: true });
-      cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
+    cy.contains(".t--entity-name", "Page1").click();
 
-      cy.get(".t--more-action-menu").should("exist");
-      cy.get(".t--more-action-menu").click({ multiple: true });
-      cy.selectAction("Copy to page");
-      cy.selectAction("Page2");
-      cy.contains(".t--entity-name", "Page2").click();
-      
-    
-      cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy").should("exist");*/
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        )
+          .trigger("click", { multiple: true, force: true })
+          .wait(1000);
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
+    cy.get(".t--more-action-menu").should("exist");
+    cy.get(".t--more-action-menu").click({ multiple: true });
+    cy.selectAction("Copy to page");
+    cy.selectAction("Page2");
+
+    cy.contains(".t--entity-name", "Page2").click();
+    cy.wait(1000);
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy").should("exist");
   });
 
-  /*
-    it("15. Test user is able to MOVE query into the Different page from Query Pane", function() {
-    });*/
+  it("15. Test user is able to MOVE query into the Different page from Query Pane", function() {
+    cy.contains(".t--entity-name", "Page1").click();
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        )
+          .trigger("click", { multiple: true, force: true })
+          .wait(1000);
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
+    cy.get(".t--more-action-menu").should("exist");
+    cy.get(".t--more-action-menu").click({ multiple: true });
+    cy.selectAction("Move to page");
+    cy.selectAction("Page2");
+
+    cy.contains(".t--entity-name", "Page2").click();
+    cy.wait(1000);
+
+    cy.xpath(
+      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+    )
+      .invoke("attr", "name")
+      .then((arrow) => {
+        cy.xpath(
+          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
+        ).trigger("click", { multiple: true, force: true });
+      });
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
@@ -10,7 +10,7 @@ import ApiEditor from "../../../../locators/ApiEditor";
     16. Ensure user is able to Name conventions that are appropriate when moved/Copied
 */
 
-describe("Test ideas Query Pane  ", function() {
+describe("Test Query Pane  ", function() {
   before(() => {
     localStorage.setItem("ApiPaneV2", "ApiPaneV2");
     cy.NavigateToApiEditor();
@@ -27,27 +27,19 @@ describe("Test ideas Query Pane  ", function() {
        3) Fetch Message     4) List Messages
        5) Schedule Message  6) Update Message
    */
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(queryLocators.createQuery)
       .click();
 
     cy.get(queryLocators.queryNameField).type("Test");
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
     cy.get(ApiEditor.dropdownTypeAuth).click();
-    cy.contains(ApiEditor.dropdownOption, "List Records").should("exist");
-    cy.contains(ApiEditor.dropdownOption, "Create Records").should("exist");
-    cy.contains(ApiEditor.dropdownOption, "Delete A Record").should("exist");
-    cy.contains(ApiEditor.dropdownOption, "Retrieve A Record").should("exist");
-    cy.contains(ApiEditor.dropdownOption, "Update Records").should("exist");
-
-    /*Twilio
     cy.contains(ApiEditor.dropdownOption, "Create Message").should("exist");
-    cy.contains(ApiEditor.dropdownOption, "Delete Message").should("exist");
-    cy.contains(ApiEditor.dropdownOption, "Fetch Message").should("exist");
-    cy.contains(ApiEditor.dropdownOption, "List Messages").should("exist");
     cy.contains(ApiEditor.dropdownOption, "Schedule Message").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "List Message").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Fetch Message").should("exist");
+    cy.contains(ApiEditor.dropdownOption, "Delete Message").should("exist");
     cy.contains(ApiEditor.dropdownOption, "Update Message").should("exist");
-    */
   });
 
   it("2. Test user is able to select Create message cmd and the following fields are displayed to the user", function() {
@@ -56,34 +48,29 @@ describe("Test ideas Query Pane  ", function() {
         3) From                   4) Body
     */
 
-    /*Twilio
-    
     cy.contains(ApiEditor.dropdownOption, "Create Message").click();
-    cy.get(ApiEditor.labelAuth).contains("Twilio Account SID").should("exist");
-    cy.get(ApiEditor.labelAuth).contains("To").should("exist");
-    cy.get(ApiEditor.labelAuth).contains("From").should("exist");
-    cy.get(ApiEditor.labelAuth).contains("Body").should("exist");
-
-    */
-    cy.contains(ApiEditor.dropdownOption, "List Records").click();
     cy.get(ApiEditor.labelAuth)
-      .contains("Base ID")
+      .contains("Twilio Account SID")
+      .should("exist");
+    cy.get(ApiEditor.labelAuth)
+      .contains("To")
+      .should("exist");
+    cy.get(ApiEditor.labelAuth)
+      .contains("From")
+      .should("exist");
+    cy.get(ApiEditor.labelAuth)
+      .contains("Body")
       .should("exist");
   });
 
   it("3. Test mandatory Fields are added in Created", function() {
-    //cy.contains(ApiEditor.dropdownOption, "Create Records").click();
     cy.get(ApiEditor.labelAuth)
-      .contains("Base ID")
+      .contains("Twilio Account SID")
       .should("exist");
-    cy.get(".label-icon-wrapper:contains('Base ID')").contains("*");
-
-    /*
     cy.get(".label-icon-wrapper:contains('Twilio Account SID')").contains("*");
     cy.get(".label-icon-wrapper:contains('To')").contains("*");
     cy.get(".label-icon-wrapper:contains('From')").contains("*");
     cy.get(".label-icon-wrapper:contains('Body')").contains("*");
-    */
   });
 
   it("7. Test user is able to change the name from the pane", function() {
@@ -95,7 +82,7 @@ describe("Test ideas Query Pane  ", function() {
 
     cy.contains(".t--entity-item", "Test").type("CREATE");
 
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
 
     cy.contains(".t--entity-item", "CREATE").should("exist");
   });
@@ -109,16 +96,12 @@ describe("Test ideas Query Pane  ", function() {
 
     cy.contains(".t--entity-item", "CREATE").type("CREATE MESSAGE TEST1");
 
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
 
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1").should("exist");
   });
 
   it("10. Test user is able to save the queries", function() {
-    //cy.get(ApiEditor.backBtn).click();
-    //cy.contains(".t--entity action .ContextMenu", "New Query Test").should("exist");
-    //cy.get(".whitespace-nowrap:contains('New Query Test')").should("exist");
-    //cy.get(".t--entity-name:contains('New Query Test')").should("exist");
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST1")
       .find(".entity-context-menu-icon")
       .click({ force: true });
@@ -129,7 +112,7 @@ describe("Test ideas Query Pane  ", function() {
       "CREATE MESSAGE TEST",
     );
 
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
 
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
     cy.wait(2000);
@@ -138,36 +121,36 @@ describe("Test ideas Query Pane  ", function() {
   it("11. Test user is able to reopen the query pane", function() {
     cy.get(ApiEditor.backBtn).click();
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
-    cy.get(ApiEditor.airtableImage).should("exist");
+    cy.get(ApiEditor.twilioImage).should("exist");
     cy.contains(".bp3-editable-text-content", "CREATE_MESSAGE_TEST");
   });
 
   it("12. Test user is able to edit the query pane and the changes get saved", function() {
     cy.get(".Datasources__ShowAll-g3whk1-0").click(); //Show all datasources
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(queryLocators.createQuery)
       .click();
 
     cy.get(queryLocators.queryNameField).type("Test");
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
     cy.get(ApiEditor.dropdownTypeAuth).click();
-    cy.contains(ApiEditor.dropdownOption, "List Records").click();
+    cy.contains(ApiEditor.dropdownOption, "List Message").click();
     cy.get(
       ':nth-child(2) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines',
-    ).type("1234");
+    ).type("12345");
     cy.get(
       ':nth-child(3) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines > [style="position: relative; outline: none;"] > .CodeMirror-code > .CodeMirror-line',
-    ).type("Project");
+    ).type("123456789");
     cy.get(ApiEditor.backBtn).click();
 
     cy.contains(".t--entity-item", "Test").click();
     cy.contains(
       ':nth-child(2) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines',
-      "1234",
+      "12345",
     ).should("exist");
     cy.contains(
       ':nth-child(3) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines > [style="position: relative; outline: none;"] > .CodeMirror-code > .CodeMirror-line',
-      "Project",
+      "123456789",
     ).should("exist");
   });
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSourceQueryPane_spec.js
@@ -7,7 +7,6 @@ import ApiEditor from "../../../../locators/ApiEditor";
     5. Ensure Long body form is added
     6. Ensure use the method from the drop-down
     9. Ensure user is able to add special characters to the name from Pane
-    16. Ensure user is able to Name conventions that are appropriate when moved/Copied
 */
 
 describe("Test Query Pane  ", function() {
@@ -126,7 +125,15 @@ describe("Test Query Pane  ", function() {
   });
 
   it("12. Test user is able to edit the query pane and the changes get saved", function() {
-    cy.get(".Datasources__ShowAll-g3whk1-0").click(); //Show all datasources
+    const query1 =
+      ':nth-child(2) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines';
+    const query2 =
+      ':nth-child(3) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines > [style="position: relative; outline: none;"] > .CodeMirror-code > .CodeMirror-line';
+
+    cy.NavigateToApiEditor();
+
+    cy.get("[data-cy=t--tab-ACTIVE]").click();
+
     cy.contains(".t--datasource-name", "Test Twilio")
       .find(queryLocators.createQuery)
       .click();
@@ -135,23 +142,14 @@ describe("Test Query Pane  ", function() {
     cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
     cy.get(ApiEditor.dropdownTypeAuth).click();
     cy.contains(ApiEditor.dropdownOption, "List Message").click();
-    cy.get(
-      ':nth-child(2) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines',
-    ).type("12345");
-    cy.get(
-      ':nth-child(3) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines > [style="position: relative; outline: none;"] > .CodeMirror-code > .CodeMirror-line',
-    ).type("123456789");
+
+    cy.get(query1).type("12345");
+    cy.get(query2).type("123456789");
     cy.get(ApiEditor.backBtn).click();
 
     cy.contains(".t--entity-item", "Test").click();
-    cy.contains(
-      ':nth-child(2) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines',
-      "12345",
-    ).should("exist");
-    cy.contains(
-      ':nth-child(3) > :nth-child(1) > [style="display: block;"] > .t--form-control-QUERY_DYNAMIC_INPUT_TEXT > [style="width: 35vw; min-height: 38px;"] > .styledComponents__DynamicAutocompleteInputWrapper-gizjok-2 > .EvaluatedValuePopup__Wrapper-dlvj8d-0 > .styledComponents__EditorWrapper-gizjok-0 > [data-testid=code-editor-target] > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer > [style="position: relative; top: 0px;"] > .CodeMirror-lines > [style="position: relative; outline: none;"] > .CodeMirror-code > .CodeMirror-line',
-      "123456789",
-    ).should("exist");
+    cy.contains(query1, "12345").should("exist");
+    cy.contains(query2, "123456789").should("exist");
   });
 
   it("13. Test user is able to COPY query into the same page from Query Pane", function() {
@@ -168,17 +166,8 @@ describe("Test Query Pane  ", function() {
     cy.Createpage("Page2");
     cy.contains(".t--entity-name", "Page1").click();
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        )
-          .trigger("click", { multiple: true, force: true })
-          .wait(1000);
-      });
+    cy.openDropdown("QUERIES/JS");
+    cy.wait(1000);
 
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
     cy.get(".t--more-action-menu").should("exist");
@@ -189,32 +178,16 @@ describe("Test Query Pane  ", function() {
     cy.contains(".t--entity-name", "Page2").click();
     cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
+    cy.openDropdown("QUERIES/JS");
+
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy").should("exist");
   });
 
   it("15. Test user is able to MOVE query into the Different page from Query Pane", function() {
     cy.contains(".t--entity-name", "Page1").click();
+    cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        )
-          .trigger("click", { multiple: true, force: true })
-          .wait(1000);
-      });
+    cy.openDropdown("QUERIES/JS");
 
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").click();
     cy.get(".t--more-action-menu").should("exist");
@@ -225,16 +198,41 @@ describe("Test Query Pane  ", function() {
     cy.contains(".t--entity-name", "Page2").click();
     cy.wait(1000);
 
-    cy.xpath(
-      "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-    )
-      .invoke("attr", "name")
-      .then((arrow) => {
-        cy.xpath(
-          "//div[text()='QUERIES/JS']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]",
-        ).trigger("click", { multiple: true, force: true });
-      });
+    cy.openDropdown("QUERIES/JS");
 
     cy.contains(".t--entity-item", "CREATE_MESSAGE_TEST").should("exist");
   });
+
+  it("16. Test user is able to Name conventions that are appropriate when moved/Copied", function() {
+    cy.contains(".t--entity-name", "Page1").click();
+    cy.wait(1000);
+
+    cy.openDropdown("QUERIES/JS");
+
+    cy.copyQuery("CREATE_MESSAGE_TESTCopy", "Page1", "Copy to page");
+    cy.copyQuery("CREATE_MESSAGE_TESTCopy", "Page1", "Copy to page");
+    cy.copyQuery("CREATE_MESSAGE_TESTCopy", "Page1", "Copy to page");
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopyCopy2").should(
+      "exist",
+    );
+
+    cy.copyQuery("CREATE_MESSAGE_TESTCopy", "Page2", "Move to page");
+
+    cy.contains(".t--entity-name", "Page2").click();
+    cy.wait(1000);
+
+    cy.openDropdown("QUERIES/JS");
+
+    cy.contains(".t--entity-item", "CREATE_MESSAGE_TESTCopy1").should("exist");
+  });
+});
+
+Cypress.Commands.add("copyQuery", (query, page, type) => {
+  cy.contains(".t--entity-item", query)
+    .find(".entity-context-menu-icon")
+    .click({ force: true });
+
+  cy.selectAction(type);
+  cy.selectAction(page);
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
@@ -1,0 +1,118 @@
+const datasourceEditor = require("../../../../locators/DatasourcesEditor.json");
+const apiwidget = require("../../../../locators/apiWidgetslocator.json");
+const pages = require("../../../../locators/Pages.json");
+const datasource = require("../../../../fixtures/datasources.json");
+import ApiEditor from "../../../../locators/ApiEditor";
+
+
+describe("Airtable Active datasource test cases", function() {
+  before(() => {
+    localStorage.setItem("ApiPaneV2", "ApiPaneV2");
+    cy.NavigateToApiEditor();
+    cy.get(pages.integrationCreateNew)
+      .should("be.visible")
+      .click({ force: true });
+  });
+
+  it("1. Test user is displayed with Twilio setup on Datasource page along with the symbol", function() {
+    cy.get(datasourceEditor.Airtable).should("exist");
+    cy.get(ApiEditor.airtableImage).should("be.visible");
+
+  });
+
+  it("2. Test user is able to click on the Twilio for establishing a connection", function() {
+    cy.get(datasourceEditor.Airtable).click();  
+  });
+
+  it("3. Test user is displayed with Auth type and user is able to select Basic Auth", function() {
+
+    cy.get(ApiEditor.dropdownTypeAuth).click();
+    //cy.contains(ApiEditor.test, 'Basic Auth').click()
+    cy.contains(ApiEditor.dropdownOption, 'Bearer Token').click();
+    //cy.get(".cs-text").should('have.value', 'Bearer Token');
+
+  });
+
+  it("4. Test selection user must be displayed with Username and Password", function() {
+
+    cy.get(ApiEditor.labelAuth).contains("Bearer Token");
+    //cy.get(ApiEditor.labelAuth).contains("Username");
+    //cy.get(ApiEditor.labelAuth).contains("Password");
+    
+  });
+
+  it("5. Test user is displayed with following button", function() {
+
+    /*5. Ensure user is displayed with following button 
+          1) Delete   2) Test (Non -Functional)
+          3) Save     4) Twilio Logo
+          5) Edit name of Datasource  
+          6) Back option
+    */
+    cy.get(".bp3-button:contains('Delete')").should("exist");
+    //Test (Non -Functional) ???
+    cy.get(apiwidget.saveButton).should("exist");
+    cy.get("[alt='Datasource']").should("be.visible");
+    cy.get(datasourceEditor.datasourceTitle).should("exist");
+    cy.get(datasourceEditor.datasourceTitle).type("Test Airtable1.2");
+    cy.get(ApiEditor.backBtn).should("exist");
+
+  });
+
+  it("6. Test clicking on Save option the DS gets saved", function() {
+
+    cy.get('input[name="datasourceConfiguration.authentication.bearerToken"]').type(datasource.bearerToken);
+    cy.get('input[name="datasourceConfiguration.authentication.bearerToken"]').should('have.value', datasource.bearerToken);
+   
+    cy.get(".bp3-button-text:contains('Save')").click();
+     
+
+    /*cy.RunAPI();
+    cy.ResponseStatusCheck("200 OK");
+    cy.get(ApiEditor.formActionButtons).should("be.visible");
+    cy.get(ApiEditor.ApiActionMenu)
+      .first()
+      .click();
+    cy.get(ApiEditor.ApiDeleteBtn).click();
+    cy.get(ApiEditor.ApiDeleteBtn)
+      .contains("Are you sure?")
+      .click();
+    cy.wait("@deleteAction");
+    cy.get("@deleteAction").then((response) => {
+      cy.expect(response.response.body.responseMeta.success).to.eq(true);
+    });*/
+
+    /*cy.importCurl();
+    cy.get("@curlImport").then((response) => {
+      cy.expect(response.response.body.responseMeta.success).to.eq(true);
+      cy.get(apiwidget.ApiName)
+        .invoke("text")
+        .then((text) => {
+          const someText = text;
+          expect(someText).to.equal(response.response.body.data.name);
+        });
+    });*/
+
+  });
+
+ /* it("7. Test clicking on Delete the DS gets deleted", function() {
+    //cy.get(".bp3-button:contains('Delete')").click();
+  });
+
+  it("8. Test  delete if the DS is associated with a query the DS must show an error and unable to delete", function() {
+    //TODO
+  });
+
+  it("9. Test Password is encrypted", function() {
+    //cy.get("[alt='Datasource']").click();
+  });
+
+  it("10. Test clicking on the back button user should be navigated to the active Datasources page", function() {
+
+    cy.get(ApiEditor.backBtn).click();
+    cy.get(".t--integrationsHomePage").should("exist");
+    cy.get(".sectionHeadings").contains("Datasource");
+
+  });*/
+
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
@@ -2,8 +2,8 @@ const datasourceEditor = require("../../../../locators/DatasourcesEditor.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 const pages = require("../../../../locators/Pages.json");
 const datasource = require("../../../../fixtures/datasources.json");
+const queryLocators = require("../../../../locators/QueryEditor.json");
 import ApiEditor from "../../../../locators/ApiEditor";
-
 
 describe("Airtable Active datasource test cases", function() {
   before(() => {
@@ -17,32 +17,26 @@ describe("Airtable Active datasource test cases", function() {
   it("1. Test user is displayed with Twilio setup on Datasource page along with the symbol", function() {
     cy.get(datasourceEditor.Airtable).should("exist");
     cy.get(ApiEditor.airtableImage).should("be.visible");
-
   });
 
   it("2. Test user is able to click on the Twilio for establishing a connection", function() {
-    cy.get(datasourceEditor.Airtable).click();  
+    cy.get(datasourceEditor.Airtable).click();
+    cy.get(".t--json-to-form-wrapper").should("exist");
   });
 
   it("3. Test user is displayed with Auth type and user is able to select Basic Auth", function() {
-
     cy.get(ApiEditor.dropdownTypeAuth).click();
     //cy.contains(ApiEditor.test, 'Basic Auth').click()
-    cy.contains(ApiEditor.dropdownOption, 'Bearer Token').click();
-    //cy.get(".cs-text").should('have.value', 'Bearer Token');
-
+    cy.contains(ApiEditor.dropdownOption, "Bearer Token").click();
   });
 
   it("4. Test selection user must be displayed with Username and Password", function() {
-
     cy.get(ApiEditor.labelAuth).contains("Bearer Token");
     //cy.get(ApiEditor.labelAuth).contains("Username");
     //cy.get(ApiEditor.labelAuth).contains("Password");
-    
   });
 
   it("5. Test user is displayed with following button", function() {
-
     /*5. Ensure user is displayed with following button 
           1) Delete   2) Test (Non -Functional)
           3) Save     4) Twilio Logo
@@ -50,69 +44,78 @@ describe("Airtable Active datasource test cases", function() {
           6) Back option
     */
     cy.get(".bp3-button:contains('Delete')").should("exist");
-    //Test (Non -Functional) ???
+    /* Test button has not been added to Create DataSource Page for SaaS Plugins
+       cy.get(".t--test-datasource").should("exist"); 
+    */
     cy.get(apiwidget.saveButton).should("exist");
     cy.get("[alt='Datasource']").should("be.visible");
     cy.get(datasourceEditor.datasourceTitle).should("exist");
     cy.get(datasourceEditor.datasourceTitle).type("Test Airtable1.2");
     cy.get(ApiEditor.backBtn).should("exist");
-
   });
 
   it("6. Test clicking on Save option the DS gets saved", function() {
+    cy.get(
+      'input[name="datasourceConfiguration.authentication.bearerToken"]',
+    ).type(datasource.bearerToken);
+    cy.get(
+      'input[name="datasourceConfiguration.authentication.bearerToken"]',
+    ).should("have.value", datasource.bearerToken);
 
-    cy.get('input[name="datasourceConfiguration.authentication.bearerToken"]').type(datasource.bearerToken);
-    cy.get('input[name="datasourceConfiguration.authentication.bearerToken"]').should('have.value', datasource.bearerToken);
-   
     cy.get(".bp3-button-text:contains('Save')").click();
-     
 
-    /*cy.RunAPI();
-    cy.ResponseStatusCheck("200 OK");
-    cy.get(ApiEditor.formActionButtons).should("be.visible");
-    cy.get(ApiEditor.ApiActionMenu)
-      .first()
-      .click();
-    cy.get(ApiEditor.ApiDeleteBtn).click();
-    cy.get(ApiEditor.ApiDeleteBtn)
-      .contains("Are you sure?")
-      .click();
-    cy.wait("@deleteAction");
-    cy.get("@deleteAction").then((response) => {
-      cy.expect(response.response.body.responseMeta.success).to.eq(true);
-    });*/
-
-    /*cy.importCurl();
-    cy.get("@curlImport").then((response) => {
-      cy.expect(response.response.body.responseMeta.success).to.eq(true);
-      cy.get(apiwidget.ApiName)
-        .invoke("text")
-        .then((text) => {
-          const someText = text;
-          expect(someText).to.equal(response.response.body.data.name);
-        });
-    });*/
-
+    cy.wait("@saveDatasource").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
   });
 
- /* it("7. Test clicking on Delete the DS gets deleted", function() {
-    //cy.get(".bp3-button:contains('Delete')").click();
+  it("7. Test clicking on Delete the DS gets deleted", function() {
+    cy.get(pages.integrationCreateNew)
+      .should("be.visible")
+      .click({ force: true });
+
+    cy.get(datasourceEditor.Airtable).click();
+
+    cy.get(".t--delete-datasource").click();
+    cy.get(".t--delete-datasource")
+      .contains("Are you sure?")
+      .click();
+    cy.wait("@deleteDatasource").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      200,
+    );
   });
 
   it("8. Test  delete if the DS is associated with a query the DS must show an error and unable to delete", function() {
-    //TODO
+    cy.contains(".t--datasource-name", "Test Airtable1.2")
+      .find(queryLocators.createQuery)
+      .click();
+    cy.get(queryLocators.queryNameField).type("Test");
+    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.backBtn).click();
+
+    cy.contains(".t--datasource-name", "Test Airtable1.2").click();
+    cy.get(".t--delete-datasource").click();
+    cy.get(".t--delete-datasource")
+      .contains("Are you sure?")
+      .click();
+    cy.wait("@deleteDatasource").should(
+      "have.nested.property",
+      "response.body.responseMeta.status",
+      409,
+    );
   });
 
   it("9. Test Password is encrypted", function() {
-    //cy.get("[alt='Datasource']").click();
+    cy.get("[type='password']").should("exist");
   });
 
   it("10. Test clicking on the back button user should be navigated to the active Datasources page", function() {
-
     cy.get(ApiEditor.backBtn).click();
     cy.get(".t--integrationsHomePage").should("exist");
     cy.get(".sectionHeadings").contains("Datasource");
-
-  });*/
-
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
@@ -115,6 +115,8 @@ describe("Twilio Active datasource test cases", function() {
   });
 
   it("9. Test Password is encrypted", function() {
+    cy.get(ApiEditor.dropdownTypeAuth).click();
+    cy.contains(ApiEditor.test, "Basic Auth").click();
     cy.get("[type='password']").should("exist");
   });
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js
@@ -5,7 +5,7 @@ const datasource = require("../../../../fixtures/datasources.json");
 const queryLocators = require("../../../../locators/QueryEditor.json");
 import ApiEditor from "../../../../locators/ApiEditor";
 
-describe("Airtable Active datasource test cases", function() {
+describe("Twilio Active datasource test cases", function() {
   before(() => {
     localStorage.setItem("ApiPaneV2", "ApiPaneV2");
     cy.NavigateToApiEditor();
@@ -15,25 +15,23 @@ describe("Airtable Active datasource test cases", function() {
   });
 
   it("1. Test user is displayed with Twilio setup on Datasource page along with the symbol", function() {
-    cy.get(datasourceEditor.Airtable).should("exist");
-    cy.get(ApiEditor.airtableImage).should("be.visible");
+    cy.get(datasourceEditor.Twilio).should("exist");
+    cy.get(ApiEditor.twilioImage).should("be.visible");
   });
 
   it("2. Test user is able to click on the Twilio for establishing a connection", function() {
-    cy.get(datasourceEditor.Airtable).click();
+    cy.get(datasourceEditor.Twilio).click();
     cy.get(".t--json-to-form-wrapper").should("exist");
   });
 
   it("3. Test user is displayed with Auth type and user is able to select Basic Auth", function() {
     cy.get(ApiEditor.dropdownTypeAuth).click();
-    //cy.contains(ApiEditor.test, 'Basic Auth').click()
-    cy.contains(ApiEditor.dropdownOption, "Bearer Token").click();
+    cy.contains(ApiEditor.test, "Basic Auth").click();
   });
 
   it("4. Test selection user must be displayed with Username and Password", function() {
-    cy.get(ApiEditor.labelAuth).contains("Bearer Token");
-    //cy.get(ApiEditor.labelAuth).contains("Username");
-    //cy.get(ApiEditor.labelAuth).contains("Password");
+    cy.get(ApiEditor.labelAuth).contains("Account SID");
+    cy.get(ApiEditor.labelAuth).contains("Auth Token");
   });
 
   it("5. Test user is displayed with following button", function() {
@@ -50,17 +48,24 @@ describe("Airtable Active datasource test cases", function() {
     cy.get(apiwidget.saveButton).should("exist");
     cy.get("[alt='Datasource']").should("be.visible");
     cy.get(datasourceEditor.datasourceTitle).should("exist");
-    cy.get(datasourceEditor.datasourceTitle).type("Test Airtable1.2");
+    cy.get(datasourceEditor.datasourceTitle).type("Test Twilio");
     cy.get(ApiEditor.backBtn).should("exist");
   });
 
   it("6. Test clicking on Save option the DS gets saved", function() {
     cy.get(
-      'input[name="datasourceConfiguration.authentication.bearerToken"]',
-    ).type(datasource.bearerToken);
+      'input[name="datasourceConfiguration.authentication.username"]',
+    ).type(datasource.username);
     cy.get(
-      'input[name="datasourceConfiguration.authentication.bearerToken"]',
-    ).should("have.value", datasource.bearerToken);
+      'input[name="datasourceConfiguration.authentication.username"]',
+    ).should("have.value", datasource.username);
+
+    cy.get(
+      'input[name="datasourceConfiguration.authentication.password"]',
+    ).type(datasource.password);
+    cy.get(
+      'input[name="datasourceConfiguration.authentication.password"]',
+    ).should("have.value", datasource.password);
 
     cy.get(".bp3-button-text:contains('Save')").click();
 
@@ -76,7 +81,7 @@ describe("Airtable Active datasource test cases", function() {
       .should("be.visible")
       .click({ force: true });
 
-    cy.get(datasourceEditor.Airtable).click();
+    cy.get(datasourceEditor.Twilio).click();
 
     cy.get(".t--delete-datasource").click();
     cy.get(".t--delete-datasource")
@@ -90,14 +95,14 @@ describe("Airtable Active datasource test cases", function() {
   });
 
   it("8. Test  delete if the DS is associated with a query the DS must show an error and unable to delete", function() {
-    cy.contains(".t--datasource-name", "Test Airtable1.2")
+    cy.contains(".t--datasource-name", "Test Twilio")
       .find(queryLocators.createQuery)
       .click();
     cy.get(queryLocators.queryNameField).type("Test");
-    cy.get(ApiEditor.airtableImage).click(); //Only to save the query name
+    cy.get(ApiEditor.twilioImage).click(); //Only to save the query name
     cy.get(ApiEditor.backBtn).click();
 
-    cy.contains(".t--datasource-name", "Test Airtable1.2").click();
+    cy.contains(".t--datasource-name", "Test Twilio").click();
     cy.get(".t--delete-datasource").click();
     cy.get(".t--delete-datasource")
       .contains("Are you sure?")

--- a/app/client/cypress/locators/ApiEditor.js
+++ b/app/client/cypress/locators/ApiEditor.js
@@ -30,4 +30,10 @@ export default {
   rawResponseTab: "[data-cy=t--tab-RAW]",
   datasourcesRightPane: "[data-cy=t--tab-datasources]",
   connectionsRightPane: "[data-cy=t--tab-Connections]",
+  airtableImage: "[alt='Airtable']",
+  twilioImage: "[alt='Twilio']",
+  dropdownTypeAuth: ".t--form-control-DROP_DOWN .bp3-popover-wrapper",
+  dropdownOption: ".t--dropdown-option",
+  labelAuth: ".label-icon-wrapper",
+  backBtn: ".t--close-editor"
 };

--- a/app/client/cypress/locators/DatasourcesEditor.json
+++ b/app/client/cypress/locators/DatasourcesEditor.json
@@ -9,6 +9,8 @@
   "authenticationAuthtype": "[data-cy=datasourceConfiguration\\.authentication\\.authType]",
   "url": "input[name='url']",
   "MongoDB": ".t--plugin-name:contains('MongoDB')",
+  "Airtable": ".t--plugin-name:contains('Airtable')",
+  "Twilio": ".t--plugin-name:contains('Twilio')",
   "RESTAPI": ".t--plugin-name:contains('REST API')",
   "PostgreSQL": ".t--plugin-name:contains('PostgreSQL')",
   "SMTP":".t--plugin-name:contains('SMTP')",

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1667,3 +1667,16 @@ Cypress.Commands.add(
     });
   },
 );
+
+Cypress.Commands.add("openDropdown", (option) => {
+  const query =
+    "//div[text()='" +
+    option +
+    "']/ancestor::div/preceding-sibling::a[contains(@class, 't--entity-collapse-toggle')]";
+
+  cy.xpath(query)
+    .invoke("attr", "name")
+    .then((arrow) => {
+      cy.xpath(query).trigger("click", { multiple: true, force: true });
+    });
+});


### PR DESCRIPTION
## Description

List of test to establish connection with Twilio.

Fixes issue [#1866](https://github.com/appsmithorg/TestSmith/issues/1866)



## Relevant details for test configuration.

The following variables must be added to `app/client/cypress/fixtures/datasources.json`:

    "bearerToken":"keyXXXXXXX",
    "username":"ACXXXXXXXXX",
    "password":"XXXXXX

 If you have access to Notion you can check Twilio EngSpec for trial credentials. 

The file to be tested has the name `TwilioDataSource_spec.js` and is located in the path `app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/TwilioDataSource_spec.js`

## Checklist:

- [X] Ensure is user is displayed with Twilio setup on Datasource page along with the symbol
- [X] Ensure the user is able to click on the Twilio for establishing a connection
- [X] Ensure user is displayed with Auth type and user is able to select Basic Auth
- [X]  On selection user must be displayed with Username and Password
- [X]  Ensure user is displayed with following button 1) Delete2) Test (Non -Functional)3) Save 4) Twilio Logo5) Edit name of Datasource6) Back option
- [X]  Ensure clicking on Save option the DS gets saved
- [X]  Ensure clicking on Delete the DS gets deleted
- [X]  Ensure on delete if the DS is associated with a query the DS must show an error and unable to delete
- [X]  Ensure the Password is encrypted
- [X] Ensure clicking on the back button user should be navigated to the active Datasources page
