### PR TITLE
perf: Widget layer optimization

### DIFF
--- a/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
+++ b/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
@@ -165,7 +165,7 @@ export function PositionedContainer(props: PositionedContainerProps) {
 
   const onClickFn = useCallback(
     (e) => {
-      clickToSelectWidget(e, props.widgetId);
+      clickToSelectWidget(e);
     },
     [props.widgetId, clickToSelectWidget],
   );

--- a/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
+++ b/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
@@ -94,10 +94,12 @@ export function PositionedContainer(props: PositionedContainerProps) {
     );
   }, [props.widgetType, props.widgetId]);
   const isDropTarget = checkIsDropTarget(props.widgetType);
-  const { onHoverZIndex, zIndex } = usePositionedContainerZIndex(
+  const [onHoverZIndex, zIndex] = usePositionedContainerZIndex(
     props,
     isDropTarget,
-  );
+  )
+    .split("__")
+    .map((a) => parseInt(a));
 
   const reflowSelector = getReflowSelector(props.widgetId);
 
@@ -193,5 +195,9 @@ export function PositionedContainer(props: PositionedContainerProps) {
   );
 }
 
+PositionedContainer.whyDidYouRender = {
+  logOnDifferentValues: true,
+  customName: "Menu",
+};
 PositionedContainer.padding = WIDGET_PADDING;
 export default PositionedContainer;

