### PR TITLE
fix: re-install graphql plugin in workspaces

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -54,6 +54,7 @@ import com.appsmith.server.domains.QNotification;
 import com.appsmith.server.domains.QOrganization;
 import com.appsmith.server.domains.QPlugin;
 import com.appsmith.server.domains.QUserData;
+import com.appsmith.server.domains.QWorkspace;
 import com.appsmith.server.domains.Role;
 import com.appsmith.server.domains.Sequence;
 import com.appsmith.server.domains.User;
@@ -235,7 +236,14 @@ public class DatabaseChangelog {
     }
 
     public static void installPluginToAllWorkspaces(MongockTemplate mongockTemplate, String pluginId) {
-        for (Workspace workspace : mongockTemplate.findAll(Workspace.class)) {
+        Query queryToFetchAllWorkspaceIds = new Query();
+        queryToFetchAllWorkspaceIds.fields().include(fieldName(QWorkspace.workspace.id));
+        List<Workspace> workspacesWithOnlyId = mongockTemplate.find(queryToFetchAllWorkspaceIds, Workspace.class);
+        for (Workspace workspaceWithId : workspacesWithOnlyId) {
+            Workspace workspace =
+                    mongockTemplate.findOne(query(where(fieldName(QWorkspace.workspace.id)).is(workspaceWithId.getId())),
+                    Workspace.class);
+
             if (CollectionUtils.isEmpty(workspace.getPlugins())) {
                 workspace.setPlugins(new HashSet<>());
             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -2580,4 +2580,17 @@ public class DatabaseChangelog2 {
 
         installPluginToAllWorkspaces(mongoTemplate, plugin.getId());
     }
+
+    /**
+     * This method attempts to add GraphQL plugin to all workspaces once again since the last migration was
+     * interrupted due to issues on prod cluster. Hence, during the last migration the plugin could not be installed in
+     * few workspaces.The method installPluginToAllWorkspaces only installs the plugin in those workspaces where it is
+     * missing.
+     */
+    @ChangeSet(order = "037", id = "install-graphql-plugin-to-remaining-workspaces", author = "")
+    public void reInstallGraphQLPluginToWorkspaces(MongockTemplate mongoTemplate) {
+        Plugin graphQLPlugin = mongoTemplate
+                .findOne(query(where("packageName").is("graphql-plugin")), Plugin.class);
+        installPluginToAllWorkspaces(mongoTemplate, graphQLPlugin.getId());
+    }
 }


### PR DESCRIPTION
## Description
- During the last migration run on prod, the migration was interrupted due to some issue with RTS and hence the installation of `GraphQL` plugin could not take place in few workspaces. This PR adds a new migration method to re-attempt the installation. 
- I also attempted to re-factor the installation method so that the entire migration process runs as a single query on the DB however I couldn't finish it. Since it is a `critical` issue I feel we should go ahead with the fix in the interest of time. I have raised a new issue to track the re-factor chane: https://github.com/appsmithorg/appsmith/issues/16762


Fixes #16752 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Automated testing does not seem possible for this change.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
