### PR TITLE
fix: Fix X-Forwarded-Host with multiple rev-proxies

### DIFF
--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -13,6 +13,12 @@ map \$http_x_forwarded_proto \$origin_scheme {
   default \$http_x_forwarded_proto;
   '' \$scheme;
 }
+
+map \$http_x_forwarded_proto \$origin_host {
+  default \$http_x_forwarded_host;
+  '' \$host;
+}
+
 # redirect log to stdout for supervisor to capture
 access_log /dev/stdout;
 
@@ -49,8 +55,8 @@ server {
 
     proxy_set_header  Host             	\$http_host/supervisor/;
     proxy_set_header  X-Forwarded-For  	\$proxy_add_x_forwarded_for;
-    proxy_set_header 	X-Forwarded-Proto \$scheme;
-    proxy_set_header 	X-Forwarded-Host 	\$http_host;
+    proxy_set_header 	X-Forwarded-Proto \$origin_scheme;
+    proxy_set_header 	X-Forwarded-Host 	\$origin_host;
     proxy_set_header  Connection       "";
 
     proxy_pass http://localhost:9001/;
@@ -60,7 +66,7 @@ server {
   }
 
   proxy_set_header X-Forwarded-Proto \$origin_scheme;
-  proxy_set_header X-Forwarded-Host \$host;
+  proxy_set_header X-Forwarded-Host \$origin_host;
 
   location / {
     try_files \$uri /index.html =404;

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -19,6 +19,12 @@ map \$http_x_forwarded_proto \$origin_scheme {
   default \$http_x_forwarded_proto;
   '' \$scheme;
 }
+
+map \$http_x_forwarded_proto \$origin_host {
+  default \$http_x_forwarded_host;
+  '' \$host;
+}
+
 # redirect log to stdout for supervisor to capture
 access_log /dev/stdout;
 
@@ -47,23 +53,23 @@ server {
   }
 
   location /supervisor/ {
-      proxy_http_version 1.1;
-      proxy_buffering    off;
-      proxy_max_temp_file_size 0;
-      proxy_redirect    off;
-      proxy_set_header  Host             \$http_host/supervisor/;
-      proxy_set_header  X-Real-IP        \$remote_addr;
-      proxy_set_header  X-Forwarded-For  \$proxy_add_x_forwarded_for;
-      proxy_set_header 	X-Forwarded-Proto \$origin_scheme;
-      proxy_set_header 	X-Forwarded-Host \$http_host;
-      proxy_set_header   Connection       "";
-      proxy_pass http://localhost:9001/;
-      auth_basic "Protected";
-      auth_basic_user_file /etc/nginx/passwords;
+		proxy_http_version 1.1;
+		proxy_buffering    off;
+		proxy_max_temp_file_size 0;
+		proxy_redirect    off;
+		proxy_set_header  Host              \$http_host/supervisor/;
+		proxy_set_header  X-Real-IP         \$remote_addr;
+		proxy_set_header  X-Forwarded-For   \$proxy_add_x_forwarded_for;
+		proxy_set_header 	X-Forwarded-Proto \$origin_scheme;
+		proxy_set_header 	X-Forwarded-Host 	\$origin_host;
+		proxy_set_header   Connection       "";
+		proxy_pass http://localhost:9001/;
+		auth_basic "Protected";
+		auth_basic_user_file /etc/nginx/passwords;
   }
 
   proxy_set_header X-Forwarded-Proto \$origin_scheme;
-  proxy_set_header X-Forwarded-Host \$host;
+  proxy_set_header X-Forwarded-Host \$origin_host;
 
   client_max_body_size 100m;
 


### PR DESCRIPTION
When there's another reverse proxy in front of Appsmith container, in addition to the NGINX that comes with Appsmith, the Forwarded host is not carried over.

## Steps to reproduce

Start a new fat container with

```bash
docker run --rm -p 8001:80 -v "$PWD"/stacks-ee:/appsmith-stacks -e APPSMITH_OAUTH2_GOOGLE_CLIENT_ID="dummy-id" -e APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET="dummy-secret" -d --pull always appsmith/appsmith-ee
```

Now, once that is up, run the following curl command to see where the Google OAuth button would take you:

```bash
curl -sSI -H 'X-Forwarded-Host: another.com' -H 'X-Forwarded-Proto: https' http://localhost:8001/oauth2/authorization/google | grep -Eo 'redirect_uri=[^&]*'
```

The `redirect_uri` doesn't have the correct host. We expect `another.com`, but we see `localhost`.
