### PR TITLE
fix: UI for members page when workspace name is too long

### DIFF
--- a/app/client/src/pages/workspace/Members.tsx
+++ b/app/client/src/pages/workspace/Members.tsx
@@ -49,27 +49,18 @@ const MembersWrapper = styled.div<{
     margin-top: 12px;
     thead {
       tr {
-        border-bottom: 1px solid #E8E8E8;
+        border-bottom: 1px solid #e8e8e8;
         th {
           font-size: 14px;
           font-weight: 500;
           line-height: 1.5;
           color: var(--appsmith-color-black-700);
-          padding: 8px 20px 4px 20px;
+          padding: 8px 20px;
           text-align: center;
 
-            svg {
-              margin: auto;
-            }
-
-            &:first-child {
-              text-align: left;
-
-              svg {
-                margin-left: 8px;
-              }
-            }
-
+          svg {
+            margin: auto 8px;
+            display: initial;
           }
         }
       }
@@ -79,10 +70,10 @@ const MembersWrapper = styled.div<{
       tr {
         td {
           text-align: center;
+          word-break: break-word;
 
           &:first-child {
             text-align: left;
-            word-break: break-word;
           }
 
           .t--deleteUser {


### PR DESCRIPTION
## Description

> Fixed UI for members page when workspace name is too long. Earlier in this case the user email id was breaking letter-wise to the next line.

Fixes #16063 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested the UI now with long workspace name to see if the members table is readable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
