### PR TITLE
chore: add back button on individual authentication config pages

### DIFF
--- a/app/client/src/pages/Settings/SettingsForm.tsx
+++ b/app/client/src/pages/Settings/SettingsForm.tsx
@@ -37,6 +37,7 @@ import {
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import {
   Wrapper,
+  BackButton,
   BottomSpace,
   HeaderWrapper,
   SettingsHeader,
@@ -182,6 +183,7 @@ export function SettingsForm(
 
   return (
     <Wrapper>
+      {subCategory && <BackButton />}
       <SettingsFormWrapper>
         <HeaderWrapper>
           <SettingsHeader>{pageTitle}</SettingsHeader>

--- a/app/client/src/pages/Settings/components.tsx
+++ b/app/client/src/pages/Settings/components.tsx
@@ -1,5 +1,7 @@
+import React from "react";
 import styled from "styled-components";
 import { Classes } from "@blueprintjs/core";
+import { Icon, IconSize } from "components/ads";
 
 export const Wrapper = styled.div`
   flex-basis: calc(100% - ${(props) => props.theme.homePage.leftPane.width}px);
@@ -39,3 +41,29 @@ export const BottomSpace = styled.div`
 `;
 
 export const ContentWrapper = styled.div``;
+
+export const StyledBackButton = styled.div`
+  display: flex;
+  cursor: pointer;
+  margin: 0 0 20px 0;
+`;
+
+export const BackButtonText = styled.span`
+  margin: 0 0 0 8px;
+`;
+
+export function BackButton() {
+  const onBack = () => {
+    history.back();
+  };
+
+  return (
+    <StyledBackButton
+      className="t--admin-settings-back-button"
+      onClick={onBack}
+    >
+      <Icon name="chevron-left" size={IconSize.XS} />
+      <BackButtonText>Back</BackButtonText>
+    </StyledBackButton>
+  );
+}


### PR DESCRIPTION
## Description

> Add back button on individual authentication config pages

Fixes #15137 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Checked if the back button is displayed on individual authentication config pages and on clicking it the page is taken back to authentication list page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
