### PR TITLE
fix: dynamic height signifiers for modal widget

### DIFF
--- a/app/client/src/components/editorComponents/DynamicHeightOverlay.tsx
+++ b/app/client/src/components/editorComponents/DynamicHeightOverlay.tsx
@@ -326,11 +326,18 @@ const OverlayHandles: React.FC<OverlayHandlesProps> = ({
   );
 };
 
+export interface DynamicHeightOverlayStyle {
+  width: string | number;
+  height: string | number;
+  top: number;
+  left: number;
+}
+
 interface DynamicHeightOverlayProps extends MinMaxHeightProps, WidgetProps {
   batchUpdate: (height: number) => void;
   onMaxHeightSet: (height: number) => void;
   onMinHeightSet: (height: number) => void;
-  style: BaseStyle;
+  style: DynamicHeightOverlayStyle;
 }
 
 const getSnappedValues = (
@@ -591,14 +598,16 @@ const DynamicHeightOverlay: React.FC<DynamicHeightOverlayProps> = memo(
     const isOverlayToBeDisplayed =
       isWidgetSelected && !multipleWidgetsSelected && !isDragging;
 
+    console.log("StyledDynamicHeightOverlay", isOverlayToBeDisplayed);
+
     return (
       <StyledDynamicHeightOverlay
         style={{
           position: "absolute",
-          height: style.componentHeight,
-          width: style.componentWidth,
-          left: style.xPosition,
-          top: style.yPosition,
+          height: style.height,
+          width: style.width,
+          left: style.left,
+          top: style.top,
           zIndex: 3,
           pointerEvents: "none",
         }}

--- a/app/client/src/components/editorComponents/DynamicHeightOverlay.tsx
+++ b/app/client/src/components/editorComponents/DynamicHeightOverlay.tsx
@@ -14,7 +14,7 @@ import {
 } from "utils/hooks/dragResizeHooks";
 import { getParentToOpenIfAny } from "utils/hooks/useClickToSelectWidget";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
-import { BaseStyle, WidgetProps } from "widgets/BaseWidget";
+import { WidgetProps } from "widgets/BaseWidget";
 import { GridDefaults, WidgetHeightLimits } from "constants/WidgetConstants";
 
 const StyledDynamicHeightOverlay = styled.div`
@@ -597,8 +597,6 @@ const DynamicHeightOverlay: React.FC<DynamicHeightOverlayProps> = memo(
     const multipleWidgetsSelected = selectedWidgets.length > 1;
     const isOverlayToBeDisplayed =
       isWidgetSelected && !multipleWidgetsSelected && !isDragging;
-
-    console.log("StyledDynamicHeightOverlay", isOverlayToBeDisplayed);
 
     return (
       <StyledDynamicHeightOverlay

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -489,7 +489,6 @@ abstract class BaseWidget<
   };
 
   private getWidgetView(): ReactNode {
-    console.log("getWidgetView", this.props.renderMode);
     let content: ReactNode;
     switch (this.props.renderMode) {
       case RenderModes.CANVAS:
@@ -502,7 +501,6 @@ abstract class BaseWidget<
           content = this.makeSnipeable(content);
           // NOTE: In sniping mode we are not blocking onClick events from PositionWrapper.
           content = this.makePositioned(content);
-          console.log("AUTO_HEIGHT_WITH_LIMITS", this.props.dynamicHeight);
           if (
             this.props.dynamicHeight === DynamicHeight.AUTO_HEIGHT_WITH_LIMITS
           ) {

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -42,7 +42,9 @@ import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import PreviewModeComponent from "components/editorComponents/PreviewModeComponent";
 import { DynamicHeight } from "utils/WidgetFeatures";
 import { isDynamicHeightEnabledForWidget } from "./WidgetUtils";
-import DynamicHeightOverlay from "components/editorComponents/DynamicHeightOverlay";
+import DynamicHeightOverlay, {
+  DynamicHeightOverlayStyle,
+} from "components/editorComponents/DynamicHeightOverlay";
 import log from "loglevel";
 import { CanvasWidgetStructure } from "./constants";
 import { DataTreeWidget } from "entities/DataTree/dataTreeFactory";
@@ -421,7 +423,10 @@ abstract class BaseWidget<
     );
   }
 
-  addDynamicHeightOverlay(content: ReactNode) {
+  addDynamicHeightOverlay(
+    content: ReactNode,
+    style?: DynamicHeightOverlayStyle,
+  ) {
     const onMaxHeightSet = (height: number) => {
       this.updateWidgetProperty("maxDynamicHeight", Math.floor(height / 10));
     };
@@ -439,6 +444,8 @@ abstract class BaseWidget<
       });
     };
 
+    const position = this.getPositionStyle();
+
     return (
       <div>
         <DynamicHeightOverlay
@@ -448,7 +455,13 @@ abstract class BaseWidget<
           minDynamicHeight={this.props.minDynamicHeight}
           onMaxHeightSet={onMaxHeightSet}
           onMinHeightSet={onMinHeightSet}
-          style={this.getPositionStyle()}
+          style={{
+            width: position.componentWidth,
+            height: position.componentHeight,
+            top: position.yPosition,
+            left: position.xPosition,
+            ...style,
+          }}
         />
         {content}
       </div>
@@ -476,6 +489,7 @@ abstract class BaseWidget<
   };
 
   private getWidgetView(): ReactNode {
+    console.log("getWidgetView", this.props.renderMode);
     let content: ReactNode;
     switch (this.props.renderMode) {
       case RenderModes.CANVAS:
@@ -488,7 +502,7 @@ abstract class BaseWidget<
           content = this.makeSnipeable(content);
           // NOTE: In sniping mode we are not blocking onClick events from PositionWrapper.
           content = this.makePositioned(content);
-
+          console.log("AUTO_HEIGHT_WITH_LIMITS", this.props.dynamicHeight);
           if (
             this.props.dynamicHeight === DynamicHeight.AUTO_HEIGHT_WITH_LIMITS
           ) {

--- a/app/client/src/widgets/ModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/ModalWidget/widget/index.tsx
@@ -16,6 +16,7 @@ import { getCanvasWidth, snipingModeSelector } from "selectors/editorSelectors";
 import { deselectAllInitAction } from "actions/widgetSelectionActions";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { isDynamicHeightEnabledForWidget } from "widgets/WidgetUtils";
+import { DynamicHeight } from "utils/WidgetFeatures";
 
 const minSize = 100;
 
@@ -333,6 +334,14 @@ export class ModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
     let children = this.getChildren();
     children = this.makeModalSelectable(children);
     children = this.showWidgetName(children, true);
+    if (this.props.dynamicHeight === DynamicHeight.AUTO_HEIGHT_WITH_LIMITS) {
+      children = this.addDynamicHeightOverlay(children, {
+        width: "100%",
+        height: "100%",
+        left: 0,
+        top: 0,
+      });
+    }
     return this.makeModalComponent(children, true);
   }
 


### PR DESCRIPTION
Dynamic height signifiers for modal widget