### PR TITLE
fix: glitchy dropdown due to state updates after delayed responses

### DIFF
--- a/app/client/src/components/ads/TableDropdown.tsx
+++ b/app/client/src/components/ads/TableDropdown.tsx
@@ -20,6 +20,7 @@ export type DropdownProps = CommonComponentProps & {
   selectedIndex: number;
   position?: Position;
   selectedTextWidth?: string;
+  isDisabled?: boolean;
 };
 
 const SelectedItem = styled.div<{
@@ -112,6 +113,7 @@ function TableDropdown(props: DropdownProps) {
   ) : (
     <Popover
       data-cy={props.cypressSelector}
+      disabled={props.isDisabled}
       interactionKind={PopoverInteractionKind.CLICK}
       isOpen={isDropdownOpen}
       onInteraction={(state) => setIsDropdownOpen(state)}

--- a/app/client/src/pages/workspace/Members.tsx
+++ b/app/client/src/pages/workspace/Members.tsx
@@ -172,6 +172,10 @@ const DeleteIcon = styled(Icon)`
   right: ${(props) => props.theme.spaces[7]}px;
 `;
 
+const TableDropdownWrapper = styled.div<{ isDisabled?: boolean }>`
+  opacity: ${(props) => (props.isDisabled ? "0.5" : "1")};
+`;
+
 export default function MemberSettings(props: PageProps) {
   const {
     match: {
@@ -284,26 +288,31 @@ export default function MemberSettings(props: PageProps) {
         if (cellProps.cell.row.values.username === currentUser?.username) {
           return cellProps.cell.value;
         }
+        const isDisabled =
+          roleChangingUserInfo && roleChangingUserInfo.isChangingRole;
         return (
-          <TableDropdown
-            isLoading={
-              roleChangingUserInfo &&
-              roleChangingUserInfo.username ===
-                cellProps.cell.row.values.username
-            }
-            onSelect={(option) => {
-              dispatch(
-                changeWorkspaceUserRole(
-                  workspaceId,
-                  option.name,
-                  cellProps.cell.row.values.username,
-                ),
-              );
-            }}
-            options={roles}
-            selectedIndex={index}
-            selectedTextWidth="90px"
-          />
+          <TableDropdownWrapper isDisabled={isDisabled}>
+            <TableDropdown
+              isDisabled={isDisabled}
+              isLoading={
+                roleChangingUserInfo &&
+                roleChangingUserInfo.username ===
+                  cellProps.cell.row.values.username
+              }
+              onSelect={(option) => {
+                dispatch(
+                  changeWorkspaceUserRole(
+                    workspaceId,
+                    option.name,
+                    cellProps.cell.row.values.username,
+                  ),
+                );
+              }}
+              options={roles ?? []}
+              selectedIndex={index}
+              selectedTextWidth="90px"
+            />
+          </TableDropdownWrapper>
         );
       },
     },


### PR DESCRIPTION
## Description

On role change, when the server takes a long time to respond, we show the loader on the dropdown but still allow the user to make changes to other dropdown (changing other user's role). While doing so, if you have the dropdown open for another user and the still loading dropdown's network call is done, then it triggers a re render which closes the other dropdown. This cause a glitchy kind of feel. So disabled other dropdowns while any one of it is in loading state. 

Fixes #16018 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
