### PR TITLE
feat: Add pod labels to allow for selector labels across different configs

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -88,6 +88,7 @@ The command uninstalls the release and removes all Kubernetes resources associat
 | `strategyType`							| Appsmith deployment strategy type										| `RollingUpdate` |
 | `schedulerName`							| Alternate scheduler																	| `""`						|
 | `podAnnotations`						| Annotations for Appsmith pods												| `{}`						|
+| `podLabels`						| Labels for Appsmith pods												| `{}`						|
 | `podSecurityContext`				| Appsmith pods security context											| `{}`						|
 | `securityContext`						| Set security context																| `{}`						|
 | `resources.limit`						| The resources limits for the Appsmith container			| `{}`						|

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -21,9 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "appsmith.selectorLabels" . | nindent 8 }}
-{{- if .Values.podsLabels }}
-{{ toYaml .Values.podsLabels | indent 8 }}
-{{- end }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName | quote }}

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "appsmith.selectorLabels" . | nindent 8 }}
+{{- if .Values.podsLabels }}
+{{ toYaml .Values.podsLabels | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -55,6 +55,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
## Description

Some services such as istio need labels to identify pods. This will allow those services to be configurable.

Fixes #15351 

## Type of change

New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Using this in our production cluster

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
