### PR TITLE
fix: gsheets insert command placeholder issue fixed

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/GoogleSheetsQuery_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/GoogleSheetsQuery_spec.js
@@ -1,0 +1,44 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+const datasource = require("../../../../locators/DatasourcesEditor.json");
+const explorer = require("../../../../locators/explorerlocators.json");
+
+let dataSources = ObjectsRegistry.DataSources;
+let queryName;
+let datasourceName;
+let pluginName = "Google Sheets";
+let placeholderText = "{\n  \"name\": {{nameInput.text}},\n  \"dob\": {{dobPicker.formattedDate}},\n  \"gender\": {{genderSelect.selectedOptionValue}} \n}"
+
+describe("Google Sheets datasource row objects placeholder", function() {
+    it("Bug: 16391 - Google Sheets DS, placeholder objects keys should have quotes", function() {
+      // create new Google Sheets datasource
+      dataSources.NavigateToDSCreateNew();
+      dataSources.CreatePlugIn(pluginName);
+      
+      // navigate to create query tab and create a new query
+      cy.get("@createDatasource").then((httpResponse) => {
+        datasourceName = httpResponse.response.body.data.name;
+        // clicking on new query to write a query
+        cy.NavigateToQueryEditor();
+        cy.get(explorer.createNew).click();
+        cy.get("div:contains('" + datasourceName + " Query')").last().click();
+  
+        // fill the create new api google sheets form
+        // and check for rowobject placeholder text
+        cy.get(datasource.gSheetsOperationDropdown).click();
+        cy.get(datasource.gSheetsInsertOneOption).click();
+  
+        cy.get(datasource.gSheetsEntityDropdown).click();
+        cy.get(datasource.gSheetsSheetRowsOption).click();
+  
+        cy.get(datasource.gSheetsCodeMirrorPlaceholder).should('have.text', placeholderText);
+
+        // delete query and datasource after test is done
+        cy.get("@createNewApi").then((httpResponse) => {
+          queryName = httpResponse.response.body.data.name;
+          cy.deleteQueryUsingContext();
+          cy.deleteDatasource(datasourceName);
+        })
+      });
+    });
+  }
+);

--- a/app/client/cypress/locators/DatasourcesEditor.json
+++ b/app/client/cypress/locators/DatasourcesEditor.json
@@ -73,5 +73,11 @@
   "useSelfSignedCert": ".t--connection\\.ssl\\.authType",
   "useCertInAuth": "[data-cy='authentication.useSelfSignedCert'] input",
   "certificateDetails": "[data-cy='section-Certificate Details']",
-  "saveBtn": ".t--save-datasource"
+  "saveBtn": ".t--save-datasource",
+  "gSheetsOperationDropdown": "[data-cy='actionConfiguration.formData.command.data']",
+  "gSheetsEntityDropdown": "[data-cy='actionConfiguration.formData.entityType.data']",
+  "gSheetsInsertOneOption": ".t--dropdown-option:contains('Insert One')",
+  "gSheetsSheetRowsOption": ".t--dropdown-option:contains('Sheet Row(s)')",
+  "gSheetsCodeMirrorPlaceholder": ".CodeMirror-placeholder"
+
 }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/insert.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/insert.json
@@ -36,7 +36,7 @@
           "conditionals": {
             "show": "{{actionConfiguration.formData.smartSubstitution.data === true && actionConfiguration.formData.entityType.data === 'ROWS' && actionConfiguration.formData.command.data === 'INSERT_ONE'}}"
           },
-          "placeholderText": "{\n  name: {{nameInput.text}},\n  dob: {{dobPicker.formattedDate}},\n  gender: {{genderSelect.selectedOptionValue}} \n}"
+          "placeholderText": "{\n  \"name\": {{nameInput.text}},\n  \"dob\": {{dobPicker.formattedDate}},\n  \"gender\": {{genderSelect.selectedOptionValue}} \n}"
         },
         {
           "label": "Row Object",
@@ -49,7 +49,7 @@
           "conditionals": {
             "show": "{{actionConfiguration.formData.smartSubstitution.data === false && actionConfiguration.formData.entityType.data === 'ROWS' && actionConfiguration.formData.command.data === 'INSERT_ONE'}}"
           },
-          "placeholderText": "{\n  name: {{nameInput.text}},\n  dob: {{dobPicker.formattedDate}},\n  gender: {{genderSelect.selectedOptionValue}} \n}"
+          "placeholderText": "{\n  \"name\": {{nameInput.text}},\n  \"dob\": {{dobPicker.formattedDate}},\n  \"gender\": {{genderSelect.selectedOptionValue}} \n}"
         },
         {
           "label": "Row Object(s)",
@@ -61,7 +61,7 @@
           "conditionals": {
             "show": "{{actionConfiguration.formData.smartSubstitution.data === true && ((actionConfiguration.formData.entityType.data === 'ROWS' && actionConfiguration.formData.command.data === 'INSERT_MANY') || (actionConfiguration.formData.entityType.data === 'SPREADSHEET' && actionConfiguration.formData.command.data === 'INSERT_ONE'))}}"
           },
-          "placeholderText": "[{\n  name: {{nameInput.text}},\n  dob: {{dobPicker.formattedDate}},\n  gender: {{genderSelect.selectedOptionValue}} \n}]"
+          "placeholderText": "[{\n  \"name\": {{nameInput.text}},\n  \"dob\": {{dobPicker.formattedDate}},\n  \"gender\": {{genderSelect.selectedOptionValue}} \n}]"
         },
         {
           "label": "Row Object(s)",
@@ -73,7 +73,7 @@
           "conditionals": {
             "show": "{{actionConfiguration.formData.smartSubstitution.data === false && ((actionConfiguration.formData.entityType.data === 'ROWS' && actionConfiguration.formData.command.data === 'INSERT_MANY') || (actionConfiguration.formData.entityType.data === 'SPREADSHEET' && actionConfiguration.formData.command.data === 'INSERT_ONE'))}}"
           },
-          "placeholderText": "[{\n  name: {{nameInput.text}},\n  dob: {{dobPicker.formattedDate}},\n  gender: {{genderSelect.selectedOptionValue}} \n}]"
+          "placeholderText": "[{\n  \"name\": {{nameInput.text}},\n  \"dob\": {{dobPicker.formattedDate}},\n  \"gender\": {{genderSelect.selectedOptionValue}} \n}]"
         }
       ]
     }


### PR DESCRIPTION
## Description

When creating insert queries for google sheets datasource, the rowObject placeholder text was not accurate. In the placeholder text of rowObject, the keys in the placeholder text object did not have any quotes around them, so if user passes the rowObject in this format without any quotes around the keys then "Plugin Failed to parse JSON" issue is thrown on running such query.

Fixes #16391

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Cypress Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
