### PR TITLE
ci: Update ok-to-test.yml to run only on pull request comments

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run for PRs, not issue comments
     if: |
-      ${{ github.event.issue.pull_request }}
+      github.event.issue.pull_request
     steps:
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
The expression was treated as a string and always evaluated as true.