### PR TITLE
fix: Add top level entities in extracted subpath references

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15407_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15407_spec.ts
@@ -36,7 +36,7 @@ describe("Linting for incorrect paths", () => {
     propPane.UpdatePropertyFieldValue("Label", `{{JSObject1.unknown}}`);
     propPane.UpdatePropertyFieldValue("Tooltip", `{{Api1.unknown2}}`);
     jsEditor.EnterJSContext("onClick", `{{JSObject1.unknown3()}}`, true, true);
-    cy.contains(locator._lintErrorElement).should("not.exist");
+    cy.get(locator._lintErrorElement).should("not.exist");
 
     ee.ExpandCollapseEntity("QUERIES/JS");
     // Delete JSObject & Api
@@ -44,7 +44,7 @@ describe("Linting for incorrect paths", () => {
     ee.ActionContextMenuByEntityName("Api1", "Delete", "Are you sure?");
 
     ee.SelectEntityByName("Button1");
-    cy.contains(locator._lintErrorElement).should("have.length", 3);
+    cy.get(locator._lintErrorElement).should("have.length", 3);
 
     // Recreate jsobject & Api
     jsEditor.CreateJSObject(JS_OBJECT_BODY, {
@@ -56,13 +56,13 @@ describe("Linting for incorrect paths", () => {
     apiPage.CreateApi();
 
     ee.SelectEntityByName("Button1");
-    cy.contains(locator._lintErrorElement).should("not.exist");
+    cy.get(locator._lintErrorElement).should("not.exist");
 
     ee.DragDropWidgetNVerify("buttonwidget", 500, 600);
     propPane.UpdatePropertyFieldValue("Label", `{{JSObject2.unknown}}`);
 
     ee.SelectEntityByName("Button2");
-    cy.contains(locator._lintErrorElement).should("have.length", 1);
+    cy.get(locator._lintErrorElement).should("have.length", 1);
 
     jsEditor.CreateJSObject(JS_OBJECT_BODY, {
       paste: true,
@@ -71,6 +71,6 @@ describe("Linting for incorrect paths", () => {
       shouldCreateNewJSObj: true,
     });
     ee.SelectEntityByName("Button2");
-    cy.contains(locator._lintErrorElement).should("not.exist");
+    cy.get(locator._lintErrorElement).should("not.exist");
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15407_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15407_spec.ts
@@ -1,0 +1,76 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+const jsEditor = ObjectsRegistry.JSEditor,
+  locator = ObjectsRegistry.CommonLocators,
+  ee = ObjectsRegistry.EntityExplorer,
+  apiPage = ObjectsRegistry.ApiPage,
+  propPane = ObjectsRegistry.PropertyPane;
+
+describe("Linting for incorrect paths", () => {
+  before(() => {
+    ee.DragDropWidgetNVerify("buttonwidget", 300, 300);
+  });
+
+  it("1. TC. 1975 - Linting is reactive for incorrect paths", () => {
+    const JS_OBJECT_BODY = `export default {
+        myVar1: [],
+        myVar2: {},
+        myFun1: () => {
+            //write code here
+        }, 
+        myFun2: async () => {
+            //use async-await or promises
+        }
+    }`;
+    // create js object
+    jsEditor.CreateJSObject(JS_OBJECT_BODY, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+    // create api
+    apiPage.CreateApi();
+
+    ee.SelectEntityByName("Button1");
+    propPane.UpdatePropertyFieldValue("Label", `{{JSObject1.unknown}}`);
+    propPane.UpdatePropertyFieldValue("Tooltip", `{{Api1.unknown2}}`);
+    jsEditor.EnterJSContext("onClick", `{{JSObject1.unknown3()}}`, true, true);
+    cy.contains(locator._lintErrorElement).should("not.exist");
+
+    ee.ExpandCollapseEntity("QUERIES/JS");
+    // Delete JSObject & Api
+    ee.ActionContextMenuByEntityName("JSObject1", "Delete", "Are you sure?");
+    ee.ActionContextMenuByEntityName("Api1", "Delete", "Are you sure?");
+
+    ee.SelectEntityByName("Button1");
+    cy.contains(locator._lintErrorElement).should("have.length", 3);
+
+    // Recreate jsobject & Api
+    jsEditor.CreateJSObject(JS_OBJECT_BODY, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+    apiPage.CreateApi();
+
+    ee.SelectEntityByName("Button1");
+    cy.contains(locator._lintErrorElement).should("not.exist");
+
+    ee.DragDropWidgetNVerify("buttonwidget", 500, 600);
+    propPane.UpdatePropertyFieldValue("Label", `{{JSObject2.unknown}}`);
+
+    ee.SelectEntityByName("Button2");
+    cy.contains(locator._lintErrorElement).should("have.length", 1);
+
+    jsEditor.CreateJSObject(JS_OBJECT_BODY, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+    ee.SelectEntityByName("Button2");
+    cy.contains(locator._lintErrorElement).should("not.exist");
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Linting/BasicLint_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Linting/BasicLint_spec.ts
@@ -68,7 +68,7 @@ describe("Linting", () => {
         }catch(e){
           showAlert("${errorMessage}")
         }
-      }()}}`
+      }()}}`,
     );
 
     propPane.UpdatePropertyFieldValue("Tooltip", "{{Api1.name}}");
@@ -121,7 +121,7 @@ describe("Linting", () => {
         }catch(e){
           showAlert("${errorMessage}")
         }
-      }()}}`
+      }()}}`,
     );
     propPane.UpdatePropertyFieldValue("Tooltip", `{{JSObject1.myVar1}}`);
 
@@ -196,7 +196,7 @@ describe("Linting", () => {
       }catch(e){
         showAlert("${errorMessage}")
       }
-    }()}}`
+    }()}}`,
     );
     propPane.UpdatePropertyFieldValue("Tooltip", `{{Query1.name}}`);
     clickButtonAndAssertLintError(true);
@@ -241,7 +241,7 @@ describe("Linting", () => {
         }catch(e){
           showAlert("${errorMessage}")
         }
-      }()}}`
+      }()}}`,
     );
     propPane.UpdatePropertyFieldValue(
       "Tooltip",

--- a/app/client/src/workers/DependencyMap/utils.ts
+++ b/app/client/src/workers/DependencyMap/utils.ts
@@ -8,6 +8,7 @@ import { convertPathToString } from "../evaluationUtils";
 export const extractReferencesFromBinding = (
   script: string,
   allPaths: Record<string, true>,
+  includeSubpathTopLevelEntities = false,
 ): string[] => {
   const references: Set<string> = new Set<string>();
   const identifiers = extractIdentifiersFromCode(script);
@@ -22,9 +23,10 @@ export const extractReferencesFromBinding = (
     let current = "";
     // We want to keep going till we reach top level, but not add top level
     // Eg: Input1.text should not depend on entire Table1 unless it explicitly asked for that.
-    // This is mainly to avoid a lot of unnecessary evals, if we feel this is wrong
-    // we can remove the length requirement, and it will still work
-    while (subpaths.length > 1) {
+    // This is mainly to avoid a lot of unnecessary evals. To explicitly include top level entities
+    // set includeSubpathTopLevelEntities to "true"
+    const minSubpathLength = includeSubpathTopLevelEntities ? 0 : 1;
+    while (subpaths.length > minSubpathLength) {
       current = convertPathToString(subpaths);
       // We've found the dep, add it and return
       if (allPaths.hasOwnProperty(current)) {
@@ -56,6 +58,7 @@ export const getEntityReferencesFromPropertyBindings = (
               extractReferencesFromBinding(
                 binding,
                 dataTreeEvalRef.allKeys,
+                true,
               ).map((reference) => reference.split(".")[0]),
             ),
           ];

--- a/app/client/typings/eslint4b/index.d.ts
+++ b/app/client/typings/eslint4b/index.d.ts
@@ -1,0 +1,1 @@
+declare module "eslint4b-prebuilt";


### PR DESCRIPTION
## Description

We remove all top-level entities for subpath references when extracting identifiers from code. For linting, these top-level entities are required. 

Fixes #15407


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
**TEST PLAN**
- [ ] https://github.com/appsmithorg/TestSmith/issues/1975

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
