### PR TITLE
fix: sign up flow on instances with google recaptcha site key

### DIFF
--- a/app/client/src/ce/pages/UserAuth/SignUp.tsx
+++ b/app/client/src/ce/pages/UserAuth/SignUp.tsx
@@ -140,8 +140,8 @@ export function SignUp(props: SignUpFormProps) {
         .then(function(token: any) {
           const actionURL =
             signupURL.indexOf("?") > -1
-              ? `${signupURL}?recaptchaToken=${token}`
-              : `${signupURL}&recaptchaToken=${token}`;
+              ? `${signupURL}&recaptchaToken=${token}`
+              : `${signupURL}?recaptchaToken=${token}`;
           formElement && formElement.setAttribute("action", actionURL);
           formElement && formElement.submit();
         });

--- a/app/client/src/ce/pages/UserAuth/SignUp.tsx
+++ b/app/client/src/ce/pages/UserAuth/SignUp.tsx
@@ -138,11 +138,11 @@ export function SignUp(props: SignUpFormProps) {
           action: "submit",
         })
         .then(function(token: any) {
-          formElement &&
-            formElement.setAttribute(
-              "action",
-              `${signupURL}?recaptchaToken=${token}`,
-            );
+          const actionURL =
+            signupURL.indexOf("?") > -1
+              ? `${signupURL}?recaptchaToken=${token}`
+              : `${signupURL}&recaptchaToken=${token}`;
+          formElement && formElement.setAttribute("action", actionURL);
           formElement && formElement.submit();
         });
     } else {


### PR DESCRIPTION
## Description
The sign up form action URL had multiple "?" making it invalid. Fix is to check if there is a "?" already and append query params with "&" when necessary.

Fixes #15103 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
