### PR TITLE
chore: Added isMock and isTemplate to action execution analytics

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -1085,10 +1085,14 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                             "statusCode", ObjectUtils.defaultIfNull(actionExecutionResult.getStatusCode(), ""),
                             "timeElapsed", timeElapsed,
                             "actionCreated", DateUtils.ISO_FORMATTER.format(action.getCreatedAt()),
-                            "actionId", ObjectUtils.defaultIfNull(action.getId(), ""),
+                            "actionId", ObjectUtils.defaultIfNull(action.getId(), "")
+                    ));
+                    data.putAll(Map.of(
                             "dsId", ObjectUtils.defaultIfNull(datasource.getId(), ""),
+                            "dsName", datasource.getName(),
+                            "dsIsTemplate", ObjectUtils.defaultIfNull(datasource.getIsTemplate(), ""),
+                            "dsIsMock", ObjectUtils.defaultIfNull(datasource.getIsMock(), ""),
                             "dsCreatedAt", dsCreatedAt
-
                     ));
 
                     // Add the error message in case of erroneous execution


### PR DESCRIPTION
## Description

Also introduced `dsName` which is the flattened location for `datasource.name`. Have not removed the older property in this PR.

The properties will now look like:
```
{
    "actionCreated": "2022-07-28T09:39:16.558Z",
    "actionId": "62e259443d32b3767ffbd3d5",
    "appId": "62b18a27cb9b083be9d9e3f2",
    "appMode": "edit",
    "appName": "My first application",
    "datasource": {
      "name": "Movies"
    },
    "dsCreatedAt": "2022-07-18T07:33:58.461Z",
    "dsId": "62d50ce64cd13c70bf5db4ae",
    "dsIsMock": true,
    "dsIsTemplate": "",
    "dsName": "Movies",
    "instanceId": "62b189f7cb9b083be9d9e34d",
    "isExampleApp": false,
    "isSuccessfulExecution": true,
    "name": "Query1",
    "orgId": "62b18a27cb9b083be9d9e3f1",
    "originService": "appsmith-server",
    "pageId": "62b18a28cb9b083be9d9e3f5",
    "pageName": "Page1",
    "pluginName": "MongoDB",
    "request": {
      "actionId": "62e259443d32b3767ffbd3d5",
      "query": "{\"find\": \"movies\", \"filter\": {}, \"limit\": 10, \"batchSize\": 10}",
      "requestedAt": {
        "nanos": 369733000,
        "seconds": 1659001166
      }
    }
```

Fixes #15504

## Type of change
- Chore

## How Has This Been Tested?
- Manually tested with local Segment key

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
