### PR TITLE
fix: Adding checks to prevent disallowed hosts from connecting via Elasticsearch plugin

### DIFF
--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/main/java/com/external/plugins/ElasticSearchPlugin.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/main/java/com/external/plugins/ElasticSearchPlugin.java
@@ -23,7 +23,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.nio.entity.NStringEntity;
-import org.eclipse.jgit.util.SystemReader;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -38,8 +37,10 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,6 +72,10 @@ public class ElasticSearchPlugin extends BasePlugin {
 
         public static final String esDatasourceNotFoundPattern = ".*(?:not.?found)|(?:refused)|(?:not.?known)|(?:timed?\\s?out).*";
 
+        private static final Set<String> DISALLOWED_HOSTS = Set.of(
+                "169.254.169.254",
+                "metadata.google.internal"
+        );
 
         @Override
         public Mono<ActionExecutionResult> execute(RestClient client,
@@ -83,64 +88,64 @@ public class ElasticSearchPlugin extends BasePlugin {
             List<RequestParamDTO> requestParams = new ArrayList<>();
 
             return Mono.fromCallable(() -> {
-                final ActionExecutionResult result = new ActionExecutionResult();
+                        final ActionExecutionResult result = new ActionExecutionResult();
 
-                String body = query;
+                        String body = query;
 
-                final String path = actionConfiguration.getPath();
-                requestData.put("path", path);
+                        final String path = actionConfiguration.getPath();
+                        requestData.put("path", path);
 
-                HttpMethod httpMethod = actionConfiguration.getHttpMethod();
-                requestData.put("method", httpMethod.name());
-                requestParams.add(new RequestParamDTO("actionConfiguration.httpMethod", httpMethod.name(), null,
-                        null, null));
-                requestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_PATH, path, null, null, null));
-                requestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_BODY,  query, null, null, null));
+                        HttpMethod httpMethod = actionConfiguration.getHttpMethod();
+                        requestData.put("method", httpMethod.name());
+                        requestParams.add(new RequestParamDTO("actionConfiguration.httpMethod", httpMethod.name(), null,
+                                null, null));
+                        requestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_PATH, path, null, null, null));
+                        requestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_BODY, query, null, null, null));
 
-                final Request request = new Request(httpMethod.toString(), path);
-                ContentType contentType = ContentType.APPLICATION_JSON;
+                        final Request request = new Request(httpMethod.toString(), path);
+                        ContentType contentType = ContentType.APPLICATION_JSON;
 
-                if (isBulkQuery(path)) {
-                    contentType = ContentType.create("application/x-ndjson");
+                        if (isBulkQuery(path)) {
+                            contentType = ContentType.create("application/x-ndjson");
 
-                    // If body is a JSON Array, convert it to an ND-JSON string.
-                    if (body != null && body.trim().startsWith("[")) {
-                        final StringBuilder ndJsonBuilder = new StringBuilder();
-                        try {
-                            List<Object> commands = objectMapper.readValue(body, ArrayList.class);
-                            for (Object object : commands) {
-                                ndJsonBuilder.append(objectMapper.writeValueAsString(object)).append("\n");
+                            // If body is a JSON Array, convert it to an ND-JSON string.
+                            if (body != null && body.trim().startsWith("[")) {
+                                final StringBuilder ndJsonBuilder = new StringBuilder();
+                                try {
+                                    List<Object> commands = objectMapper.readValue(body, ArrayList.class);
+                                    for (Object object : commands) {
+                                        ndJsonBuilder.append(objectMapper.writeValueAsString(object)).append("\n");
+                                    }
+                                } catch (IOException e) {
+                                    final String message = "Error converting array to ND-JSON: " + e.getMessage();
+                                    log.warn(message, e);
+                                    return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, message));
+                                }
+                                body = ndJsonBuilder.toString();
                             }
-                        } catch (IOException e) {
-                            final String message = "Error converting array to ND-JSON: " + e.getMessage();
-                            log.warn(message, e);
-                            return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, message));
                         }
-                        body = ndJsonBuilder.toString();
-                    }
-                }
 
-                if (body != null) {
-                    request.setEntity(new NStringEntity(body, contentType));
-                }
+                        if (body != null) {
+                            request.setEntity(new NStringEntity(body, contentType));
+                        }
 
