### PR TITLE
fix: Fix template filtering version mismatch

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationTemplateServiceCEImpl.java
@@ -63,7 +63,7 @@ public class ApplicationTemplateServiceCEImpl implements ApplicationTemplateServ
                 .fromUriString(cloudServicesConfig.getBaseUrl())
                 .pathSegment("api/v1/app-templates", templateId, "similar")
                 .queryParams(params)
-                .queryParam("version", releaseNotesService.getReleasedVersion())
+                .queryParam("version", releaseNotesService.getRunningVersion())
                 .build();
 
         String apiUrl = uriComponents.toUriString();
@@ -87,7 +87,7 @@ public class ApplicationTemplateServiceCEImpl implements ApplicationTemplateServ
         final String baseUrl = cloudServicesConfig.getBaseUrl();
 
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance()
-                .queryParam("version", releaseNotesService.getReleasedVersion());
+                .queryParam("version", releaseNotesService.getRunningVersion());
 
         if (!CollectionUtils.isEmpty(templateIds)) {
             uriComponentsBuilder.queryParam("id", templateIds);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ReleaseNotesServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ReleaseNotesServiceCE.java
@@ -13,6 +13,8 @@ public interface ReleaseNotesServiceCE {
 
     String getReleasedVersion();
 
+    String getRunningVersion();
+
     void refreshReleaseNotes();
 
     List<ReleaseNode> getReleaseNodesCache();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ReleaseNotesServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ReleaseNotesServiceCEImpl.java
@@ -98,6 +98,7 @@ public class ReleaseNotesServiceCEImpl implements ReleaseNotesServiceCE {
         return newCount == releaseNodesCache.size() ? ((newCount - 1) + "+") : String.valueOf(newCount);
     }
 
+    @Override
     public String getReleasedVersion() {
         final String version = projectProperties.getVersion();
 
@@ -110,6 +111,11 @@ public class ReleaseNotesServiceCEImpl implements ReleaseNotesServiceCE {
         }
 
         return releaseNodesCache.get(0).getTagName();
+    }
+
+    @Override
+    public String getRunningVersion() {
+        return projectProperties.getVersion();
     }
 
     /**


### PR DESCRIPTION
The `getReleasedVersion` method returns the current running version, _only_ if it dosen't end with `-SNAPSHOT`. If it does end with `-SNAPSHOT`, then it'll return the version from the most recent entry in the release notes.

The effect of this is that when fetching template applications, on version `v1.8.1-SNAPSHOT`, we pass in version as `v1.8.0` (which would be the most recent in release notes), which means the latest and greatest of templates won't ever be listed on prod.

The cloud-services API is actually capable of handling versions with `-SNAPSHOT` in them just fine. This server just isn't sending it.

This fix will send the current running version as is to cloud-services so we get more accurate results.
