### PR TITLE
fix: large app icons

### DIFF
--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -331,6 +331,8 @@ const CircleAppIcon = styled(AppIcon)`
   border-radius: 50%;
 
   svg {
+    width: unset;
+    height: unset;
     path {
       fill: #000 !important;
     }

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -331,8 +331,8 @@ const CircleAppIcon = styled(AppIcon)`
   border-radius: 50%;
 
   svg {
-    width: unset;
-    height: unset;
+    width: 100%;
+    height: 100%;
     path {
       fill: #000 !important;
     }


### PR DESCRIPTION
## Description

Chrome 105 gives precedence for the width and height of an element set by css over that set by an svg. 
Fixes https://github.com/appsmithorg/appsmith/issues/16470

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On local on Chrome 105 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
