### PR TITLE
fix: JSONForm input field REGEX validation

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/JSONFormWidget/JSONForm_FieldProperties_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/JSONFormWidget/JSONForm_FieldProperties_spec.js
@@ -64,6 +64,11 @@ describe("Text Field Property Control", () => {
     cy.testJsontext("errormessage", "Custom error message");
     cy.get(`${fieldPrefix}-name input`).click({ force: true });
     cy.get(".bp3-popover-content").contains("Custom error message");
+
+    // Reset the error message
+    cy.testJsontext("errormessage", "");
+    // Reset valid
+    cy.testJsontext("valid", "");
   });
 
   it("hides field when visible switched off", () => {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/JSONFormWidget/JSONForm_FieldProperties_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/JSONFormWidget/JSONForm_FieldProperties_spec.js
@@ -82,6 +82,19 @@ describe("Text Field Property Control", () => {
 
     cy.togglebarDisable(`.t--property-control-disabled input`);
   });
+
+  it("throws error when REGEX does not match the input value", () => {
+    cy.testJsontext("regex", "^\\d+$");
+    cy.get(`${fieldPrefix}-name input`)
+      .clear()
+      .type("abcd");
+    cy.get(".bp3-popover-content").contains("Invalid input");
+
+    cy.get(`${fieldPrefix}-name input`)
+      .clear()
+      .type("1234");
+    cy.get(".bp3-popover-content").should("not.exist");
+  });
 });
 
 describe("Checkbox Field Property Control", () => {

--- a/app/client/src/components/propertyControls/JSONFormComputeControl.tsx
+++ b/app/client/src/components/propertyControls/JSONFormComputeControl.tsx
@@ -182,6 +182,8 @@ class JSONFormComputeControl extends BaseControl<JSONFormComputeControlProps> {
     propertyValue: string,
     widgetName: string,
   ) => {
+    if (!isDynamicValue(propertyValue)) return propertyValue;
+
     const { prefixTemplate, suffixTemplate } = getBindingTemplate(widgetName);
 
     const value = propertyValue.substring(
@@ -194,6 +196,22 @@ class JSONFormComputeControl extends BaseControl<JSONFormComputeControlProps> {
 
   getComputedValue = (value: string) => {
     const { widgetName } = this.props.widgetProperties;
+
+    /**
+     * If the input value is not a binding then there is no need of adding binding template
+     * to the value as it would be of no use.
+     *
+     * Original motivation of doing this to allow REGEX to work. If the value is REGEX, eg - ^\d+$ and the
+     * binding template is added, the REGEX is processed by evaluation and the "\" is considered as a escape and
+     * is removed from the final value and the regex become ^d+$. In order to make it work inside a binding the "\"
+     * has to be escaped by doing ^\\d+$.
+     * As the user is unaware of this binding template being added under the hood, it is not obvious for the user
+     * to escape the "\".
+     * Thus now we only add the binding template around a value only if the original value has a binding as that could
+     * be an indication of the usage of formData/sourceData/fieldState in the value.
+     */
+    if (!isDynamicValue(value)) return value;
+
     const stringToEvaluate = stringToJS(value);
     const { prefixTemplate, suffixTemplate } = getBindingTemplate(widgetName);
 


### PR DESCRIPTION
## Description

When a Regex property is entered a value like `^\d+$`. Under the hood, the value for the JSONForm is stored in this format
```{{sourceData, formData, fieldState) => (`^\d+$`))(JSONForm1.sourceData, JSONForm1.formData, JSONForm1.fieldState)}}```

As this is a binding, it is evaluated and due to evaluation the `\d` is treated as an escape sequence and the `\` is removed.

So the solution is to not use the default binding template of the JSONForm when the value that is being entered in the property pane is not a dynamic value. In this way the regex will be treated as a plain text and won't get evaluated

If a user wants to use a regex in a binding the `\` has to be escaped i.e `{{^\\d+$}}`

Fixes #14109 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1 cypress test is added to an existing spec

Test steps:
1. A new JSONForm is added 
2. The source data is updated to
```json
{ "name": "John" }
```
3. The property pane is opened and the `Regex` property is updated to `^\d+$` (accepts only numeric values).
4. The `name` field is entered an alphabetic value "abcd" and it is observed that the error popup shows up with message `Invalid input`
5. The `name` field is cleared and entered a numeric value "1234" and it is observed for no error pop ups.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
