### PR TITLE
fix: Fix error toast messages displayed when an action is cancelled on pag…

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad1_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad1_Spec.ts
@@ -306,7 +306,6 @@ describe("JSObjects OnLoad Actions tests", function() {
       agHelper.AssertElementVisible(jsEditor._dialogBody("Quotes"));
       agHelper.ClickButton("No");
       agHelper.WaitUntilToastDisappear("Quotes was cancelled");
-      aza;
 
       //Another for API called via JS callQuotes()
       agHelper.AssertElementVisible(jsEditor._dialogBody("Quotes"));

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad1_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad1_Spec.ts
@@ -538,7 +538,7 @@ describe("JSObjects OnLoad Actions tests", function() {
     // agHelper.AssertElementPresence(jsEditor._dialogBody("getCountry"));
     // agHelper.ClickButton("No");
 
-    agHelper.WaitUntilToastDisappear('The action "getBooks" has failed');
+    agHelper.WaitUntilToastDisappear("getBooks was cancelled");
     agHelper.GetNClick(locator._widgetInDeployed("imagewidget"));
     agHelper.AssertElementVisible(jsEditor._dialogBody("getBooks"));
     agHelper.ClickButton("Yes");

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad1_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/OnLoadTests/JSOnLoad1_Spec.ts
@@ -305,7 +305,8 @@ describe("JSObjects OnLoad Actions tests", function() {
       //One Quotes confirmation - for API true
       agHelper.AssertElementVisible(jsEditor._dialogBody("Quotes"));
       agHelper.ClickButton("No");
-      agHelper.WaitUntilToastDisappear('The action "Quotes" has failed');
+      agHelper.WaitUntilToastDisappear("Quotes was cancelled");
+      aza;
 
       //Another for API called via JS callQuotes()
       agHelper.AssertElementVisible(jsEditor._dialogBody("Quotes"));
@@ -357,7 +358,7 @@ describe("JSObjects OnLoad Actions tests", function() {
     deployMode.NavigateBacktoEditor();
     agHelper.AssertElementVisible(jsEditor._dialogBody("Quotes"));
     agHelper.ClickButton("No");
-    agHelper.AssertContains('The action "Quotes" has failed');
+    agHelper.AssertContains("Quotes was cancelled");
 
     agHelper.WaitUntilAllToastsDisappear();
     agHelper.AssertElementVisible(jsEditor._dialogBody("Quotes"));
@@ -392,9 +393,9 @@ describe("JSObjects OnLoad Actions tests", function() {
     deployMode.DeployApp();
     agHelper.AssertElementVisible(jsEditor._dialogBody("CatFacts"));
     agHelper.ClickButton("No");
-    agHelper.ValidateToastMessage('The action "CatFacts" has failed');
+    agHelper.ValidateToastMessage("CatFacts was cancelled");
 
-    agHelper.WaitUntilToastDisappear('The action "CatFacts" has failed');
+    agHelper.WaitUntilToastDisappear("CatFacts was cancelled");
     agHelper.GetNClick(locator._widgetInDeployed("imagewidget"));
     agHelper.AssertElementVisible(jsEditor._dialogBody("CatFacts"));
     agHelper.ClickButton("Yes");
@@ -525,7 +526,7 @@ describe("JSObjects OnLoad Actions tests", function() {
     deployMode.DeployApp();
     agHelper.AssertElementVisible(jsEditor._dialogBody("getBooks"));
     agHelper.ClickButton("No");
-    agHelper.ValidateToastMessage('The action "getBooks" has failed');
+    agHelper.ValidateToastMessage("getBooks was cancelled");
     agHelper
       .GetText(locator._jsonFormInputField("name"), "val")
       .should("be.empty");
@@ -555,7 +556,7 @@ describe("JSObjects OnLoad Actions tests", function() {
     deployMode.NavigateBacktoEditor();
     agHelper.AssertElementVisible(jsEditor._dialogBody("getBooks"));
     agHelper.ClickButton("No");
-    agHelper.ValidateToastMessage('The action "getBooks" has failed');
+    agHelper.ValidateToastMessage("getBooks was cancelled");
 
     ee.SelectEntityByName(jsName as string, "Queries/JS");
     ee.ActionContextMenuByEntityName(

--- a/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/PluginActionSaga.ts
@@ -763,7 +763,7 @@ function* executePageLoadAction(pageAction: PageAction) {
 
     let payload = EMPTY_RESPONSE;
     let isError = true;
-    const error = createMessage(ACTION_EXECUTION_FAILED, pageAction.name);
+    let error = createMessage(ACTION_EXECUTION_FAILED, pageAction.name);
     try {
       const executePluginActionResponse: ExecutePluginActionResponse = yield call(
         executePluginActionSaga,
@@ -773,6 +773,10 @@ function* executePageLoadAction(pageAction: PageAction) {
       isError = executePluginActionResponse.isError;
     } catch (e) {
       log.error(e);
+
+      if (e instanceof UserCancelledActionExecutionError) {
+        error = createMessage(ACTION_EXECUTION_CANCELLED, pageAction.name);
+      }
     }
 
     if (isError) {


### PR DESCRIPTION
When an action is run onpageload with confirmation, Whenever the user picks No in the confirmation dialog, the Toast messages are inconsistent. This PR resolves the confusing toast messages seen.

Fixes #17189

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
