### PR TITLE
fix: Display community edition along with version

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -111,6 +111,7 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_ID=${{ steps.vars.outputs.version }} \
             REACT_APP_VERSION_RELEASE_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ') \
+            REACT_APP_VERSION_EDITION="Community" \
             yarn build
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -85,6 +85,7 @@ jobs:
           REACT_APP_SEGMENT_CE_KEY: "${{ secrets.APPSMITH_SEGMENT_CE_KEY }}"
           REACT_APP_VERSION_ID: "${{ needs.prelude.outputs.tag }}"
           REACT_APP_INTERCOM_APP_ID: "${{ secrets.APPSMITH_INTERCOM_ID }}"
+          REACT_APP_VERSION_EDITION: "Community"
         run: |
           REACT_APP_VERSION_RELEASE_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             yarn build

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -250,6 +250,7 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_ID=${{ steps.vars.outputs.version }} \
             REACT_APP_VERSION_RELEASE_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ') \
+            REACT_APP_VERSION_EDITION="Community" \
             yarn build
 
       # Restore the previous built bundle if present. If not push the newly built into the cache
@@ -444,7 +445,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [0, 1,]
+        job: [0, 1]
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -804,7 +805,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+        job:
+          [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+          ]
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -1500,7 +1527,7 @@ jobs:
           token: ${{ secrets.APPSMITH_PERF_INFRA_REPO_PAT }}
           ref: main
           path: app/client/perf
-        
+
       - name: Installing performance tests dependencies
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: app/client/perf
@@ -1559,4 +1586,3 @@ jobs:
 
         # Set status = success
       - run: echo "::set-output name=run_result::success" > ~/run_result
-

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -146,6 +146,7 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
             REACT_APP_VERSION_ID=${{ steps.vars.outputs.version }} \
             REACT_APP_VERSION_RELEASE_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ') \
+            REACT_APP_VERSION_EDITION="Community" \
             REACT_APP_INTERCOM_APP_ID=${{ secrets.APPSMITH_INTERCOM_ID }} \
             yarn build
           ls -l build
@@ -423,7 +424,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [0, 1,]
+        job: [0, 1]
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -1437,4 +1438,3 @@ jobs:
           docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:nightly .
           docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${GITHUB_SHA}
           docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:nightly
-

--- a/app/client/src/ce/configs/index.ts
+++ b/app/client/src/ce/configs/index.ts
@@ -40,6 +40,7 @@ export interface INJECTED_CONFIGS {
   appVersion: {
     id: string;
     releaseDate: string;
+    edition: string;
   };
   intercomAppID: string;
   mailEnabled: boolean;
@@ -116,6 +117,7 @@ export const getConfigsFromEnvVars = (): INJECTED_CONFIGS => {
     appVersion: {
       id: process.env.REACT_APP_VERSION_ID || "",
       releaseDate: process.env.REACT_APP_VERSION_RELEASE_DATE || "",
+      edition: process.env.REACT_APP_VERSION_EDITION || "",
     },
     intercomAppID: process.env.REACT_APP_INTERCOM_APP_ID || "",
     mailEnabled: process.env.REACT_APP_MAIL_ENABLED

--- a/app/client/src/ce/configs/types.ts
+++ b/app/client/src/ce/configs/types.ts
@@ -56,6 +56,7 @@ export interface AppsmithUIConfigs {
   appVersion: {
     id: string;
     releaseDate: string;
+    edition: string;
   };
   intercomAppID: string;
   mailEnabled: boolean;

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -5,6 +5,8 @@ export function createMessage(
   return format(...args);
 }
 
+export const APPSMITH_DISPLAY_VERSION = (edition: string, version: string) =>
+  `Appsmith ${edition} ${version}`;
 export const YES = () => `Yes`;
 export const ARE_YOU_SURE = () => `Are you sure?`;
 export const ERROR_ADD_API_INVALID_URL = () =>

--- a/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
+++ b/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
@@ -25,6 +25,10 @@ import moment from "moment";
 import { getCurrentUser } from "selectors/usersSelectors";
 import { User } from "constants/userConstants";
 import { Colors } from "constants/Colors";
+import {
+  createMessage,
+  APPSMITH_DISPLAY_VERSION,
+} from "@appsmith/constants/messages";
 
 const { algolia, appVersion, intercomAppID } = getAppsmithConfigs();
 const searchClient = algoliasearch(algolia.apiId, algolia.apiKey);
@@ -417,7 +421,13 @@ class DocumentationSearch extends React.Component<Props, State> {
             </HelpBody>
             {appVersion.id && (
               <HelpFooter>
-                <span>Appsmith {appVersion.id}</span>
+                <span>
+                  {createMessage(
+                    APPSMITH_DISPLAY_VERSION,
+                    appVersion.edition,
+                    appVersion.id,
+                  )}
+                </span>
                 <span>Released {moment(appVersion.releaseDate).fromNow()}</span>
               </HelpFooter>
             )}

--- a/app/client/src/pages/Home/LeftPaneBottomSection.tsx
+++ b/app/client/src/pages/Home/LeftPaneBottomSection.tsx
@@ -7,6 +7,7 @@ import {
   createMessage,
   DOCUMENTATION,
   WELCOME_TOUR,
+  APPSMITH_DISPLAY_VERSION,
 } from "@appsmith/constants/messages";
 import { getIsFetchingApplications } from "selectors/applicationSelectors";
 import { getOnboardingWorkspaces } from "selectors/onboardingSelectors";
@@ -89,7 +90,13 @@ function LeftPaneBottomSection() {
       )}
       <ProductUpdatesModal />
       <LeftPaneVersionData>
-        <span>Appsmith {appVersion.id}</span>
+        <span>
+          {createMessage(
+            APPSMITH_DISPLAY_VERSION,
+            appVersion.edition,
+            appVersion.id,
+          )}
+        </span>
         {howMuchTimeBefore !== "" && (
           <span>Released {howMuchTimeBefore} ago</span>
         )}

--- a/app/client/src/pages/common/MobileSidebar.tsx
+++ b/app/client/src/pages/common/MobileSidebar.tsx
@@ -15,6 +15,7 @@ import {
   createMessage,
   ADMIN_SETTINGS,
   DOCUMENTATION,
+  APPSMITH_DISPLAY_VERSION,
 } from "@appsmith/constants/messages";
 import { getAppsmithConfigs } from "@appsmith/configs";
 import { howMuchTimeBeforeText } from "utils/helpers";
@@ -155,7 +156,13 @@ export default function MobileSideBar(props: MobileSideBarProps) {
         />
       </Section>
       <LeftPaneVersionData>
-        <span>Appsmith {appVersion.id}</span>
+        <span>
+          {createMessage(
+            APPSMITH_DISPLAY_VERSION,
+            appVersion.edition,
+            appVersion.id,
+          )}
+        </span>
         {howMuchTimeBefore !== "" && (
           <span>Released {howMuchTimeBefore} ago</span>
         )}


### PR DESCRIPTION
## Description

This PR adds the string `Community` along with the Appsmith version. This will help users identify the type of instance that they are running.

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
