### PR TITLE
fix: Make projection fields refresh when table heading row index selection is updated

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/fetch_many.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/fetch_many.json
@@ -17,16 +17,17 @@
       "fetchOptionsConditionally": true,
       "alternateViewTypes": ["json"],
       "conditionals": {
-        "enable": "{{!!actionConfiguration.formData.sheetUrl.data && !!actionConfiguration.formData.sheetName.data}}",
+        "enable": "{{!!actionConfiguration.formData.sheetUrl.data && !!actionConfiguration.formData.sheetName.data && !!actionConfiguration.formData.tableHeaderIndex.data}}",
         "fetchDynamicValues": {
-          "condition": "{{!!actionConfiguration.formData.sheetUrl.data && !!actionConfiguration.formData.sheetName.data}}",
+          "condition": "{{!!actionConfiguration.formData.sheetUrl.data && !!actionConfiguration.formData.sheetName.data && !!actionConfiguration.formData.tableHeaderIndex.data}}",
           "config": {
             "params": {
               "requestType": "COLUMNS_SELECTOR",
               "displayType": "DROP_DOWN",
               "parameters": {
                 "sheetUrl": "{{actionConfiguration.formData.sheetUrl.data}}",
-                "sheetName": "{{actionConfiguration.formData.sheetName.data}}"
+                "sheetName": "{{actionConfiguration.formData.sheetName.data}}",
+                "tableHeaderIndex": "{{actionConfiguration.formData.tableHeaderIndex.data}}"
               }
             }
           }


### PR DESCRIPTION
## Description

We weren't sending table heading row index information along with the sheet url and name parameters to fetch the columns in Google Sheets integration. This PR starts to send this information along. As a result, every time the table heading row index value changes, we can expect the projection field to get updated.

Fixes #16868 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually tested on local, no possibility of unit tests or integration tests for GSheets.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
