### PR TITLE
chore: Making the error pages conform to the design system

### DIFF
--- a/app/client/src/pages/common/ClientError.tsx
+++ b/app/client/src/pages/common/ClientError.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
-import Button from "components/editorComponents/Button";
+import { Button, Size } from "design-system";
 import { flushErrors } from "actions/errorActions";
 import PageUnavailableImage from "assets/images/404-image.png";
 
@@ -28,26 +28,26 @@ function ClientError(props: Props) {
   const { flushErrors } = props;
 
   return (
-    <Wrapper>
+    <Wrapper className="space-y-6">
       <img
         alt="Page Unavailable"
         className="page-unavailable-img"
         src={PageUnavailableImage}
       />
-      <div>
+      <div className="space-y-2">
         <p className="bold-text">Whoops something went wrong!</p>
         <p>This is embarrassing, please contact Appsmith support for help</p>
         <Button
+          category="primary"
           className="button-position"
-          filled
-          icon="arrow-right"
+          fill="true"
+          icon="right-arrow"
           iconAlignment="right"
-          intent="primary"
           onClick={() => {
             flushErrors();
             window.open("https://discord.gg/rBTTVJp", "_blank");
           }}
-          size="small"
+          size={Size.large}
           text="Contact us on discord"
         />
       </div>

--- a/app/client/src/pages/common/PageNotFound.tsx
+++ b/app/client/src/pages/common/PageNotFound.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { APPLICATIONS_URL } from "constants/routes";
-import Button from "components/editorComponents/Button";
+import { Button, IconPositions, Size } from "design-system";
 import { flushErrorsAndRedirect } from "actions/errorActions";
 import PageUnavailableImage from "assets/images/404-image.png";
 import {
@@ -50,17 +50,19 @@ function PageNotFound(props: Props) {
         <p>
           Either this page doesn&apos;t exist, or you don&apos;t have access to{" "}
           <br />
-          this page.
+          this page
         </p>
         <Button
+          category="primary"
           className="button-position"
-          filled
-          icon="arrow-right"
-          iconAlignment="right"
-          intent="primary"
+          fill="true"
+          icon="right-arrow"
+          iconPosition={IconPositions.right}
           onClick={() => flushErrorsAndRedirect(APPLICATIONS_URL)}
-          size="small"
+          size={Size.large}
+          tag="button"
           text={createMessage(BACK_TO_HOMEPAGE)}
+          variant="info"
         />
       </div>
     </Wrapper>

--- a/app/client/src/pages/common/ServerTimeout.tsx
+++ b/app/client/src/pages/common/ServerTimeout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import AppTimeoutImage from "assets/images/timeout-image.png";
+import { Button, Size } from "design-system";
 
 const Wrapper = styled.div`
   display: flex;
@@ -21,33 +22,29 @@ const Wrapper = styled.div`
   }
 `;
 
-const RetryButton = styled.button`
-  background-color: #f3672a;
-  color: white;
-  height: 40px;
-  width: 300px;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  font-size: 17px;
-`;
-
 function ServerTimeout() {
   return (
-    <Wrapper>
+    <Wrapper className="space-y-6">
       <img
         alt="Page Unavailable"
         className="page-unavailable-img"
         src={AppTimeoutImage}
       />
-      <div>
+      <div className="space-y-2">
         <p className="bold-text">
           Appsmith server is taking too long to respond
         </p>
         <p>Please retry after some time</p>
-        <RetryButton onClick={() => window.location.reload()}>
-          {"Retry"}
-        </RetryButton>
+        <Button
+          category="primary"
+          className="button-position"
+          fill="true"
+          onClick={() => window.location.reload()}
+          size={Size.large}
+          tag="button"
+          text="Retry"
+          variant="info"
+        />
       </div>
     </Wrapper>
   );

--- a/app/client/src/pages/common/ServerUnavailable.tsx
+++ b/app/client/src/pages/common/ServerUnavailable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import PageUnavailableImage from "assets/images/404-image.png";
+import { Button, Size } from "design-system";
 
 const Wrapper = styled.div`
   height: calc(100vh - ${(props) => props.theme.headerHeight});
@@ -19,32 +20,28 @@ const Wrapper = styled.div`
     margin: auto;
   }
 `;
-const RetryButton = styled.button`
-  background-color: #f3672a;
-  color: white;
-  height: 40px;
-  width: 300px;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  font-size: 17px;
-  margin-top: 16px;
-`;
 
 function ServerUnavailable() {
   return (
-    <Wrapper>
+    <Wrapper className="space-y-6">
       <img
         alt="Page Unavailable"
         className="page-unavailable-img"
         src={PageUnavailableImage}
       />
-      <div>
+      <div className="space-y-2">
         <p className="bold-text">Appsmith server is unavailable</p>
         <p>Please try again after some time</p>
-        <RetryButton onClick={() => window.location.reload()}>
-          {"Retry"}
-        </RetryButton>
+        <Button
+          category="primary"
+          className="button-position"
+          fill="true"
+          onClick={() => window.location.reload()}
+          size={Size.large}
+          tag="button"
+          text={"Retry"}
+          variant="info"
+        />
       </div>
     </Wrapper>
   );


### PR DESCRIPTION
## Description

The error pages within Appsmith weren't using the design system components. Now they conform to the Appsmith Design System

## Type of change

- Bug fix (non-breaking change which fixes an issue)

**Before**
<img width="1676" alt="Screenshot 2022-09-27 at 11 27 41 PM" src="https://user-images.githubusercontent.com/458946/192601688-f3cf956f-1827-4bfb-85d8-6f0fcb5edf59.png">

**After**
<img width="1667" alt="Screenshot 2022-09-27 at 11 27 29 PM" src="https://user-images.githubusercontent.com/458946/192601761-a08ef878-2699-47ab-98c9-a20745b6d6b0.png">

## How Has This Been Tested?
Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
