### PR TITLE
fix: xlsx not getting listed fixed

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/FileListMethod.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/FileListMethod.java
@@ -33,7 +33,7 @@ public class FileListMethod implements ExecutionMethod, TriggerMethod {
     @Override
     public WebClient.RequestHeadersSpec<?> getExecutionClient(WebClient webClient, MethodConfig methodConfig) {
         UriComponentsBuilder uriBuilder = getBaseUriBuilder(this.BASE_DRIVE_API_URL,
-                "?q=mimeType%3D'application%2Fvnd.google-apps.spreadsheet'%20and%20trashed%3Dfalse", true);
+                "?q=mimeType%3D'application%2Fvnd.google-apps.spreadsheet'%20or%20mimeType%3D'application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet'%20and%20trashed%3Dfalse", true);
 
         return webClient.method(HttpMethod.GET)
                 .uri(uriBuilder.build(true).toUri())


### PR DESCRIPTION
## Description

In google sheets ds, when we create a Query and choose Fetch Many and choose Fetch Spreadsheets - xslx extension files are not seen in the list that is fetched

Fixes #17108 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
