### PR TITLE
fix: Not able to right click on app home button in view mode

### DIFF
--- a/app/client/src/pages/AppViewer/BackToHomeButton.tsx
+++ b/app/client/src/pages/AppViewer/BackToHomeButton.tsx
@@ -1,20 +1,17 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { useHistory } from "react-router";
 import AppsIcon from "remixicon-react/AppsLineIcon";
 
 import { getSelectedAppTheme } from "selectors/appThemingSelectors";
 
 function BackToHomeButton() {
-  const history = useHistory();
   const selectedTheme = useSelector(getSelectedAppTheme);
 
   return (
-    <button
-      className="flex items-center gap-1 group t--back-to-home"
-      onClick={() => {
-        history.push("/applications");
-      }}
+    <Link
+      className="flex items-center gap-1 group t--back-to-home hover:no-underline"
+      to="/applications"
     >
       <AppsIcon
         className="p-1 text-[#858282] w-7 h-7 group-hover:bg-gray-100"
@@ -23,7 +20,7 @@ function BackToHomeButton() {
         }}
       />
       <span className="hidden md:block text-[#4B4848]">Apps</span>
-    </button>
+    </Link>
   );
 }
 


### PR DESCRIPTION
We used a button instead of an anchor in app home button in view mode. Due to this, we were not able to right-click on it. This PR replaces the button with a link

Fixes #15086

## Type of change
- Bug fix

## How Has This Been Tested?
- Manually tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
