### PR TITLE
feat: added accentColor and fontFamily to the theme config chartwidget

### DIFF
--- a/app/server/appsmith-server/src/main/resources/system-themes.json
+++ b/app/server/appsmith-server/src/main/resources/system-themes.json
@@ -63,7 +63,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -456,7 +458,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -852,7 +856,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -1242,7 +1248,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -1629,7 +1637,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -2016,7 +2026,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -2403,7 +2415,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -2790,7 +2804,9 @@
       },
       "CHART_WIDGET": {
         "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
-        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}"
+        "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+        "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+        "fontFamily": "{{appsmith.theme.fontFamily.appFont}}"
       },
       "CHECKBOX_WIDGET": {
         "accentColor": "{{appsmith.theme.colors.primaryColor}}",


### PR DESCRIPTION
## Description

This PR - adds `accentColor` and `fontFamily`properties to the chart widget's config for all the themes.

Fixes #10974 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

N/A

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
