### PR TITLE
chore: Fix host error message in Elasticsearch config

### DIFF
--- a/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/elasticSearchPlugin/src/main/resources/form.json
@@ -10,7 +10,7 @@
               "label": "Host URL",
               "configProperty": "datasourceConfiguration.endpoints[*].host",
               "controlType": "KEYVALUE_ARRAY",
-              "validationMessage": "Please enter a valid host URL",
+              "validationMessage": "Please enter a valid URL, for example, https://example.com",
               "validationRegex": "^(http|https)://"
             },
             {


### PR DESCRIPTION
The current error message gives no clue that I need to add a `http://` at the start.
