### PR TITLE
fix: Improve ssh url checking for git import

### DIFF
--- a/app/client/src/pages/Editor/gitSync/utils.test.ts
+++ b/app/client/src/pages/Editor/gitSync/utils.test.ts
@@ -26,6 +26,9 @@ const validUrls = [
   "git@ssh.dev.azure.com:v3/something/other/thing.git",
   "git@ssh.dev.azure.com:v3/something/other/(thing).git",
   "git@ssh.dev.azure.com:v3/(((something)/(other)/(thing).git",
+  "git@abcd.org:org__v3/(((something)/(other)/(thing).git",
+  "git@gitlab-abcd.test.org:org__org/repoName.git",
+  "git@gitlab__abcd.test.org:org__org/repoName.git",
 ];
 
 const invalidUrls = [

--- a/app/client/src/pages/Editor/gitSync/utils.ts
+++ b/app/client/src/pages/Editor/gitSync/utils.ts
@@ -18,7 +18,7 @@ export const getIsStartingWithRemoteBranches = (
   );
 };
 
-const GIT_REMOTE_URL_PATTERN = /^((git|ssh)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~\(\)]+)[^\/]$/im;
+const GIT_REMOTE_URL_PATTERN = /^((git|ssh)|(git@[\w\-\.]+))(:(\/\/)?)([\w\.@\:\/\-~\(\)]+)[^\/]$/im;
 
 const gitRemoteUrlRegExp = new RegExp(GIT_REMOTE_URL_PATTERN);
 


### PR DESCRIPTION
## Description

Fixes issue by allowing `-` in subdomain/domain.

Fixes #15432 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
