### PR TITLE
fix: Evaluated popup & binding prompt being trimmed

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/EvaluatedValuePopup.tsx
@@ -37,6 +37,7 @@ const modifiers: IPopoverSharedProps["modifiers"] = {
   preventOverflow: {
     enabled: true,
     boundariesElement: "viewport",
+    padding: 38,
   },
 };
 const Wrapper = styled.div`

--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneTab.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneTab.tsx
@@ -14,6 +14,7 @@ const StyledTabComponent = styled(TabComponent)`
 
   .react-tabs__tab-panel {
     overflow: initial;
+    padding-bottom: 18px; // space for the BindingPrompt in case it shows at the last property
   }
 `;
 


### PR DESCRIPTION
## Description

The evaluated value & binding prompt popups are used to get partially hidden if they appear at the bottom of the property pane. This PR fixes that.

Fixes #17079

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
