### PR TITLE
fix: unable to enable JS toggle button even if the value is empty

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -521,9 +521,8 @@ const PropertyControl = memo((props: Props) => {
     ) {
       if (
         // Check if value is not empty
-        (propertyValue !== undefined && propertyValue !== "") ||
-        // No need to disable the button if value is default value
-        propertyValue !== config.defaultValue
+        propertyValue !== undefined &&
+        propertyValue !== ""
       ) {
         let value = propertyValue;
         // extract out the value from binding, if there is custom JS control (Table & JSONForm widget)


### PR DESCRIPTION
## Description

Fix a bug in the release where the js toggle button was getting disabled even when we clear the input field.

Fixes #17106

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
