### PR TITLE
feat: flexible table cell width

### DIFF
--- a/app/client/src/entities/Widget/utils.test.ts
+++ b/app/client/src/entities/Widget/utils.test.ts
@@ -136,8 +136,6 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.status.buttonLabel":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isDisabled": EvaluationSubstitutionType.TEMPLATE,
-        "primaryColumns.status.isCellFlexible":
-          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.cellBackground":
@@ -156,8 +154,6 @@ describe("getAllPathsFromPropertyConfig", () => {
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.inputFormat":
           EvaluationSubstitutionType.TEMPLATE,
-        "primaryColumns.createdAt.isCellFlexible":
-          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.computedValue":
@@ -170,8 +166,6 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.name.fontStyle": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.textSize": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.horizontalAlignment":
-          EvaluationSubstitutionType.TEMPLATE,
-        "primaryColumns.name.isCellFlexible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
@@ -232,10 +226,6 @@ describe("getAllPathsFromPropertyConfig", () => {
           },
         },
         "primaryColumns.status.isDisabled": {
-          type: ValidationTypes.TABLE_PROPERTY,
-          params: { type: "BOOLEAN" },
-        },
-        "primaryColumns.status.isCellFlexible": {
           type: ValidationTypes.TABLE_PROPERTY,
           params: { type: "BOOLEAN" },
         },
@@ -339,10 +329,6 @@ describe("getAllPathsFromPropertyConfig", () => {
             },
           },
         },
-        "primaryColumns.createdAt.isCellFlexible": {
-          type: ValidationTypes.TABLE_PROPERTY,
-          params: { type: "BOOLEAN" },
-        },
         "primaryColumns.createdAt.isCellVisible": {
           type: ValidationTypes.TABLE_PROPERTY,
           params: { type: "BOOLEAN" },
@@ -382,10 +368,6 @@ describe("getAllPathsFromPropertyConfig", () => {
             type: ValidationTypes.TEXT,
             params: { allowedValues: ["LEFT", "CENTER", "RIGHT"] },
           },
-        },
-        "primaryColumns.name.isCellFlexible": {
-          type: ValidationTypes.TABLE_PROPERTY,
-          params: { type: "BOOLEAN" },
         },
         "primaryColumns.name.isCellVisible": {
           type: ValidationTypes.TABLE_PROPERTY,
@@ -430,8 +412,6 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.status.buttonLabel":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isDisabled": EvaluationSubstitutionType.TEMPLATE,
-        "primaryColumns.status.isCellFlexible":
-          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.cellBackground":
@@ -450,8 +430,6 @@ describe("getAllPathsFromPropertyConfig", () => {
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.inputFormat":
           EvaluationSubstitutionType.TEMPLATE,
-        "primaryColumns.createdAt.isCellFlexible":
-          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.computedValue":
@@ -464,8 +442,6 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.name.fontStyle": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.textSize": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.horizontalAlignment":
-          EvaluationSubstitutionType.TEMPLATE,
-        "primaryColumns.name.isCellFlexible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,

--- a/app/client/src/entities/Widget/utils.test.ts
+++ b/app/client/src/entities/Widget/utils.test.ts
@@ -136,6 +136,8 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.status.buttonLabel":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isDisabled": EvaluationSubstitutionType.TEMPLATE,
+        "primaryColumns.status.isCellFlexible":
+          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.cellBackground":
@@ -154,6 +156,8 @@ describe("getAllPathsFromPropertyConfig", () => {
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.inputFormat":
           EvaluationSubstitutionType.TEMPLATE,
+        "primaryColumns.createdAt.isCellFlexible":
+          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.computedValue":
@@ -166,6 +170,8 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.name.fontStyle": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.textSize": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.horizontalAlignment":
+          EvaluationSubstitutionType.TEMPLATE,
+        "primaryColumns.name.isCellFlexible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
@@ -226,6 +232,10 @@ describe("getAllPathsFromPropertyConfig", () => {
           },
         },
         "primaryColumns.status.isDisabled": {
+          type: ValidationTypes.TABLE_PROPERTY,
+          params: { type: "BOOLEAN" },
+        },
+        "primaryColumns.status.isCellFlexible": {
           type: ValidationTypes.TABLE_PROPERTY,
           params: { type: "BOOLEAN" },
         },
@@ -329,6 +339,10 @@ describe("getAllPathsFromPropertyConfig", () => {
             },
           },
         },
+        "primaryColumns.createdAt.isCellFlexible": {
+          type: ValidationTypes.TABLE_PROPERTY,
+          params: { type: "BOOLEAN" },
+        },
         "primaryColumns.createdAt.isCellVisible": {
           type: ValidationTypes.TABLE_PROPERTY,
           params: { type: "BOOLEAN" },
@@ -368,6 +382,10 @@ describe("getAllPathsFromPropertyConfig", () => {
             type: ValidationTypes.TEXT,
             params: { allowedValues: ["LEFT", "CENTER", "RIGHT"] },
           },
+        },
+        "primaryColumns.name.isCellFlexible": {
+          type: ValidationTypes.TABLE_PROPERTY,
+          params: { type: "BOOLEAN" },
         },
         "primaryColumns.name.isCellVisible": {
           type: ValidationTypes.TABLE_PROPERTY,
@@ -412,6 +430,8 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.status.buttonLabel":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isDisabled": EvaluationSubstitutionType.TEMPLATE,
+        "primaryColumns.status.isCellFlexible":
+          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.status.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.cellBackground":
@@ -430,6 +450,8 @@ describe("getAllPathsFromPropertyConfig", () => {
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.inputFormat":
           EvaluationSubstitutionType.TEMPLATE,
+        "primaryColumns.createdAt.isCellFlexible":
+          EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.createdAt.computedValue":
@@ -442,6 +464,8 @@ describe("getAllPathsFromPropertyConfig", () => {
         "primaryColumns.name.fontStyle": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.textSize": EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.horizontalAlignment":
+          EvaluationSubstitutionType.TEMPLATE,
+        "primaryColumns.name.isCellFlexible":
           EvaluationSubstitutionType.TEMPLATE,
         "primaryColumns.name.isCellVisible":
           EvaluationSubstitutionType.TEMPLATE,

--- a/app/client/src/widgets/TableWidgetV2/component/Constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/component/Constants.ts
@@ -111,6 +111,7 @@ export interface CellLayoutProperties {
   borderRadius: string;
   boxShadow: string;
   isCellVisible: boolean;
+  isCellFlexible?: boolean;
   isCompact?: boolean;
   menuItems: MenuItems;
   menuVariant?: ButtonVariant;
@@ -189,6 +190,7 @@ export interface ColumnProperties {
   label?: string;
   columnType: string;
   isVisible: boolean;
+  isCellFlexible?: boolean;
   isDisabled?: boolean;
   index: number;
   width: number;

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -189,18 +189,38 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
     }
 
     if (totalColumnWidth < componentWidth) {
-      const lastColumnIndex = columns.length - 1;
+      const flexibleColumns = columns.filter(
+        (c) => c.columnProperties?.isCellFlexible || false,
+      );
+      if (flexibleColumns.length > 0) {
+        let remainingColumnsSize = 0;
+        for (let i = 0; i < columns.length; i++) {
+          if (!(columns[i].columnProperties?.isCellFlexible || false)) {
+            remainingColumnsSize += columns[i].width || DEFAULT_COLUMN_WIDTH;
+          }
+        }
+        if (flexibleColumns.length > 0) {
+          const flexibleColumnWidth = componentWidth - remainingColumnsSize;
+          for (let i = 0; i < columns.length; i++) {
+            if (columns[i].columnProperties.isCellFlexible || false) {
+              columns[i].width = flexibleColumnWidth / flexibleColumns.length;
+            }
+          }
+        }
+      } else {
+        const lastColumnIndex = columns.length - 1;
 
-      if (columns[lastColumnIndex]) {
-        const lastColumnWidth =
-          columns[lastColumnIndex].width || DEFAULT_COLUMN_WIDTH;
-        const remainingWidth = componentWidth - totalColumnWidth;
+        if (columns[lastColumnIndex]) {
+          const lastColumnWidth =
+            columns[lastColumnIndex].width || DEFAULT_COLUMN_WIDTH;
+          const remainingWidth = componentWidth - totalColumnWidth;
 
-        columns[lastColumnIndex].width =
-          lastColumnWidth +
-          (remainingWidth < DEFAULT_COLUMN_WIDTH
-            ? DEFAULT_COLUMN_WIDTH
-            : remainingWidth);
+          columns[lastColumnIndex].width =
+            lastColumnWidth +
+            (remainingWidth < DEFAULT_COLUMN_WIDTH
+              ? DEFAULT_COLUMN_WIDTH
+              : remainingWidth);
+        }
       }
     }
 

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/ColumnControl.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/ColumnControl.ts
@@ -170,6 +170,24 @@ export default {
       },
     },
     {
+      propertyName: "isCellFlexible",
+      dependencies: ["primaryColumns", "derivedColumns", "columnType"],
+      label: "Flxible Width",
+      helpText: "Allow the cell width to be flexible in the table",
+      defaultValue: false,
+      controlType: "SWITCH",
+      customJSControl: "COMPUTE_VALUE",
+      isJSConvertible: true,
+      isBindProperty: true,
+      isTriggerProperty: false,
+      validation: {
+        type: ValidationTypes.TABLE_PROPERTY,
+        params: {
+          type: ValidationTypes.BOOLEAN,
+        },
+      },
+    },
+    {
       propertyName: "allowCellWrapping",
       dependencies: ["primaryColumns", "columnType"],
       label: "Cell Wrapping",

--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
@@ -309,6 +309,10 @@ export const getCellProperties = (
       textColor: getPropertyValue(columnProperties.textColor, rowIndex),
       fontStyle: getPropertyValue(columnProperties.fontStyle, rowIndex), //Fix this
       isVisible: getBooleanPropertyValue(columnProperties.isVisible, rowIndex),
+      isCellFlexible: getBooleanPropertyValue(
+        columnProperties.isCellFlexible,
+        rowIndex,
+      ),
       isDisabled: getBooleanPropertyValue(
         columnProperties.isDisabled,
         rowIndex,


### PR DESCRIPTION
> Pull Request Template
>
> Use this template to quickly create a well written pull request. Delete all quotes before creating the pull request.

## Description

Current Table widget assume the last cell to have flexible width and take the remaining screen. This PR would allow user to choose the cells that they want to have flexible width, instead of the last cell. 
- user can select one or multiple cells. Cells with flexible width enable will share the remaining width.
- if no cells set, it will default to last cell

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually 

- Drag Table widget
- In each cell, there will be a `Flexible Width` options. 
- Enable the option on the cell that you want to span across the screen. E.g `task` cell for default Table Data.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
