### PR TITLE
fix: fix self cyclic dep error in GraphQL plugin

### DIFF
--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -270,7 +270,12 @@ public class GraphQLPlugin extends BasePlugin {
          */
         @Override
         public Set<String> getSelfReferencingDataPaths() {
-            return Set.of("pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value");
+            return Set.of("pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value.limitBased.limit.value",
+                    "pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value.limitBased.offset.value",
+                    "pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value.cursorBased.next.limit.value",
+                    "pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value.cursorBased.next.cursor.value",
+                    "pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value.cursorBased.previous.limit.value",
+                    "pluginSpecifiedTemplates[" + PAGINATION_DATA_INDEX + "].value.cursorBased.previous.cursor.value");
         }
     }
 }


### PR DESCRIPTION
## Description
- fix self cyclic dep error in GraphQL plugin
- self referencing data path concept was introduced in one of the earlier commits. The idea is to ignore any dynamic binding in these paths when computing on page load actions / cyclic dep errors.

Fixes #15529 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
