### PR TITLE
fix: For a public app, do not export the default permission group

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -192,6 +192,7 @@ public class Application extends BaseDomain {
         this.setServerSchemaVersion(null);
         this.setIsManualUpdate(false);
         this.sanitiseToExportBaseObject();
+        this.setDefaultPermissionGroup(null);
     }
 
     public List<ApplicationPage> getPages() {


### PR DESCRIPTION
Today, every public app has its own permission group which provides access to anonymous user. When such an app is exported, the permission group must not be exported as well to ensure that only the configuration (and not the access) is exported.