### PR TITLE
fix: unable to remove Icon on Input widget

### DIFF
--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -25,7 +25,6 @@ import { BaseInputWidgetProps } from "widgets/BaseInputWidget/widget";
 import { mergeWidgetConfig } from "utils/helpers";
 import { InputTypes } from "widgets/BaseInputWidget/constants";
 import { getParsedText } from "./Utilities";
-import { IconNames } from "@blueprintjs/icons";
 
 export function defaultValueValidation(
   value: any,

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -310,7 +310,6 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
                 type: ValidationTypes.TEXT,
                 params: {
                   allowedValues: ICON_NAMES,
-                  default: IconNames.PLUS,
                 },
               },
             },
@@ -505,7 +504,6 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
                 type: ValidationTypes.TEXT,
                 params: {
                   allowedValues: ICON_NAMES,
-                  default: IconNames.PLUS,
                 },
               },
             },

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
@@ -429,7 +429,6 @@ const PROPERTIES = {
         type: ValidationTypes.TEXT,
         params: {
           allowedValues: ICON_NAMES,
-          default: IconNames.PLUS,
         },
       },
       hidden: (...args: HiddenFnParams) =>
@@ -805,7 +804,6 @@ const PROPERTIES = {
           type: ValidationTypes.TEXT,
           params: {
             allowedValues: ICON_NAMES,
-            default: IconNames.PLUS,
           },
         },
         hidden: (...args: HiddenFnParams) =>

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
@@ -14,7 +14,6 @@ import {
   ValidationTypes,
 } from "constants/WidgetValidation";
 import { ICON_NAMES } from "widgets/constants";
-import { IconNames } from "@blueprintjs/icons";
 
 function defaultValueValidation(
   value: any,


### PR DESCRIPTION
## Description

Fix a bug where the users are unable to clear icon in an Input widget.

Fixes #16006

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
