### PR TITLE
ci: Moving server builds to Buildjet to confirm if it's faster and more reliable

### DIFF
--- a/.github/workflows/build-rts.yml
+++ b/.github/workflows/build-rts.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [release, release-frozen, master]
+    branches: [release, master]
     # Only trigger if files have changed in this specific path
     paths:
       - "app/rts/**"
@@ -63,14 +63,6 @@ jobs:
       # Build release Docker image and push to Docker Hub
       - name: Push release image to Docker Hub
         if: success() && github.ref == 'refs/heads/release'
-        run: |
-          docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{steps.vars.outputs.tag}} .
-          echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
-          docker push ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{steps.vars.outputs.tag}}
-
-      # Build release-frozen Docker image and push to Docker Hub
-      - name: Push release-frozen image to Docker Hub
-        if: success() && github.ref == 'refs/heads/release-frozen'
         run: |
           docker build -t ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-rts:${{steps.vars.outputs.tag}} .
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   server-build:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     if: |
       github.event_name == 'repository_dispatch' &&
       github.event.client_payload.slash_command.sha != '' &&
@@ -1291,7 +1291,7 @@ jobs:
       run:
         working-directory: app/client
     # Run this job only if all the previous steps are a success and the reference if the release or master branch
-    if: success() && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/release-frozen' || github.ref == 'refs/heads/master')
+    if: success() && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/master')
 
     steps:
       # Update check run called "package"

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [release, release-frozen, master]
+    branches: [release, master]
     # Only trigger if files have changed in this specific path
     paths:
       - "app/server/**"
@@ -23,7 +23,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     # Only run this workflow for internally triggered events
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||
@@ -94,26 +94,6 @@ jobs:
             -DgenerateBackupPoms=false \
             -DprocessAllModules=true
           ./build.sh
-
-  # These are dummy jobs in the CI build to satisfy required status checks for merging PRs. This is a hack because Github doesn't support conditional
-  # required checks in monorepos. These jobs are a clone of similarly named jobs in client.yml.
-  #
-  # Check support request at: https://github.community/t/feature-request-conditional-required-checks/16761
-  ui-test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-
-    steps:
-      # Checkout the code
-      - uses: actions/checkout@v2
-
-      - name: Do nothing as this is a dummy step
-        shell: bash
-        run: |
-          exit 0
 
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -6,7 +6,7 @@ on:
 
   # trigger for pushes to release and master
   push:
-    branches: [release, release-frozen, master]
+    branches: [release, master]
     paths:
       - "app/client/**"
       - "app/server/**"
@@ -175,7 +175,7 @@ jobs:
     defaults:
       run:
         working-directory: app/server
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     # Only run this workflow for internally triggered events
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -417,7 +417,7 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       github.event.pull_request.head.repo.full_name == github.repository))
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Description

This PR moves the server compilation for in standalone workflow, `ok-to-test` and `test-build-push` workflows to Buildjet. This is an experiment to see if we can prevent jobs from being queued in Github and also if there is greater reliability when server JUnit tests run on self-hosted runners via Buildjet.

Also, cleaning up some CI workflows to remove references to release-frozen branch.

## Type of change

- Tech debt

## How Has This Been Tested?

- CI run in this PR

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
