### PR TITLE
chore: Removing the Community/Business edition display for cloud hosting. 

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -5,8 +5,16 @@ export function createMessage(
   return format(...args);
 }
 
-export const APPSMITH_DISPLAY_VERSION = (edition: string, version: string) =>
-  `Appsmith ${edition} ${version}`;
+/*
+  For self hosted, it displays the string "Appsmith Community v1.10.0" or "Appsmith Business v1.10.0".
+  For cloud hosting, it displays "Appsmith v1.10.0". 
+  This is because Appsmith Cloud doesn't support business features yet.
+ */
+export const APPSMITH_DISPLAY_VERSION = (
+  edition: string,
+  version: string,
+  cloudHosting: boolean,
+) => `Appsmith ${!cloudHosting ? edition : ""} ${version}`;
 export const YES = () => `Yes`;
 export const ARE_YOU_SURE = () => `Are you sure?`;
 export const ERROR_ADD_API_INVALID_URL = () =>

--- a/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
+++ b/app/client/src/components/designSystems/appsmith/help/DocumentationSearch.tsx
@@ -30,7 +30,12 @@ import {
   APPSMITH_DISPLAY_VERSION,
 } from "@appsmith/constants/messages";
 
-const { algolia, appVersion, intercomAppID } = getAppsmithConfigs();
+const {
+  algolia,
+  appVersion,
+  cloudHosting,
+  intercomAppID,
+} = getAppsmithConfigs();
 const searchClient = algoliasearch(algolia.apiId, algolia.apiKey);
 
 const OenLinkIcon = HelpIcons.OPEN_LINK;
@@ -426,6 +431,7 @@ class DocumentationSearch extends React.Component<Props, State> {
                     APPSMITH_DISPLAY_VERSION,
                     appVersion.edition,
                     appVersion.id,
+                    cloudHosting,
                   )}
                 </span>
                 <span>Released {moment(appVersion.releaseDate).fromNow()}</span>

--- a/app/client/src/pages/Home/LeftPaneBottomSection.tsx
+++ b/app/client/src/pages/Home/LeftPaneBottomSection.tsx
@@ -50,7 +50,7 @@ function LeftPaneBottomSection() {
   const dispatch = useDispatch();
   const onboardingWorkspaces = useSelector(getOnboardingWorkspaces);
   const isFetchingApplications = useSelector(getIsFetchingApplications);
-  const { appVersion } = getAppsmithConfigs();
+  const { appVersion, cloudHosting } = getAppsmithConfigs();
   const howMuchTimeBefore = howMuchTimeBeforeText(appVersion.releaseDate);
 
   return (
@@ -95,6 +95,7 @@ function LeftPaneBottomSection() {
             APPSMITH_DISPLAY_VERSION,
             appVersion.edition,
             appVersion.id,
+            cloudHosting,
           )}
         </span>
         {howMuchTimeBefore !== "" && (

--- a/app/client/src/pages/common/MobileSidebar.tsx
+++ b/app/client/src/pages/common/MobileSidebar.tsx
@@ -97,7 +97,7 @@ const LeftPaneVersionData = styled.div`
 
 export default function MobileSideBar(props: MobileSideBarProps) {
   const user = useSelector(getCurrentUser);
-  const { appVersion } = getAppsmithConfigs();
+  const { appVersion, cloudHosting } = getAppsmithConfigs();
   const howMuchTimeBefore = howMuchTimeBeforeText(appVersion.releaseDate);
 
   return (
@@ -161,6 +161,7 @@ export default function MobileSideBar(props: MobileSideBarProps) {
             APPSMITH_DISPLAY_VERSION,
             appVersion.edition,
             appVersion.id,
+            cloudHosting,
           )}
         </span>
         {howMuchTimeBefore !== "" && (


### PR DESCRIPTION
The edition string will only be shown for self hosted instances. This change is being done because Appsmith Cloud doesn't yet support Business edition yet.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
