### PR TITLE
fix: prevent children rerender in listwidget

### DIFF
--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -767,11 +767,11 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
 
       return canvasChildren;
     },
-    (prev: any, next: any) => this.deepEqual(prev, next),
+    (prev: any, next: any) => this.compareProps(prev, next),
   );
 
-  // deepEqual
-  deepEqual = (prev: any[], next: any[]) => {
+  // DeepEqual Comparison
+  compareProps = (prev: any[], next: any[]) => {
     return (
       equal(prev[0], next[0]) &&
       shallowEqual(prev[1], next[1]) &&

--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -14,7 +14,6 @@ import {
   isEqual,
 } from "lodash";
 import memoizeOne from "memoize-one";
-import shallowEqual from "shallowequal";
 import WidgetFactory from "utils/WidgetFactory";
 import { removeFalsyEntries } from "utils/helpers";
 import BaseWidget, { WidgetProps, WidgetState } from "widgets/BaseWidget";
@@ -41,6 +40,7 @@ import { DSLWidget } from "widgets/constants";
 import { entityDefinitions } from "utils/autocomplete/EntityDefinitions";
 import { escapeSpecialChars } from "../../WidgetUtils";
 import { PrivateWidgets } from "entities/DataTree/dataTreeFactory";
+import equal from "fast-deep-equal/es6";
 
 import { klona } from "klona";
 
@@ -765,17 +765,22 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
     (prev: any, next: any) => {
       // not comparing canvasChildren becuase template acts as a proxy
 
-      return (
-        shallowEqual(prev[0], next[0]) &&
-        shallowEqual(prev[1], next[1]) &&
-        shallowEqual(prev[2], next[2]) &&
-        prev[3] === next[3] &&
-        prev[4] === next[4] &&
-        prev[5] === next[6] &&
-        prev[6] === next[6]
-      );
+      return this.deepEqual(prev, next);
     },
   );
+
+  // deepEqual
+  deepEqual = (prev: any, next: any) => {
+    return (
+      equal(prev[0], next[0]) &&
+      equal(prev[1], next[1]) &&
+      equal(prev[2], next[2]) &&
+      equal(prev[3], next[3]) &&
+      prev[4] === next[4] &&
+      prev[5] === next[5] &&
+      prev[6] === next[6]
+    );
+  };
 
   /**
    * 400

--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -18,13 +18,15 @@ import shallowEqual from "shallowequal";
 import WidgetFactory from "utils/WidgetFactory";
 import { removeFalsyEntries } from "utils/helpers";
 import BaseWidget, { WidgetProps, WidgetState } from "widgets/BaseWidget";
-import { RenderModes, WidgetType } from "constants/WidgetConstants";
+import {
+  RenderModes,
+  WidgetType,
+  GridDefaults,
+} from "constants/WidgetConstants";
 import ListComponent, {
   ListComponentEmpty,
   ListComponentLoading,
 } from "../component";
-// import { ContainerStyle } from "components/designSystems/appsmith/ContainerComponent";
-// import { ContainerWidgetProps } from "../ContainerWidget";
 import propertyPaneConfig, {
   PropertyPaneContentConfig,
   PropertyPaneStyleConfig,
@@ -34,7 +36,6 @@ import { getDynamicBindings } from "utils/DynamicBindingUtils";
 import ListPagination, {
   ServerSideListPagination,
 } from "../component/ListPagination";
-import { GridDefaults } from "constants/WidgetConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import derivedProperties from "./parseDerivedProperties";
 import { DSLWidget } from "widgets/constants";
@@ -43,7 +44,7 @@ import { escapeSpecialChars } from "../../WidgetUtils";
 import { PrivateWidgets } from "entities/DataTree/dataTreeFactory";
 import equal from "fast-deep-equal/es6";
 
-import { klona } from "klona";
+import { klona } from "klona/lite";
 
 const LIST_WIDGET_PAGINATION_HEIGHT = 36;
 
@@ -757,7 +758,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       const canvasChildrenList = [];
       if (listData.length > 0) {
         for (let i = 0; i < listData.length; i++) {
-          canvasChildrenList[i] = JSON.parse(JSON.stringify(template));
+          canvasChildrenList[i] = klona(template);
         }
         canvasChildren = this.updateGridChildrenProps(canvasChildrenList);
       } else {

--- a/app/client/src/widgets/ListWidget/widget/index.tsx
+++ b/app/client/src/widgets/ListWidget/widget/index.tsx
@@ -14,6 +14,7 @@ import {
   isEqual,
 } from "lodash";
 import memoizeOne from "memoize-one";
+import shallowEqual from "shallowequal";
 import WidgetFactory from "utils/WidgetFactory";
 import { removeFalsyEntries } from "utils/helpers";
 import BaseWidget, { WidgetProps, WidgetState } from "widgets/BaseWidget";
@@ -712,6 +713,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       const { page } = this.state;
       const children = removeFalsyEntries(klona(this.props.children));
       const childCanvas = children[0];
+      const { perPage } = this.shouldPaginate();
 
       const canvasChildren = childCanvas.children;
       const template = canvasChildren.slice(0, 1).shift();
@@ -727,6 +729,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
           page,
           gridGap,
           this.props.itemBackgroundColor,
+          perPage,
         );
       } catch (e) {
         log.error(e);
@@ -749,6 +752,7 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       itemBackgroundColor,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      perPage,
     ) => {
       const canvasChildrenList = [];
       if (listData.length > 0) {
@@ -762,23 +766,20 @@ class ListWidget extends BaseWidget<ListWidgetProps<WidgetProps>, WidgetState> {
 
       return canvasChildren;
     },
-    (prev: any, next: any) => {
-      // not comparing canvasChildren becuase template acts as a proxy
-
-      return this.deepEqual(prev, next);
-    },
+    (prev: any, next: any) => this.deepEqual(prev, next),
   );
 
   // deepEqual
-  deepEqual = (prev: any, next: any) => {
+  deepEqual = (prev: any[], next: any[]) => {
     return (
       equal(prev[0], next[0]) &&
-      equal(prev[1], next[1]) &&
+      shallowEqual(prev[1], next[1]) &&
       equal(prev[2], next[2]) &&
       equal(prev[3], next[3]) &&
       prev[4] === next[4] &&
       prev[5] === next[5] &&
-      prev[6] === next[6]
+      prev[6] === next[6] &&
+      prev[7] === next[7]
     );
   };
 


### PR DESCRIPTION
## Description

Avoid re-rendering the list widget children in the List widget when making Canvas operations

Fixes #11620

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
