### PR TITLE
fix: Converted ApplicationForkingServiceTests to synchronous

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -786,7 +786,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
 
         // Clone Application is currently a slow API because it needs to create application, clone all the pages, and then
         // clone all the actions. This process may take time and the client may cancel the request. This leads to the flow
-        // getting stopped mid way producing corrupted clones. The following ensures that even though the client may have
+        // getting stopped midway producing corrupted clones. The following ensures that even though the client may have
         // cancelled the flow, the cloning of the application should proceed uninterrupted and whenever the user refreshes
         // the page, the cloned application is available and is in sane state.
         // To achieve this, we use a synchronous sink which does not take subscription cancellations into account. This

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ApplicationForkingServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ApplicationForkingServiceCEImpl.java
@@ -81,7 +81,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
 
         // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
         // copy all the actions and collections. This process may take time and the client may cancel the request.
-        // This leads to the flow getting stopped mid way producing corrupted DB objects. The following ensures that even
+        // This leads to the flow getting stopped midway producing corrupted DB objects. The following ensures that even
         // though the client may have cancelled the flow, the forking of the application should proceed uninterrupted
         // and whenever the user refreshes the page, the sane forked application is available.
         // To achieve this, we use a synchronous sink which does not take subscription cancellations into account. This

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -1152,7 +1152,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
 
         // Import Application is currently a slow API because it needs to import and create application, pages, actions
         // and action collection. This process may take time and the client may cancel the request. This leads to the flow
