### PR TITLE
Fix / Compact property not functional for menu widget

### DIFF
--- a/app/client/src/widgets/MenuButtonWidget/component/index.tsx
+++ b/app/client/src/widgets/MenuButtonWidget/component/index.tsx
@@ -208,8 +208,8 @@ const BaseMenuItem = styled(MenuItem)<ThemeProp & BaseStyleProps>`
   ${({ isCompact }) =>
     isCompact &&
     `
-      padding-top: 3px;
-      padding-bottom: 3px;
+      padding-top: 3px !important;
+      padding-bottom: 3px !important;
       font-size: 12px;
   `}
 `;

--- a/app/client/src/widgets/TableWidget/component/components/menuButtonTableComponent.tsx
+++ b/app/client/src/widgets/TableWidget/component/components/menuButtonTableComponent.tsx
@@ -188,8 +188,8 @@ const BaseMenuItem = styled(MenuItem)<ThemeProp & BaseStyleProps>`
   ${({ isCompact }) =>
     isCompact &&
     `
-      padding-top: 3px;
-      padding-bottom: 3px;
+      padding-top: 3px !important;
+      padding-bottom: 3px !important;
       font-size: 12px;
   `}
 `;


### PR DESCRIPTION
## Description

This PR fixes the issue where compact property does not work for menu widget and menu type in table widget.
The CSS for compact property were getting overridden by some popover CSS

Fixes #13583 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
