### PR TITLE
fix: build error due to fn name change, copy node_modules on mac error

### DIFF
--- a/app/rts/build.sh
+++ b/app/rts/build.sh
@@ -8,4 +8,4 @@ npx tsc && npx tsc-alias
 # Copying node_modules directory into dist as rts server requires node_modules to run server build properly. 
 # This was previously being done in dockerfile which was copying the symlinks to image rather than the whole directory of shared modules (e.g. AST)
 # Also, we copy node_modules with -L flag in order to follow the symlinks for @shared folder and copy the contents instead of just the symlink
-cp -rL node_modules ./dist
+cp -rL node_modules ./dist || cp -r node_modules ./dist

--- a/app/rts/build.sh
+++ b/app/rts/build.sh
@@ -8,4 +8,5 @@ npx tsc && npx tsc-alias
 # Copying node_modules directory into dist as rts server requires node_modules to run server build properly. 
 # This was previously being done in dockerfile which was copying the symlinks to image rather than the whole directory of shared modules (e.g. AST)
 # Also, we copy node_modules with -L flag in order to follow the symlinks for @shared folder and copy the contents instead of just the symlink
+# || command is added because on Mac -L flag doesn't work, so if the first command throws an error only then the command after || symbol will run
 cp -rL node_modules ./dist || cp -r node_modules ./dist

--- a/app/rts/build.sh
+++ b/app/rts/build.sh
@@ -8,5 +8,4 @@ npx tsc && npx tsc-alias
 # Copying node_modules directory into dist as rts server requires node_modules to run server build properly. 
 # This was previously being done in dockerfile which was copying the symlinks to image rather than the whole directory of shared modules (e.g. AST)
 # Also, we copy node_modules with -L flag in order to follow the symlinks for @shared folder and copy the contents instead of just the symlink
-# || command is added because on Mac -L flag doesn't work, so if the first command throws an error only then the command after || symbol will run
-cp -rL node_modules ./dist || cp -r node_modules ./dist
+cp -RL node_modules ./dist

--- a/app/rts/src/services/AstService.ts
+++ b/app/rts/src/services/AstService.ts
@@ -1,4 +1,4 @@
-import { extractIdentifiersFromCode } from "@shared/ast";
+import { extractInfoFromCode } from "@shared/ast";
 
 export default class AstService {
   static async getIdentifiersFromScript(
@@ -7,7 +7,7 @@ export default class AstService {
   ): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        const extractions = extractIdentifiersFromCode(
+        const extractions = extractInfoFromCode(
           script,
           evalVersion
         );


### PR DESCRIPTION
## Description

- Due to change in the function name in the AST shared module, rts build was not getting completed successfully which was giving errors for the file aliasing.
- Copy of node_modules was not working on the mac machine due to `-L` flag, so added a `Or` condition to run the same command with `-r` only.

Fixes #16875

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
