### PR TITLE
fix: Property pane dropdown for currency and phone input widgets.

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/CurrencyInput/CurrencyInput_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/CurrencyInput/CurrencyInput_spec.js
@@ -280,4 +280,16 @@ describe("Currency widget - ", () => {
       cy.get(themelocators.popover).should("not.exist");
     });
   });
+
+  it("Currency change dropdown should not close unexpectedly", function() {
+    cy.openPropertyPane(widgetName);
+
+    // Select the Currency dropdown option from property pane
+    // and enter a value that has space and returns 0 results
+    cy.get(".t--property-control-currency").click();
+    cy.get(".t--search-input input").type("gdp gdp");
+
+    // assert that the dropdown is still option
+    cy.get(".t--search-input input").should("be.visible");
+  });
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/PhoneInput/Phone_input_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/PhoneInput/Phone_input_spec.js
@@ -128,4 +128,16 @@ describe("Phone input widget - ", () => {
     // Check if isDirty is set to false
     cy.get(".t--widget-textwidget").should("contain", "false");
   });
+
+  it("Currency change dropdown should not close unexpectedly", function() {
+    cy.openPropertyPane(widgetName);
+
+    // Select the Currency dropdown option from property pane
+    // and enter a value that has space and returns 0 results
+    cy.get(".t--property-control-defaultcountrycode").click();
+    cy.get(".t--search-input input").type("AFDB (+93)");
+
+    // assert that the dropdown is still option
+    cy.get(".t--search-input input").should("be.visible");
+  });
 });

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -45,7 +45,7 @@
     "cypress-log-to-output": "^1.1.2",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",
-    "design-system": "npm:@appsmithorg/design-system@1.0.15",
+    "design-system": "npm:@appsmithorg/design-system@1.0.18",
     "downloadjs": "^1.4.7",
     "draft-js": "^0.11.7",
     "emoji-mart": "^3.0.1",

--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -83,6 +83,7 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
     return (
       <StyledDropDownContainer ref={this.containerRef}>
         <StyledDropDown
+          closeOnSpace={false}
           dropdownHeight={this.props.dropdownHeight}
           dropdownMaxHeight="200px"
           enableSearch={this.props.enableSearch}
@@ -98,6 +99,7 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
           removeSelectedOption={this.onItemRemove}
           searchPlaceholder={this.props.searchPlaceholderText}
           selected={defaultSelected}
+          showEmptyOptions
           showLabelOnly
           width="100%"
         />

--- a/app/client/src/components/propertyControls/DropDownControl.tsx
+++ b/app/client/src/components/propertyControls/DropDownControl.tsx
@@ -97,6 +97,7 @@ class DropDownControl extends BaseControl<DropDownControlProps> {
           options={options}
           placeholder={this.props.placeholderText}
           removeSelectedOption={this.onItemRemove}
+          searchAutoFocus
           searchPlaceholder={this.props.searchPlaceholderText}
           selected={defaultSelected}
           showEmptyOptions

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -6153,10 +6153,10 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
 
-"design-system@npm:@appsmithorg/design-system@1.0.15":
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system/-/design-system-1.0.15.tgz#40b855d82d349f25c399e62e7b82a1ddadaa6975"
-  integrity sha512-H43r0UriBVXfbWZg3vhBokDNW5kJKG+NoLae0BPNN6+72aYxfDBl+DocCI2KO6BYTdRnXZf9JQHi25t9t2yj/w==
+"design-system@npm:@appsmithorg/design-system@1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system/-/design-system-1.0.18.tgz#0f75d0bceb7bb0e4f2b561bae78a1fdb91cf7933"
+  integrity sha512-Zj8WNcKoYFFoY9jntr3Hmi82T++zCK3M7+jf0bdNJN0jiUu8GHOUz1jvAegPwmj4OUjp19RcrQXoNHQEtZRcXQ==
   dependencies:
     "@blueprintjs/datetime" "3.23.6"
     copy-to-clipboard "^3.3.1"


### PR DESCRIPTION
## Description

- PropertyPane Dropdowns for the `currencyInput` & `phoneInput` widgets close on when user types in space or if no result match.

Fixes #16369 
Fixes #16374

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Tested Manually on the canvas.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
