### PR TITLE
fix: GraphQL plugin: remove duplicate warning message from action execution response

### DIFF
--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -145,23 +145,20 @@ public class GraphQLPlugin extends BasePlugin {
                 return Mono.error(e);
             }
 
-            Set<String> hintMessages = new HashSet<String>();
             if (actionConfiguration.getPaginationType() != null && !PaginationType.NONE.equals(actionConfiguration.getPaginationType())) {
-                updateVariablesWithPaginationValues(actionConfiguration, executeActionDTO, hintMessages);
+                updateVariablesWithPaginationValues(actionConfiguration, executeActionDTO);
             }
 
             // Filter out any empty headers
             headerUtils.removeEmptyHeaders(actionConfiguration);
 
-            return this.executeCommon(connection, datasourceConfiguration, actionConfiguration, parameters,
-                    hintMessages);
+            return this.executeCommon(connection, datasourceConfiguration, actionConfiguration, parameters);
         }
 
         public Mono<ActionExecutionResult> executeCommon(APIConnection apiConnection,
                                                          DatasourceConfiguration datasourceConfiguration,
                                                          ActionConfiguration actionConfiguration,
-                                                         List<Map.Entry<String, String>> insertedParams,
-                                                         Set<String> hintMessages) {
+                                                         List<Map.Entry<String, String>> insertedParams) {
 
             // Initializing object for error condition
             ActionExecutionResult errorResult = new ActionExecutionResult();
@@ -269,6 +266,7 @@ public class GraphQLPlugin extends BasePlugin {
                     EXCHANGE_STRATEGIES, requestCaptureFilter);
 
             /* Triggering the actual REST API call */
+            Set<String> hintMessages = new HashSet<String>();
             return triggerUtils.triggerApiCall(client, httpMethod, uri, requestBodyObj, actionExecutionRequest,
                     objectMapper,
                     hintMessages, errorResult, requestCaptureFilter);

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -104,10 +104,7 @@ public class GraphQLPaginationUtils {
     }
 
     public static void updateVariablesWithPaginationValues(ActionConfiguration actionConfiguration,
-                                                           ExecuteActionDTO executeActionDTO,
-                                                           Set<String> hintMessages) throws AppsmithPluginException {
-        hintMessages.addAll(getHintMessagesForDuplicatesInQueryVariables(actionConfiguration));
-
+                                                           ExecuteActionDTO executeActionDTO) throws AppsmithPluginException {
         final List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
         String variables = getValueSafelyFromPropertyList(properties, QUERY_VARIABLES_INDEX, String.class);
         JSONObject queryVariablesJson = new JSONObject();


### PR DESCRIPTION
## Description
- When a variable is defined in both the pagination section and the query variables section then a warning message is shown to the user. Currently, this warning message is displayed twice on the screen because it is returned back by the API server as part of two different responses i.e. as a response to the update endpoint call and as a response to the execute endpoint call. This PR removes the warning message from the execute response so that it gets displayed only at one place. 

Fixes #16099 

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- JUnit TC will be added as part of another issue: #12388

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
