### PR TITLE
fix: entrypoint.sh external mongo replica set check

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -168,7 +168,7 @@ init_replica_set() {
     # Check mongodb cloud Replica Set
     echo "Checking Replica Set of external MongoDB"
 
-    if appsmithctl check_replica_set; then
+    if [[ $(mongo $APPSMITH_MONGODB_URI --quiet --eval "rs.status().members.length") -gt 1 ]]; then
       echo "Mongodb cloud Replica Set is enabled"
     else
       echo -e "\033[0;31m********************************************************************\033[0m"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -168,7 +168,7 @@ init_replica_set() {
     # Check mongodb cloud Replica Set
     echo "Checking Replica Set of external MongoDB"
 
-    if [[ $(mongo $APPSMITH_MONGODB_URI --quiet --eval "rs.status().ok") -eq 1 ]]; then
+    if [[ $(mongo "$APPSMITH_MONGODB_URI" --quiet --eval "rs.status().ok") -eq 1 ]]; then
       echo "Mongodb cloud Replica Set is enabled"
     else
       echo -e "\033[0;31m********************************************************************\033[0m"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -168,7 +168,7 @@ init_replica_set() {
     # Check mongodb cloud Replica Set
     echo "Checking Replica Set of external MongoDB"
 
-    if [[ $(mongo $APPSMITH_MONGODB_URI --quiet --eval "rs.status().members.length") -gt 1 ]]; then
+    if [[ $(mongo $APPSMITH_MONGODB_URI --quiet --eval "rs.status().ok") -eq 1 ]]; then
       echo "Mongodb cloud Replica Set is enabled"
     else
       echo -e "\033[0;31m********************************************************************\033[0m"


### PR DESCRIPTION
Updated `entrypoint.sh` to use a mongo shell eval command instead of` appsmithctl check-replica-set` for **external mongo db**.

Partially fixes(Workaround): [16104](https://github.com/appsmithorg/appsmith/issues/16104)