### PR TITLE
fix: Disable polling transport for RTS

### DIFF
--- a/app/client/src/sagas/WebsocketSagas/WebsocketSagas.ts
+++ b/app/client/src/sagas/WebsocketSagas/WebsocketSagas.ts
@@ -36,6 +36,10 @@ import { SOCKET_CONNECTION_EVENTS } from "./socketEvents";
 function connect(namespace?: string) {
   const options = {
     path: RTS_BASE_PATH,
+    // The default transports is ["polling", "websocket"], so polling is tried first. But polling
+    //   needs sticky session to be turned on, in a clustered environment, even for it to upgrade to websockets.
+    // Ref: <https://github.com/socketio/socket.io/issues/2140>.
+    transports: ["websocket"],
   };
   const socket = !!namespace ? io(namespace, options) : io(options);
 


### PR DESCRIPTION
When Appsmith is running in a cluster, the websocket connections from client to RTS fail to establish. Here's what happens:

## Current situation

We don't set `transports` explicitly, when connecting to RTS, so it takes the default of `["polling", "websocket"]`.

So, socket.io first tries to connect to RTS with polling, with the intention to upgrade to a websocket later. However, the polling transport type doesn't work, when RTS is running as a cluster.

The issue we are seeing here, is exactly as described in this SO post (https://stackoverflow.com/a/45063176/151048), copied here to preserve:

<blockquote markdown>
For socket.io v2.0.3 (js client),when you use socket.io on client side the client socket.io makes some network calls as explained:

1. When io.connect() is called, the  socket.io library makes a call to the server which looks like 

   `?EIO=3&transport=polling&t=LqtOnHh`, 

    server responds with something like  

    `"90:0{"sid":"pcJM_AEZirrJT-DuAAUy","upgrades[],
     "pingInterval":3600000,"pingTimeout":3600000}2:40"`

     here the server generates a socket object on server side and sends its 
     id back to the client.

2. After this client makes another call to the server which is something like 

  `?EIO=3&transport=polling&t=LqtR6Rn&sid=0JFGcEFNdrS-XBZeAAXM` 

  this is the long poll call that client makes to the server, if you see here it is passing the sessionId which it received in first call above, if the call goes to same node which generated that sessionId, the node identifies the socket connection for which the request has been made and responds.

 But behind ELB the call may go to some other node that didn't generate this sessioId, in that case the node will not be able to identify the sessionId for which the call was made and hence responds with `{"code":1,"message":"Session ID unknown"}`

You will also see this error in case of long polling not getting answered or getting timeout.
</blockquote>

## After this PR is merged

In this PR, we explicitly set the allowed transports to just `["websocket"]`, so the very first request from the client to RTS, will be immediately upgraded to a websocket connection.
