### PR TITLE
GraphQL: handle case where cursor value is null

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
@@ -3,7 +3,6 @@ package com.appsmith.external.helpers.restApiUtils.helpers;
 import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.Property;
-import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.util.CollectionUtils;

--- a/app/server/appsmith-plugins/graphqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/graphqlPlugin/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.16.0</version>
+            <version>1.17.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLConstants.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLConstants.java
@@ -1,13 +1,6 @@
 package com.external.utils;
 
 public class GraphQLConstants {
-    public static final String PREV = "previous";
-    public static final String NEXT = "next";
-    public static final String CURSOR = "cursor";
-    public static final String LIMIT = "limit";
-    public static final String OFFSET = "offset";
-    public static final String NAME = "name";
-    public static final String VALUE = "value";
     public static final String PREV_LIMIT_VARIABLE_NAME = "prevLimitVariableName";
     public static final String PREV_LIMIT_VAL = "prevLimitValue";
     public static final String PREV_CURSOR_VARIABLE_NAME = "prevCursorVariableName";

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -33,10 +33,14 @@ import static com.external.utils.GraphQLConstants.PREV_CURSOR_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.PREV_LIMIT_VAL;
 import static com.external.utils.GraphQLConstants.PREV_LIMIT_VARIABLE_NAME;
 import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
+import static org.apache.commons.lang3.ObjectUtils.NULL;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class GraphQLPaginationUtils {
+
+    private static String NULL_STRING = "null";
+
     public static Map getPaginationData(ActionConfiguration actionConfiguration) throws AppsmithPluginException {
         List<Property> properties = actionConfiguration.getPluginSpecifiedTemplates();
         if (properties.size() < PAGINATION_DATA_INDEX + 1) {
@@ -158,6 +162,7 @@ public class GraphQLPaginationUtils {
                             "a valid integer value for the previous page limit variable in the pagination tab. " +
                             "Current value: " + prevLimitValueString);
                 }
+                queryVariablesJson.put(prevLimitVarName, prevLimitValue);
 
                 String prevCursorVarName = paginationDataMap.get(PREV_CURSOR_VARIABLE_NAME);
                 String prevCursorValue = paginationDataMap.get(PREV_CURSOR_VAL);
@@ -169,8 +174,18 @@ public class GraphQLPaginationUtils {
                     );
                 }
 
-                queryVariablesJson.put(prevLimitVarName, prevLimitValue);
-                queryVariablesJson.put(prevCursorVarName, prevCursorValue);
+                /**
+                 * This check ensures that during the very first run when the query does not have any cursor data the
+                 * cursor related variable does not get added. In this case since the cursor data is not available
+                 * the dynamic binding value returned by the client is "null" string. Some GraphQL severs are able to
+                 * handle the "null" string as cursor value but some are not e.g. GitHub's GraphQL endpoints are not
+                 * able to handle "null" as value. Hence, it is better to skip passing the variable and allow the
+                 * GraphQL servers to run the query without cursor value. The GraphQL servers against which we are
+                 * testing seem to handle the case well where the value is skipped.
+                 */
+                if (!NULL_STRING.equals(prevCursorValue)) {
+                    queryVariablesJson.put(prevCursorVarName, prevCursorValue);
+                }
             }
             else {
                 String nextLimitVarName = paginationDataMap.get(NEXT_LIMIT_VARIABLE_NAME);
@@ -183,6 +198,7 @@ public class GraphQLPaginationUtils {
                             "a valid integer value for the next page limit variable in the pagination tab. " +
                             "Current value: " + nextLimitValueString);
                 }
+                queryVariablesJson.put(nextLimitVarName, nextLimitValue);
 
                 String nextCursorVarName = paginationDataMap.get(NEXT_CURSOR_VARIABLE_NAME);
                 String nextCursorValue = paginationDataMap.get(NEXT_CURSOR_VAL);
@@ -193,8 +209,18 @@ public class GraphQLPaginationUtils {
                     );
                 }
 
-                queryVariablesJson.put(nextLimitVarName, nextLimitValue);
-                queryVariablesJson.put(nextCursorVarName, nextCursorValue);
+                /**
+                 * This check ensures that during the very first run when the query does not have any cursor data the
+                 * cursor related variable does not get added. In this case since the cursor data is not available
+                 * the dynamic binding value returned by the client is "null" string. Some GraphQL severs are able to
+                 * handle the "null" string as cursor value but some are not e.g. GitHub's GraphQL endpoints are not
+                 * able to handle "null" as value. Hence, it is better to skip passing the variable and allow the
+                 * GraphQL servers to run the query without cursor value. The GraphQL servers against which we are
+                 * testing seem to handle the case well where the value is skipped.
+                 */
+                if (!NULL_STRING.equals(nextCursorValue)) {
+                    queryVariablesJson.put(nextCursorVarName, nextCursorValue);
+                }
             }
         }
         else {

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -13,7 +13,6 @@ import org.json.JSONException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromFormData;
 import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromPropertyList;
@@ -33,7 +32,6 @@ import static com.external.utils.GraphQLConstants.PREV_CURSOR_VARIABLE_NAME;
 import static com.external.utils.GraphQLConstants.PREV_LIMIT_VAL;
 import static com.external.utils.GraphQLConstants.PREV_LIMIT_VARIABLE_NAME;
 import static com.external.utils.GraphQLBodyUtils.QUERY_VARIABLES_INDEX;
-import static org.apache.commons.lang3.ObjectUtils.NULL;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 


### PR DESCRIPTION
## Description
- Handle the use case where the cursor value is `undefined` during the first run. This is expected because the cursor value is supposed to be fetched using a query run. Since during the first query run (no query has been run before this) no data is available the cursor value is `undefined` for which the client returns `null` string back to the API server. The API server handles this case by skipping to add the `cursor` key value pair as variables when the value is `null` string which is interpreted by the GraphQL server as a simple non paginated query.

Fixes #16477 


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC
- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
