### PR TITLE
fix: auto height text widget hide overflow

### DIFF
--- a/app/client/src/widgets/TextWidget/widget/index.tsx
+++ b/app/client/src/widgets/TextWidget/widget/index.tsx
@@ -58,9 +58,6 @@ class TextWidget extends BaseWidget<TextWidgetProps, WidgetState> {
             defaultValue: OverflowTypes.NONE,
             isBindProperty: false,
             isTriggerProperty: false,
-            hidden: (props: WidgetProps) =>
-              isDynamicHeightEnabledForWidget(props),
-            dependencies: ["dynamicHeight"],
           },
           {
             propertyName: "isVisible",
@@ -356,6 +353,9 @@ class TextWidget extends BaseWidget<TextWidgetProps, WidgetState> {
             defaultValue: OverflowTypes.NONE,
             isBindProperty: false,
             isTriggerProperty: false,
+            hidden: (props: WidgetProps) =>
+              isDynamicHeightEnabledForWidget(props),
+            dependencies: ["dynamicHeight"],
           },
           {
             propertyName: "isVisible",


### PR DESCRIPTION
Hiding the Overflow options in the Text widget if Auto Height is enabled.