### PR TITLE
ci: Fixing the package step for test-build-docker workflow

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -20,7 +20,7 @@ defaults:
 
 jobs:
   perf-test:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
     # Only run this workflow for internally triggered events
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -656,8 +656,6 @@ jobs:
           - 27017:27017
 
     steps:
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
 
       # Checkout the code
       - name: Checkout the merged commit from PR and base branch
@@ -750,15 +748,13 @@ jobs:
           name: rts-build-deps
           path: app/rts/node_modules/
 
+      # We don't use Depot Docker builds because it's faster for local Docker images to be built locally. 
+      # It's slower and more expensive to build these Docker images on Depot and download it back to the CI node.
       - name: Build  docker image
         if: steps.run_result.outputs.run_result != 'success'
-        uses: depot/build-push-action@v1
-        with:
-          context: .
-          push: false
-          load: true
-          tags: |
-            fatcontainer
+        working-directory: "."
+          run: |
+            docker build -t fatcontainer .
 
       - name: Create folder
         if: steps.run_result.outputs.run_result != 'success'
@@ -1559,6 +1555,9 @@ jobs:
       - name: Get the version to tag the Docker image
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
## Description

The depot docker step wasn't initialized. This was causing Docker builds to fail.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Relying on CI

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
