### PR TITLE
fix: failing rts build due to jest config

### DIFF
--- a/app/rts/build.sh
+++ b/app/rts/build.sh
@@ -3,6 +3,7 @@
 set -o errexit
 
 cd "$(dirname "$0")"
+rm -rf dist/
 yarn install --frozen-lockfile
 npx tsc && npx tsc-alias
 # Copying node_modules directory into dist as rts server requires node_modules to run server build properly. 

--- a/app/rts/package.json
+++ b/app/rts/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.2.3"
   },
   "scripts": {
-    "test:unit": "export APPSMITH_API_BASE_URL=http APPSMITH_MONGODB_URI=mongodb && $(npm bin)/jest -b --colors --no-cache --silent --coverage --collectCoverage=true --coverageDirectory='../../' --coverageReporters='json-summary'",
+    "test:unit": "export APPSMITH_API_BASE_URL=http APPSMITH_MONGODB_URI=mongodb && $(npm bin)/jest -b --colors --no-cache --silent --coverage --collectCoverage=true --coverageDirectory='./' --coverageReporters='json-summary'",
     "test:jest": "export APPSMITH_API_BASE_URL=http APPSMITH_MONGODB_URI=mongodb && $(npm bin)/jest --watch ",
     "preinstall": "CURRENT_SCOPE=rts node ../shared/build-shared-dep.js",
     "build": "./build.sh",

--- a/app/rts/tsconfig.json
+++ b/app/rts/tsconfig.json
@@ -17,5 +17,6 @@
       "@utils/*": ["./src/utils/*"]
     }
   },
+  "exclude": ["jest.config.js", "src/test"],
   "lib": ["es2015"]
 }


### PR DESCRIPTION
## Description

Adding of Jest Test Cases resulted in wrong build which was unable to start the rts server.

Added :
- removal of old build folder to create fresh build everytime
- exclusion of jest config and test cases in build directory
- changed coverage directory

Fixes #17176

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
