### PR TITLE
feat: List v2 POC - Override base widgets default API

### DIFF
--- a/app/client/src/widgets/ListWidgetV2/index.ts
+++ b/app/client/src/widgets/ListWidgetV2/index.ts
@@ -122,11 +122,11 @@ export const CONFIG = {
           const pathChunks = dataTreePath.split(".");
           const widgetName = pathChunks[0];
           const path = pathChunks.slice(1, pathChunks.length).join(".");
-          const { template } = parentProps;
+          const { flattenedChildCanvasWidgets = {} } = parentProps;
 
-          const templateWidget = Object.values(template).find(
-            (w) => w.widgetName === widgetName,
-          );
+          const templateWidget = Object.values(
+            flattenedChildCanvasWidgets,
+          ).find((w) => w.widgetName === widgetName);
 
           return `${parentProps.widgetName}.template.${templateWidget?.widgetId}.${path}`;
         },

--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -748,7 +748,7 @@ class ListWidget extends BaseWidget<
 
   onClientPageChange = (page: number) => this.setState({ page });
 
-  meta_executeAction = (triggerPayload: ExecuteTriggerPayload) => {
+  overrideExecuteAction = (triggerPayload: ExecuteTriggerPayload) => {
     const { id: metaWidgetId } = triggerPayload?.source || {};
 
     if (metaWidgetId) {
@@ -774,7 +774,7 @@ class ListWidget extends BaseWidget<
     }
   };
 
-  meta_batchUpdateWidgetProperty = (
+  overrideBatchUpdateWidgetProperty = (
     metaWidgetId: string,
     updates: BatchPropertyUpdatePayload,
     shouldReplay: boolean,
@@ -788,7 +788,7 @@ class ListWidget extends BaseWidget<
     );
   };
 
-  meta_updateWidget = (
+  overrideUpdateWidget = (
     operation: WidgetOperation,
     metaWidgetId: string,
     payload: any,
@@ -798,7 +798,7 @@ class ListWidget extends BaseWidget<
     this.context?.updateWidget?.(operation, templateWidgetId, payload);
   };
 
-  meta_updateWidgetProperty = (
+  overrideUpdateWidgetProperty = (
     metaWidgetId: string,
     propertyName: string,
     propertyValue: any,
@@ -812,7 +812,7 @@ class ListWidget extends BaseWidget<
     );
   };
 
-  meta_deleteWidgetProperty = (
+  overrideDeleteWidgetProperty = (
     metaWidgetId: string,
     propertyPaths: string[],
   ) => {
@@ -888,11 +888,11 @@ class ListWidget extends BaseWidget<
         listData={this.props.listData || []}
       >
         <MetaWidgetContextProvider
-          batchUpdateWidgetProperty={this.meta_batchUpdateWidgetProperty}
-          deleteWidgetProperty={this.meta_deleteWidgetProperty}
-          executeAction={this.meta_executeAction}
-          updateWidget={this.meta_updateWidget}
-          updateWidgetProperty={this.meta_updateWidgetProperty}
+          batchUpdateWidgetProperty={this.overrideBatchUpdateWidgetProperty}
+          deleteWidgetProperty={this.overrideDeleteWidgetProperty}
+          executeAction={this.overrideExecuteAction}
+          updateWidget={this.overrideUpdateWidget}
+          updateWidgetProperty={this.overrideUpdateWidgetProperty}
         >
           {this.renderChildren()}
         </MetaWidgetContextProvider>

--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -11,14 +11,17 @@ import {
   difference,
 } from "lodash";
 import WidgetFactory from "utils/WidgetFactory";
-import BaseWidget, { WidgetProps } from "widgets/BaseWidget";
+import BaseWidget, { WidgetProps, WidgetOperation } from "widgets/BaseWidget";
 import { RenderModes, WidgetType } from "constants/WidgetConstants";
 import ListComponent, {
   ListComponentEmpty,
   ListComponentLoading,
 } from "../component";
 import propertyPaneConfig from "./propertyConfig";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import {
+  EventType,
+  ExecuteTriggerPayload,
+} from "constants/AppsmithActionConstants/ActionConstants";
 import {
   combineDynamicBindings,
   getDynamicBindings,
@@ -33,16 +36,22 @@ import { entityDefinitions } from "utils/autocomplete/EntityDefinitions";
 import { PrivateWidgets } from "entities/DataTree/dataTreeFactory";
 import { klona } from "klona";
 import { generateReactKey } from "utils/generators";
+import MetaWidgetContextProvider from "../../MetaWidgetContextProvider";
+import { BatchPropertyUpdatePayload } from "actions/controlActions";
 
 export type DynamicPathList = Record<string, string[]>;
 
-export type Template = Record<string, FlattenedWidgetProps>;
+type MetaWidget = FlattenedWidgetProps & {
+  __index: number;
+};
+
+export type MetaWidgets = Record<string, MetaWidget>;
 
 export type GenerateMetaWidgetOptions = {
   parentId: string;
   widgetId?: string; // TODO: (Ashit) Remove this
   templateWidgetId?: string;
-  metaWidgets?: Template;
+  metaWidgets?: MetaWidgets;
   key: string; // TODO: (Ashit) - Make this field optional and use hash of data items
   prevFlattenedChildCanvasWidgets: ListWidgetProps<
     WidgetProps
@@ -51,6 +60,13 @@ export type GenerateMetaWidgetOptions = {
 
 type MetaWidgetIdCache = {
   [key: string]: Record<string, string>;
+};
+
+type MetaWidgetsReferenceData = {
+  [key: string]: {
+    index: number;
+    templateWidgetId: string;
+  };
 };
 
 type ListWidgetState = {
@@ -99,6 +115,11 @@ class ListWidget extends BaseWidget<
   currentViewMetaWidgetsRef: Set<string>;
 
   /**
+   * Contains metadata for each meta widget generated, eg - index, actual widgetId that was created from (templateWidget)
+   */
+  metaWidgetsReferenceData: MetaWidgetsReferenceData;
+
+  /**
    * returns the property pane config of the widget
    */
   static getPropertyPaneConfig() {
@@ -134,6 +155,7 @@ class ListWidget extends BaseWidget<
 
     this.metaWidgetIdCache = {};
     this.currentViewMetaWidgetsRef = new Set();
+    this.metaWidgetsReferenceData = {};
   }
 
   componentDidMount() {
@@ -491,11 +513,23 @@ class ListWidget extends BaseWidget<
       set(metaWidget, dynamicPath, dynamicValue);
     });
 
-    metaWidgets[metaWidget.widgetId] = metaWidget;
+    this.updateMetaWidgetReferenceData(metaWidget, templateWidgetId);
+
+    metaWidgets[metaWidget.widgetId] = metaWidget as MetaWidget;
 
     return {
       metaWidgets,
       metaWidgetId,
+    };
+  };
+
+  updateMetaWidgetReferenceData = (
+    metaWidget: FlattenedWidgetProps,
+    templateWidgetId: string,
+  ) => {
+    this.metaWidgetsReferenceData[metaWidget.widgetId] = {
+      index: metaWidget?.__index,
+      templateWidgetId: templateWidgetId,
     };
   };
 
@@ -714,6 +748,79 @@ class ListWidget extends BaseWidget<
 
   onClientPageChange = (page: number) => this.setState({ page });
 
+  meta_executeAction = (triggerPayload: ExecuteTriggerPayload) => {
+    const { id: metaWidgetId } = triggerPayload?.source || {};
+
+    if (metaWidgetId) {
+      const metadata = this.metaWidgetsReferenceData[metaWidgetId];
+      const { listData = [] } = this.props;
+
+      const globalContext = {
+        currentIndex: metadata.index,
+        currentItem: listData[metadata.index],
+        ...triggerPayload.globalContext,
+      };
+
+      const payload = {
+        ...triggerPayload,
+        globalContext,
+      };
+
+      super.executeAction(payload);
+    } else {
+      log.error(
+        `LIST_WIDGET_V2 ${this.props.widgetName} - meta widget not found on "executeAction" call`,
+      );
+    }
+  };
+
+  meta_batchUpdateWidgetProperty = (
+    metaWidgetId: string,
+    updates: BatchPropertyUpdatePayload,
+    shouldReplay: boolean,
+  ) => {
+    const { templateWidgetId } = this.metaWidgetsReferenceData[metaWidgetId];
+
+    this.context?.batchUpdateWidgetProperty?.(
+      templateWidgetId,
+      updates,
+      shouldReplay,
+    );
+  };
+
+  meta_updateWidget = (
+    operation: WidgetOperation,
+    metaWidgetId: string,
+    payload: any,
+  ) => {
+    const { templateWidgetId } = this.metaWidgetsReferenceData[metaWidgetId];
+
+    this.context?.updateWidget?.(operation, templateWidgetId, payload);
+  };
+
+  meta_updateWidgetProperty = (
+    metaWidgetId: string,
+    propertyName: string,
+    propertyValue: any,
+  ) => {
+    const { templateWidgetId } = this.metaWidgetsReferenceData[metaWidgetId];
+
+    this.context?.updateWidgetProperty?.(
+      templateWidgetId,
+      propertyName,
+      propertyValue,
+    );
+  };
+
+  meta_deleteWidgetProperty = (
+    metaWidgetId: string,
+    propertyPaths: string[],
+  ) => {
+    const { templateWidgetId } = this.metaWidgetsReferenceData[metaWidgetId];
+
+    this.context?.deleteWidgetProperty?.(templateWidgetId, propertyPaths);
+  };
+
   /**
    * view that is rendered in editor
    */
@@ -780,7 +887,15 @@ class ListWidget extends BaseWidget<
         key={`list-widget-page-${this.state.page}`}
         listData={this.props.listData || []}
       >
-        {this.renderChildren()}
+        <MetaWidgetContextProvider
+          batchUpdateWidgetProperty={this.meta_batchUpdateWidgetProperty}
+          deleteWidgetProperty={this.meta_deleteWidgetProperty}
+          executeAction={this.meta_executeAction}
+          updateWidget={this.meta_updateWidget}
+          updateWidgetProperty={this.meta_updateWidgetProperty}
+        >
+          {this.renderChildren()}
+        </MetaWidgetContextProvider>
         {shouldPaginate &&
           (serverSidePaginationEnabled ? (
             <ServerSideListPagination
@@ -825,7 +940,6 @@ export interface ListWidgetProps<T extends WidgetProps> extends WidgetProps {
   mainContainerId?: string;
   onListItemClick?: string;
   shouldScrollContents?: boolean;
-  template: Template;
 }
 
 export default ListWidget;

--- a/app/client/src/widgets/MetaWidgetContextProvider.tsx
+++ b/app/client/src/widgets/MetaWidgetContextProvider.tsx
@@ -1,0 +1,86 @@
+import React, { useContext, useMemo } from "react";
+
+import {
+  EditorContext,
+  EditorContextType,
+} from "components/editorComponents/EditorContextProvider";
+
+type MetaWidgetContextProviderProps = React.PropsWithChildren<
+  EditorContextType
+>;
+
+function MetaWidgetContextProvider({
+  children,
+  ...metaEditorContextProps
+}: MetaWidgetContextProviderProps) {
+  const editorContextProps = useContext(EditorContext);
+
+  if (!editorContextProps.executeAction) {
+    throw new Error(
+      "EditorContext not found - Use EditorContextProvider in a parent component.",
+    );
+  }
+
+  const executeAction =
+    metaEditorContextProps.executeAction ?? editorContextProps.executeAction;
+  const updateWidget =
+    metaEditorContextProps.updateWidget ?? editorContextProps.updateWidget;
+  const updateWidgetProperty =
+    metaEditorContextProps.updateWidgetProperty ??
+    editorContextProps.updateWidgetProperty;
+  const syncUpdateWidgetMetaProperty =
+    metaEditorContextProps.syncUpdateWidgetMetaProperty ??
+    editorContextProps.syncUpdateWidgetMetaProperty;
+  const disableDrag =
+    metaEditorContextProps.disableDrag ?? editorContextProps.disableDrag;
+  const resetChildrenMetaProperty =
+    metaEditorContextProps.resetChildrenMetaProperty ??
+    editorContextProps.resetChildrenMetaProperty;
+  const deleteWidgetProperty =
+    metaEditorContextProps.deleteWidgetProperty ??
+    editorContextProps.deleteWidgetProperty;
+  const batchUpdateWidgetProperty =
+    metaEditorContextProps.batchUpdateWidgetProperty ??
+    editorContextProps.batchUpdateWidgetProperty;
+  const triggerEvalOnMetaUpdate =
+    metaEditorContextProps.triggerEvalOnMetaUpdate ??
+    editorContextProps.triggerEvalOnMetaUpdate;
+  const modifyMetaWidgets =
+    metaEditorContextProps.modifyMetaWidgets ??
+    editorContextProps.modifyMetaWidgets;
+
+  const contextValue = useMemo(
+    () => ({
+      executeAction,
+      updateWidget,
+      updateWidgetProperty,
+      syncUpdateWidgetMetaProperty,
+      disableDrag,
+      resetChildrenMetaProperty,
+      deleteWidgetProperty,
+      batchUpdateWidgetProperty,
+      triggerEvalOnMetaUpdate,
+      modifyMetaWidgets,
+    }),
+    [
+      executeAction,
+      updateWidget,
+      updateWidgetProperty,
+      syncUpdateWidgetMetaProperty,
+      disableDrag,
+      resetChildrenMetaProperty,
+      deleteWidgetProperty,
+      batchUpdateWidgetProperty,
+      triggerEvalOnMetaUpdate,
+      modifyMetaWidgets,
+    ],
+  );
+
+  return (
+    <EditorContext.Provider value={contextValue}>
+      {children}
+    </EditorContext.Provider>
+  );
+}
+
+export default MetaWidgetContextProvider;


### PR DESCRIPTION
## Description
Meta widget's APIs such as `updateWidgetProperty`/`executeAction` would get called on the meta widgets properties. Ideally any sort of such updates should be propagated to the actual widgets so that it gets cloned to the reset of the meta widgets present in different rows of the list widget.

In order to override, the EditorContext's values are overridden and that in turn would modify the behaviour in the `BaseWidget` of every meta widget.

The `MetaWidgetContextProvider` can be used in any widget to override any child widgets API. Only those methods that are passed to `MetaWidgetContextProvider` are overridden the rest stay the same as the original API methods.

Fixes #15778 

#### Note: The method `resetChildrenMetaProperty` is not overridden in this PR and will be implemented separately.

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
