### PR TITLE
fix: MongoPlugin smart substitution for regex arguments

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -157,6 +157,14 @@ public class MongoPlugin extends BasePlugin {
     private static final String MONGO_URI_REGEX = "^(mongodb(?:\\+srv)?://)(?:(.+):(.+)@)?([^/?]+)/?([^?]+)?\\??(.+)?$";
 
     /**
+     * We use this regex to identify the $regex attribute and the respective argument provided:
+     * e.g. {"code" : {$regex: value, $options: value}} / {"code" : {$regex: value}}
+     * capturing the value group for regex.
+     * e.g {"code" : {$regex: 8777}}, this whole substring will be matched and 8777 is captured for further processing.
+     */
+    private static final String mongo$regexWithNumberIdentifier = ".*\\{[\\s\\n]*\\$regex[\\s\\n]*:([\\s\\n]*(?:(?:\\\"[/]*)|(?:/[\\\"]*)|)[\\d]*(?:(?:[/]*\\\")|(?:[\\\"]*/)|)[\\s\\n]*)(?:,|\\})";
+
+    /**
      * We use this regex to find usage of special Mongo data types like ObjectId(...) wrapped inside double quotes
      * e.g. "ObjectId(...)". Case for single quotes e.g. 'ObjectId(...)' is not added because the way client sends
      * back the data to the API server it would be extremely uncommon to encounter this case.
@@ -574,7 +582,94 @@ public class MongoPlugin extends BasePlugin {
                     params,
                     parameters);
 
+            updatedQuery = mongoRegexSmartSubstitutionHelper (updatedQuery);
+
             return updatedQuery;
+        }
+
+
+        private static StringBuilder makeValidForRegex(String value) {
+
+            // equivalent to new StringBuilder(value.trim()); but takes lesser memory
+            StringBuilder valueSB = trimAndBuildStringBuilderFromString(value);
+
+            char quote = '\"';
+            char forwardSlash = '/';
+            if ( valueSB.charAt(0) != quote && valueSB.charAt(0) != forwardSlash) {
+                valueSB.insert(0, quote );
+                // adds quote at the end of the line
+                valueSB.append(quote);
+            }
+
+            return valueSB;
+        }
+
+        private static StringBuilder trimAndBuildStringBuilderFromString(String input) {
+
+            int startIndex = 0;
+            int endIndex = input.length() -1;
+            for (int i = 0; i < input.length(); i++) {
+                if (!Character.isWhitespace(input.charAt(i))) {
+                    startIndex = i;
+                    break;
+                }
+            }
+
+            for  (int i = input.length()-1; i>= 0 ; i--) {
+                if (!Character.isWhitespace(input.charAt(i))) {
+                    endIndex = i;
+                    break;
+                }
+            }
+
+            return  endIndex >= startIndex ? new StringBuilder( input.substring(startIndex, endIndex+1)) : new StringBuilder("");
+        }
+
+
+        /**
+         * Smart Substitution Helper for mongo regex: Regex takes pattern as "<pattern>" or /<pattern>/,
+         * Rest are not illegal arguments to the $regex attribute in mongo.
+         * @Param: Smart substituted query string.
+         * @Returns: Updated query string.
+         */
+        private static String mongoRegexSmartSubstitutionHelper(String inputQuery) {
+
+
+
+            int startIndex = 0;
+            StringBuilder inputQuerySB = new StringBuilder();
+
+            Pattern mongo$regexIdentifierPattern = Pattern.compile(mongo$regexWithNumberIdentifier);
+            Matcher mongo$regexIdentifierMatcher = mongo$regexIdentifierPattern.matcher(inputQuery);
+
+            while (mongo$regexIdentifierMatcher.find()) {
+
+                StringBuilder valueSB;
+                try {
+                    valueSB = makeValidForRegex(mongo$regexIdentifierMatcher.group(1));
+
+                } catch(StringIndexOutOfBoundsException e) {
+                    // when the match group detected is of length zero this error is thrown;
+                    return inputQuery;
+                } catch (Exception e) {
+                    return inputQuery;
+                }
+
+
+                //groups are discovered in greedy manner hence it's sorted by default
+                // a sub-group within a big group could be due to the regex arguments provide by user hence will not parse that
+                if (startIndex > mongo$regexIdentifierMatcher.start()) {
+                    // the matcher walks greedily to find the pattern, if there is a group overlapping with other group means that it's a subquery, and it's not meant to be parsed.
+                    continue;
+                }
+                inputQuerySB.append(inputQuery.substring(startIndex, mongo$regexIdentifierMatcher.start(1)));
+                inputQuerySB.append(valueSB);
+                startIndex = mongo$regexIdentifierMatcher.end(1);
+            }
+
+            inputQuerySB.append(inputQuery.substring(startIndex));
+
+            return inputQuerySB.toString();
         }
 
         /**

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginTest.java
@@ -2895,9 +2895,9 @@ public class MongoPluginTest {
         executeActionDTO.setParams(List.of(new Param("appsmith.store.variable", "[a-zA-Z]{0,3}.*Ci.*")));
 
         Mono<ActionExecutionResult> actionExecutionResultMono = dsConnectionMono.flatMap(clientConnection -> pluginExecutor.executeParameterized(clientConnection,
-                executeActionDTO,
-                dsConfig,
-                actionConfiguration));
+                                                                                                                                                executeActionDTO,
+                                                                                                                                                dsConfig,
+                                                                                                                                                actionConfiguration));
         StepVerifier.create(actionExecutionResultMono)
                 .assertNext(actionExecutionResult -> {
                     assertNotNull(actionExecutionResult);
@@ -2930,9 +2930,9 @@ public class MongoPluginTest {
         executeActionDTO.setParams(List.of(new Param("appsmith.store.variable", "35")));
 
         Mono<ActionExecutionResult> actionExecutionResultMono = dsConnectionMono.flatMap(clientConnection -> pluginExecutor.executeParameterized(clientConnection,
-                executeActionDTO,
-                dsConfig,
-                actionConfiguration));
+                                                                                                                                                executeActionDTO,
+                                                                                                                                                dsConfig,
+                                                                                                                                                actionConfiguration));
 
         StepVerifier.create(actionExecutionResultMono)
                 .assertNext(actionExecutionResult -> {
@@ -2966,9 +2966,9 @@ public class MongoPluginTest {
         executeActionDTO.setParams(List.of(new Param("appsmith.store.variable", "5-.*")));
 
         Mono<ActionExecutionResult> actionExecutionResultMono = dsConnectionMono.flatMap(clientConnection -> pluginExecutor.executeParameterized(clientConnection,
-                executeActionDTO,
-                dsConfig,
-                actionConfiguration));
+                                                                                                                                                executeActionDTO,
+                                                                                                                                                dsConfig,
+                                                                                                                                                actionConfiguration));
         StepVerifier.create(actionExecutionResultMono)
                 .assertNext(actionExecutionResult -> {
                     assertNotNull(actionExecutionResult);
@@ -3002,9 +3002,9 @@ public class MongoPluginTest {
         executeActionDTO.setParams(List.of(new Param("appsmith.store.variable", "-7")));
 
         Mono<ActionExecutionResult> actionExecutionResultMono = dsConnectionMono.flatMap(clientConnection -> pluginExecutor.executeParameterized(clientConnection,
-                executeActionDTO,
-                dsConfig,
-                actionConfiguration));
+                                                                                                                                                executeActionDTO,
+                                                                                                                                                dsConfig,
+                                                                                                                                                actionConfiguration));
         StepVerifier.create(actionExecutionResultMono)
                 .assertNext(actionExecutionResult -> {
                     assertNotNull(actionExecutionResult);
@@ -3039,9 +3039,9 @@ public class MongoPluginTest {
         executeActionDTO.setParams(List.of(new Param("appsmith.store.variable", "-2.5")));
 
         Mono<ActionExecutionResult> actionExecutionResultMono = dsConnectionMono.flatMap(clientConnection -> pluginExecutor.executeParameterized(clientConnection,
-                executeActionDTO,
-                dsConfig,
-                actionConfiguration));
+                                                                                                                                                executeActionDTO,
+                                                                                                                                                dsConfig,
+                                                                                                                                                actionConfiguration));
         StepVerifier.create(actionExecutionResultMono)
                 .assertNext(actionExecutionResult -> {
                     assertNotNull(actionExecutionResult);


### PR DESCRIPTION
## Description

Fixes #11880 

Server side smart substitution parses js bounded (numbers/string representation of number arguments) as  **whole numbers**, and **decimal numbers** regardless if they are placed in quotes **" "**. This feature creates a bug for mongo regex substitution as **mongo regex attributes** only takes string arguments.  This PR fixes before mentioned characteristic.

## Type of change

> Bug Fix: Now, digit/ number arguments could be provided to the $regex with smart substitution turned on. 


## How Has This Been Tested?

The backend changes has been tested:
- Junit test cases
- Manually


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

