### PR TITLE
fix: docker entrypoint script to check mongo replicaset

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -168,7 +168,7 @@ init_replica_set() {
     # Check mongodb cloud Replica Set
     echo "Checking Replica Set of external MongoDB"
 
-    mongo_state=$(mongo --host $APPSMITH_MONGODB_URI --quiet --eval "rs.status().ok")
+    mongo_state="$(mongo --host "$APPSMITH_MONGODB_URI" --quiet --eval "rs.status().ok")"
     if [[ ${mongo_state: -1} -eq 1 ]]; then
       echo "Mongodb cloud Replica Set is enabled"
     else

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -168,7 +168,8 @@ init_replica_set() {
     # Check mongodb cloud Replica Set
     echo "Checking Replica Set of external MongoDB"
 
-    if [[ $(mongo "$APPSMITH_MONGODB_URI" --quiet --eval "rs.status().ok") -eq 1 ]]; then
+    mongo_state=$(mongo --host $APPSMITH_MONGODB_URI --quiet --eval "rs.status().ok")
+    if [[ ${mongo_state: -1} -eq 1 ]]; then
       echo "Mongodb cloud Replica Set is enabled"
     else
       echo -e "\033[0;31m********************************************************************\033[0m"


### PR DESCRIPTION
docker-compose used 
entrypoint.sh ---> commited entrypoint_script.
APPSMITH_MONGODB_URI --> the release mongo_db url
```
version: "3"

services:
  appsmith:
    image: index.docker.io/appsmith/appsmith-ee@sha256:652eaee6e60fe8e057da3045bd72050442a8ecb0eeb48dc3ef0f5c92ba2f6c7d
    container_name: appsmith
    ports:
      - "80:80"
      - "443:443"
    volumes:
      - ./stacks:/appsmith-stacks
      - ./entrypoint.sh:/opt/appsmith/entrypoint.sh
    environment:
      APPSMITH_MONGODB_URI: mongodb+srv://appsmithadmin:mL43Druzp2O9DufEMK0V@mobtools-test-cluster-swrsq.mongodb.net/mobtools?retryWrites=true&minPoolSize=1&maxPoolSize=10&maxIdleTimeMS=900000&authSource=admin
    restart: unless-stopped
```

output of docker-compose up :
```
Attaching to appsmith
^[[36mappsmith    |^[[0m Initialize .env file
^[[36mappsmith    |^[[0m Load environment configuration
^[[36mappsmith    |^[[0m Checking environment configuration
^[[36mappsmith    |^[[0m Checking APPSMITH_MONGODB_URI
^[[36mappsmith    |^[[0m Checking initialized database
^[[36mappsmith    |^[[0m Checking Replica Set of external MongoDB
^[[36mappsmith    |^[[0m Mongodb cloud Replica Set is enabled
^[[36mappsmith    |^[[0m Clearing symlinks in /etc/ssl/certs...
^[[36mappsmith    |^[[0m done.
```