### PR TITLE
fix: Fix potential delay in sending setup completion

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SegmentConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SegmentConfig.java
@@ -83,14 +83,14 @@ public class SegmentConfig {
         public void print(Level level, Throwable error, String format, Object... args) {
             final String message = "SEGMENT: " + format;
             if (level == Level.VERBOSE) {
-                log.trace(message, error, args);
+                log.trace(String.format(message, args), error);
             } else if (level == Level.DEBUG) {
-                log.debug(message, error, args);
+                log.debug(String.format(message, args), error);
             } else if (level == Level.ERROR) {
                 if (errorHandler != null) {
                     errorHandler.accept(new LogData(error, format, args));
                 }
-                log.error(message, error, args);
+                log.error(String.format(message, args), error);
             }
         }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -204,9 +204,10 @@ public class UserSignupCEImpl implements UserSignupCE {
                     userData.setUseCase(userFromRequest.getUseCase());
 
                     return Mono.when(
-                            userDataService.updateForUser(user, userData)
-                                    .then(configService.getInstanceId())
-                                    .doOnSuccess(instanceId -> {
+                            userDataService.updateForUser(user, userData),
+                            configService.getInstanceId()
+                                    .map(instanceId -> {
+                                        log.debug("Installation setup complete.");
                                         analyticsService.sendEvent(
                                                 AnalyticsEvents.INSTALLATION_SETUP_COMPLETE.getEventName(),
                                                 instanceId,


### PR DESCRIPTION
The Installation setup complete event is not getting sent _sometimes_, and it's behavior looks very much like there's some race condition somewhere. I'm proposing this change towards two goals.

One, currently, we send the event after the user-entered data is saved to the DB. But, there's no actual dependency, no point to waiting on that for sending the event. The actual user itself, is already created and signed up. So, one change is that we don't wait for the DB update to be applied. I'm also changing `.onSuccess` to `.map`, hoping that might make a difference.

Two, make a debug log entry to see if it is our callback function that's not getting invoked, or if Segment's API isn't doing it's job, when the event is not sent.

This PR also fixes formatting of Segment error messages.
