### PR TITLE
fix: Placeholder being shown when value is zero

### DIFF
--- a/app/client/src/components/propertyControls/InputTextControl.tsx
+++ b/app/client/src/components/propertyControls/InputTextControl.tsx
@@ -86,7 +86,7 @@ class InputTextControl extends BaseControl<InputControlProps> {
         onChange={this.onTextChange}
         placeholder={placeholderText}
         theme={this.props.theme}
-        value={propertyValue ? propertyValue : defaultValue}
+        value={propertyValue !== undefined ? propertyValue : defaultValue}
       />
     );
   }


### PR DESCRIPTION
## Description

When the default value to INPUT_TEXT property control is 0, instead of showing the value 0, it is showing the placeholder text. This was because we were not properly checking for undefined value while rendering the component. This is fixed in this PR.

Fixes #17080
Fixes #17063 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
