### PR TITLE
fix: Set button type to prevent reload of page when clicked

### DIFF
--- a/app/client/src/pages/Editor/JSEditor/utils.ts
+++ b/app/client/src/pages/Editor/JSEditor/utils.ts
@@ -76,6 +76,9 @@ export const getJSFunctionStartLineFromCode = (
 
 export const createGutterMarker = (gutterOnclick: () => void) => {
   const marker = document.createElement("button");
+  // For most browsers the default type of button is submit, this causes the page to reload when marker is clicked
+  // Set type to button, to prevent this behaviour
+  marker.type = "button";
   marker.innerHTML = "&#9654;";
   marker.classList.add(RUN_GUTTER_CLASSNAME);
   marker.onmousedown = function(e) {


### PR DESCRIPTION
## Description
For most browsers the default type of button is `submit`, this could cause the page to reload when clicked. Setting button type to `button`, prevents this behavior.

Fixes #15502


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[[Manual](https://github.com/appsmithorg/TestSmith/issues/2025)](https://github.com/appsmithorg/TestSmith/issues/2025)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
