### PR TITLE
fix: catch block not working in firefox and safari for async functions

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15372_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15372_spec.js
@@ -1,0 +1,28 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+let jsEditor = ObjectsRegistry.JSEditor;
+
+describe("[Bug]: Catch block was not triggering in Safari/firefox", () => {
+  it("1. Triggers the catch block when the API hits a 404", () => {
+    cy.NavigateToAPI_Panel();
+    cy.createAndFillApi("https://swapi.dev/api/people/18261826");
+    cy.wait(3000);
+
+    jsEditor.CreateJSObject(
+      `export default {
+      fun: async () => {
+        return await Api1.run().catch(() => showAlert("404 hit"));
+      }
+    }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: true,
+        shouldCreateNewJSObj: true,
+      },
+    );
+
+    cy.validateToastMessage("fun ran successfully");
+    cy.validateToastMessage("404 hit");
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15372_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15372_spec.ts
@@ -14,7 +14,7 @@ describe("[Bug]: Catch block was not triggering in Safari/firefox", () => {
     jsEditor.CreateJSObject(
       `export default {
       fun: async () => {
-        return await Api1.run().catch(() => showAlert("404 hit"));
+        return await Api1.run().catch((e) => showAlert("404 hit : " + e.message));
       }
     }`,
       {
@@ -24,6 +24,6 @@ describe("[Bug]: Catch block was not triggering in Safari/firefox", () => {
         shouldCreateNewJSObj: true,
       },
     );
-    agHelper.WaitUntilToastDisappear("404 hit");
+    agHelper.WaitUntilToastDisappear("404 hit : Api1 failed to execute");
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15372_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15372_spec.ts
@@ -1,11 +1,14 @@
 import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
-let jsEditor = ObjectsRegistry.JSEditor;
+const {
+  AggregateHelper: agHelper,
+  ApiPage: apiPage,
+  JSEditor: jsEditor,
+} = ObjectsRegistry;
 
 describe("[Bug]: Catch block was not triggering in Safari/firefox", () => {
   it("1. Triggers the catch block when the API hits a 404", () => {
-    cy.NavigateToAPI_Panel();
-    cy.createAndFillApi("https://swapi.dev/api/people/18261826");
+    apiPage.CreateAndFillApi("https://swapi.dev/api/people/18261826", "Api1");
     cy.wait(3000);
 
     jsEditor.CreateJSObject(
@@ -21,8 +24,6 @@ describe("[Bug]: Catch block was not triggering in Safari/firefox", () => {
         shouldCreateNewJSObj: true,
       },
     );
-
-    cy.validateToastMessage("fun ran successfully");
-    cy.validateToastMessage("404 hit");
+    agHelper.WaitUntilToastDisappear("404 hit");
   });
 });

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -336,7 +336,7 @@ function* executeTriggerRequestSaga(
     // a success: false is sent to reject the promise
 
     // @ts-expect-error: reason is of type string
-    responsePayload.data.reason = error.message;
+    responsePayload.data.reason = { message: error.message };
     responsePayload.success = false;
   }
   responseChannel.put({

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -299,7 +299,7 @@ export function* evaluateAndExecuteDynamicTrigger(
 interface ResponsePayload {
   data: {
     subRequestId: string;
-    reason?: string;
+    reason?: Error;
     resolve?: unknown;
   };
   success: boolean;
@@ -335,9 +335,10 @@ function* executeTriggerRequestSaga(
     // When error occurs in execution of triggers,
     // a success: false is sent to reject the promise
 
-    // @ts-expect-error: reason is of type string
-    responsePayload.data.reason = new Error(error.message);
-    responsePayload.success = false;
+    if (error instanceof Error) {
+      responsePayload.data.reason = new Error(error.message);
+      responsePayload.success = false;
+    }
   }
   responseChannel.put({
     method: EVAL_WORKER_ACTIONS.PROCESS_TRIGGER,

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -336,7 +336,7 @@ function* executeTriggerRequestSaga(
     // a success: false is sent to reject the promise
 
     // @ts-expect-error: reason is of type string
-    responsePayload.data.reason = error;
+    responsePayload.data.reason = error.message;
     responsePayload.success = false;
   }
   responseChannel.put({

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -299,7 +299,7 @@ export function* evaluateAndExecuteDynamicTrigger(
 interface ResponsePayload {
   data: {
     subRequestId: string;
-    reason?: Error;
+    reason?: string;
     resolve?: unknown;
   };
   success: boolean;
@@ -335,12 +335,9 @@ function* executeTriggerRequestSaga(
     // When error occurs in execution of triggers,
     // a success: false is sent to reject the promise
 
+    // @ts-expect-error: reason is of type string
+    responsePayload.data.reason = { message: error.message };
     responsePayload.success = false;
-    if (error instanceof Error) {
-      responsePayload.data.reason = new Error(error.message);
-    } else {
-      responsePayload.data.reason = new Error("Unknown error");
-    }
   }
   responseChannel.put({
     method: EVAL_WORKER_ACTIONS.PROCESS_TRIGGER,

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -336,7 +336,7 @@ function* executeTriggerRequestSaga(
     // a success: false is sent to reject the promise
 
     // @ts-expect-error: reason is of type string
-    responsePayload.data.reason = { message: error.message };
+    responsePayload.data.reason = new Error(error.message);
     responsePayload.success = false;
   }
   responseChannel.put({

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -335,9 +335,11 @@ function* executeTriggerRequestSaga(
     // When error occurs in execution of triggers,
     // a success: false is sent to reject the promise
 
+    responsePayload.success = false;
     if (error instanceof Error) {
       responsePayload.data.reason = new Error(error.message);
-      responsePayload.success = false;
+    } else {
+      responsePayload.data.reason = new Error("Unknown error");
     }
   }
   responseChannel.put({


### PR DESCRIPTION
## Description

The catch block was not working for an async function in safari/firefox. On further debugging we found that different browsers were sending different call stacks to the response payload, making it fail on firefox and safari. We are only extracting the error message now to keep it consistent across browsers.

Screen recording (firefox) - 

https://user-images.githubusercontent.com/10229595/180390210-bb578a5a-f930-4dbe-aaff-6fafbd536dd9.mov

Fixes #15372 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- [ ] https://github.com/appsmithorg/TestSmith/issues/2011

- Cypress tests


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
