### PR TITLE
chore: Fixing lint errors in the Cypress code base

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_API_with_List_Widget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_API_with_List_Widget_spec.js
@@ -24,7 +24,6 @@ describe("Test Create Api and Bind to List widget", function() {
           .split('"')
           .join("")}`;
         cy.log(valueToTest);
-        apiData = valueToTest;
         cy.log("val1:" + valueToTest);
       });
   });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_TableV2Widget_selectedRow_Input_widget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_TableV2Widget_selectedRow_Input_widget_spec.js
@@ -1,8 +1,6 @@
 /// <reference types="Cypress" />
 
-const commonlocators = require("../../../../locators/commonlocators.json");
 const dsl = require("../../../../fixtures/formInputTableV2Dsl.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const testdata = require("../../../../fixtures/testdata.json");
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_TableWidget_selectedRow_Input_widget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Bind_TableWidget_selectedRow_Input_widget_spec.js
@@ -1,8 +1,6 @@
 /// <reference types="Cypress" />
 
-const commonlocators = require("../../../../locators/commonlocators.json");
 const dsl = require("../../../../fixtures/formInputTableDsl.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const testdata = require("../../../../fixtures/testdata.json");
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Binding_TableV2_Widget_DefaultSearch_Input_widget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Binding_TableV2_Widget_DefaultSearch_Input_widget_spec.js
@@ -1,6 +1,4 @@
-const commonlocators = require("../../../../locators/commonlocators.json");
 const dsl = require("../../../../fixtures/formInputTableV2Dsl.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const testdata = require("../../../../fixtures/testdata.json");
 
@@ -22,7 +20,7 @@ describe("Binding the Table and input Widget", function() {
 
   it("2. validation of data displayed in input widgets based on search value set", function() {
     cy.SearchEntityandOpen("Table1");
-    cy.get(".t--property-control-allowsearching input").click({force:true})
+    cy.get(".t--property-control-allowsearching input").click({ force: true });
     cy.testJsontext("defaultsearchtext", "2736212");
     cy.wait("@updateLayout").isSelectRow(0);
     cy.readTableV2dataPublish("0", "0").then((tabData) => {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Binding_Table_Widget_DefaultSearch_Input_widget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Binding_Table_Widget_DefaultSearch_Input_widget_spec.js
@@ -1,6 +1,4 @@
-const commonlocators = require("../../../../locators/commonlocators.json");
 const dsl = require("../../../../fixtures/formInputTableDsl.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const testdata = require("../../../../fixtures/testdata.json");
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Table_Property_ToggleJs_With_Binding_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Table_Property_ToggleJs_With_Binding_spec.js
@@ -1,10 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 
 const widgetsPage = require("../../../../locators/Widgets.json");
-const commonlocators = require("../../../../locators/commonlocators.json");
-const publish = require("../../../../locators/publishWidgetspage.json");
 const dsl = require("../../../../fixtures/tableNewDsl.json");
-const pages = require("../../../../locators/Pages.json");
 const testdata = require("../../../../fixtures/testdata.json");
 
 describe("Table Widget property pane feature validation", function() {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Widgets_Default_data_validation_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Binding/Widgets_Default_data_validation_spec.js
@@ -1,7 +1,4 @@
-const commonlocators = require("../../../../locators/commonlocators.json");
-const formWidgetsPage = require("../../../../locators/FormWidgets.json");
 const dsl = require("../../../../fixtures/MultipleWidgetDsl.json");
-const pages = require("../../../../locators/Pages.json");
 const widgetsPage = require("../../../../locators/Widgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
 const testdata = require("../../../../fixtures/testdata.json");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_DragAndDropWidget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_DragAndDropWidget_spec.js
@@ -1,12 +1,8 @@
-const testdata = require("../../../../fixtures/testdata.json");
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 const explorer = require("../../../../locators/explorerlocators.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
 const formWidgetsPage = require("../../../../locators/FormWidgets.json");
 const publish = require("../../../../locators/publishWidgetspage.json");
-
-const pageid = "MyPage";
 
 describe("Entity explorer Drag and Drop widgets testcases", function() {
   it("Drag and drop form widget and validate", function() {

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Git/GitDiscardChange/DiscardChanges_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Git/GitDiscardChange/DiscardChanges_spec.js
@@ -9,7 +9,6 @@ describe("Git discard changes:", function() {
   const query1 = "get_users";
   const query2 = "get_allusers";
   const jsObject = "JSObject1";
-  const jsObject2 = "JSObject2";
   const page2 = "Page_2";
   const page3 = "Page_3";
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/DuplicateApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/DuplicateApplication_spec.js
@@ -1,7 +1,5 @@
 const dsl = require("../../../../fixtures/basicDsl.json");
 import homePage from "../../../../locators/HomePage";
-const commonlocators = require("../../../../locators/commonlocators.json");
-const widgetsPage = require("../../../../locators/Widgets.json");
 
 let duplicateApplicationDsl;
 let parentApplicationDsl;

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/PropertyPane/PropertyPaneJsEnabledVisible_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/PropertyPane/PropertyPaneJsEnabledVisible_spec.js
@@ -1,6 +1,5 @@
 const dsl = require("../../../../fixtures/jsonFormDslWithSchema.json");
 const { ObjectsRegistry } = require("../../../../support/Objects/Registry");
-let ee = ObjectsRegistry.EntityExplorer;
 
 describe("Property pane js enabled field", function() {
   before(() => {
@@ -15,7 +14,7 @@ describe("Property pane js enabled field", function() {
     cy.get(".t--property-control-buttonvariant")
       .find(".t--js-toggle")
       .first()
-      .click({force:true});
+      .click({ force: true });
 
     cy.get(".t--property-control-buttonvariant")
       .find(".t--js-toggle")

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ThemingTests/Theme_FormWidget_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ThemingTests/Theme_FormWidget_spec.js
@@ -1,10 +1,7 @@
-const testdata = require("../../../../fixtures/testdata.json");
-const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 const widgetsPage = require("../../../../locators/Widgets.json");
 const explorer = require("../../../../locators/explorerlocators.json");
 const commonlocators = require("../../../../locators/commonlocators.json");
 const formWidgetsPage = require("../../../../locators/FormWidgets.json");
-const publish = require("../../../../locators/publishWidgetspage.json");
 const themelocator = require("../../../../locators/ThemeLocators.json");
 
 let themeBackgroudColor;

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Button/ButtonGroup_MenuButton_Width_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Button/ButtonGroup_MenuButton_Width_spec.js
@@ -32,7 +32,6 @@ describe("In a button group widget, menu button width", function() {
   it("If target width is bigger than min width, The menu button popover width should always be the same as the target width", () => {
     const minWidth = 12 * 11.9375;
     const widgetId = "t5l24fccio";
-    const menuButtonId = "groupButton3";
 
     // Get the default menu button
     cy.get(`.appsmith_widget_${widgetId} div.t--buttongroup-widget`)
@@ -87,7 +86,6 @@ describe("In a button group widget, menu button width", function() {
   it("If an existing menu button width changes, its popover width should always be the same as the changed target width", () => {
     const minWidth = 12 * 11.9375;
     const widgetId = "t5l24fccio";
-    const menuButtonId = "groupButton1";
     cy.get(".t--property-pane-back-btn").click();
     // Change the first button text
     cy.get(".t--property-control-buttons input")
@@ -121,7 +119,6 @@ describe("In a button group widget, menu button width", function() {
 
   it("After changing the orientation to vertical , The menu button popover width should always be the same as the target width", () => {
     const widgetId = "mr048y04aq";
-    const menuButtonId = "groupButton3";
     // Open property pane of ButtonGroup3
     cy.get(`.appsmith_widget_${widgetId} div.t--buttongroup-widget`)
       .children()

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Chart/Custom_Chart_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Chart/Custom_Chart_spec.js
@@ -4,7 +4,7 @@ const publish = require("../../../../../locators/publishWidgetspage.json");
 const dsl = require("../../../../../fixtures/chartUpdatedDsl.json");
 const widgetsPage = require("../../../../../locators/Widgets.json");
 
-describe("Chart Widget Functionality around custom chart feature", function () {
+describe("Chart Widget Functionality around custom chart feature", function() {
   before(() => {
     cy.addDsl(dsl);
   });
@@ -13,7 +13,7 @@ describe("Chart Widget Functionality around custom chart feature", function () {
     cy.openPropertyPane("chartwidget");
   });
 
-  it("1. Fill the Chart Widget Properties.", function () {
+  it("1. Fill the Chart Widget Properties.", function() {
     //changing the Chart Name
     /**
      * @param{Text} Random Text
@@ -65,7 +65,7 @@ describe("Chart Widget Functionality around custom chart feature", function () {
     cy.PublishtheApp();
   });
 
-  it("2. Custom Chart Widget Functionality", function () {
+  it("2. Custom Chart Widget Functionality", function() {
     //changing the Chart type
     //cy.get(widgetsPage.toggleChartType).click({ force: true });
     cy.UpdateChartType("Custom Chart");
@@ -89,7 +89,7 @@ describe("Chart Widget Functionality around custom chart feature", function () {
     cy.PublishtheApp();
   });
 
-  it("3. Toggle JS - Custom Chart Widget Functionality", function () {
+  it("3. Toggle JS - Custom Chart Widget Functionality", function() {
     cy.get(widgetsPage.toggleChartType).click({ force: true });
     //changing the Chart type
     cy.testJsontext("charttype", "CUSTOM_FUSION_CHART");
@@ -117,15 +117,14 @@ describe("Chart Widget Functionality around custom chart feature", function () {
     cy.PublishtheApp();
   });
 
-  it("4. Chart-Copy Verification", function () {
-    const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
+  it("4. Chart-Copy Verification", function() {
     //Copy Chart and verify all properties
     cy.wait(1000);
     cy.copyWidget("chartwidget", viewWidgetsPage.chartWidget);
     cy.PublishtheApp();
   });
 
-  it("5. Chart-Delete Verification", function () {
+  it("5. Chart-Delete Verification", function() {
     // Delete the Chart widget
     cy.deleteWidget(viewWidgetsPage.chartWidget);
     cy.PublishtheApp();
@@ -136,5 +135,4 @@ describe("Chart Widget Functionality around custom chart feature", function () {
     cy.wait(2000);
     cy.get(publish.backToEditor).click({ force: true });
   });
-  
 });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Form/FormWidget_With_RichTextEditor_spec.js
@@ -25,7 +25,6 @@ describe("RichTextEditor Widget Functionality in Form", function() {
     //   Make RTE Required
     cy.CheckWidgetProperties(formWidgetsPage.requiredJs);
 
-    const widgetId = "tcayiqdf7f";
     //   Clear the input
     cy.testJsontext("defaultvalue", "");
 

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/List/List4_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/List/List4_spec.js
@@ -172,7 +172,6 @@ describe("Container Widget Functionality", function() {
   });
 
   it("11. ListWidget-Copy & Delete Verification", function() {
-    const modifierKey = Cypress.platform === "darwin" ? "meta" : "ctrl";
     //Copy Chart and verify all properties
     cy.CheckAndUnfoldEntityItem("WIDGETS");
     cy.selectEntityByName("List1");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Migration_Spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Migration_Spec.js
@@ -15,17 +15,9 @@ describe("Migration Validate", function() {
     cy.xpath(homePage.uploadLogo)
       .attachFile("TableMigrationAppExported.json")
       .wait(500);
-    // cy.get(homePage.workspaceImportAppButton)
-    //   .trigger("click")
-    //   .wait(500);
     cy.get(homePage.workspaceImportAppModal).should("not.exist");
 
-    cy.wait("@importNewApplication").then((interception) => {
-      // let appId = interception.response.body.data.id;
-      // let defaultPage = interception.response.body.data.pages.find(
-      //   (eachPage) => !!eachPage.isDefault,
-      // );
-
+    cy.wait("@importNewApplication").then(() => {
       cy.get(homePage.toastMessage).should(
         "contain",
         "Application imported successfully",

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Others/MapChart_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Others/MapChart_spec.js
@@ -1,7 +1,6 @@
 const commonLocators = require("../../../../../locators/commonlocators.json");
 const viewWidgetsPage = require("../../../../../locators/ViewWidgets.json");
 const widgetsPage = require("../../../../../locators/Widgets.json");
-const modalWidgetPage = require("../../../../../locators/ModalWidget.json");
 const dsl = require("../../../../../fixtures/MapChartDsl.json");
 
 describe("Map Chart Widget Functionality", function() {
@@ -18,7 +17,7 @@ describe("Map Chart Widget Functionality", function() {
   });
 
   it("Change Title", function() {
-    cy.testJsontext("title",this.data.chartIndata);
+    cy.testJsontext("title", this.data.chartIndata);
     cy.get(viewWidgetsPage.chartInnerText)
       .contains("App Sign Up")
       .should("have.text", "App Sign Up");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Switch/SwitchGroup2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Switch/SwitchGroup2_spec.js
@@ -1,7 +1,5 @@
 const commonlocators = require("../../../../../locators/commonlocators.json");
 const formWidgetsPage = require("../../../../../locators/FormWidgets.json");
-const modalWidgetPage = require("../../../../../locators/ModalWidget.json");
-const publish = require("../../../../../locators/publishWidgetspage.json");
 const dsl = require("../../../../../fixtures/SwitchGroupWidgetDsl.json");
 
 describe("Switch Group Widget Functionality", function() {
@@ -12,7 +10,7 @@ describe("Switch Group Widget Functionality", function() {
   beforeEach(() => {
     cy.openPropertyPane("switchgroupwidget");
   });
-/*
+  /*
   afterEach(() => {
     cy.goToEditFromPublish();
   });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV2/pagesize_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV2/pagesize_spec.js
@@ -1,4 +1,3 @@
-const dsl = require("../../../../../fixtures/tableV2WithTextWidgetDsl.json");
 import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
 
 const propPane = ObjectsRegistry.PropertyPane;

--- a/app/client/cypress/support/ApiCommands.js
+++ b/app/client/cypress/support/ApiCommands.js
@@ -1,6 +1,5 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
-/* eslint-disable cypress/no-assigning-return-
-alues */
+/* eslint-disable cypress/no-assigning-return-values */
 
 require("cy-verify-downloads").addCustomCommand();
 require("cypress-file-upload");

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -15,30 +15,20 @@ const loginPage = require("../locators/LoginPage.json");
 const signupPage = require("../locators/SignupPage.json");
 import homePage from "../locators/HomePage";
 const pages = require("../locators/Pages.json");
-const datasourceFormData = require("../fixtures/datasources.json");
 const commonlocators = require("../locators/commonlocators.json");
-const queryEditor = require("../locators/QueryEditor.json");
-const modalWidgetPage = require("../locators/ModalWidget.json");
 const widgetsPage = require("../locators/Widgets.json");
-const LayoutPage = require("../locators/Layout.json");
-const formWidgetsPage = require("../locators/FormWidgets.json");
 import ApiEditor from "../locators/ApiEditor";
 const apiwidget = require("../locators/apiWidgetslocator.json");
-const dynamicInputLocators = require("../locators/DynamicInput.json");
 const explorer = require("../locators/explorerlocators.json");
 const datasource = require("../locators/DatasourcesEditor.json");
 const viewWidgetsPage = require("../locators/ViewWidgets.json");
 const generatePage = require("../locators/GeneratePage.json");
 const jsEditorLocators = require("../locators/JSEditor.json");
-const commonLocators = require("../locators/commonlocators.json");
 const queryLocators = require("../locators/QueryEditor.json");
 const welcomePage = require("../locators/welcomePage.json");
 const publishWidgetspage = require("../locators/publishWidgetspage.json");
-const themelocator = require("../locators/ThemeLocators.json");
-import gitSyncLocators from "../locators/gitSyncLocators";
 
 let pageidcopy = " ";
-const GITHUB_API_BASE = "https://api.github.com";
 const chainStart = Symbol();
 
 export const initLocalstorage = () => {
@@ -1019,7 +1009,7 @@ Cypress.Commands.add("startErrorRoutes", () => {
 Cypress.Commands.add("NavigateToPaginationTab", () => {
   cy.get(ApiEditor.apiTab)
     .contains("Pagination")
-    .click({force:true});
+    .click({ force: true });
   cy.xpath(apiwidget.paginationWithUrl).click({ force: true });
 });
 

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -493,7 +493,7 @@ Cypress.Commands.add("testJsontext", (endp, value, paste = true) => {
   cy.wait(2500); //Allowing time for Evaluate value to capture value
 });
 
-Cypress.Commands.add("testJsontextclear", (endp, value, paste = true) => {
+Cypress.Commands.add("testJsontextclear", (endp) => {
   cy.get(".t--property-control-" + endp + " .CodeMirror textarea")
     .first()
     .focus({ force: true })
@@ -948,7 +948,6 @@ Cypress.Commands.add("Createpage", (pageName, navigateToCanvasPage = true) => {
       });
       cy.get(pages.editName).click({ force: true });
       cy.get(pages.editInput).type(pageName + "{enter}");
-      pageidcopy = pageName;
       cy.wrap(pageId).as("currentPageId");
     }
     if (navigateToCanvasPage) {
@@ -1253,14 +1252,11 @@ Cypress.Commands.add(
   },
 );
 
-Cypress.Commands.add(
-  "readTableV2dataPublish",
-  (rowNum, colNum, shouldNotGoOneLeveDeeper) => {
-    const selector = `.t--widget-tablewidgetv2 .tbody .td[data-rowindex=${rowNum}][data-colindex=${colNum}]`;
-    const tabVal = cy.get(selector).invoke("text");
-    return tabVal;
-  },
-);
+Cypress.Commands.add("readTableV2dataPublish", (rowNum, colNum) => {
+  const selector = `.t--widget-tablewidgetv2 .tbody .td[data-rowindex=${rowNum}][data-colindex=${colNum}]`;
+  const tabVal = cy.get(selector).invoke("text");
+  return tabVal;
+});
 
 Cypress.Commands.add(
   "readTabledataValidateCSS",


### PR DESCRIPTION
## Description

This PR fixes linting errors thrown by eslint in the Cypress code base. Ideally, we shouldn't have any such linting errors.

## Type of change

- Refactoring change

## How Has This Been Tested?

- Since there is no change in actual logic, relying on CI to ensure that all the tests pass.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
