### PR TITLE
Fixes issue where multiselect height decreases on selecting more options

### DIFF
--- a/app/client/src/widgets/MultiSelectWidgetV2/component/index.styled.tsx
+++ b/app/client/src/widgets/MultiSelectWidgetV2/component/index.styled.tsx
@@ -415,6 +415,10 @@ export const MultiSelectContainer = styled.div<{
         appearance: none;
       }
     }
+    .rc-select-selection-overflow-item-suffix {
+      position: relative !important;
+      left: 0px !important;
+    }
   }
   && .rc-select-disabled {
     cursor: not-allowed;


### PR DESCRIPTION
## Description

Height of multi select widget decreases when we select label position top and then add enough options such that the widget shows "+1 more".
Compared the multi select widget to multi tree select widget (same issue not present in multi tree select) and found that there were 2 CSS properties missing in multi select which were applied in multi tree select. Applying these CSS properties solved the inconsistent height issue with multi select widget

Fixes #13970 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
