### PR TITLE
ops: use jdk instead of jre to generate heapdumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
   && apt-get upgrade --yes \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     supervisor curl cron certbot nginx gnupg wget netcat openssh-client \
-    software-properties-common gettext openjdk-11-jre \
+    software-properties-common gettext openjdk-11-jdk \
     python3-pip python-setuptools git ca-certificates-java \
   && pip install --no-cache-dir git+https://github.com/coderanger/supervisor-stdout@973ba19967cdaf46d9c1634d1675fc65b9574f6e \
   && apt-get remove -y git python3-pip


### PR DESCRIPTION
We need to generate heapdumps in release/prod and to generate we need jcmd and jstack in the fat-container