### PR TITLE
fix: Do not cache updatable connections

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -1,6 +1,5 @@
 package com.appsmith.server.services;
 
-import com.appsmith.external.services.EncryptionService;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.services.ce.DatasourceContextServiceCEImpl;
 import lombok.extern.slf4j.Slf4j;
@@ -13,9 +12,8 @@ public class DatasourceContextServiceImpl extends DatasourceContextServiceCEImpl
     public DatasourceContextServiceImpl(DatasourceService datasourceService,
                                         PluginService pluginService,
                                         PluginExecutorHelper pluginExecutorHelper,
-                                        EncryptionService encryptionService,
                                         ConfigService configService) {
 
-        super(datasourceService, pluginService, pluginExecutorHelper, encryptionService, configService);
+        super(datasourceService, pluginService, pluginExecutorHelper, configService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -6,7 +6,6 @@ import com.appsmith.external.exceptions.pluginExceptions.StaleConnectionExceptio
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.UpdatableConnection;
 import com.appsmith.external.plugins.PluginExecutor;
-import com.appsmith.external.services.EncryptionService;
 import com.appsmith.server.domains.DatasourceContext;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.helpers.PluginExecutorHelper;
@@ -34,19 +33,16 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
     private final DatasourceService datasourceService;
     private final PluginService pluginService;
     private final PluginExecutorHelper pluginExecutorHelper;
-    private final EncryptionService encryptionService;
     private final ConfigService configService;
 
     @Autowired
     public DatasourceContextServiceCEImpl(DatasourceService datasourceService,
                                           PluginService pluginService,
                                           PluginExecutorHelper pluginExecutorHelper,
-                                          EncryptionService encryptionService,
                                           ConfigService configService) {
         this.datasourceService = datasourceService;
         this.pluginService = pluginService;
         this.pluginExecutorHelper = pluginExecutorHelper;
-        this.encryptionService = encryptionService;
         this.datasourceContextMap = new ConcurrentHashMap<>();
         this.datasourceContextMonoMap = new ConcurrentHashMap<>();
         this.datasourceContextSynchronizationMonitorMap = new ConcurrentHashMap<>();
@@ -80,11 +76,14 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                 final Object connection = datasourceContextMap.get(datasourceId).getConnection();
                 if (connection != null) {
                     try {
+                        // Basically remove entry from both cache maps
                         pluginExecutor.datasourceDestroy(connection);
                     } catch (Exception e) {
                         log.info("Error destroying stale datasource connection", e);
                     }
                 }
+                datasourceContextMonoMap.remove(datasourceId);
+                datasourceContextMap.remove(datasourceId);
             }
 
             /*
@@ -134,11 +133,7 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                     )
                     .cache(); /* Cache the value so that further evaluations don't result in new connections */
             if (datasourceId != null) {
-                return connectionMono.doOnNext(connection -> {
-                    if(!(connection instanceof UpdatableConnection)) {
-                        datasourceContextMonoMap.put(datasourceId, datasourceContextMonoCache);
-                    }
-                }).then(datasourceContextMonoCache);
+                datasourceContextMonoMap.put(datasourceId, datasourceContextMonoCache);
             }
             return datasourceContextMonoCache;
         }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -190,9 +190,9 @@ public class DatasourceContextServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void testDatasourceCreate_withUpdatableConnection_recreatesConnectionAlways() {
-        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
-
         MockPluginExecutor mockPluginExecutor = new MockPluginExecutor();
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(mockPluginExecutor));
+
         MockPluginExecutor spyMockPluginExecutor = spy(mockPluginExecutor);
         /* Return two different connection objects if `datasourceCreate` method is called twice */
         doReturn(Mono.just((UpdatableConnection) auth -> new DBAuth()))
@@ -201,7 +201,7 @@ public class DatasourceContextServiceTest {
 
         Mono<Plugin> pluginMono = pluginService.findByName("Installed Plugin Name");
         Datasource datasource = new Datasource();
-        datasource.setName("test datasource name for authenticated fields decryption test");
+        datasource.setName("test datasource name for updatable connection test");
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
         datasourceConfiguration.setUrl("http://test.com");
         DBAuth authenticationDTO = new DBAuth();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -1,13 +1,16 @@
 package com.appsmith.server.services;
 
+import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.external.models.BasicAuth;
 import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.UpdatableConnection;
 import com.appsmith.external.services.EncryptionService;
 import com.appsmith.server.acl.AclPermission;
-import com.appsmith.external.models.Datasource;
 import com.appsmith.server.domains.DatasourceContext;
-import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.domains.Plugin;
+import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.WorkspaceRepository;
@@ -28,10 +31,11 @@ import reactor.test.StepVerifier;
 import reactor.util.function.Tuple2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -159,22 +163,78 @@ public class DatasourceContextServiceTest {
         doReturn(Mono.just("connection_1")).doReturn(Mono.just("connection_2")).when(spyMockPluginExecutor).datasourceCreate(any());
 
         Datasource datasource = new Datasource();
-        datasource.setId("id");
+        datasource.setId("id1");
+        datasource.setDatasourceConfiguration(new DatasourceConfiguration());
 
         Object monitor = new Object();
-        Mono<DatasourceContext> dsContextMono1 = datasourceContextService.getCachedDatasourceContextMono(datasource,
+        Mono<DatasourceContext<?>> dsContextMono1 = datasourceContextService.getCachedDatasourceContextMono(datasource,
                 spyMockPluginExecutor, monitor);
-        Mono<DatasourceContext> dsContextMono2 = datasourceContextService.getCachedDatasourceContextMono(datasource,
+        Mono<DatasourceContext<?>> dsContextMono2 = datasourceContextService.getCachedDatasourceContextMono(datasource,
                 spyMockPluginExecutor, monitor);
-        Mono<Tuple2<DatasourceContext, DatasourceContext>> zipMono = Mono.zip(dsContextMono1, dsContextMono2);
+        Mono<Tuple2<DatasourceContext, DatasourceContext<?>>> zipMono = Mono.zip(dsContextMono1, dsContextMono2);
         StepVerifier.create(zipMono)
                 .assertNext(tuple -> {
-                    DatasourceContext dsContext1 = tuple.getT1();
-                    DatasourceContext dsContext2 = tuple.getT2();
+                    DatasourceContext<?> dsContext1 = tuple.getT1();
+                    DatasourceContext<?> dsContext2 = tuple.getT2();
                     /* They can only be equal if the `datasourceCreate` method was called only once */
                     assertEquals(dsContext1.getConnection(), dsContext2.getConnection());
                     assertEquals("connection_1", dsContext1.getConnection());
                 })
                 .verifyComplete();
+    }
+
+    /**
+     * This test checks that if `getCachedDatasourceCreate` method is called two times for the same datasource id, then
+     * the datasource creation happens again and again for UpdatableConnection types
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testDatasourceCreate_withUpdatableConnection_recreatesConnectionAlways() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
+
+        MockPluginExecutor mockPluginExecutor = new MockPluginExecutor();
+        MockPluginExecutor spyMockPluginExecutor = spy(mockPluginExecutor);
+        /* Return two different connection objects if `datasourceCreate` method is called twice */
+        doReturn(Mono.just((UpdatableConnection) auth -> new DBAuth()))
+                .doReturn(Mono.just((UpdatableConnection) auth -> new BasicAuth()))
+                .when(spyMockPluginExecutor).datasourceCreate(any());
+
+        Mono<Plugin> pluginMono = pluginService.findByName("Installed Plugin Name");
+        Datasource datasource = new Datasource();
+        datasource.setName("test datasource name for authenticated fields decryption test");
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        DBAuth authenticationDTO = new DBAuth();
+        String username = "username";
+        String password = "password";
+        authenticationDTO.setUsername(username);
+        authenticationDTO.setPassword(password);
+        datasourceConfiguration.setAuthentication(authenticationDTO);
+        datasource.setDatasourceConfiguration(datasourceConfiguration);
+        datasource.setWorkspaceId(workspaceId);
+
+        final Datasource createdDatasource = pluginMono
+                .map(plugin -> {
+                    datasource.setPluginId(plugin.getId());
+                    return datasource;
+                })
+                .flatMap(datasourceService::create)
+                .block();
+
+        assert createdDatasource != null;
+
+        Object monitor = new Object();
+        final DatasourceContext<?> dsc1 = (DatasourceContext) datasourceContextService.getCachedDatasourceContextMono(createdDatasource,
+                spyMockPluginExecutor, monitor).block();
+        assertNotNull(dsc1);
+        assertTrue(dsc1.getConnection() instanceof UpdatableConnection);
+        assertTrue(((UpdatableConnection) dsc1.getConnection()).getAuthenticationDTO(new ApiKeyAuth()) instanceof DBAuth);
+
+
+        final DatasourceContext<?> dsc2 = (DatasourceContext) datasourceContextService.getCachedDatasourceContextMono(createdDatasource,
+                spyMockPluginExecutor, monitor).block();
+        assertNotNull(dsc2);
+        assertTrue(dsc2.getConnection() instanceof UpdatableConnection);
+        assertTrue(((UpdatableConnection) dsc2.getConnection()).getAuthenticationDTO(new ApiKeyAuth()) instanceof BasicAuth);
     }
 }


### PR DESCRIPTION
## Description

We were not refreshing the datasourceContext cache in case of stale connections, this PR fixes that and tests it via `UpdatableConnection` types which would be the most frequent use case that saw such failures. 

Reproduction on release:
1. Create an Authorization Code OAuth2 enabled REST API datasource
2. Go through authentication, create an API and ensure that it works
3. Create a new workspace, and fork this app into that workspace
4. Try to authorize the datasource in the new workspace and re-run the API. This will not work on release. It should work on this branch,

Fixes #15597 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
-JUnit test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
