### PR TITLE
fix: Change to allow all domains to embed Appsmith apps

### DIFF
--- a/deploy/docker/templates/docker.env.sh
+++ b/deploy/docker/templates/docker.env.sh
@@ -96,5 +96,5 @@ APPSMITH_SUPERVISOR_PASSWORD=$SUPERVISOR_PASSWORD
 # Example: "https://mydomain.com https://another-trusted-domain.com" will allow embedding on those two domains.
 # Default value, if commented or not set, is "'none'", which disables embedding completely.
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-APPSMITH_ALLOWED_FRAME_ANCESTORS="'self'"
+APPSMITH_ALLOWED_FRAME_ANCESTORS="'self' *"
 EOF

--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -28,7 +28,7 @@ server {
   index index.html index.htm;
 
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-  add_header Content-Security-Policy "frame-ancestors ${APPSMITH_ALLOWED_FRAME_ANCESTORS-'self'}";
+  add_header Content-Security-Policy "frame-ancestors ${APPSMITH_ALLOWED_FRAME_ANCESTORS-'self' *}";
 
   location /.well-known/acme-challenge/ {
     root /appsmith-stacks/data/certificate/certbot;

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -40,7 +40,7 @@ server {
   ssl_dhparam /appsmith-stacks/data/certificate/conf/ssl-dhparams.pem;
 
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
-  add_header Content-Security-Policy "frame-ancestors ${APPSMITH_ALLOWED_FRAME_ANCESTORS-'self'}";
+  add_header Content-Security-Policy "frame-ancestors ${APPSMITH_ALLOWED_FRAME_ANCESTORS-'self' *}";
 
   location = /supervisor {
     return 301 /supervisor/;


### PR DESCRIPTION
The control to configure what domains are allowed to embed Appsmith apps is still available, but the default of not allowing anything except for `'self'` is changed to allow everything.

While this is convenient, we encourage our users to configure their frame ancestors to limit what domains can embed their Appsmith apps.

