### PR TITLE
fix: Better autocomplete for fast-xml-parser

### DIFF
--- a/app/client/src/constants/defs/xmlParser.json
+++ b/app/client/src/constants/defs/xmlParser.json
@@ -3,11 +3,37 @@
   "xmlParser": {
     "parse": {
       "!doc": "converts xml string to json object",
-      "!type": "fn(xml: string, options?: object) -> object"
+      "!type": "fn(xml: string, options?: object, validationOption?: object) -> object"
     },
     "validate": {
       "!doc": "validate xml data",
       "!type": "fn(xml: string) -> bool"
+    },
+    "convertToJson": {
+      "!type": "fn(node: ?, options: object) -> ?"
+    },
+    "convertToJsonString": {
+      "!type": "fn(node: ?, options: object) -> string"
+    },
+    "convertTonimn": {
+      "!type": "fn(node: ?, e_schema: ?, options: object) -> bool"
+    },
+    "getTraversalObj": {
+      "!type": "fn(xmlData: ?, options: object) -> ?"
+    },
+    "j2xParser": {
+      "!type": "fn(options: object) -> object",
+      "prototype": {
+        "parse": {
+          "!type": "ƒn(jObj: ?)"
+        },
+        "j2x": {
+          "!type": "fn(jObj: ?, level: ?)"
+        }
+      }
+    },
+    "parseToNimn": {
+      "!type": "fn(xmlData: ?, schema: ?, options: ?) -> ?"
     }
   }
 }


### PR DESCRIPTION
## Description
Adds other supported APIs in autocomplete suggestions for xmlParser object.

Fixes #16426 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
