### PR TITLE
fix: Re-render of PropertyPaneConnections

### DIFF
--- a/app/client/src/selectors/debuggerSelectors.tsx
+++ b/app/client/src/selectors/debuggerSelectors.tsx
@@ -1,20 +1,25 @@
 import { matchDatasourcePath } from "constants/routes";
 import { DataTree, DataTreeWidget } from "entities/DataTree/dataTreeFactory";
+import { isEmpty } from "lodash";
 import { AppState } from "reducers";
 import { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
 import { createSelector } from "reselect";
 import { getWidgets } from "sagas/selectors";
 import { isWidget } from "workers/evaluationUtils";
 import { getDataTree } from "./dataTreeSelectors";
+
 export const getDebuggerErrors = (state: AppState) => state.ui.debugger.errors;
 export const hideErrors = (state: AppState) => state.ui.debugger.hideErrors;
+const emptyObejct = {};
+
 export const getFilteredErrors = createSelector(
   getDebuggerErrors,
   hideErrors,
   getWidgets,
   getDataTree,
   (errors, hideErrors, canvasWidgets, dataTree: DataTree) => {
-    if (hideErrors) return {};
+    if (hideErrors) return emptyObejct;
+    if (isEmpty(errors)) return emptyObejct;
 
     const alwaysShowEntities: Record<string, boolean> = {};
     Object.entries(errors).forEach(([, error]) => {


### PR DESCRIPTION
## Description

Prevents the re-rendering of PropertyPane connections when a property changes

Fixes #15528

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
