### PR TITLE
fix: ssh url validation to include a few cases where `-` is present in the url

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -47,7 +47,7 @@ public class GitUtils {
      */
     public static String getRepoName(String remoteUrl) {
         // Pattern to match git SSH URL
-        final Matcher matcher = Pattern.compile("((git|ssh|http(s)?)|(git@[\\w.]+))(:(\\/\\/)?)([\\w.@:/\\-~]+)(\\.git|)(\\/)?").matcher(remoteUrl);
+        final Matcher matcher = Pattern.compile("((git|ssh|http(s)?)|(git@[\\w\\-\\.]+))(:(\\/\\/)?)([\\w.@:/\\-~]+)(\\.git|)(\\/)?").matcher(remoteUrl);
         if (matcher.find()) {
             // To trim the postfix and prefix
             return matcher.group(7)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -68,6 +68,8 @@ public class GitUtilsTest {
                 .isEqualTo("fort-cheporder");
         assertThat(GitUtils.getRepoName("git@tim.tam.example.com:v3/sladeping/pyhe/SpaceJunk"))
                 .isEqualTo("SpaceJunk");
+        assertThat(GitUtils.getRepoName("git@examplelab-abcd.test.org:org_org/testNewRepo.git"))
+                .isEqualTo("testNewRepo");
     }
 
     @Test


### PR DESCRIPTION
## Description

> Update the regex which validates the ssh url to include a few cases as listed in the issue.

Fixes [# (issue)](https://github.com/appsmithorg/appsmith/issues/15432)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


- Locally
- JUnit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
