### PR TITLE
chore: Added script to run Appsmith branches locally

### DIFF
--- a/scripts/local_testing.sh
+++ b/scripts/local_testing.sh
@@ -51,4 +51,4 @@ popd
 docker build -t appsmith/appsmith-ce:local-testing . > /dev/null && pretty_print "Docker image build successful. Triggering run now ..."
 
 (docker stop appsmith || true) && (docker rm appsmith || true)
-docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" appsmith/appsmith-ce:local-testing && pretty_print "Local instance is up! Open Appsmith at http://localhost! "
+docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" appsmith/appsmith-ce:local-testing && sleep 15 && pretty_print "Local instance is up! Open Appsmith at http://localhost! "

--- a/scripts/local_testing.sh
+++ b/scripts/local_testing.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -o errexit
+
+# check whether user had supplied -h or --help . If yes display usage
+if [[ ( $@ == "--help") ||  $@ == "-h" ]]
+then 
+	echo "Usage: $0 [branchName]"
+	exit 0
+fi 
+
+BRANCH=${1:-release}
+
+echo "Setting up instance to run on branch: $BRANCH"
+cd "$(dirname "$0")"/..
+git fetch origin $BRANCH
+git checkout $BRANCH
+git pull origin $BRANCH
+echo "Local branch is now up to date"
+
+pushd app/server > /dev/null && ./build.sh -DskipTests > /dev/null && echo "Server build successful"
+
+popd
+pushd app/client > /dev/null && yarn > /dev/null && yarn build > /dev/null && echo "Client build successful"
+
+popd
+pushd app/rts > /dev/null && ./build.sh > /dev/null && echo "RTS build successful"
+
+popd
+docker build -t appsmith/appsmith-ce:local-testing . > /dev/null && echo "Docker image build successful. Triggering run now ..."
+
+(docker stop appsmith || true) && (docker rm appsmith || true)
+docker run -d --name appsmith -p 80:80 -v "$PWD/stacks:/appsmith-stacks" appsmith/appsmith-ce:local-testing && echo "Local instance is up! Open Appsmith at http://localhost! "

--- a/scripts/local_testing.sh
+++ b/scripts/local_testing.sh
@@ -37,21 +37,17 @@ cd "$(dirname "$0")"/..
 git fetch origin $BRANCH
 git checkout $BRANCH
 git pull origin $BRANCH
-pretty_print "Local branch is now up to date"
+pretty_print "Local branch is now up to date. Starting server build ..."
 
-pretty_print "Starting server build ..."
-pushd app/server > /dev/null && ./build.sh -DskipTests > /dev/null && pretty_print "Server build successful"
-
-popd
-pretty_print "Starting client build ..."
-pushd app/client > /dev/null && yarn > /dev/null && yarn build > /dev/null && pretty_print "Client build successful"
+pushd app/server > /dev/null && ./build.sh -DskipTests > /dev/null && pretty_print "Server build successful. Starting client build ..."
 
 popd
-pretty_print "Starting RTS build ..."
-pushd app/rts > /dev/null && ./build.sh > /dev/null && pretty_print "RTS build successful"
+pushd app/client > /dev/null && yarn > /dev/null && yarn build > /dev/null && pretty_print "Client build successful. Starting RTS build ..."
 
 popd
-pretty_print "Starting Docker build ..."
+pushd app/rts > /dev/null && ./build.sh > /dev/null && pretty_print "RTS build successful. Starting Docker build ..."
+
+popd
 docker build -t appsmith/appsmith-ce:local-testing . > /dev/null && pretty_print "Docker image build successful. Triggering run now ..."
 
 (docker stop appsmith || true) && (docker rm appsmith || true)


### PR DESCRIPTION
## Description

This script enables running any given branch as a fat container locally. Pre-requisites for running this script are that Docker be installed and running on your machine, and port 80 be open for use.

The script defaults to running on `release` branch if no argument is provided.

Usage:
```
./scripts/local_testing.sh chore/local-testing
```

Fixes #15078 

## Type of change

- Utility script

## How Has This Been Tested?

- Manually tested