### PR TITLE
fix: Show invalid page UI for invalid jsobject page

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug16047_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug16047_spec.ts
@@ -1,17 +1,10 @@
 import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
 const jsEditor = ObjectsRegistry.JSEditor,
-  ee = ObjectsRegistry.EntityExplorer,
-  agHelper = ObjectsRegistry.AggregateHelper;
+  ee = ObjectsRegistry.EntityExplorer;
 
-describe("Lint error reporting", () => {
-  before(() => {
-    ee.DragDropWidgetNVerify("tablewidgetv2", 300, 500);
-    ee.DragDropWidgetNVerify("buttonwidget", 300, 300);
-    ee.NavigateToSwitcher("explorer");
-  });
-
-  it("1. Shows empty page UI with invalid JS Object page url", () => {
+describe("Invalid page routing", () => {
+  it("1. Shows Invalid URL UI for invalid JS Object page url", () => {
     const JS_OBJECT_BODY = `export default {
         myVar1: [],
         myVar2: {},
@@ -29,10 +22,11 @@ describe("Lint error reporting", () => {
       toRun: false,
       shouldCreateNewJSObj: true,
     });
+
     cy.url().then((url) => {
-      const invalidURL = url + "invalid";
+      const urlWithoutQueryParams = url.split("?")[0];
+      const invalidURL = urlWithoutQueryParams + "invalid";
       cy.visit(invalidURL);
-      agHelper.Sleep(2000);
       cy.contains(`The page you’re looking for either does not exist`).should(
         "exist",
       );

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug16047_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug16047_spec.ts
@@ -1,0 +1,41 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+const jsEditor = ObjectsRegistry.JSEditor,
+  ee = ObjectsRegistry.EntityExplorer,
+  agHelper = ObjectsRegistry.AggregateHelper;
+
+describe("Lint error reporting", () => {
+  before(() => {
+    ee.DragDropWidgetNVerify("tablewidgetv2", 300, 500);
+    ee.DragDropWidgetNVerify("buttonwidget", 300, 300);
+    ee.NavigateToSwitcher("explorer");
+  });
+
+  it("1. Shows empty page UI with invalid JS Object page url", () => {
+    const JS_OBJECT_BODY = `export default {
+        myVar1: [],
+        myVar2: {},
+        myFun1: () => {
+            //write code here
+           
+        },
+        myFun2: async () => {
+            //use async-await or promises
+        }
+    }`;
+    jsEditor.CreateJSObject(JS_OBJECT_BODY, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: true,
+    });
+    cy.url().then((url) => {
+      const invalidURL = url + "invalid";
+      cy.visit(invalidURL);
+      agHelper.Sleep(2000);
+      cy.contains(`The page you’re looking for either does not exist`).should(
+        "exist",
+      );
+    });
+  });
+});

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Linting/BasicLint_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Linting/BasicLint_spec.ts
@@ -68,7 +68,7 @@ describe("Linting", () => {
         }catch(e){
           showAlert("${errorMessage}")
         }
-      }()}}`
+      }()}}`,
     );
 
     propPane.UpdatePropertyFieldValue("Tooltip", "{{Api1.name}}");
@@ -121,7 +121,7 @@ describe("Linting", () => {
         }catch(e){
           showAlert("${errorMessage}")
         }
-      }()}}`
+      }()}}`,
     );
     propPane.UpdatePropertyFieldValue("Tooltip", `{{JSObject1.myVar1}}`);
 
@@ -196,7 +196,7 @@ describe("Linting", () => {
       }catch(e){
         showAlert("${errorMessage}")
       }
-    }()}}`
+    }()}}`,
     );
     propPane.UpdatePropertyFieldValue("Tooltip", `{{Query1.name}}`);
     clickButtonAndAssertLintError(true);
@@ -241,7 +241,7 @@ describe("Linting", () => {
         }catch(e){
           showAlert("${errorMessage}")
         }
-      }()}}`
+      }()}}`,
     );
     propPane.UpdatePropertyFieldValue(
       "Tooltip",

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Linting/ErrorReporting_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Linting/ErrorReporting_spec.ts
@@ -62,7 +62,7 @@ describe("Lint error reporting", () => {
       `{{
         () => {
         await showAlert('test')
-    }}}`
+    }}}`,
     );
 
     MouseHoverNVerify(
@@ -116,7 +116,7 @@ describe("Lint error reporting", () => {
           myVar2: {}
           myFun1: () => {
           }
-        }}}`
+        }}}`,
     );
     MouseHoverNVerify(
       "myFun1",
@@ -169,7 +169,7 @@ describe("Lint error reporting", () => {
           myVar2: {};
           myFun1: () => {
           }
-        }}}`
+        }}}`,
     );
     MouseHoverNVerify(
       ";",

--- a/app/client/src/pages/Editor/JSEditor/index.tsx
+++ b/app/client/src/pages/Editor/JSEditor/index.tsx
@@ -9,6 +9,7 @@ import { getJSCollectionById } from "selectors/editorSelectors";
 import CenteredWrapper from "components/designSystems/appsmith/CenteredWrapper";
 import Spinner from "components/editorComponents/Spinner";
 import styled from "styled-components";
+import EntityNotFoundPane from "../EntityNotFoundPane";
 
 const LoadingContainer = styled(CenteredWrapper)`
   height: 50%;
@@ -34,7 +35,7 @@ class JSEditor extends React.Component<Props> {
     if (!!jsCollection) {
       return <JsEditorForm jsCollection={jsCollection} />;
     }
-    return null;
+    return <EntityNotFoundPane />;
   }
 }
 


### PR DESCRIPTION
## Description

Shows page not found URL for invalid JSEditor link

<img width="1536" alt="Screenshot 2022-08-16 at 11 22 02" src="https://user-images.githubusercontent.com/46670083/184857076-82e83eed-59bd-4ba2-b73b-2a2c72fda662.png">


Fixes #16047 


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] https://github.com/appsmithorg/TestSmith/issues/2026

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
