### PR TITLE
test: Add user details for tests

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/CurlImporterServiceTest.java
@@ -88,6 +88,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void lexerTests() {
         assertThat(curlImporterService.lex("curl http://httpbin.org/get"))
                 .isEqualTo(List.of("curl", "http://httpbin.org/get"));
@@ -141,6 +142,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void lexComments() {
         assertThat(curlImporterService.lex("curl some args # comment here"))
                 .isEqualTo(List.of("curl", "some", "args"));
@@ -153,6 +155,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void lexWhiteSpace() {
         assertThat(curlImporterService.lex("curl 'some args    with lots of   space'"))
                 .isEqualTo(List.of("curl", "some args    with lots of   space"));
@@ -295,6 +298,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void urlInSingleQuotes() throws AppsmithException {
         String command = "curl --location --request POST 'http://localhost:8080/scrap/api?slugifiedName=Freshdesk&ownerName=volodimir.kudriachenko'";
         ActionDTO action = curlImporterService.curlToAction(command);
@@ -314,6 +318,7 @@ public class CurlImporterServiceTest {
 
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void missingMethod() throws AppsmithException {
         String command = "curl http://localhost:8080/scrap/api";
         ActionDTO action = curlImporterService.curlToAction(command);
@@ -332,6 +337,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void multilineCommand() throws AppsmithException {
         String command = "curl -d '{\"message\": \"The force is strong with this one...\"}' \\\n" +
                 "  -H \"Content-Type: application/json\" \\\n" +
@@ -353,6 +359,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void testUrlEncodedData() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction(
                 "curl --data-urlencode '=all of this exactly, but url encoded ' http://loc"
@@ -380,6 +387,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void chromeCurlCommands1() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction(
                 "curl 'http://localhost:3000/applications/5ea054c531cc0f7a61af0cbe/pages/5ea054c531cc0f7a61af0cc0/edit/api' \\\n" +
@@ -445,6 +453,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void firefoxCurlCommands1() throws AppsmithException {
         final ActionDTO action = curlImporterService.curlToAction("curl 'http://localhost:8080/api/v1/actions?applicationId=5ea054c531cc0f7a61af0cbe' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:75.0) Gecko/20100101 Firefox/75.0' -H 'Accept: application/json, text/plain, */*' -H 'Accept-Language: en-US,en;q=0.5' --compressed -H 'Origin: http://localhost:3000' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Referer: http://localhost:3000/' -H 'Cookie: SESSION=69b4b392-03b6-4e0a-a889-49ca4b8e267e'");
         assertMethod(action, HttpMethod.GET);
@@ -464,6 +473,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void postmanExportCommands1() throws AppsmithException {
         final ActionDTO action = curlImporterService.curlToAction(
                 "curl --location --request PUT 'https://release-api.appsmith.com/api/v1/users/5d81feb218e1c8217d20e13f' \\\n" +
@@ -488,6 +498,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void postmanCreateDatasource() throws AppsmithException {
         final ActionDTO action = curlImporterService.curlToAction(
                 "curl --location --request POST 'https://release-api.appsmith.com/api/v1/datasources' \\\n" +
@@ -530,6 +541,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void postmanCreateProvider() throws AppsmithException {
         final ActionDTO action = curlImporterService.curlToAction(
                 "curl --location --request POST 'https://release-api.appsmith.com/api/v1/providers' \\\n" +
@@ -598,6 +610,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseCurlJsTestsPart1() throws AppsmithException {
         // Tests adapted from <https://github.com/tj/parse-curl.js/blob/master/test.js>.
 
@@ -639,6 +652,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseCurlJsTestsPart2() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl -d \"foo=bar\" https://api.sloths.com");
         assertMethod(action, HttpMethod.POST);
@@ -716,6 +730,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseWithoutProtocol() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl api.sloths.com");
         assertMethod(action, HttpMethod.GET);
@@ -726,6 +741,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseWithDashedUrlArgument() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl --url http://api.sloths.com");
         assertMethod(action, HttpMethod.GET);
@@ -736,6 +752,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseWithDashedUrlArgument2() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl -X POST -d '{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}' --url http://dummy.restapiexample.com/api/v1/create");
         assertMethod(action, HttpMethod.POST);
@@ -747,6 +764,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseWithJson() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl -X POST -H'Content-Type: application/json' -d '{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}' --url http://dummy.restapiexample.com/api/v1/create");
         assertMethod(action, HttpMethod.POST);
@@ -757,6 +775,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseWithSpacedHeader() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl -H \"Accept:application/json\" http://httpbin.org/get");
         assertMethod(action, HttpMethod.GET);
@@ -767,6 +786,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseCurlCommand1() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl -i -H \"Accept: application/json\" -H \"Content-Type: application/json\" -X POST -d '{\"name\":\"test\",\"salary\":\"123\",\"age\":\"23\"}' --url http://dummy.restapiexample.com/api/v1/create");
         assertMethod(action, HttpMethod.POST);
@@ -777,6 +797,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseMultipleData() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl https://api.stripe.com/v1/refunds -d payment_intent=pi_Aabcxyz01aDfoo -d amount=1000");
         assertMethod(action, HttpMethod.POST);
@@ -792,6 +813,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void parseMultiFormData() throws AppsmithException {
         // In the curl command, we test for a combination of --form and -F
         // Also some values are double-quoted while some aren't. This tests a permutation of all such fields
@@ -809,6 +831,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void dontEatBackslashesInSingleQuotes() throws AppsmithException {
         ActionDTO action = curlImporterService.curlToAction("curl http://httpbin.org/post -d 'a\\n'");
         assertMethod(action, HttpMethod.POST);
@@ -819,6 +842,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void importInvalidMethod() {
         assertThatThrownBy(() -> {
             curlImporterService.curlToAction("curl -X invalid-method http://httpbin.org/get");
@@ -828,6 +852,7 @@ public class CurlImporterServiceTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void importInvalidHeader() {
         assertThatThrownBy(() -> {
             curlImporterService.curlToAction("curl -H x-custom http://httpbin.org/headers");


### PR DESCRIPTION
## Description

> CurlImport tests were failing in EE AuditLog PR because of the missing workspaceId. It was because of the missing annotation `withUserDetails`. 


## Type of change

- Test changes

## How Has This Been Tested?

- Locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
