### PR TITLE
Cleanup on PolicyUtils

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -1678,8 +1678,8 @@ public class DatabaseChangelog2 {
         // Apply the permissions to the permission groups
         for (PermissionGroup permissionGroup : savedPermissionGroups) {
             for (PermissionGroup nestedPermissionGroup : savedPermissionGroups) {
-                Map<String, Policy> policyMap = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, nestedPermissionGroup.getId());
-                policyUtils.addPoliciesToExistingObject(policyMap, nestedPermissionGroup);
+                Set<Policy> policySet = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, nestedPermissionGroup.getId());
+                policyUtils.addPoliciesToExistingObject(policySet, nestedPermissionGroup);
             }
         }
 
@@ -1746,8 +1746,8 @@ public class DatabaseChangelog2 {
                         // Apply the permissions to the workspace
                         for (PermissionGroup permissionGroup : permissionGroups) {
                             // Apply the permissions to the workspace
-                            Map<String, Policy> policyMap = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, workspace.getId());
-                            workspace = policyUtils.addPoliciesToExistingObject(policyMap, workspace);
+                            Set<Policy> policySet = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, workspace.getId());
+                            workspace = policyUtils.addPoliciesToExistingObject(policySet, workspace);
                         }
                         // Save the workspace
                         mongockTemplate.save(workspace);
@@ -1894,9 +1894,9 @@ public class DatabaseChangelog2 {
 
         String permissionGroupId = publicPermissionGroup.getId();
 
-        Map<String, Policy> applicationPolicyMap = policyUtils
+        Set<Policy> applicationPolicySet = policyUtils
                 .generatePolicyFromPermissionWithPermissionGroup(AclPermission.READ_APPLICATIONS, permissionGroupId);
-        Map<String, Policy> datasourcePolicyMap = policyUtils
+        Set<Policy> datasourcePolicySet = policyUtils
                 .generatePolicyFromPermissionWithPermissionGroup(AclPermission.EXECUTE_DATASOURCES, permissionGroupId);
 
         Set<String> datasourceIds = new HashSet<>();
@@ -1920,7 +1920,7 @@ public class DatabaseChangelog2 {
                 });
 
         // Update and save application
-        application = policyUtils.addPoliciesToExistingObject(applicationPolicyMap, application);
+        application = policyUtils.addPoliciesToExistingObject(applicationPolicySet, application);
         mongockTemplate.save(application);
         applicationPolicies = application.getPolicies();
 
@@ -1928,7 +1928,7 @@ public class DatabaseChangelog2 {
         mongockTemplate.stream(new Query().addCriteria(Criteria.where(fieldName(QDatasource.datasource.id)).in(datasourceIds)), Datasource.class)
                 .stream()
                 .forEach(datasource -> {
-                    datasource = policyUtils.addPoliciesToExistingObject(datasourcePolicyMap, datasource);
+                    datasource = policyUtils.addPoliciesToExistingObject(datasourcePolicySet, datasource);
                     mongockTemplate.save(datasource);
                 });
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommentServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CommentServiceCEImpl.java
@@ -233,10 +233,10 @@ public class CommentServiceCEImpl extends BaseService<CommentRepository, Comment
                             Application.class,
                             CommentThread.class
                     ));
-                    policies.add(policyUtils.generatePolicyFromPermission(
-                            Set.of(AclPermission.MANAGE_THREADS),
-                            commentThread.getAuthorUsername()
-                    ).get(AclPermission.MANAGE_THREADS.getValue()));
+                    // policies.add(policyUtils.generatePolicyFromPermission(
+                    //         Set.of(AclPermission.MANAGE_THREADS),
+                    //         commentThread.getAuthorUsername()
+                    // ).get(AclPermission.MANAGE_THREADS.getValue()));
                     commentThread.setPolicies(policies);
                     return commentThread;
                 });
@@ -265,10 +265,10 @@ public class CommentServiceCEImpl extends BaseService<CommentRepository, Comment
                 CommentThread.class,
                 Comment.class
         );
-        policies.add(policyUtils.generatePolicyFromPermission(
-                Set.of(AclPermission.MANAGE_COMMENTS),
-                user
-        ).get(AclPermission.MANAGE_COMMENTS.getValue()));
+        // policies.add(policyUtils.generatePolicyFromPermission(
+        //         Set.of(AclPermission.MANAGE_COMMENTS),
+        //         user
+        // ).get(AclPermission.MANAGE_COMMENTS.getValue()));
         comment.setPolicies(policies);
 
         Mono<Comment> commentMono;
