### PR TITLE
fix: Add `startupProbe` to Appsmith pods

### DIFF
--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -56,6 +56,11 @@ spec:
             - name: supervisord
               containerPort: 9001
               protocol: TCP
+          startupProbe:
+            # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.
+            httpGet:
+              path: /
+              port: http
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
This is so that the `livenessProbe` doesn't aggressively
restart the pod before the Appsmith container is live.

Fixes #10778.
