### PR TITLE
fix: cURL not detecting the right body type

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -52,7 +52,6 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
     private static final String ARG_USER = "--user";
     private static final String ARG_USER_AGENT = "--user-agent";
     private static final String FORM_DATA_KEY = "apiContentType";
-    private static final String CONTENT_TYPE = "content-type";
 
     private final PluginService pluginService;
     private final LayoutActionService layoutActionService;
@@ -350,7 +349,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
                 }
                 if ("content-type".equalsIgnoreCase(parts[0])) {
                     contentType = parts[1];
-                    parts[0] = CONTENT_TYPE;
+                    parts[0] = HttpHeaders.CONTENT_TYPE;
                     //Setting the apiContentType to the content-type detected in the header with the key word content-type.
                     // required for RestAPI calls with GET method having body.
                     actionConfiguration.setFormData(Map.of(FORM_DATA_KEY, contentType));
@@ -413,7 +412,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
         if (contentType == null) {
             contentType = guessTheContentType(dataParts, formParts);
             if (contentType != null) {
-                headers.add(new Property(CONTENT_TYPE, contentType));
+                headers.add(new Property(HttpHeaders.CONTENT_TYPE, contentType));
                 // Setting the apiContentType to the content type detected by guessing the elements from  -f/ --form flag or -d/ --data flag
                 // required for RestAPI calls with GET method having body.
                 actionConfiguration.setFormData(Map.of(FORM_DATA_KEY, contentType));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -31,6 +31,7 @@ import reactor.test.StepVerifier;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -335,7 +336,7 @@ public class CurlImporterServiceTest {
 
         final ActionConfiguration actionConfiguration = action.getActionConfiguration();
         assertEmptyPath(action);
-        assertHeaders(action, new Property("Content-Type", "application/json"));
+        assertHeaders(action, new Property("content-type", "application/json"));
         assertThat(actionConfiguration.getQueryParameters()).isNullOrEmpty();
         assertMethod(action, HttpMethod.POST);
         assertBody(action, "{\"message\": \"The force is strong with this one...\"}");
@@ -467,9 +468,9 @@ public class CurlImporterServiceTest {
         assertUrl(action, "https://release-api.appsmith.com");
         assertPath(action, "/api/v1/users/5d81feb218e1c8217d20e13f");
         assertHeaders(action,
-                new Property("Content-Type", "application/json"),
+                new Property("content-type", "application/json"),
                 new Property("Authorization", "Basic abcdefghijklmnop=="),
-                new Property("Content-Type", "text/plain")
+                new Property("content-type", "text/plain")
         );
         assertBody(action, "{\n" +
                 "\t\"workspaceId\" : \"5d8c9e946599b93bd51a3400\"\n" +
@@ -500,9 +501,9 @@ public class CurlImporterServiceTest {
         assertUrl(action, "https://release-api.appsmith.com");
         assertPath(action, "/api/v1/datasources");
         assertHeaders(action,
-                new Property("Content-Type", "application/json"),
+                new Property("content-type", "application/json"),
                 new Property("Cookie", "SESSION=61ee9df5-3cab-400c-831b-9533218d8f9f"),
-                new Property("Content-Type", "text/plain")
+                new Property("content-type", "text/plain")
         );
         assertBody(action, "{\n" +
                 "    \"name\": \"testPostgres\",\n" +
@@ -556,8 +557,8 @@ public class CurlImporterServiceTest {
         assertPath(action, "/api/v1/providers");
         assertHeaders(action,
                 new Property("Cookie", "SESSION=61ee9df5-3cab-400c-831b-9533218d8f9f"),
-                new Property("Content-Type", "application/json"),
-                new Property("Content-Type", "application/json")
+                new Property("content-type", "application/json"),
+                new Property("content-type", "application/json")
         );
         assertBody(action, "{\n" +
                 "    \"name\": \"Delta Video\",\n" +
@@ -633,7 +634,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "https://api.sloths.com");
         assertEmptyPath(action);
-        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
+        assertHeaders(action, new Property("content-type", "application/x-www-form-urlencoded"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -644,7 +645,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "https://api.sloths.com");
         assertEmptyPath(action);
-        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
+        assertHeaders(action, new Property("content-type", "application/x-www-form-urlencoded"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -730,7 +731,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
-        assertHeaders(action, new Property("Content-Type", "application/json"));
+        assertHeaders(action, new Property("content-type", "application/json"));
         assertBody(action, "{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
         assertEmptyBodyFormData(action);
     }
@@ -741,7 +742,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
-        assertHeaders(action, new Property("Content-Type", "application/json"));
+        assertHeaders(action, new Property("content-type", "application/json"));
         assertBody(action, "{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
     }
 
@@ -761,7 +762,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
-        assertHeaders(action, new Property("Accept", "application/json"), new Property("Content-Type", "application/json"));
+        assertHeaders(action, new Property("Accept", "application/json"), new Property("content-type", "application/json"));
         assertBody(action, "{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
     }
 
@@ -771,7 +772,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "https://api.stripe.com");
         assertPath(action, "/v1/refunds");
-        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
+        assertHeaders(action, new Property("content-type", "application/x-www-form-urlencoded"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -788,7 +789,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://httpbin.org");
         assertPath(action, "/post");
-        assertHeaders(action, new Property("Content-Type", "multipart/form-data"));
+        assertHeaders(action, new Property("content-type", "multipart/form-data"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -837,6 +838,24 @@ public class CurlImporterServiceTest {
                 .verifyError();
     }
 
+    @Test
+    public void checkActionConfigurationFormData() {
+        final String API_CONTENT_TYPE = "apiContentType";
+        String cURLCommand = "curl -X POST https://mockurl.com -H \"Content-Type: application/json\" -d '{\"productId\": 123456, \"quantity\": 100}'";
+        String contentType = "application/json";
+        String name = "actionName";
+
+        ActionDTO actionDTO = curlImporterService.curlToAction(cURLCommand, name);
+        assertThat(actionDTO).isNotNull();
+        assertThat(actionDTO.getActionConfiguration()).isNotNull();
+        Map<String, Object> map =  actionDTO.getActionConfiguration().getFormData();
+
+        assert(map != null);
+        assert(!map.isEmpty());
+        assert(map.containsKey(API_CONTENT_TYPE));
+        assert(map.get(API_CONTENT_TYPE).equals(contentType));
+
+    }
     // Assertion utilities for working with Action assertions.
     private static void assertMethod(ActionDTO action, HttpMethod method) {
         assertThat(action.getActionConfiguration().getHttpMethod()).isEqualByComparingTo(method);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -336,7 +336,7 @@ public class CurlImporterServiceTest {
 
         final ActionConfiguration actionConfiguration = action.getActionConfiguration();
         assertEmptyPath(action);
-        assertHeaders(action, new Property("content-type", "application/json"));
+        assertHeaders(action, new Property("Content-Type", "application/json"));
         assertThat(actionConfiguration.getQueryParameters()).isNullOrEmpty();
         assertMethod(action, HttpMethod.POST);
         assertBody(action, "{\"message\": \"The force is strong with this one...\"}");
@@ -468,9 +468,9 @@ public class CurlImporterServiceTest {
         assertUrl(action, "https://release-api.appsmith.com");
         assertPath(action, "/api/v1/users/5d81feb218e1c8217d20e13f");
         assertHeaders(action,
-                new Property("content-type", "application/json"),
+                new Property("Content-Type", "application/json"),
                 new Property("Authorization", "Basic abcdefghijklmnop=="),
-                new Property("content-type", "text/plain")
+                new Property("Content-Type", "text/plain")
         );
         assertBody(action, "{\n" +
                 "\t\"workspaceId\" : \"5d8c9e946599b93bd51a3400\"\n" +
@@ -501,9 +501,9 @@ public class CurlImporterServiceTest {
         assertUrl(action, "https://release-api.appsmith.com");
         assertPath(action, "/api/v1/datasources");
         assertHeaders(action,
-                new Property("content-type", "application/json"),
+                new Property("Content-Type", "application/json"),
                 new Property("Cookie", "SESSION=61ee9df5-3cab-400c-831b-9533218d8f9f"),
-                new Property("content-type", "text/plain")
+                new Property("Content-Type", "text/plain")
         );
         assertBody(action, "{\n" +
                 "    \"name\": \"testPostgres\",\n" +
@@ -557,8 +557,8 @@ public class CurlImporterServiceTest {
         assertPath(action, "/api/v1/providers");
         assertHeaders(action,
                 new Property("Cookie", "SESSION=61ee9df5-3cab-400c-831b-9533218d8f9f"),
-                new Property("content-type", "application/json"),
-                new Property("content-type", "application/json")
+                new Property("Content-Type", "application/json"),
+                new Property("Content-Type", "application/json")
         );
         assertBody(action, "{\n" +
                 "    \"name\": \"Delta Video\",\n" +
@@ -634,7 +634,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "https://api.sloths.com");
         assertEmptyPath(action);
-        assertHeaders(action, new Property("content-type", "application/x-www-form-urlencoded"));
+        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -645,7 +645,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "https://api.sloths.com");
         assertEmptyPath(action);
-        assertHeaders(action, new Property("content-type", "application/x-www-form-urlencoded"));
+        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -731,7 +731,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
-        assertHeaders(action, new Property("content-type", "application/json"));
+        assertHeaders(action, new Property("Content-Type", "application/json"));
         assertBody(action, "{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
         assertEmptyBodyFormData(action);
     }
@@ -742,7 +742,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
-        assertHeaders(action, new Property("content-type", "application/json"));
+        assertHeaders(action, new Property("Content-Type", "application/json"));
         assertBody(action, "{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
     }
 
@@ -762,7 +762,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://dummy.restapiexample.com");
         assertPath(action, "/api/v1/create");
-        assertHeaders(action, new Property("Accept", "application/json"), new Property("content-type", "application/json"));
+        assertHeaders(action, new Property("Accept", "application/json"), new Property("Content-Type", "application/json"));
         assertBody(action, "{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}");
     }
 
@@ -772,7 +772,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "https://api.stripe.com");
         assertPath(action, "/v1/refunds");
-        assertHeaders(action, new Property("content-type", "application/x-www-form-urlencoded"));
+        assertHeaders(action, new Property("Content-Type", "application/x-www-form-urlencoded"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,
@@ -789,7 +789,7 @@ public class CurlImporterServiceTest {
         assertMethod(action, HttpMethod.POST);
         assertUrl(action, "http://httpbin.org");
         assertPath(action, "/post");
-        assertHeaders(action, new Property("content-type", "multipart/form-data"));
+        assertHeaders(action, new Property("Content-Type", "multipart/form-data"));
         assertEmptyBody(action);
         assertBodyFormData(
                 action,

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -29,7 +29,11 @@ import org.springframework.test.context.junit4.SpringRunner;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.util.*;
+import java.util.Map;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.HashSet;
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -880,8 +884,7 @@ public class CurlImporterServiceTest {
     }
 
     private static void assertHeaders(ActionDTO action, Property... headers) {
-        // since this step is case sensitive -let's make this case insensitive.
-        // this implementation only works if Property has an object which works with equals function
+        // this implementation only works if Property has a subclass of object which works implements equal function.
         // let's compare sizes of both first
         if (action.getActionConfiguration().getHeaders().size() != headers.length) {
             assert(false);
@@ -938,7 +941,6 @@ public class CurlImporterServiceTest {
             assert(false);
         }
         // if all header matches then only it will reach here.
-        //assertThat(action.getActionConfiguration().getHeaders()).containsExactlyInAnyOrder(headers);
     }
 
     private static void assertEmptyBody(ActionDTO action) {


### PR DESCRIPTION

## Description

This commit fixes the bug https://github.com/appsmithorg/appsmith/issues/13978 and changes two files:
- CurlImporterServiceTest.java
- CurlImporterServiceCEImpl.java

Additionally this commit fixes the Body type detection for REST APIs with GET method  when imported from cURL.

Fixes https://github.com/appsmithorg/appsmith/issues/13978

## Type of change

- Bug fix (Now the cURL import will be able to detect the right body type)

## How Has This Been Tested?
- This PR has been tested:
        * Manually
        * Junit
        
- As the Junit coverage is adequate, we don't require Cypress test case for this PR. 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
