### PR TITLE
fix: For paths with an extension, give 404 if missing

### DIFF
--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -5,7 +5,7 @@ set -o nounset
 CUSTOM_DOMAIN="$1"
 
 if [[ -z $CUSTOM_DOMAIN ]]; then
-	CUSTOM_DOMAIN=_
+  CUSTOM_DOMAIN=_
 fi
 
 cat <<EOF
@@ -28,7 +28,8 @@ server {
   server_tokens off;
 
   root /opt/appsmith/editor;
-  index index.html index.htm;
+  index index.html;
+  error_page 404 /;
 
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
   add_header Content-Security-Policy "frame-ancestors ${APPSMITH_ALLOWED_FRAME_ANCESTORS-'self' *}";
@@ -64,6 +65,11 @@ server {
 
   location / {
     try_files \$uri /index.html =404;
+  }
+
+  # If the path has an extension at the end, then respond with 404 status if the file not found.
+  location ~ \.[a-z]+$ {
+    try_files \$uri =404;
   }
 
   location /api {

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -10,8 +10,8 @@ SSL_KEY_PATH="/etc/letsencrypt/live/$CUSTOM_DOMAIN/privkey.pem"
 
 # In case of existing custom certificate, container will use them to configure SSL
 if [[ -e "/appsmith-stacks/ssl/fullchain.pem" ]] && [[ -e "/appsmith-stacks/ssl/privkey.pem" ]]; then
-	SSL_CERT_PATH="/appsmith-stacks/ssl/fullchain.pem"
-	SSL_KEY_PATH="/appsmith-stacks/ssl/privkey.pem"
+  SSL_CERT_PATH="/appsmith-stacks/ssl/fullchain.pem"
+  SSL_KEY_PATH="/appsmith-stacks/ssl/privkey.pem"
 fi
 
 cat <<EOF
@@ -73,7 +73,8 @@ server {
   server_tokens off;
 
   root /opt/appsmith/editor;
-  index index.html index.htm;
+  index index.html;
+  error_page 404 /;
 
   location /.well-known/acme-challenge/ {
     root /appsmith-stacks/data/certificate/certbot;
@@ -81,6 +82,11 @@ server {
 
   location / {
     try_files \$uri /index.html =404;
+  }
+
+  # If the path has an extension at the end, then respond with 404 status if the file not found.
+  location ~ \.[a-z]+$ {
+    try_files \$uri =404;
   }
 
   location /api {


### PR DESCRIPTION
This is a fix towards the chunk loading errors problem. When a URL to an asset responds with 404, no matter it's content, it shouldn't be cached.

Slack conversation: <https://theappsmith.slack.com/archives/CGBPVEJ5C/p1663899164615419?thread_ts=1663753895.315929&cid=CGBPVEJ5C>.


With this change, we get a 404 for missing assets, but 200 for missing paths:

![Screenshot 2022-09-23 at 07 41 05](https://user-images.githubusercontent.com/120119/192190124-9afc4f9b-9682-4cb8-9612-cb1f969d61e9.png)

![Screenshot 2022-09-23 at 07 41 12](https://user-images.githubusercontent.com/120119/192190147-fe7f92a9-8834-4dbc-bc62-1af5c07177e5.png)
