### PR TITLE
ci: Fixing the caches for server,client and rts build

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -61,19 +61,13 @@ jobs:
       - name: Print the Github event
         run: echo ${{ github.event_name }}
 
-      # Timestamp will be used to create cache key
-      - id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M:%S')"
-
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
         uses: actions/cache@v2
         with:
           path: |
             ~/run_result
-          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}-
+          key: ${{ github.run_id }}-${{ github.job }}-client
 
       # Fetch prior run result
       - name: Get the previous run result
@@ -157,9 +151,7 @@ jobs:
         with:
           path: |
             app/client/build/
-          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}
+          key: ${{ github.run_id }}-${{ github.job }}-client
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload react build bundle

--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -60,19 +60,13 @@ jobs:
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
 
-      # Timestamp will be used to create cache key
-      - id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M:%S')"
-
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
         uses: actions/cache@v2
         with:
           path: |
             ~/run_result
-          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}-
+          key: ${{ github.run_id }}-${{ github.job }}-rts
 
       # Fetch prior run result
       - name: Get the previous run result
@@ -137,9 +131,7 @@ jobs:
         with:
           path: |
             app/rts/dist/
-          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}
+          key: ${{ github.run_id }}-${{ github.job }}-rts
 
       # Tar the bundles to speed up the upload & download process
       - name: Tar the rts bundles

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -67,19 +67,13 @@ jobs:
       - name: Print the Github event
         run: echo ${{ github.event_name }}
 
-      # Timestamp will be used to create cache key
-      - id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y-%m-%dT%H:%M:%S')"
-
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result
         uses: actions/cache@v2
         with:
           path: |
             ~/run_result
-          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}-
+          key: ${{ github.run_id }}-${{ github.job }}-server
 
       # Fetch prior run result
       - name: Get the previous run result
@@ -149,9 +143,7 @@ jobs:
         with:
           path: |
             app/server/dist/
-          key: ${{ github.run_id }}-${{ github.job }}-${{ steps.timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}
+          key: ${{ github.run_id }}-${{ github.job }}-server
 
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload server build bundle


### PR DESCRIPTION
The problem was being caused by reusable modules taking the same job id
