### PR TITLE
fix: Fix LinkageError with macOS DNSResolver class

### DIFF
--- a/app/server/appsmith-interfaces/pom.xml
+++ b/app/server/appsmith-interfaces/pom.xml
@@ -140,6 +140,10 @@
                     <groupId>io.projectreactor</groupId>
                     <artifactId>reactor-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns-native-macos</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/app/server/appsmith-plugins/mysqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/mysqlPlugin/pom.xml
@@ -73,6 +73,22 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <scope>runtime</scope>
+            <classifier>osx-x86_64</classifier>
+            <version>4.1.75.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <scope>runtime</scope>
+            <classifier>osx-aarch_64</classifier>
+            <version>4.1.75.Final</version>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>mysql</groupId>

--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -264,14 +264,6 @@
             <artifactId>ff4j-config-yaml</artifactId>
             <version>${ff4j.version}</version>
         </dependency>
-        <!-- Optional: the following dependency is required to avoid MacOSDnsServerAddressStreamProvider class not found exception
-        It's required for MacOS only
-         ref: https://stackoverflow.com/a/65976398/997566 -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <scope>runtime</scope>
-        </dependency>
         <dependency>
             <groupId>com.appsmith</groupId>
             <artifactId>reactiveCaching</artifactId>


### PR DESCRIPTION
On macOS, when running a MySQL query, we see the following error:

```
java.lang.ClassCastException: class io.netty.channel.kqueue.KQueueEventLoopGroup cannot be cast to class io.netty.channel.EventLoopGroup
```

This is because of a `LinkageError`, caused because these classes exist both in the parent `server` module classpath, as well as in this plugin's classpath separately. To fix this, we removed this dependency from the server module.

But then, this caused a problem with how the `DNSResolver` class was being, well, resolved by the application class loader, vs the plugin class loader. This is a macOS specific problem, and doesn't affect other operating systems.

For this, we add just this package as a dependency to the MySQL plugin.