-                try {
-                    final String responseBody = new String(
-                            client.performRequest(request).getEntity().getContent().readAllBytes());
-                    result.setBody(objectMapper.readValue(responseBody, HashMap.class));
-                } catch (IOException e) {
-                    final String message = "Error performing request: " + e.getMessage();
-                    log.warn(message, e);
-                    return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, message));
-                }
+                        try {
+                            final String responseBody = new String(
+                                    client.performRequest(request).getEntity().getContent().readAllBytes());
+                            result.setBody(objectMapper.readValue(responseBody, HashMap.class));
+                        } catch (IOException e) {
+                            final String message = "Error performing request: " + e.getMessage();
+                            log.warn(message, e);
+                            return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, message));
+                        }
 
-                result.setIsExecutionSuccess(true);
-                log.debug("In the Elastic Search Plugin, got action execution result");
-                return Mono.just(result);
-            })
+                        result.setIsExecutionSuccess(true);
+                        log.debug("In the Elastic Search Plugin, got action execution result");
+                        return Mono.just(result);
+                    })
                     .flatMap(obj -> obj)
                     .map(obj -> (ActionExecutionResult) obj)
-                    .onErrorResume(error  -> {
+                    .onErrorResume(error -> {
                         ActionExecutionResult result = new ActionExecutionResult();
                         result.setIsExecutionSuccess(false);
                         result.setErrorInfo(error);
@@ -166,55 +171,57 @@ public class ElasticSearchPlugin extends BasePlugin {
         @Override
         public Mono<RestClient> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
 
-            return (Mono<RestClient>) Mono.fromCallable(() -> {
-                final List<HttpHost> hosts = new ArrayList<>();
+            final List<HttpHost> hosts = new ArrayList<>();
 
-                for (Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
-                    URL url;
-                    try {
-                        url = new URL(endpoint.getHost());
-                    } catch (MalformedURLException e) {
-                        return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
-                                "Invalid host provided. It should be of the form http(s)://your-es-url.com"));
+            for (Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
+                URL url;
+                try {
+                    url = new URL(endpoint.getHost());
+                    if (DISALLOWED_HOSTS.contains(url.getHost())
+                            || DISALLOWED_HOSTS.contains(InetAddress.getByName(endpoint.getHost()).getHostAddress())) {
+                        return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, "Invalid host provided."));
                     }
-                    String scheme = "http";
-                    if (url.getProtocol() != null) {
-                        scheme = url.getProtocol();
-                    }
-
-                    hosts.add(new HttpHost(url.getHost(), endpoint.getPort().intValue(), scheme));
+                } catch (MalformedURLException | UnknownHostException e) {
+                    return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
+                            "Invalid host provided. It should be of the form http(s)://your-es-url.com"));
+                }
+                String scheme = "http";
+                if (url.getProtocol() != null) {
+                    scheme = url.getProtocol();
                 }
 
-                final RestClientBuilder clientBuilder = RestClient.builder(hosts.toArray(new HttpHost[]{}));
+                hosts.add(new HttpHost(url.getHost(), endpoint.getPort().intValue(), scheme));
+            }
 
-                final DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
-                if (authentication != null
-                        && !StringUtils.isEmpty(authentication.getUsername())
-                        && !StringUtils.isEmpty(authentication.getPassword())) {
-                    final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-                    credentialsProvider.setCredentials(
-                            AuthScope.ANY,
-                            new UsernamePasswordCredentials(authentication.getUsername(), authentication.getPassword())
-                    );
+            final RestClientBuilder clientBuilder = RestClient.builder(hosts.toArray(new HttpHost[]{}));
 
-                    clientBuilder
-                            .setHttpClientConfigCallback(
-                                    httpClientBuilder -> httpClientBuilder
-                                            .setDefaultCredentialsProvider(credentialsProvider)
-                            );
-                }
+            final DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
+            if (authentication != null
+                    && !StringUtils.isEmpty(authentication.getUsername())
+                    && !StringUtils.isEmpty(authentication.getPassword())) {
+                final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(
+                        AuthScope.ANY,
+                        new UsernamePasswordCredentials(authentication.getUsername(), authentication.getPassword())
+                );
 
-                if (!CollectionUtils.isEmpty(datasourceConfiguration.getHeaders())) {
-                    clientBuilder.setDefaultHeaders(
-                            (Header[]) datasourceConfiguration.getHeaders()
-                                    .stream()
-                                    .map(h -> new BasicHeader(h.getKey(), (String) h.getValue()))
-                                    .toArray()
-                    );
-                }
+                clientBuilder
+                        .setHttpClientConfigCallback(
+                                httpClientBuilder -> httpClientBuilder
+                                        .setDefaultCredentialsProvider(credentialsProvider)
+                        );
+            }
 
-                return Mono.just(clientBuilder.build());
-            })
+            if (!CollectionUtils.isEmpty(datasourceConfiguration.getHeaders())) {
+                clientBuilder.setDefaultHeaders(
+                        (Header[]) datasourceConfiguration.getHeaders()
+                                .stream()
+                                .map(h -> new BasicHeader(h.getKey(), (String) h.getValue()))
+                                .toArray()
+                );
+            }
+
+            return Mono.fromCallable(() -> Mono.just(clientBuilder.build()))
                     .flatMap(obj -> obj)
                     .subscribeOn(scheduler);
         }
