### PR TITLE
feat: parent message listener

### DIFF
--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -18,7 +18,8 @@ export enum ActionTriggerType {
   WATCH_CURRENT_LOCATION = "WATCH_CURRENT_LOCATION",
   STOP_WATCHING_CURRENT_LOCATION = "STOP_WATCHING_CURRENT_LOCATION",
   CONFIRMATION_MODAL = "CONFIRMATION_MODAL",
-  LISTEN_TO_PARENT_MESSAGES = "LISTEN_TO_PARENT_MESSAGES",
+  SUBSCRIBE_PARENT_MESSAGES = "LISTEN_TO_PARENT_MESSAGES",
+  UNSUBSCRIBE_PARENT_MESSAGES = "UNSUBSCRIBE_PARENT_LISTENER",
 }
 
 export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
@@ -38,15 +39,8 @@ export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
   [ActionTriggerType.WATCH_CURRENT_LOCATION]: "watchLocation",
   [ActionTriggerType.STOP_WATCHING_CURRENT_LOCATION]: "stopWatch",
   [ActionTriggerType.CONFIRMATION_MODAL]: "ConfirmationModal",
-  [ActionTriggerType.LISTEN_TO_PARENT_MESSAGES]: "listenToParentMessages",
-};
-
-export type ParentMessageListenerDescription = {
-  type: ActionTriggerType.LISTEN_TO_PARENT_MESSAGES;
-  payload: {
-    acceptedOrigin: string;
-    callback: () => void;
-  };
+  [ActionTriggerType.SUBSCRIBE_PARENT_MESSAGES]: "subscribeParentMessages",
+  [ActionTriggerType.UNSUBSCRIBE_PARENT_MESSAGES]: "unsubscribeParentMessages",
 };
 
 export type RunPluginActionDescription = {
@@ -176,6 +170,21 @@ export type ConfirmationModal = {
   payload?: Record<string, any>;
 };
 
+export type SubscribeParentDescription = {
+  type: ActionTriggerType.SUBSCRIBE_PARENT_MESSAGES;
+  payload: {
+    acceptedOrigin: string;
+    callbackString: string;
+  };
+};
+
+export type UnsubscribeParentDescription = {
+  type: ActionTriggerType.UNSUBSCRIBE_PARENT_MESSAGES;
+  payload: {
+    origin: string;
+  };
+};
+
 export type ActionDescription =
   | RunPluginActionDescription
   | ClearPluginActionDescription
@@ -192,4 +201,6 @@ export type ActionDescription =
   | GetCurrentLocationDescription
   | WatchCurrentLocationDescription
   | StopWatchingCurrentLocationDescription
-  | ConfirmationModal;
+  | ConfirmationModal
+  | SubscribeParentDescription
+  | UnsubscribeParentDescription;

--- a/app/client/src/entities/DataTree/actionTriggers.ts
+++ b/app/client/src/entities/DataTree/actionTriggers.ts
@@ -18,6 +18,7 @@ export enum ActionTriggerType {
   WATCH_CURRENT_LOCATION = "WATCH_CURRENT_LOCATION",
   STOP_WATCHING_CURRENT_LOCATION = "STOP_WATCHING_CURRENT_LOCATION",
   CONFIRMATION_MODAL = "CONFIRMATION_MODAL",
+  LISTEN_TO_PARENT_MESSAGES = "LISTEN_TO_PARENT_MESSAGES",
 }
 
 export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
@@ -37,6 +38,15 @@ export const ActionTriggerFunctionNames: Record<ActionTriggerType, string> = {
   [ActionTriggerType.WATCH_CURRENT_LOCATION]: "watchLocation",
   [ActionTriggerType.STOP_WATCHING_CURRENT_LOCATION]: "stopWatch",
   [ActionTriggerType.CONFIRMATION_MODAL]: "ConfirmationModal",
+  [ActionTriggerType.LISTEN_TO_PARENT_MESSAGES]: "listenToParentMessages",
+};
+
+export type ParentMessageListenerDescription = {
+  type: ActionTriggerType.LISTEN_TO_PARENT_MESSAGES;
+  payload: {
+    acceptedOrigin: string;
+    callback: () => void;
+  };
 };
 
 export type RunPluginActionDescription = {

--- a/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
+++ b/app/client/src/sagas/ActionExecution/ActionExecutionSagas.ts
@@ -50,6 +50,10 @@ import {
 import { requestModalConfirmationSaga } from "sagas/UtilSagas";
 import { ModalType } from "reducers/uiReducers/modalActionReducer";
 import { get, set, size } from "lodash";
+import {
+  listenToParentMessages,
+  unsubscribeParentMessages,
+} from "./ParentMessageListenerSaga";
 
 export type TriggerMeta = {
   source?: TriggerSource;
@@ -148,6 +152,21 @@ export function* executeActionTriggers(
       if (!flag) {
         throw new UserCancelledActionExecutionError();
       }
+      break;
+    case ActionTriggerType.SUBSCRIBE_PARENT_MESSAGES:
+      response = yield call(
+        listenToParentMessages,
+        trigger.payload,
+        eventType,
+        triggerMeta,
+      );
+      break;
+    case ActionTriggerType.UNSUBSCRIBE_PARENT_MESSAGES:
+      response = yield call(
+        unsubscribeParentMessages,
+        trigger.payload,
+        triggerMeta,
+      );
       break;
     default:
       log.error("Trigger type unknown", trigger);

--- a/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
+++ b/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
@@ -18,7 +18,6 @@ interface MessageChannelPayload {
 const subscriptionsMap = new Map<
   string,
   {
-    // messageChannel: Channel<MessageChannelPayload>;
     windowListenerUnSubscribe: () => void;
     spawnedTask: Task;
     triggerMeta: TriggerMeta;
@@ -39,7 +38,7 @@ function* messageChannelHandler(channel: Channel<MessageChannelPayload>) {
       });
     }
   } finally {
-    console.log("------------- cancelled task");
+    // console.log("------------- cancelled task");
     channel.close();
   }
 }
@@ -49,7 +48,7 @@ export function* listenToParentMessages(
   eventType: EventType,
   triggerMeta: TriggerMeta,
 ) {
-  console.log("------------- Parent listener called");
+  // console.log("------------- Parent listener called");
   const existingSubscription = subscriptionsMap.get(
     actionPayload.acceptedOrigin,
   );
@@ -87,7 +86,6 @@ export function* listenToParentMessages(
   window.addEventListener("message", messageHandler);
 
   subscriptionsMap.set(actionPayload.acceptedOrigin, {
-    // messageChannel,
     windowListenerUnSubscribe: () =>
       window.removeEventListener("message", messageHandler),
     spawnedTask,
@@ -110,7 +108,6 @@ export function* unsubscribeParentMessages(
   }
 
   existingSubscription.windowListenerUnSubscribe();
-  // existingSubscription.messageChannel.close();
   yield cancel(existingSubscription.spawnedTask);
   subscriptionsMap.delete(actionPayload.origin);
 }

--- a/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
+++ b/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
@@ -1,0 +1,18 @@
+import { ParentMessageListenerDescription } from "entities/DataTree/actionTriggers";
+
+export function listenToParentMessages(
+  actionPayload: ParentMessageListenerDescription["payload"],
+) {
+  const messageHandler = (ev: Event) => {
+    const event = ev as MessageEvent;
+    const src = event.source as Window;
+
+    if (event.type !== "message") return;
+    if (src.location.origin !== actionPayload.acceptedOrigin) return;
+
+    actionPayload.callback();
+  };
+
+  window.addEventListener("messages", messageHandler);
+  return () => window.removeEventListener("messages", messageHandler);
+}

--- a/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
+++ b/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
@@ -1,18 +1,111 @@
-import { ParentMessageListenerDescription } from "entities/DataTree/actionTriggers";
+import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import {
+  SubscribeParentDescription,
+  UnsubscribeParentDescription,
+} from "entities/DataTree/actionTriggers";
+import { Channel, channel, Task } from "redux-saga";
+import { call, take, spawn, cancel } from "redux-saga/effects";
+import { executeAppAction, TriggerMeta } from "./ActionExecutionSagas";
+import { logActionExecutionError } from "./errorUtils";
 
-export function listenToParentMessages(
-  actionPayload: ParentMessageListenerDescription["payload"],
+interface MessageChannelPayload {
+  callbackString: string;
+  callbackData: unknown;
+  eventType: EventType;
+  triggerMeta: TriggerMeta;
+}
+
+const subscriptionsMap = new Map<
+  string,
+  {
+    // messageChannel: Channel<MessageChannelPayload>;
+    windowListenerUnSubscribe: () => void;
+    spawnedTask: Task;
+    triggerMeta: TriggerMeta;
+  }
+>();
+
+function* messageChannelHandler(channel: Channel<MessageChannelPayload>) {
+  try {
+    while (true) {
+      const payload: MessageChannelPayload = yield take(channel);
+      const { callbackData, callbackString, eventType, triggerMeta } = payload;
+      yield call(executeAppAction, {
+        dynamicString: callbackString,
+        callbackData: [callbackData],
+        event: { type: eventType },
+        triggerPropertyName: triggerMeta.triggerPropertyName,
+        source: triggerMeta.source,
+      });
+    }
+  } finally {
+    console.log("------------- cancelled task");
+    channel.close();
+  }
+}
+
+export function* listenToParentMessages(
+  actionPayload: SubscribeParentDescription["payload"],
+  eventType: EventType,
+  triggerMeta: TriggerMeta,
 ) {
-  const messageHandler = (ev: Event) => {
-    const event = ev as MessageEvent;
-    const src = event.source as Window;
+  console.log("------------- Parent listener called");
+  const existingSubscription = subscriptionsMap.get(
+    actionPayload.acceptedOrigin,
+  );
+  if (existingSubscription) {
+    logActionExecutionError(
+      `Already listening to ${actionPayload.acceptedOrigin}. 
+      ${existingSubscription.triggerMeta.source} -> ${existingSubscription.triggerMeta.triggerPropertyName}`,
+      triggerMeta.source,
+      triggerMeta.triggerPropertyName,
+    );
+    return;
+  }
 
+  const messageChannel = channel<MessageChannelPayload>();
+  const spawnedTask: Task = yield spawn(messageChannelHandler, messageChannel);
+
+  const messageHandler = (event: MessageEvent) => {
+    if (event.currentTarget !== window) return;
     if (event.type !== "message") return;
-    if (src.location.origin !== actionPayload.acceptedOrigin) return;
+    if (event.origin !== actionPayload.acceptedOrigin) return;
 
-    actionPayload.callback();
+    messageChannel.put({
+      callbackString: actionPayload.callbackString,
+      callbackData: event.data,
+      eventType,
+      triggerMeta,
+    });
   };
 
-  window.addEventListener("messages", messageHandler);
-  return () => window.removeEventListener("messages", messageHandler);
+  window.addEventListener("message", messageHandler);
+
+  subscriptionsMap.set(actionPayload.acceptedOrigin, {
+    // messageChannel,
+    windowListenerUnSubscribe: () =>
+      window.removeEventListener("message", messageHandler),
+    spawnedTask,
+    triggerMeta,
+  });
+}
+
+export function* unsubscribeParentMessages(
+  actionPayload: UnsubscribeParentDescription["payload"],
+  triggerMeta: TriggerMeta,
+) {
+  const existingSubscription = subscriptionsMap.get(actionPayload.origin);
+  if (!existingSubscription) {
+    logActionExecutionError(
+      `No subcriptions to ${actionPayload.origin}`,
+      triggerMeta.source,
+      triggerMeta.triggerPropertyName,
+    );
+    return;
+  }
+
+  existingSubscription.windowListenerUnSubscribe();
+  // existingSubscription.messageChannel.close();
+  yield cancel(existingSubscription.spawnedTask);
+  subscriptionsMap.delete(actionPayload.origin);
 }

--- a/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
+++ b/app/client/src/sagas/ActionExecution/ParentMessageListenerSaga.ts
@@ -56,7 +56,12 @@ export function* listenToParentMessages(
   if (existingSubscription) {
     logActionExecutionError(
       `Already listening to ${actionPayload.acceptedOrigin}. 
-      ${existingSubscription.triggerMeta.source} -> ${existingSubscription.triggerMeta.triggerPropertyName}`,
+      ${
+        existingSubscription.triggerMeta.source?.name &&
+        existingSubscription.triggerMeta.triggerPropertyName
+          ? `${existingSubscription.triggerMeta.source?.name} -> ${existingSubscription.triggerMeta.triggerPropertyName}`
+          : ""
+      }`,
       triggerMeta.source,
       triggerMeta.triggerPropertyName,
     );

--- a/app/client/src/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/utils/autocomplete/EntityDefinitions.ts
@@ -695,6 +695,14 @@ export const GLOBAL_FUNCTIONS = {
     "!doc": "Stop executing a setInterval with id",
     "!type": "fn(id: string) -> void",
   },
+  subscribeParentMessages: {
+    "!doc": "Subscribe to messages from parent window",
+    "!type": "fn(origin: string, callback: fn) -> void",
+  },
+  unsubscribeParentMessages: {
+    "!doc": "Unsubscribe to messages from parent window",
+    "!type": "fn(origin: string) -> void",
+  },
 };
 
 export const getPropsForJSActionEntity = ({

--- a/app/client/src/workers/Actions.ts
+++ b/app/client/src/workers/Actions.ts
@@ -261,6 +261,25 @@ export const DATA_TREE_FUNCTIONS: Record<
         };
       },
   },
+  subscribeParentMessages: function(origin: string, callback: Function) {
+    return {
+      type: ActionTriggerType.SUBSCRIBE_PARENT_MESSAGES,
+      payload: {
+        acceptedOrigin: origin,
+        callbackString: callback.toString(),
+      },
+      executionType: ExecutionType.TRIGGER,
+    };
+  },
+  unsubscribeParentMessages: function(origin: string) {
+    return {
+      type: ActionTriggerType.UNSUBSCRIBE_PARENT_MESSAGES,
+      payload: {
+        origin,
+      },
+      executionType: ExecutionType.TRIGGER,
+    };
+  },
 };
 
 export const enhanceDataTreeWithFunctions = (


### PR DESCRIPTION
## Description
When appsmith is embedded as an iframe, listen to messages from parent window.


Fixes #15538

## Global methods added
- `subscribeParentMessages`
```
subscribeParentMessages(
	"https://eco-monk.github.io", 
	(message) => { showAlert(message) }
)
```

- `unsubscribeParentMessages`
```
unsubscribeParentMessages("https://eco-monk.github.io")
```

## Todo
- [ ] `messageHandler` - check `event.currentTarget` vs `event.target` for event bubbling.
- [ ] Add methods in action creator

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual:
- Test by calling multiple subscribes and unsubscribes for same website (error message shown)
- Test with different origins (messages received only for subscribed origins)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
