### PR TITLE
POC: Dynamic height undo redo issue

### DIFF
--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -165,6 +165,7 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     // e.stopPropagation();
     e.preventDefault();
   };
+
   const height = canDropTargetExtend
     ? `${Math.max(rowRef.current * props.snapRowSpace, props.minHeight)}px`
     : "100%";

--- a/app/client/src/reducers/entityReducers/widgetConfigReducer.ts
+++ b/app/client/src/reducers/entityReducers/widgetConfigReducer.ts
@@ -34,7 +34,7 @@ export interface WidgetConfig
   key: string;
   isCanvas?: boolean;
   needsMeta?: boolean;
-  canvasHeightOffset?: number;
+  canvasHeightOffset?: (props: WidgetProps) => number;
 }
 
 export interface WidgetConfigReducerState {

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -119,6 +119,7 @@ import { DataTree } from "entities/DataTree/dataTreeFactory";
 import { builderURL, generateTemplateURL } from "RouteBuilder";
 import { failFastApiCalls } from "./InitSagas";
 import { takeEvery } from "redux-saga/effects";
+import { generateDynamicHeightComputationTree } from "actions/dynamicHeightActions";
 
 const WidgetTypes = WidgetFactory.widgetTypes;
 
@@ -248,6 +249,10 @@ export function* handleFetchedPage({
       type: ReduxActionTypes.UPDATE_CANVAS_STRUCTURE,
       payload: extractedDSL,
     });
+
+    // Since new page has new layout, we need to generate a data structure
+    // to compute dynamic height based on the new layout.
+    yield put(generateDynamicHeightComputationTree(true));
 
     if (willPageBeMigrated) {
       yield put(saveLayout());

--- a/app/client/src/sagas/dynamicHeightSagas.ts
+++ b/app/client/src/sagas/dynamicHeightSagas.ts
@@ -715,7 +715,7 @@ export default function* widgetOperationSagas() {
       batchCallsToUpdateWidgetDynamicHeightSaga,
     ),
     debounce(
-      500,
+      200,
       ReduxActionTypes.PROCESS_DYNAMIC_HEIGHT_UPDATES,
       updateWidgetDynamicHeightSaga,
     ),

--- a/app/client/src/selectors/editorSelectors.tsx
+++ b/app/client/src/selectors/editorSelectors.tsx
@@ -207,9 +207,11 @@ export const getCurrentPageName = createSelector(
 export const getCanvasHeightOffset = (
   state: AppState,
   widgetType: WidgetType,
+  props: WidgetProps,
 ) => {
   const config = state.entities.widgetConfig.config[widgetType];
-  return config.canvasHeightOffset || 0;
+  if (config.canvasHeightOffset) return config.canvasHeightOffset(props);
+  else return 0;
 };
 
 export const getWidgetCards = createSelector(

--- a/app/client/src/utils/hooks/useDynamicAppLayout.tsx
+++ b/app/client/src/utils/hooks/useDynamicAppLayout.tsx
@@ -22,7 +22,6 @@ import { useWindowSizeHooks } from "./dragResizeHooks";
 import { getAppMode } from "selectors/entitiesSelector";
 import { updateCanvasLayoutAction } from "actions/editorActions";
 import { getIsCanvasInitialized } from "selectors/mainCanvasSelectors";
-import { calculateDynamicHeight } from "utils/DSLMigrations";
 
 const BORDERS_WIDTH = 2;
 const GUTTER_WIDTH = 72;
@@ -32,19 +31,19 @@ export const useDynamicAppLayout = () => {
   const explorerWidth = useSelector(getExplorerWidth);
   const isExplorerPinned = useSelector(getExplorerPinned);
   const appMode: APP_MODE | undefined = useSelector(getAppMode);
-  const { height: screenHeight, width: screenWidth } = useWindowSizeHooks();
+  const { width: screenWidth } = useWindowSizeHooks();
   const mainCanvasProps = useSelector(getMainCanvasProps);
   const isPreviewMode = useSelector(previewModeSelector);
   const currentPageId = useSelector(getCurrentPageId);
   const isCanvasInitialized = useSelector(getIsCanvasInitialized);
   const appLayout = useSelector(getCurrentApplicationLayout);
 
-  /**
-   * calculates min height
-   */
-  const calculatedMinHeight = useMemo(() => {
-    return calculateDynamicHeight();
-  }, [mainCanvasProps]);
+  // /**
+  //  * calculates min height
+  //  */
+  // const calculatedMinHeight = useMemo(() => {
+  //   return calculateDynamicHeight();
+  // }, [mainCanvasProps]);
 
   /**
    * app layout range i.e minWidth and maxWidth for the current layout
@@ -147,11 +146,11 @@ export const useDynamicAppLayout = () => {
   /**
    * when screen height is changed, update canvas layout
    */
-  useEffect(() => {
-    if (calculatedMinHeight !== mainCanvasProps?.height) {
-      dispatch(updateCanvasLayoutAction(mainCanvasProps?.width));
-    }
-  }, [screenHeight, mainCanvasProps?.height]);
+  // useEffect(() => {
+  //   if (calculatedMinHeight !== mainCanvasProps?.height) {
+  //     // dispatch(updateCanvasLayoutAction(mainCanvasProps?.width));
+  //   }
+  // }, [screenHeight, mainCanvasProps?.height]);
 
   useEffect(() => {
     if (isCanvasInitialized) debouncedResize();

--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -86,7 +86,7 @@ function ContainerComponentWrapper(props: ContainerComponentProps) {
 }
 
 function ContainerComponent(props: ContainerComponentProps) {
-  useCanvasMinHeightUpdateHook(props.widgetId, props.minHeight);
+  // useCanvasMinHeightUpdateHook(props.widgetId, props.minHeight);
   return props.widgetId === MAIN_CONTAINER_WIDGET_ID ? (
     <ContainerComponentWrapper {...props} />
   ) : (

--- a/app/client/src/widgets/ContainerWidget/widget/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/widget/index.tsx
@@ -321,14 +321,16 @@ class ContainerWidget extends BaseWidget<
                 snapRows={snapRows}
                 widgetId={props.widgetId}
               />
+
+              <WidgetsMultiSelectBox
+                {...this.getSnapSpaces()}
+                noContainerOffset={!!props.noContainerOffset}
+                widgetId={this.props.widgetId}
+                widgetType={this.props.type}
+              />
             </>
           )}
-        <WidgetsMultiSelectBox
-          {...this.getSnapSpaces()}
-          noContainerOffset={!!props.noContainerOffset}
-          widgetId={this.props.widgetId}
-          widgetType={this.props.type}
-        />
+
         {/* without the wrapping div onClick events are triggered twice */}
         <>{this.renderChildren()}</>
       </ContainerComponent>

--- a/app/client/src/widgets/TabsWidget/index.ts
+++ b/app/client/src/widgets/TabsWidget/index.ts
@@ -9,7 +9,8 @@ export const CONFIG = {
   iconSVG: IconSVG,
   needsMeta: true,
   isCanvas: true,
-  canvasHeightOffset: 4,
+  canvasHeightOffset: (props: WidgetProps): number =>
+    props.showTabs === true ? 4 : 0,
   features: {
     dynamicHeight: true,
   },


### PR DESCRIPTION
- Fixes issue where scroll height of container like widget's canvas was never resetting after we fixed the undo-redo issue
- Fixes issue where undo after move/add/delete/cut/paste/resize of a widget was not working.