### PR TITLE
fix: Hiding the add new button in new workspace created if user has app viewer access

### DIFF
--- a/app/client/src/pages/Applications/index.tsx
+++ b/app/client/src/pages/Applications/index.tsx
@@ -607,21 +607,6 @@ function ApplicationsSection(props: any) {
     );
   }
 
-  const onClickAddNewButton = (workspaceId: string, applications: any) => {
-    if (
-      Object.entries(creatingApplicationMap).length === 0 ||
-      (creatingApplicationMap && !creatingApplicationMap[workspaceId])
-    ) {
-      createNewApplication(
-        getNextEntityName(
-          "Untitled application ",
-          applications.map((el: any) => el.name),
-        ),
-        workspaceId,
-      );
-    }
-  };
-
   const createNewApplication = (
     applicationName: string,
     workspaceId: string,
@@ -681,6 +666,22 @@ function ApplicationsSection(props: any) {
             workspace.userPermissions,
             PERMISSION_TYPE.CREATE_APPLICATION,
           ) && !isMobile;
+
+        const onClickAddNewButton = (workspaceId: string) => {
+          if (
+            Object.entries(creatingApplicationMap).length === 0 ||
+            (creatingApplicationMap && !creatingApplicationMap[workspaceId])
+          ) {
+            createNewApplication(
+              getNextEntityName(
+                "Untitled application ",
+                applications.map((el: any) => el.name),
+              ),
+              workspaceId,
+            );
+          }
+        };
+
         return (
           <WorkspaceSection
             className="t--workspace-section"
@@ -747,9 +748,7 @@ function ApplicationsSection(props: any) {
                             creatingApplicationMap &&
                             creatingApplicationMap[workspace.id]
                           }
-                          onClick={() =>
-                            onClickAddNewButton(workspace.id, applications)
-                          }
+                          onClick={() => onClickAddNewButton(workspace.id)}
                           size={Size.medium}
                           tag="button"
                           text={"New"}
@@ -922,9 +921,7 @@ function ApplicationsSection(props: any) {
                         creatingApplicationMap &&
                         creatingApplicationMap[workspace.id]
                       }
-                      onClick={() =>
-                        onClickAddNewButton(workspace.id, applications)
-                      }
+                      onClick={() => onClickAddNewButton(workspace.id)}
                       size={Size.medium}
                       tag="button"
                       text={"New"}

--- a/app/client/src/pages/Applications/index.tsx
+++ b/app/client/src/pages/Applications/index.tsx
@@ -607,6 +607,21 @@ function ApplicationsSection(props: any) {
     );
   }
 
+  const onClickAddNewButton = (workspaceId: string, applications: any) => {
+    if (
+      Object.entries(creatingApplicationMap).length === 0 ||
+      (creatingApplicationMap && !creatingApplicationMap[workspaceId])
+    ) {
+      createNewApplication(
+        getNextEntityName(
+          "Untitled application ",
+          applications.map((el: any) => el.name),
+        ),
+        workspaceId,
+      );
+    }
+  };
+
   const createNewApplication = (
     applicationName: string,
     workspaceId: string,
@@ -661,6 +676,11 @@ function ApplicationsSection(props: any) {
           workspace.userPermissions,
           PERMISSION_TYPE.MANAGE_WORKSPACE,
         );
+        const hasCreateNewApplicationPermission =
+          isPermitted(
+            workspace.userPermissions,
+            PERMISSION_TYPE.CREATE_APPLICATION,
+          ) && !isMobile;
         return (
           <WorkspaceSection
             className="t--workspace-section"
@@ -717,11 +737,7 @@ function ApplicationsSection(props: any) {
                         workspaceId={workspace.id}
                       />
                     )}
-                    {isPermitted(
-                      workspace.userPermissions,
-                      PERMISSION_TYPE.CREATE_APPLICATION,
-                    ) &&
-                      !isMobile &&
+                    {hasCreateNewApplicationPermission &&
                       !isFetchingApplications &&
                       applications.length !== 0 && (
                         <Button
@@ -731,22 +747,9 @@ function ApplicationsSection(props: any) {
                             creatingApplicationMap &&
                             creatingApplicationMap[workspace.id]
                           }
-                          onClick={() => {
-                            if (
-                              Object.entries(creatingApplicationMap).length ===
-                                0 ||
-                              (creatingApplicationMap &&
-                                !creatingApplicationMap[workspace.id])
-                            ) {
-                              createNewApplication(
-                                getNextEntityName(
-                                  "Untitled application ",
-                                  applications.map((el: any) => el.name),
-                                ),
-                                workspace.id,
-                              );
-                            }
-                          }}
+                          onClick={() =>
+                            onClickAddNewButton(workspace.id, applications)
+                          }
                           size={Size.medium}
                           tag="button"
                           text={"New"}
@@ -911,39 +914,22 @@ function ApplicationsSection(props: any) {
                   <NoAppsFoundIcon />
                   <span>There’s nothing inside this workspace</span>
                   {/* below component is duplicate. This is because of cypress test were failing */}
-                  {isPermitted(
-                    workspace.userPermissions,
-                    PERMISSION_TYPE.CREATE_APPLICATION,
-                  ) &&
-                    !isMobile && (
-                      <Button
-                        className="t--new-button createnew"
-                        icon={"plus"}
-                        isLoading={
-                          creatingApplicationMap &&
-                          creatingApplicationMap[workspace.id]
-                        }
-                        onClick={() => {
-                          if (
-                            Object.entries(creatingApplicationMap).length ===
-                              0 ||
-                            (creatingApplicationMap &&
-                              !creatingApplicationMap[workspace.id])
-                          ) {
-                            createNewApplication(
-                              getNextEntityName(
-                                "Untitled application ",
-                                applications.map((el: any) => el.name),
-                              ),
-                              workspace.id,
-                            );
-                          }
-                        }}
-                        size={Size.medium}
-                        tag="button"
-                        text={"New"}
-                      />
-                    )}
+                  {hasCreateNewApplicationPermission && (
+                    <Button
+                      className="t--new-button createnew"
+                      icon={"plus"}
+                      isLoading={
+                        creatingApplicationMap &&
+                        creatingApplicationMap[workspace.id]
+                      }
+                      onClick={() =>
+                        onClickAddNewButton(workspace.id, applications)
+                      }
+                      size={Size.medium}
+                      tag="button"
+                      text={"New"}
+                    />
+                  )}
                 </NoAppsFound>
               )}
             </ApplicationCardsWrapper>

--- a/app/client/src/pages/Applications/index.tsx
+++ b/app/client/src/pages/Applications/index.tsx
@@ -911,34 +911,39 @@ function ApplicationsSection(props: any) {
                   <NoAppsFoundIcon />
                   <span>There’s nothing inside this workspace</span>
                   {/* below component is duplicate. This is because of cypress test were failing */}
-                  {!isMobile && (
-                    <Button
-                      className="t--new-button createnew"
-                      icon={"plus"}
-                      isLoading={
-                        creatingApplicationMap &&
-                        creatingApplicationMap[workspace.id]
-                      }
-                      onClick={() => {
-                        if (
-                          Object.entries(creatingApplicationMap).length === 0 ||
-                          (creatingApplicationMap &&
-                            !creatingApplicationMap[workspace.id])
-                        ) {
-                          createNewApplication(
-                            getNextEntityName(
-                              "Untitled application ",
-                              applications.map((el: any) => el.name),
-                            ),
-                            workspace.id,
-                          );
+                  {isPermitted(
+                    workspace.userPermissions,
+                    PERMISSION_TYPE.CREATE_APPLICATION,
+                  ) &&
+                    !isMobile && (
+                      <Button
+                        className="t--new-button createnew"
+                        icon={"plus"}
+                        isLoading={
+                          creatingApplicationMap &&
+                          creatingApplicationMap[workspace.id]
                         }
-                      }}
-                      size={Size.medium}
-                      tag="button"
-                      text={"New"}
-                    />
-                  )}
+                        onClick={() => {
+                          if (
+                            Object.entries(creatingApplicationMap).length ===
+                              0 ||
+                            (creatingApplicationMap &&
+                              !creatingApplicationMap[workspace.id])
+                          ) {
+                            createNewApplication(
+                              getNextEntityName(
+                                "Untitled application ",
+                                applications.map((el: any) => el.name),
+                              ),
+                              workspace.id,
+                            );
+                          }
+                        }}
+                        size={Size.medium}
+                        tag="button"
+                        text={"New"}
+                      />
+                    )}
                 </NoAppsFound>
               )}
             </ApplicationCardsWrapper>

--- a/app/client/src/pages/common/PageWrapper.tsx
+++ b/app/client/src/pages/common/PageWrapper.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.section<{ isFixed?: boolean }>`
     props.isFixed
       ? `margin: 0;
   position: fixed;
-  top: ${props.theme.homePage.header}px;;
+  top: ${props.theme.homePage.header}px;
   width: 100%;`
       : `margin-top: ${props.theme.homePage.header}px;`}
   && .fade {


### PR DESCRIPTION
## Description

> Hiding the add new button in new workspace created if user has app viewer access

Fixes #9041 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Logged in with User A and created a new workspace with no applications in it.
- Shared this Organization with User B with App viewer permission only.
- Logged in with User B and verify the workspace doesn't show any add new button inside or next to the share button.

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/28362912/187141058-46097fe2-c8df-4a1e-886e-cee3420cf3aa.png">
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/28362912/187141150-8a8e2b53-8a21-4ec0-856e-76da5e4e1107.png">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
