### PR TITLE
fix: fix class def not found error

### DIFF
--- a/app/server/appsmith-plugins/graphqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/graphqlPlugin/pom.xml
@@ -32,21 +32,21 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.2.3.RELEASE</version>
+            <version>5.3.20</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>5.3.15</version>
+            <version>5.3.20</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
-            <version>5.2.3.RELEASE</version>
+            <version>5.3.20</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.projectreactor</groupId>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
+            <version>2.12.6.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -164,13 +164,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>2.5.5</version>
+            <version>2.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.2.3.RELEASE</version>
+            <version>5.3.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/app/server/appsmith-plugins/graphqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/graphqlPlugin/pom.xml
@@ -98,11 +98,17 @@
             <version>0.11.2</version>
         </dependency>
 
+        <!--
+            Ideally this dependency should have been added with 'compile' scope here. But that is causing 'java.lang
+            .NoClassDefFoundError'. After trying to fix it right way many times, I decided to move the dependency to
+            the main server module's pom.xml file and keep the dependency here with 'provided' scope. This seems to
+            fix the problem for now.
+         -->
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>17.3</version>
-            <scope>compile</scope>
+            <version>19.0</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -40,6 +40,43 @@
     </repositories>
 
     <dependencies>
+        <!--
+            Ideally this dependency should have been added in the pom.xml file of GraphQLPlugin module, but it is
+            causing 'java.lang.NoClassDefFoundError' error. Hence, adding it here after many attempts of fixing it the right
+            way. Somehow adding it here makes it work. GraphQLPlugin module's pom.xml file also has this dependency
+            defined with 'provided' scope
+         -->
+        <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java</artifactId>
+            <version>19.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>reactor-core</artifactId>
+                    <groupId>io.projectreactor</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-core</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-web</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>reactive-streams</artifactId>
+                    <groupId>org.reactivestreams</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>


### PR DESCRIPTION
## Description
- Currently, the graphql branch code builds and runs fine on the terminal but on IntelliJ it throws the following runtime error: `java.lang.NoClassDefFoundError: graphql/parser/InvalidSyntaxException`. To overcome this error I tried to figure out any dependency conflicts or class path related issues but couldn't come up with any way to resolve it. Finally as a workaround I have moved the dependency to the `pom.xml` file of the main API server module while keeping the dependency in the `GraphQLPlugin`'s `pom.xml` under `provided` scope. This has resolved the issue for now. This fix may not be the most accurate but is not expected to cause any harm. 
- Created a new issue to track its proper fix: https://github.com/appsmithorg/appsmith/issues/15718
- Update package version.

Fixes #13145 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually
- No test case can be written for this at the moment.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
