### PR TITLE
fix: navigate to throws error when changing from same to new window and vice versa

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/Fields.tsx
@@ -18,7 +18,6 @@ import HightlightedCode from "components/editorComponents/HighlightedCode";
 import { Skin } from "constants/DefaultTheme";
 import { DropdownOption } from "components/constants";
 import { AutocompleteDataType } from "utils/autocomplete/TernServer";
-import { NavigationTargetType } from "sagas/ActionExecution/NavigateActionSaga";
 import DividerComponent from "widgets/DividerWidget/component";
 import store from "store";
 import { getPageList } from "selectors/entitiesSelector";
@@ -262,7 +261,7 @@ const fieldConfigs: FieldConfigs = {
   },
   [FieldType.NAVIGATION_TARGET_FIELD]: {
     getter: (value: any) => {
-      return enumTypeGetter(value, 2, NavigationTargetType.SAME_WINDOW);
+      return enumTypeGetter(value, 2, NAVIGATION_TARGET_FIELD_OPTIONS[0].value);
     },
     setter: (option: any, currentValue: string) => {
       return enumTypeSetter(option.value, currentValue, 2);

--- a/app/client/src/components/editorComponents/ActionCreator/constants.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/constants.ts
@@ -44,12 +44,12 @@ export const FILE_TYPE_OPTIONS = [
 export const NAVIGATION_TARGET_FIELD_OPTIONS = [
   {
     label: "Same window",
-    value: "SAME_WINDOW",
+    value: "'SAME_WINDOW'",
     id: "SAME_WINDOW",
   },
   {
     label: "New window",
-    value: "NEW_WINDOW",
+    value: "'NEW_WINDOW'",
     id: "NEW_WINDOW",
   },
 ];

--- a/app/client/src/components/editorComponents/ActionCreator/utils.test.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/utils.test.ts
@@ -284,6 +284,20 @@ describe("Test enumTypeSetter", () => {
       expected: "{{showAlert(,info)}}",
       argNum: 1,
     },
+    {
+      index: 3,
+      value: "'NEW_WINDOW'",
+      input: "{{navigateTo('', {}, 'SAME_WINDOW')}}",
+      expected: "{{navigateTo('', {},'NEW_WINDOW')}}",
+      argNum: 2,
+    },
+    {
+      index: 4,
+      value: "'SAME_WINDOW'",
+      input: "{{navigateTo('', {}, 'NEW_WINDOW')}}",
+      expected: "{{navigateTo('', {},'SAME_WINDOW')}}",
+      argNum: 2,
+    },
   ];
   test.each(
     cases.map((x) => [x.index, x.input, x.expected, x.value, x.argNum]),


### PR DESCRIPTION
## Description

Navigate to was throwing an error when the target window was changed from same -> new and vice versa.

The issue was occurring because PR #16947 removed the quotes surrounding the navigation field's values. Restoring the quotes back results in the regex being replaced correctly

Fixes #17050 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually

- [ ] https://github.com/appsmithorg/TestSmith/issues/2053

- Updated jest tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