--- a/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
+++ b/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
@@ -26,7 +26,6 @@ const PositionedWidget = styled.div<{ zIndexOnHover: number }>`
   }
 `;
 export type PositionedContainerProps = {
-  // style: BaseStyle;
   componentWidth: number;
   componentHeight: number;
   children: ReactNode;
@@ -52,21 +51,21 @@ export const checkIsDropTarget = memoize(function isDropTarget(
 export function PositionedContainer(props: PositionedContainerProps) {
   const { componentHeight, componentWidth } = props;
 
-  const getStyle = (componentWidth: number, componentHeight: number) => ({
-    positionType: PositionTypes.ABSOLUTE,
-    componentHeight,
-    componentWidth,
-    yPosition:
-      props.topRow * props.parentRowSpace +
-      (props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
-    xPosition:
-      props.leftColumn * props.parentColumnSpace +
-      (props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
-    xPositionUnit: CSSUnits.PIXEL,
-    yPositionUnit: CSSUnits.PIXEL,
-  });
+  // Moemoizing the style
   const style: BaseStyle = useMemo(
-    () => getStyle(componentWidth, componentHeight),
+    () => ({
+      positionType: PositionTypes.ABSOLUTE,
+      componentHeight,
+      componentWidth,
+      yPosition:
+        props.topRow * props.parentRowSpace +
+        (props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
+      xPosition:
+        props.leftColumn * props.parentColumnSpace +
+        (props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
+      xPositionUnit: CSSUnits.PIXEL,
+      yPositionUnit: CSSUnits.PIXEL,
+    }),
     [
       componentWidth,
       componentHeight,
@@ -94,12 +93,11 @@ export function PositionedContainer(props: PositionedContainerProps) {
     );
   }, [props.widgetType, props.widgetId]);
   const isDropTarget = checkIsDropTarget(props.widgetType);
-  const [onHoverZIndex, zIndex] = usePositionedContainerZIndex(
+
+  const { onHoverZIndex, zIndex } = usePositionedContainerZIndex(
     props,
     isDropTarget,
-  )
-    .split("__")
-    .map((a) => parseInt(a));
+  );
 
   const reflowSelector = getReflowSelector(props.widgetId);
 
@@ -195,9 +193,5 @@ export function PositionedContainer(props: PositionedContainerProps) {
   );
 }
 
-PositionedContainer.whyDidYouRender = {
-  logOnDifferentValues: true,
-  customName: "Menu",
-};
 PositionedContainer.padding = WIDGET_PADDING;
 export default PositionedContainer;

--- a/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
+++ b/app/client/src/components/designSystems/appsmith/PositionedContainer.tsx
@@ -163,13 +163,6 @@ export function PositionedContainer(props: PositionedContainerProps) {
     reflowedPosition,
   ]);
 
-  const onClickFn = useCallback(
-    (e) => {
-      clickToSelectWidget(e);
-    },
-    [props.widgetId, clickToSelectWidget],
-  );
-
   // TODO: Experimental fix for sniping mode. This should be handled with a single event
   const stopEventPropagation = (e: any) => {
     !isSnipingMode && e.stopPropagation();
@@ -181,9 +174,9 @@ export function PositionedContainer(props: PositionedContainerProps) {
       data-testid="test-widget"
       id={props.widgetId}
       key={`positioned-container-${props.widgetId}`}
-      // Positioned Widget is the top enclosure for all widgets and clicks on/inside the widget should not be propogated/bubbled out of this Container.
+      // Positioned Widget is the top enclosure for all widgets and clicks on/inside the widget should not be propagated/bubbled out of this Container.
       onClick={stopEventPropagation}
-      onClickCapture={onClickFn}
+      onClickCapture={clickToSelectWidget}
       //Before you remove: This is used by property pane to reference the element
       style={containerStyle}
       zIndexOnHover={onHoverZIndex}

--- a/app/client/src/components/editorComponents/ResizableComponent.tsx
+++ b/app/client/src/components/editorComponents/ResizableComponent.tsx
@@ -42,6 +42,12 @@ import { GridDefaults } from "constants/WidgetConstants";
 import { DropTargetContext } from "./DropTargetComponent";
 import { XYCord } from "pages/common/CanvasArenas/hooks/useCanvasDragging";
 import { getParentToOpenSelector } from "selectors/widgetSelectors";
+import {
+  isCurrentWidgetFocused,
+  isCurrentWidgetLastSelected,
+  isWidgetSelected,
+  isMultiSelectedWidget,
+} from "selectors/widgetSelectors";
 
 export type ResizableComponentProps = WidgetProps & {
   paddingOffset: number;
@@ -60,15 +66,15 @@ export const ResizableComponent = memo(function ResizableComponent(
   const showTableFilterPane = useShowTableFilterPane();
   const { selectWidget } = useWidgetSelection();
   const { setIsResizing } = useWidgetDragResize();
-  const selectedWidget = useSelector(
-    (state: AppState) => state.ui.widgetDragResize.lastSelectedWidget,
+  // Check if current widget is in the list of selected widgets
+  const isSelected = useSelector(isWidgetSelected(props.widgetId));
+  // Check if current widget is the last selected widget
+  const isLastSelected = useSelector(
+    isCurrentWidgetLastSelected(props.widgetId),
   );
-  const selectedWidgets = useSelector(
-    (state: AppState) => state.ui.widgetDragResize.selectedWidgets,
-  );
-  const focusedWidget = useSelector(
-    (state: AppState) => state.ui.widgetDragResize.focusedWidget,
-  );
+  const isFocused = useSelector(isCurrentWidgetFocused(props.widgetId));
+  // Check if current widget is one of multiple selected widgets
+  const isMultiSelected = useSelector(isMultiSelectedWidget(props.widgetId));
 
   const isDragging = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isDragging,
@@ -79,11 +85,10 @@ export const ResizableComponent = memo(function ResizableComponent(
   const parentWidgetToSelect = useSelector(
     getParentToOpenSelector(props.widgetId),
   );
-
-  const isWidgetFocused =
-    focusedWidget === props.widgetId ||
-    selectedWidget === props.widgetId ||
-    selectedWidgets.includes(props.widgetId);
+  const isParentWidgetSelected = useSelector(
+    isCurrentWidgetLastSelected(parentWidgetToSelect?.widgetId || ""),
+  );
+  const isWidgetFocused = isFocused || isLastSelected || isSelected;
 
   // Calculate the dimensions of the widget,
   // The ResizableContainer's size prop is controlled
@@ -186,19 +191,17 @@ export const ResizableComponent = memo(function ResizableComponent(
     // Tell the Canvas to put the focus back to this widget
     // By setting the focus, we enable the control buttons on the widget
     selectWidget &&
-      selectedWidget !== props.widgetId &&
+      !isLastSelected &&
       parentWidgetToSelect?.widgetId !== props.widgetId &&
       selectWidget(props.widgetId);
 
     if (parentWidgetToSelect) {
       selectWidget &&
-        selectedWidget !== parentWidgetToSelect.widgetId &&
+        !isParentWidgetSelected &&
         selectWidget(parentWidgetToSelect.widgetId);
       focusWidget(parentWidgetToSelect.widgetId);
     } else {
-      selectWidget &&
-        selectedWidget !== props.widgetId &&
-        selectWidget(props.widgetId);
+      selectWidget && !isLastSelected && selectWidget(props.widgetId);
     }
     // Property pane closes after a resize/drag
     showPropertyPane && showPropertyPane();
@@ -214,9 +217,7 @@ export const ResizableComponent = memo(function ResizableComponent(
 
   const handleResizeStart = () => {
     setIsResizing && !isResizing && setIsResizing(true);
-    selectWidget &&
-      selectedWidget !== props.widgetId &&
-      selectWidget(props.widgetId);
+    selectWidget && !isLastSelected && selectWidget(props.widgetId);
     // Make sure that this tableFilterPane should close
     showTableFilterPane && showTableFilterPane();
     AnalyticsUtil.logEvent("WIDGET_RESIZE_START", {
@@ -245,10 +246,7 @@ export const ResizableComponent = memo(function ResizableComponent(
     !props.resizeDisabled &&
     !isSnipingMode &&
     !isPreviewMode;
-  const isMultiSelectedWidget =
-    selectedWidgets &&
-    selectedWidgets.length > 1 &&
-    selectedWidgets.includes(props.widgetId);
+
   const { updateDropTargetRows } = useContext(DropTargetContext);
 
   const gridProps = {
@@ -273,7 +271,7 @@ export const ResizableComponent = memo(function ResizableComponent(
 
   return (
     <Resizable
-      allowResize={!isMultiSelectedWidget}
+      allowResize={!isMultiSelected}
       componentHeight={dimensions.height}
       componentWidth={dimensions.width}
       enable={isEnabled}

--- a/app/client/src/components/editorComponents/SnipeableComponent.tsx
+++ b/app/client/src/components/editorComponents/SnipeableComponent.tsx
@@ -10,6 +10,7 @@ import { snipingModeSelector } from "selectors/editorSelectors";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
 import { Layers } from "constants/Layers";
 import { bindDataToWidget } from "actions/propertyPaneActions";
+import equal from "fast-deep-equal";
 
 const SnipeableWrapper = styled.div<{ isFocused: boolean }>`
   position: absolute;
@@ -35,7 +36,7 @@ type SnipeableComponentProps = WidgetProps;
 function SnipeableComponent(props: SnipeableComponentProps) {
   const { focusWidget } = useWidgetSelection();
   const dispatch = useDispatch();
-  const isSnipingMode = useSelector(snipingModeSelector);
+  const isSnipingMode = useSelector(snipingModeSelector, equal);
 
   const isFocusedWidget = useSelector(
     (state: AppState) =>

--- a/app/client/src/components/editorComponents/SnipeableComponent.tsx
+++ b/app/client/src/components/editorComponents/SnipeableComponent.tsx
@@ -5,12 +5,10 @@ import { WIDGET_PADDING } from "constants/WidgetConstants";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "@appsmith/reducers";
 import { getColorWithOpacity } from "constants/DefaultTheme";
-// import AnalyticsUtil from "utils/AnalyticsUtil";
 import { snipingModeSelector } from "selectors/editorSelectors";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
 import { Layers } from "constants/Layers";
 import { bindDataToWidget } from "actions/propertyPaneActions";
-import equal from "fast-deep-equal";
 
 const SnipeableWrapper = styled.div<{ isFocused: boolean }>`
   position: absolute;

--- a/app/client/src/components/editorComponents/SnipeableComponent.tsx
+++ b/app/client/src/components/editorComponents/SnipeableComponent.tsx
@@ -36,7 +36,7 @@ type SnipeableComponentProps = WidgetProps;
 function SnipeableComponent(props: SnipeableComponentProps) {
   const { focusWidget } = useWidgetSelection();
   const dispatch = useDispatch();
-  const isSnipingMode = useSelector(snipingModeSelector, equal);
+  const isSnipingMode = useSelector(snipingModeSelector);
 
   const isFocusedWidget = useSelector(
     (state: AppState) =>

--- a/app/client/src/selectors/ui.tsx
+++ b/app/client/src/selectors/ui.tsx
@@ -29,3 +29,6 @@ export const getIsSavingForJSObjectName = (state: AppState, id: string) =>
  */
 export const getErrorForJSObjectName = (state: AppState, id: string) =>
   state.ui.jsObjectName.errors[id];
+
+export const getFocusedWidget = (state: AppState) =>
+  state.ui.widgetDragResize.focusedWidget;

--- a/app/client/src/selectors/widgetReflowSelectors.tsx
+++ b/app/client/src/selectors/widgetReflowSelectors.tsx
@@ -16,3 +16,21 @@ export const getReflowSelector = (widgetId: string) => {
     return undefined;
   });
 };
+
+export const getIsReflowEffectedSelector = (
+  widgetId: string | undefined,
+  reflowed: boolean,
+) => {
+  return createSelector(
+    (state: AppState) => state.ui.widgetDragResize.dragDetails,
+    (dragDetails) => {
+      return (
+        widgetId &&
+        dragDetails &&
+        !!dragDetails.draggedOn &&
+        dragDetails.draggedOn === widgetId &&
+        reflowed
+      );
+    },
+  );
+};

--- a/app/client/src/selectors/widgetSelectors.ts
+++ b/app/client/src/selectors/widgetSelectors.ts
@@ -6,6 +6,7 @@ import { getNextEntityName } from "utils/AppsmithUtils";
 
 import WidgetFactory from "utils/WidgetFactory";
 import { getParentToOpenIfAny } from "utils/hooks/useClickToSelectWidget";
+import { getFocusedWidget, getSelectedWidgets } from "./ui";
 
 export const getIsDraggingOrResizing = (state: AppState) =>
   state.ui.widgetDragResize.isResizing || state.ui.widgetDragResize.isDragging;
@@ -69,4 +70,18 @@ export const getParentToOpenSelector = (widgetId: string) => {
   return createSelector(getCanvasWidgets, (canvasWidgets) => {
     return getParentToOpenIfAny(widgetId, canvasWidgets);
   });
+};
+
+// Check if widget is in the list of selected widgets
+export const isWidgetSelected = (widgetId: string) => {
+  return createSelector(getSelectedWidgets, (widgets): boolean =>
+    widgets.includes(widgetId),
+  );
+};
+
+export const isCurrentWidgetFocused = (widgetId: string) => {
+  return createSelector(
+    getFocusedWidget,
+    (widget): boolean => widget === widgetId,
+  );
 };

--- a/app/client/src/selectors/widgetSelectors.ts
+++ b/app/client/src/selectors/widgetSelectors.ts
@@ -11,6 +11,9 @@ import WidgetFactory from "utils/WidgetFactory";
 import { getFocusedWidget, getSelectedWidget, getSelectedWidgets } from "./ui";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { get } from "lodash";
+import { getAppMode } from "selectors/applicationSelectors";
+import { APP_MODE } from "entities/App";
+import { getIsTableFilterPaneVisible } from "selectors/tableFilterSelectors";
 
 export const getIsDraggingOrResizing = (state: AppState) =>
   state.ui.widgetDragResize.isResizing || state.ui.widgetDragResize.isDragging;
@@ -133,3 +136,30 @@ export function getParentToOpenIfAny(
 
   return;
 }
+
+export const shouldWidgetIgnoreClicksSelector = (widgetId: string) => {
+  return createSelector(
+    getFocusedWidget,
+    getIsTableFilterPaneVisible,
+    (state: AppState) => state.ui.widgetDragResize.isResizing,
+    (state: AppState) => state.ui.widgetDragResize.isDragging,
+    getAppMode,
+    (
+      focusedWidgetId,
+      isTableFilterPaneVisible,
+      isResizing,
+      isDragging,
+      appMode,
+    ) => {
+      const isFocused = focusedWidgetId === widgetId;
+
+      return (
+        isResizing ||
+        isDragging ||
+        appMode !== APP_MODE.EDIT ||
+        !isFocused ||
+        isTableFilterPaneVisible
+      );
+    },
+  );
+};

--- a/app/client/src/selectors/widgetSelectors.ts
+++ b/app/client/src/selectors/widgetSelectors.ts
@@ -113,12 +113,12 @@ export function getParentToOpenIfAny(
   if (widgetId) {
     let widget = get(widgets, widgetId, undefined);
 
-    // While this widget has a openParentPropertyPane equql to true
+    // While this widget has a openParentPropertyPane equal to true
     while (widget?.openParentPropertyPane) {
       // Get parent widget props
       const parent = get(widgets, `${widget.parentId}`, undefined);
 
-      // If parent has openParentPropertyPane = false, return the currnet parent
+      // If parent has openParentPropertyPane = false, return the current parent
       if (!parent?.openParentPropertyPane) {
         return parent;
       }

--- a/app/client/src/utils/hooks/useClickToSelectWidget.tsx
+++ b/app/client/src/utils/hooks/useClickToSelectWidget.tsx
@@ -13,41 +13,11 @@ import { getAppMode } from "selectors/applicationSelectors";
 import { useWidgetSelection } from "./useWidgetSelection";
 import React, { ReactNode, useCallback } from "react";
 import { stopEventPropagation } from "utils/AppsmithUtils";
-import { getFocusedParentToOpen } from "selectors/widgetSelectors";
-
-/**
- *
- * @param widgetId
- * @param widgets
- * @returns
- */
-export function getParentToOpenIfAny(
-  widgetId: string | undefined,
-  widgets: CanvasWidgetsReduxState,
-) {
-  if (widgetId) {
-    let widget = get(widgets, widgetId, undefined);
-
-    // While this widget has a openParentPropertyPane equql to true
-    while (widget?.openParentPropertyPane) {
-      // Get parent widget props
-      const parent = get(widgets, `${widget.parentId}`, undefined);
-
-      // If parent has openParentPropertyPane = false, return the currnet parent
-      if (!parent?.openParentPropertyPane) {
-        return parent;
-      }
-
-      if (parent?.parentId && parent.parentId !== MAIN_CONTAINER_WIDGET_ID) {
-        widget = get(widgets, `${widget.parentId}`, undefined);
-
-        continue;
-      }
-    }
-  }
-
-  return;
-}
+import {
+  getFocusedParentToOpen,
+  isCurrentWidgetFocused,
+  isWidgetSelected,
+} from "selectors/widgetSelectors";
 
 export function ClickContentToOpenPropPane({
   children,
@@ -58,7 +28,7 @@ export function ClickContentToOpenPropPane({
 }) {
   const { focusWidget } = useWidgetSelection();
 
-  const clickToSelectWidget = useClickToSelectWidget();
+  const clickToSelectWidget = useClickToSelectWidget(widgetId);
   const clickToSelectFn = useCallback(
     (e) => {
       clickToSelectWidget(e, widgetId);
@@ -99,14 +69,15 @@ export function ClickContentToOpenPropPane({
   );
 }
 
-export const useClickToSelectWidget = () => {
+export const useClickToSelectWidget = (widgetId: string) => {
   const { focusWidget, selectWidget } = useWidgetSelection();
   const isPropPaneVisible = useSelector(getIsPropertyPaneVisible);
   const isTableFilterPaneVisible = useSelector(getIsTableFilterPaneVisible);
-  const selectedWidgetId = useSelector(getCurrentWidgetId);
-  const focusedWidgetId = useSelector(
-    (state: AppState) => state.ui.widgetDragResize.focusedWidget,
-  );
+
+  const isFocused = useSelector(isCurrentWidgetFocused(widgetId));
+  const isSelected = useSelector(isWidgetSelected(widgetId));
+  // const parentWidgetToOpen = useSelector(getParentToOpenIfAny(widgetId));
+
   // This state tells us whether a `ResizableComponent` is resizing
   const isResizing = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isResizing,
@@ -119,6 +90,7 @@ export const useClickToSelectWidget = () => {
   );
 
   const parentWidgetToOpen = useSelector(getFocusedParentToOpen);
+
   const clickToSelectWidget = (e: any, targetWidgetId: string) => {
     // ignore click captures
     // 1. if the component was resizing or dragging coz it is handled internally in draggable component
@@ -127,21 +99,18 @@ export const useClickToSelectWidget = () => {
       isResizing ||
       isDragging ||
       appMode !== APP_MODE.EDIT ||
-      targetWidgetId !== focusedWidgetId ||
+      !isFocused ||
       isTableFilterPaneVisible
     )
       return;
-    if (
-      (!isPropPaneVisible && selectedWidgetId === focusedWidgetId) ||
-      selectedWidgetId !== focusedWidgetId
-    ) {
+    if ((!isPropPaneVisible && isSelected) || !isSelected) {
       const isMultiSelect = e.metaKey || e.ctrlKey || e.shiftKey;
 
       if (parentWidgetToOpen) {
         selectWidget(parentWidgetToOpen.widgetId, isMultiSelect);
       } else {
-        selectWidget(focusedWidgetId, isMultiSelect);
-        focusWidget(focusedWidgetId);
+        selectWidget(widgetId, isMultiSelect);
+        focusWidget(widgetId);
       }
 
       if (isMultiSelect) {

--- a/app/client/src/utils/hooks/useClickToSelectWidget.tsx
+++ b/app/client/src/utils/hooks/useClickToSelectWidget.tsx
@@ -1,4 +1,4 @@
-import { get } from "lodash";
+import { eq, get } from "lodash";
 import { getIsPropertyPaneVisible } from "selectors/propertyPaneSelectors";
 import { getIsTableFilterPaneVisible } from "selectors/tableFilterSelectors";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
@@ -15,6 +15,7 @@ import {
   isCurrentWidgetFocused,
   isWidgetSelected,
 } from "selectors/widgetSelectors";
+import equal from "fast-deep-equal/es6";
 
 export function getParentToOpenIfAny(
   widgetId: string | undefined,
@@ -96,25 +97,33 @@ export function ClickContentToOpenPropPane({
 
 export const useClickToSelectWidget = (widgetId: string) => {
   const { focusWidget, selectWidget } = useWidgetSelection();
-  const isPropPaneVisible = useSelector(getIsPropertyPaneVisible);
-  const isTableFilterPaneVisible = useSelector(getIsTableFilterPaneVisible);
+  const isPropPaneVisible = useSelector(getIsPropertyPaneVisible, equal);
+  const isTableFilterPaneVisible = useSelector(
+    getIsTableFilterPaneVisible,
+    equal,
+  );
 
-  const isFocused = useSelector(isCurrentWidgetFocused(widgetId));
-  const isSelected = useSelector(isWidgetSelected(widgetId));
+  const isFocused = useSelector(isCurrentWidgetFocused(widgetId), equal);
+  console.log({ widgetId, isFocused });
+  // const isFocused = false;
+
+  const isSelected = useSelector(isWidgetSelected(widgetId), equal);
   // const parentWidgetToOpen = useSelector(getParentToOpenIfAny(widgetId));
 
   // This state tells us whether a `ResizableComponent` is resizing
   const isResizing = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isResizing,
+    equal,
   );
-  const appMode = useSelector(getAppMode);
+  const appMode = useSelector(getAppMode, equal);
 
   // This state tells us whether a `DraggableComponent` is dragging
   const isDragging = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isDragging,
+    equal,
   );
 
-  const parentWidgetToOpen = useSelector(getFocusedParentToOpen);
+  const parentWidgetToOpen = useSelector(getFocusedParentToOpen, equal);
 
   const clickToSelectWidget = (e: any) => {
     // ignore click captures

--- a/app/client/src/utils/hooks/useClickToSelectWidget.tsx
+++ b/app/client/src/utils/hooks/useClickToSelectWidget.tsx
@@ -104,7 +104,6 @@ export const useClickToSelectWidget = (widgetId: string) => {
   );
 
   const isFocused = useSelector(isCurrentWidgetFocused(widgetId), equal);
-  console.log({ widgetId, isFocused });
   // const isFocused = false;
 
   const isSelected = useSelector(isWidgetSelected(widgetId), equal);

--- a/app/client/src/utils/hooks/useClickToSelectWidget.tsx
+++ b/app/client/src/utils/hooks/useClickToSelectWidget.tsx
@@ -1,4 +1,4 @@
-import { eq, get } from "lodash";
+import { get } from "lodash";
 import { getIsPropertyPaneVisible } from "selectors/propertyPaneSelectors";
 import { getIsTableFilterPaneVisible } from "selectors/tableFilterSelectors";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";

--- a/app/client/src/utils/hooks/useClickToSelectWidget.tsx
+++ b/app/client/src/utils/hooks/useClickToSelectWidget.tsx
@@ -1,10 +1,7 @@
-import { get } from "lodash";
 import { getIsPropertyPaneVisible } from "selectors/propertyPaneSelectors";
 import { getIsTableFilterPaneVisible } from "selectors/tableFilterSelectors";
-import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
 import { useSelector } from "store";
 import { AppState } from "@appsmith/reducers";
-import { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidgetsReducer";
 import { APP_MODE } from "entities/App";
 import { getAppMode } from "selectors/applicationSelectors";
 import { useWidgetSelection } from "./useWidgetSelection";
@@ -16,34 +13,6 @@ import {
   isWidgetSelected,
 } from "selectors/widgetSelectors";
 import equal from "fast-deep-equal/es6";
-
-export function getParentToOpenIfAny(
-  widgetId: string | undefined,
-  widgets: CanvasWidgetsReduxState,
-) {
-  if (widgetId) {
-    let widget = get(widgets, widgetId, undefined);
-
-    // While this widget has a openParentPropertyPane equql to true
-    while (widget?.openParentPropertyPane) {
-      // Get parent widget props
-      const parent = get(widgets, `${widget.parentId}`, undefined);
-
-      // If parent has openParentPropertyPane = false, return the currnet parent
-      if (!parent?.openParentPropertyPane) {
-        return parent;
-      }
-
-      if (parent?.parentId && parent.parentId !== MAIN_CONTAINER_WIDGET_ID) {
-        widget = get(widgets, `${widget.parentId}`, undefined);
-
-        continue;
-      }
-    }
-  }
-
-  return;
-}
 
 export function ClickContentToOpenPropPane({
   children,
@@ -104,10 +73,8 @@ export const useClickToSelectWidget = (widgetId: string) => {
   );
 
   const isFocused = useSelector(isCurrentWidgetFocused(widgetId), equal);
-  // const isFocused = false;
 
   const isSelected = useSelector(isWidgetSelected(widgetId), equal);
-  // const parentWidgetToOpen = useSelector(getParentToOpenIfAny(widgetId));
 
   // This state tells us whether a `ResizableComponent` is resizing
   const isResizing = useSelector(

--- a/app/client/src/utils/hooks/useClickToSelectWidget.tsx
+++ b/app/client/src/utils/hooks/useClickToSelectWidget.tsx
@@ -66,27 +66,22 @@ export function ClickContentToOpenPropPane({
 
 export const useClickToSelectWidget = (widgetId: string) => {
   const { focusWidget, selectWidget } = useWidgetSelection();
-  const isPropPaneVisible = useSelector(getIsPropertyPaneVisible, equal);
-  const isTableFilterPaneVisible = useSelector(
-    getIsTableFilterPaneVisible,
-    equal,
-  );
+  const isPropPaneVisible = useSelector(getIsPropertyPaneVisible);
+  const isTableFilterPaneVisible = useSelector(getIsTableFilterPaneVisible);
 
-  const isFocused = useSelector(isCurrentWidgetFocused(widgetId), equal);
+  const isFocused = useSelector(isCurrentWidgetFocused(widgetId));
 
-  const isSelected = useSelector(isWidgetSelected(widgetId), equal);
+  const isSelected = useSelector(isWidgetSelected(widgetId));
 
   // This state tells us whether a `ResizableComponent` is resizing
   const isResizing = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isResizing,
-    equal,
   );
-  const appMode = useSelector(getAppMode, equal);
+  const appMode = useSelector(getAppMode);
 
   // This state tells us whether a `DraggableComponent` is dragging
   const isDragging = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isDragging,
-    equal,
   );
 
   const parentWidgetToOpen = useSelector(getFocusedParentToOpen, equal);

--- a/app/client/src/utils/hooks/useClickToSelectWidget.tsx
+++ b/app/client/src/utils/hooks/useClickToSelectWidget.tsx
@@ -1,16 +1,13 @@
 import { getIsPropertyPaneVisible } from "selectors/propertyPaneSelectors";
-import { getIsTableFilterPaneVisible } from "selectors/tableFilterSelectors";
 import { useSelector } from "store";
 import { AppState } from "@appsmith/reducers";
-import { APP_MODE } from "entities/App";
-import { getAppMode } from "selectors/applicationSelectors";
 import { useWidgetSelection } from "./useWidgetSelection";
-import React, { ReactNode, useCallback, useMemo } from "react";
+import React, { ReactNode, useCallback } from "react";
 import { stopEventPropagation } from "utils/AppsmithUtils";
 import {
   getFocusedParentToOpen,
-  isCurrentWidgetFocused,
   isWidgetSelected,
+  shouldWidgetIgnoreClicksSelector,
 } from "selectors/widgetSelectors";
 import equal from "fast-deep-equal/es6";
 
@@ -62,31 +59,11 @@ export function ClickContentToOpenPropPane({
 export const useClickToSelectWidget = (widgetId: string) => {
   const { focusWidget, selectWidget } = useWidgetSelection();
   const isPropPaneVisible = useSelector(getIsPropertyPaneVisible);
-  const isTableFilterPaneVisible = useSelector(getIsTableFilterPaneVisible);
-
-  const isFocused = useSelector(isCurrentWidgetFocused(widgetId));
-
   const isSelected = useSelector(isWidgetSelected(widgetId));
-
-  // This state tells us whether a `ResizableComponent` is resizing
-  const isResizing = useSelector(
-    (state: AppState) => state.ui.widgetDragResize.isResizing,
-  );
-  const appMode = useSelector(getAppMode);
-
-  // This state tells us whether a `DraggableComponent` is dragging
-  const isDragging = useSelector(
-    (state: AppState) => state.ui.widgetDragResize.isDragging,
-  );
-
   const parentWidgetToOpen = useSelector(getFocusedParentToOpen, equal);
-
-  const shouldIgnoreClicks =
-    isResizing ||
-    isDragging ||
-    appMode !== APP_MODE.EDIT ||
-    !isFocused ||
-    isTableFilterPaneVisible;
+  const shouldIgnoreClicks = useSelector(
+    shouldWidgetIgnoreClicksSelector(widgetId),
+  );
 
   const clickToSelectWidget = useCallback(
     (e: any) => {

--- a/app/client/src/utils/hooks/usePositionedContainerZIndex.ts
+++ b/app/client/src/utils/hooks/usePositionedContainerZIndex.ts
@@ -6,6 +6,7 @@ import { AppState } from "@appsmith/reducers";
 
 import { getSelectedWidgets } from "selectors/ui";
 import { useSelector } from "store";
+import equal from "fast-deep-equal/es6";
 
 export const usePositionedContainerZIndex = (
   props: PositionedContainerProps,
@@ -14,7 +15,7 @@ export const usePositionedContainerZIndex = (
   const isDragging = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isDragging,
   );
-  const selectedWidgets = useSelector(getSelectedWidgets);
+  const selectedWidgets = useSelector(getSelectedWidgets, equal);
   const isThisWidgetDragging =
     isDragging && selectedWidgets.includes(props.widgetId);
 
@@ -47,7 +48,7 @@ export const usePositionedContainerZIndex = (
 
   const zIndicesObj = useMemo(() => {
     const onHoverZIndex = isDragging ? zIndex : Layers.positionedWidget + 1;
-    return { zIndex, onHoverZIndex };
+    return `${zIndex}__${onHoverZIndex}`;
   }, [isDragging, zIndex]);
 
   return zIndicesObj;

--- a/app/client/src/utils/hooks/usePositionedContainerZIndex.ts
+++ b/app/client/src/utils/hooks/usePositionedContainerZIndex.ts
@@ -45,8 +45,8 @@ export const usePositionedContainerZIndex = (
 
   const zIndicesObj = useMemo(() => {
     const onHoverZIndex = isDragging ? zIndex : Layers.positionedWidget + 1;
-    return `${zIndex}__${onHoverZIndex}`;
-  }, [isDragging, zIndex]);
+    return { zIndex, onHoverZIndex };
+  }, [isDragging, zIndex, Layers.positionedWidget]);
 
   return zIndicesObj;
 };

--- a/app/client/src/utils/hooks/usePositionedContainerZIndex.ts
+++ b/app/client/src/utils/hooks/usePositionedContainerZIndex.ts
@@ -3,10 +3,8 @@ import { Layers } from "constants/Layers";
 
 import { useMemo } from "react";
 import { AppState } from "@appsmith/reducers";
-
-import { getSelectedWidgets } from "selectors/ui";
+import { isWidgetSelected } from "selectors/widgetSelectors";
 import { useSelector } from "store";
-import equal from "fast-deep-equal/es6";
 
 export const usePositionedContainerZIndex = (
   props: PositionedContainerProps,
@@ -15,9 +13,8 @@ export const usePositionedContainerZIndex = (
   const isDragging = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isDragging,
   );
-  const selectedWidgets = useSelector(getSelectedWidgets, equal);
-  const isThisWidgetDragging =
-    isDragging && selectedWidgets.includes(props.widgetId);
+  const isSelected = useSelector(isWidgetSelected(props.widgetId));
+  const isThisWidgetDragging = isDragging && isSelected;
 
   const zIndex = useMemo(() => {
     if (isDragging) {

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -273,15 +273,45 @@ abstract class BaseWidget<
     return <SnipeableComponent {...this.props}>{content}</SnipeableComponent>;
   }
 
+  /**
+   * generates styles that positions the widget
+   */
+  private getPositionStyle_(): BaseStyle {
+    const { componentHeight, componentWidth } = this.getComponentDimensions();
+
+    return {
+      positionType: PositionTypes.ABSOLUTE,
+      componentHeight,
+      componentWidth,
+      yPosition:
+        this.props.topRow * this.props.parentRowSpace +
+        (this.props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
+      xPosition:
+        this.props.leftColumn * this.props.parentColumnSpace +
+        (this.props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
+      xPositionUnit: CSSUnits.PIXEL,
+      yPositionUnit: CSSUnits.PIXEL,
+    };
+  }
+
   makePositioned(content: ReactNode) {
-    const style = this.getPositionStyle();
+    // const style = this.getPositionStyle();
+    const { componentHeight, componentWidth } = this.getComponentDimensions();
+
     return (
       <PositionedContainer
+        componentHeight={componentHeight}
+        componentWidth={componentWidth}
         focused={this.props.focused}
+        leftColumn={this.props.leftColumn}
+        // style={style}
+        noContainerOffset={this.props.noContainerOffset}
+        parentColumnSpace={this.props.parentColumnSpace}
         parentId={this.props.parentId}
+        parentRowSpace={this.props.parentRowSpace}
         resizeDisabled={this.props.resizeDisabled}
         selected={this.props.selected}
-        style={style}
+        topRow={this.props.topRow}
         widgetId={this.props.widgetId}
         widgetType={this.props.type}
       >

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -379,27 +379,6 @@ abstract class BaseWidget<
     );
   }
 
-  /**
-   * generates styles that positions the widget
-   */
-  private getPositionStyle(): BaseStyle {
-    const { componentHeight, componentWidth } = this.getComponentDimensions();
-
-    return {
-      positionType: PositionTypes.ABSOLUTE,
-      componentHeight,
-      componentWidth,
-      yPosition:
-        this.props.topRow * this.props.parentRowSpace +
-        (this.props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
-      xPosition:
-        this.props.leftColumn * this.props.parentColumnSpace +
-        (this.props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
-      xPositionUnit: CSSUnits.PIXEL,
-      yPositionUnit: CSSUnits.PIXEL,
-    };
-  }
-
   // TODO(abhinav): These defaultProps seem unneccessary. Check it out.
   static defaultProps: Partial<WidgetProps> | undefined = {
     parentRowSpace: 1,

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -4,11 +4,8 @@
  * Widgets are also responsible for dispatching actions and updating the state tree
  */
 import {
-  CONTAINER_GRID_PADDING,
   CSSUnit,
-  CSSUnits,
   PositionType,
-  PositionTypes,
   RenderMode,
   RenderModes,
   WidgetType,

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -273,29 +273,7 @@ abstract class BaseWidget<
     return <SnipeableComponent {...this.props}>{content}</SnipeableComponent>;
   }
 
-  /**
-   * generates styles that positions the widget
-   */
-  private getPositionStyle_(): BaseStyle {
-    const { componentHeight, componentWidth } = this.getComponentDimensions();
-
-    return {
-      positionType: PositionTypes.ABSOLUTE,
-      componentHeight,
-      componentWidth,
-      yPosition:
-        this.props.topRow * this.props.parentRowSpace +
-        (this.props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
-      xPosition:
-        this.props.leftColumn * this.props.parentColumnSpace +
-        (this.props.noContainerOffset ? 0 : CONTAINER_GRID_PADDING),
-      xPositionUnit: CSSUnits.PIXEL,
-      yPositionUnit: CSSUnits.PIXEL,
-    };
-  }
-
   makePositioned(content: ReactNode) {
-    // const style = this.getPositionStyle();
     const { componentHeight, componentWidth } = this.getComponentDimensions();
 
     return (
@@ -304,7 +282,6 @@ abstract class BaseWidget<
         componentWidth={componentWidth}
         focused={this.props.focused}
         leftColumn={this.props.leftColumn}
-        // style={style}
         noContainerOffset={this.props.noContainerOffset}
         parentColumnSpace={this.props.parentColumnSpace}
         parentId={this.props.parentId}


### PR DESCRIPTION
## Description
Fixes the wasted widget layer renders in edit mode. Makes the hover on widget 4x faster, and drag and drop, resizing smoother.

Fixes #12949 

This PR optimizes dragging and resizing to some extent, reaming will be taken up as a separate issue #16610

## Type of change
No breaking performance improvement

## How Has This Been Tested?

Profiling before and after.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
