### PR TITLE
chore: Converted server log timestamps to UTC

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -24,7 +24,7 @@ spring.mongodb.embedded.version=4.2.13
 logging.level.root=info
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
-logging.pattern.console=[%d{ISO8601}] %X - %m%n
+logging.pattern.console=[%d{ISO8601, UTC}] %X - %m%n
 
 #Spring security
 spring.security.oauth2.client.registration.google.client-id=${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:missing_value_sentinel}


### PR DESCRIPTION
To make the server log timestamp agnostic of the individual instance set up, we've configured all logs to always show timestamp as per UTC.