### PR TITLE
fix: fix Mongo plugin query execution failure 

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -617,7 +617,7 @@ public class MongoPlugin extends BasePlugin {
                     .map(uriString -> MongoClients.create(
                             MongoClientSettings
                                     .builder()
-                                    .applyToConnectionPoolSettings(pool -> pool.applySettings(ConnectionPoolSettings.builder().minSize(0).build()))
+                                    .applyToConnectionPoolSettings(t -> t.applySettings(ConnectionPoolSettings.builder().minSize(0).build()))
                                     .applyConnectionString(new ConnectionString(uriString))
                                     .build()
                     ))

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -336,6 +336,15 @@ public class MongoPlugin extends BasePlugin {
                                     error.getErrorMessage()
                             )
                     )
+                    /**
+                     * This is to catch the cases when Mongo connection pool closes for some reason and hence throws
+                     * IllegalStateException when query is run.
+                     * Ref: https://github.com/appsmithorg/appsmith/issues/15548
+                     */
+                    .onErrorMap(
+                            IllegalStateException.class,
+                            error -> new StaleConnectionException()
+                    )
                     // This is an experimental fix to handle the scenario where after a period of inactivity, the mongo
                     // database drops the connection which makes the client throw the following exception.
                     .onErrorMap(
@@ -608,7 +617,7 @@ public class MongoPlugin extends BasePlugin {
                     .map(uriString -> MongoClients.create(
                             MongoClientSettings
                                     .builder()
-                                    .applyToConnectionPoolSettings(t -> t.applySettings(ConnectionPoolSettings.builder().minSize(0).build()))
+                                    .applyToConnectionPoolSettings(pool -> pool.applySettings(ConnectionPoolSettings.builder().minSize(0).build()))
                                     .applyConnectionString(new ConnectionString(uriString))
                                     .build()
                     ))
@@ -810,6 +819,21 @@ public class MongoPlugin extends BasePlugin {
                     })
                     .collectList()
                     .thenReturn(structure)
+                    /**
+                     * This is to catch the cases when Mongo connection pool closes for some reason and hence throws
+                     * IllegalStateException when query is run.
+                     * Ref: https://github.com/appsmithorg/appsmith/issues/15548
+                     */
+                    .onErrorMap(
+                            IllegalStateException.class,
+                            error -> new StaleConnectionException()
+                    )
+                    // This is an experimental fix to handle the scenario where after a period of inactivity, the mongo
+                    // database drops the connection which makes the client throw the following exception.
+                    .onErrorMap(
+                            MongoSocketWriteException.class,
+                            error -> new StaleConnectionException()
+                    )
                     .onErrorMap(
                             MongoCommandException.class,
                             error -> {


### PR DESCRIPTION
## Description
- Currently some cases have been seen where a Mongo plugin query fails with error message: `state should be: server session pool is open`. 
  - As per my investigation, this occurs because the connection pool at this point has already been closed. Hence running any query against the closed connection pool results in a `IllegalStateException`. 
  - At this point it is not known what is causing the connection pool to close. 
- This PR introduces a change to handle the `IllegalConnectionException` as a `StaleConnectionException` which would result in the connection pool being re-created. 
  - Note: It was not possible to check for closed connection before executing the query because the `MongoClient` object does not seem to expose any `isClosed` kind of method.  

Fixes #15548

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- JUnit TC

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
