### PR TITLE
fix: Correctly update trigger field dependency map

### DIFF
--- a/app/client/src/workers/DataTreeEvaluator/test.ts
+++ b/app/client/src/workers/DataTreeEvaluator/test.ts
@@ -385,55 +385,6 @@ describe("DataTreeEvaluator", () => {
     });
   });
 
-  describe("triggerfield dependency map", () => {
-    beforeEach(() => {
-      // @ts-expect-error: Types are not available
-      dataTreeEvaluator.createFirstTree(lintingUnEvalTree as DataTree);
-    });
-    it("Creates correct triggerFieldDependencyMap", () => {
-      expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
-        "Button3.onClick": ["Api1", "Button2", "Api2"],
-        "Button2.onClick": ["Api2"],
-      });
-    });
-    it("Creates correct triggerFieldInverseDependencyMap", () => {
-      expect(dataTreeEvaluator.triggerFieldInverseDependencyMap).toEqual({
-        Api1: ["Button3.onClick"],
-        Api2: ["Button3.onClick", "Button2.onClick"],
-        Button2: ["Button3.onClick"],
-      });
-    });
-    it("Correctly updates triggerFieldDependencyMap and triggerFieldInverseDependencyMap", () => {
-      const newUnEvalTree = ({ ...lintingUnEvalTree } as unknown) as DataTree;
-      // delete Api2
-      delete newUnEvalTree["Api2"];
-      dataTreeEvaluator.updateDataTree(newUnEvalTree);
-      expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
-        "Button3.onClick": ["Api1", "Button2"],
-        "Button2.onClick": [],
-      });
-      expect(dataTreeEvaluator.triggerFieldInverseDependencyMap).toEqual({
-        Api1: ["Button3.onClick"],
-        Button2: ["Button3.onClick"],
-      });
-
-      // Add Api2
-      // @ts-expect-error: Types are not available
-      newUnEvalTree["Api2"] = { ...lintingUnEvalTree }["Api2"];
-      dataTreeEvaluator.updateDataTree(newUnEvalTree);
-      expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
-        "Button3.onClick": ["Api1", "Button2", "Api2"],
-        "Button2.onClick": ["Api2"],
-      });
-
-      expect(dataTreeEvaluator.triggerFieldInverseDependencyMap).toEqual({
-        Api1: ["Button3.onClick"],
-        Api2: ["Button3.onClick", "Button2.onClick"],
-        Button2: ["Button3.onClick"],
-      });
-    });
-  });
-
   describe("lintTree", () => {
     const dataTreeEvaluator = new DataTreeEvaluator(widgetConfigMap);
     beforeEach(() => {
@@ -536,6 +487,75 @@ describe("DataTreeEvaluator", () => {
           "onClick",
         ),
       ).toEqual(expectedButton2LintError);
+    });
+  });
+
+  describe("triggerfield dependency map", () => {
+    beforeEach(() => {
+      // @ts-expect-error: Types are not available
+      dataTreeEvaluator.createFirstTree(lintingUnEvalTree as DataTree);
+    });
+    it("Creates correct triggerFieldDependencyMap", () => {
+      expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
+        "Button3.onClick": ["Api1", "Button2", "Api2"],
+        "Button2.onClick": ["Api2"],
+      });
+    });
+    it("Creates correct triggerFieldInverseDependencyMap", () => {
+      expect(dataTreeEvaluator.triggerFieldInverseDependencyMap).toEqual({
+        Api1: ["Button3.onClick"],
+        Api2: ["Button3.onClick", "Button2.onClick"],
+        Button2: ["Button3.onClick"],
+      });
+    });
+    it("Correctly updates triggerFieldDependencyMap and triggerFieldInverseDependencyMap", () => {
+      const newUnEvalTree = ({ ...lintingUnEvalTree } as unknown) as DataTree;
+      // delete Api2
+      delete newUnEvalTree["Api2"];
+      dataTreeEvaluator.updateDataTree(newUnEvalTree);
+      expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
+        "Button3.onClick": ["Api1", "Button2"],
+        "Button2.onClick": [],
+      });
+      expect(dataTreeEvaluator.triggerFieldInverseDependencyMap).toEqual({
+        Api1: ["Button3.onClick"],
+        Button2: ["Button3.onClick"],
+      });
+
+      // Add Api2
+      // @ts-expect-error: Types are not available
+      newUnEvalTree["Api2"] = { ...lintingUnEvalTree }["Api2"];
+      dataTreeEvaluator.updateDataTree(newUnEvalTree);
+      expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
+        "Button3.onClick": ["Api1", "Button2", "Api2"],
+        "Button2.onClick": ["Api2"],
+      });
+
+      expect(dataTreeEvaluator.triggerFieldInverseDependencyMap).toEqual({
+        Api1: ["Button3.onClick"],
+        Api2: ["Button3.onClick", "Button2.onClick"],
+        Button2: ["Button3.onClick"],
+      });
+
+      // self-reference Button2
+      const newButton2 = { ...lintingUnEvalTree }["Button2"];
+      newButton2.onClick = "{{Api2.run(); AbsentEntity.run(); Button2}}";
+      // @ts-expect-error: Types are not available
+      newUnEvalTree["Button2"] = newButton2;
+      dataTreeEvaluator.updateDataTree(newUnEvalTree);
+
+      // delete Button2
+      delete newUnEvalTree["Button2"];
+      dataTreeEvaluator.updateDataTree(newUnEvalTree);
+
+      expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
+        "Button3.onClick": ["Api1", "Api2"],
+      });
+
+      expect(dataTreeEvaluator.triggerFieldInverseDependencyMap).toEqual({
+        Api1: ["Button3.onClick"],
+        Api2: ["Button3.onClick"],
+      });
     });
   });
 });

--- a/app/client/src/workers/DependencyMap/index.ts
+++ b/app/client/src/workers/DependencyMap/index.ts
@@ -239,14 +239,6 @@ export const updateDependencyMap = ({
           );
 
           if (entityName === dataTreeDiff.payload.propertyPath) {
-            if (isWidget(entity)) {
-              entity.dynamicTriggerPathList?.forEach((triggerFieldName) => {
-                delete dataTreeEvalRef.triggerFieldDependencyMap[
-                  `${entityName}.${triggerFieldName.key}`
-                ];
-                didUpdateTriggerDependencyMap = true;
-              });
-            }
             // When deleted entity is referenced in a trigger field, remove deleted entity from it's triggerfieldDependencyMap
             if (
               entityName in dataTreeEvalRef.triggerFieldInverseDependencyMap
@@ -263,6 +255,16 @@ export const updateDependencyMap = ({
                 ] = dataTreeEvalRef.triggerFieldDependencyMap[
                   triggerField
                 ].filter((field) => field !== entityName);
+              });
+            }
+
+            // Remove deleted trigger fields from triggerFieldDependencyMap
+            if (isWidget(entity)) {
+              entity.dynamicTriggerPathList?.forEach((triggerFieldName) => {
+                delete dataTreeEvalRef.triggerFieldDependencyMap[
+                  `${entityName}.${triggerFieldName.key}`
+                ];
+                didUpdateTriggerDependencyMap = true;
               });
             }
           }


### PR DESCRIPTION
## Description

This PR simply re-orders the update of the triggerfieldDependencyMap. Deleted trigger fields are deleted from the map after updating their references. So that in the case where there is a self-referencing (eg, button1.onClick depending on button1), we don't try to update deleted entries.

Fixes #15695 


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
 Jest
   
- [x] https://github.com/appsmithorg/TestSmith/issues/1999


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
