### PR TITLE
fix: widget field array validation

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Autcomplete-bugs.spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Autcomplete-bugs.spec.js
@@ -1,0 +1,33 @@
+const explorer = require("../../../../locators/explorerlocators.json");
+
+describe("Widget field validation on invalid inputs", () => {
+  it("Check if options field of a select widget should validation error when bound to a non existing field", () => {
+    cy.get(explorer.addWidget).click();
+    cy.dragAndDropToCanvas("tablewidgetv2", { x: 200, y: 200 });
+    cy.dragAndDropToCanvas("selectwidget", { x: 200, y: 600 });
+    cy.openPropertyPane("selectwidget");
+    cy.EnableAllCodeEditors();
+    cy.get(".CodeMirror textarea")
+      .first()
+      .focus()
+      .type("{ctrl}{shift}{downarrow}")
+      .then(($cm) => {
+        if ($cm.val() !== "") {
+          cy.get(".CodeMirror textarea")
+            .first()
+            .clear({
+              force: true,
+            });
+        }
+        cy.get(".CodeMirror textarea")
+          .first()
+          .type("{{Table1.test", {
+            force: true,
+            parseSpecialCharSequences: false,
+          });
+      });
+    cy.evaluateErrorMessage(
+      'This value does not evaluate to type Array<{ "label": "string", "value": "string" }>',
+    );
+  });
+});

--- a/app/client/src/constants/WidgetValidation.ts
+++ b/app/client/src/constants/WidgetValidation.ts
@@ -25,13 +25,15 @@ export type ValidationResponse = {
   transformed?: any;
 };
 
-export type Validator = (
-  config: ValidationConfig,
-  value: unknown,
-  props: Record<string, unknown>,
-  propertyPath: string,
-  unEvalValue: string,
-) => ValidationResponse;
+export type ValidatorParams<T = unknown> = {
+  config: ValidationConfig;
+  value: T;
+  props: Record<string, unknown>;
+  propertyPath: string;
+  unEvalValue: string;
+};
+
+export type Validator = (params: ValidatorParams) => ValidationResponse;
 
 export const ISO_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ss.sssZ";
 

