### PR TITLE
fix: break branch creation text, fix text casing

### DIFF
--- a/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
@@ -80,7 +80,8 @@ const CreateNewBranchContainer = styled.div`
   }
 
   & div {
-    display: inline-block;
+    margin-left: ${(props) => props.theme.spaces[4]}px;
+    display: block;
     word-break: break-all;
   }
 
@@ -139,8 +140,8 @@ function CreateNewBranch({
         size={IconSize.XXXL}
       />
       <CreateNewBranchContainer className={className} ref={itemRef}>
-        <div className="large-text">{`Create Branch: ${branch} `}</div>
-        <div className="small-text">{`from \`${currentBranch}\``}</div>
+        <div className="large-text">{`Create branch: ${branch} `}</div>
+        <div className="small-text">{`from '${currentBranch}'`}</div>
       </CreateNewBranchContainer>
       <SpinnerContainer>{isCreatingNewBranch && <Spinner />}</SpinnerContainer>
     </div>


### PR DESCRIPTION
## Description

During branch creation, a bit of text was clinging to each other. Put them as per the design.

Fixes #15014 

### Issue:

![image](https://user-images.githubusercontent.com/1573771/179294901-7820fe79-4f35-47fd-9f63-98a886f102b5.png)

### design:

![Screenshot 2022-07-16 at 12 40 39 AM](https://user-images.githubusercontent.com/1573771/179295031-bbb5ef67-8955-4901-997a-1f455bdf5bb0.png)

### fix:


https://user-images.githubusercontent.com/1573771/179295053-d5940ba7-2a9f-41a9-965d-596bff69ac71.mov

![Screenshot 2022-07-16 at 12 36 52 AM](https://user-images.githubusercontent.com/1573771/179295067-c82d3905-f325-47ed-9007-06b0c7104e86.png)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
