### PR TITLE
fix: Delay in display of Intercom pop up when user tries to upgrade the Watermark property

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/authentication/AuthPage.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication/AuthPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useHistory } from "react-router-dom";
 import { SettingCategories } from "../types";
 import styled from "styled-components";
@@ -15,9 +15,6 @@ import {
 } from "@appsmith/constants/messages";
 import { Callout, CalloutType } from "components/ads/CalloutV2";
 import { getAppsmithConfigs } from "@appsmith/configs";
-import { getCurrentUser } from "selectors/usersSelectors";
-import { useSelector } from "react-redux";
-import bootIntercom from "utils/bootIntercom";
 import { Colors } from "constants/Colors";
 import Icon from "components/ads/Icon";
 import { TooltipComponent } from "design-system";
@@ -134,11 +131,6 @@ const Label = styled.span<{ enterprise?: boolean }>`
 
 export function AuthPage({ authMethods }: { authMethods: AuthMethodType[] }) {
   const history = useHistory();
-  const user = useSelector(getCurrentUser);
-
-  useEffect(() => {
-    bootIntercom(user);
-  }, [user?.email]);
 
   const triggerIntercom = (authLabel: string) => {
     if (intercomAppID && window.Intercom) {

--- a/app/client/src/ce/pages/AdminSettings/index.tsx
+++ b/app/client/src/ce/pages/AdminSettings/index.tsx
@@ -8,6 +8,8 @@ import styled from "styled-components";
 import LeftPane from "@appsmith/pages/AdminSettings/LeftPane";
 import Main from "@appsmith/pages/AdminSettings/Main";
 import WithSuperUserHOC from "pages/Settings/WithSuperUserHoc";
+import { getCurrentUser } from "selectors/usersSelectors";
+import bootIntercom from "utils/bootIntercom";
 
 const FlexContainer = styled.div`
   display: flex;
@@ -22,7 +24,9 @@ const LoaderContainer = styled.div`
 
 function Settings() {
   const dispatch = useDispatch();
+  const user = useSelector(getCurrentUser);
   const isLoading = useSelector(getSettingsLoadingState);
+
   useEffect(() => {
     dispatch({
       type: ReduxActionTypes.FETCH_ADMIN_SETTINGS,
@@ -31,6 +35,10 @@ function Settings() {
       type: ReduxActionTypes.FETCH_RELEASES,
     });
   }, []);
+
+  useEffect(() => {
+    bootIntercom(user);
+  }, [user?.email]);
 
   return (
     <PageWrapper>

--- a/app/client/src/utils/hooks/useOnUpgrade.ts
+++ b/app/client/src/utils/hooks/useOnUpgrade.ts
@@ -1,9 +1,4 @@
-import { useEffect } from "react";
-import { useSelector } from "react-redux";
-
-import bootIntercom from "utils/bootIntercom";
 import { getAppsmithConfigs } from "@appsmith/configs";
-import { getCurrentUser } from "selectors/usersSelectors";
 import { createMessage, UPGRADE_TO_EE_GENERIC } from "ce/constants/messages";
 import AnalyticsUtil, { EventName } from "utils/AnalyticsUtil";
 
@@ -16,12 +11,6 @@ type Props = {
 };
 
 const useOnUpgrade = (props: Props) => {
-  const user = useSelector(getCurrentUser);
-
-  useEffect(() => {
-    bootIntercom(user);
-  }, [user?.email]);
-
   const { intercomMessage, logEventData, logEventName } = props;
 
   const triggerIntercom = (message: string) => {

--- a/app/client/src/utils/hooks/useOnUpgrade.ts
+++ b/app/client/src/utils/hooks/useOnUpgrade.ts
@@ -1,4 +1,9 @@
+import { useEffect } from "react";
+import { useSelector } from "react-redux";
+
+import bootIntercom from "utils/bootIntercom";
 import { getAppsmithConfigs } from "@appsmith/configs";
+import { getCurrentUser } from "selectors/usersSelectors";
 import { createMessage, UPGRADE_TO_EE_GENERIC } from "ce/constants/messages";
 import AnalyticsUtil, { EventName } from "utils/AnalyticsUtil";
 
@@ -11,6 +16,12 @@ type Props = {
 };
 
 const useOnUpgrade = (props: Props) => {
+  const user = useSelector(getCurrentUser);
+
+  useEffect(() => {
+    bootIntercom(user);
+  }, [user?.email]);
+
   const { intercomMessage, logEventData, logEventName } = props;
 
   const triggerIntercom = (message: string) => {


### PR DESCRIPTION
We were booting intercom only on auth pages of admin settings, this PR boots the intercom on all admin settings.

Fixes #15570

## Type of change

- Bug fix

## How Has This Been Tested?
- by QA manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
