### PR TITLE
chore: update-bad-theme should only run once.

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -2376,7 +2376,7 @@ public class DatabaseChangelog2 {
         return mongockTemplate.save(user);
     }
 
-    @ChangeSet(order = "034", id = "update-bad-theme-state", author = "", runAlways = true)
+    @ChangeSet(order = "034", id = "update-bad-theme-state", author = "")
     public void updateBadThemeState(MongockTemplate mongockTemplate, @NonLockGuarded PolicyGenerator policyGenerator,
                                     CacheableRepositoryHelper cacheableRepositoryHelper) {
         Query query = new Query();


### PR DESCRIPTION
Update bad theme migration should only run once.