### PR TITLE
fix: Fix border bottom highlight issue

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/styledComponents.ts
@@ -125,7 +125,6 @@ export const EditorWrapper = styled.div<{
       }};
       background: ${(props) => props.theme.colors.apiPane.bg};
       color: ${Colors.CHARCOAL};
-      ${(props) => props.size === EditorSize.COMPACT && `min-height: 36px;`}
       & {
         span.cm-operator {
           color: ${(props) => props.theme.colors.textDefault};


### PR DESCRIPTION
This PR fixes the border bottom of the code editor component not being highlighted when it is in focus using the Keyboard tab key.

Fixes #15696

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual Test.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