--- a/app/client/src/constants/WidgetValidation.ts
+++ b/app/client/src/constants/WidgetValidation.ts
@@ -30,6 +30,7 @@ export type Validator = (
   value: unknown,
   props: Record<string, unknown>,
   propertyPath: string,
+  unEvalValue: string,
 ) => ValidationResponse;
 
 export const ISO_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ss.sssZ";

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -598,7 +598,7 @@ export function* evaluateArgumentSaga(action: any) {
       (error: any) => error.errorType !== PropertyEvaluationErrorType.LINT,
     );
     if (workerResponse.result) {
-      const validation = validate({ type }, workerResponse.result, {}, "");
+      const validation = validate({ type }, workerResponse.result, {}, "", "");
       if (!validation.isValid)
         validation.messages?.map((message) => {
           lintErrors.unshift({

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -598,7 +598,13 @@ export function* evaluateArgumentSaga(action: any) {
       (error: any) => error.errorType !== PropertyEvaluationErrorType.LINT,
     );
     if (workerResponse.result) {
-      const validation = validate({ type }, workerResponse.result, {}, "", "");
+      const validation = validate({
+        config: { type },
+        value: workerResponse.result,
+        props: {},
+        propertyPath: "",
+        unEvalValue: "",
+      });
       if (!validation.isValid)
         validation.messages?.map((message) => {
           lintErrors.unshift({

--- a/app/client/src/workers/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/DataTreeEvaluator/index.ts
@@ -167,7 +167,7 @@ export default class DataTreeEvaluator {
     const evaluateEnd = performance.now();
     // Validate Widgets
     const validateStart = performance.now();
-    this.evalTree = getValidatedTree(evaluatedTree);
+    this.evalTree = getValidatedTree(evaluatedTree, localUnEvalTree);
     const validateEnd = performance.now();
 
     this.oldUnEvalTree = klona(localUnEvalTree);

--- a/app/client/src/workers/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/DataTreeEvaluator/index.ts
@@ -1034,6 +1034,7 @@ export default class DataTreeEvaluator {
       const { isValid, messages } = validateActionProperty(
         validationConfig,
         evalPropertyValue,
+        unEvalPropertyValue,
       );
       if (!isValid) {
         const evalErrors: EvaluationError[] =

--- a/app/client/src/workers/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/DataTreeEvaluator/index.ts
@@ -987,6 +987,7 @@ export default class DataTreeEvaluator {
       evalPropertyValue,
       widget,
       propertyPath,
+      unEvalPropertyValue,
     );
 
     const evaluatedValue = isValid

--- a/app/client/src/workers/evaluation.worker.ts
+++ b/app/client/src/workers/evaluation.worker.ts
@@ -268,7 +268,7 @@ ctx.addEventListener(
       case EVAL_WORKER_ACTIONS.VALIDATE_PROPERTY: {
         const { property, props, validation, value } = requestData;
         return removeFunctions(
-          validateWidgetProperty(validation, value, props, property),
+          validateWidgetProperty(validation, value, props, property, ""),
         );
       }
       case EVAL_WORKER_ACTIONS.UNDO: {

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -487,7 +487,7 @@ export function validateWidgetProperty(
   value: unknown,
   props: Record<string, unknown>,
   propertyPath: string,
-  unEvalValue = "",
+  unEvalValue: string,
 ) {
   if (!config) {
     return {
@@ -501,7 +501,7 @@ export function validateWidgetProperty(
 export function validateActionProperty(
   config: ValidationConfig,
   value: unknown,
-  unEvalValue = "",
+  unEvalValue: string,
 ) {
   if (!config) {
     return {

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -487,6 +487,7 @@ export function validateWidgetProperty(
   value: unknown,
   props: Record<string, unknown>,
   propertyPath: string,
+  unEvalValue = "",
 ) {
   if (!config) {
     return {
@@ -494,12 +495,13 @@ export function validateWidgetProperty(
       parsed: value,
     };
   }
-  return validate(config, value, props, propertyPath);
+  return validate(config, value, props, propertyPath, unEvalValue);
 }
 
 export function validateActionProperty(
   config: ValidationConfig,
   value: unknown,
+  unEvalValue = "",
 ) {
   if (!config) {
     return {
@@ -507,24 +509,27 @@ export function validateActionProperty(
       parsed: value,
     };
   }
-  return validate(config, value, {}, "");
+  return validate(config, value, {}, "", unEvalValue);
 }
 
-export function getValidatedTree(tree: DataTree) {
+export function getValidatedTree(tree: DataTree, unEvalTree: DataTree) {
   return Object.keys(tree).reduce((tree, entityKey: string) => {
     const entity = tree[entityKey] as DataTreeWidget;
+    const unEvalEntity = unEvalTree[entityKey];
     if (!isWidget(entity)) {
       return tree;
     }
     const parsedEntity = { ...entity };
     Object.entries(entity.validationPaths).forEach(([property, validation]) => {
       const value = _.get(entity, property);
+      const unEvalValue = _.get(unEvalEntity, property);
       // Pass it through parse
       const { isValid, messages, parsed, transformed } = validateWidgetProperty(
         validation,
         value,
         entity,
         property,
+        unEvalValue,
       );
       _.set(parsedEntity, property, parsed);
       const evaluatedValue = isValid
@@ -625,6 +630,7 @@ export function getSafeToRenderDataTree(
         value,
         entity,
         property,
+        value,
       );
       _.set(safeToRenderEntity, property, parsed);
     });

--- a/app/client/src/workers/evaluationUtils.ts
+++ b/app/client/src/workers/evaluationUtils.ts
@@ -495,7 +495,7 @@ export function validateWidgetProperty(
       parsed: value,
     };
   }
-  return validate(config, value, props, propertyPath, unEvalValue);
+  return validate({ config, value, props, propertyPath, unEvalValue });
 }
 
 export function validateActionProperty(
@@ -509,7 +509,7 @@ export function validateActionProperty(
       parsed: value,
     };
   }
-  return validate(config, value, {}, "", unEvalValue);
+  return validate({ config, value, props: {}, propertyPath: "", unEvalValue });
 }
 
 export function getValidatedTree(tree: DataTree, unEvalTree: DataTree) {

--- a/app/client/src/workers/validations.test.ts
+++ b/app/client/src/workers/validations.test.ts
@@ -82,7 +82,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(validation, input, DUMMY_WIDGET);
+      const result = validate({
+        config: validation,
+        value: input,
+        props: DUMMY_WIDGET,
+        propertyPath: "",
+        unEvalValue: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -126,7 +132,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(validation, input, DUMMY_WIDGET);
+      const result = validate({
+        config: validation,
+        value: input,
+        props: DUMMY_WIDGET,
+        propertyPath: "",
+        unEvalValue: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -174,7 +186,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(validation, input, DUMMY_WIDGET);
+      const result = validate({
+        config: validation,
+        value: input,
+        props: DUMMY_WIDGET,
+        propertyPath: "",
+        unEvalValue: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -195,7 +213,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(validation, input, DUMMY_WIDGET);
+      const result = validate({
+        config: validation,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -230,7 +254,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(validation, input, DUMMY_WIDGET);
+      const result = validate({
+        config: validation,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -279,7 +309,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -340,7 +376,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -371,7 +413,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -430,7 +478,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -451,7 +505,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -541,7 +601,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -599,7 +665,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -658,7 +730,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -711,7 +789,13 @@ describe("Validate Validators", () => {
       ],
     };
 
-    const result = validate(config, input, DUMMY_WIDGET);
+    const result = validate({
+      config,
+      value: input,
+      props: DUMMY_WIDGET,
+      unEvalValue: "",
+      propertyPath: "",
+    });
     expect(result).toStrictEqual(expected);
   });
 
@@ -825,7 +909,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -852,7 +942,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -939,7 +1035,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -979,7 +1081,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -1035,7 +1143,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -1060,7 +1174,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
       expect(result).not.toStrictEqual(defaultDate);
     });
@@ -1160,7 +1280,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -1184,7 +1310,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -1208,7 +1340,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -1249,7 +1387,13 @@ describe("Validate Validators", () => {
     ];
 
     inputs.forEach((input, index) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[index]);
     });
   });
@@ -1268,7 +1412,13 @@ describe("Validate Validators", () => {
       parsed: [],
     };
     inputs.forEach((input) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected);
     });
   });
@@ -1316,7 +1466,13 @@ describe("Validate Validators", () => {
       ],
     };
 
-    const result = validate(config, input, DUMMY_WIDGET);
+    const result = validate({
+      config,
+      value: input,
+      props: DUMMY_WIDGET,
+      unEvalValue: "",
+      propertyPath: "",
+    });
     expect(result).toStrictEqual(expected);
   });
 
@@ -1364,7 +1520,13 @@ describe("Validate Validators", () => {
       },
     ];
     inputs.forEach((input, i) => {
-      const result = validate(config, input, DUMMY_WIDGET);
+      const result = validate({
+        config,
+        value: input,
+        props: DUMMY_WIDGET,
+        unEvalValue: "",
+        propertyPath: "",
+      });
       expect(result).toStrictEqual(expected[i]);
     });
   });

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -667,7 +667,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
       value === null ||
       (isString(value) && value.trim().length === 0)
     ) {
-      if (config.params && config.params.required) {
+      if ((config.params && config.params.required) || unEvalValue) {
         return {
           isValid: false,
           parsed: config.params?.default || {},
@@ -733,6 +733,9 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
       messages: [`${WIDGET_TYPE_VALIDATION_ERROR} ${getExpectedType(config)}`],
     };
     if (value === undefined || value === null || value === "") {
+      if (unEvalValue) {
+        return invalidResponse;
+      }
       if (
         config.params &&
         config.params.required &&

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -59,6 +59,7 @@ function validatePlainObject(
   value: Record<string, unknown>,
   props: Record<string, unknown>,
   propertyPath: string,
+  unEvalValue: string,
 ) {
   if (config.params?.allowedKeys) {
     let _valid = true;
@@ -73,6 +74,7 @@ function validatePlainObject(
           value[entryName],
           props,
           propertyPath,
+          unEvalValue,
         );
         if (!isValid) {
           value[entryName] = parsed;
@@ -112,6 +114,7 @@ function validateArray(
   value: unknown[],
   props: Record<string, unknown>,
   propertyPath: string,
+  unEvalValue: string,
 ) {
   let _isValid = true; // Let's first assume that this is valid
   const _messages: string[] = []; // Initialise messages array
@@ -223,6 +226,7 @@ function validateArray(
         entry,
         props,
         `${propertyPath}[${index}]`,
+        unEvalValue,
       );
 
       // If invalid, append to messages
@@ -297,12 +301,14 @@ export const validate = (
   value: unknown,
   props: Record<string, unknown>,
   propertyPath = "",
+  unEvalValue: string,
 ): ValidationResponse => {
   const _result = VALIDATORS[config.type as ValidationTypes](
     config,
     value,
     props,
     propertyPath,
+    unEvalValue,
   );
 
   return _result;
@@ -493,12 +499,14 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     value: unknown,
     props: Record<string, unknown>,
     propertyPath: string,
+    unEvalValue: string,
   ): ValidationResponse => {
     const { isValid, messages, parsed } = VALIDATORS[ValidationTypes.TEXT](
       config,
       value,
       props,
       propertyPath,
+      unEvalValue,
     );
 
     if (!isValid) {
@@ -652,6 +660,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     value: unknown,
     props: Record<string, unknown>,
     propertyPath: string,
+    unEvalValue: string,
   ): ValidationResponse => {
     if (
       value === undefined ||
@@ -679,13 +688,20 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
         value as Record<string, unknown>,
         props,
         propertyPath,
+        unEvalValue,
       );
     }
 
     try {
       const result = { parsed: JSON.parse(value as string), isValid: true };
       if (isPlainObject(result.parsed)) {
-        return validatePlainObject(config, result.parsed, props, propertyPath);
+        return validatePlainObject(
+          config,
+          result.parsed,
+          props,
+          propertyPath,
+          unEvalValue,
+        );
       }
       return {
         isValid: false,
@@ -709,6 +725,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     value: unknown,
     props: Record<string, unknown>,
     propertyPath: string,
+    unEvalValue: string,
   ): ValidationResponse => {
     const invalidResponse = {
       isValid: false,
@@ -749,7 +766,13 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
       try {
         const _value = JSON.parse(value);
         if (Array.isArray(_value)) {
-          const result = validateArray(config, _value, props, propertyPath);
+          const result = validateArray(
+            config,
+            _value,
+            props,
+            propertyPath,
+            unEvalValue,
+          );
           return result;
         }
       } catch (e) {
@@ -758,7 +781,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     }
 
     if (Array.isArray(value)) {
-      return validateArray(config, value, props, propertyPath);
+      return validateArray(config, value, props, propertyPath, unEvalValue);
     }
 
     return invalidResponse;
@@ -829,13 +852,20 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     value: unknown,
     props: Record<string, unknown>,
     propertyPath: string,
+    unEvalValue: string,
   ): ValidationResponse => {
     let response: ValidationResponse = {
       isValid: false,
       parsed: config.params?.default || [],
       messages: [`${WIDGET_TYPE_VALIDATION_ERROR} ${getExpectedType(config)}`],
     };
-    response = VALIDATORS.ARRAY(config, value, props, propertyPath);
+    response = VALIDATORS.ARRAY(
+      config,
+      value,
+      props,
+      propertyPath,
+      unEvalValue,
+    );
 
     if (!response.isValid) {
       return response;
@@ -1016,6 +1046,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
     value: unknown,
     props: Record<string, unknown>,
     propertyPath: string,
+    unEvalValue: string,
   ): ValidationResponse => {
     if (!config.params?.type)
       return {
@@ -1030,6 +1061,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
       value,
       props,
       propertyPath,
+      unEvalValue,
     );
     if (result.isValid) return result;
 
@@ -1042,6 +1074,7 @@ export const VALIDATORS: Record<ValidationTypes, Validator> = {
           item,
           props,
           propertyPath,
+          unEvalValue,
         );
         if (!result.isValid) return result;
         resultValue.push(result.parsed);

--- a/app/client/src/workers/validations.ts
+++ b/app/client/src/workers/validations.ts
@@ -301,7 +301,7 @@ export const validate = (
   value: unknown,
   props: Record<string, unknown>,
   propertyPath = "",
-  unEvalValue: string,
+  unEvalValue = "",
 ): ValidationResponse => {
   const _result = VALIDATORS[config.type as ValidationTypes](
     config,


### PR DESCRIPTION
## Description
Show validation error, when a field that accepts values of type array has bindings, but not the ones that evaluate to an array.

Fixes #14895 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
