### PR TITLE
ci: Fixing the github release workflow to push the latest tags for Docker images

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -240,7 +240,7 @@ jobs:
 
       # Only build & tag with latest if the tag doesn't contain beta
       - name: Build and push client image latest
-        if: contains(needs.prelude.outputs.tag, 'beta') == 'false'
+        if: needs.prelude.outputs.is_beta == 'false'
         uses: depot/build-push-action@v1
         with:
           context: app/client
@@ -261,7 +261,7 @@ jobs:
 
       # Only build & tag with latest if the tag doesn't contain beta
       - name: Build and push fat image latest
-        if: contains(needs.prelude.outputs.tag, 'beta') == 'false'
+        if: needs.prelude.outputs.is_beta == 'false'
         uses: depot/build-push-action@v1
         with:
           context: .
@@ -284,7 +284,7 @@ jobs:
 
       # Only build & tag with latest if the tag doesn't contain beta
       - name: Build and push server image latest
-        if: contains(needs.prelude.outputs.tag, 'beta') == 'false'
+        if: needs.prelude.outputs.is_beta == 'false'
         uses: depot/build-push-action@v1
         with:
           context: app/server
@@ -305,7 +305,7 @@ jobs:
 
       # Only build & tag with latest if the tag doesn't contain beta
       - name: Build and push RTS image latest
-        if: contains(needs.prelude.outputs.tag, 'beta') == 'false'
+        if: needs.prelude.outputs.is_beta == 'false'
         uses: depot/build-push-action@v1
         with:
           context: app/rts


### PR DESCRIPTION
## Description

The if condition was erroneous in the github release workflow which caused the Docker images to built for a specific tag but not be pushed as the `latest` tag. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Personal repository

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
