### PR TITLE
feat: Added unconfigured datasources to the template API response

### DIFF
--- a/app/client/src/api/TemplatesApi.ts
+++ b/app/client/src/api/TemplatesApi.ts
@@ -3,6 +3,7 @@ import Api from "api/Api";
 import { ApiResponse } from "./ApiResponses";
 import { WidgetType } from "constants/WidgetConstants";
 import { ApplicationResponsePayload } from "./ApplicationApi";
+import { Datasource } from "entities/Datasource";
 
 export interface Template {
   id: string;
@@ -23,7 +24,11 @@ export type FilterKeys = "widgets" | "datasources";
 
 export type FetchTemplateResponse = ApiResponse<Template>;
 
-export type ImportTemplateResponse = ApiResponse<ApplicationResponsePayload>;
+export type ImportTemplateResponse = ApiResponse<{
+  isPartialImport: boolean;
+  unConfiguredDatasourceList: Datasource[];
+  application: ApplicationResponsePayload;
+}>;
 
 class TemplatesAPI extends Api {
   static baseUrl = "v1";

--- a/app/client/src/pages/Templates/TemplateView.tsx
+++ b/app/client/src/pages/Templates/TemplateView.tsx
@@ -41,6 +41,7 @@ import {
   VIEW_ALL_TEMPLATES,
 } from "@appsmith/constants/messages";
 import AnalyticsUtil from "utils/AnalyticsUtil";
+import ReconnectDatasourceModal from "pages/Editor/gitSync/ReconnectDatasourceModal";
 
 const breakpointColumnsObject = {
   default: 4,
@@ -289,6 +290,7 @@ function TemplateView() {
         <TemplateNotFound />
       ) : (
         <Wrapper ref={containerRef}>
+          <ReconnectDatasourceModal />
           <TemplateViewWrapper>
             <HeaderWrapper>
               <div className="left">

--- a/app/client/src/pages/Templates/index.tsx
+++ b/app/client/src/pages/Templates/index.tsx
@@ -31,6 +31,7 @@ import { getAllApplications } from "actions/applicationActions";
 import { getTypographyByKey } from "constants/DefaultTheme";
 import { Colors } from "constants/Colors";
 import { createMessage, SEARCH_TEMPLATES } from "@appsmith/constants/messages";
+import ReconnectDatasourceModal from "pages/Editor/gitSync/ReconnectDatasourceModal";
 const SentryRoute = Sentry.withSentryRouting(Route);
 
 const PageWrapper = styled.div`
@@ -162,6 +163,7 @@ function Templates() {
 
   return (
     <PageWrapper>
+      <ReconnectDatasourceModal />
       <Filters />
       <TemplateListWrapper>
         {isLoading ? (

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationTemplateControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/ApplicationTemplateControllerCE.java
@@ -2,6 +2,7 @@ package com.appsmith.server.controllers.ce;
 
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Application;
+import com.appsmith.server.dtos.ApplicationImportDTO;
 import com.appsmith.server.dtos.ApplicationTemplate;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.services.ApplicationTemplateService;
@@ -52,8 +53,8 @@ public class ApplicationTemplateControllerCE {
     }
 
     @PostMapping("{templateId}/import/{workspaceId}")
-    public Mono<ResponseDTO<Application>> importApplicationFromTemplate(@PathVariable String templateId,
-                                                           @PathVariable String workspaceId) {
+    public Mono<ResponseDTO<ApplicationImportDTO>> importApplicationFromTemplate(@PathVariable String templateId,
+                                                                                 @PathVariable String workspaceId) {
         return applicationTemplateService.importApplicationFromTemplate(templateId, workspaceId)
                 .map(importedApp -> new ResponseDTO<>(HttpStatus.OK.value(), importedApp, null));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCE.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.services.ce;
 
 import com.appsmith.server.domains.Application;
+import com.appsmith.server.dtos.ApplicationImportDTO;
 import com.appsmith.server.dtos.ApplicationTemplate;
 import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
@@ -9,11 +10,18 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 
 public interface ApplicationTemplateServiceCE {
+
     Mono<List<ApplicationTemplate>> getActiveTemplates(List<String> templateIds);
+
     Flux<ApplicationTemplate> getSimilarTemplates(String templateId, MultiValueMap<String, String> params);
+
     Mono<List<ApplicationTemplate>> getRecentlyUsedTemplates();
+
     Mono<ApplicationTemplate> getTemplateDetails(String templateId);
-    Mono<Application> importApplicationFromTemplate(String templateId, String workspaceId);
+
+    Mono<ApplicationImportDTO> importApplicationFromTemplate(String templateId, String workspaceId);
+
     Mono<Application> mergeTemplateWithApplication(String templateId, String applicationId, String workspaceId, String branchName, List<String> pagesToImport);
+
     Mono<ApplicationTemplate> getFilters();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.external.converters.GsonISOStringToInstantConverter;
 import com.appsmith.server.configurations.CloudServicesConfig;
 import com.appsmith.server.domains.Application;
 import com.appsmith.server.domains.UserData;
+import com.appsmith.server.dtos.ApplicationImportDTO;
 import com.appsmith.server.dtos.ApplicationJson;
 import com.appsmith.server.dtos.ApplicationTemplate;
 import com.appsmith.server.exceptions.AppsmithError;
@@ -181,18 +182,32 @@ public class ApplicationTemplateServiceCEImpl implements ApplicationTemplateServ
     }
 
     @Override
-    public Mono<Application> importApplicationFromTemplate(String templateId, String workspaceId) {
-        return getApplicationJsonFromTemplate(templateId).flatMap(applicationJson ->
-            importExportApplicationService.importApplicationInWorkspace(workspaceId, applicationJson)
-        ).flatMap(application -> {
-            ApplicationTemplate applicationTemplate = new ApplicationTemplate();
-            applicationTemplate.setId(templateId);
-            Map<String, Object>  extraProperties = new HashMap<>();
-            extraProperties.put("templateAppName", application.getName());
-            return userDataService.addTemplateIdToLastUsedList(templateId).then(
+    public Mono<ApplicationImportDTO> importApplicationFromTemplate(String templateId, String workspaceId) {
+        return getApplicationJsonFromTemplate(templateId)
+                .flatMap(applicationJson ->
+                        importExportApplicationService.importApplicationInWorkspace(workspaceId, applicationJson)
+                ).flatMap(application -> {
+                    ApplicationTemplate applicationTemplate = new ApplicationTemplate();
+                    applicationTemplate.setId(templateId);
+                    Map<String, Object> extraProperties = new HashMap<>();
+                    extraProperties.put("templateAppName", application.getName());
+                    return userDataService.addTemplateIdToLastUsedList(templateId).then(
                             analyticsService.sendObjectEvent(AnalyticsEvents.FORK, applicationTemplate, extraProperties)
-            ).thenReturn(application);
-        });
+                    ).thenReturn(application);
+                })
+                .flatMap(application -> importExportApplicationService.findDatasourceByApplicationId(application.getId(), application.getWorkspaceId())
+                        .map(datasources -> {
+                            ApplicationImportDTO applicationImportDTO = new ApplicationImportDTO();
+                            applicationImportDTO.setApplication(application);
+                            Long unConfiguredDatasource = datasources.stream().filter(datasource -> Boolean.FALSE.equals(datasource.getIsConfigured())).count();
+                            if (unConfiguredDatasource != 0) {
+                                applicationImportDTO.setIsPartialImport(true);
+                                applicationImportDTO.setUnConfiguredDatasourceList(datasources);
+                            } else {
+                                applicationImportDTO.setIsPartialImport(false);
+                            }
+                            return applicationImportDTO;
+                        }));
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
@@ -1999,19 +1999,7 @@ public class GitServiceCEImpl implements GitServiceCE {
                             });
                 })
                 // Add un-configured datasource to the list to response
-                .flatMap(application -> importExportApplicationService.findDatasourceByApplicationId(application.getId(), application.getWorkspaceId())
-                        .map(datasources -> {
-                            ApplicationImportDTO applicationImportDTO = new ApplicationImportDTO();
-                            applicationImportDTO.setApplication(application);
-                            long unConfiguredDatasource = datasources.stream().filter(datasource -> Boolean.FALSE.equals(datasource.getIsConfigured())).count();
-                            if (unConfiguredDatasource != 0) {
-                                applicationImportDTO.setIsPartialImport(true);
-                                applicationImportDTO.setUnConfiguredDatasourceList(datasources);
-                            } else {
-                                applicationImportDTO.setIsPartialImport(false);
-                            }
-                            return applicationImportDTO;
-                        }))
+                .flatMap(application -> importExportApplicationService.getApplicationImportDTO(application.getId(), application.getWorkspaceId(), application))
                 // Add analytics event
                 .flatMap(applicationImportDTO -> {
                     Application application = applicationImportDTO.getApplication();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCE.java
@@ -61,4 +61,6 @@ public interface ImportExportApplicationServiceCE {
 
     Mono<List<Datasource>> findDatasourceByApplicationId(String applicationId, String orgId);
 
+    Mono<ApplicationImportDTO> getApplicationImportDTO(String applicationId, String workspaceId, Application application);
+
 }


### PR DESCRIPTION
## Description

Add datasource's that are not configured to the template API response. This is to ensure that for SAAS templates, user is prompted the with reconnect datasource modal. 

Frontend changes involves adding reconnect modal to be shown in the template list page and in the template detailed view page. The deploy preview won't have templates fork working as it requires backend changes to be merged to release.

https://user-images.githubusercontent.com/67054171/182368698-53de623d-4f9d-4035-a47b-52e205619d89.mov



Fixes #15463

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
