### PR TITLE
fix: auto height limits deploy mode

### DIFF
--- a/app/client/src/utils/WidgetFeatures.ts
+++ b/app/client/src/utils/WidgetFeatures.ts
@@ -156,8 +156,6 @@ function updateMinMaxDynamicHeight(
     });
   }
 
-  console.log("updateMinMaxDynamicHeight", props);
-
   if (props.type === "TEXT_WIDGET") {
     updates.push({
       propertyPath: "overflow",

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -485,9 +485,15 @@ abstract class BaseWidget<
       return <Skeleton />;
     }
 
-    return renderMode === RenderModes.CANVAS
-      ? this.getCanvasView()
-      : this.getPageView();
+    if (renderMode === RenderModes.CANVAS) {
+      return this.getCanvasView();
+    } else {
+      if (isDynamicHeightEnabledForWidget(this.props) && !this.props.isCanvas) {
+        return this.addDynamicHeightContainer(this.getPageView());
+      }
+
+      return this.getPageView();
+    }
   };
 
   addDynamicHeightContainer = (content: ReactNode) => {


### PR DESCRIPTION
Added the dynamic container into the deploy mode as well by enhancing the `getWidgetComponent` to add the dynamicHeightContainer in the getPageView. I didn't try to refactor the code because that will involve removing some code from the `getCanvasView` (ErrorBoundary).