### PR TITLE
chore: remove mockServiceWorker.js from build since its not needed in prod

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -176,6 +176,7 @@
     "test:unit": "$(npm bin)/jest -b --colors --no-cache --silent --coverage --collectCoverage=true --coverageDirectory='../../' --coverageReporters='json-summary'",
     "test:jest": "$(npm bin)/jest --watch",
     "generate:widget": "plop --plopfile generators/index.js",
+    "postbuild": "rm build/mockServiceWorker.js",
     "postinstall": "patch-package && CURRENT_SCOPE=client node ../shared/install-dependencies.js",
     "preinstall": "CURRENT_SCOPE=client node ../shared/build-shared-dep.js"
   },


### PR DESCRIPTION
## Description
Though we only use msw in `development` environment, when we run `yarn build` the `public/mockServiceWorker.js` still gets bundled and will be an unused file in build. We don't want that, so added a `postbuild` script which removes the file from the build folder post build.

Fixes #14395

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
