### PR TITLE
fix: auto height limits horizontal scroll

### DIFF
--- a/app/client/src/widgets/DynamicHeightContainer.tsx
+++ b/app/client/src/widgets/DynamicHeightContainer.tsx
@@ -5,6 +5,7 @@ import { DynamicHeight } from "utils/WidgetFeatures";
 
 const StyledDynamicHeightContainer = styled.div<{ isOverflow?: boolean }>`
   overflow-y: ${(props) => (props.isOverflow ? "auto" : "unset")};
+  overflow-x: ${(props) => (props.isOverflow ? "hidden" : "unset")};
 `;
 
 interface DynamicHeightContainerProps {


### PR DESCRIPTION
Added overflow-x hidden when overflow-y is active in the dynamic height container.