### PR TITLE
fix: Arango plugin: change default db name to _system

### DIFF
--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/form.json
@@ -27,7 +27,7 @@
           "configProperty": "datasourceConfiguration.authentication.databaseName",
           "controlType": "INPUT_TEXT",
           "placeholderText": "Database name",
-          "initialValue": "default"
+          "initialValue": "_system"
         }
       ]
     },


### PR DESCRIPTION
## Description

> ArangoDB has changed it's default db name from `default` to `_system`. This PR make the corresponding changes.

Fixes #15899 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> I ran corresponding plugin test cases and passed all test cases.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
