### PR TITLE
chore: Adding the appsmithctl command to estimate the bill for an existing Appsmith user

### DIFF
--- a/deploy/docker/utils/bin/estimate_billing.js
+++ b/deploy/docker/utils/bin/estimate_billing.js
@@ -1,0 +1,151 @@
+const { MongoClient } = require("mongodb");
+const { DateTime } = require("luxon");
+const cliProgress = require("cli-progress");
+var args = require("minimist")(process.argv.slice(2));
+
+const MONGODB_URL = args.mongoUrl || process.env.APPSMITH_MONGODB_URI;
+const SESSION_PRICE = args.sessionPrice || 0.3;
+const PRICE_CAP_FOR_USER = args.priceCap || 15;
+
+let BILL = {};
+async function run() {
+  if (MONGODB_URL == undefined || MONGODB_URL.trim() === "") {
+    console.log(`
+Did you forget to specify the mandatory parameter MongoDB URL?
+
+Options:
+  --sessionPrice    The price per active session. Defaults to 0.3 
+  --priceCap        The price cap for a user in a given month. Defaults to 15
+    `);
+    return;
+  }
+  const client = new MongoClient(MONGODB_URL);
+  try {
+    initializeBill();
+    await client.connect();
+
+    const uniqueEmails = await getUniqueEmails(client);
+    console.log("Got all unique users. Going to calculate the estimated bill.");
+
+    // Since this is can potentially be a long process, show a progress bar to the user
+    const progressBar = new cliProgress.SingleBar(
+      {
+        format: "{bar} {percentage}% | ETA: {eta}s | {value}/{total} users",
+      },
+      cliProgress.Presets.shades_classic
+    );
+    progressBar.start(uniqueEmails.emails.length, 0);
+
+    // For each user calculate their monthly bill and append it to the global BILL object
+    for (const email of uniqueEmails.emails) {
+      const billingEventsForUser = await getBillingEventsForUser(client, email);
+      calculateBillForUser(billingEventsForUser);
+      progressBar.increment();
+    }
+    progressBar.stop();
+
+    console.log("\nYour estimated monthly bill for Appsmith is:");
+    console.log(BILL);
+  } catch (e) {
+    console.error(e);
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Initialize the monthly bill amount to 0 for all months
+ */
+function initializeBill() {
+  BILL["January"] = 0;
+  BILL["February"] = 0;
+  BILL["March"] = 0;
+  BILL["April"] = 0;
+  BILL["May"] = 0;
+  BILL["June"] = 0;
+  BILL["July"] = 0;
+  BILL["August"] = 0;
+  BILL["September"] = 0;
+  BILL["October"] = 0;
+  BILL["November"] = 0;
+  BILL["December"] = 0;
+}
+
+/**
+ * Get all the unique user emails from the usagePulse collection
+ * @param {MongoClient} client
+ * @returns
+ */
+async function getUniqueEmails(client) {
+  const dbClient = await client.db();
+  const query = [
+    {
+      $group: { _id: null, emails: { $addToSet: "$email" } },
+    },
+  ];
+  const aggCursor = dbClient.collection("usagePulse").aggregate(query);
+  for await (const doc of aggCursor) {
+    return doc;
+  }
+}
+
+/**
+ * This function returns all the billing events of a user based on 30 min active session window
+ *
+ * @param {MongoClient} client The MongoClient object
+ * @param {String} email The email ID of the user for whom we are fetching the billing events
+ * @returns Array of billing events
+ */
+async function getBillingEventsForUser(client, email) {
+  const dbClient = await client.db();
+  const query = [
+    { $match: { email: email } },
+    {
+      $group: {
+        _id: {
+          $toDate: {
+            $subtract: [
+              { $toLong: { $toDate: "$_id" } },
+              { $mod: [{ $toLong: { $toDate: "$_id" } }, 1000 * 60 * 30] },
+            ],
+          },
+        },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ];
+
+  const aggCursor = dbClient.collection("usagePulse").aggregate(query);
+  let billingEvents = [];
+  for await (const doc of aggCursor) {
+    billingEvents.push(doc);
+  }
+  return billingEvents;
+}
+
+/**
+ * This function calculates the monthly bill for the user and appends it to the global BILL object
+ *
+ * @param {Array} billingEventsForUser
+ */
+function calculateBillForUser(billingEventsForUser) {
+  let user = {};
+  billingEventsForUser.forEach((event) => {
+    const time = event._id;
+    const dateTime = DateTime.fromJSDate(time);
+    if (!(dateTime.monthLong in user)) {
+      user[dateTime.monthLong] = 0;
+    }
+
+    if (user[dateTime.monthLong] < PRICE_CAP_FOR_USER) {
+      user[dateTime.monthLong] += SESSION_PRICE;
+      BILL[dateTime.monthLong] += SESSION_PRICE;
+      BILL[dateTime.monthLong] =
+        Math.round(BILL[dateTime.monthLong] * 100) / 100;
+    }
+  });
+}
+
+module.exports = {
+  run,
+};

--- a/deploy/docker/utils/bin/index.js
+++ b/deploy/docker/utils/bin/index.js
@@ -1,50 +1,55 @@
 #!/usr/bin/env node
 
-const process = require('process');
-const utils = require('./utils');
-const export_db = require('./export_db.js');
-const import_db = require('./import_db.js');
-const migrate = require('./migrate.js');
-const check_replica_set = require('./check_replica_set.js');
+const process = require("process");
+const utils = require("./utils");
+const export_db = require("./export_db.js");
+const import_db = require("./import_db.js");
+const migrate = require("./migrate.js");
+const check_replica_set = require("./check_replica_set.js");
+const estimate_billing = require("./estimate_billing.js");
 
-const APPLICATION_CONFIG_PATH = '/appsmith-stacks/configuration/docker.env';
+const APPLICATION_CONFIG_PATH = "/appsmith-stacks/configuration/docker.env";
 
 // Loading latest application configuration
-require('dotenv').config({ path: APPLICATION_CONFIG_PATH });
+require("dotenv").config({ path: APPLICATION_CONFIG_PATH });
 
 const command = process.argv[2];
-console.log('command', command);
 
-if (['export-db', 'export_db', 'ex'].includes(command)) {
-  console.log('Exporting database');
+if (["export-db", "export_db", "ex"].includes(command)) {
+  console.log("Exporting database");
   export_db.run();
-  console.log('Export database done');
+  console.log("Export database done");
   return;
 }
 
-if (['import-db', 'import_db', 'im'].includes(command)) {
-  console.log('Importing database');
+if (["import-db", "import_db", "im"].includes(command)) {
+  console.log("Importing database");
   // Get Force option flag to run import DB immediately
-  const forceOption = process.argv[3] === '-f';
+  const forceOption = process.argv[3] === "-f";
   import_db.runImportDatabase(forceOption);
-  console.log('Importing database done');
+  console.log("Importing database done");
   return;
 }
 
-if (['migrate', 'mi'].includes(command) && process.argv[3]) {
-  const arrString = process.argv[3].split('@');
-  console.log('Start migrate instance');
+if (["migrate", "mi"].includes(command) && process.argv[3]) {
+  const arrString = process.argv[3].split("@");
+  console.log("Start migrate instance");
   migrate.runMigrate(arrString[0], arrString[1]);
   return;
 }
 
-if (['check-replica-set', 'check_replica_set', 'crs'].includes(command)) {
+if (["check-replica-set", "check_replica_set", "crs"].includes(command)) {
   check_replica_set.exec();
   return;
 }
 
-if (['backup', 'restore'].includes(command)) {
+if (["backup", "restore"].includes(command)) {
   require(`./${command}.js`).run(process.argv.slice(3));
+  return;
+}
+
+if (["estimate-billing", "estimate_billing"].includes(command)) {
+  estimate_billing.run(process.argv.slice(3));
   return;
 }
 

--- a/deploy/docker/utils/bin/utils.js
+++ b/deploy/docker/utils/bin/utils.js
@@ -1,32 +1,35 @@
-const shell = require('shelljs');
-const fsPromises = require('fs/promises');
-const Constants = require('./constants')
-const childProcess = require('child_process');
+const shell = require("shelljs");
+const fsPromises = require("fs/promises");
+const Constants = require("./constants");
+const childProcess = require("child_process");
 
 function showHelp() {
-  console.log('\nUsage: appsmith <command> to interactive with appsmith utils tool');
-  console.log('\nOptions:\r');
-  console.log('\tex, export_db\t\tExport interal database.\r');
-  console.log('\tim, import_db\t\tImport interal database.\r');
-  console.log('\tmi, migrate\t\tMigrate new server.\r');
-  console.log('\tcrs, check_replica_set\tcheck replica set mongoDB.\r');
-  console.log('\tbackup\t\t\tTake a backup of Appsmith instance.\r');
-  console.log('\trestore\t\t\tRestore Appsmith instance from a backup.\r');
-  console.log('\t--help\t\t\t' + 'Show help.' + '\t\t\t' + '[boolean]\n');
+  console.log(
+    "\nUsage: appsmith <command> to interact with appsmith utils tool"
+  );
+  console.log("\nOptions:\r");
+  console.log("\tex, export_db\t\tExport interal database.\r");
+  console.log("\tim, import_db\t\tImport interal database.\r");
+  console.log("\tmi, migrate\t\tMigrate new server.\r");
+  console.log("\tcrs, check_replica_set\tCheck replica set mongoDB.\r");
+  console.log("\tbackup\t\t\tTake a backup of Appsmith instance.\r");
+  console.log("\trestore\t\t\tRestore Appsmith instance from a backup.\r");
+  console.log("\testimate_billing\tEstimate billing based on past usage.\r");
+  console.log("\t--help\t\t\t" + "Show help.");
 }
 
 function stop(apps) {
-  const appsStr = apps.join(' ')
-  console.log('Stopping ' + appsStr);
-  shell.exec('/usr/bin/supervisorctl stop ' + appsStr);
-  console.log('Stopped ' + appsStr);
+  const appsStr = apps.join(" ");
+  console.log("Stopping " + appsStr);
+  shell.exec("/usr/bin/supervisorctl stop " + appsStr);
+  console.log("Stopped " + appsStr);
 }
 
 function start(apps) {
-  const appsStr = apps.join(' ')
-  console.log('Starting ' + appsStr);
-  shell.exec('/usr/bin/supervisorctl start ' + appsStr);
-  console.log('Started ' + appsStr);
+  const appsStr = apps.join(" ");
+  console.log("Starting " + appsStr);
+  shell.exec("/usr/bin/supervisorctl start " + appsStr);
+  console.log("Started " + appsStr);
 }
 
 function execCommand(cmd, options) {
@@ -34,11 +37,11 @@ function execCommand(cmd, options) {
     let isPromiseDone = false;
 
     const p = childProcess.spawn(cmd[0], cmd.slice(1), {
-      stdio: 'inherit',
+      stdio: "inherit",
       ...options,
     });
 
-    p.on('exit', (code) => {
+    p.on("exit", (code) => {
       if (isPromiseDone) {
         return;
       }
@@ -48,28 +51,34 @@ function execCommand(cmd, options) {
       } else {
         reject();
       }
-    })
+    });
 
-    p.on('error', (err) => {
+    p.on("error", (err) => {
       if (isPromiseDone) {
         return;
       }
       isPromiseDone = true;
-      log.error('Error rynning command', err);
+      log.error("Error running command", err);
       reject();
-    })
-  })
+    });
+  });
 }
 
-async function listLocalBackupFiles(){ // Ascending order
+async function listLocalBackupFiles() {
+  // Ascending order
   const backupFiles = [];
-  await fsPromises.readdir(Constants.BACKUP_PATH).then(filenames => {
-    for (let filename of filenames) {
-      if (filename.match(/^appsmith-backup-.*\.tar\.gz$/)) {
-        backupFiles.push(filename);
-        }}}).catch(err => {
-          console.log(err);
-      });
+  await fsPromises
+    .readdir(Constants.BACKUP_PATH)
+    .then((filenames) => {
+      for (let filename of filenames) {
+        if (filename.match(/^appsmith-backup-.*\.tar\.gz$/)) {
+          backupFiles.push(filename);
+        }
+      }
+    })
+    .catch((err) => {
+      console.log(err);
+    });
   return backupFiles;
 }
 

--- a/deploy/docker/utils/package-lock.json
+++ b/deploy/docker/utils/package-lock.json
@@ -23,6 +23,11 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -59,6 +64,14 @@
         "ieee754": "^1.1.13"
       }
     },
+    "cli-progress": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
+      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "requires": {
+        "string-width": "^4.2.3"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -73,6 +86,11 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -142,6 +160,16 @@
         "has": "^1.0.3"
       }
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "luxon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
+      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw=="
+    },
     "memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -155,6 +183,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mongodb": {
       "version": "4.4.0",
@@ -176,6 +209,11 @@
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
       }
+    },
+    "nodemailer": {
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.5.tgz",
+      "integrity": "sha512-6VtMpwhsrixq1HDYSBBHvW0GwiWawE75dS3oal48VqRhUvKJNnKnJo2RI/bCVQubj1vgrgscMNW4DHaD6xtMCg=="
     },
     "once": {
       "version": "1.4.0",
@@ -262,6 +300,24 @@
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
       }
     },
     "tr46": {

--- a/deploy/docker/utils/package.json
+++ b/deploy/docker/utils/package.json
@@ -16,7 +16,10 @@
     "mongodb": "^4.4.0",
     "readline-sync": "1.4.10",
     "shelljs": "0.8.5",
-    "nodemailer": "6.7.5"
+    "nodemailer": "6.7.5",
+    "cli-progress": "^3.11.2",
+    "luxon": "^3.0.1",
+    "minimist": "^1.2.6"
   },
   "bin": {
     "appsmithctl": "./bin/index.js"


### PR DESCRIPTION
## Description

This PR adds to the `estimate_billing` option to the `appsmithctl` command. This will help existing users estimate their bill when they consider upgrading to the paid edition.

Usage: 
```
appsmithctl estimate_billing 

Options:
  --sessionPrice    The price per active session. Defaults to 0.3 
  --priceCap        The price cap for a user in a given month. Defaults to 15
```

A user can also run the command for various scenarios to determine the optimum capacity tier.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
