### PR TITLE
fix: Table filter issues

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV2/TableV2Filter2_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV2/TableV2Filter2_Spec.ts
@@ -18,7 +18,10 @@ describe("Verify various Table_Filter combinations", function() {
   it("1. Adding Data to Table Widget", function() {
     ee.DragDropWidgetNVerify("tablewidgetv2", 250, 250);
     //propPane.EnterJSContext("Table Data", JSON.stringify(dataSet.TableInput));
-    propPane.UpdatePropertyFieldValue("Table Data", JSON.stringify(dataSet.TableInput))
+    propPane.UpdatePropertyFieldValue(
+      "Table Data",
+      JSON.stringify(dataSet.TableInput),
+    );
     agHelper.ValidateNetworkStatus("@updateLayout", 200);
     agHelper.PressEscape();
     deployMode.DeployApp();
@@ -412,6 +415,39 @@ describe("Verify various Table_Filter combinations", function() {
 
     table.OpenFilter();
     table.RemoveFilterNVerify("1", true, false);
+  });
+
+  it("14. Verify Table Filter for correct value in filter value input after removing second filter - Bug 12638", function() {
+    table.OpenNFilterTable("seq", "greater than", "5");
+
+    table.OpenNFilterTable("FirstName", "contains", "r", "AND", 1);
+
+    table.OpenNFilterTable("LastName", "contains", "son", "AND", 2);
+    table.agHelper.GetNClick(".t--table-filter-remove-btn", 1);
+    cy.wait(500);
+    cy.get(
+      ".t--table-filter:nth-child(2) .t--table-filter-value-input input[type=text]",
+    ).should("have.value", "son");
+    table.agHelper.GetNClick(".t--clear-all-filter-btn");
+    table.agHelper.GetNClick(".t--close-filter-btn");
+  });
+
+  it("15. Verify Table Filter operator for correct value after removing where clause condition - Bug 12642", function() {
+    table.OpenNFilterTable("seq", "greater than", "5");
+
+    table.OpenNFilterTable("FirstName", "contains", "r", "AND", 1);
+
+    table.OpenNFilterTable("LastName", "contains", "son", "AND", 2);
+    table.agHelper.GetNClick(".t--table-filter-operators-dropdown");
+    cy.get(".t--dropdown-option")
+      .contains("OR")
+      .click();
+    table.agHelper.GetNClick(".t--table-filter-remove-btn", 0);
+    cy.get(".t--table-filter-operators-dropdown div div span").should(
+      "contain",
+      "OR",
+    );
+    table.agHelper.GetNClick(".t--clear-all-filter-btn");
   });
 
   function filterOnlyCondition(

--- a/app/client/src/widgets/TableWidgetV2/component/CascadeFields.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/CascadeFields.tsx
@@ -290,7 +290,11 @@ type CascadeFieldProps = {
   operator: Operator;
   index: number;
   hasAnyFilters: boolean;
-  applyFilter: (filter: ReactTableFilter, index: number) => void;
+  applyFilter: (
+    filter: ReactTableFilter,
+    index: number,
+    isOperatorChange: boolean,
+  ) => void;
   removeFilter: (index: number) => void;
   accentColor: string;
   borderRadius: string;
@@ -307,6 +311,7 @@ type CascadeFieldState = {
   showDateInput: boolean;
   isDeleted: boolean;
   isUpdate: boolean;
+  isOperatorChange: boolean;
 };
 
 const getConditions = (props: CascadeFieldProps) => {
@@ -373,6 +378,7 @@ function calculateInitialState(props: CascadeFieldProps) {
     showDateInput: showDateInput,
     isDeleted: false,
     isUpdate: false,
+    isOperatorChange: false,
   };
 }
 
@@ -425,6 +431,7 @@ function CaseCaseFieldReducer(
         ...state,
         operator: action.payload,
         isUpdate: true,
+        isOperatorChange: true,
       };
     case CascadeFieldActionTypes.UPDATE_FILTER:
       const calculatedState = calculateInitialState(action.payload);
@@ -491,6 +498,7 @@ function Fields(props: CascadeFieldProps & { state: CascadeFieldState }) {
     condition,
     conditions,
     isDeleted,
+    isOperatorChange,
     isUpdate,
     operator,
     showConditions,
@@ -500,7 +508,11 @@ function Fields(props: CascadeFieldProps & { state: CascadeFieldState }) {
   } = state;
   useEffect(() => {
     if (!isDeleted && isUpdate) {
-      applyFilter({ operator, column, condition, value }, index);
+      applyFilter(
+        { operator, column, condition, value },
+        index,
+        isOperatorChange,
+      );
     } else if (isDeleted) {
       removeFilter(index);
     }
@@ -510,6 +522,7 @@ function Fields(props: CascadeFieldProps & { state: CascadeFieldState }) {
     condition,
     value,
     isDeleted,
+    isOperatorChange,
     isUpdate,
     index,
     applyFilter,


### PR DESCRIPTION
## Description

**Bug 12638**
After adding 3 filters to a table and removing the second filter, the current second filter `value` was showing the old second filter `value`. This was happening because we were not passing unique keys to the filters while rendering the filters list.
Hence added a unique key to filter in filters list.

**Bug 12642**
After adding 3 filters and then changing the operator of second filter from `AND` to `OR` or vice versa, then removing the **first** filter caused the operator to go back to the previous value.
This was happening because we are adding the `OR` operator to a filter by default. When we are changing the operator from the dropdown the value gets updated to the second filter only in the state. All other filters persisted with the previous operator value.
Hence this has been solved by updating the operator of all filters (after the second filter) whenever user changes the operator of the second filter from the operator dropdown.

Fixes #12642, #12638

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Cypress tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
