### PR TITLE
chore: Fixing bug where the Mongo DB URL wasn't being picked up by the billing script

### DIFF
--- a/deploy/docker/utils/bin/estimate_billing.js
+++ b/deploy/docker/utils/bin/estimate_billing.js
@@ -3,12 +3,12 @@ const { DateTime } = require("luxon");
 const cliProgress = require("cli-progress");
 var args = require("minimist")(process.argv.slice(2));
 
-const MONGODB_URL = args.mongoUrl || process.env.APPSMITH_MONGODB_URI;
 const SESSION_PRICE = args.sessionPrice || 0.3;
 const PRICE_CAP_FOR_USER = args.priceCap || 15;
 
 let BILL = {};
 async function run() {
+  const MONGODB_URL = args.mongoUrl || process.env.APPSMITH_MONGODB_URI;
   if (MONGODB_URL == undefined || MONGODB_URL.trim() === "") {
     console.log(`
 Did you forget to specify the mandatory parameter MongoDB URL?


### PR DESCRIPTION
## Description

This PR fixes a bug where the `appsmithctl` command was not able to read the environment variable property for the MongoDB URL when estimating the billing. This renders the billing script unusable in Docker containers.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
