### PR TITLE
feat: JS toggle for icon property of Inputs

### DIFF
--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -16,7 +16,7 @@ import {
   INPUT_TEXT_MAX_CHAR_ERROR,
 } from "@appsmith/constants/messages";
 import { DerivedPropertiesMap } from "utils/WidgetFactory";
-import { GRID_DENSITY_MIGRATION_V1 } from "widgets/constants";
+import { GRID_DENSITY_MIGRATION_V1, ICON_NAMES } from "widgets/constants";
 import { AutocompleteDataType } from "utils/autocomplete/TernServer";
 import BaseInputWidget from "widgets/BaseInputWidget";
 import { isNil, isNumber, merge, toString } from "lodash";
@@ -25,6 +25,7 @@ import { BaseInputWidgetProps } from "widgets/BaseInputWidget/widget";
 import { mergeWidgetConfig } from "utils/helpers";
 import { InputTypes } from "widgets/BaseInputWidget/constants";
 import { getParsedText } from "./Utilities";
+import { IconNames } from "@blueprintjs/icons";
 
 export function defaultValueValidation(
   value: any,
@@ -302,9 +303,16 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
               label: "Icon",
               helpText: "Sets the icon to be used in input field",
               controlType: "ICON_SELECT",
-              isBindProperty: false,
+              isBindProperty: true,
               isTriggerProperty: false,
-              validation: { type: ValidationTypes.TEXT },
+              isJSConvertible: true,
+              validation: {
+                type: ValidationTypes.TEXT,
+                params: {
+                  allowedValues: ICON_NAMES,
+                  default: IconNames.PLUS,
+                },
+              },
             },
             {
               propertyName: "iconAlign",
@@ -490,9 +498,16 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
               label: "Icon",
               helpText: "Sets the icon to be used in input field",
               controlType: "ICON_SELECT",
-              isBindProperty: false,
+              isBindProperty: true,
               isTriggerProperty: false,
-              validation: { type: ValidationTypes.TEXT },
+              isJSConvertible: true,
+              validation: {
+                type: ValidationTypes.TEXT,
+                params: {
+                  allowedValues: ICON_NAMES,
+                  default: IconNames.PLUS,
+                },
+              },
             },
             {
               propertyName: "iconAlign",

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
@@ -13,6 +13,8 @@ import {
   ValidationResponse,
   ValidationTypes,
 } from "constants/WidgetValidation";
+import { ICON_NAMES } from "widgets/constants";
+import { IconNames } from "@blueprintjs/icons";
 
 function defaultValueValidation(
   value: any,
@@ -420,9 +422,16 @@ const PROPERTIES = {
       label: "Icon",
       helpText: "Sets the icon to be used in input field",
       controlType: "ICON_SELECT",
-      isBindProperty: false,
+      isBindProperty: true,
       isTriggerProperty: false,
-      validation: { type: ValidationTypes.TEXT },
+      isJSConvertible: true,
+      validation: {
+        type: ValidationTypes.TEXT,
+        params: {
+          allowedValues: ICON_NAMES,
+          default: IconNames.PLUS,
+        },
+      },
       hidden: (...args: HiddenFnParams) =>
         getSchemaItem(...args).fieldTypeNotIncludes([
           FieldType.TEXT_INPUT,
@@ -789,9 +798,16 @@ const PROPERTIES = {
         label: "Icon",
         helpText: "Sets the icon to be used in input field",
         controlType: "ICON_SELECT",
-        isBindProperty: false,
+        isBindProperty: true,
         isTriggerProperty: false,
-        validation: { type: ValidationTypes.TEXT },
+        isJSConvertible: true,
+        validation: {
+          type: ValidationTypes.TEXT,
+          params: {
+            allowedValues: ICON_NAMES,
+            default: IconNames.PLUS,
+          },
+        },
         hidden: (...args: HiddenFnParams) =>
           getSchemaItem(...args).fieldTypeNotIncludes([
             FieldType.TEXT_INPUT,

--- a/app/client/src/widgets/constants.ts
+++ b/app/client/src/widgets/constants.ts
@@ -1,3 +1,4 @@
+import { IconNames } from "@blueprintjs/icons";
 import { PropertyPaneConfig } from "constants/PropertyControlConstants";
 import { WidgetConfigProps } from "reducers/entityReducers/widgetConfigReducer";
 import { DerivedPropertiesMap } from "utils/WidgetFactory";
@@ -163,3 +164,7 @@ export const JSON_FORM_WIDGET_CHILD_STYLESHEET = {
 };
 
 export const YOUTUBE_URL_REGEX = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=|\?v=)([^#&?]*).*/;
+
+export const ICON_NAMES = Object.keys(IconNames).map(
+  (name: string) => IconNames[name as keyof typeof IconNames],
+);


### PR DESCRIPTION
## Description

Added JS toggle button for Icon property of Input widget and JSON Form widget's text, email, number and password input fields so that icon can be dynamically configured for these inputs.

Fixes #9614

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
