### PR TITLE
fix: set HOSTNAME env for heroku deployment

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -290,6 +290,8 @@ else
   # These functions are used to limit heap size for Backend process when deployed on Heroku
   get_maximum_heap
   setup_backend_heap_arg
+  # set the hostname for heroku dyno
+  export HOSTNAME="heroku_dyno"
 fi
 
 check_setup_custom_ca_certificates


### PR DESCRIPTION
Fix for setting the env `HOSTNAME` to '`heroku_dyno`' for heroku deployment.