### PR TITLE
fix: Naming convention moved objects with same names in different pages

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15304_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15304_spec.ts
@@ -1,0 +1,69 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+const {
+  AggregateHelper: agHelper,
+  ApiPage: apiPage,
+  EntityExplorer: ee,
+  JSEditor: jsEditor,
+} = ObjectsRegistry;
+
+describe("Move objects/actions/queries to different pages", () => {
+  it("1. Appends copy to name of JS object when it already exist in another page", () => {
+    // create object in page 1
+    jsEditor.CreateJSObject('return "Hello World";', {
+      paste: true,
+      completeReplace: false,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+
+    // create a new page and a js object in it
+    ee.AddNewPage(); // page 2
+    jsEditor.CreateJSObject('return "Hello World";', {
+      paste: true,
+      completeReplace: false,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+
+    ee.ExpandCollapseEntity("QUERIES/JS");
+    ee.ActionContextMenuByEntityName("JSObject1", "Move to page", "Page1");
+
+    agHelper.WaitUntilToastDisappear(
+      "JSObject1Copy moved to page Page1 successfully",
+    );
+
+    // check that the copy and original objects both exist in page 1
+    ee.AssertEntityPresenceInExplorer("JSObject1Copy");
+    ee.AssertEntityPresenceInExplorer("JSObject1");
+
+    // check that js object no longer exists in page 2
+    ee.SelectEntityByName("Page2");
+    ee.AssertEntityAbsenceInExplorer("JSObject1");
+  });
+
+  it("2. Appends copy to name of Api when it already exist in another page", () => {
+    // create Api in page 1
+    ee.SelectEntityByName("Page1");
+    apiPage.CreateAndFillApi("https://randomuser.me/api/", "Api1");
+
+    // create api in page 2
+    ee.SelectEntityByName("Page2");
+    apiPage.CreateAndFillApi("https://randomuser.me/api/", "Api1");
+
+    ee.ExpandCollapseEntity("QUERIES/JS");
+    ee.ActionContextMenuByEntityName("Api1", "Move to page", "Page1");
+
+    agHelper.WaitUntilToastDisappear(
+      "Api1Copy action moved to page Page1 successfully",
+    );
+
+    // check that the copy and original objects both exist in page 1
+    ee.AssertEntityPresenceInExplorer("Api1Copy");
+    ee.AssertEntityPresenceInExplorer("Api1");
+
+    // check that js object no longer exists in page 2
+    ee.SelectEntityByName("Page2");
+    ee.AssertEntityAbsenceInExplorer("Api1");
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15304_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug15304_spec.ts
@@ -74,14 +74,13 @@ describe("Move objects/actions/queries to different pages", () => {
     ee.AssertEntityAbsenceInExplorer("Api1");
   });
 
-  it("3. Create a new MySQL DS", () => {
+  it("3. Appends copy to name of Query when it already exist in another page", () => {
+    ee.SelectEntityByName("Page1");
     dataSources.CreateDataSource("MySql");
     cy.get("@dsName").then(($dsName) => {
       dsName = $dsName;
     });
-  });
 
-  it("4. Appends copy to name of Query when it already exist in another page", () => {
     dataSources.NavigateFromActiveDS(dsName, true);
     agHelper.GetNClick(dataSources._templateMenu);
     agHelper.RenameWithInPane("verifyDescribe");
@@ -93,6 +92,35 @@ describe("Move objects/actions/queries to different pages", () => {
       "Default",
       "Extra",
     ]);
+
+    ee.SelectEntityByName("Page2");
+    dataSources.CreateDataSource("MySql");
+    cy.get("@dsName").then(($dsName) => {
+      dsName = $dsName;
+    });
+
+    dataSources.NavigateFromActiveDS(dsName, true);
+    agHelper.GetNClick(dataSources._templateMenu);
+    agHelper.RenameWithInPane("verifyDescribe");
+    runQueryNValidate("Describe customers;", [
+      "Field",
+      "Type",
+      "Null",
+      "Key",
+      "Default",
+      "Extra",
+    ]);
+
+    ee.ExpandCollapseEntity("QUERIES/JS");
+    ee.ActionContextMenuByEntityName("Query1", "Move to page", "Page1");
+
+    // check that the copy and original objects both exist in page 1
+    ee.AssertEntityPresenceInExplorer("Query1Copy");
+    ee.AssertEntityPresenceInExplorer("Query1");
+
+    // check that js object no longer exists in page 2
+    ee.SelectEntityByName("Page2");
+    ee.AssertEntityAbsenceInExplorer("Query1");
   });
 });
 

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -127,6 +127,11 @@ export const getNextEntityName = (
   existingNames: string[],
   startWithoutIndex?: boolean,
 ) => {
+  // if prefix exists in existingName, append copy to the prefix and return it
+  if (existingNames.includes(prefix)) {
+    return prefix + "Copy";
+  }
+
   const regex = new RegExp(`^${prefix}(\\d+)$`);
 
   const usedIndices: number[] = existingNames.map((name) => {


### PR DESCRIPTION
## Description

When moving entities to another page, where another entity with the same name exists, the entities were taking on weird naming conventions (eg, Api1 became Api11, etc.,). To rectify this issue, I am checking before if the name already exists on that page, and if it does, I am appending copy to the name for a more consistent conflict resolution of the names.

Changelog:
1. If the name of an entity already exists on a page, append "copy" to it
2. Add a cypress test to prove the change is effective

Fixes #15304 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually
- Covered by cypress tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
