### PR TITLE
fix: changed the marker(default) value string to number

### DIFF
--- a/app/client/src/widgets/MapWidget/component/index.tsx
+++ b/app/client/src/widgets/MapWidget/component/index.tsx
@@ -188,7 +188,7 @@ const MyMapComponent = withGoogleMap((props: any) => {
             onDragEnd={(de) => {
               props.updateMarker(de.latLng.lat(), de.latLng.lng(), index);
             }}
-            position={{ lat: marker.lat, lng: marker.long }}
+            position={{ lat: Number(marker.lat), lng: Number(marker.long) }}
             title={marker.title}
           />
         ))}


### PR DESCRIPTION
## Description

> Map widget is not working properly when I change the default value of lat and lang to string. so I changed the default value string to a number.

Fixes #9844 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Drop a Map widget on canvas
- Set the default value to `{
    "lat": "25.122",
    "long": "50.132",
    "title": "Location1"
  }`
- Look the map is not showing any marker on the Map widget.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
