### PR TITLE
fix: fix GraphQL query run behaviour post cursor based pagination configuration

### DIFF
--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/utils/GraphQLPaginationUtils.java
@@ -208,15 +208,19 @@ public class GraphQLPaginationUtils {
                 }
 
                 /**
-                 * This check ensures that during the very first run when the query does not have any cursor data the
-                 * cursor related variable does not get added. In this case since the cursor data is not available
-                 * the dynamic binding value returned by the client is "null" string. Some GraphQL severs are able to
-                 * handle the "null" string as cursor value but some are not e.g. GitHub's GraphQL endpoints are not
-                 * able to handle "null" as value. Hence, it is better to skip passing the variable and allow the
-                 * GraphQL servers to run the query without cursor value. The GraphQL servers against which we are
-                 * testing seem to handle the case well where the value is skipped.
+                 * The cursor being non-empty check ensures that during the very first run when the query does not have
+                 * any cursor data the cursor related variable does not get added. In this case since the cursor data
+                 * is not available the dynamic binding value returned by the client is "null" string. Some GraphQL
+                 * severs are able to handle the "null" string as cursor value but some are not e.g. GitHub's GraphQL
+                 * endpoints are not able to handle "null" as value. Hence, it is better to skip passing the variable
+                 * and allow the GraphQL servers to run the query without cursor value. The GraphQL servers against
+                 * which we are testing seem to handle the case well where the value is skipped.
+                 * The pagination field check ensures that when a query is run by clicking the run button as opposed
+                 * to clicking the next button on any paginated widget, then it only takes the limit value and not
+                 * the cursor value. This will make sure that the just clicking on the run button will not fetch
+                 * paginated results based on the cursor value.
                  */
-                if (!NULL_STRING.equals(nextCursorValue)) {
+                if (!NULL_STRING.equals(nextCursorValue) && PaginationField.NEXT.equals(executeActionDTO.getPaginationField())) {
                     queryVariablesJson.put(nextCursorVarName, nextCursorValue);
                 }
             }

--- a/app/server/appsmith-plugins/graphqlPlugin/src/test/java/com/external/plugins/GraphQLPluginTest.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/test/java/com/external/plugins/GraphQLPluginTest.java
@@ -1033,7 +1033,7 @@ public class GraphQLPluginTest {
      * into a simple non paginated query.
      */
     @Test
-    public void testNextCursorKeyIsSkippedWhenValueIsNull() {
+    public void testNextCursorKeyIsSkippedWhenCursorValueIsNull() {
         ActionConfiguration actionConfig = getDefaultActionConfiguration();
         actionConfig.setPaginationType(PaginationType.CURSOR);
         actionConfig.getPluginSpecifiedTemplates().get(QUERY_VARIABLES_INDEX).setValue("{}");
@@ -1063,7 +1063,7 @@ public class GraphQLPluginTest {
      * into a simple non paginated query.
      */
     @Test
-    public void testPrevCursorKeyIsSkippedWhenValueIsNull() {
+    public void testPrevCursorKeyIsSkippedWhenCursorValueIsNull() {
         ActionConfiguration actionConfig = getDefaultActionConfiguration();
         actionConfig.setPaginationType(PaginationType.CURSOR);
         actionConfig.getPluginSpecifiedTemplates().get(QUERY_VARIABLES_INDEX).setValue("{}");
@@ -1086,4 +1086,37 @@ public class GraphQLPluginTest {
         assertEquals(expectedVariableString,
                 actionConfig.getPluginSpecifiedTemplates().get(QUERY_VARIABLES_INDEX).getValue());
     }
+
+    /**
+     * This method tests that when the value for pagination type is "null", then the cursor key should be skipped from
+     * being added to the query variables. This would ensure that when a user clicks on the `run` button after
+     * configuring the pagination settings then it runs without taking the pagination value otherwise every
+     * subsequent click would fetch the next `n` values instead of getting the same values. It should consider the
+     * cursor value only when the query is triggered via a paginated widget.
+     */
+    @Test
+    public void testNextCursorKeyIsSkippedWhenPaginationValueIsNull() {
+        ActionConfiguration actionConfig = getDefaultActionConfiguration();
+        actionConfig.setPaginationType(PaginationType.CURSOR);
+        actionConfig.getPluginSpecifiedTemplates().get(QUERY_VARIABLES_INDEX).setValue("{}");
+
+        Map<String, Object> paginationDataMap = new HashMap<String, Object>();
+        setValueSafelyInFormData(paginationDataMap, "cursorBased.next.limit.name", "first");
+        setValueSafelyInFormData(paginationDataMap, "cursorBased.next.limit.value", "3");
+        setValueSafelyInFormData(paginationDataMap, "cursorBased.next.cursor.name", "endCursor");
+        setValueSafelyInFormData(paginationDataMap, "cursorBased.next.cursor.value", "null");
+        Property property = new Property();
+        property.setKey("paginationData");
+        property.setValue(paginationDataMap);
+        actionConfig.getPluginSpecifiedTemplates().add(property);
+
+        ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
+        executeActionDTO.setPaginationField(PaginationField.NEXT);
+
+        updateVariablesWithPaginationValues(actionConfig, executeActionDTO);
+        String expectedVariableString = "{\"first\":3}";
+        assertEquals(expectedVariableString,
+                actionConfig.getPluginSpecifiedTemplates().get(QUERY_VARIABLES_INDEX).getValue());
+    }
+
 }


### PR DESCRIPTION
## Description
- Currently, if cursor-based pagination has been configured for a GraphQL query then it tries to fetch the next page results irrespective of whether the query run has been triggered via a paginated widget (e.g. table widget) or simply run by clicking the `run` button on the query config page. As a result, if a GraphQL query has the pagination tab configured with cursor pagination then clicking on the `run` button `k` times will fetch `k` next page results instead of showing the same result each time. The expected behavior is that it should fetch the next page results only when triggered via a paginated widget. This PR fixes this behavior. 

Fixes #17086 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- JUnit TC

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