-        // getting stopped mid way producing corrupted objects in DB. The following ensures that even though the client may have
+        // getting stopped midway producing corrupted objects in DB. The following ensures that even though the client may have
         // cancelled the flow, the importing the application should proceed uninterrupted and whenever the user refreshes
         // the page, the imported application is available and is in sane state.
         // To achieve this, we use a synchronous sink which does not take subscription cancellations into account. This

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
@@ -391,11 +391,15 @@ public class ApplicationForkingServiceTests {
         Workspace targetWorkspace = new Workspace();
         targetWorkspace.setName("test-user-workspace");
 
-        final Mono<Application> resultMono = workspaceService.create(targetWorkspace)
-                .flatMap(workspace -> {
-                    testUserWorkspaceId = workspace.getId();
-                    return applicationForkingService.forkApplicationToWorkspace(sourceAppId, workspace.getId());
-                });
+        // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
+        // copy all the actions and collections. This process may take time and since some of the test cases in
+        // ApplicationForkingServiceTests observed failure in the CI due to timeoutException, to unblock this temporarily,
+        // synchronous block() is being used until it is fixed.
+        // TODO: Investigate working of applicationForkingService.forkApplicationToWorkspace() further and fix the timeoutException.
+        Workspace workspace = workspaceService.create(targetWorkspace).block();
+        testUserWorkspaceId = workspace.getId();
+        Application targetApplication = applicationForkingService.forkApplicationToWorkspace(sourceAppId, testUserWorkspaceId).block();
+        final Mono<Application> resultMono = Mono.just(targetApplication);
 
         StepVerifier.create(resultMono)
                 .assertNext(application -> {
@@ -521,36 +525,35 @@ public class ApplicationForkingServiceTests {
     @Test
     @WithUserDetails("api_user")
     public void forkApplicationToWorkspace_WhenAppHasUnsavedThemeCustomization_ForkedWithCustomizations() {
+        // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
+        // copy all the actions and collections. This process may take time and since some of the test cases in
+        // ApplicationForkingServiceTests observed failure in the CI due to timeoutException, to unblock this temporarily,
+        // synchronous block() is being used until it is fixed.
+        // TODO: Investigate working of applicationForkingService.forkApplicationToWorkspace() further and fix the timeoutException.
         String uniqueString = UUID.randomUUID().toString();
-        Workspace workspace = new Workspace();
-        workspace.setName("org_" + uniqueString);
+        Workspace srcWorkspace = new Workspace();
+        srcWorkspace.setName("ws_" + uniqueString);
+        Workspace createdSrcWorkspace = workspaceService.create(srcWorkspace).block();
 
-        Mono<Tuple4<Theme, Theme, Application, Application>> tuple4Mono = workspaceService.create(workspace)
-                .flatMap(createdOrg -> {
-                    Application application = new Application();
-                    application.setName("app_" + uniqueString);
-                    return applicationPageService.createApplication(application, createdOrg.getId());
-                }).flatMap(srcApplication -> {
-                    Theme theme = new Theme();
-                    theme.setDisplayName("theme_" + uniqueString);
-                    return themeService.updateTheme(srcApplication.getId(), null, theme)
-                            .then(applicationService.findById(srcApplication.getId()));
-                }).flatMap(srcApplication -> {
-                    Workspace desOrg = new Workspace();
-                    desOrg.setName("org_dest_" + uniqueString);
-                    return workspaceService.create(desOrg).flatMap(createdOrg ->
-                            applicationForkingService.forkApplicationToWorkspace(srcApplication.getId(), createdOrg.getId())
-                    ).zipWith(Mono.just(srcApplication));
-                }).flatMap(applicationTuple2 -> {
-                    Application forkedApp = applicationTuple2.getT1();
-                    Application srcApp = applicationTuple2.getT2();
-                    return Mono.zip(
-                            themeService.getApplicationTheme(forkedApp.getId(), ApplicationMode.EDIT, null),
-                            themeService.getApplicationTheme(forkedApp.getId(), ApplicationMode.PUBLISHED, null),
-                            Mono.just(forkedApp),
-                            Mono.just(srcApp)
-                    );
-                });
+        Application srcApplication = new Application();
+        srcApplication.setName("app_" + uniqueString);
+        Application createdSrcApplication = applicationPageService.createApplication(srcApplication, createdSrcWorkspace.getId()).block();
+
+        Theme theme = new Theme();
+        theme.setDisplayName("theme_" + uniqueString);
+
+        themeService.updateTheme(createdSrcApplication.getId(), null, theme).block();
+        createdSrcApplication = applicationService.findById(srcApplication.getId()).block();
+
+        Workspace destWorkspace = new Workspace();
+        destWorkspace.setName("ws_dest_" + uniqueString);
+        Workspace createdDestWorkspace = workspaceService.create(destWorkspace).block();
+        Application forkedApplication = applicationForkingService.forkApplicationToWorkspace(srcApplication.getId(), createdDestWorkspace.getId()).block();
+
+        Theme forkedApplicationEditModeTheme = themeService.getApplicationTheme(forkedApplication.getId(), ApplicationMode.EDIT, null).block();
+        Theme forkedApplicationPublishedModeTheme = themeService.getApplicationTheme(forkedApplication.getId(), ApplicationMode.PUBLISHED, null).block();
+
+        final Mono<Tuple4<Theme, Theme, Application, Application>> tuple4Mono = Mono.zip(Mono.just(forkedApplicationEditModeTheme), Mono.just(forkedApplicationPublishedModeTheme), Mono.just(forkedApplication), Mono.just(srcApplication));
 
         StepVerifier.create(tuple4Mono).assertNext(objects -> {
             Theme editModeTheme = objects.getT1();
@@ -587,30 +590,29 @@ public class ApplicationForkingServiceTests {
     @Test
     @WithUserDetails("api_user")
     public void forkApplicationToWorkspace_WhenAppHasSystemTheme_SystemThemeSet() {
+        // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
+        // copy all the actions and collections. This process may take time and since some of the test cases in
+        // ApplicationForkingServiceTests observed failure in the CI due to timeoutException, to unblock this temporarily,
+        // synchronous block() is being used until it is fixed.
+        // TODO: Investigate working of applicationForkingService.forkApplicationToWorkspace() further and fix the timeoutException.
         String uniqueString = UUID.randomUUID().toString();
         Workspace workspace = new Workspace();
-        workspace.setName("org_" + uniqueString);
+        workspace.setName("ws_" + uniqueString);
 
-        Mono<Tuple3<Theme, Application, Application>> tuple3Mono = workspaceService.create(workspace)
-                .flatMap(createdOrg -> {
-                    Application application = new Application();
-                    application.setName("app_" + uniqueString);
-                    return applicationPageService.createApplication(application, createdOrg.getId());
-                }).flatMap(srcApplication -> {
-                    Workspace desOrg = new Workspace();
-                    desOrg.setName("org_dest_" + uniqueString);
-                    return workspaceService.create(desOrg).flatMap(createdOrg ->
-                            applicationForkingService.forkApplicationToWorkspace(srcApplication.getId(), createdOrg.getId())
-                    ).zipWith(Mono.just(srcApplication));
-                }).flatMap(applicationTuple2 -> {
-                    Application forkedApp = applicationTuple2.getT1();
-                    Application srcApp = applicationTuple2.getT2();
-                    return Mono.zip(
-                            themeService.getApplicationTheme(forkedApp.getId(), ApplicationMode.EDIT, null),
-                            Mono.just(forkedApp),
-                            Mono.just(srcApp)
-                    );
-                });
+        Workspace createdWorkspace = workspaceService.create(workspace).block();
+
+        Application application = new Application();
+        application.setName("app_" + uniqueString);
+        Application createdSrcApplication = applicationPageService.createApplication(application, createdWorkspace.getId()).block();
+
+        Workspace destWorkspace = new Workspace();
+        destWorkspace.setName("ws_dest_" + uniqueString);
+        Workspace createdDestWorkspace = workspaceService.create(destWorkspace).block();
+
+        Application forkedApplication = applicationForkingService.forkApplicationToWorkspace(createdSrcApplication.getId(), createdDestWorkspace.getId()).block();
+        Theme forkedApplicationTheme = themeService.getApplicationTheme(forkedApplication.getId(), ApplicationMode.EDIT, null).block();
+
+        Mono<Tuple3<Theme, Application, Application>> tuple3Mono = Mono.zip(Mono.just(forkedApplicationTheme), Mono.just(forkedApplication), Mono.just(createdSrcApplication));
 
         StepVerifier.create(tuple3Mono).assertNext(objects -> {
             Theme editModeTheme = objects.getT1();
@@ -638,37 +640,36 @@ public class ApplicationForkingServiceTests {
     @Test
     @WithUserDetails("api_user")
     public void forkApplicationToWorkspace_WhenAppHasCustomSavedTheme_NewCustomThemeCreated() {
+        // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
+        // copy all the actions and collections. This process may take time and since some of the test cases in
+        // ApplicationForkingServiceTests observed failure in the CI due to timeoutException, to unblock this temporarily,
+        // synchronous block() is being used until it is fixed.
+        // TODO: Investigate working of applicationForkingService.forkApplicationToWorkspace() further and fix the timeoutException.
         String uniqueString = UUID.randomUUID().toString();
         Workspace workspace = new Workspace();
-        workspace.setName("org_" + uniqueString);
+        workspace.setName("ws_" + uniqueString);
+        Workspace createdSrcWorkspace = workspaceService.create(workspace).block();
 
-        Mono<Tuple4<Theme, Theme, Application, Application>> tuple4Mono = workspaceService.create(workspace)
-                .flatMap(createdOrg -> {
-                    Application application = new Application();
-                    application.setName("app_" + uniqueString);
-                    return applicationPageService.createApplication(application, createdOrg.getId());
-                }).flatMap(srcApplication -> {
-                    Theme theme = new Theme();
-                    theme.setDisplayName("theme_" + uniqueString);
-                    return themeService.updateTheme(srcApplication.getId(), null, theme)
-                            .then(themeService.persistCurrentTheme(srcApplication.getId(), null, theme))
-                            .then(applicationService.findById(srcApplication.getId()));
-                }).flatMap(srcApplication -> {
-                    Workspace desOrg = new Workspace();
-                    desOrg.setName("org_dest_" + uniqueString);
-                    return workspaceService.create(desOrg).flatMap(createdOrg ->
-                            applicationForkingService.forkApplicationToWorkspace(srcApplication.getId(), createdOrg.getId())
-                    ).zipWith(Mono.just(srcApplication));
-                }).flatMap(applicationTuple2 -> {
-                    Application forkedApp = applicationTuple2.getT1();
-                    Application srcApp = applicationTuple2.getT2();
-                    return Mono.zip(
-                            themeService.getApplicationTheme(forkedApp.getId(), ApplicationMode.EDIT, null),
-                            themeService.getApplicationTheme(forkedApp.getId(), ApplicationMode.PUBLISHED, null),
-                            Mono.just(forkedApp),
-                            Mono.just(srcApp)
-                    );
-                });
+        Application application = new Application();
+        application.setName("app_" + uniqueString);
+        Application createdSrcApplication = applicationPageService.createApplication(application, createdSrcWorkspace.getId()).block();
+
+        Theme theme = new Theme();
+        theme.setDisplayName("theme_" + uniqueString);
+        themeService.updateTheme(createdSrcApplication.getId(), null, theme).block();
+        themeService.persistCurrentTheme(createdSrcApplication.getId(), null, theme).block();
+        createdSrcApplication = applicationService.findById(createdSrcApplication.getId()).block();
+
+        Workspace destWorkspace = new Workspace();
+        destWorkspace.setName("ws_dest_" + uniqueString);
+        Workspace createdDestWorkspace = workspaceService.create(destWorkspace).block();
+
+        Application forkedApplication = applicationForkingService.forkApplicationToWorkspace(createdSrcApplication.getId(), createdDestWorkspace.getId()).block();
+
+        Theme forkedApplicationEditModeTheme = themeService.getApplicationTheme(forkedApplication.getId(), ApplicationMode.EDIT, null).block();
+        Theme forkedApplicationPublishedModeTheme = themeService.getApplicationTheme(forkedApplication.getId(), ApplicationMode.PUBLISHED, null).block();
+
+        Mono<Tuple4<Theme, Theme, Application, Application>> tuple4Mono = Mono.zip(Mono.just(forkedApplicationEditModeTheme), Mono.just(forkedApplicationPublishedModeTheme), Mono.just(forkedApplication), Mono.just(createdSrcApplication));
 
         StepVerifier.create(tuple4Mono).assertNext(objects -> {
             Theme editModeTheme = objects.getT1();
@@ -707,7 +708,11 @@ public class ApplicationForkingServiceTests {
     @Test
     @WithUserDetails(value = "api_user")
     public void forkApplication_deletePageAfterBeingPublished_deletedPageIsNotCloned() {
-
+        // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
+        // copy all the actions and collections. This process may take time and since some of the test cases in
+        // ApplicationForkingServiceTests observed failure in the CI due to timeoutException, to unblock this temporarily,
+        // synchronous block() is being used until it is fixed.
+        // TODO: Investigate working of applicationForkingService.forkApplicationToWorkspace() further and fix the timeoutException.
         Workspace targetWorkspace = new Workspace();
         targetWorkspace.setName("delete-edit-mode-page-target-org");
         targetWorkspace = workspaceService.create(targetWorkspace).block();
@@ -726,9 +731,10 @@ public class ApplicationForkingServiceTests {
         pageDTO.setName("delete-edit-mode-page");
         pageDTO.setApplicationId(originalAppId);
         final String pageId = Objects.requireNonNull(applicationPageService.createPage(pageDTO).block()).getId();
-        final Mono<Application> resultMono = applicationPageService.publish(originalAppId, true)
-                .flatMap(ignored -> applicationPageService.deleteUnpublishedPage(pageId))
-                .flatMap(page -> applicationForkingService.forkApplicationToWorkspace(pageDTO.getApplicationId(), targetWorkspaceId));
+        applicationPageService.publish(originalAppId, true).block();
+        applicationPageService.deleteUnpublishedPage(pageId).block();
+        Application resultApplication = applicationForkingService.forkApplicationToWorkspace(pageDTO.getApplicationId(), targetWorkspaceId).block();
+        final Mono<Application> resultMono = Mono.just(resultApplication);
 
         StepVerifier.create(resultMono
                         .zipWhen(application1 -> newPageService.findNewPagesByApplicationId(application1.getId(), READ_PAGES).collectList()
@@ -764,66 +770,62 @@ public class ApplicationForkingServiceTests {
     @Test
     @WithUserDetails(value = "api_user")
     public void forkGitConnectedApplication_defaultBranchUpdated_forkDefaultBranchApplication() {
+        // Fork application is currently a slow API because it needs to create application, clone all the pages, and then
+        // copy all the actions and collections. This process may take time and since some of the test cases in
+        // ApplicationForkingServiceTests observed failure in the CI due to timeoutException, to unblock this temporarily,
+        // synchronous block() is being used until it is fixed.
+        // TODO: Investigate working of applicationForkingService.forkApplicationToWorkspace() further and fix the timeoutException.
         String uniqueString = UUID.randomUUID().toString();
         Workspace workspace = new Workspace();
-        workspace.setName("org_" + uniqueString);
+        workspace.setName("ws_" + uniqueString);
+        Workspace createdWorkspace = workspaceService.create(workspace).block();
 
-        Mono<Application> applicationMono = workspaceService.create(workspace)
-                .flatMap(createdOrg -> {
-                    Application application = new Application();
-                    application.setName("app_" + uniqueString);
-                    return applicationPageService.createApplication(application, createdOrg.getId());
-                }).flatMap(srcApplication -> {
-                    Theme theme = new Theme();
-                    theme.setDisplayName("theme_" + uniqueString);
-                    GitApplicationMetadata gitApplicationMetadata = new GitApplicationMetadata();
-                    gitApplicationMetadata.setDefaultApplicationId(srcApplication.getId());
-                    gitApplicationMetadata.setBranchName("master");
-                    gitApplicationMetadata.setDefaultBranchName("feature1");
-                    gitApplicationMetadata.setIsRepoPrivate(false);
-                    gitApplicationMetadata.setRepoName("testRepo");
-                    GitAuth gitAuth = new GitAuth();
-                    gitAuth.setPublicKey("testkey");
-                    gitAuth.setPrivateKey("privatekey");
-                    gitApplicationMetadata.setGitAuth(gitAuth);
-                    srcApplication.setGitApplicationMetadata(gitApplicationMetadata);
-                    return themeService.updateTheme(srcApplication.getId(), null, theme)
-                            .then(applicationService.save(srcApplication))
-                            .flatMap(application -> {
-                                // Create a branch application
-                                Application branchApp = new Application();
-                                branchApp.setName("app_" + uniqueString);
-                                return applicationPageService.createApplication(branchApp, srcApplication.getWorkspaceId())
-                                        .zipWith(Mono.just(srcApplication));
-                            });
-                })
-                .flatMap(tuple -> {
-                    Application branchApp = tuple.getT1();
-                    Application srcApplication = tuple.getT2();
-                    GitApplicationMetadata gitApplicationMetadata1 = new GitApplicationMetadata();
-                    gitApplicationMetadata1.setDefaultApplicationId(srcApplication.getId());
-                    gitApplicationMetadata1.setBranchName("feature1");
-                    gitApplicationMetadata1.setDefaultBranchName("feature1");
-                    gitApplicationMetadata1.setIsRepoPrivate(false);
-                    gitApplicationMetadata1.setRepoName("testRepo");
-                    branchApp.setGitApplicationMetadata(gitApplicationMetadata1);
-                    return applicationService.save(branchApp)
-                            .flatMap(application -> {
-                                PageDTO page = new PageDTO();
-                                page.setName("discard-page-test");
-                                page.setApplicationId(branchApp.getId());
-                                return applicationPageService.createPage(page)
-                                        .then(Mono.just(srcApplication));
-                            });
-                })
-                .flatMap(srcApplication -> {
-                    Workspace desOrg = new Workspace();
-                    desOrg.setName("org_dest_" + uniqueString);
+        Application application = new Application();
+        application.setName("app_" + uniqueString);
+        Application createdSrcApplication = applicationPageService.createApplication(application, createdWorkspace.getId()).block();
 
-                    return workspaceService.create(desOrg).flatMap(createdOrg ->
-                            applicationForkingService.forkApplicationToWorkspace(srcApplication.getGitApplicationMetadata().getDefaultApplicationId(), createdOrg.getId())
-                    );
-                });
+        Theme theme = new Theme();
+        theme.setDisplayName("theme_" + uniqueString);
+        GitApplicationMetadata gitApplicationMetadata = new GitApplicationMetadata();
+        gitApplicationMetadata.setDefaultApplicationId(createdSrcApplication.getId());
+        gitApplicationMetadata.setBranchName("master");
+        gitApplicationMetadata.setDefaultBranchName("feature1");
+        gitApplicationMetadata.setIsRepoPrivate(false);
+        gitApplicationMetadata.setRepoName("testRepo");
+        GitAuth gitAuth = new GitAuth();
+        gitAuth.setPublicKey("testkey");
+        gitAuth.setPrivateKey("privatekey");
+        gitApplicationMetadata.setGitAuth(gitAuth);
+        createdSrcApplication.setGitApplicationMetadata(gitApplicationMetadata);
+
+        themeService.updateTheme(createdSrcApplication.getId(), null, theme).block();
+        createdSrcApplication = applicationService.save(createdSrcApplication).block();
+
+        // Create a branch application
+        Application branchApp = new Application();
+        branchApp.setName("app_" + uniqueString);
+        Application createdBranchApplication = applicationPageService.createApplication(branchApp, createdSrcApplication.getWorkspaceId()).block();
+
+        GitApplicationMetadata gitApplicationMetadata1 = new GitApplicationMetadata();
+        gitApplicationMetadata1.setDefaultApplicationId(createdSrcApplication.getId());
+        gitApplicationMetadata1.setBranchName("feature1");
+        gitApplicationMetadata1.setDefaultBranchName("feature1");
+        gitApplicationMetadata1.setIsRepoPrivate(false);
+        gitApplicationMetadata1.setRepoName("testRepo");
+        createdBranchApplication.setGitApplicationMetadata(gitApplicationMetadata1);
+        createdBranchApplication = applicationService.save(createdBranchApplication).block();
+
+        PageDTO page = new PageDTO();
+        page.setName("discard-page-test");
+        page.setApplicationId(createdBranchApplication.getId());
+        applicationPageService.createPage(page).block();
+
+        Workspace destWorkspace = new Workspace();
+        destWorkspace.setName("ws_dest_" + uniqueString);
+        Workspace createdDestWorkspace = workspaceService.create(destWorkspace).block();
+        Application resultApplication = applicationForkingService.forkApplicationToWorkspace(createdBranchApplication.getGitApplicationMetadata().getDefaultApplicationId(), createdDestWorkspace.getId()).block();
+
+        Mono<Application> applicationMono = Mono.just(resultApplication);
 
         StepVerifier
                 .create(applicationMono)


### PR DESCRIPTION
## Description

This PR temporarily fixes the ApplicationForkingServiceTests failing on CI. Since `applicationForkingService.forkApplicationToWorkspace()` is long running process some of the occurrences of this is converted to synchronous `block()` to avoid test failures.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tests on local

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
