### PR TITLE
fix: No-op Asserts

### DIFF
--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/PluginUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/PluginUtilsTest.java
@@ -70,12 +70,12 @@ public class PluginUtilsTest {
             Map<String, Object> unparsedWhereClause = (Map<String, Object>) whereClause.get("where");
             Condition condition = parseWhereClause(unparsedWhereClause);
 
-            assertThat(condition.getOperator().equals(ConditionalOperator.AND));
+            assertThat(condition.getOperator()).isEqualTo(ConditionalOperator.AND);
             Object conditionValue = condition.getValue();
             assertThat(conditionValue).isNotNull();
-            assertThat(conditionValue instanceof List);
+            assertThat(conditionValue).isInstanceOf(List.class);
             List<Condition> conditionList = (List<Condition>) conditionValue;
-            assertThat(conditionList.size()).isEqualTo(3);
+            assertThat(conditionList).hasSize(3);
             for (Condition conditionFromChildren : conditionList) {
                 ConditionalOperator operator = conditionFromChildren.getOperator();
                 assertThat(operator).isNotNull();
@@ -84,10 +84,10 @@ public class PluginUtilsTest {
                 Object value = conditionFromChildren.getValue();
                 if (operator.equals(ConditionalOperator.AND)) {
                     assertThat(path).isNull();
-                    assertThat(value instanceof List);
+                    assertThat(value).isInstanceOf(List.class);
                 } else {
                     assertThat(path).isNotNull();
-                    assertThat(value instanceof String);
+                    assertThat(value).isInstanceOf(String.class);
                 }
             }
 
@@ -109,7 +109,7 @@ public class PluginUtilsTest {
             Map<String, Object> unparsedWhereClause = (Map<String, Object>) whereClause.get("where");
             Condition condition = parseWhereClause(unparsedWhereClause);
 
-            assertThat(condition.getOperator().equals(ConditionalOperator.AND));
+            assertThat(condition.getOperator()).isEqualTo(ConditionalOperator.AND);
             Object conditionValue = condition.getValue();
             assertThat(conditionValue).isNull();
 

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/services/FilterDataServiceTest.java
@@ -24,7 +24,7 @@ import static com.appsmith.external.services.ce.FilterDataServiceCE.PAGINATE_LIM
 import static com.appsmith.external.services.ce.FilterDataServiceCE.PAGINATE_OFFSET_KEY;
 import static com.appsmith.external.services.ce.FilterDataServiceCE.SORT_BY_COLUMN_NAME_KEY;
 import static com.appsmith.external.services.ce.FilterDataServiceCE.SORT_BY_TYPE_KEY;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -134,7 +134,7 @@ public class FilterDataServiceTest {
             List<Condition> conditions = (List<Condition>) condition.getValue();
 
             String expression = filterDataService.generateLogicalExpression(conditions, new ArrayList<>(), schema, operator);
-            assertThat(expression.equals("( \"i\" >= ? )  and (  ( \"d\" <= ? )  and (  ( \"a\" <= ? )  )  )  and (  ( \"u\" <= ? )  ) "));
+            assertThat(expression).isEqualTo(" ( \"i\" >= ? )  and (  ( \"d\" <= ? )  and (  ( \"a\" <= ? )  )  )  and (  ( \"u\" <= ? )  ) ");
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -533,8 +533,7 @@ public class FilterDataServiceTest {
                     .map(n -> fieldNamesIterator.next())
                     .collect(Collectors.toList());
 
-            assertThat(columnNames.containsAll(List.of("id", "email id", "userName", "productName", "orderAmount", "orderStatus")));
-
+            assertThat(columnNames).containsAll(List.of("id", "email id", "userName", "productName", "orderAmount", "orderStatus"));
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -55,6 +55,7 @@ import static com.external.helpers.HintMessageUtils.DUPLICATE_ATTRIBUTE_LOCATION
 import static com.external.helpers.HintMessageUtils.DUPLICATE_ATTRIBUTE_LOCATION.DATASOURCE_CONFIG_ONLY;
 import static com.external.helpers.HintMessageUtils.getAllDuplicateHeaders;
 import static com.external.helpers.HintMessageUtils.getAllDuplicateParams;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -338,7 +339,7 @@ public class RestApiPluginTest {
 
         StepVerifier
                 .create(invalidsMono)
-                .assertNext(invalids -> invalids.containsAll(Set.of("Missing Client ID", "Missing Client Secret", "Missing Access Token URL")));
+                .assertNext(invalids -> assertThat(invalids).containsAll(Set.of("Missing Client ID", "Missing Client Secret", "Missing Access Token URL")));
     }
 
     @Test

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/WidgetSuggestionHelper.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/WidgetSuggestionHelper.java
@@ -238,7 +238,9 @@ public class WidgetSuggestionHelper {
         WidgetSuggestionDTO widgetSuggestionDTO = new WidgetSuggestionDTO();
         widgetSuggestionDTO.setType(widgetType);
         String query = String.format(widgetType.getMessage(), args);
-        query = query.replace("data", "data."+nestedFieldName);
+        if (nestedFieldName != null) {
+            query = query.replace("data", "data." + nestedFieldName);
+        }
         widgetSuggestionDTO.setBindingQuery(query);
         return  widgetSuggestionDTO;
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/git/GitExecutorTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/git/GitExecutorTest.java
@@ -139,7 +139,7 @@ public class GitExecutorTest {
         StepVerifier
                 .create(mergeableStatus)
                 .assertNext( s -> {
-                    assertThat(s.isMergeAble());
+                    assertThat(s.isMergeAble()).isTrue();
                 })
                 .verifyComplete();
 
@@ -164,7 +164,7 @@ public class GitExecutorTest {
         StepVerifier
                 .create(mergeableStatus)
                 .assertNext( s -> {
-                    assertThat(s.isMergeAble());
+                    assertThat(s.isMergeAble()).isTrue();
                 })
                 .verifyComplete();
 
@@ -281,7 +281,7 @@ public class GitExecutorTest {
                 .create(gitBranchDTOMono)
                 .assertNext(gitBranchDTOS -> {
                    assertThat(gitBranchDTOS.stream().count()).isEqualTo(3);
-                   
+
                 });
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -192,7 +192,7 @@ public class ApplicationServiceTest {
 
     @Autowired
     UserRepository userRepository;
-    
+
     @Autowired
     SessionUserService sessionUserService;
 
@@ -382,7 +382,7 @@ public class ApplicationServiceTest {
                     assertThat(page.getName()).isEqualTo(FieldName.DEFAULT_PAGE_NAME);
                     assertThat(page.getLayouts()).isNotEmpty();
                     assertThat(page.getPolicies()).isNotEmpty();
-                    assertThat(page.getPolicies().containsAll(Set.of(managePagePolicy, readPagePolicy)));
+                    assertThat(page.getPolicies()).containsAll(Set.of(managePagePolicy, readPagePolicy));
                 })
                 .verifyComplete();
     }
@@ -533,7 +533,7 @@ public class ApplicationServiceTest {
                 .collectList()
                 .block();
 
-        assertThat(applicationList.size() > 0);
+        assertThat(applicationList).isNotEmpty();
         applicationList
                 .stream()
                 .filter(t -> t.getName().equals("validGetApplications-Test"))
@@ -676,7 +676,7 @@ public class ApplicationServiceTest {
                             Application application = workspaceApplicationDTO.getApplications().get(0);
                             assertThat(application.getUserPermissions()).contains("read:applications");
                             assertThat(application.isAppIsExample()).isFalse();
-                            assertThat(workspaceApplicationDTO.getUsers().get(0).getPermissionGroupName().startsWith(FieldName.ADMINISTRATOR));
+                            assertThat(workspaceApplicationDTO.getUsers().get(0).getPermissionGroupName()).startsWith(FieldName.ADMINISTRATOR);
                         }
                     }
 
@@ -762,7 +762,7 @@ public class ApplicationServiceTest {
 
                     // There should be atleast one workspace present in the output.
                     WorkspaceApplicationsDTO orgAppDto = workspaceApplications.get(0);
-                    assertThat(orgAppDto.getWorkspace().getUserPermissions().contains("read:workspaces"));
+                    assertThat(orgAppDto.getWorkspace().getUserPermissions()).contains("read:workspaces");
                 })
                 .verifyComplete();
 
@@ -1335,9 +1335,9 @@ public class ApplicationServiceTest {
                     assertThat(clonedApplication).isNotNull();
                     assertThat(clonedApplication.isAppIsExample()).isFalse();
                     assertThat(clonedApplication.getId()).isNotNull();
-                    assertThat(clonedApplication.getName().equals("ApplicationServiceTest Clone Source TestApp Copy"));
+                    assertThat(clonedApplication.getName()).isEqualTo("gitConnectedApp Copy");
                     assertThat(clonedApplication.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
-                    assertThat(clonedApplication.getWorkspaceId().equals(workspaceId));
+                    assertThat(clonedApplication.getWorkspaceId()).isEqualTo(workspaceId);
                     assertThat(clonedApplication.getModifiedBy()).isEqualTo("api_user");
                     assertThat(clonedApplication.getUpdatedAt()).isNotNull();
                     assertThat(clonedApplication.getEvaluationVersion()).isNotNull();
@@ -1349,7 +1349,7 @@ public class ApplicationServiceTest {
                     Set<String> clonedPageIdsFromApplication = pages.stream().map(page -> page.getId()).collect(Collectors.toSet());
                     Set<String> clonedPageIdsFromDb = clonedPageList.stream().map(page -> page.getId()).collect(Collectors.toSet());
 
-                    assertThat(clonedPageIdsFromApplication.containsAll(clonedPageIdsFromDb));
+                    assertThat(clonedPageIdsFromApplication).containsAll(clonedPageIdsFromDb);
 
                     Set<String> srcPageIdsFromDb = srcPageList.stream().map(page -> page.getId()).collect(Collectors.toSet());
                     Set<String> defaultSrcPageIdsFromDb = srcPageList.stream().map(page -> page.getDefaultResources().getPageId()).collect(Collectors.toSet());
@@ -1505,7 +1505,7 @@ public class ApplicationServiceTest {
                             .build();
 
                     assertThat(clonedApplication.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
-                    assertThat(clonedApplication.getWorkspaceId().equals(workspaceId));
+                    assertThat(clonedApplication.getWorkspaceId()).isEqualTo(workspaceId);
                     assertThat(clonedApplication.getModifiedBy()).isEqualTo("api_user");
                     assertThat(clonedApplication.getUpdatedAt()).isNotNull();
 
@@ -1707,16 +1707,16 @@ public class ApplicationServiceTest {
                     assertThat(application).isNotNull();
                     assertThat(application.isAppIsExample()).isFalse();
                     assertThat(application.getId()).isNotNull();
-                    assertThat(application.getName().equals("ApplicationServiceTest Clone Source TestApp Copy"));
+                    assertThat(application.getName()).isEqualTo("ApplicationServiceTest Clone Source TestApp Copy");
                     assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
-                    assertThat(application.getWorkspaceId().equals(workspaceId));
+                    assertThat(application.getWorkspaceId()).isEqualTo(workspaceId);
                     assertThat(application.getModifiedBy()).isEqualTo("api_user");
                     assertThat(application.getUpdatedAt()).isNotNull();
                     List<ApplicationPage> pages = application.getPages();
                     Set<String> pageIdsFromApplication = pages.stream().map(page -> page.getId()).collect(Collectors.toSet());
                     Set<String> pageIdsFromDb = pageList.stream().map(page -> page.getId()).collect(Collectors.toSet());
 
-                    assertThat(pageIdsFromApplication.containsAll(pageIdsFromDb));
+                    assertThat(pageIdsFromApplication).containsAll(pageIdsFromDb);
 
                     assertThat(pageList).isNotEmpty();
                     for (NewPage page : pageList) {
@@ -2043,16 +2043,16 @@ public class ApplicationServiceTest {
                     assertThat(application).isNotNull();
                     assertThat(application.isAppIsExample()).isFalse();
                     assertThat(application.getId()).isNotNull();
-                    assertThat(application.getName().equals("ApplicationServiceTest Clone Source TestApp Copy"));
+                    assertThat(application.getName()).isEqualTo("ApplicationServiceTest-clone-application-deleted-action-within-collection Copy");
                     assertThat(application.getPolicies()).containsAll(Set.of(manageAppPolicy, readAppPolicy));
-                    assertThat(application.getWorkspaceId().equals(workspaceId));
+                    assertThat(application.getWorkspaceId()).isEqualTo(workspaceId);
                     assertThat(application.getModifiedBy()).isEqualTo("api_user");
                     assertThat(application.getUpdatedAt()).isNotNull();
                     List<ApplicationPage> pages = application.getPages();
-                    Set<String> pageIdsFromApplication = pages.stream().map(page -> page.getId()).collect(Collectors.toSet());
-                    Set<String> pageIdsFromDb = pageList.stream().map(page -> page.getId()).collect(Collectors.toSet());
+                    Set<String> pageIdsFromApplication = pages.stream().map(ApplicationPage::getId).collect(Collectors.toSet());
+                    Set<String> pageIdsFromDb = pageList.stream().map(BaseDomain::getId).collect(Collectors.toSet());
 
-                    assertThat(pageIdsFromApplication.containsAll(pageIdsFromDb));
+                    assertThat(pageIdsFromApplication).containsAll(pageIdsFromDb);
 
                     assertThat(pageList).isNotEmpty();
                     for (NewPage page : pageList) {
@@ -2204,11 +2204,11 @@ public class ApplicationServiceTest {
                     assertThat(application).isNotNull();
                     assertThat(application.isAppIsExample()).isFalse();
                     assertThat(application.getId()).isNotNull();
-                    assertThat(application.getName().equals(appName));
-                    assertThat(application.getPages().size()).isEqualTo(1);
-                    assertThat(application.getPublishedPages().size()).isEqualTo(1);
+                    assertThat(application.getName()).isEqualTo(appName);
+                    assertThat(application.getPages()).hasSize(1);
+                    assertThat(application.getPublishedPages()).hasSize(1);
 
-                    assertThat(pages.size()).isEqualTo(1);
+                    assertThat(pages).hasSize(1);
                     NewPage newPage = pages.get(0);
                     assertThat(newPage.getUnpublishedPage().getName()).isEqualTo(newPage.getPublishedPage().getName());
                     assertThat(newPage.getUnpublishedPage().getLayouts().get(0).getId()).isEqualTo(newPage.getPublishedPage().getLayouts().get(0).getId());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -86,6 +86,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.appsmith.server.acl.AclPermission.DELETE_PAGES;
 import static com.appsmith.server.acl.AclPermission.EXECUTE_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.EXECUTE_DATASOURCES;
 import static com.appsmith.server.acl.AclPermission.EXPORT_APPLICATIONS;
@@ -94,6 +95,7 @@ import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.MANAGE_DATASOURCES;
 import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
 import static com.appsmith.server.acl.AclPermission.MANAGE_THEMES;
+import static com.appsmith.server.acl.AclPermission.PAGE_CREATE_PAGE_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.PUBLISH_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.READ_ACTIONS;
 import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
@@ -382,7 +384,8 @@ public class ApplicationServiceTest {
                     assertThat(page.getName()).isEqualTo(FieldName.DEFAULT_PAGE_NAME);
                     assertThat(page.getLayouts()).isNotEmpty();
                     assertThat(page.getPolicies()).isNotEmpty();
-                    assertThat(page.getPolicies()).containsAll(Set.of(managePagePolicy, readPagePolicy));
+                    assertThat(page.getPolicies().stream().map(Policy::getPermission).collect(Collectors.toSet()))
+                            .containsExactlyInAnyOrder(MANAGE_PAGES.getValue(), READ_PAGES.getValue(), PAGE_CREATE_PAGE_ACTIONS.getValue(), DELETE_PAGES.getValue());
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -177,7 +177,7 @@ public class DatasourceServiceTest {
                     assertThat(createdDatasource.getId()).isNotEmpty();
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
                     assertThat(createdDatasource.getIsValid()).isFalse();
-                    assertThat(createdDatasource.getInvalids().contains("Missing plugin id. Please input correct plugin id"));
+                    assertThat(createdDatasource.getInvalids()).containsExactlyInAnyOrder("Missing plugin id. Please enter one.");
                 })
                 .verifyComplete();
     }
@@ -193,7 +193,7 @@ public class DatasourceServiceTest {
                 .assertNext(datasource1 -> {
                     assertThat(datasource1.getName()).isEqualTo(datasource.getName());
                     assertThat(datasource1.getIsValid()).isFalse();
-                    assertThat(datasource1.getInvalids().contains(AppsmithError.WORKSPACE_ID_NOT_GIVEN.getMessage()));
+                    assertThat(datasource1.getInvalids()).contains(AppsmithError.WORKSPACE_ID_NOT_GIVEN.getMessage());
                 })
                 .verifyComplete();
     }
@@ -245,7 +245,7 @@ public class DatasourceServiceTest {
                     assertThat(createdDatasource.getPluginId()).isEqualTo(datasource.getPluginId());
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
                     assertThat(createdDatasource.getIsValid()).isFalse();
-                    assertThat(createdDatasource.getInvalids().contains("Plugin " + datasource.getPluginId() + " not installed"));
+                    assertThat(createdDatasource.getInvalids()).contains("Plugin " + datasource.getPluginId() + " not installed");
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/MockDataServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/MockDataServiceTest.java
@@ -123,15 +123,13 @@ public class MockDataServiceTest {
         StepVerifier
                 .create(mockDataService.getMockDataSet())
                 .assertNext( mockDataSets -> {
-                    assertThat(mockDataSets.getMockdbs().size()).isEqualTo(2);
-                    assertThat(mockDataSets.getMockdbs().stream().anyMatch(data -> {
-                        return data.getName().equals("movies") &&
-                                data.getPackageName().equals("mongo-plugin");
-                    }));
-                    assertThat(mockDataSets.getMockdbs().stream().anyMatch(data -> {
-                        return data.getName().equals("users") &&
-                                data.getPackageName().equals("postgres-plugin");
-                    }));
+                    assertThat(mockDataSets.getMockdbs()).hasSize(2);
+                    assertThat(mockDataSets.getMockdbs()).anyMatch(
+                            data -> data.getName().equals("movies") && data.getPackageName().equals("mongo-plugin")
+                    );
+                    assertThat(mockDataSets.getMockdbs()).anyMatch(
+                            data -> data.getName().equals("users") && data.getPackageName().equals("postgres-plugin")
+                    );
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/PageServiceTest.java
@@ -311,7 +311,7 @@ public class PageServiceTest {
                     PageDTO page = tuple.getT1();
                     assertThat(page).isNotNull();
                     assertThat(page.getId()).isNotNull();
-                    assertThat("PageServiceTest TestApp".equals(page.getName()));
+                    assertThat("PageServiceTest TestApp").isEqualTo(page.getName());
 
                     assertThat(page.getPolicies()).isNotEmpty();
 
@@ -668,18 +668,18 @@ public class PageServiceTest {
                     assertThat(actionWithoutCollection.getUnpublishedAction().getName()).isEqualTo("PageAction");
 
                     // Confirm that executeOnLoad is cloned as well.
-                    assertThat(Boolean.TRUE.equals(actionWithoutCollection.getUnpublishedAction().getExecuteOnLoad()));
+                    assertThat(actionWithoutCollection.getUnpublishedAction().getExecuteOnLoad()).isTrue();
 
                     // Check if collections got copied too
                     List<ActionCollection> collections = tuple.getT3();
-                    assertThat(collections.size()).isEqualTo(1);
+                    assertThat(collections).hasSize(1);
                     assertThat(collections.get(0).getPublishedCollection()).isNull();
                     assertThat(collections.get(0).getUnpublishedCollection()).isNotNull();
                     assertThat(collections.get(0).getUnpublishedCollection().getPageId()).isEqualTo(clonedPage.getId());
 
                     // Check if the parent page collections are not altered
                     List<ActionCollection> parentPageCollections = tuple.getT4();
-                    assertThat(parentPageCollections.size()).isEqualTo(1);
+                    assertThat(parentPageCollections).hasSize(1);
                     assertThat(parentPageCollections.get(0).getPublishedCollection()).isNotNull();
                     assertThat(parentPageCollections.get(0).getUnpublishedCollection()).isNotNull();
                     assertThat(parentPageCollections.get(0).getUnpublishedCollection().getPageId()).isEqualTo(page.getId());
@@ -863,11 +863,11 @@ public class PageServiceTest {
                     assertThat(actionWithoutCollection.getUnpublishedAction().getDefaultResources().getPageId()).isEqualTo(clonedPage.getDefaultResources().getPageId());
 
                     // Confirm that executeOnLoad is cloned as well.
-                    assertThat(Boolean.TRUE.equals(actions.get(0).getUnpublishedAction().getExecuteOnLoad()));
+                    assertThat(actions.get(0).getUnpublishedAction().getExecuteOnLoad()).isTrue();
 
                     // Check if collections got copied too
                     List<ActionCollection> collections = tuple.getT3();
-                    assertThat(collections.size()).isEqualTo(1);
+                    assertThat(collections).hasSize(1);
                     ActionCollection collection = collections.get(0);
                     assertThat(collection.getPublishedCollection()).isNull();
                     assertThat(collection.getUnpublishedCollection()).isNotNull();
@@ -880,7 +880,7 @@ public class PageServiceTest {
 
                     // Check if the parent page collections are not altered
                     List<ActionCollection> parentPageCollections = tuple.getT4();
-                    assertThat(parentPageCollections.size()).isEqualTo(1);
+                    assertThat(parentPageCollections).hasSize(1);
                     assertThat(parentPageCollections.get(0).getUnpublishedCollection()).isNotNull();
                     assertThat(parentPageCollections.get(0).getUnpublishedCollection().getPageId()).isEqualTo(page.getId());
 
@@ -925,7 +925,7 @@ public class PageServiceTest {
                 .assertNext(page -> {
                     assertThat(page).isNotNull();
                     assertThat(page.getId()).isNotNull();
-                    assertThat("reuseDeletedPageName".equals(page.getName()));
+                    assertThat("reuseDeletedPageName").isEqualTo(page.getName());
 
                 })
                 .verifyComplete();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -197,7 +197,7 @@ public class UserServiceTest {
                     assertThat(user.getId()).isNotNull();
                     assertThat(user.getEmail()).isEqualTo("new-user-email@email.com");
                     assertThat(user.getName()).isNullOrEmpty();
-                    assertThat(user.getTenantId() != null);
+                    assertThat(user.getTenantId()).isNotNull();
 
                     Set<Policy> userPolicies = user.getPolicies();
                     assertThat(userPolicies).isNotEmpty();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
@@ -170,7 +170,7 @@ public class WorkspaceServiceTest {
                             .map(PermissionGroup::getId)
                             .collect(Collectors.toSet());
 
-                    assertThat(userPermissionGroupIds.contains(adminPermissionGroup.getId()));
+                    assertThat(userPermissionGroupIds).contains(adminPermissionGroup.getId());
 
                 })
                 .verifyComplete();
@@ -268,7 +268,7 @@ public class WorkspaceServiceTest {
                     Policy manageWorkspacePolicy = Policy.builder().permission(MANAGE_WORKSPACES.getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId()))
                             .build();
-                    
+
                     Policy workspaceCreateApplicationPolicy = Policy.builder().permission(AclPermission.WORKSPACE_CREATE_APPLICATION.getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -1103,10 +1103,9 @@ public class ActionServiceCE_Test {
                     assertThat(result).isNotNull();
                     assertThat(result.getBody()).isEqualTo(mockResult.getBody());
                     assertThat(result.getDataTypes()).hasToString(expectedReturnDataTypes.toString());
-                    assertThat(result.getSuggestedWidgets()).hasSameSizeAs(expectedWidgets);
                     assertThat(result.getSuggestedWidgets())
                             .usingRecursiveFieldByFieldElementComparator()
-                            .containsExactlyInAnyOrderElementsOf(expectedWidgets);  // This line is causing >15 test failures.
+                            .containsExactlyInAnyOrderElementsOf(expectedWidgets);
                     assertThat(result.getRequest().getActionId()).isEqualTo(executeActionDTO.getActionId());
                     assertThat(result.getRequest().getRequestedAt()).isBefore(Instant.now());
                 })
@@ -2423,6 +2422,52 @@ public class ActionServiceCE_Test {
         final String data = "{\"data\": {\n" +
                 "    \"next\": \"https://mock-api.appsmith.com/users?page=2&pageSize=10\",\n" +
                 "    \"previous\": null,\n" +
+                "    \"users\": [1, 2, 3]\n" +
+                "}}";
+        final JsonNode arrNode = new ObjectMapper().readTree(data).get("data");;
+
+        mockResult.setIsExecutionSuccess(true);
+        mockResult.setBody(arrNode);
+        mockResult.setStatusCode("200");
+        mockResult.setHeaders(objectMapper.valueToTree(Map.of("response-header-key", "response-header-value")));
+        mockResult.setDataTypes(List.of(new ParsedDataType(DisplayDataType.RAW)));
+
+        List<WidgetSuggestionDTO> widgetTypeList = new ArrayList<>();
+        widgetTypeList.add(WidgetSuggestionHelper.getWidgetNestedData(WidgetType.TEXT_WIDGET, "users"));
+        widgetTypeList.add(WidgetSuggestionHelper.getWidgetNestedData(WidgetType.TABLE_WIDGET_V2, "users"));
+        mockResult.setSuggestedWidgets(widgetTypeList);
+
+        ActionDTO action = new ActionDTO();
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.POST);
+        actionConfiguration.setBody("random-request-body");
+        actionConfiguration.setHeaders(List.of(new Property("random-header-key", "random-header-value")));
+        action.setActionConfiguration(actionConfiguration);
+        action.setPageId(testPage.getId());
+        action.setName("testActionExecute");
+        action.setDatasource(datasource);
+        ActionDTO createdAction = layoutActionService.createSingleAction(action).block();
+
+        ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
+        executeActionDTO.setActionId(createdAction.getId());
+        executeActionDTO.setViewMode(false);
+
+        executeAndAssertAction(executeActionDTO, actionConfiguration, mockResult,
+                List.of(new ParsedDataType(DisplayDataType.RAW)));
+
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testWidgetSuggestionNestedDataEmpty() throws JsonProcessingException {
+
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(pluginExecutor));
+        Mockito.when(pluginExecutor.getHintMessages(Mockito.any(), Mockito.any()))
+                .thenReturn(Mono.zip(Mono.just(new HashSet<>()), Mono.just(new HashSet<>())));
+        ActionExecutionResult mockResult = new ActionExecutionResult();
+        final String data = "{\"data\": {\n" +
+                "    \"next\": \"https://mock-api.appsmith.com/users?page=2&pageSize=10\",\n" +
+                "    \"previous\": null,\n" +
                 "    \"users\": []\n" +
                 "}}";
         final JsonNode arrNode = new ObjectMapper().readTree(data).get("data");;
@@ -2434,7 +2479,7 @@ public class ActionServiceCE_Test {
         mockResult.setDataTypes(List.of(new ParsedDataType(DisplayDataType.RAW)));
 
         List<WidgetSuggestionDTO> widgetTypeList = new ArrayList<>();
-        widgetTypeList.add(WidgetSuggestionHelper.getWidgetNestedData(WidgetType.TEXT_WIDGET,"users"));
+        widgetTypeList.add(WidgetSuggestionHelper.getWidgetNestedData(WidgetType.TEXT_WIDGET, null));
         mockResult.setSuggestedWidgets(widgetTypeList);
 
         ActionDTO action = new ActionDTO();
@@ -2716,7 +2761,7 @@ public class ActionServiceCE_Test {
                 .create(actionMono)
                 .assertNext(updatedAction -> {
                     Datasource datasource1 = updatedAction.getDatasource();
-                    assertThat(datasource1.getWorkspaceId()).isNull();
+                    assertThat(datasource1.getWorkspaceId()).isNotNull();
                     assertThat(datasource1.getInvalids()).isEmpty();
                 })
                 .verifyComplete();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -1102,10 +1102,11 @@ public class ActionServiceCE_Test {
                 .assertNext(result -> {
                     assertThat(result).isNotNull();
                     assertThat(result.getBody()).isEqualTo(mockResult.getBody());
-                    assertThat(result.getDataTypes().toString()).isEqualTo(expectedReturnDataTypes.toString());
-                    assertThat(result.getSuggestedWidgets().size()).isEqualTo(expectedWidgets.size());
-                    assertThat(result.getSuggestedWidgets().containsAll(expectedWidgets));
-                    assertThat(expectedWidgets.containsAll(result.getSuggestedWidgets()));
+                    assertThat(result.getDataTypes()).hasToString(expectedReturnDataTypes.toString());
+                    assertThat(result.getSuggestedWidgets()).hasSameSizeAs(expectedWidgets);
+                    assertThat(result.getSuggestedWidgets())
+                            .usingRecursiveFieldByFieldElementComparator()
+                            .containsExactlyInAnyOrderElementsOf(expectedWidgets);  // This line is causing >15 test failures.
                     assertThat(result.getRequest().getActionId()).isEqualTo(executeActionDTO.getActionId());
                     assertThat(result.getRequest().getRequestedAt()).isBefore(Instant.now());
                 })
@@ -2715,7 +2716,7 @@ public class ActionServiceCE_Test {
                 .create(actionMono)
                 .assertNext(updatedAction -> {
                     Datasource datasource1 = updatedAction.getDatasource();
-                    assertThat(datasource1.getWorkspaceId() != null);
+                    assertThat(datasource1.getWorkspaceId()).isNull();
                     assertThat(datasource1.getInvalids()).isEmpty();
                 })
                 .verifyComplete();


### PR DESCRIPTION
There are many occurrences of the following:

```java
assertThat(...)
```

This call itself, doesn't _assert_ anything. It's return value has to be followed up with the actual assertion we want to do. This PR fixes such calls to actually perform the assertion.

So, turns out, quite a few of these were failing, so this PR also fixes them.
