### PR TITLE
fix: Fix key file permissions error on Windows

### DIFF
--- a/deploy/docker/templates/supervisord/mongodb.conf
+++ b/deploy/docker/templates/supervisord/mongodb.conf
@@ -1,6 +1,6 @@
 [program:mongodb]
 directory=/appsmith-stacks/data/mongodb
-command=mongod --port 27017 --dbpath . --logpath /appsmith-stacks/logs/%(program_name)s/db.log --replSet mr1 --keyFile key --bind_ip localhost
+command=mongod --port 27017 --dbpath . --logpath /appsmith-stacks/logs/%(program_name)s/db.log --replSet mr1 --keyFile /mongodb-key --bind_ip localhost
 priority=10
 autostart=true
 autorestart=true


### PR DESCRIPTION
Docker for Windows, is documented to not support Linux style file permissions in container volumes. So, `chmod 600` on the MongoDB key file does't seem to do anything, and we still see the key file at 755.

However, WSL2 is itself an Ubuntu environment, and so supports chmod style file permissions at any path that's not mounted as a volume to the Windows host.

To fix this, in this PR, we copy the key file from the volume path to a location that's not mounted as a volume (`/mongodb-key`), and set appropriate permissions on that file.
