### PR TITLE
fix: Fix h2 version mismatch

### DIFF
--- a/app/server/appsmith-interfaces/pom.xml
+++ b/app/server/appsmith-interfaces/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.1.210</version>
+            <version>${h2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -25,6 +25,7 @@
         <!-- By default skip the dockerization step. Only activate if necessary -->
         <skipDockerBuild>true</skipDockerBuild>
         <log4j2.version>2.17.1</log4j2.version>
+        <h2.version>2.1.210</h2.version>
     </properties>
 
     <build>


### PR DESCRIPTION
The `interfaces` module has h2 version set at 2.1.210, but what all the plugins are actually using is 1.4.200.

This is because `org.springframework.boot:spring-boot-dependencies:2.6.5` sets `h2.version` as `1.4.200`, overriding what the `interfaces` module lists.

The sources for this conclusion are, one, the output of `mvn dependency:tree -Dincludes=com.h2database`, copied below. This clearly shows that while the `interfaces` module loads version `2.1.210`, all plugins load `1.4.200`.

```
...
[INFO] ----------------------< com.appsmith:integrated >-----------------------
[INFO] Building Integrated Appsmith 1.0-SNAPSHOT                         [1/25]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ integrated ---
[INFO] 
[INFO] --------------------< com.appsmith:reactiveCaching >--------------------
[INFO] Building reactiveCaching 1.0-SNAPSHOT                             [2/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ reactiveCaching ---
[INFO] 
[INFO] ----------------------< com.appsmith:interfaces >-----------------------
[INFO] Building interfaces 1.0-SNAPSHOT                                  [3/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ interfaces ---
[INFO] com.appsmith:interfaces:jar:1.0-SNAPSHOT
[INFO] \- com.h2database:h2:jar:2.1.210:compile
[INFO] 
[INFO] -------------------< com.appsmith:appsmith-plugins >--------------------
[INFO] Building appsmith-plugins 1.0-SNAPSHOT                            [4/25]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ appsmith-plugins ---
[INFO] com.appsmith:appsmith-plugins:pom:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ----------------< com.external.plugins:postgresPlugin >-----------------
[INFO] Building postgresPlugin 1.0-SNAPSHOT                              [5/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ postgresPlugin ---
[INFO] com.external.plugins:postgresPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] -----------------< com.external.plugins:restApiPlugin >-----------------
[INFO] Building restApiPlugin 1.0-SNAPSHOT                               [6/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ restApiPlugin ---
[INFO] com.external.plugins:restApiPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ------------------< com.external.plugins:mongoPlugin >------------------
[INFO] Building mongoPlugin 1.0-SNAPSHOT                                 [7/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ mongoPlugin ---
[INFO] com.external.plugins:mongoPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ----------------< com.external.plugins:rapidApiPlugin >-----------------
[INFO] Building rapidApiPlugin 1.0-SNAPSHOT                              [8/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ rapidApiPlugin ---
[INFO] com.external.plugins:rapidApiPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ------------------< com.external.plugins:mysqlPlugin >------------------
[INFO] Building mysqlPlugin 1.0-SNAPSHOT                                 [9/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ mysqlPlugin ---
[INFO] com.external.plugins:mysqlPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] --------------< com.external.plugins:elasticSearchPlugin >--------------
[INFO] Building elasticSearchPlugin 1.0-SNAPSHOT                        [10/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ elasticSearchPlugin ---
[INFO] com.external.plugins:elasticSearchPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] -----------------< com.external.plugins:dynamoPlugin >------------------
[INFO] Building dynamoPlugin 1.0-SNAPSHOT                               [11/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ dynamoPlugin ---
[INFO] com.external.plugins:dynamoPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ------------------< com.external.plugins:redisPlugin >------------------
[INFO] Building redisPlugin 1.0-SNAPSHOT                                [12/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ redisPlugin ---
[INFO] com.external.plugins:redisPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ------------------< com.external.plugins:mssqlPlugin >------------------
[INFO] Building mssqlPlugin 1.0-SNAPSHOT                                [13/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ mssqlPlugin ---
[INFO] com.external.plugins:mssqlPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ----------------< com.external.plugins:firestorePlugin >----------------
[INFO] Building firestorePlugin 1.0-SNAPSHOT                            [14/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ firestorePlugin ---
[INFO] com.external.plugins:firestorePlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ----------------< com.external.plugins:redshiftPlugin >-----------------
[INFO] Building redshiftPlugin 1.0-SNAPSHOT                             [15/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ redshiftPlugin ---
[INFO] com.external.plugins:redshiftPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ----------------< com.external.plugins:amazons3Plugin >-----------------
[INFO] Building amazons3Plugin 1.0-SNAPSHOT                             [16/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ amazons3Plugin ---
[INFO] com.external.plugins:amazons3Plugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] --------------< com.external.plugins:googleSheetsPlugin >---------------
[INFO] Building googleSheetsPlugin 1.0-SNAPSHOT                         [17/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ googleSheetsPlugin ---
[INFO] com.external.plugins:googleSheetsPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] -----------------< com.external.plugins:graphqlPlugin >-----------------
[INFO] Building graphqlPlugin 1.0-SNAPSHOT                              [18/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ graphqlPlugin ---
[INFO] com.external.plugins:graphqlPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ----------------< com.external.plugins:snowflakePlugin >----------------
[INFO] Building snowflakePlugin 1.0-SNAPSHOT                            [19/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ snowflakePlugin ---
[INFO] com.external.plugins:snowflakePlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ----------------< com.external.plugins:arangodbPlugin >-----------------
[INFO] Building arangodbPlugin 1.0-SNAPSHOT                             [20/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ arangodbPlugin ---
[INFO] com.external.plugins:arangodbPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] -------------------< com.external.plugins:jsPlugin >--------------------
[INFO] Building jsPlugin 1.0-SNAPSHOT                                   [21/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ jsPlugin ---
[INFO] com.external.plugins:jsPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ------------------< com.external.plugins:saasPlugin >-------------------
[INFO] Building saasPlugin 1.0-SNAPSHOT                                 [22/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ saasPlugin ---
[INFO] com.external.plugins:saasPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ------------------< com.external.plugins:smtpPlugin >-------------------
[INFO] Building smtpPlugin 1.0-SNAPSHOT                                 [23/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ smtpPlugin ---
[INFO] com.external.plugins:smtpPlugin:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:provided
[INFO]    \- com.h2database:h2:jar:1.4.200:provided
[INFO] 
[INFO] ---------------------< com.appsmith:appsmith-git >----------------------
[INFO] Building appsmith-git 1.0-SNAPSHOT                               [24/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ appsmith-git ---
[INFO] com.appsmith:appsmith-git:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:compile
[INFO]    \- com.h2database:h2:jar:1.4.200:compile
[INFO] 
[INFO] ------------------------< com.appsmith:server >-------------------------
[INFO] Building server 1.0-SNAPSHOT                                     [25/25]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ server ---
[INFO] com.appsmith:server:jar:1.0-SNAPSHOT
[INFO] \- com.appsmith:interfaces:jar:1.0-SNAPSHOT:compile
[INFO]    \- com.h2database:h2:jar:1.4.200:compile
...
```

The other source for this is the `effective-pom.xml` generated by `mvn help:effective-pom -Dverbose=true -Doutput=effective-pom.xml`. This file is too big to paste here, so I'll just include the relevant bits:

```
...
      <h2.version>1.4.200</h2.version>  <!-- org.springframework.boot:spring-boot-dependencies:2.6.5, line 64 -->
...
        <dependency>
          <groupId>com.h2database</groupId>  <!-- org.springframework.boot:spring-boot-dependencies:2.6.5, line 765 -->
          <artifactId>h2</artifactId>  <!-- org.springframework.boot:spring-boot-dependencies:2.6.5, line 766 -->
          <version>1.4.200</version>  <!-- org.springframework.boot:spring-boot-dependencies:2.6.5, line 767 -->
        </dependency>
...
```
 
Related: https://github.com/appsmithorg/appsmith/issues/10398
