### PR TITLE
ci: Fix `build_args` to be `build-args` for Depot builds

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -1596,7 +1596,7 @@ jobs:
           context: .
           push: true
           platforms: linux/arm64,linux/amd64
-          build_args: |
+          build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}
           tags: |
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{steps.vars.outputs.tag}}
@@ -1608,7 +1608,7 @@ jobs:
           context: .
           push: true
           platforms: linux/arm64,linux/amd64
-          build_args: |
+          build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${GITHUB_SHA}
@@ -1643,7 +1643,7 @@ jobs:
         with:
           context: app/server
           push: true
-          build_args: |
+          build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}
           tags: |
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{steps.vars.outputs.tag}}
@@ -1655,7 +1655,7 @@ jobs:
         with:
           context: app/server
           push: true
-          build_args: |
+          build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
             ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${GITHUB_SHA}


### PR DESCRIPTION
It looks like this was a typo carried over from merging in https://github.com/appsmithorg/appsmith/pull/16658. This allows the arg to actually be passed into the action going forward.

cc: @trishaanand @mohanarpit 