### PR TITLE
fix: Fix NGINX in start-https clashing with system conf

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -281,13 +281,19 @@ if type docker &>/dev/null; then
 fi
 
 if [[ -f $nginx_pid ]]; then
-    nginx -g "pid $nginx_pid;" -s quit
-    rm "$nginx_pid"
+    # We never run `nginx` without the `-c` argument, since that can load the default system configuration, which is
+    # different for different systems. It introduces too many unknowns, with little value.
+    # So we build a temp config, just to have a predictable value for the `pid` directive.
+    temp_nginx_conf="$PWD/nginx/temp.nginx.conf"
+    echo "pid $nginx_pid; events { worker_connections  1024; }" > "$temp_nginx_conf"
+    nginx -c "$temp_nginx_conf" -s quit
+    rm "$nginx_pid" "$temp_nginx_conf"
+    unset temp_nginx_conf
 fi
 
 if [[ $run_as == nginx ]]; then
     nginx -c "$nginx_dev_conf"
-    stop_cmd="nginx -g 'pid $nginx_pid;' -s quit"
+    stop_cmd="nginx -c '$nginx_dev_conf' -s quit"
 
 elif [[ $run_as == docker ]]; then
     docker run \


### PR DESCRIPTION
When the system NGINX conf has a `pid` directive, the additional `pid` directive in the value to `-g` argument causes a `duplicate pid directive` error.

In this fix, we _always_ specify a conf file for `nginx`, and never let it have the system config. This way, no matter what the system config contains or not contains, the behaviour of this script shouldn't be influenced by it.
