### PR TITLE
fix: Avoid closing a Toast message when auto-close is false

### DIFF
--- a/app/client/src/components/ads/Toast.tsx
+++ b/app/client/src/components/ads/Toast.tsx
@@ -236,10 +236,12 @@ export const Toaster = {
         hideProgressBar: config.hideProgressBar,
       },
     );
-    // Update autoclose everytime to keep resetting the timer.
-    toast.update(toastId, {
-      autoClose: config.duration || 5000,
-    });
+    if (config.autoClose !== false) {
+      // Update autoclose everytime to keep resetting the timer.
+      toast.update(toastId, {
+        autoClose: config.duration || 5000,
+      });
+    }
   },
   clear: () => toast.dismiss(),
 };


### PR DESCRIPTION
## Description
It was noticed that the toast message component would close after some time even if `autoClose` option was false
This quick change will fix it

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
