### PR TITLE
fix: Default Port for MsSQL

### DIFF
--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/java/com/external/plugins/MssqlPlugin.java
@@ -561,7 +561,7 @@ public class MssqlPlugin extends BasePlugin {
             urlBuilder
                     .append(endpoint.getHost())
                     .append(":")
-                    .append(ObjectUtils.defaultIfNull(endpoint.getPort(), 5432L))
+                    .append(ObjectUtils.defaultIfNull(endpoint.getPort(), 1433L))
                     .append(";");
         }
 


### PR DESCRIPTION
## Description

Fixes #16808 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Go to Datasources -> Create New
- Choose Microsoft SQL Server as the datasource
- Provide all the information in the datasource-create page
- Leave the port blank

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
