### PR TITLE
fix: Never cache index.html via Service Worker

### DIFF
--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -27,7 +27,11 @@ const regexMap = {
 };
 
 /* eslint-disable no-restricted-globals */
-precacheAndRoute(self.__WB_MANIFEST || []);
+// precacheAndRoute(self.__WB_MANIFEST || []);
+const toPrecache = self.__WB_MANIFEST.filter(
+  (file) => !file.url.includes("index.html"),
+);
+precacheAndRoute(toPrecache);
 self.__WB_DISABLE_DEV_DEBUG_LOGS = false;
 skipWaiting();
 clientsClaim();
@@ -59,3 +63,7 @@ registerRoute(
     ],
   }),
 );
+
+registerRoute(({ url }) => {
+  return url.pathname.includes("index.html");
+}, new NetworkOnly());

--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -27,11 +27,11 @@ const regexMap = {
 };
 
 /* eslint-disable no-restricted-globals */
-// precacheAndRoute(self.__WB_MANIFEST || []);
-const toPrecache = self.__WB_MANIFEST.filter(
-  (file) => !file.url.includes("index.html"),
-);
-precacheAndRoute(toPrecache);
+precacheAndRoute(self.__WB_MANIFEST || []);
+// const toPrecache = self.__WB_MANIFEST.filter(
+//   (file) => !file.url.includes("index.html"),
+// );
+// precacheAndRoute(toPrecache);
 self.__WB_DISABLE_DEV_DEBUG_LOGS = false;
 skipWaiting();
 clientsClaim();
@@ -64,6 +64,6 @@ registerRoute(
   }),
 );
 
-registerRoute(({ url }) => {
-  return url.pathname.includes("index.html");
-}, new NetworkOnly());
+// registerRoute(({ url }) => {
+//   return url.pathname.includes("index.html");
+// }, new NetworkOnly());

--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -27,11 +27,11 @@ const regexMap = {
 };
 
 /* eslint-disable no-restricted-globals */
-precacheAndRoute(self.__WB_MANIFEST || []);
-// const toPrecache = self.__WB_MANIFEST.filter(
-//   (file) => !file.url.includes("index.html"),
-// );
-// precacheAndRoute(toPrecache);
+const toPrecache = self.__WB_MANIFEST.filter(
+  (file) => !file.url.includes("index.html"),
+);
+precacheAndRoute(toPrecache);
+
 self.__WB_DISABLE_DEV_DEBUG_LOGS = false;
 skipWaiting();
 clientsClaim();
@@ -64,6 +64,6 @@ registerRoute(
   }),
 );
 
-// registerRoute(({ url }) => {
-//   return url.pathname.includes("index.html");
-// }, new NetworkOnly());
+registerRoute(({ url }) => {
+  return url.pathname.includes("index.html");
+}, new NetworkOnly());


### PR DESCRIPTION
## Description

After this change, we will actively avoid index.html from SW cache. It will always fetch it from the network instead

Fixes # (issue)

> if no issue exists, please create an issue and ask the maintainers about this first

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