@@ -235,21 +242,29 @@ public class ElasticSearchPlugin extends BasePlugin {
             if (CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
                 invalids.add("No endpoint provided. Please provide a host:port where ElasticSearch is reachable.");
             } else {
-                for(Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
-                    if (endpoint.getHost() == null) {
-                        invalids.add("Missing host for endpoint");
-                    } else {
-                        try {
-                            URL url = new URL(endpoint.getHost());
-                        } catch (MalformedURLException e) {
-                            invalids.add("Invalid host provided. It should be of the form http(s)://your-es-url.com");
+                for (Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
+                    try {
+                        if (endpoint.getHost() == null) {
+                            invalids.add("Missing host for endpoint");
+                        } else if (DISALLOWED_HOSTS.contains(endpoint.getHost())
+                                || DISALLOWED_HOSTS.contains(InetAddress.getByName(endpoint.getHost()).getHostAddress())) {
+                            invalids.add("Invalid host provided.");
+                        } else {
+                            try {
+                                URL url = new URL(endpoint.getHost());
+                            } catch (MalformedURLException e) {
+                                invalids.add("Invalid host provided. It should be of the form http(s)://your-es-url.com");
+                            }
                         }
+                    } catch (UnknownHostException e) {
+                        invalids.add("Unable to resolve endpoint. Please check the host provided.");
                     }
 
                     if (endpoint.getPort() == null) {
                         invalids.add("Missing port for endpoint");
                     }
                 }
+
             }
 
             return invalids;
@@ -274,16 +289,16 @@ public class ElasticSearchPlugin extends BasePlugin {
 
                             /* since the 401, and 403 are registered as IOException, but for the given connection it
                              * in the current rest-client. We will figure out with matching patterns with regexes.
-                            */
+                             */
 
                             Pattern patternForUnauthorized = Pattern.compile(esDatasourceUnauthorizedPattern, Pattern.CASE_INSENSITIVE);
-                            Pattern patterForNotFound = Pattern.compile(esDatasourceNotFoundPattern,Pattern.CASE_INSENSITIVE);
+                            Pattern patternForNotFound = Pattern.compile(esDatasourceNotFoundPattern, Pattern.CASE_INSENSITIVE);
 
-                            if (patternForUnauthorized.matcher(e.getMessage()).find()){
+                            if (patternForUnauthorized.matcher(e.getMessage()).find()) {
                                 return new DatasourceTestResult(esDatasourceUnauthorizedMessage);
                             }
 
-                            if (patterForNotFound.matcher(e.getMessage()).find()){
+                            if (patternForNotFound.matcher(e.getMessage()).find()) {
                                 return new DatasourceTestResult(esDatasourceNotFoundMessage);
                             }
 
@@ -300,7 +315,7 @@ public class ElasticSearchPlugin extends BasePlugin {
                         }
                         // earlier it was 404 and 200, now it has been changed to just expect 200 status code
                         // here it checks if it is anything else than 200, even 404 is not allowed!
-                        if (statusLine.getStatusCode() == 404){
+                        if (statusLine.getStatusCode() == 404) {
                             return new DatasourceTestResult(esDatasourceNotFoundMessage);
                         }
 

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
@@ -1,6 +1,7 @@
 package com.external.plugins;
 
 import com.appsmith.external.constants.Authentication;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.DBAuth;
@@ -48,13 +49,12 @@ public class ElasticSearchPluginTest {
     public static final ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.12.1")
             .withEnv("discovery.type", "single-node")
             .withPassword("esPassword");
-    private static String username ="elastic";
+    private static String username = "elastic";
     private static String password = "esPassword";
     private static final DatasourceConfiguration dsConfig = new DatasourceConfiguration();
-    private static DBAuth elasticInstanceCredentials = new DBAuth(DBAuth.Type.USERNAME_PASSWORD,username,password, null);
+    private static DBAuth elasticInstanceCredentials = new DBAuth(DBAuth.Type.USERNAME_PASSWORD, username, password, null);
     private static String host;
     private static Integer port;
-
 
 
     @BeforeClass
@@ -65,10 +65,10 @@ public class ElasticSearchPluginTest {
         final CredentialsProvider credentialsProvider =
                 new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY,
-                new UsernamePasswordCredentials(username,password));
+                new UsernamePasswordCredentials(username, password));
 
         RestClient client = RestClient.builder(
-                        new HttpHost(container.getContainerIpAddress(),port,"http"))
+                        new HttpHost(container.getContainerIpAddress(), port, "http"))
                 .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
                     @Override
                     public HttpAsyncClientBuilder customizeHttpClient(
@@ -157,7 +157,7 @@ public class ElasticSearchPluginTest {
                     expectedRequestParams.add(new RequestParamDTO("actionConfiguration.httpMethod", HttpMethod.GET.toString(),
                             null, null, null));
                     expectedRequestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_PATH, "/planets/_mget", null, null, null));
-                    expectedRequestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_BODY,  contentJson, null, null, null));
+                    expectedRequestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_BODY, contentJson, null, null, null));
                     assertEquals(result.getRequest().getRequestParams().toString(), expectedRequestParams.toString());
                 })
                 .verifyComplete();
@@ -235,12 +235,12 @@ public class ElasticSearchPluginTest {
     public void testBulkWithDirectBody() {
         final String contentJson =
                 "{ \"index\" : { \"_index\" : \"test2\", \"_type\": \"doc\", \"_id\" : \"1\" } }\n" +
-                "{ \"field1\" : \"value1\" }\n" +
-                "{ \"delete\" : { \"_index\" : \"test2\", \"_type\": \"doc\", \"_id\" : \"2\" } }\n" +
-                "{ \"create\" : { \"_index\" : \"test2\", \"_type\": \"doc\", \"_id\" : \"3\" } }\n" +
-                "{ \"field1\" : \"value3\" }\n" +
-                "{ \"update\" : {\"_id\" : \"1\", \"_type\": \"doc\", \"_index\" : \"test2\"} }\n" +
-                "{ \"doc\" : {\"field2\" : \"value2\"} }\n";
+                        "{ \"field1\" : \"value1\" }\n" +
+                        "{ \"delete\" : { \"_index\" : \"test2\", \"_type\": \"doc\", \"_id\" : \"2\" } }\n" +
+                        "{ \"create\" : { \"_index\" : \"test2\", \"_type\": \"doc\", \"_id\" : \"3\" } }\n" +
+                        "{ \"field1\" : \"value3\" }\n" +
+                        "{ \"update\" : {\"_id\" : \"1\", \"_type\": \"doc\", \"_index\" : \"test2\"} }\n" +
+                        "{ \"doc\" : {\"field2\" : \"value2\"} }\n";
 
         StepVerifier.create(execute(HttpMethod.POST, "/_bulk", contentJson))
                 .assertNext(result -> {
@@ -340,15 +340,15 @@ public class ElasticSearchPluginTest {
     @Test
     public void shouldVerifyUnauthorized() {
         final Integer secureHostPort = container.getMappedPort(9200);
-        final String secureHostEndpoint =   "http://" + container.getHttpHostAddress();
+        final String secureHostEndpoint = "http://" + container.getHttpHostAddress();
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
-        Endpoint endpoint = new Endpoint(secureHostEndpoint,Long.valueOf(secureHostPort));
+        Endpoint endpoint = new Endpoint(secureHostEndpoint, Long.valueOf(secureHostPort));
         datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
 
         StepVerifier.create(pluginExecutor.testDatasource(datasourceConfiguration)
                         .map(result -> {
-                            return  (Set<String>) result.getInvalids();
+                            return (Set<String>) result.getInvalids();
                         }))
                 .expectNext(Set.of(ElasticSearchPlugin.ElasticSearchPluginExecutor.esDatasourceUnauthorizedMessage))
                 .verifyComplete();
@@ -359,19 +359,83 @@ public class ElasticSearchPluginTest {
     @Test
     public void shouldVerifyNotFound() {
         final Integer secureHostPort = container.getMappedPort(9200);
-        final String secureHostEndpoint =   "http://esdatabasenotfound.co" ;
+        final String secureHostEndpoint = "http://esdatabasenotfound.co";
         DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
-        Endpoint endpoint = new Endpoint(secureHostEndpoint,Long.valueOf(secureHostPort));
+        Endpoint endpoint = new Endpoint(secureHostEndpoint, Long.valueOf(secureHostPort));
         datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
         StepVerifier.create(pluginExecutor.testDatasource(datasourceConfiguration)
                         .map(result -> {
-                            return  (Set<String>) result.getInvalids();
+                            return (Set<String>) result.getInvalids();
                         }))
                 .expectNext(Set.of(ElasticSearchPlugin.ElasticSearchPluginExecutor.esDatasourceNotFoundMessage))
                 .verifyComplete();
 
     }
 
+    @Test
+    public void itShouldDenyTestDatasourceWithInstanceMetadataAws() {
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(elasticInstanceCredentials);
+        Endpoint endpoint = new Endpoint();
+        endpoint.setHost("http://169.254.169.254");
+        endpoint.setPort(Long.valueOf(port));
+        datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
 
+        StepVerifier.create(pluginExecutor.testDatasource(datasourceConfiguration))
+                .assertNext(result -> {
+                    assertFalse(result.getInvalids().isEmpty());
+                    assertTrue(result.getInvalids().contains("Invalid host provided."));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void itShouldDenyTestDatasourceWithInstanceMetadataGcp() {
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(elasticInstanceCredentials);
+        Endpoint endpoint = new Endpoint();
+        endpoint.setHost("http://metadata.google.internal");
+        endpoint.setPort(Long.valueOf(port));
+        datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
+
+        StepVerifier.create(pluginExecutor.testDatasource(datasourceConfiguration))
+                .assertNext(result -> {
+                    assertFalse(result.getInvalids().isEmpty());
+                    assertTrue(result.getInvalids().contains("Invalid host provided."));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void itShouldDenyCreateDatasourceWithInstanceMetadataAws() {
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(elasticInstanceCredentials);
+        Endpoint endpoint = new Endpoint();
+        endpoint.setHost("http://169.254.169.254");
+        endpoint.setPort(Long.valueOf(port));
+        datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
+
+        StepVerifier.create(pluginExecutor.datasourceCreate(datasourceConfiguration))
+                .verifyErrorSatisfies(e -> {
+                    assertTrue(e instanceof AppsmithPluginException);
+                    assertEquals("Invalid host provided.", e.getMessage());
+                });
+    }
+
+    @Test
+    public void itShouldDenyCreateDatasourceWithInstanceMetadataGcp() {
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(elasticInstanceCredentials);
+        Endpoint endpoint = new Endpoint();
+        endpoint.setHost("https://metadata.google.internal");
+        endpoint.setPort(Long.valueOf(port));
+        datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
+
+        StepVerifier.create(pluginExecutor.datasourceCreate(datasourceConfiguration))
+                .verifyErrorSatisfies(e -> {
+                    assertTrue(e instanceof AppsmithPluginException);
+                    assertEquals("Invalid host provided.", e.getMessage());
+                });
+    }
 }

--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/test/java/com/external/plugins/ElasticSearchPluginTest.java
@@ -438,4 +438,28 @@ public class ElasticSearchPluginTest {
                     assertEquals("Invalid host provided.", e.getMessage());
                 });
     }
+
+    @Test
+    public void itShouldValidateDatasourceWithInstanceMetadataAws() {
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(elasticInstanceCredentials);
+        Endpoint endpoint = new Endpoint();
+        endpoint.setHost("http://169.254.169.254");
+        endpoint.setPort(Long.valueOf(port));
+        datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
+
+        Assert.assertEquals(Set.of("Invalid host provided."), pluginExecutor.validateDatasource(datasourceConfiguration));
+    }
+
+    @Test
+    public void itShouldValidateDatasourceWithInstanceMetadataGcp() {
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setAuthentication(elasticInstanceCredentials);
+        Endpoint endpoint = new Endpoint();
+        endpoint.setHost("https://metadata.google.internal");
+        endpoint.setPort(Long.valueOf(port));
+        datasourceConfiguration.setEndpoints(Collections.singletonList(endpoint));
+
+        Assert.assertEquals(Set.of("Invalid host provided."), pluginExecutor.validateDatasource(datasourceConfiguration));
+    }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where a potentially malicious user can connect to disallowed hosts from the Elasticsearch plugin within Appsmith. This is because Elasticsearch client SDK is a HTTP interface underneath the hood. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Junits for the following:
  - create datasource with disallowed host
  - validate datasource with disallowed host
  - test datasource with disallowed host

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
