### PR TITLE
fix: Table widget default selected row should display value "0" instead of a watermark

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -284,7 +284,7 @@ export default [
         propertyName: "defaultSelectedRowIndex",
         label: "Default Selected Row",
         controlType: "INPUT_TEXT",
-        defaultValue: "0",
+        defaultValue: 0,
         isBindProperty: true,
         isTriggerProperty: false,
         validation: {

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/contentConfig.ts
@@ -284,7 +284,7 @@ export default [
         propertyName: "defaultSelectedRowIndex",
         label: "Default Selected Row",
         controlType: "INPUT_TEXT",
-        placeholderText: "0",
+        defaultValue: "0",
         isBindProperty: true,
         isTriggerProperty: false,
         validation: {


### PR DESCRIPTION
## Description

To resolve this issue I swapped out two properties of this object, `placeholderText` and `defaultValue`, to change the placeholder zero for an actual 0 character.

Fixes #15810

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I followed these steps:

1. Start your development environment and login
2. Create a new app
3. D&D a table widget onto the canvas and select it
4. Check in the properties pane that the `Default Selected Row` property contains a zero character

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