@@ -589,9 +589,10 @@ public class CommentServiceCEImpl extends BaseService<CommentRepository, Comment
                     User currentUser = objects.getT2();
 
                     // if user is app viewer, return the comments in published mode only
-                    Boolean permissionPresentForUser = policyUtils.isPermissionPresentForUser(
-                            application.getPolicies(), MANAGE_APPLICATIONS.getValue(), currentUser.getUsername()
-                    );
+                    Boolean permissionPresentForUser = false;
+                    // policyUtils.isPermissionPresentForUser(
+                    //         application.getPolicies(), MANAGE_APPLICATIONS.getValue(), currentUser.getUsername()
+                    // );
                     if(!permissionPresentForUser) {
                         // user is app viewer, show only PUBLISHED comment threads
                         commentThreadFilterDTO.setMode(ApplicationMode.PUBLISHED);
@@ -717,11 +718,11 @@ public class CommentServiceCEImpl extends BaseService<CommentRepository, Comment
         final Set<Policy> policies = new HashSet<>();
         Mono<Long> commentSeq;
         if (TRUE.equals(commentThread.getIsPrivate())) {
-            Collection<Policy> policyCollection = policyUtils.generatePolicyFromPermission(
-                    Set.of(AclPermission.MANAGE_THREADS, AclPermission.COMMENT_ON_THREADS),
-                    user
-            ).values();
-            policies.addAll(policyCollection);
+            // Collection<Policy> policyCollection = policyUtils.generatePolicyFromPermission(
+            //         Set.of(AclPermission.MANAGE_THREADS, AclPermission.COMMENT_ON_THREADS),
+            //         user
+            // ).values();
+            // policies.addAll(policyCollection);
             commentSeq = Mono.just(0L);
         } else {
             policies.addAll(policyGenerator.getAllChildPolicies(
@@ -729,10 +730,10 @@ public class CommentServiceCEImpl extends BaseService<CommentRepository, Comment
                     Application.class,
                     CommentThread.class
             ));
-            policies.add(policyUtils.generatePolicyFromPermission(
-                    Set.of(AclPermission.MANAGE_THREADS),
-                    user
-            ).get(AclPermission.MANAGE_THREADS.getValue()));
+            // policies.add(policyUtils.generatePolicyFromPermission(
+            //         Set.of(AclPermission.MANAGE_THREADS),
+            //         user
+            // ).get(AclPermission.MANAGE_THREADS.getValue()));
             commentSeq = sequenceService.getNext(CommentThread.class, application.getId());
         }
         commentThread.setPolicies(policies);
@@ -755,10 +756,10 @@ public class CommentServiceCEImpl extends BaseService<CommentRepository, Comment
                 CommentThread.class,
                 Comment.class
         );
-        policies.add(policyUtils.generatePolicyFromPermission(
-                Set.of(AclPermission.MANAGE_COMMENTS),
-                user
-        ).get(AclPermission.MANAGE_COMMENTS.getValue()));
+        // policies.add(policyUtils.generatePolicyFromPermission(
+        //         Set.of(AclPermission.MANAGE_COMMENTS),
+        //         user
+        // ).get(AclPermission.MANAGE_COMMENTS.getValue()));
         comment.setPolicies(policies);
 
         Comment.Block block = new Comment.Block();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -1868,13 +1868,13 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                                                 return Mono.error(new AppsmithException(AppsmithError.PUBLIC_APP_NO_PERMISSION_GROUP));
                                             }
 
-                                            Map<String, Policy> datasourcePolicyMap =
+                                            Set<Policy> datasourcePolicySet =
                                                     policyUtils.generatePolicyFromPermissionWithPermissionGroup(
                                                             EXECUTE_DATASOURCES, defaultPermissionGroup
                                                     );
 
                                             Datasource updatedDatasource =
-                                                    policyUtils.addPoliciesToExistingObject(datasourcePolicyMap, datasource);
+                                                    policyUtils.addPoliciesToExistingObject(datasourcePolicySet, datasource);
 
 
                                             // Update the permission group to store the datasource execute permission

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
@@ -67,8 +67,8 @@ public class PermissionGroupServiceCEImpl extends BaseService<PermissionGroupRep
                     // so user can unassign himself from permission group
                     permissions.add(new Permission(pg.getId(), AclPermission.UNASSIGN_PERMISSION_GROUPS));
                     pg.setPermissions(permissions);
