### PR TITLE
fix: auto height text widget overflow none

### DIFF
--- a/app/client/src/utils/WidgetFeatures.ts
+++ b/app/client/src/utils/WidgetFeatures.ts
@@ -1,6 +1,7 @@
 import { WidgetHeightLimits } from "constants/WidgetConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import { WidgetProps } from "widgets/BaseWidget";
+import { OverflowTypes } from "widgets/TextWidget/constants";
 
 import { AutocompleteDataType } from "./autocomplete/TernServer";
 import EventEmitter from "./EventEmitter";
@@ -154,6 +155,15 @@ function updateMinMaxDynamicHeight(
     updates.push({
       propertyPath: "shouldScrollContents",
       propertyValue: true,
+    });
+  }
+
+  console.log("updateMinMaxDynamicHeight", props);
+
+  if (props.type === "TEXT_WIDGET") {
+    updates.push({
+      propertyPath: "overflow",
+      propertyValue: OverflowTypes.NONE,
     });
   }
 


### PR DESCRIPTION
Updated the `dynamicHeight` update property hook to set overflow none for text widget. Also referenced here in this PR, #16949.