### PR TITLE
fix: Fix unused reactive publisher

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -1019,8 +1019,8 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
             // This is to have consistency in how the AnalyticsService is being called.
             // Even though sendObjectEvent is triggered, AnalyticsService would still reject this and prevent the event
             // from being sent to analytics provider if telemetry is disabled.
-            analyticsService.sendObjectEvent(AnalyticsEvents.EXECUTE_ACTION, action);
-            return Mono.empty();
+            return analyticsService.sendObjectEvent(AnalyticsEvents.EXECUTE_ACTION, action)
+                    .then(Mono.empty());
         }
         ActionExecutionRequest actionExecutionRequest = actionExecutionResult.getRequest();
         ActionExecutionRequest request;


### PR DESCRIPTION
Fixes a regression introduced in #15684.

The `Mono` returned after sending the action event is not being subscribed, and so the event is never sent. This PR fixes it by including it in the chain.

The PR was merged 9-Aug-2022 6:35 PM IST, and v1.7.12 was tagged at 9-Aug-2022 6:12 PM IST. So the regression was introduced to prod in v1.7.13, which was tagged on 16-Aug-2022.

We started noticing a dip in data points around 17-Aug-2022.