-                    Map<String, Policy> policyMap = policyUtils.generatePolicyFromPermissionGroupForObject(pg, pg.getId());
-                    policyUtils.addPoliciesToExistingObject(policyMap, pg);
+                    Set<Policy> policySet = policyUtils.generatePolicyFromPermissionGroupForObject(pg, pg.getId());
+                    policyUtils.addPoliciesToExistingObject(policySet, pg);
                     return pg;
                 })
                 .flatMap(pg -> repository.save(pg));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -434,7 +434,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
         return permissionGroupService.save(userManagementPermissionGroup)
                 .flatMap(savedPermissionGroup -> {
 
-                    Map<String, Policy> crudUserPolicies = policyUtils.generatePolicyFromPermissionGroupForObject(savedPermissionGroup,
+                    Set<Policy> crudUserPolicies = policyUtils.generatePolicyFromPermissionGroupForObject(savedPermissionGroup,
                             savedUser.getId());
 
                     User updatedWithPolicies = policyUtils.addPoliciesToExistingObject(crudUserPolicies, savedUser);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -208,9 +208,9 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
 
                                 // Apply the permissions to the workspace
                                 for (PermissionGroup permissionGroup : permissionGroups) {
-                                    Map<String, Policy> policyMap = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, createdWorkspace.getId());
+                                    Set<Policy> policySet = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, createdWorkspace.getId());
 
-                                    createdWorkspace = policyUtils.addPoliciesToExistingObject(policyMap, createdWorkspace);
+                                    createdWorkspace = policyUtils.addPoliciesToExistingObject(policySet, createdWorkspace);
                                 }
 
                                 return repository.save(createdWorkspace);
@@ -354,8 +354,8 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
                     // Apply the permissions to the permission groups
                     for (PermissionGroup permissionGroup : savedPermissionGroups) {
                         for (PermissionGroup nestedPermissionGroup : savedPermissionGroups) {
-                            Map<String, Policy> policyMap = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, nestedPermissionGroup.getId());
-                            policyUtils.addPoliciesToExistingObject(policyMap, nestedPermissionGroup);
+                            Set<Policy> policySet = policyUtils.generatePolicyFromPermissionGroupForObject(permissionGroup, nestedPermissionGroup.getId());
+                            policyUtils.addPoliciesToExistingObject(policySet, nestedPermissionGroup);
                         }
                     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EmailEventHandlerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EmailEventHandlerCEImpl.java
@@ -135,9 +135,10 @@ public class EmailEventHandlerCEImpl implements EmailEventHandlerCE {
     }
 
     private String getCommentThreadLink(Application application, String pageId, String threadId, String username, String originHeader) {
-        Boolean canManageApplication = policyUtils.isPermissionPresentForUser(
-                application.getPolicies(), MANAGE_APPLICATIONS.getValue(), username
-        );
+        Boolean canManageApplication = false;
+        // policyUtils.isPermissionPresentForUser(
+        //         application.getPolicies(), MANAGE_APPLICATIONS.getValue(), username
+        // );
         String urlPostfix = "/edit";
         if (Boolean.FALSE.equals(canManageApplication)) {  // user has no permission to manage application
             urlPostfix = "";

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserWorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserWorkspaceServiceTest.java
@@ -123,30 +123,6 @@ public class UserWorkspaceServiceTest {
 
     }
 
-    private UserRole createUserRole(String username, String userId, AppsmithRole role) {
-        UserRole userRole = new UserRole();
-        userRole.setUsername(username);
-        userRole.setUserId(userId);
-        userRole.setName(username);
-        if (role != null) {
-            userRole.setRoleName(role.getName());
-            userRole.setRole(role);
-        }
-        return userRole;
-    }
-
-    private void addRolesToWorkspace(List<UserRole> roles) {
-        this.workspace.setUserRoles(roles);
-        for (UserRole userRole : roles) {
-            Set<AclPermission> rolePermissions = userRole.getRole().getPermissions();
-            Map<String, Policy> workspacePolicyMap = policyUtils.generatePolicyFromPermission(
-                    rolePermissions, userRole.getUsername()
-            );
-            this.workspace = policyUtils.addPoliciesToExistingObject(workspacePolicyMap, workspace);
-        }
-        this.workspace = workspaceRepository.save(workspace).block();
-    }
-
     @After
     public void clear() {
         User currentUser = userRepository.findByEmail("api_user").block();


### PR DESCRIPTION
1. Removed outdated functions that uses users and commented the code using them, that was mostly from Comment feature.
2. Made functions to return and use Set of Policy as it is more appropriate return type, that also removes unnecessary creation of Map and Map if required can be created by the calling function.
3. Removed deepcopy and optimized the logic for adding and removing Policies to the object.