### PR TITLE
feat:reset end focus

### DIFF
--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -728,6 +728,10 @@ function* resetChildrenMetaSaga(action: ReduxAction<{ widgetId: string }>) {
     ];
     yield put(resetWidgetMetaProperty(childId, childWidget));
   }
+
+  (document.querySelector(
+    "#" + parentWidgetId + " .bp3-input",
+  ) as HTMLInputElement)?.focus();
 }
 
 function* updateCanvasSize(


### PR DESCRIPTION
## Description

There is no function to set the focus on the input window.
When reset, if it is an input, the focus is fixed

Fixes #16965 



## Type of change

> Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?
https://user-images.githubusercontent.com/33475816/194231270-fa6ab2de-b816-4a2d-ba16-796d595a3105.mov
Try executing the 'resetWidget' function as input.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
