### PR TITLE
fix: Reset sync function fields on each update

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -70,416 +70,416 @@ describe("JS Function Execution", function() {
     });
   }
 
-  // it("1. Allows execution of js function when lint warnings(not errors) are present in code", function() {
-  //   jsEditor.CreateJSObject(
-  //     `export default {
-  // 	myFun1: ()=>{
-  // 		f;
-  // 		return "yes"
-  // 	}
-  // }`,
-  //     {
-  //       paste: true,
-  //       completeReplace: true,
-  //       toRun: false,
-  //       shouldCreateNewJSObj: true,
-  //     },
-  //   );
+  it("1. Allows execution of js function when lint warnings(not errors) are present in code", function() {
+    jsEditor.CreateJSObject(
+      `export default {
+  	myFun1: ()=>{
+  		f;
+  		return "yes"
+  	}
+  }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: true,
+      },
+    );
 
-  //   jsEditor.AssertParseError(false, false);
-  //   agHelper.ActionContextMenuWithInPane("Delete", "", true);
-  // });
+    jsEditor.AssertParseError(false, false);
+    agHelper.ActionContextMenuWithInPane("Delete", "", true);
+  });
 
-  // it("2. Prevents execution of js function when parse errors are present in code", function() {
-  //   jsEditor.CreateJSObject(
-  //     `export default {
-  // 	myFun1: ()=>>{
-  // 		return "yes"
-  // 	}
-  // }`,
-  //     {
-  //       paste: true,
-  //       completeReplace: true,
-  //       toRun: false,
-  //       shouldCreateNewJSObj: true,
-  //     },
-  //   );
+  it("2. Prevents execution of js function when parse errors are present in code", function() {
+    jsEditor.CreateJSObject(
+      `export default {
+  	myFun1: ()=>>{
+  		return "yes"
+  	}
+  }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: true,
+      },
+    );
 
-  //   jsEditor.AssertParseError(true, false);
-  //   agHelper.ActionContextMenuWithInPane("Delete", "", true);
-  // });
+    jsEditor.AssertParseError(true, false);
+    agHelper.ActionContextMenuWithInPane("Delete", "", true);
+  });
 
-  // it("3. Prioritizes parse errors that render JS Object invalid over function execution parse errors in debugger callouts", function() {
-  //   const JSObjectWithFunctionExecutionParseErrors = `export default {
-  //     myFun1 :()=>{
-  //       return f
-  //     }
-  //   }`;
+  it("3. Prioritizes parse errors that render JS Object invalid over function execution parse errors in debugger callouts", function() {
+    const JSObjectWithFunctionExecutionParseErrors = `export default {
+      myFun1 :()=>{
+        return f
+      }
+    }`;
 
-  //   const JSObjectWithParseErrors = `export default {
-  //     myFun1:  (a ,b)=>>{
-  //     return "yes"
-  //     }
-  //   }`;
+    const JSObjectWithParseErrors = `export default {
+      myFun1:  (a ,b)=>>{
+      return "yes"
+      }
+    }`;
 
-  //   // create jsObject with parse error (that doesn't render JS Object invalid)
-  //   jsEditor.CreateJSObject(JSObjectWithFunctionExecutionParseErrors, {
-  //     paste: true,
-  //     completeReplace: true,
-  //     toRun: true,
-  //     shouldCreateNewJSObj: true,
-  //   });
+    // create jsObject with parse error (that doesn't render JS Object invalid)
+    jsEditor.CreateJSObject(JSObjectWithFunctionExecutionParseErrors, {
+      paste: true,
+      completeReplace: true,
+      toRun: true,
+      shouldCreateNewJSObj: true,
+    });
 
-  //   // Assert presence of function execution parse error callout
-  //   jsEditor.AssertParseError(true, true);
+    // Assert presence of function execution parse error callout
+    jsEditor.AssertParseError(true, true);
 
-  //   // Add parse error that renders JS Object invalid in code
-  //   jsEditor.CreateJSObject(JSObjectWithParseErrors, {
-  //     paste: true,
-  //     completeReplace: true,
-  //     toRun: false,
-  //     shouldCreateNewJSObj: false,
-  //   });
+    // Add parse error that renders JS Object invalid in code
+    jsEditor.CreateJSObject(JSObjectWithParseErrors, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: false,
+    });
 
-  //   // Assert presence of parse error callout (entire JS Object is invalid)
-  //   jsEditor.AssertParseError(true, false);
-  //   agHelper.ActionContextMenuWithInPane("Delete", "", true);
-  // });
+    // Assert presence of parse error callout (entire JS Object is invalid)
+    jsEditor.AssertParseError(true, false);
+    agHelper.ActionContextMenuWithInPane("Delete", "", true);
+  });
 
-  // it("4. Shows lint error and toast modal when JS Object doesn't start with 'export default'", () => {
-  //   const invalidJSObjectStartToastMessage = "Start object with export default";
-  //   const jsComment = "// This is a comment";
-  //   const jsObjectStartLine = "export default{";
-  //   const jsObjectStartingWithAComment = `${jsComment}
-  // ${jsObjectStartLine}
-  //       fun1:()=>true
-  //     }`;
-  //   const jsObjectStartingWithASpace = ` ${jsObjectStartLine}
-  //       fun1:()=>true
-  //     }`;
+  it("4. Shows lint error and toast modal when JS Object doesn't start with 'export default'", () => {
+    const invalidJSObjectStartToastMessage = "Start object with export default";
+    const jsComment = "// This is a comment";
+    const jsObjectStartLine = "export default{";
+    const jsObjectStartingWithAComment = `${jsComment}
+  ${jsObjectStartLine}
+        fun1:()=>true
+      }`;
+    const jsObjectStartingWithASpace = ` ${jsObjectStartLine}
+        fun1:()=>true
+      }`;
 
-  //   const jsObjectStartingWithANewLine = `
-  // ${jsObjectStartLine}
-  //       fun1:()=>true
-  //     }`;
+    const jsObjectStartingWithANewLine = `
+  ${jsObjectStartLine}
+        fun1:()=>true
+      }`;
 
-  //   const assertInvalidJSObjectStart = (
-  //     jsCode: string,
-  //     highlightedLintText: string,
-  //   ) => {
-  //     // create jsObject that doesn't start with 'export default'
-  //     jsEditor.CreateJSObject(jsCode, {
-  //       paste: true,
-  //       completeReplace: true,
-  //       toRun: false,
-  //       shouldCreateNewJSObj: true,
-  //     });
-  //     // Assert presence of toast message
-  //     agHelper.WaitUntilToastDisappear(invalidJSObjectStartToastMessage);
+    const assertInvalidJSObjectStart = (
+      jsCode: string,
+      highlightedLintText: string,
+    ) => {
+      // create jsObject that doesn't start with 'export default'
+      jsEditor.CreateJSObject(jsCode, {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: true,
+      });
+      // Assert presence of toast message
+      agHelper.WaitUntilToastDisappear(invalidJSObjectStartToastMessage);
 
-  //     // Assert presence of lint error at the start line
-  //     cy.get(locator._lintErrorElement)
-  //       .should("exist")
-  //       .should("contain.text", highlightedLintText);
-  //     agHelper.ActionContextMenuWithInPane("Delete", "", true);
-  //   };
+      // Assert presence of lint error at the start line
+      cy.get(locator._lintErrorElement)
+        .should("exist")
+        .should("contain.text", highlightedLintText);
+      agHelper.ActionContextMenuWithInPane("Delete", "", true);
+    };
 
-  //   assertInvalidJSObjectStart(jsObjectStartingWithAComment, jsComment);
-  //   assertInvalidJSObjectStart(jsObjectStartingWithANewLine, jsObjectStartLine);
-  //   assertInvalidJSObjectStart(jsObjectStartingWithASpace, jsObjectStartLine);
-  // });
+    assertInvalidJSObjectStart(jsObjectStartingWithAComment, jsComment);
+    assertInvalidJSObjectStart(jsObjectStartingWithANewLine, jsObjectStartLine);
+    assertInvalidJSObjectStart(jsObjectStartingWithASpace, jsObjectStartLine);
+  });
 
-  // it("5. Verify that js function execution errors are logged in debugger and removed when function is deleted", () => {
-  //   const JS_OBJECT_WITH_PARSE_ERROR = `export default {
-  //     myVar1: [],
-  //     myVar2: {},
-  //     myFun1: () => {
-  //       //write code here
-  //       return Table1.unknown.name
-  //     }
-  //   }`;
+  it("5. Verify that js function execution errors are logged in debugger and removed when function is deleted", () => {
+    const JS_OBJECT_WITH_PARSE_ERROR = `export default {
+      myVar1: [],
+      myVar2: {},
+      myFun1: () => {
+        //write code here
+        return Table1.unknown.name
+      }
+    }`;
 
-  //   const JS_OBJECT_WITHOUT_PARSE_ERROR = `export default {
-  //     myVar1: [],
-  //     myVar2: {},
-  //     myFun1: () => {
-  //       //write code here
-  //       return Table1.unknown
-  //     }
-  //   }`;
+    const JS_OBJECT_WITHOUT_PARSE_ERROR = `export default {
+      myVar1: [],
+      myVar2: {},
+      myFun1: () => {
+        //write code here
+        return Table1.unknown
+      }
+    }`;
 
-  //   const JS_OBJECT_WITH_DELETED_FUNCTION = `export default {
-  //     myVar1: [],
-  //     myVar2: {}
-  //   }`;
+    const JS_OBJECT_WITH_DELETED_FUNCTION = `export default {
+      myVar1: [],
+      myVar2: {}
+    }`;
 
-  //   // Create js object
-  //   jsEditor.CreateJSObject(JS_OBJECT_WITH_PARSE_ERROR, {
-  //     paste: true,
-  //     completeReplace: true,
-  //     toRun: true,
-  //     shouldCreateNewJSObj: true,
-  //   });
+    // Create js object
+    jsEditor.CreateJSObject(JS_OBJECT_WITH_PARSE_ERROR, {
+      paste: true,
+      completeReplace: true,
+      toRun: true,
+      shouldCreateNewJSObj: true,
+    });
 
-  //   // Assert that there is a function execution parse error
-  //   jsEditor.AssertParseError(true, true);
-  //   // click the debug icon
-  //   agHelper.GetNClick(jsEditor._debugCTA);
-  //   // Assert that errors tab is not empty
-  //   cy.contains("No signs of trouble here!").should("not.exist");
-  //   // Assert presence of typeError
-  //   cy.contains(
-  //     "TypeError: Cannot read properties of undefined (reading 'name')",
-  //   ).should("exist");
+    // Assert that there is a function execution parse error
+    jsEditor.AssertParseError(true, true);
+    // click the debug icon
+    agHelper.GetNClick(jsEditor._debugCTA);
+    // Assert that errors tab is not empty
+    cy.contains("No signs of trouble here!").should("not.exist");
+    // Assert presence of typeError
+    cy.contains(
+      "TypeError: Cannot read properties of undefined (reading 'name')",
+    ).should("exist");
 
-  //   // Fix parse error and assert that debugger error is removed
-  //   jsEditor.EditJSObj(JS_OBJECT_WITHOUT_PARSE_ERROR);
-  //   agHelper.GetNClick(jsEditor._runButton);
-  //   jsEditor.AssertParseError(false, true);
-  //   agHelper.GetNClick(locator._errorTab);
-  //   cy.contains(
-  //     "TypeError: Cannot read properties of undefined (reading 'name')",
-  //   ).should("not.exist");
+    // Fix parse error and assert that debugger error is removed
+    jsEditor.EditJSObj(JS_OBJECT_WITHOUT_PARSE_ERROR);
+    agHelper.GetNClick(jsEditor._runButton);
+    jsEditor.AssertParseError(false, true);
+    agHelper.GetNClick(locator._errorTab);
+    cy.contains(
+      "TypeError: Cannot read properties of undefined (reading 'name')",
+    ).should("not.exist");
 
-  //   // Switch back to response tab
-  //   agHelper.GetNClick(locator._responseTab);
-  //   // Re-introduce parse errors
-  //   jsEditor.EditJSObj(JS_OBJECT_WITH_PARSE_ERROR);
-  //   agHelper.GetNClick(jsEditor._runButton);
-  //   agHelper.WaitUntilToastDisappear("ran successfully"); //to not hinder with next toast msg in next case!
-  //   // Assert that there is a function execution parse error
-  //   jsEditor.AssertParseError(true, true);
+    // Switch back to response tab
+    agHelper.GetNClick(locator._responseTab);
+    // Re-introduce parse errors
+    jsEditor.EditJSObj(JS_OBJECT_WITH_PARSE_ERROR);
+    agHelper.GetNClick(jsEditor._runButton);
+    agHelper.WaitUntilToastDisappear("ran successfully"); //to not hinder with next toast msg in next case!
+    // Assert that there is a function execution parse error
+    jsEditor.AssertParseError(true, true);
 
-  //   // Delete function
-  //   jsEditor.EditJSObj(JS_OBJECT_WITH_DELETED_FUNCTION);
-  //   // Assert that parse error is removed from debugger when function is deleted
-  //   agHelper.GetNClick(locator._errorTab);
-  //   cy.contains(
-  //     "TypeError: Cannot read properties of undefined (reading 'name')",
-  //   ).should("not.exist");
-  // });
+    // Delete function
+    jsEditor.EditJSObj(JS_OBJECT_WITH_DELETED_FUNCTION);
+    // Assert that parse error is removed from debugger when function is deleted
+    agHelper.GetNClick(locator._errorTab);
+    cy.contains(
+      "TypeError: Cannot read properties of undefined (reading 'name')",
+    ).should("not.exist");
+  });
 
-  // it("6. Supports the use of large JSON data (doesn't crash)", () => {
-  //   const jsObjectWithLargeJSONData = `export default{
-  //     largeData: ${JSON.stringify(largeJSONData)},
-  //     myfun1: ()=> this.largeData
-  //   }`;
-  //   const crashMessage = "Oops! Something went wrong";
-  //   // create jsObject with large json data and run
-  //   jsEditor.CreateJSObject(jsObjectWithLargeJSONData, {
-  //     paste: true,
-  //     completeReplace: true,
-  //     toRun: false,
-  //     shouldCreateNewJSObj: true,
-  //   });
+  it("6. Supports the use of large JSON data (doesn't crash)", () => {
+    const jsObjectWithLargeJSONData = `export default{
+      largeData: ${JSON.stringify(largeJSONData)},
+      myfun1: ()=> this.largeData
+    }`;
+    const crashMessage = "Oops! Something went wrong";
+    // create jsObject with large json data and run
+    jsEditor.CreateJSObject(jsObjectWithLargeJSONData, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
 
-  //   // wait for 3 secs and assert that App doesn't crash
-  //   cy.wait(3000);
-  //   cy.contains(crashMessage).should("not.exist");
+    // wait for 3 secs and assert that App doesn't crash
+    cy.wait(3000);
+    cy.contains(crashMessage).should("not.exist");
 
-  //   // Edit JSObject and run
-  //   jsEditor.CreateJSObject(" ", {
-  //     paste: true,
-  //     completeReplace: false,
-  //     toRun: true,
-  //     shouldCreateNewJSObj: false,
-  //   });
+    // Edit JSObject and run
+    jsEditor.CreateJSObject(" ", {
+      paste: true,
+      completeReplace: false,
+      toRun: true,
+      shouldCreateNewJSObj: false,
+    });
 
-  //   cy.get("@jsObjName").then((jsObjName) => {
-  //     ee.SelectEntityByName("Table1", "WIDGETS");
-  //     propPane.UpdatePropertyFieldValue(
-  //       "Table Data",
-  //       `{{${jsObjName}.largeData}}`,
-  //     );
-  //   });
+    cy.get("@jsObjName").then((jsObjName) => {
+      ee.SelectEntityByName("Table1", "WIDGETS");
+      propPane.UpdatePropertyFieldValue(
+        "Table Data",
+        `{{${jsObjName}.largeData}}`,
+      );
+    });
 
-  //   // Deploy App and test that table loads properly
-  //   deployMode.DeployApp();
-  //   table.WaitUntilTableLoad();
-  //   table.ReadTableRowColumnData(0, 1, 2000).then(($cellData) => {
-  //     expect($cellData).to.eq("1"); //validating id column value - row 0
-  //     deployMode.NavigateBacktoEditor();
-  //   });
-  // });
+    // Deploy App and test that table loads properly
+    deployMode.DeployApp();
+    table.WaitUntilTableLoad();
+    table.ReadTableRowColumnData(0, 1, 2000).then(($cellData) => {
+      expect($cellData).to.eq("1"); //validating id column value - row 0
+      deployMode.NavigateBacktoEditor();
+    });
+  });
 
-  // it("7. Doesn't cause cyclic dependency when function name is edited", () => {
-  //   const syncJSCode = `export default {
-  //     myFun1 :()=>{
-  //       return "yes"
-  //     }
-  //   }`;
+  it("7. Doesn't cause cyclic dependency when function name is edited", () => {
+    const syncJSCode = `export default {
+      myFun1 :()=>{
+        return "yes"
+      }
+    }`;
 
-  //   const syncJSCodeWithRenamedFunction1 = `export default {
-  //     myFun2 :()=>{
-  //       return "yes"
-  //     }
-  //   }`;
+    const syncJSCodeWithRenamedFunction1 = `export default {
+      myFun2 :()=>{
+        return "yes"
+      }
+    }`;
 
-  //   const syncJSCodeWithRenamedFunction2 = `export default {
-  //     myFun3 :()=>{
-  //       return "yes"
-  //     }
-  //   }`;
+    const syncJSCodeWithRenamedFunction2 = `export default {
+      myFun3 :()=>{
+        return "yes"
+      }
+    }`;
 
-  //   const asyncJSCode = `export default {
-  //     myFun1 :async ()=>{
-  //       return "yes"
-  //     }
-  //   }`;
+    const asyncJSCode = `export default {
+      myFun1 :async ()=>{
+        return "yes"
+      }
+    }`;
 
-  //   const asyncJSCodeWithRenamedFunction1 = `export default {
-  //     myFun2 :async ()=>{
-  //       return "yes"
-  //     }
-  //   }`;
+    const asyncJSCodeWithRenamedFunction1 = `export default {
+      myFun2 :async ()=>{
+        return "yes"
+      }
+    }`;
 
-  //   const asyncJSCodeWithRenamedFunction2 = `export default {
-  //     myFun3 :async ()=>{
-  //       return "yes"
-  //     }
-  //   }`;
+    const asyncJSCodeWithRenamedFunction2 = `export default {
+      myFun3 :async ()=>{
+        return "yes"
+      }
+    }`;
 
-  //   jsEditor.CreateJSObject(syncJSCode, {
-  //     paste: true,
-  //     completeReplace: true,
-  //     toRun: false,
-  //     shouldCreateNewJSObj: true,
-  //   });
+    jsEditor.CreateJSObject(syncJSCode, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
 
-  //   // change sync function name and test that cyclic dependency is not created
-  //   jsEditor.EditJSObj(syncJSCodeWithRenamedFunction1);
-  //   agHelper.AssertElementAbsence(locator._toastMsg);
-  //   jsEditor.EditJSObj(syncJSCodeWithRenamedFunction2);
-  //   agHelper.AssertElementAbsence(locator._toastMsg);
+    // change sync function name and test that cyclic dependency is not created
+    jsEditor.EditJSObj(syncJSCodeWithRenamedFunction1);
+    agHelper.AssertElementAbsence(locator._toastMsg);
+    jsEditor.EditJSObj(syncJSCodeWithRenamedFunction2);
+    agHelper.AssertElementAbsence(locator._toastMsg);
 
-  //   jsEditor.CreateJSObject(asyncJSCode, {
-  //     paste: true,
-  //     completeReplace: true,
-  //     toRun: false,
-  //     shouldCreateNewJSObj: true,
-  //   });
-  //   // change async function name and test that cyclic dependency is not created
-  //   jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction1);
-  //   agHelper.AssertElementAbsence(locator._toastMsg);
-  //   jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction2);
-  //   agHelper.AssertElementAbsence(locator._toastMsg);
-  // });
+    jsEditor.CreateJSObject(asyncJSCode, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+    // change async function name and test that cyclic dependency is not created
+    jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction1);
+    agHelper.AssertElementAbsence(locator._toastMsg);
+    jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction2);
+    agHelper.AssertElementAbsence(locator._toastMsg);
+  });
 
-  // it("8. Maintains order of async functions in settings tab alphabetically at all times", function() {
-  //   functionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.length;
-  //   // Number of functions set to run on page load and should also confirm before execute
-  //   onPageLoadAndConfirmExecuteFunctionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.filter(
-  //     (func) => func.onPageLoad && func.confirmBeforeExecute,
-  //   ).length;
+  it("8. Maintains order of async functions in settings tab alphabetically at all times", function() {
+    functionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.length;
+    // Number of functions set to run on page load and should also confirm before execute
+    onPageLoadAndConfirmExecuteFunctionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.filter(
+      (func) => func.onPageLoad && func.confirmBeforeExecute,
+    ).length;
 
-  //   getJSObject = (data: IFunctionSettingData[]) => {
-  //     let JS_OBJECT_BODY = `export default`;
-  //     for (let i = 0; i < functionsLength; i++) {
-  //       const functionName = data[i].name;
-  //       JS_OBJECT_BODY +=
-  //         i === 0
-  //           ? `{
-  //             ${functionName}: async ()=>"${functionName}",`
-  //           : i === functionsLength - 1
-  //           ? `
-  //           ${functionName}: async ()=>"${functionName}",
-  //         }`
-  //           : `
-  //           ${functionName}: async ()=> "${functionName}",`;
-  //     }
-  //     return JS_OBJECT_BODY;
-  //   };
+    getJSObject = (data: IFunctionSettingData[]) => {
+      let JS_OBJECT_BODY = `export default`;
+      for (let i = 0; i < functionsLength; i++) {
+        const functionName = data[i].name;
+        JS_OBJECT_BODY +=
+          i === 0
+            ? `{
+              ${functionName}: async ()=>"${functionName}",`
+            : i === functionsLength - 1
+            ? `
+            ${functionName}: async ()=>"${functionName}",
+          }`
+            : `
+            ${functionName}: async ()=> "${functionName}",`;
+      }
+      return JS_OBJECT_BODY;
+    };
 
-  //   // Create js object
-  //   jsEditor.CreateJSObject(getJSObject(FUNCTIONS_SETTINGS_DEFAULT_DATA), {
-  //     paste: true,
-  //     completeReplace: true,
-  //     toRun: false,
-  //     shouldCreateNewJSObj: true,
-  //   });
+    // Create js object
+    jsEditor.CreateJSObject(getJSObject(FUNCTIONS_SETTINGS_DEFAULT_DATA), {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
 
-  //   cy.get("@jsObjName").then((jsObjName: any) => {
-  //     jsObj = jsObjName;
-  //   });
-  //   // Switch to settings tab
-  //   agHelper.GetNClick(jsEditor._settingsTab);
-  //   // Add settings for each function (according to data)
-  //   Object.values(FUNCTIONS_SETTINGS_DEFAULT_DATA).forEach(
-  //     (functionSetting) => {
-  //       jsEditor.EnableDisableAsyncFuncSettings(
-  //         functionSetting.name,
-  //         functionSetting.onPageLoad,
-  //         functionSetting.confirmBeforeExecute,
-  //       );
-  //     },
-  //   );
-  //   // Switch to settings tab
-  //   agHelper.GetNClick(jsEditor._settingsTab);
-  //   //After JSObj is created - check methods are in alphabetical order
-  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
+    cy.get("@jsObjName").then((jsObjName: any) => {
+      jsObj = jsObjName;
+    });
+    // Switch to settings tab
+    agHelper.GetNClick(jsEditor._settingsTab);
+    // Add settings for each function (according to data)
+    Object.values(FUNCTIONS_SETTINGS_DEFAULT_DATA).forEach(
+      (functionSetting) => {
+        jsEditor.EnableDisableAsyncFuncSettings(
+          functionSetting.name,
+          functionSetting.onPageLoad,
+          functionSetting.confirmBeforeExecute,
+        );
+      },
+    );
+    // Switch to settings tab
+    agHelper.GetNClick(jsEditor._settingsTab);
+    //After JSObj is created - check methods are in alphabetical order
+    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
 
-  //   agHelper.RefreshPage();
-  //   // click "Yes" button for all onPageload && ConfirmExecute functions
-  //   for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
-  //     //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
-  //     agHelper.ClickButton("Yes");
-  //     agHelper.Sleep();
-  //   }
-  //   // Switch to settings tab and assert order
-  //   agHelper.GetNClick(jsEditor._settingsTab);
-  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
-  // });
+    agHelper.RefreshPage();
+    // click "Yes" button for all onPageload && ConfirmExecute functions
+    for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
+      //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
+      agHelper.ClickButton("Yes");
+      agHelper.Sleep();
+    }
+    // Switch to settings tab and assert order
+    agHelper.GetNClick(jsEditor._settingsTab);
+    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
+  });
 
-  // it("9. Verify Async methods have alphabetical order after cloning page and renaming it", () => {
-  //   const FUNCTIONS_SETTINGS_RENAMED_DATA: IFunctionSettingData[] = [
-  //     {
-  //       name: "newGetId",
-  //       onPageLoad: true,
-  //       confirmBeforeExecute: false,
-  //     },
-  //     {
-  //       name: "zip1",
-  //       onPageLoad: true,
-  //       confirmBeforeExecute: true,
-  //     },
-  //     {
-  //       name: "base",
-  //       onPageLoad: false,
-  //       confirmBeforeExecute: false,
-  //     },
-  //     {
-  //       name: "newAssert",
-  //       onPageLoad: true,
-  //       confirmBeforeExecute: false,
-  //     },
-  //     {
-  //       name: "test",
-  //       onPageLoad: true,
-  //       confirmBeforeExecute: true,
-  //     },
-  //   ];
+  it("9. Verify Async methods have alphabetical order after cloning page and renaming it", () => {
+    const FUNCTIONS_SETTINGS_RENAMED_DATA: IFunctionSettingData[] = [
+      {
+        name: "newGetId",
+        onPageLoad: true,
+        confirmBeforeExecute: false,
+      },
+      {
+        name: "zip1",
+        onPageLoad: true,
+        confirmBeforeExecute: true,
+      },
+      {
+        name: "base",
+        onPageLoad: false,
+        confirmBeforeExecute: false,
+      },
+      {
+        name: "newAssert",
+        onPageLoad: true,
+        confirmBeforeExecute: false,
+      },
+      {
+        name: "test",
+        onPageLoad: true,
+        confirmBeforeExecute: true,
+      },
+    ];
 
-  //   // clone page and assert order of functions
-  //   ee.ClonePage();
-  //   // click "Yes" button for all onPageload && ConfirmExecute functions
-  //   for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
-  //     //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
-  //     agHelper.ClickButton("Yes");
-  //     agHelper.Sleep();
-  //   }
+    // clone page and assert order of functions
+    ee.ClonePage();
+    // click "Yes" button for all onPageload && ConfirmExecute functions
+    for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
+      //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
+      agHelper.ClickButton("Yes");
+      agHelper.Sleep();
+    }
 
-  //   ee.SelectEntityByName(jsObj, "QUERIES/JS");
+    ee.SelectEntityByName(jsObj, "QUERIES/JS");
 
-  //   agHelper.GetNClick(jsEditor._settingsTab);
-  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
+    agHelper.GetNClick(jsEditor._settingsTab);
+    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
 
-  //   // rename functions and assert order
-  //   agHelper.GetNClick(jsEditor._codeTab);
-  //   jsEditor.EditJSObj(getJSObject(FUNCTIONS_SETTINGS_RENAMED_DATA));
-  //   cy.wait(3000);
-  //   agHelper.GetNClick(jsEditor._settingsTab);
-  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_RENAMED_DATA);
-  // });
+    // rename functions and assert order
+    agHelper.GetNClick(jsEditor._codeTab);
+    jsEditor.EditJSObj(getJSObject(FUNCTIONS_SETTINGS_RENAMED_DATA));
+    cy.wait(3000);
+    agHelper.GetNClick(jsEditor._settingsTab);
+    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_RENAMED_DATA);
+  });
 
   it("10. Bug-13197: Verify converting async functions to sync resets all settings", () => {
     const asyncJSCode = `export default {

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -70,416 +70,418 @@ describe("JS Function Execution", function() {
     });
   }
 
-  it("1. Allows execution of js function when lint warnings(not errors) are present in code", function() {
-    jsEditor.CreateJSObject(
-      `export default {
-  	myFun1: ()=>{
-  		f;
-  		return "yes"
-  	}
-  }`,
-      {
-        paste: true,
-        completeReplace: true,
-        toRun: false,
-        shouldCreateNewJSObj: true,
-      },
-    );
+  // it("1. Allows execution of js function when lint warnings(not errors) are present in code", function() {
+  //   jsEditor.CreateJSObject(
+  //     `export default {
+  // 	myFun1: ()=>{
+  // 		f;
+  // 		return "yes"
+  // 	}
+  // }`,
+  //     {
+  //       paste: true,
+  //       completeReplace: true,
+  //       toRun: false,
+  //       shouldCreateNewJSObj: true,
+  //     },
+  //   );
 
-    jsEditor.AssertParseError(false, false);
-    agHelper.ActionContextMenuWithInPane("Delete", "", true);
-  });
+  //   jsEditor.AssertParseError(false, false);
+  //   agHelper.ActionContextMenuWithInPane("Delete", "", true);
+  // });
 
-  it("2. Prevents execution of js function when parse errors are present in code", function() {
-    jsEditor.CreateJSObject(
-      `export default {
-  	myFun1: ()=>>{
-  		return "yes"
-  	}
-  }`,
-      {
-        paste: true,
-        completeReplace: true,
-        toRun: false,
-        shouldCreateNewJSObj: true,
-      },
-    );
+  // it("2. Prevents execution of js function when parse errors are present in code", function() {
+  //   jsEditor.CreateJSObject(
+  //     `export default {
+  // 	myFun1: ()=>>{
+  // 		return "yes"
+  // 	}
+  // }`,
+  //     {
+  //       paste: true,
+  //       completeReplace: true,
+  //       toRun: false,
+  //       shouldCreateNewJSObj: true,
+  //     },
+  //   );
 
-    jsEditor.AssertParseError(true, false);
-    agHelper.ActionContextMenuWithInPane("Delete", "", true);
-  });
+  //   jsEditor.AssertParseError(true, false);
+  //   agHelper.ActionContextMenuWithInPane("Delete", "", true);
+  // });
 
-  it("3. Prioritizes parse errors that render JS Object invalid over function execution parse errors in debugger callouts", function() {
-    const JSObjectWithFunctionExecutionParseErrors = `export default {
-      myFun1 :()=>{
-        return f
-      }
-    }`;
+  // it("3. Prioritizes parse errors that render JS Object invalid over function execution parse errors in debugger callouts", function() {
+  //   const JSObjectWithFunctionExecutionParseErrors = `export default {
+  //     myFun1 :()=>{
+  //       return f
+  //     }
+  //   }`;
 
-    const JSObjectWithParseErrors = `export default {
-      myFun1:  (a ,b)=>>{
-      return "yes"
-      }
-    }`;
+  //   const JSObjectWithParseErrors = `export default {
+  //     myFun1:  (a ,b)=>>{
+  //     return "yes"
+  //     }
+  //   }`;
 
-    // create jsObject with parse error (that doesn't render JS Object invalid)
-    jsEditor.CreateJSObject(JSObjectWithFunctionExecutionParseErrors, {
-      paste: true,
-      completeReplace: true,
-      toRun: true,
-      shouldCreateNewJSObj: true,
-    });
+  //   // create jsObject with parse error (that doesn't render JS Object invalid)
+  //   jsEditor.CreateJSObject(JSObjectWithFunctionExecutionParseErrors, {
+  //     paste: true,
+  //     completeReplace: true,
+  //     toRun: true,
+  //     shouldCreateNewJSObj: true,
+  //   });
 
-    // Assert presence of function execution parse error callout
-    jsEditor.AssertParseError(true, true);
+  //   // Assert presence of function execution parse error callout
+  //   jsEditor.AssertParseError(true, true);
 
-    // Add parse error that renders JS Object invalid in code
-    jsEditor.CreateJSObject(JSObjectWithParseErrors, {
-      paste: true,
-      completeReplace: true,
-      toRun: false,
-      shouldCreateNewJSObj: false,
-    });
+  //   // Add parse error that renders JS Object invalid in code
+  //   jsEditor.CreateJSObject(JSObjectWithParseErrors, {
+  //     paste: true,
+  //     completeReplace: true,
+  //     toRun: false,
+  //     shouldCreateNewJSObj: false,
+  //   });
 
-    // Assert presence of parse error callout (entire JS Object is invalid)
-    jsEditor.AssertParseError(true, false);
-    agHelper.ActionContextMenuWithInPane("Delete", "", true);
-  });
+  //   // Assert presence of parse error callout (entire JS Object is invalid)
+  //   jsEditor.AssertParseError(true, false);
+  //   agHelper.ActionContextMenuWithInPane("Delete", "", true);
+  // });
 
-  it("4. Shows lint error and toast modal when JS Object doesn't start with 'export default'", () => {
-    const invalidJSObjectStartToastMessage = "Start object with export default";
-    const jsComment = "// This is a comment";
-    const jsObjectStartLine = "export default{";
-    const jsObjectStartingWithAComment = `${jsComment}
-  ${jsObjectStartLine}
-        fun1:()=>true
-      }`;
-    const jsObjectStartingWithASpace = ` ${jsObjectStartLine}
-        fun1:()=>true
-      }`;
+  // it("4. Shows lint error and toast modal when JS Object doesn't start with 'export default'", () => {
+  //   const invalidJSObjectStartToastMessage = "Start object with export default";
+  //   const jsComment = "// This is a comment";
+  //   const jsObjectStartLine = "export default{";
+  //   const jsObjectStartingWithAComment = `${jsComment}
+  // ${jsObjectStartLine}
+  //       fun1:()=>true
+  //     }`;
+  //   const jsObjectStartingWithASpace = ` ${jsObjectStartLine}
+  //       fun1:()=>true
+  //     }`;
 
-    const jsObjectStartingWithANewLine = `
-  ${jsObjectStartLine}
-        fun1:()=>true
-      }`;
+  //   const jsObjectStartingWithANewLine = `
+  // ${jsObjectStartLine}
+  //       fun1:()=>true
+  //     }`;
 
-    const assertInvalidJSObjectStart = (
-      jsCode: string,
-      highlightedLintText: string,
-    ) => {
-      // create jsObject that doesn't start with 'export default'
-      jsEditor.CreateJSObject(jsCode, {
-        paste: true,
-        completeReplace: true,
-        toRun: false,
-        shouldCreateNewJSObj: true,
-      });
-      // Assert presence of toast message
-      agHelper.WaitUntilToastDisappear(invalidJSObjectStartToastMessage);
+  //   const assertInvalidJSObjectStart = (
+  //     jsCode: string,
+  //     highlightedLintText: string,
+  //   ) => {
+  //     // create jsObject that doesn't start with 'export default'
+  //     jsEditor.CreateJSObject(jsCode, {
+  //       paste: true,
+  //       completeReplace: true,
+  //       toRun: false,
+  //       shouldCreateNewJSObj: true,
+  //     });
+  //     // Assert presence of toast message
+  //     agHelper.WaitUntilToastDisappear(invalidJSObjectStartToastMessage);
 
-      // Assert presence of lint error at the start line
-      cy.get(locator._lintErrorElement)
-        .should("exist")
-        .should("contain.text", highlightedLintText);
-      agHelper.ActionContextMenuWithInPane("Delete", "", true);
-    };
+  //     // Assert presence of lint error at the start line
+  //     cy.get(locator._lintErrorElement)
+  //       .should("exist")
+  //       .should("contain.text", highlightedLintText);
+  //     agHelper.ActionContextMenuWithInPane("Delete", "", true);
+  //   };
 
-    assertInvalidJSObjectStart(jsObjectStartingWithAComment, jsComment);
-    assertInvalidJSObjectStart(jsObjectStartingWithANewLine, jsObjectStartLine);
-    assertInvalidJSObjectStart(jsObjectStartingWithASpace, jsObjectStartLine);
-  });
-  it("5. Verify that js function execution errors are logged in debugger and removed when function is deleted", () => {
-    const JS_OBJECT_WITH_PARSE_ERROR = `export default {
-      myVar1: [],
-      myVar2: {},
-      myFun1: () => {
-        //write code here
-        return Table1.unknown.name
-      }
-    }`;
+  //   assertInvalidJSObjectStart(jsObjectStartingWithAComment, jsComment);
+  //   assertInvalidJSObjectStart(jsObjectStartingWithANewLine, jsObjectStartLine);
+  //   assertInvalidJSObjectStart(jsObjectStartingWithASpace, jsObjectStartLine);
+  // });
 
-    const JS_OBJECT_WITHOUT_PARSE_ERROR = `export default {
-      myVar1: [],
-      myVar2: {},
-      myFun1: () => {
-        //write code here
-        return Table1.unknown
-      }
-    }`;
+  // it("5. Verify that js function execution errors are logged in debugger and removed when function is deleted", () => {
+  //   const JS_OBJECT_WITH_PARSE_ERROR = `export default {
+  //     myVar1: [],
+  //     myVar2: {},
+  //     myFun1: () => {
+  //       //write code here
+  //       return Table1.unknown.name
+  //     }
+  //   }`;
 
-    const JS_OBJECT_WITH_DELETED_FUNCTION = `export default {
-      myVar1: [],
-      myVar2: {}
-    }`;
+  //   const JS_OBJECT_WITHOUT_PARSE_ERROR = `export default {
+  //     myVar1: [],
+  //     myVar2: {},
+  //     myFun1: () => {
+  //       //write code here
+  //       return Table1.unknown
+  //     }
+  //   }`;
 
-    // Create js object
-    jsEditor.CreateJSObject(JS_OBJECT_WITH_PARSE_ERROR, {
-      paste: true,
-      completeReplace: true,
-      toRun: true,
-      shouldCreateNewJSObj: true,
-    });
+  //   const JS_OBJECT_WITH_DELETED_FUNCTION = `export default {
+  //     myVar1: [],
+  //     myVar2: {}
+  //   }`;
 
-    // Assert that there is a function execution parse error
-    jsEditor.AssertParseError(true, true);
-    // click the debug icon
-    agHelper.GetNClick(jsEditor._debugCTA);
-    // Assert that errors tab is not empty
-    cy.contains("No signs of trouble here!").should("not.exist");
-    // Assert presence of typeError
-    cy.contains(
-      "TypeError: Cannot read properties of undefined (reading 'name')",
-    ).should("exist");
+  //   // Create js object
+  //   jsEditor.CreateJSObject(JS_OBJECT_WITH_PARSE_ERROR, {
+  //     paste: true,
+  //     completeReplace: true,
+  //     toRun: true,
+  //     shouldCreateNewJSObj: true,
+  //   });
 
-    // Fix parse error and assert that debugger error is removed
-    jsEditor.EditJSObj(JS_OBJECT_WITHOUT_PARSE_ERROR);
-    agHelper.GetNClick(jsEditor._runButton);
-    jsEditor.AssertParseError(false, true);
-    agHelper.GetNClick(locator._errorTab);
-    cy.contains(
-      "TypeError: Cannot read properties of undefined (reading 'name')",
-    ).should("not.exist");
+  //   // Assert that there is a function execution parse error
+  //   jsEditor.AssertParseError(true, true);
+  //   // click the debug icon
+  //   agHelper.GetNClick(jsEditor._debugCTA);
+  //   // Assert that errors tab is not empty
+  //   cy.contains("No signs of trouble here!").should("not.exist");
+  //   // Assert presence of typeError
+  //   cy.contains(
+  //     "TypeError: Cannot read properties of undefined (reading 'name')",
+  //   ).should("exist");
 
-    // Switch back to response tab
-    agHelper.GetNClick(locator._responseTab);
-    // Re-introduce parse errors
-    jsEditor.EditJSObj(JS_OBJECT_WITH_PARSE_ERROR);
-    agHelper.GetNClick(jsEditor._runButton);
-    agHelper.WaitUntilToastDisappear("ran successfully"); //to not hinder with next toast msg in next case!
-    // Assert that there is a function execution parse error
-    jsEditor.AssertParseError(true, true);
+  //   // Fix parse error and assert that debugger error is removed
+  //   jsEditor.EditJSObj(JS_OBJECT_WITHOUT_PARSE_ERROR);
+  //   agHelper.GetNClick(jsEditor._runButton);
+  //   jsEditor.AssertParseError(false, true);
+  //   agHelper.GetNClick(locator._errorTab);
+  //   cy.contains(
+  //     "TypeError: Cannot read properties of undefined (reading 'name')",
+  //   ).should("not.exist");
 
-    // Delete function
-    jsEditor.EditJSObj(JS_OBJECT_WITH_DELETED_FUNCTION);
-    // Assert that parse error is removed from debugger when function is deleted
-    agHelper.GetNClick(locator._errorTab);
-    cy.contains(
-      "TypeError: Cannot read properties of undefined (reading 'name')",
-    ).should("not.exist");
-  });
+  //   // Switch back to response tab
+  //   agHelper.GetNClick(locator._responseTab);
+  //   // Re-introduce parse errors
+  //   jsEditor.EditJSObj(JS_OBJECT_WITH_PARSE_ERROR);
+  //   agHelper.GetNClick(jsEditor._runButton);
+  //   agHelper.WaitUntilToastDisappear("ran successfully"); //to not hinder with next toast msg in next case!
+  //   // Assert that there is a function execution parse error
+  //   jsEditor.AssertParseError(true, true);
 
-  it("6. Supports the use of large JSON data (doesn't crash)", () => {
-    const jsObjectWithLargeJSONData = `export default{
-      largeData: ${JSON.stringify(largeJSONData)},
-      myfun1: ()=> this.largeData
-    }`;
-    const crashMessage = "Oops! Something went wrong";
-    // create jsObject with large json data and run
-    jsEditor.CreateJSObject(jsObjectWithLargeJSONData, {
-      paste: true,
-      completeReplace: true,
-      toRun: false,
-      shouldCreateNewJSObj: true,
-    });
+  //   // Delete function
+  //   jsEditor.EditJSObj(JS_OBJECT_WITH_DELETED_FUNCTION);
+  //   // Assert that parse error is removed from debugger when function is deleted
+  //   agHelper.GetNClick(locator._errorTab);
+  //   cy.contains(
+  //     "TypeError: Cannot read properties of undefined (reading 'name')",
+  //   ).should("not.exist");
+  // });
 
-    // wait for 3 secs and assert that App doesn't crash
-    cy.wait(3000);
-    cy.contains(crashMessage).should("not.exist");
+  // it("6. Supports the use of large JSON data (doesn't crash)", () => {
+  //   const jsObjectWithLargeJSONData = `export default{
+  //     largeData: ${JSON.stringify(largeJSONData)},
+  //     myfun1: ()=> this.largeData
+  //   }`;
+  //   const crashMessage = "Oops! Something went wrong";
+  //   // create jsObject with large json data and run
+  //   jsEditor.CreateJSObject(jsObjectWithLargeJSONData, {
+  //     paste: true,
+  //     completeReplace: true,
+  //     toRun: false,
+  //     shouldCreateNewJSObj: true,
+  //   });
 
-    // Edit JSObject and run
-    jsEditor.CreateJSObject(" ", {
-      paste: true,
-      completeReplace: false,
-      toRun: true,
-      shouldCreateNewJSObj: false,
-    });
+  //   // wait for 3 secs and assert that App doesn't crash
+  //   cy.wait(3000);
+  //   cy.contains(crashMessage).should("not.exist");
 
-    cy.get("@jsObjName").then((jsObjName) => {
-      ee.SelectEntityByName("Table1", "WIDGETS");
-      propPane.UpdatePropertyFieldValue(
-        "Table Data",
-        `{{${jsObjName}.largeData}}`,
-      );
-    });
+  //   // Edit JSObject and run
+  //   jsEditor.CreateJSObject(" ", {
+  //     paste: true,
+  //     completeReplace: false,
+  //     toRun: true,
+  //     shouldCreateNewJSObj: false,
+  //   });
 
-    // Deploy App and test that table loads properly
-    deployMode.DeployApp();
-    table.WaitUntilTableLoad();
-    table.ReadTableRowColumnData(0, 1, 2000).then(($cellData) => {
-      expect($cellData).to.eq("1"); //validating id column value - row 0
-      deployMode.NavigateBacktoEditor();
-    });
-  });
+  //   cy.get("@jsObjName").then((jsObjName) => {
+  //     ee.SelectEntityByName("Table1", "WIDGETS");
+  //     propPane.UpdatePropertyFieldValue(
+  //       "Table Data",
+  //       `{{${jsObjName}.largeData}}`,
+  //     );
+  //   });
 
-  it("7. Doesn't cause cyclic dependency when function name is edited", () => {
-    const syncJSCode = `export default {
-      myFun1 :()=>{
-        return "yes"
-      }
-    }`;
+  //   // Deploy App and test that table loads properly
+  //   deployMode.DeployApp();
+  //   table.WaitUntilTableLoad();
+  //   table.ReadTableRowColumnData(0, 1, 2000).then(($cellData) => {
+  //     expect($cellData).to.eq("1"); //validating id column value - row 0
+  //     deployMode.NavigateBacktoEditor();
+  //   });
+  // });
 
-    const syncJSCodeWithRenamedFunction1 = `export default {
-      myFun2 :()=>{
-        return "yes"
-      }
-    }`;
+  // it("7. Doesn't cause cyclic dependency when function name is edited", () => {
+  //   const syncJSCode = `export default {
+  //     myFun1 :()=>{
+  //       return "yes"
+  //     }
+  //   }`;
 
-    const syncJSCodeWithRenamedFunction2 = `export default {
-      myFun3 :()=>{
-        return "yes"
-      }
-    }`;
+  //   const syncJSCodeWithRenamedFunction1 = `export default {
+  //     myFun2 :()=>{
+  //       return "yes"
+  //     }
+  //   }`;
 
-    const asyncJSCode = `export default {
-      myFun1 :async ()=>{
-        return "yes"
-      }
-    }`;
+  //   const syncJSCodeWithRenamedFunction2 = `export default {
+  //     myFun3 :()=>{
+  //       return "yes"
+  //     }
+  //   }`;
 
-    const asyncJSCodeWithRenamedFunction1 = `export default {
-      myFun2 :async ()=>{
-        return "yes"
-      }
-    }`;
+  //   const asyncJSCode = `export default {
+  //     myFun1 :async ()=>{
+  //       return "yes"
+  //     }
+  //   }`;
 
-    const asyncJSCodeWithRenamedFunction2 = `export default {
-      myFun3 :async ()=>{
-        return "yes"
-      }
-    }`;
+  //   const asyncJSCodeWithRenamedFunction1 = `export default {
+  //     myFun2 :async ()=>{
+  //       return "yes"
+  //     }
+  //   }`;
 
-    jsEditor.CreateJSObject(syncJSCode, {
-      paste: true,
-      completeReplace: true,
-      toRun: false,
-      shouldCreateNewJSObj: true,
-    });
+  //   const asyncJSCodeWithRenamedFunction2 = `export default {
+  //     myFun3 :async ()=>{
+  //       return "yes"
+  //     }
+  //   }`;
 
-    // change sync function name and test that cyclic dependency is not created
-    jsEditor.EditJSObj(syncJSCodeWithRenamedFunction1);
-    agHelper.AssertElementAbsence(locator._toastMsg);
-    jsEditor.EditJSObj(syncJSCodeWithRenamedFunction2);
-    agHelper.AssertElementAbsence(locator._toastMsg);
+  //   jsEditor.CreateJSObject(syncJSCode, {
+  //     paste: true,
+  //     completeReplace: true,
+  //     toRun: false,
+  //     shouldCreateNewJSObj: true,
+  //   });
 
-    jsEditor.CreateJSObject(asyncJSCode, {
-      paste: true,
-      completeReplace: true,
-      toRun: false,
-      shouldCreateNewJSObj: true,
-    });
-    // change async function name and test that cyclic dependency is not created
-    jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction1);
-    agHelper.AssertElementAbsence(locator._toastMsg);
-    jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction2);
-    agHelper.AssertElementAbsence(locator._toastMsg);
-  });
-  it("8. Maintains order of async functions in settings tab alphabetically at all times", function() {
-    functionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.length;
-    // Number of functions set to run on page load and should also confirm before execute
-    onPageLoadAndConfirmExecuteFunctionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.filter(
-      (func) => func.onPageLoad && func.confirmBeforeExecute,
-    ).length;
+  //   // change sync function name and test that cyclic dependency is not created
+  //   jsEditor.EditJSObj(syncJSCodeWithRenamedFunction1);
+  //   agHelper.AssertElementAbsence(locator._toastMsg);
+  //   jsEditor.EditJSObj(syncJSCodeWithRenamedFunction2);
+  //   agHelper.AssertElementAbsence(locator._toastMsg);
 
-    getJSObject = (data: IFunctionSettingData[]) => {
-      let JS_OBJECT_BODY = `export default`;
-      for (let i = 0; i < functionsLength; i++) {
-        const functionName = data[i].name;
-        JS_OBJECT_BODY +=
-          i === 0
-            ? `{
-              ${functionName}: async ()=>"${functionName}",`
-            : i === functionsLength - 1
-            ? `
-            ${functionName}: async ()=>"${functionName}",
-          }`
-            : `
-            ${functionName}: async ()=> "${functionName}",`;
-      }
-      return JS_OBJECT_BODY;
-    };
+  //   jsEditor.CreateJSObject(asyncJSCode, {
+  //     paste: true,
+  //     completeReplace: true,
+  //     toRun: false,
+  //     shouldCreateNewJSObj: true,
+  //   });
+  //   // change async function name and test that cyclic dependency is not created
+  //   jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction1);
+  //   agHelper.AssertElementAbsence(locator._toastMsg);
+  //   jsEditor.EditJSObj(asyncJSCodeWithRenamedFunction2);
+  //   agHelper.AssertElementAbsence(locator._toastMsg);
+  // });
 
-    // Create js object
-    jsEditor.CreateJSObject(getJSObject(FUNCTIONS_SETTINGS_DEFAULT_DATA), {
-      paste: true,
-      completeReplace: true,
-      toRun: false,
-      shouldCreateNewJSObj: true,
-    });
+  // it("8. Maintains order of async functions in settings tab alphabetically at all times", function() {
+  //   functionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.length;
+  //   // Number of functions set to run on page load and should also confirm before execute
+  //   onPageLoadAndConfirmExecuteFunctionsLength = FUNCTIONS_SETTINGS_DEFAULT_DATA.filter(
+  //     (func) => func.onPageLoad && func.confirmBeforeExecute,
+  //   ).length;
 
-    cy.get("@jsObjName").then((jsObjName: any) => {
-      jsObj = jsObjName;
-    });
-    // Switch to settings tab
-    agHelper.GetNClick(jsEditor._settingsTab);
-    // Add settings for each function (according to data)
-    Object.values(FUNCTIONS_SETTINGS_DEFAULT_DATA).forEach(
-      (functionSetting) => {
-        jsEditor.EnableDisableAsyncFuncSettings(
-          functionSetting.name,
-          functionSetting.onPageLoad,
-          functionSetting.confirmBeforeExecute,
-        );
-      },
-    );
-    // Switch to settings tab
-    agHelper.GetNClick(jsEditor._settingsTab);
-    //After JSObj is created - check methods are in alphabetical order
-    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
+  //   getJSObject = (data: IFunctionSettingData[]) => {
+  //     let JS_OBJECT_BODY = `export default`;
+  //     for (let i = 0; i < functionsLength; i++) {
+  //       const functionName = data[i].name;
+  //       JS_OBJECT_BODY +=
+  //         i === 0
+  //           ? `{
+  //             ${functionName}: async ()=>"${functionName}",`
+  //           : i === functionsLength - 1
+  //           ? `
+  //           ${functionName}: async ()=>"${functionName}",
+  //         }`
+  //           : `
+  //           ${functionName}: async ()=> "${functionName}",`;
+  //     }
+  //     return JS_OBJECT_BODY;
+  //   };
 
-    agHelper.RefreshPage();
-    // click "Yes" button for all onPageload && ConfirmExecute functions
-    for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
-      //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
-      agHelper.ClickButton("Yes");
-      agHelper.Sleep();
-    }
-    // Switch to settings tab and assert order
-    agHelper.GetNClick(jsEditor._settingsTab);
-    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
-  });
+  //   // Create js object
+  //   jsEditor.CreateJSObject(getJSObject(FUNCTIONS_SETTINGS_DEFAULT_DATA), {
+  //     paste: true,
+  //     completeReplace: true,
+  //     toRun: false,
+  //     shouldCreateNewJSObj: true,
+  //   });
 
-  it("9. Verify Async methods have alphabetical order after cloning page and renaming it", () => {
-    const FUNCTIONS_SETTINGS_RENAMED_DATA: IFunctionSettingData[] = [
-      {
-        name: "newGetId",
-        onPageLoad: true,
-        confirmBeforeExecute: false,
-      },
-      {
-        name: "zip1",
-        onPageLoad: true,
-        confirmBeforeExecute: true,
-      },
-      {
-        name: "base",
-        onPageLoad: false,
-        confirmBeforeExecute: false,
-      },
-      {
-        name: "newAssert",
-        onPageLoad: true,
-        confirmBeforeExecute: false,
-      },
-      {
-        name: "test",
-        onPageLoad: true,
-        confirmBeforeExecute: true,
-      },
-    ];
+  //   cy.get("@jsObjName").then((jsObjName: any) => {
+  //     jsObj = jsObjName;
+  //   });
+  //   // Switch to settings tab
+  //   agHelper.GetNClick(jsEditor._settingsTab);
+  //   // Add settings for each function (according to data)
+  //   Object.values(FUNCTIONS_SETTINGS_DEFAULT_DATA).forEach(
+  //     (functionSetting) => {
+  //       jsEditor.EnableDisableAsyncFuncSettings(
+  //         functionSetting.name,
+  //         functionSetting.onPageLoad,
+  //         functionSetting.confirmBeforeExecute,
+  //       );
+  //     },
+  //   );
+  //   // Switch to settings tab
+  //   agHelper.GetNClick(jsEditor._settingsTab);
+  //   //After JSObj is created - check methods are in alphabetical order
+  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
 
-    // clone page and assert order of functions
-    ee.ClonePage();
-    // click "Yes" button for all onPageload && ConfirmExecute functions
-    for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
-      //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
-      agHelper.ClickButton("Yes");
-      agHelper.Sleep();
-    }
+  //   agHelper.RefreshPage();
+  //   // click "Yes" button for all onPageload && ConfirmExecute functions
+  //   for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
+  //     //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
+  //     agHelper.ClickButton("Yes");
+  //     agHelper.Sleep();
+  //   }
+  //   // Switch to settings tab and assert order
+  //   agHelper.GetNClick(jsEditor._settingsTab);
+  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
+  // });
 
-    ee.SelectEntityByName(jsObj, "QUERIES/JS");
+  // it("9. Verify Async methods have alphabetical order after cloning page and renaming it", () => {
+  //   const FUNCTIONS_SETTINGS_RENAMED_DATA: IFunctionSettingData[] = [
+  //     {
+  //       name: "newGetId",
+  //       onPageLoad: true,
+  //       confirmBeforeExecute: false,
+  //     },
+  //     {
+  //       name: "zip1",
+  //       onPageLoad: true,
+  //       confirmBeforeExecute: true,
+  //     },
+  //     {
+  //       name: "base",
+  //       onPageLoad: false,
+  //       confirmBeforeExecute: false,
+  //     },
+  //     {
+  //       name: "newAssert",
+  //       onPageLoad: true,
+  //       confirmBeforeExecute: false,
+  //     },
+  //     {
+  //       name: "test",
+  //       onPageLoad: true,
+  //       confirmBeforeExecute: true,
+  //     },
+  //   ];
 
-    agHelper.GetNClick(jsEditor._settingsTab);
-    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
+  //   // clone page and assert order of functions
+  //   ee.ClonePage();
+  //   // click "Yes" button for all onPageload && ConfirmExecute functions
+  //   for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
+  //     //agHelper.AssertElementPresence(jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
+  //     agHelper.ClickButton("Yes");
+  //     agHelper.Sleep();
+  //   }
 
-    // rename functions and assert order
-    agHelper.GetNClick(jsEditor._codeTab);
-    jsEditor.EditJSObj(getJSObject(FUNCTIONS_SETTINGS_RENAMED_DATA));
-    cy.wait(3000);
-    agHelper.GetNClick(jsEditor._settingsTab);
-    assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_RENAMED_DATA);
-  });
+  //   ee.SelectEntityByName(jsObj, "QUERIES/JS");
 
-  it("10. Verify converting async functions to sync resets all settings", () => {
+  //   agHelper.GetNClick(jsEditor._settingsTab);
+  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_DEFAULT_DATA);
+
+  //   // rename functions and assert order
+  //   agHelper.GetNClick(jsEditor._codeTab);
+  //   jsEditor.EditJSObj(getJSObject(FUNCTIONS_SETTINGS_RENAMED_DATA));
+  //   cy.wait(3000);
+  //   agHelper.GetNClick(jsEditor._settingsTab);
+  //   assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_RENAMED_DATA);
+  // });
+
+  it("10. Bug-13197: Verify converting async functions to sync resets all settings", () => {
     const asyncJSCode = `export default {
       myFun1 : async ()=>{
         return "yes"
@@ -499,23 +501,18 @@ describe("JS Function Execution", function() {
       shouldCreateNewJSObj: true,
     });
 
-    cy.get("@jsObjName").then((jsObjName: any) => {
-      jsObj = jsObjName;
-    });
-
     // Switch to settings tab
     agHelper.GetNClick(jsEditor._settingsTab);
     // Enable all settings
     jsEditor.EnableDisableAsyncFuncSettings("myFun1", true, true);
 
     // Modify js object
-    jsEditor.CreateJSObject(syncJSCode, {
-      paste: true,
-      completeReplace: true,
-      toRun: false,
-      shouldCreateNewJSObj: false,
-    });
+    jsEditor.EditJSObj(syncJSCode);
 
     agHelper.RefreshPage();
+    cy.wait("@jsCollections").then(({ response }) => {
+      expect(response?.body.data.actions[0].executeOnLoad).to.eq(false);
+      expect(response?.body.data.actions[0].confirmBeforeExecute).to.eq(false);
+    });
   });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -478,4 +478,44 @@ describe("JS Function Execution", function() {
     agHelper.GetNClick(jsEditor._settingsTab);
     assertAsyncFunctionsOrder(FUNCTIONS_SETTINGS_RENAMED_DATA);
   });
+
+  it("10. Verify converting async functions to sync resets all settings", () => {
+    const asyncJSCode = `export default {
+      myFun1 : async ()=>{
+        return "yes"
+      }
+    }`;
+
+    const syncJSCode = `export default {
+      myFun1 : ()=>{
+        return "yes"
+      }
+    }`;
+
+    jsEditor.CreateJSObject(asyncJSCode, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+
+    cy.get("@jsObjName").then((jsObjName: any) => {
+      jsObj = jsObjName;
+    });
+
+    // Switch to settings tab
+    agHelper.GetNClick(jsEditor._settingsTab);
+    // Enable all settings
+    jsEditor.EnableDisableAsyncFuncSettings("myFun1", true, true);
+
+    // Modify js object
+    jsEditor.CreateJSObject(syncJSCode, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: false,
+    });
+
+    agHelper.RefreshPage();
+  });
 });

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -181,6 +181,7 @@ export class JSEditor {
       .then((el: JQuery<HTMLElement>) => {
         this.agHelper.Paste(el, newContent);
       });
+    this.agHelper.AssertAutoSave();
   }
 
   public EnterJSContext(

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -999,6 +999,7 @@ Cypress.Commands.add("startServerAndRoutes", () => {
   cy.route("POST", "/api/v1/collections/actions").as("createNewJSCollection");
   cy.route("DELETE", "/api/v1/collections/actions/*").as("deleteJSCollection");
   cy.route("POST", "/api/v1/pages/crud-page").as("replaceLayoutWithCRUDPage");
+  cy.intercept("PUT", "api/v1/collections/actions/*").as("jsCollections");
 
   cy.intercept("POST", "/api/v1/users/super").as("createSuperUser");
   cy.intercept("POST", "/api/v1/actions/execute").as("postExecute");

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -546,7 +546,18 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         Mono<NewAction> updatedActionMono = repository.findById(id, MANAGE_ACTIONS)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.ACTION, id)))
                 .map(dbAction -> {
-                    copyNewFieldValuesIntoOldObject(action, dbAction.getUnpublishedAction());
+                    final ActionDTO unpublishedAction = dbAction.getUnpublishedAction();
+                    copyNewFieldValuesIntoOldObject(action, unpublishedAction);
+
+                    // In case this update is for an action that represents a JS function,
+                    // perform a check to reset values for sync functions
+                    final boolean isSyncJSFunction = PluginType.JS.equals(action.getPluginType()) &&
+                            FALSE.equals(action.getActionConfiguration().getIsAsync());
+                    if (isSyncJSFunction) {
+                        unpublishedAction.setUserSetOnLoad(false);
+                        unpublishedAction.setConfirmBeforeExecute(false);
+                        unpublishedAction.setExecuteOnLoad(false);
+                    }
                     return dbAction;
                 })
                 .flatMap(this::extractAndSetNativeQueryFromFormData)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
@@ -11,11 +11,11 @@ import com.appsmith.server.domains.ActionCollection;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.Layout;
 import com.appsmith.server.domains.NewAction;
-import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.PluginType;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserRole;
+import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.ActionCollectionDTO;
 import com.appsmith.server.dtos.ActionCollectionViewDTO;
 import com.appsmith.server.dtos.ActionDTO;
@@ -26,8 +26,8 @@ import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
-import com.appsmith.server.repositories.WorkspaceRepository;
 import com.appsmith.server.repositories.PluginRepository;
+import com.appsmith.server.repositories.WorkspaceRepository;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
@@ -525,19 +525,35 @@ public class ActionCollectionServiceTest {
 
     /**
      * For a given collection testActionCollection,
-     * When the collection is updated after creation,
-     * The updatedAt field should have a greater value than the updatedAt value when it was created.
+     * When the collection is updated after creation such that the JS function becomes sync,
+     * The executeOnLoad, confirmBeforeExecute and userSetOnLoad should be reset to false
      */
     @Test
     @WithUserDetails(value = "api_user")
-    public void testUpdateActionCollection_verifyUpdatedAtFieldUpdated() {
+    public void testUpdateActionCollection_fromAsyncToSync_resetsSyncFunctionFields() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(pluginExecutor));
+        Mockito.when(pluginExecutor.getHintMessages(Mockito.any(), Mockito.any()))
+                .thenReturn(Mono.zip(Mono.just(new HashSet<>()), Mono.just(new HashSet<>())));
+
         ActionCollectionDTO actionCollectionDTO = new ActionCollectionDTO();
-        actionCollectionDTO.setName("testActionCollection");
-        actionCollectionDTO.setApplicationId(testApp.getId());
-        actionCollectionDTO.setWorkspaceId(testApp.getWorkspaceId());
+        actionCollectionDTO.setName("testCollection1");
         actionCollectionDTO.setPageId(testPage.getId());
+        actionCollectionDTO.setApplicationId(testApp.getId());
+        actionCollectionDTO.setWorkspaceId(workspaceId);
         actionCollectionDTO.setPluginId(datasource.getPluginId());
+        actionCollectionDTO.setVariables(List.of(new JSValue("test", "String", "test", true)));
+        actionCollectionDTO.setBody("collectionBody");
+        ActionDTO action1 = new ActionDTO();
+        action1.setName("testAction1");
+        action1.setActionConfiguration(new ActionConfiguration());
+        action1.getActionConfiguration().setBody("mockBody");
+        action1.getActionConfiguration().setIsValid(false);
+        action1.getActionConfiguration().setIsAsync(true);
+        action1.setExecuteOnLoad(true);
+        action1.setUserSetOnLoad(true);
+        action1.setConfirmBeforeExecute(true);
         actionCollectionDTO.setPluginType(PluginType.JS);
+        actionCollectionDTO.setActions(List.of(action1));
 
         ActionCollection createdActionCollection = layoutCollectionService.createCollection(actionCollectionDTO)
                 .flatMap(createdCollection -> {
@@ -550,13 +566,23 @@ public class ActionCollectionServiceTest {
                     return actionCollectionService.findById(createdCollection.getId(), READ_ACTIONS);
                 }).block();
 
+        action1.getActionConfiguration().setIsAsync(false);
+        final Mono<List<ActionCollectionViewDTO>> viewModeCollectionsMono = layoutCollectionService.updateUnpublishedActionCollection(createdActionCollection.getId(), actionCollectionDTO, null)
+                .flatMap(updatedCollection -> applicationPageService.publish(testApp.getId(), true))
+                .thenMany(actionCollectionService.getActionCollectionsForViewMode(testApp.getId(), null))
+                .collectList();
 
-        Mono<ActionCollection> updatedActionCollectionMono = layoutCollectionService.updateUnpublishedActionCollection(createdActionCollection.getId(), actionCollectionDTO, null)
-                .flatMap(createdCollection -> actionCollectionService.findById(createdCollection.getId(), READ_ACTIONS));
+        StepVerifier.create(viewModeCollectionsMono)
+                .assertNext(viewModeCollections -> {
+                    assertThat(viewModeCollections.size()).isEqualTo(1);
 
-        StepVerifier.create(updatedActionCollectionMono)
-                .assertNext(updatedActionCollection -> {
-                    assertThat(updatedActionCollection.getUpdatedAt().isAfter(createdActionCollection.getUpdatedAt())).isTrue();
+                    final ActionCollectionViewDTO actionCollectionViewDTO = viewModeCollections.get(0);
+                    final List<ActionDTO> actions = actionCollectionViewDTO.getActions();
+                    Assert.assertFalse(actions.isEmpty());
+                    final ActionDTO actionDTO = actions.get(0);
+                    Assert.assertFalse(actionDTO.getExecuteOnLoad());
+                    Assert.assertFalse(actionDTO.getUserSetOnLoad());
+                    Assert.assertFalse(actionDTO.getConfirmBeforeExecute());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

Sync JS functions are not meant to ever run on page load automatically, since we have disabled the ability for users to set them to run on page load. This fix resets the relevant props on each update, so that the fields are not reused from when the function used to be recognized as async.

[Slack thread](https://theappsmith.slack.com/archives/C02K0SZQ7V3/p1658734579510539)

Fixes #13197 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually tested
- JUnit tested
- Cypress tested

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
