### PR TITLE
fix: replaced all the refs for simpler widgets

### DIFF
--- a/app/client/src/widgets/BaseInputWidget/component/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/component/index.tsx
@@ -641,62 +641,60 @@ class BaseInputComponent extends React.Component<
     const showLabelHeader = label || tooltip;
 
     return (
-      <div ref={this.props.innerRef}>
-        <InputComponentWrapper
-          compactMode={compactMode}
-          data-testid="input-container"
-          disabled={disabled}
-          fill
-          hasError={isInvalid}
-          inputType={inputType}
-          labelPosition={labelPosition}
-          labelStyle={labelStyle}
-          labelTextColor={labelTextColor}
-          labelTextSize={labelTextSize ?? "inherit"}
-          multiline={(!!multiline).toString()}
-          numeric={isNumberInputType(inputHTMLType)}
-        >
-          {showLabelHeader && (
-            <LabelWithTooltip
-              alignment={labelAlignment}
-              className="t--input-widget-label"
-              color={labelTextColor}
-              compact={compactMode}
-              cyHelpTextClassName="t--input-widget-tooltip"
-              disabled={disabled}
-              fontSize={labelTextSize}
-              fontStyle={labelStyle}
-              helpText={tooltip}
-              isDynamicHeightEnabled={isDynamicHeightEnabled}
-              loading={isLoading}
-              position={labelPosition}
-              text={label}
-              width={labelWidth}
-            />
-          )}
-          <TextInputWrapper
-            accentColor={this.props.accentColor}
-            borderRadius={this.props.borderRadius}
-            boxShadow={this.props.boxShadow}
-            className="text-input-wrapper"
+      <InputComponentWrapper
+        compactMode={compactMode}
+        data-testid="input-container"
+        disabled={disabled}
+        fill
+        hasError={isInvalid}
+        inputType={inputType}
+        labelPosition={labelPosition}
+        labelStyle={labelStyle}
+        labelTextColor={labelTextColor}
+        labelTextSize={labelTextSize ?? "inherit"}
+        multiline={(!!multiline).toString()}
+        numeric={isNumberInputType(inputHTMLType)}
+      >
+        {showLabelHeader && (
+          <LabelWithTooltip
+            alignment={labelAlignment}
+            className="t--input-widget-label"
+            color={labelTextColor}
             compact={compactMode}
-            disabled={this.props.disabled}
-            hasError={this.props.isInvalid}
-            inputHtmlType={inputHTMLType}
-            labelPosition={labelPosition}
+            cyHelpTextClassName="t--input-widget-tooltip"
+            disabled={disabled}
+            fontSize={labelTextSize}
+            fontStyle={labelStyle}
+            helpText={tooltip}
+            isDynamicHeightEnabled={isDynamicHeightEnabled}
+            loading={isLoading}
+            position={labelPosition}
+            text={label}
+            width={labelWidth}
+          />
+        )}
+        <TextInputWrapper
+          accentColor={this.props.accentColor}
+          borderRadius={this.props.borderRadius}
+          boxShadow={this.props.boxShadow}
+          className="text-input-wrapper"
+          compact={compactMode}
+          disabled={this.props.disabled}
+          hasError={this.props.isInvalid}
+          inputHtmlType={inputHTMLType}
+          labelPosition={labelPosition}
+        >
+          <ErrorTooltip
+            isOpen={isInvalid && showError}
+            message={
+              errorMessage ||
+              createMessage(INPUT_WIDGET_DEFAULT_VALIDATION_ERROR)
+            }
           >
-            <ErrorTooltip
-              isOpen={isInvalid && showError}
-              message={
-                errorMessage ||
-                createMessage(INPUT_WIDGET_DEFAULT_VALIDATION_ERROR)
-              }
-            >
-              {this.renderInputComponent(inputHTMLType, !!multiline)}
-            </ErrorTooltip>
-          </TextInputWrapper>
-        </InputComponentWrapper>
-      </div>
+            {this.renderInputComponent(inputHTMLType, !!multiline)}
+          </ErrorTooltip>
+        </TextInputWrapper>
+      </InputComponentWrapper>
     );
   }
 }
@@ -757,17 +755,9 @@ export interface BaseInputComponentProps extends ComponentProps {
   inputRef?: MutableRefObject<
     HTMLTextAreaElement | HTMLInputElement | undefined | null
   >;
-  innerRef?: React.RefObject<HTMLDivElement>;
   borderRadius?: string;
   boxShadow?: string;
   accentColor?: string;
 }
 
-export default React.forwardRef<HTMLDivElement, BaseInputComponentProps>(
-  (props, ref) => (
-    <BaseInputComponent
-      {...props}
-      innerRef={ref as React.RefObject<HTMLDivElement>}
-    />
-  ),
-);
+export default BaseInputComponent;

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -425,16 +425,20 @@ abstract class BaseWidget<
     content: ReactNode,
     style?: DynamicHeightOverlayStyle,
   ) {
-    const onMaxHeightSet = (height: number) => {
-      const maxDynamicHeightInRows = Math.floor(
-        height / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
-      );
-      this.updateWidgetProperty("maxDynamicHeight", maxDynamicHeightInRows);
+    const updateDynamicHeight = () => {
       requestAnimationFrame(() => {
         setTimeout(() => {
           this.updateDynamicHeight(this.expectedHeight);
         }, 0);
       });
+    };
+
+    const onMaxHeightSet = (height: number) => {
+      const maxDynamicHeightInRows = Math.floor(
+        height / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+      );
+      this.updateWidgetProperty("maxDynamicHeight", maxDynamicHeightInRows);
+      updateDynamicHeight();
     };
 
     const onMinHeightSet = (height: number) => {
@@ -442,20 +446,21 @@ abstract class BaseWidget<
         height / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
       );
       this.updateWidgetProperty("minDynamicHeight", minDynamicHeightInRows);
-      requestAnimationFrame(() => {
-        setTimeout(() => {
-          this.updateDynamicHeight(this.expectedHeight);
-        }, 0);
-      });
+      updateDynamicHeight();
     };
 
     const onBatchUpdate = (height: number) => {
       this.batchUpdateWidgetProperty({
         modify: {
-          maxDynamicHeight: Math.floor(height / 10),
-          minDynamicHeight: Math.floor(height / 10),
+          maxDynamicHeight: Math.floor(
+            height / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+          ),
+          minDynamicHeight: Math.floor(
+            height / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+          ),
         },
       });
+      updateDynamicHeight();
     };
 
     const position = this.getPositionStyle();

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -431,96 +431,15 @@ abstract class BaseWidget<
     content: ReactNode,
     style?: DynamicHeightOverlayStyle,
   ) {
-    const shouldUpdateHeight = (
-      minDynamicHeightInRows: number,
-      maxDynamicHeightInRows: number,
-    ) => {
-      const expectedHeight = this.expectedHeight;
-      const expectedHeightInRows = Math.ceil(
-        expectedHeight / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
-      );
-      const currentHeightInRows = this.props.bottomRow - this.props.topRow;
-
-      console.log(
-        "shouldUpdateHeight",
-        expectedHeightInRows,
-        currentHeightInRows,
-        minDynamicHeightInRows,
-        maxDynamicHeightInRows,
-      );
-
-      if (currentHeightInRows === expectedHeightInRows) {
-        if (
-          minDynamicHeightInRows <= expectedHeightInRows &&
-          maxDynamicHeightInRows >= expectedHeightInRows
-        ) {
-          return false;
-        }
-      }
-
-      // If current height is less than the expected height
-      // We're trying to see if we can increase the height
-      if (currentHeightInRows < expectedHeightInRows) {
-        // If we're not already at the max height, we can increase height
-        if (
-          maxDynamicHeightInRows >= currentHeightInRows &&
-          Math.abs(currentHeightInRows - expectedHeightInRows) >= 1
-        ) {
-          return true;
-        }
-      }
-
-      // If current height is greater than expected height
-      // We're trying to see if we can reduce the height
-      if (currentHeightInRows > expectedHeightInRows) {
-        // If our attempt to reduce does not go below the min possible height
-        // We can safely reduce the height
-        if (
-          minDynamicHeightInRows <= expectedHeightInRows &&
-          Math.abs(currentHeightInRows - expectedHeightInRows) >= 1
-        ) {
-          return true;
-        }
-      }
-
-      // If current height is more than the maxDynamicHeightInRows
-      // We're trying to see if we can decrease the height
-      if (currentHeightInRows > maxDynamicHeightInRows) {
-        return true;
-      }
-
-      // The widget height should always be at least minDynamicHeightInRows
-      if (currentHeightInRows !== minDynamicHeightInRows) {
-        return true;
-      }
-
-      // Since the conditions to change height already return true
-      // If we reach this point, we don't have to change height
-      return false;
-    };
-
-    const updateHeight = (height: number) => {
-      const { updateWidgetDynamicHeight } = this.context;
-      if (updateWidgetDynamicHeight) {
-        updateWidgetDynamicHeight(this.props.widgetId, height);
-      }
-    };
-
     const onMaxHeightSet = (height: number) => {
       const maxDynamicHeightInRows = Math.floor(
         height / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
       );
       this.updateWidgetProperty("maxDynamicHeight", maxDynamicHeightInRows);
       requestAnimationFrame(() => {
-        if (
-          shouldUpdateHeight(
-            this.props.minDynamicHeight,
-            maxDynamicHeightInRows,
-          )
-        ) {
-          console.log("shouldUpdateHeight", true);
-          updateHeight(this.expectedHeight);
-        }
+        setTimeout(() => {
+          this.updateDynamicHeight(this.expectedHeight);
+        }, 0);
       });
     };
 
@@ -530,15 +449,9 @@ abstract class BaseWidget<
       );
       this.updateWidgetProperty("minDynamicHeight", minDynamicHeightInRows);
       requestAnimationFrame(() => {
-        if (
-          shouldUpdateHeight(
-            minDynamicHeightInRows,
-            this.props.maxDynamicHeight,
-          )
-        ) {
-          console.log("shouldUpdateHeight", true);
-          updateHeight(this.expectedHeight);
-        }
+        setTimeout(() => {
+          this.updateDynamicHeight(this.expectedHeight);
+        }, 0);
       });
     };
 

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -274,6 +274,13 @@ abstract class BaseWidget<
     return false;
   }
 
+  /* eslint-disable @typescript-eslint/no-empty-function */
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  componentDidUpdate(prevProps: T) {}
+
+  componentDidMount(): void {}
+  /* eslint-enable @typescript-eslint/no-empty-function */
+
   getComponentDimensions = () => {
     return this.calculateWidgetBounds(
       this.props.rightColumn,

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -72,7 +72,6 @@ abstract class BaseWidget<
   K extends WidgetState
 > extends Component<T, K> {
   static contextType = EditorContext;
-  contentRef = React.createRef<HTMLDivElement>();
 
   static getPropertyPaneConfig(): PropertyPaneConfig[] {
     return [];
@@ -274,20 +273,6 @@ abstract class BaseWidget<
     // If we reach this point, we don't have to change height
     return false;
   }
-
-  /* eslint-disable @typescript-eslint/no-empty-function */
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  componentDidUpdate(prevProps: T) {
-    requestAnimationFrame(() => {
-      const expectedHeight = this.contentRef.current?.scrollHeight;
-      if (expectedHeight !== undefined) {
-        this.updateDynamicHeight(expectedHeight);
-      }
-    });
-  }
-
-  componentDidMount(): void {}
-  /* eslint-enable @typescript-eslint/no-empty-function */
 
   getComponentDimensions = () => {
     return this.calculateWidgetBounds(
@@ -501,7 +486,9 @@ abstract class BaseWidget<
 
   addDynamicHeightContainer = (content: ReactNode) => {
     const onHeightUpdate = (height: number) => {
-      this.updateDynamicHeight(height);
+      requestAnimationFrame(() => {
+        this.updateDynamicHeight(height);
+      });
     };
 
     return (

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -227,12 +227,6 @@ abstract class BaseWidget<
 
     let minDynamicHeightInRows = getWidgetMinDynamicHeight(this.props);
 
-    console.log(
-      "shouldUpdateDynamicHeight",
-      minDynamicHeightInRows,
-      maxDynamicHeightInRows,
-    );
-
     if (
       (this.props.renderMode === RenderModes.PAGE ||
         this.props.renderMode === RenderModes.PREVIEW) &&

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -430,23 +430,60 @@ abstract class BaseWidget<
     content: ReactNode,
     style?: DynamicHeightOverlayStyle,
   ) {
+    const shouldUpdateHeight = (
+      minDynamicHeightInRows: number,
+      maxDynamicHeightInRows: number,
+    ) => {
+      const currentHeightInRows = this.props.bottomRow - this.props.topRow;
+
+      if (minDynamicHeightInRows <= currentHeightInRows) {
+        return true;
+      }
+
+      // If current height is more than the maxDynamicHeightInRows
+      // We're trying to see if we can decrease the height
+      if (currentHeightInRows > maxDynamicHeightInRows) {
+        return true;
+      }
+
+      // The widget height should always be at least minDynamicHeightInRows
+      if (currentHeightInRows !== minDynamicHeightInRows) {
+        return true;
+      }
+
+      // Since the conditions to change height already return true
+      // If we reach this point, we don't have to change height
+      return false;
+    };
+
+    const updateHeight = (height: number) => {
+      const { updateWidgetDynamicHeight } = this.context;
+      if (updateWidgetDynamicHeight) {
+        updateWidgetDynamicHeight(this.props.widgetId, height);
+      }
+    };
+
     const onMaxHeightSet = (height: number) => {
       this.updateWidgetProperty("maxDynamicHeight", Math.floor(height / 10));
       requestAnimationFrame(() => {
-        this.updateDynamicHeight(
-          (this.props.bottomRow - this.props.topRow) *
-            GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
-        );
+        if (shouldUpdateHeight(this.props.minDynamicHeight, height)) {
+          updateHeight(
+            (this.props.bottomRow - this.props.topRow) *
+              GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+          );
+        }
       });
     };
 
     const onMinHeightSet = (height: number) => {
       this.updateWidgetProperty("minDynamicHeight", Math.floor(height / 10));
       requestAnimationFrame(() => {
-        this.updateDynamicHeight(
-          (this.props.bottomRow - this.props.topRow) *
-            GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
-        );
+        if (shouldUpdateHeight(this.props.minDynamicHeight, height)) {
+          updateHeight(
+            (this.props.bottomRow - this.props.topRow) *
+              GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+          );
+        }
       });
     };
 

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -226,6 +226,12 @@ abstract class BaseWidget<
 
     let minDynamicHeightInRows = getWidgetMinDynamicHeight(this.props);
 
+    console.log(
+      "shouldUpdateDynamicHeight",
+      minDynamicHeightInRows,
+      maxDynamicHeightInRows,
+    );
+
     if (
       (this.props.renderMode === RenderModes.PAGE ||
         this.props.renderMode === RenderModes.PREVIEW) &&
@@ -426,10 +432,22 @@ abstract class BaseWidget<
   ) {
     const onMaxHeightSet = (height: number) => {
       this.updateWidgetProperty("maxDynamicHeight", Math.floor(height / 10));
+      requestAnimationFrame(() => {
+        this.updateDynamicHeight(
+          (this.props.bottomRow - this.props.topRow) *
+            GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+        );
+      });
     };
 
     const onMinHeightSet = (height: number) => {
       this.updateWidgetProperty("minDynamicHeight", Math.floor(height / 10));
+      requestAnimationFrame(() => {
+        this.updateDynamicHeight(
+          (this.props.bottomRow - this.props.topRow) *
+            GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+        );
+      });
     };
 
     const onBatchUpdate = (height: number) => {

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -500,10 +500,15 @@ abstract class BaseWidget<
   };
 
   addDynamicHeightContainer = (content: ReactNode) => {
+    const onHeightUpdate = (height: number) => {
+      this.updateDynamicHeight(height);
+    };
+
     return (
       <DynamicHeightContainer
         dynamicHeight={this.props.dynamicHeight}
         maxDynamicHeight={this.props.maxDynamicHeight}
+        onHeightUpdate={onHeightUpdate}
       >
         {content}
       </DynamicHeightContainer>

--- a/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
@@ -157,10 +157,7 @@ export interface CheckboxGroupComponentProps extends ComponentProps {
   borderRadius: string;
   maxDynamicHeight?: number;
 }
-const CheckboxGroupComponent = React.forwardRef<
-  HTMLDivElement,
-  CheckboxGroupComponentProps
->((props, ref) => {
+function CheckboxGroupComponent(props: CheckboxGroupComponentProps) {
   const {
     accentColor,
     borderRadius,
@@ -204,7 +201,6 @@ const CheckboxGroupComponent = React.forwardRef<
       data-testid="checkboxgroup-container"
       isDynamicHeightEnabled={isDynamicHeightEnabled}
       labelPosition={labelPosition}
-      ref={ref}
     >
       {labelText && (
         <LabelWithTooltip
@@ -267,8 +263,6 @@ const CheckboxGroupComponent = React.forwardRef<
       </InputContainer>
     </CheckboxGroupContainer>
   );
-});
-
-CheckboxGroupComponent.displayName = "CheckboxGroupComponent";
+}
 
 export default CheckboxGroupComponent;

--- a/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/widget/index.tsx
@@ -851,7 +851,6 @@ class CheckboxGroupWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: CheckboxGroupWidgetProps) {
-    super.componentDidUpdate(prevProps);
     if (
       Array.isArray(prevProps.options) &&
       Array.isArray(this.props.options) &&
@@ -923,7 +922,6 @@ class CheckboxGroupWidget extends BaseWidget<
         onSelectAllChange={this.handleSelectAllChange}
         optionAlignment={this.props.optionAlignment}
         options={compact(this.props.options)}
-        ref={this.contentRef}
         selectedValues={this.props.selectedValues || []}
         widgetId={this.props.widgetId}
       />

--- a/app/client/src/widgets/CheckboxWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxWidget/component/index.tsx
@@ -72,10 +72,6 @@ class CheckboxComponent extends React.Component<CheckboxComponentProps> {
       <CheckboxContainer
         isValid={isValid}
         noContainerPadding={this.props.noContainerPadding}
-        ref={this.props.innerRef}
-        style={
-          this.props.isDynamicHeightEnabled ? { height: "auto" } : undefined
-        }
       >
         <StyledCheckbox
           accentColor={this.props.accentColor || DEFAULT_BACKGROUND_COLOR}
@@ -121,7 +117,6 @@ export interface CheckboxComponentProps extends ComponentProps {
   label: string;
   onCheckChange: (isChecked: boolean) => void;
   rowSpace: number;
-  innerRef?: React.MutableRefObject<HTMLDivElement>;
   inputRef?: (el: HTMLInputElement | null) => any;
   accentColor: string;
   borderRadius: string;
@@ -132,11 +127,4 @@ export interface CheckboxComponentProps extends ComponentProps {
   labelStyle?: string;
 }
 
-export default React.forwardRef<HTMLDivElement, CheckboxComponentProps>(
-  (props, ref) => (
-    <CheckboxComponent
-      {...props}
-      innerRef={ref as React.MutableRefObject<HTMLDivElement>}
-    />
-  ),
-);
+export default CheckboxComponent;

--- a/app/client/src/widgets/CheckboxWidget/widget/index.tsx
+++ b/app/client/src/widgets/CheckboxWidget/widget/index.tsx
@@ -502,7 +502,6 @@ class CheckboxWidget extends BaseWidget<CheckboxWidgetProps, WidgetState> {
   }
 
   componentDidUpdate(prevProps: CheckboxWidgetProps) {
-    super.componentDidUpdate(prevProps);
     if (
       this.props.defaultCheckedState !== prevProps.defaultCheckedState &&
       this.props.isDirty
@@ -529,7 +528,6 @@ class CheckboxWidget extends BaseWidget<CheckboxWidgetProps, WidgetState> {
         labelTextColor={this.props.labelTextColor}
         labelTextSize={this.props.labelTextSize}
         onCheckChange={this.onCheckChange}
-        ref={this.contentRef}
         rowSpace={this.props.parentRowSpace}
         widgetId={this.props.widgetId}
       />

--- a/app/client/src/widgets/CurrencyInputWidget/component/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/component/index.tsx
@@ -82,7 +82,6 @@ class CurrencyInputComponent extends React.Component<
         onStep={this.props.onStep}
         onValueChange={this.props.onValueChange}
         placeholder={this.props.placeholder}
-        ref={this.props.innerRef}
         showError={this.props.showError}
         stepSize={1}
         tooltip={this.props.tooltip}
@@ -98,17 +97,9 @@ export interface CurrencyInputComponentProps extends BaseInputComponentProps {
   noOfDecimals?: number;
   allowCurrencyChange?: boolean;
   decimals?: number;
-  innerRef?: React.RefObject<HTMLDivElement>;
   onCurrencyTypeChange: (code?: string) => void;
   onStep: (direction: number) => void;
   renderMode: string;
 }
 
-export default React.forwardRef<HTMLDivElement, CurrencyInputComponentProps>(
-  (props, ref) => (
-    <CurrencyInputComponent
-      {...props}
-      innerRef={ref as React.RefObject<HTMLDivElement>}
-    />
-  ),
-);
+export default CurrencyInputComponent;

--- a/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
@@ -312,7 +312,6 @@ class CurrencyInputWidget extends BaseInputWidget<
   }
 
   componentDidUpdate(prevProps: CurrencyInputWidgetProps) {
-    super.componentDidUpdate(prevProps);
     if (
       prevProps.text !== this.props.text &&
       !this.props.isFocused &&
@@ -490,7 +489,6 @@ class CurrencyInputWidget extends BaseInputWidget<
         onStep={this.onStep}
         onValueChange={this.onValueChange}
         placeholder={this.props.placeholderText}
-        ref={this.contentRef}
         renderMode={this.props.renderMode}
         showError={!!this.props.isFocused}
         tooltip={this.props.tooltip}

--- a/app/client/src/widgets/DatePickerWidget2/component/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/component/index.tsx
@@ -255,89 +255,82 @@ class DatePickerComponent extends React.Component<
     const initialMonth = getInitialMonth();
 
     return (
-      <div
-        ref={this.props.innerRef}
-        style={
-          this.props.isDynamicHeightEnabled ? { height: "auto" } : undefined
-        }
+      <StyledControlGroup
+        accentColor={this.props.accentColor}
+        borderRadius={this.props.borderRadius}
+        boxShadow={this.props.boxShadow}
+        compactMode={this.props.compactMode}
+        data-testid="datepicker-container"
+        fill
+        isValid={isValid}
+        labelPosition={this.props.labelPosition}
+        onClick={(e: any) => {
+          e.stopPropagation();
+        }}
       >
-        <StyledControlGroup
+        {labelText && (
+          <LabelWithTooltip
+            alignment={labelAlignment}
+            className={`datepicker-label`}
+            color={labelTextColor}
+            compact={compactMode}
+            disabled={isDisabled}
+            fontSize={labelTextSize}
+            fontStyle={labelStyle}
+            isDynamicHeightEnabled={this.props.isDynamicHeightEnabled}
+            loading={isLoading}
+            position={labelPosition}
+            text={labelText}
+            width={labelWidth}
+          />
+        )}
+        <DateInputWrapper
+          compactMode={compactMode}
+          labelPosition={labelPosition}
+        >
+          <ErrorTooltip
+            isOpen={!isValid}
+            message={createMessage(DATE_WIDGET_DEFAULT_VALIDATION_ERROR)}
+          >
+            <DateInput
+              className={this.props.isLoading ? "bp3-skeleton" : ""}
+              closeOnSelection={this.props.closeOnSelection}
+              dayPickerProps={{
+                firstDayOfWeek: this.props.firstDayOfWeek || 0,
+              }}
+              disabled={this.props.isDisabled}
+              formatDate={this.formatDate}
+              initialMonth={initialMonth}
+              inputProps={{
+                inputRef: this.props.inputRef,
+              }}
+              maxDate={maxDate}
+              minDate={minDate}
+              onChange={this.onDateSelected}
+              parseDate={this.parseDate}
+              placeholder={"Select Date"}
+              popoverProps={{
+                usePortal: !this.props.withoutPortal,
+                canEscapeKeyClose: true,
+                portalClassName: `${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`,
+              }}
+              shortcuts={this.props.shortcuts}
+              showActionsBar
+              timePrecision={
+                this.props.timePrecision === TimePrecision.NONE
+                  ? undefined
+                  : this.props.timePrecision
+              }
+              value={value}
+            />
+          </ErrorTooltip>
+        </DateInputWrapper>
+        <PopoverStyles
           accentColor={this.props.accentColor}
           borderRadius={this.props.borderRadius}
-          boxShadow={this.props.boxShadow}
-          compactMode={this.props.compactMode}
-          data-testid="datepicker-container"
-          fill
-          isValid={isValid}
-          labelPosition={this.props.labelPosition}
-          onClick={(e: any) => {
-            e.stopPropagation();
-          }}
-        >
-          {labelText && (
-            <LabelWithTooltip
-              alignment={labelAlignment}
-              className={`datepicker-label`}
-              color={labelTextColor}
-              compact={compactMode}
-              disabled={isDisabled}
-              fontSize={labelTextSize}
-              fontStyle={labelStyle}
-              isDynamicHeightEnabled={this.props.isDynamicHeightEnabled}
-              loading={isLoading}
-              position={labelPosition}
-              text={labelText}
-              width={labelWidth}
-            />
-          )}
-          <DateInputWrapper
-            compactMode={compactMode}
-            labelPosition={labelPosition}
-          >
-            <ErrorTooltip
-              isOpen={!isValid}
-              message={createMessage(DATE_WIDGET_DEFAULT_VALIDATION_ERROR)}
-            >
-              <DateInput
-                className={this.props.isLoading ? "bp3-skeleton" : ""}
-                closeOnSelection={this.props.closeOnSelection}
-                dayPickerProps={{
-                  firstDayOfWeek: this.props.firstDayOfWeek || 0,
-                }}
-                disabled={this.props.isDisabled}
-                formatDate={this.formatDate}
-                initialMonth={initialMonth}
-                inputProps={{
-                  inputRef: this.props.inputRef,
-                }}
-                maxDate={maxDate}
-                minDate={minDate}
-                onChange={this.onDateSelected}
-                parseDate={this.parseDate}
-                placeholder={"Select Date"}
-                popoverProps={{
-                  usePortal: !this.props.withoutPortal,
-                  canEscapeKeyClose: true,
-                  portalClassName: `${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`,
-                }}
-                shortcuts={this.props.shortcuts}
-                showActionsBar
-                timePrecision={
-                  this.props.timePrecision === TimePrecision.NONE
-                    ? undefined
-                    : this.props.timePrecision
-                }
-                value={value}
-              />
-            </ErrorTooltip>
-          </DateInputWrapper>
-          <PopoverStyles
-            accentColor={this.props.accentColor}
-            borderRadius={this.props.borderRadius}
-            portalClassName={`${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`}
-          />
-        </StyledControlGroup>
-      </div>
+          portalClassName={`${DATEPICKER_POPUP_CLASSNAME}-${this.props.widgetId}`}
+        />
+      </StyledControlGroup>
     );
   }
 
@@ -430,7 +423,6 @@ interface DatePickerComponentProps extends ComponentProps {
   shortcuts: boolean;
   firstDayOfWeek?: number;
   timePrecision: TimePrecision;
-  innerRef?: React.RefObject<HTMLDivElement>;
   inputRef?: IRef<HTMLInputElement>;
   borderRadius: string;
   boxShadow?: string;
@@ -441,11 +433,4 @@ interface DatePickerComponentState {
   selectedDate?: string;
 }
 
-export default React.forwardRef<HTMLDivElement, DatePickerComponentProps>(
-  (props, ref) => (
-    <DatePickerComponent
-      {...props}
-      innerRef={ref as React.RefObject<HTMLDivElement>}
-    />
-  ),
-);
+export default DatePickerComponent;

--- a/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
+++ b/app/client/src/widgets/DatePickerWidget2/widget/index.tsx
@@ -812,7 +812,6 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
   }
 
   componentDidUpdate(prevProps: DatePickerWidget2Props): void {
-    super.componentDidUpdate(prevProps);
     if (
       this.props.defaultDate !== prevProps.defaultDate &&
       this.props.isDirty
@@ -852,7 +851,6 @@ class DatePickerWidget extends BaseWidget<DatePickerWidget2Props, WidgetState> {
         maxDate={this.props.maxDate}
         minDate={this.props.minDate}
         onDateSelected={this.onDateSelected}
-        ref={this.contentRef}
         selectedDate={this.props.value}
         shortcuts={this.props.shortcuts}
         timePrecision={this.props.timePrecision}

--- a/app/client/src/widgets/DynamicHeightContainer.tsx
+++ b/app/client/src/widgets/DynamicHeightContainer.tsx
@@ -47,8 +47,6 @@ export default function DynamicHeightContainer({
     };
   }, [observer]);
 
-  console.log("onHeightUpdate ResizeObserver");
-
   if (isAutoHeightWithLimits) {
     const expectedHeightInRows = Math.ceil(
       expectedHeight / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,

--- a/app/client/src/widgets/DynamicHeightContainer.tsx
+++ b/app/client/src/widgets/DynamicHeightContainer.tsx
@@ -11,19 +11,27 @@ const StyledDynamicHeightContainer = styled.div<{ isOverflow?: boolean }>`
 interface DynamicHeightContainerProps {
   maxDynamicHeight: number;
   dynamicHeight: string;
+  onHeightUpdate: (height: number) => void;
 }
 
-function WithLimitsContainer({
+export default function DynamicHeightContainer({
   children,
+  dynamicHeight,
   maxDynamicHeight,
-}: PropsWithChildren<{ maxDynamicHeight: number }>) {
+  onHeightUpdate,
+}: PropsWithChildren<DynamicHeightContainerProps>) {
+  const isAutoHeightWithLimits =
+    dynamicHeight === DynamicHeight.AUTO_HEIGHT_WITH_LIMITS;
+
   const [expectedHeight, setExpectedHeight] = useState(0);
 
   const ref = useRef<HTMLDivElement>(null);
 
   const observer = React.useRef(
     new ResizeObserver((entries) => {
-      setExpectedHeight(entries[0].contentRect.height);
+      const height = entries[0].contentRect.height;
+      setExpectedHeight(height);
+      onHeightUpdate(height);
     }),
   );
 
@@ -39,36 +47,27 @@ function WithLimitsContainer({
     };
   }, [observer]);
 
-  const expectedHeightInRows = Math.ceil(
-    expectedHeight / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
-  );
-
-  return (
-    <StyledDynamicHeightContainer
-      isOverflow={maxDynamicHeight < expectedHeightInRows}
-    >
-      <div ref={ref} style={{ height: "auto" }}>
-        {children}
-      </div>
-    </StyledDynamicHeightContainer>
-  );
-}
-
-export default function DynamicHeightContainer({
-  children,
-  dynamicHeight,
-  maxDynamicHeight,
-}: PropsWithChildren<DynamicHeightContainerProps>) {
-  const isAutoHeightWithLimits =
-    dynamicHeight === DynamicHeight.AUTO_HEIGHT_WITH_LIMITS;
+  console.log("onHeightUpdate ResizeObserver");
 
   if (isAutoHeightWithLimits) {
+    const expectedHeightInRows = Math.ceil(
+      expectedHeight / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+    );
+
     return (
-      <WithLimitsContainer maxDynamicHeight={maxDynamicHeight}>
-        {children}
-      </WithLimitsContainer>
+      <StyledDynamicHeightContainer
+        isOverflow={maxDynamicHeight < expectedHeightInRows}
+      >
+        <div ref={ref} style={{ height: "auto" }}>
+          {children}
+        </div>
+      </StyledDynamicHeightContainer>
     );
   }
 
-  return <div style={{ height: "auto" }}>{children}</div>;
+  return (
+    <div ref={ref} style={{ height: "auto" }}>
+      {children}
+    </div>
+  );
 }

--- a/app/client/src/widgets/InputWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/component/index.tsx
@@ -75,7 +75,6 @@ class InputComponent extends React.Component<InputComponentProps> {
         onKeyDown={this.props.onKeyDown}
         onValueChange={this.props.onValueChange}
         placeholder={this.props.placeholder}
-        ref={this.props.innerRef}
         showError={this.props.showError}
         spellCheck={this.props.spellCheck}
         stepSize={1}
@@ -87,7 +86,6 @@ class InputComponent extends React.Component<InputComponentProps> {
   }
 }
 export interface InputComponentProps extends BaseInputComponentProps {
-  innerRef?: React.RefObject<HTMLDivElement>;
   inputType: InputTypes;
   maxChars?: number;
   spellCheck?: boolean;
@@ -98,11 +96,4 @@ export interface InputComponentProps extends BaseInputComponentProps {
   accentColor?: string;
 }
 
-export default React.forwardRef<HTMLDivElement, InputComponentProps>(
-  (props, ref) => (
-    <InputComponent
-      {...props}
-      innerRef={ref as React.RefObject<HTMLDivElement>}
-    />
-  ),
-);
+export default InputComponent;

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -567,7 +567,6 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
   };
 
   componentDidUpdate = (prevProps: InputWidgetProps) => {
-    super.componentDidUpdate(prevProps);
     if (
       prevProps.inputText !== this.props.inputText &&
       this.props.inputText !== toString(this.props.text)
@@ -738,7 +737,6 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
         onKeyDown={this.handleKeyDown}
         onValueChange={this.onValueChange}
         placeholder={this.props.placeholderText}
-        ref={this.contentRef}
         showError={!!this.props.isFocused}
         spellCheck={!!this.props.isSpellCheck}
         stepSize={1}

--- a/app/client/src/widgets/MultiSelectTreeWidget/component/index.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/component/index.tsx
@@ -101,239 +101,224 @@ const switcherIcon = (treeNode: TreeNodeProps) => {
   return getSvg(treeNode.expanded);
 };
 
-const MultiTreeSelectComponent = React.forwardRef<
-  HTMLDivElement,
-  TreeSelectProps
->(
-  (
-    {
-      accentColor,
-      allowClear,
-      borderRadius,
-      boxShadow,
-      compactMode,
-      disabled,
-      dropdownStyle,
-      dropDownWidth,
-      expandAll,
-      filterText,
-      isDynamicHeightEnabled,
-      isFilterable,
-      isValid,
-      labelAlignment,
-      labelPosition,
-      labelStyle,
-      labelText,
-      labelTextColor,
-      labelTextSize,
-      labelWidth,
-      loading,
-      mode,
-      onChange,
-      options,
-      placeholder,
-      renderMode,
-      value,
-      widgetId,
-      width,
-    },
-    ref,
-  ): JSX.Element => {
-    const [key, setKey] = useState(Math.random());
-    const [filter, setFilter] = useState(filterText ?? "");
+function MultiTreeSelectComponent({
+  accentColor,
+  allowClear,
+  borderRadius,
+  boxShadow,
+  compactMode,
+  disabled,
+  dropdownStyle,
+  dropDownWidth,
+  expandAll,
+  filterText,
+  isDynamicHeightEnabled,
+  isFilterable,
+  isValid,
+  labelAlignment,
+  labelPosition,
+  labelStyle,
+  labelText,
+  labelTextColor,
+  labelTextSize,
+  labelWidth,
+  loading,
+  mode,
+  onChange,
+  options,
+  placeholder,
+  renderMode,
+  value,
+  widgetId,
+  width,
+}: TreeSelectProps): JSX.Element {
+  const [key, setKey] = useState(Math.random());
+  const [filter, setFilter] = useState(filterText ?? "");
 
-    const _menu = ref;
+  const _menu = useRef<HTMLDivElement>(null);
+  const labelRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-    const labelRef = useRef<HTMLDivElement>(null);
-    const inputRef = useRef<HTMLInputElement>(null);
+  const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
 
-    const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
+  const {
+    BackDrop,
+    getPopupContainer,
+    isOpen,
+    onKeyDown,
+    onOpen,
+    selectRef,
+  } = useDropdown({
+    inputRef,
+    renderMode,
+  });
 
-    const {
-      BackDrop,
-      getPopupContainer,
-      isOpen,
-      onKeyDown,
-      onOpen,
-      selectRef,
-    } = useDropdown({
-      inputRef,
-      renderMode,
-    });
+  // treeDefaultExpandAll is uncontrolled after first render,
+  // using this to force render to respond to changes in expandAll
+  useEffect(() => {
+    setKey(Math.random());
+  }, [expandAll]);
 
-    // treeDefaultExpandAll is uncontrolled after first render,
-    // using this to force render to respond to changes in expandAll
-    useEffect(() => {
-      setKey(Math.random());
-    }, [expandAll]);
+  const clearButton = useMemo(
+    () =>
+      filter ? (
+        <Button icon="cross" minimal onClick={() => setFilter("")} />
+      ) : null,
+    [filter],
+  );
 
-    const clearButton = useMemo(
-      () =>
-        filter ? (
-          <Button icon="cross" minimal onClick={() => setFilter("")} />
-        ) : null,
-      [filter],
-    );
+  const onQueryChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+    setFilter(event.target.value);
+  }, []);
 
-    const onQueryChange = useCallback(
-      (event: ChangeEvent<HTMLInputElement>) => {
-        event.stopPropagation();
-        setFilter(event.target.value);
-      },
-      [],
-    );
-
-    useEffect(() => {
-      const parentWidth = width - WidgetContainerDiff;
-      if (compactMode && labelRef.current) {
-        const labelWidth = labelRef.current.getBoundingClientRect().width;
-        const widthDiff = parentWidth - labelWidth - labelMargin;
-        setMemoDropDownWidth(
-          widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
-        );
-        return;
-      }
+  useEffect(() => {
+    const parentWidth = width - WidgetContainerDiff;
+    if (compactMode && labelRef.current) {
+      const labelWidth = labelRef.current.getBoundingClientRect().width;
+      const widthDiff = parentWidth - labelWidth - labelMargin;
       setMemoDropDownWidth(
-        parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
+        widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
       );
-    }, [compactMode, dropDownWidth, width, labelText]);
-    const dropdownRender = useCallback(
-      (
-        menu: React.ReactElement<
-          any,
-          string | React.JSXElementConstructor<any>
-        >,
-      ) => (
-        <>
-          <BackDrop />
-          {isFilterable ? (
-            <InputGroup
-              inputRef={inputRef}
-              leftIcon="search"
-              onChange={onQueryChange}
-              onKeyDown={onKeyDown}
-              placeholder="Filter..."
-              rightElement={clearButton as JSX.Element}
-              small
-              type="text"
-              value={filter}
-            />
-          ) : null}
-          <div className={`${loading ? Classes.SKELETON : ""}`}>{menu}</div>
-        </>
-      ),
-      [loading, isFilterable, filter, onQueryChange],
+      return;
+    }
+    setMemoDropDownWidth(
+      parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
     );
+  }, [compactMode, dropDownWidth, width, labelText]);
+  const dropdownRender = useCallback(
+    (
+      menu: React.ReactElement<any, string | React.JSXElementConstructor<any>>,
+    ) => (
+      <>
+        <BackDrop />
+        {isFilterable ? (
+          <InputGroup
+            inputRef={inputRef}
+            leftIcon="search"
+            onChange={onQueryChange}
+            onKeyDown={onKeyDown}
+            placeholder="Filter..."
+            rightElement={clearButton as JSX.Element}
+            small
+            type="text"
+            value={filter}
+          />
+        ) : null}
+        <div className={`${loading ? Classes.SKELETON : ""}`}>{menu}</div>
+      </>
+    ),
+    [loading, isFilterable, filter, onQueryChange],
+  );
 
-    const onClear = useCallback(() => onChange([], []), []);
-    const onDropdownVisibleChange = (open: boolean) => {
-      onOpen(open);
-      // clear the search input on closing the widget
-      setFilter("");
-    };
+  const onClear = useCallback(() => onChange([], []), []);
+  const onDropdownVisibleChange = (open: boolean) => {
+    onOpen(open);
+    // clear the search input on closing the widget
+    setFilter("");
+  };
 
-    return (
-      <TreeSelectContainer
+  return (
+    <TreeSelectContainer
+      accentColor={accentColor}
+      allowClear={allowClear}
+      borderRadius={borderRadius}
+      boxShadow={boxShadow}
+      compactMode={compactMode}
+      data-testid="multitreeselect-container"
+      isValid={isValid}
+      labelPosition={labelPosition}
+      ref={_menu as React.RefObject<HTMLDivElement>}
+    >
+      <DropdownStyles
         accentColor={accentColor}
-        allowClear={allowClear}
         borderRadius={borderRadius}
-        boxShadow={boxShadow}
-        compactMode={compactMode}
-        data-testid="multitreeselect-container"
-        isValid={isValid}
-        labelPosition={labelPosition}
-        ref={_menu as React.RefObject<HTMLDivElement>}
-      >
-        <DropdownStyles
-          accentColor={accentColor}
-          borderRadius={borderRadius}
-          dropDownWidth={memoDropDownWidth}
-          id={widgetId}
+        dropDownWidth={memoDropDownWidth}
+        id={widgetId}
+      />
+      {labelText && (
+        <LabelWithTooltip
+          alignment={labelAlignment}
+          className={`multitree-select-label`}
+          color={labelTextColor}
+          compact={compactMode}
+          disabled={disabled}
+          fontSize={labelTextSize}
+          fontStyle={labelStyle}
+          isDynamicHeightEnabled={isDynamicHeightEnabled}
+          loading={loading}
+          position={labelPosition}
+          ref={labelRef}
+          text={labelText}
+          width={labelWidth}
         />
-        {labelText && (
-          <LabelWithTooltip
-            alignment={labelAlignment}
-            className={`multitree-select-label`}
-            color={labelTextColor}
-            compact={compactMode}
-            disabled={disabled}
-            fontSize={labelTextSize}
-            fontStyle={labelStyle}
-            isDynamicHeightEnabled={isDynamicHeightEnabled}
-            loading={loading}
-            position={labelPosition}
-            ref={labelRef}
-            text={labelText}
-            width={labelWidth}
-          />
-        )}
-        <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
-          <TreeSelect
-            allowClear={allowClear}
-            animation="slide-up"
-            choiceTransitionName="rc-tree-select-selection__choice-zoom"
-            className="rc-tree-select"
-            clearIcon={
-              <Icon
-                className="clear-icon"
-                fillColor={Colors.GREY_10}
-                name="close-x"
-              />
-            }
-            disabled={disabled}
-            dropdownClassName={`tree-multiselect-dropdown multiselecttree-popover-width-${widgetId}`}
-            dropdownRender={dropdownRender}
-            dropdownStyle={dropdownStyle}
-            filterTreeNode
-            getPopupContainer={getPopupContainer}
-            inputIcon={
-              <Icon
-                className="dropdown-icon"
-                fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
-                name="dropdown"
-              />
-            }
-            key={key}
-            loading={loading}
-            maxTagCount={"responsive"}
-            maxTagPlaceholder={(e) => `+${e.length} more`}
-            multiple
-            notFoundContent={
-              <NoDataFoundContainer>No Results Found</NoDataFoundContainer>
-            }
-            onChange={onChange}
-            onClear={onClear}
-            onDropdownVisibleChange={onDropdownVisibleChange}
-            open={isOpen}
-            placeholder={placeholder}
-            ref={selectRef}
-            removeIcon={
-              <Icon
-                className="remove-icon"
-                fillColor={Colors.GREY_10}
-                name="close-x"
-              />
-            }
-            searchValue={filter}
-            showArrow
-            showCheckedStrategy={mode}
-            showSearch={false}
-            style={{ width: "100%" }}
-            switcherIcon={switcherIcon}
-            transitionName="rc-tree-select-dropdown-slide-up"
-            treeCheckable={
-              <span className={`rc-tree-select-tree-checkbox-inner`} />
-            }
-            treeData={options}
-            treeDefaultExpandAll={expandAll}
-            treeIcon
-            treeNodeFilterProp="label"
-            value={value}
-          />
-        </InputContainer>
-      </TreeSelectContainer>
-    );
-  },
-);
+      )}
+      <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
+        <TreeSelect
+          allowClear={allowClear}
+          animation="slide-up"
+          choiceTransitionName="rc-tree-select-selection__choice-zoom"
+          className="rc-tree-select"
+          clearIcon={
+            <Icon
+              className="clear-icon"
+              fillColor={Colors.GREY_10}
+              name="close-x"
+            />
+          }
+          disabled={disabled}
+          dropdownClassName={`tree-multiselect-dropdown multiselecttree-popover-width-${widgetId}`}
+          dropdownRender={dropdownRender}
+          dropdownStyle={dropdownStyle}
+          filterTreeNode
+          getPopupContainer={getPopupContainer}
+          inputIcon={
+            <Icon
+              className="dropdown-icon"
+              fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
+              name="dropdown"
+            />
+          }
+          key={key}
+          loading={loading}
+          maxTagCount={"responsive"}
+          maxTagPlaceholder={(e) => `+${e.length} more`}
+          multiple
+          notFoundContent={
+            <NoDataFoundContainer>No Results Found</NoDataFoundContainer>
+          }
+          onChange={onChange}
+          onClear={onClear}
+          onDropdownVisibleChange={onDropdownVisibleChange}
+          open={isOpen}
+          placeholder={placeholder}
+          ref={selectRef}
+          removeIcon={
+            <Icon
+              className="remove-icon"
+              fillColor={Colors.GREY_10}
+              name="close-x"
+            />
+          }
+          searchValue={filter}
+          showArrow
+          showCheckedStrategy={mode}
+          showSearch={false}
+          style={{ width: "100%" }}
+          switcherIcon={switcherIcon}
+          transitionName="rc-tree-select-dropdown-slide-up"
+          treeCheckable={
+            <span className={`rc-tree-select-tree-checkbox-inner`} />
+          }
+          treeData={options}
+          treeDefaultExpandAll={expandAll}
+          treeIcon
+          treeNodeFilterProp="label"
+          value={value}
+        />
+      </InputContainer>
+    </TreeSelectContainer>
+  );
+}
 
 export default MultiTreeSelectComponent;

--- a/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
@@ -867,7 +867,6 @@ class MultiSelectTreeWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: MultiSelectTreeWidgetProps): void {
-    super.componentDidUpdate(prevProps);
     if (
       xor(this.props.defaultOptionValue, prevProps.defaultOptionValue).length >
         0 &&
@@ -917,7 +916,6 @@ class MultiSelectTreeWidget extends BaseWidget<
         onChange={this.onOptionChange}
         options={options}
         placeholder={this.props.placeholderText as string}
-        ref={this.contentRef}
         renderMode={this.props.renderMode}
         value={this.props.selectedOptionValues}
         widgetId={this.props.widgetId}

--- a/app/client/src/widgets/MultiSelectWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidgetV2/component/index.tsx
@@ -51,7 +51,6 @@ export interface MultiSelectProps
   labelTextSize?: TextSize;
   labelStyle?: string;
   compactMode: boolean;
-  isDynamicHeightEnabled?: boolean;
   isValid: boolean;
   allowSelectAll?: boolean;
   filterText?: string;
@@ -63,321 +62,309 @@ export interface MultiSelectProps
   onFocus?: (e: React.FocusEvent) => void;
   onBlur?: (e: React.FocusEvent) => void;
   renderMode?: RenderMode;
+  isDynamicHeightEnabled?: boolean;
 }
 
 const DEBOUNCE_TIMEOUT = 1000;
 
-const MultiSelectComponent = React.forwardRef<HTMLDivElement, MultiSelectProps>(
-  (
-    {
-      accentColor,
-      allowSelectAll,
-      borderRadius,
-      boxShadow,
-      compactMode,
-      disabled,
-      dropdownStyle,
-      dropDownWidth,
-      filterText,
-      isDynamicHeightEnabled,
-      isFilterable,
-      isValid,
-      labelAlignment,
-      labelPosition,
-      labelStyle,
-      labelText,
-      labelTextColor,
-      labelTextSize,
-      labelWidth,
-      loading,
-      onBlur,
-      onChange,
-      onFilterChange,
-      onFocus,
-      options,
-      placeholder,
-      renderMode,
-      serverSideFiltering,
-      value,
-      widgetId,
-      width,
-    },
-    ref,
-  ): JSX.Element => {
-    const [isSelectAll, setIsSelectAll] = useState(false);
-    const [filter, setFilter] = useState(filterText ?? "");
-    const [filteredOptions, setFilteredOptions] = useState(options);
-    const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
+function MultiSelectComponent({
+  accentColor,
+  allowSelectAll,
+  borderRadius,
+  boxShadow,
+  compactMode,
+  disabled,
+  dropdownStyle,
+  dropDownWidth,
+  filterText,
+  isDynamicHeightEnabled,
+  isFilterable,
+  isValid,
+  labelAlignment,
+  labelPosition,
+  labelStyle,
+  labelText,
+  labelTextColor,
+  labelTextSize,
+  labelWidth,
+  loading,
+  onBlur,
+  onChange,
+  onFilterChange,
+  onFocus,
+  options,
+  placeholder,
+  renderMode,
+  serverSideFiltering,
+  value,
+  widgetId,
+  width,
+}: MultiSelectProps): JSX.Element {
+  const [isSelectAll, setIsSelectAll] = useState(false);
+  const [filter, setFilter] = useState(filterText ?? "");
+  const [filteredOptions, setFilteredOptions] = useState(options);
+  const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
 
-    const _menu = ref;
-    const labelRef = useRef<HTMLDivElement>(null);
-    const inputRef = useRef<HTMLInputElement>(null);
+  const _menu = useRef<HTMLElement | null>(null);
+  const labelRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-    const {
-      BackDrop,
-      getPopupContainer,
-      isOpen,
-      onKeyDown,
-      onOpen,
-      selectRef,
-    } = useDropdown({
-      inputRef,
-      renderMode,
-    });
+  const {
+    BackDrop,
+    getPopupContainer,
+    isOpen,
+    onKeyDown,
+    onOpen,
+    selectRef,
+  } = useDropdown({
+    inputRef,
+    renderMode,
+  });
 
-    // SelectAll if all options are in Value
-    useEffect(() => {
-      if (
-        !isSelectAll &&
-        filteredOptions.length &&
-        value.length &&
-        !checkOptionsAndValue().includes(false)
-      ) {
-        setIsSelectAll(true);
-      }
-      if (isSelectAll && filteredOptions.length !== value.length) {
-        setIsSelectAll(false);
-      }
-    }, [filteredOptions, value]);
+  // SelectAll if all options are in Value
+  useEffect(() => {
+    if (
+      !isSelectAll &&
+      filteredOptions.length &&
+      value.length &&
+      !checkOptionsAndValue().includes(false)
+    ) {
+      setIsSelectAll(true);
+    }
+    if (isSelectAll && filteredOptions.length !== value.length) {
+      setIsSelectAll(false);
+    }
+  }, [filteredOptions, value]);
 
-    // Trigger onFilterChange once filter is Updated
-    useEffect(() => {
-      const timeOutId = setTimeout(
-        () => onFilterChange(filter),
-        DEBOUNCE_TIMEOUT,
-      );
-      return () => clearTimeout(timeOutId);
-    }, [filter]);
-
-    // Filter options based on serverSideFiltering
-    useEffect(
-      () => {
-        if (serverSideFiltering) {
-          return setFilteredOptions(options);
-        }
-        const filtered = options.filter((option) => {
-          return (
-            String(option.label)
-              .toLowerCase()
-              .indexOf(filter.toLowerCase()) >= 0 ||
-            String(option.value)
-              .toLowerCase()
-              .indexOf(filter.toLowerCase()) >= 0
-          );
-        });
-        setFilteredOptions(filtered);
-      },
-      serverSideFiltering ? [options] : [filter, options],
+  // Trigger onFilterChange once filter is Updated
+  useEffect(() => {
+    const timeOutId = setTimeout(
+      () => onFilterChange(filter),
+      DEBOUNCE_TIMEOUT,
     );
+    return () => clearTimeout(timeOutId);
+  }, [filter]);
 
-    const clearButton = useMemo(
-      () =>
-        filter ? (
-          <Button icon="cross" minimal onClick={() => setFilter("")} />
-        ) : null,
-      [filter],
-    );
-
-    const handleSelectAll = () => {
-      if (!isSelectAll) {
-        // Get all options
-        const allOption: LabelInValueType[] = filteredOptions.map(
-          ({ label, value }) => ({
-            value: value || "",
-            label,
-          }),
+  // Filter options based on serverSideFiltering
+  useEffect(
+    () => {
+      if (serverSideFiltering) {
+        return setFilteredOptions(options);
+      }
+      const filtered = options.filter((option) => {
+        return (
+          String(option.label)
+            .toLowerCase()
+            .indexOf(filter.toLowerCase()) >= 0 ||
+          String(option.value)
+            .toLowerCase()
+            .indexOf(filter.toLowerCase()) >= 0
         );
-        // get unique selected values amongst SelectedAllValue and Value
-        const allSelectedOptions = uniqBy(
-          [...allOption, ...value],
-          "value",
-        ).map((val) => ({
+      });
+      setFilteredOptions(filtered);
+    },
+    serverSideFiltering ? [options] : [filter, options],
+  );
+
+  const clearButton = useMemo(
+    () =>
+      filter ? (
+        <Button icon="cross" minimal onClick={() => setFilter("")} />
+      ) : null,
+    [filter],
+  );
+
+  const handleSelectAll = () => {
+    if (!isSelectAll) {
+      // Get all options
+      const allOption: LabelInValueType[] = filteredOptions.map(
+        ({ label, value }) => ({
+          value: value || "",
+          label,
+        }),
+      );
+      // get unique selected values amongst SelectedAllValue and Value
+      const allSelectedOptions = uniqBy([...allOption, ...value], "value").map(
+        (val) => ({
           ...val,
           key: val.value,
-        }));
-        onChange(allSelectedOptions);
-        return;
-      }
-      return onChange([]);
-    };
-
-    const checkOptionsAndValue = () => {
-      const emptyFalseArr = [false];
-      if (value.length === 0 || filteredOptions.length === 0)
-        return emptyFalseArr;
-      return filteredOptions.map((x) => value.some((y) => y.value === x.value));
-    };
-
-    useEffect(() => {
-      const parentWidth = width - WidgetContainerDiff;
-      if (compactMode && labelRef.current) {
-        const labelWidth = labelRef.current.getBoundingClientRect().width;
-        const widthDiff = parentWidth - labelWidth - labelMargin;
-        setMemoDropDownWidth(
-          widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
-        );
-        return;
-      }
-      setMemoDropDownWidth(
-        parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
+        }),
       );
-    }, [compactMode, dropDownWidth, width, labelText]);
+      onChange(allSelectedOptions);
+      return;
+    }
+    return onChange([]);
+  };
 
-    const onQueryChange = useCallback(
-      (event: ChangeEvent<HTMLInputElement>) => {
-        event.stopPropagation();
-        setFilter(event.target.value);
-      },
-      [],
+  const checkOptionsAndValue = () => {
+    const emptyFalseArr = [false];
+    if (value.length === 0 || filteredOptions.length === 0)
+      return emptyFalseArr;
+    return filteredOptions.map((x) => value.some((y) => y.value === x.value));
+  };
+
+  useEffect(() => {
+    const parentWidth = width - WidgetContainerDiff;
+    if (compactMode && labelRef.current) {
+      const labelWidth = labelRef.current.getBoundingClientRect().width;
+      const widthDiff = parentWidth - labelWidth - labelMargin;
+      setMemoDropDownWidth(
+        widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
+      );
+      return;
+    }
+    setMemoDropDownWidth(
+      parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
     );
+  }, [compactMode, dropDownWidth, width, labelText]);
 
-    const onDropdownVisibleChange = (open: boolean) => {
-      onOpen(open);
+  const onQueryChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+    setFilter(event.target.value);
+  }, []);
 
-      /**
-       * Clear the search input on closing the widget
-       * and serverSideFiltering is off
-       */
-      if (!serverSideFiltering) {
-        setFilter("");
-      }
-    };
+  const onDropdownVisibleChange = (open: boolean) => {
+    onOpen(open);
 
-    const dropdownRender = useCallback(
-      (
-        menu: React.ReactElement<
-          any,
-          string | React.JSXElementConstructor<any>
-        >,
-      ) => (
-        <>
-          <BackDrop />
-          {isFilterable ? (
-            <InputGroup
-              inputRef={inputRef}
-              leftIcon="search"
-              onChange={onQueryChange}
-              onKeyDown={onKeyDown}
-              placeholder="Filter..."
-              // ref={inputRef}
-              rightElement={clearButton as JSX.Element}
-              small
-              type="text"
-              value={filter}
+    /**
+     * Clear the search input on closing the widget
+     * and serverSideFiltering is off
+     */
+    if (!serverSideFiltering) {
+      setFilter("");
+    }
+  };
+
+  const dropdownRender = useCallback(
+    (
+      menu: React.ReactElement<any, string | React.JSXElementConstructor<any>>,
+    ) => (
+      <>
+        <BackDrop />
+        {isFilterable ? (
+          <InputGroup
+            inputRef={inputRef}
+            leftIcon="search"
+            onChange={onQueryChange}
+            onKeyDown={onKeyDown}
+            placeholder="Filter..."
+            // ref={inputRef}
+            rightElement={clearButton as JSX.Element}
+            small
+            type="text"
+            value={filter}
+          />
+        ) : null}
+        <div className={`${loading ? Classes.SKELETON : ""}`}>
+          {filteredOptions.length && allowSelectAll ? (
+            <StyledCheckbox
+              accentColor={accentColor}
+              alignIndicator="left"
+              checked={isSelectAll}
+              className={`all-options ${isSelectAll ? "selected" : ""}`}
+              label="Select all"
+              onChange={handleSelectAll}
             />
           ) : null}
-          <div className={`${loading ? Classes.SKELETON : ""}`}>
-            {filteredOptions.length && allowSelectAll ? (
-              <StyledCheckbox
-                accentColor={accentColor}
-                alignIndicator="left"
-                checked={isSelectAll}
-                className={`all-options ${isSelectAll ? "selected" : ""}`}
-                label="Select all"
-                onChange={handleSelectAll}
-              />
-            ) : null}
-            {menu}
-          </div>
-        </>
-      ),
-      [
-        isSelectAll,
-        filteredOptions,
-        loading,
-        allowSelectAll,
-        isFilterable,
-        filter,
-        onQueryChange,
-      ],
-    );
+          {menu}
+        </div>
+      </>
+    ),
+    [
+      isSelectAll,
+      filteredOptions,
+      loading,
+      allowSelectAll,
+      isFilterable,
+      filter,
+      onQueryChange,
+    ],
+  );
 
-    return (
-      <MultiSelectContainer
+  return (
+    <MultiSelectContainer
+      accentColor={accentColor}
+      borderRadius={borderRadius}
+      boxShadow={boxShadow}
+      compactMode={compactMode}
+      data-testid="multiselect-container"
+      isValid={isValid}
+      labelPosition={labelPosition}
+      ref={_menu as React.RefObject<HTMLDivElement>}
+    >
+      <DropdownStyles
         accentColor={accentColor}
         borderRadius={borderRadius}
-        boxShadow={boxShadow}
-        compactMode={compactMode}
-        data-testid="multiselect-container"
-        isValid={isValid}
-        labelPosition={labelPosition}
-        ref={_menu as React.RefObject<HTMLDivElement>}
-        style={isDynamicHeightEnabled ? { height: "auto" } : undefined}
-      >
-        <DropdownStyles
-          accentColor={accentColor}
-          borderRadius={borderRadius}
-          dropDownWidth={memoDropDownWidth}
-          id={widgetId}
+        dropDownWidth={memoDropDownWidth}
+        id={widgetId}
+      />
+      {labelText && (
+        <LabelWithTooltip
+          alignment={labelAlignment}
+          className={`multiselect-label`}
+          color={labelTextColor}
+          compact={compactMode}
+          disabled={disabled}
+          fontSize={labelTextSize}
+          fontStyle={labelStyle}
+          isDynamicHeightEnabled={isDynamicHeightEnabled}
+          loading={loading}
+          position={labelPosition}
+          ref={labelRef}
+          text={labelText}
+          width={labelWidth}
         />
-        {labelText && (
-          <LabelWithTooltip
-            alignment={labelAlignment}
-            className={`multiselect-label`}
-            color={labelTextColor}
-            compact={compactMode}
-            disabled={disabled}
-            fontSize={labelTextSize}
-            fontStyle={labelStyle}
-            isDynamicHeightEnabled={isDynamicHeightEnabled}
-            loading={loading}
-            position={labelPosition}
-            ref={labelRef}
-            text={labelText}
-            width={labelWidth}
-          />
-        )}
-        <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
-          <Select
-            animation="slide-up"
-            choiceTransitionName="rc-select-selection__choice-zoom"
-            className="rc-select"
-            // TODO: Make Autofocus a variable in the property pane
-            // autoFocus
-            defaultActiveFirstOption={false}
-            disabled={disabled}
-            dropdownClassName={`multi-select-dropdown multiselect-popover-width-${widgetId}`}
-            dropdownRender={dropdownRender}
-            dropdownStyle={dropdownStyle}
-            getPopupContainer={getPopupContainer}
-            inputIcon={
-              <Icon
-                className="dropdown-icon"
-                fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
-                name="dropdown"
-              />
-            }
-            labelInValue
-            listHeight={300}
-            loading={loading}
-            maxTagCount={"responsive"}
-            maxTagPlaceholder={(e) => `+${e.length} more`}
-            menuItemSelectedIcon={menuItemSelectedIcon}
-            mode="multiple"
-            notFoundContent="No Results Found"
-            onBlur={onBlur}
-            onChange={onChange}
-            onDropdownVisibleChange={onDropdownVisibleChange}
-            onFocus={onFocus}
-            open={isOpen}
-            options={filteredOptions}
-            placeholder={placeholder || "select option(s)"}
-            ref={selectRef}
-            removeIcon={
-              <Icon
-                className="remove-icon"
-                fillColor={Colors.GREY_10}
-                name="close-x"
-              />
-            }
-            showArrow
-            showSearch={false}
-            value={value}
-          />
-        </InputContainer>
-      </MultiSelectContainer>
-    );
-  },
-);
+      )}
+      <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
+        <Select
+          animation="slide-up"
+          choiceTransitionName="rc-select-selection__choice-zoom"
+          className="rc-select"
+          // TODO: Make Autofocus a variable in the property pane
+          // autoFocus
+          defaultActiveFirstOption={false}
+          disabled={disabled}
+          dropdownClassName={`multi-select-dropdown multiselect-popover-width-${widgetId}`}
+          dropdownRender={dropdownRender}
+          dropdownStyle={dropdownStyle}
+          getPopupContainer={getPopupContainer}
+          inputIcon={
+            <Icon
+              className="dropdown-icon"
+              fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
+              name="dropdown"
+            />
+          }
+          labelInValue
+          listHeight={300}
+          loading={loading}
+          maxTagCount={"responsive"}
+          maxTagPlaceholder={(e) => `+${e.length} more`}
+          menuItemSelectedIcon={menuItemSelectedIcon}
+          mode="multiple"
+          notFoundContent="No Results Found"
+          onBlur={onBlur}
+          onChange={onChange}
+          onDropdownVisibleChange={onDropdownVisibleChange}
+          onFocus={onFocus}
+          open={isOpen}
+          options={filteredOptions}
+          placeholder={placeholder || "select option(s)"}
+          ref={selectRef}
+          removeIcon={
+            <Icon
+              className="remove-icon"
+              fillColor={Colors.GREY_10}
+              name="close-x"
+            />
+          }
+          showArrow
+          showSearch={false}
+          value={value}
+        />
+      </InputContainer>
+    </MultiSelectContainer>
+  );
+}
 
 export default MultiSelectComponent;

--- a/app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectWidgetV2/widget/index.tsx
@@ -955,7 +955,6 @@ class MultiSelectWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: MultiSelectWidgetProps): void {
-    super.componentDidUpdate(prevProps);
     // Check if defaultOptionValue is string
     let isStringArray = false;
     if (
@@ -1025,7 +1024,6 @@ class MultiSelectWidget extends BaseWidget<
         onFilterChange={this.onFilterChange}
         options={options}
         placeholder={this.props.placeholderText as string}
-        ref={this.contentRef}
         renderMode={this.props.renderMode}
         serverSideFiltering={this.props.serverSideFiltering}
         value={values}

--- a/app/client/src/widgets/PhoneInputWidget/component/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/component/index.tsx
@@ -86,7 +86,6 @@ class PhoneInputComponent extends React.PureComponent<
         onKeyDown={this.onKeyDown}
         onValueChange={this.props.onValueChange}
         placeholder={this.props.placeholder}
-        ref={this.props.innerRef}
         showError={this.props.showError}
         tooltip={this.props.tooltip}
         value={this.props.value}
@@ -101,14 +100,6 @@ export interface PhoneInputComponentProps extends BaseInputComponentProps {
   countryCode?: CountryCode;
   onISDCodeChange: (code?: string) => void;
   allowDialCodeChange: boolean;
-  innerRef?: React.RefObject<HTMLDivElement>;
 }
 
-export default React.forwardRef<HTMLDivElement, PhoneInputComponentProps>(
-  (props, ref) => (
-    <PhoneInputComponent
-      {...props}
-      innerRef={ref as React.RefObject<HTMLDivElement>}
-    />
-  ),
-);
+export default PhoneInputComponent;

--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -287,7 +287,6 @@ class PhoneInputWidget extends BaseInputWidget<
   }
 
   componentDidUpdate(prevProps: PhoneInputWidgetProps) {
-    super.componentDidUpdate(prevProps);
     if (prevProps.dialCode !== this.props.dialCode) {
       this.onISDCodeChange(this.props.dialCode);
     }
@@ -424,7 +423,6 @@ class PhoneInputWidget extends BaseInputWidget<
         onKeyDown={this.handleKeyDown}
         onValueChange={this.onValueChange}
         placeholder={this.props.placeholderText}
-        ref={this.contentRef}
         showError={!!this.props.isFocused}
         tooltip={this.props.tooltip}
         value={value}

--- a/app/client/src/widgets/RadioGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/component/index.tsx
@@ -63,10 +63,7 @@ const StyledRadioGroup = styled(RadioGroup)<StyledRadioGroupProps>`
   }
 `;
 
-const RadioGroupComponent = React.forwardRef<
-  HTMLDivElement,
-  RadioGroupComponentProps
->((props, ref) => {
+function RadioGroupComponent(props: RadioGroupComponentProps) {
   const {
     accentColor,
     alignment,
@@ -104,7 +101,6 @@ const RadioGroupComponent = React.forwardRef<
       data-testid="radiogroup-container"
       isDynamicHeightEnabled={isDynamicHeightEnabled}
       labelPosition={labelPosition}
-      ref={ref}
     >
       {labelText && (
         <LabelWithTooltip
@@ -152,9 +148,7 @@ const RadioGroupComponent = React.forwardRef<
       </StyledRadioGroup>
     </RadioGroupContainer>
   );
-});
-
-RadioGroupComponent.displayName = "RadioGroupComponent";
+}
 
 export interface RadioGroupComponentProps extends ComponentProps {
   options: RadioOption[];
@@ -179,7 +173,5 @@ export interface RadioGroupComponentProps extends ComponentProps {
   maxDynamicHeight?: number;
   required?: boolean;
 }
-
-RadioGroupComponent.displayName = "RadioGroupComponent";
 
 export default RadioGroupComponent;

--- a/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/widget/index.tsx
@@ -793,7 +793,6 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
   }
 
   componentDidUpdate(prevProps: RadioGroupWidgetProps): void {
-    super.componentDidUpdate(prevProps);
     if (
       this.props.defaultOptionValue !== prevProps.defaultOptionValue &&
       this.props.isDirty
@@ -844,7 +843,6 @@ class RadioGroupWidget extends BaseWidget<RadioGroupWidgetProps, WidgetState> {
         maxDynamicHeight={this.props.maxDynamicHeight}
         onRadioSelectionChange={this.onRadioSelectionChange}
         options={isArray(options) ? compact(options) : []}
-        ref={this.contentRef}
         required={this.props.isRequired}
         selectedOptionValue={selectedOptionValue}
         widgetId={widgetId}

--- a/app/client/src/widgets/RateWidget/component/index.tsx
+++ b/app/client/src/widgets/RateWidget/component/index.tsx
@@ -10,7 +10,6 @@ import { TooltipComponent } from "design-system";
 import { disable } from "constants/DefaultTheme";
 import { ComponentProps } from "widgets/BaseComponent";
 import { Colors } from "constants/Colors";
-import { DynamicnHeightEnabledComponentProps } from "widgets/WidgetUtils";
 
 /*
   Note:
@@ -19,8 +18,8 @@ import { DynamicnHeightEnabledComponentProps } from "widgets/WidgetUtils";
   It suffices for our target browsers
   More info: https://css-tricks.com/line-clampin/
 */
-
-interface RateContainerProps extends DynamicnHeightEnabledComponentProps {
+``;
+interface RateContainerProps {
   isDisabled: boolean;
 }
 
@@ -52,16 +51,11 @@ export const RateContainer = styled.div<RateContainerProps>`
   }
 
   ${({ isDisabled }) => isDisabled && disable}
-
-  ${({ isDynamicHeightEnabled }) =>
-    isDynamicHeightEnabled ? "&& { height: auto }" : ""};
 `;
 
 export const Star = styled(Icon)``;
 
-export interface RateComponentProps
-  extends ComponentProps,
-    DynamicnHeightEnabledComponentProps {
+export interface RateComponentProps extends ComponentProps {
   value: number;
   isLoading: boolean;
   maxCount: number;
@@ -112,48 +106,39 @@ function renderStarsWithTooltip(props: RateComponentProps) {
   return _.concat(starWithTooltip, starWithoutTooltip);
 }
 
-const RateComponent = React.forwardRef<HTMLDivElement, RateComponentProps>(
-  (props, ref) => {
-    const rateContainerRef = ref;
+function RateComponent(props: RateComponentProps) {
+  const rateContainerRef = React.createRef<HTMLDivElement>();
 
-    const {
-      inactiveColor,
-      isAllowHalf,
-      isDisabled,
-      isDynamicHeightEnabled,
-      maxCount,
-      onValueChanged,
-      readonly,
-      size,
-      value,
-    } = props;
+  const {
+    inactiveColor,
+    isAllowHalf,
+    isDisabled,
+    maxCount,
+    onValueChanged,
+    readonly,
+    size,
+    value,
+  } = props;
 
-    return (
-      <RateContainer
-        isDisabled={Boolean(isDisabled)}
-        isDynamicHeightEnabled={isDynamicHeightEnabled}
-        ref={rateContainerRef}
-      >
-        <Rating
-          emptySymbol={
-            <Star
-              color={inactiveColor || Colors.ALTO_3}
-              icon={IconNames.STAR}
-              iconSize={RATE_SIZES[size]}
-            />
-          }
-          fractions={isAllowHalf ? 2 : 1}
-          fullSymbol={renderStarsWithTooltip(props)}
-          initialRating={value}
-          onChange={onValueChanged}
-          readonly={readonly}
-          stop={maxCount}
-        />
-      </RateContainer>
-    );
-  },
-);
-
-RateComponent.displayName = "RateComponent";
+  return (
+    <RateContainer isDisabled={Boolean(isDisabled)} ref={rateContainerRef}>
+      <Rating
+        emptySymbol={
+          <Star
+            color={inactiveColor || Colors.ALTO_3}
+            icon={IconNames.STAR}
+            iconSize={RATE_SIZES[size]}
+          />
+        }
+        fractions={isAllowHalf ? 2 : 1}
+        fullSymbol={renderStarsWithTooltip(props)}
+        initialRating={value}
+        onChange={onValueChanged}
+        readonly={readonly}
+        stop={maxCount}
+      />
+    </RateContainer>
+  );
+}
 
 export default RateComponent;

--- a/app/client/src/widgets/RateWidget/widget/index.tsx
+++ b/app/client/src/widgets/RateWidget/widget/index.tsx
@@ -8,7 +8,6 @@ import { ValidationTypes } from "constants/WidgetValidation";
 import { DerivedPropertiesMap } from "utils/WidgetFactory";
 import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
 import { AutocompleteDataType } from "utils/autocomplete/TernServer";
-import { isDynamicHeightEnabledForWidget } from "widgets/WidgetUtils";
 
 function validateDefaultRate(value: unknown, props: any, _: any) {
   try {
@@ -424,10 +423,6 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
     });
   };
 
-  componentDidUpdate(prevProps: RateWidgetProps): void {
-    super.componentDidUpdate(prevProps);
-  }
-
   getPageView() {
     return (
       (this.props.rate || this.props.rate === 0) && (
@@ -437,14 +432,12 @@ class RateWidget extends BaseWidget<RateWidgetProps, WidgetState> {
           inactiveColor={this.props.inactiveColor}
           isAllowHalf={this.props.isAllowHalf}
           isDisabled={this.props.isDisabled}
-          isDynamicHeightEnabled={isDynamicHeightEnabledForWidget(this.props)}
           isLoading={this.props.isLoading}
           key={this.props.widgetId}
           leftColumn={this.props.leftColumn}
           maxCount={this.props.maxCount}
           onValueChanged={this.valueChangedHandler}
           readonly={this.props.isDisabled}
-          ref={this.contentRef}
           rightColumn={this.props.rightColumn}
           size={this.props.size}
           tooltips={this.props.tooltips}

--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -75,10 +75,7 @@ export interface RichtextEditorComponentProps {
   onValueChange: (valueAsString: string) => void;
 }
 
-const RichtextEditorComponent = React.forwardRef<
-  HTMLDivElement,
-  RichtextEditorComponentProps
->((props, ref) => {
+function RichtextEditorComponent(props: RichtextEditorComponentProps) {
   const {
     compactMode,
     isDisabled,
@@ -134,7 +131,6 @@ const RichtextEditorComponent = React.forwardRef<
       compactMode={compactMode}
       data-testid="rte-container"
       labelPosition={labelPosition}
-      ref={ref}
     >
       {labelText && (
         <LabelWithTooltip
@@ -205,6 +201,6 @@ const RichtextEditorComponent = React.forwardRef<
       </RichTextEditorInputWrapper>
     </StyledRTEditor>
   );
-});
+}
 
 export default RichtextEditorComponent;

--- a/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
@@ -618,7 +618,6 @@ class RichTextEditorWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: RichTextEditorWidgetProps): void {
-    super.componentDidUpdate(prevProps);
     if (this.props.defaultText !== prevProps.defaultText) {
       if (this.props.isDirty) {
         this.props.updateWidgetMetaProperty("isDirty", false);
@@ -674,7 +673,6 @@ class RichTextEditorWidget extends BaseWidget<
           labelWidth={this.getLabelWidth()}
           onValueChange={this.onValueChange}
           placeholder={this.props.placeholder}
-          ref={this.contentRef}
           value={value}
           widgetId={this.props.widgetId}
         />

--- a/app/client/src/widgets/SelectWidget/component/index.tsx
+++ b/app/client/src/widgets/SelectWidget/component/index.tsx
@@ -294,10 +294,6 @@ class SelectComponent extends React.Component<
         compactMode={compactMode}
         data-testid="select-container"
         labelPosition={labelPosition}
-        ref={this.props.innerRef}
-        style={
-          this.props.isDynamicHeightEnabled ? { height: "auto" } : undefined
-        }
       >
         <DropdownStyles
           accentColor={accentColor}
@@ -429,11 +425,4 @@ export interface SelectComponentProps extends ComponentProps {
   accentColor?: string;
 }
 
-export default React.memo(
-  React.forwardRef<HTMLDivElement, SelectComponentProps>((props, ref) => (
-    <SelectComponent
-      {...props}
-      innerRef={ref as React.RefObject<HTMLDivElement>}
-    />
-  )),
-);
+export default SelectComponent;

--- a/app/client/src/widgets/SelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/SelectWidget/widget/index.tsx
@@ -876,7 +876,6 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
   }
 
   componentDidUpdate(prevProps: SelectWidgetProps): void {
-    super.componentDidUpdate(prevProps);
     // Reset isDirty to false if defaultOptionValue changes
     if (
       !equal(this.props.defaultOptionValue, prevProps.defaultOptionValue) &&
@@ -932,7 +931,6 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
         onOptionSelected={this.onOptionSelected}
         options={options}
         placeholder={this.props.placeholderText}
-        ref={this.contentRef}
         selectedIndex={selectedIndex > -1 ? selectedIndex : undefined}
         serverSideFiltering={this.props.serverSideFiltering}
         value={this.props.selectedOptionValue}

--- a/app/client/src/widgets/SingleSelectTreeWidget/component/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/component/index.tsx
@@ -99,234 +99,219 @@ const switcherIcon = (treeNode: TreeNodeProps) => {
   return getSvg(treeNode.expanded);
 };
 
-const SingleSelectTreeComponent = React.forwardRef<
-  HTMLDivElement,
-  TreeSelectProps
->(
-  (
-    {
-      accentColor,
-      allowClear,
-      borderRadius,
-      boxShadow,
-      compactMode,
-      disabled,
-      dropdownStyle,
-      dropDownWidth,
-      expandAll,
-      filterText,
-      isDynamicHeightEnabled,
-      isFilterable,
-      isValid,
-      labelAlignment,
-      labelPosition,
-      labelStyle,
-      labelText,
-      labelTextColor,
-      labelTextSize,
-      labelWidth,
-      loading,
-      onChange,
-      options,
-      placeholder,
-      renderMode,
-      value,
-      widgetId,
-      width,
-    },
-    ref,
-  ): JSX.Element => {
-    const [key, setKey] = useState(Math.random());
-    const [filter, setFilter] = useState(filterText ?? "");
+function SingleSelectTreeComponent({
+  accentColor,
+  allowClear,
+  borderRadius,
+  boxShadow,
+  compactMode,
+  disabled,
+  dropdownStyle,
+  dropDownWidth,
+  expandAll,
+  filterText,
+  isDynamicHeightEnabled,
+  isFilterable,
+  isValid,
+  labelAlignment,
+  labelPosition,
+  labelStyle,
+  labelText,
+  labelTextColor,
+  labelTextSize,
+  labelWidth,
+  loading,
+  onChange,
+  options,
+  placeholder,
+  renderMode,
+  value,
+  widgetId,
+  width,
+}: TreeSelectProps): JSX.Element {
+  const [key, setKey] = useState(Math.random());
+  const [filter, setFilter] = useState(filterText ?? "");
 
-    const labelRef = useRef<HTMLDivElement>(null);
-    const _menu = ref;
-    const inputRef = useRef<HTMLInputElement>(null);
-    const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
+  const labelRef = useRef<HTMLDivElement>(null);
+  const _menu = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [memoDropDownWidth, setMemoDropDownWidth] = useState(0);
 
-    const {
-      BackDrop,
-      getPopupContainer,
-      isOpen,
-      onKeyDown,
-      onOpen,
-      selectRef,
-    } = useDropdown({
-      inputRef,
-      renderMode,
-    });
+  const {
+    BackDrop,
+    getPopupContainer,
+    isOpen,
+    onKeyDown,
+    onOpen,
+    selectRef,
+  } = useDropdown({
+    inputRef,
+    renderMode,
+  });
 
-    // treeDefaultExpandAll is uncontrolled after first render,
-    // using this to force render to respond to changes in expandAll
-    useEffect(() => {
-      setKey(Math.random());
-    }, [expandAll]);
+  // treeDefaultExpandAll is uncontrolled after first render,
+  // using this to force render to respond to changes in expandAll
+  useEffect(() => {
+    setKey(Math.random());
+  }, [expandAll]);
 
-    const onSelectionChange = useCallback(
-      (value?: DefaultValueType, labelList?: ReactNode[]) => {
-        if (value !== undefined) {
-          setFilter("");
-          onChange(value, labelList);
-        }
-      },
-      [],
-    );
-    const onClear = useCallback(() => onChange("", []), []);
-    const clearButton = useMemo(
-      () =>
-        filter ? (
-          <Button icon="cross" minimal onClick={() => setFilter("")} />
-        ) : null,
-      [filter],
-    );
-    const onQueryChange = useCallback(
-      (event: ChangeEvent<HTMLInputElement>) => {
-        event.stopPropagation();
-        setFilter(event.target.value);
-      },
-      [],
-    );
-
-    useEffect(() => {
-      const parentWidth = width - WidgetContainerDiff;
-      if (compactMode && labelRef.current) {
-        const labelWidth = labelRef.current.getBoundingClientRect().width;
-        const widthDiff = parentWidth - labelWidth - labelMargin;
-        setMemoDropDownWidth(
-          widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
-        );
-        return;
+  const onSelectionChange = useCallback(
+    (value?: DefaultValueType, labelList?: ReactNode[]) => {
+      if (value !== undefined) {
+        setFilter("");
+        onChange(value, labelList);
       }
+    },
+    [],
+  );
+  const onClear = useCallback(() => onChange("", []), []);
+  const clearButton = useMemo(
+    () =>
+      filter ? (
+        <Button icon="cross" minimal onClick={() => setFilter("")} />
+      ) : null,
+    [filter],
+  );
+  const onQueryChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+    setFilter(event.target.value);
+  }, []);
+
+  useEffect(() => {
+    const parentWidth = width - WidgetContainerDiff;
+    if (compactMode && labelRef.current) {
+      const labelWidth = labelRef.current.getBoundingClientRect().width;
+      const widthDiff = parentWidth - labelWidth - labelMargin;
       setMemoDropDownWidth(
-        parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
+        widthDiff > dropDownWidth ? widthDiff : dropDownWidth,
       );
-    }, [compactMode, dropDownWidth, width, labelText]);
-
-    const dropdownRender = useCallback(
-      (
-        menu: React.ReactElement<
-          any,
-          string | React.JSXElementConstructor<any>
-        >,
-      ) => (
-        <>
-          <BackDrop />
-          {isFilterable ? (
-            <InputGroup
-              inputRef={inputRef}
-              leftIcon="search"
-              onChange={onQueryChange}
-              onKeyDown={onKeyDown}
-              placeholder="Filter..."
-              rightElement={clearButton as JSX.Element}
-              small
-              type="text"
-              value={filter}
-            />
-          ) : null}
-          <div className={`${loading ? Classes.SKELETON : ""}`}>{menu}</div>
-        </>
-      ),
-      [loading, isFilterable, filter, onQueryChange],
+      return;
+    }
+    setMemoDropDownWidth(
+      parentWidth > dropDownWidth ? parentWidth : dropDownWidth,
     );
+  }, [compactMode, dropDownWidth, width, labelText]);
 
-    const onDropdownVisibleChange = (open: boolean) => {
-      onOpen(open);
-      // Clear the search input on closing the widget
-      setFilter("");
-    };
+  const dropdownRender = useCallback(
+    (
+      menu: React.ReactElement<any, string | React.JSXElementConstructor<any>>,
+    ) => (
+      <>
+        <BackDrop />
+        {isFilterable ? (
+          <InputGroup
+            inputRef={inputRef}
+            leftIcon="search"
+            onChange={onQueryChange}
+            onKeyDown={onKeyDown}
+            placeholder="Filter..."
+            rightElement={clearButton as JSX.Element}
+            small
+            type="text"
+            value={filter}
+          />
+        ) : null}
+        <div className={`${loading ? Classes.SKELETON : ""}`}>{menu}</div>
+      </>
+    ),
+    [loading, isFilterable, filter, onQueryChange],
+  );
 
-    return (
-      <TreeSelectContainer
+  const onDropdownVisibleChange = (open: boolean) => {
+    onOpen(open);
+    // Clear the search input on closing the widget
+    setFilter("");
+  };
+
+  return (
+    <TreeSelectContainer
+      accentColor={accentColor}
+      allowClear={allowClear}
+      borderRadius={borderRadius}
+      boxShadow={boxShadow}
+      compactMode={compactMode}
+      data-testid="treeselect-container"
+      isValid={isValid}
+      labelPosition={labelPosition}
+      ref={_menu as React.RefObject<HTMLDivElement>}
+    >
+      <DropdownStyles
         accentColor={accentColor}
-        allowClear={allowClear}
         borderRadius={borderRadius}
-        boxShadow={boxShadow}
-        compactMode={compactMode}
-        data-testid="treeselect-container"
-        isValid={isValid}
-        labelPosition={labelPosition}
-        ref={_menu as React.RefObject<HTMLDivElement>}
-        style={isDynamicHeightEnabled ? { height: "auto" } : undefined}
-      >
-        <DropdownStyles
-          accentColor={accentColor}
-          borderRadius={borderRadius}
-          dropDownWidth={memoDropDownWidth}
-          id={widgetId}
+        dropDownWidth={memoDropDownWidth}
+        id={widgetId}
+      />
+      {labelText && (
+        <LabelWithTooltip
+          alignment={labelAlignment}
+          className={`tree-select-label`}
+          color={labelTextColor}
+          compact={compactMode}
+          disabled={disabled}
+          fontSize={labelTextSize}
+          fontStyle={labelStyle}
+          isDynamicHeightEnabled={isDynamicHeightEnabled}
+          loading={loading}
+          position={labelPosition}
+          ref={labelRef}
+          text={labelText}
+          width={labelWidth}
         />
-        {labelText && (
-          <LabelWithTooltip
-            alignment={labelAlignment}
-            className={`tree-select-label`}
-            color={labelTextColor}
-            compact={compactMode}
-            disabled={disabled}
-            fontSize={labelTextSize}
-            fontStyle={labelStyle}
-            isDynamicHeightEnabled={isDynamicHeightEnabled}
-            loading={loading}
-            position={labelPosition}
-            ref={labelRef}
-            text={labelText}
-            width={labelWidth}
-          />
-        )}
-        <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
-          <TreeSelect
-            allowClear={allowClear}
-            animation="slide-up"
-            choiceTransitionName="rc-tree-select-selection__choice-zoom"
-            className="rc-tree-select"
-            clearIcon={
-              <Icon
-                className="clear-icon"
-                fillColor={Colors.GREY_10}
-                name="close-x"
-              />
-            }
-            disabled={disabled}
-            dropdownClassName={`tree-select-dropdown single-tree-select-dropdown treeselect-popover-width-${widgetId}`}
-            dropdownRender={dropdownRender}
-            dropdownStyle={dropdownStyle}
-            filterTreeNode
-            getPopupContainer={getPopupContainer}
-            inputIcon={
-              <Icon
-                className="dropdown-icon"
-                fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
-                name="dropdown"
-              />
-            }
-            key={key}
-            loading={loading}
-            maxTagCount={"responsive"}
-            maxTagPlaceholder={(e) => `+${e.length} more`}
-            notFoundContent={
-              <NoDataFoundContainer>No Results Found</NoDataFoundContainer>
-            }
-            onChange={onSelectionChange}
-            onClear={onClear}
-            onDropdownVisibleChange={onDropdownVisibleChange}
-            open={isOpen}
-            placeholder={placeholder}
-            ref={selectRef}
-            searchValue={filter}
-            showArrow
-            showSearch={false}
-            style={{ width: "100%" }}
-            switcherIcon={switcherIcon}
-            transitionName="rc-tree-select-dropdown-slide-up"
-            treeData={options}
-            treeDefaultExpandAll={expandAll}
-            treeIcon
-            treeNodeFilterProp="label"
-            value={filter ? "" : value} // value should empty when filter value exist otherwise dropdown flickers #12714
-          />
-        </InputContainer>
-      </TreeSelectContainer>
-    );
-  },
-);
+      )}
+      <InputContainer compactMode={compactMode} labelPosition={labelPosition}>
+        <TreeSelect
+          allowClear={allowClear}
+          animation="slide-up"
+          choiceTransitionName="rc-tree-select-selection__choice-zoom"
+          className="rc-tree-select"
+          clearIcon={
+            <Icon
+              className="clear-icon"
+              fillColor={Colors.GREY_10}
+              name="close-x"
+            />
+          }
+          disabled={disabled}
+          dropdownClassName={`tree-select-dropdown single-tree-select-dropdown treeselect-popover-width-${widgetId}`}
+          dropdownRender={dropdownRender}
+          dropdownStyle={dropdownStyle}
+          filterTreeNode
+          getPopupContainer={getPopupContainer}
+          inputIcon={
+            <Icon
+              className="dropdown-icon"
+              fillColor={disabled ? Colors.GREY_7 : Colors.GREY_10}
+              name="dropdown"
+            />
+          }
+          key={key}
+          loading={loading}
+          maxTagCount={"responsive"}
+          maxTagPlaceholder={(e) => `+${e.length} more`}
+          notFoundContent={
+            <NoDataFoundContainer>No Results Found</NoDataFoundContainer>
+          }
+          onChange={onSelectionChange}
+          onClear={onClear}
+          onDropdownVisibleChange={onDropdownVisibleChange}
+          open={isOpen}
+          placeholder={placeholder}
+          ref={selectRef}
+          searchValue={filter}
+          showArrow
+          showSearch={false}
+          style={{ width: "100%" }}
+          switcherIcon={switcherIcon}
+          transitionName="rc-tree-select-dropdown-slide-up"
+          treeData={options}
+          treeDefaultExpandAll={expandAll}
+          treeIcon
+          treeNodeFilterProp="label"
+          value={filter ? "" : value} // value should empty when filter value exist otherwise dropdown flickers #12714
+        />
+      </InputContainer>
+    </TreeSelectContainer>
+  );
+}
 
 export default SingleSelectTreeComponent;

--- a/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
@@ -808,7 +808,6 @@ class SingleSelectTreeWidget extends BaseWidget<
   }
 
   componentDidUpdate(prevProps: SingleSelectTreeWidgetProps): void {
-    super.componentDidUpdate(prevProps);
     if (
       this.props.defaultOptionValue !== prevProps.defaultOptionValue &&
       this.props.isDirty
@@ -856,7 +855,6 @@ class SingleSelectTreeWidget extends BaseWidget<
         onChange={this.onOptionChange}
         options={options}
         placeholder={this.props.placeholderText as string}
-        ref={this.contentRef}
         renderMode={this.props.renderMode}
         value={this.props.selectedOptionValue}
         widgetId={this.props.widgetId}

--- a/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
@@ -159,6 +159,4 @@ export interface SwitchGroupComponentProps {
   maxDynamicHeight?: number;
 }
 
-SwitchGroupComponent.displayName = "SwitchGroupComponent";
-
 export default SwitchGroupComponent;

--- a/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/widget/index.tsx
@@ -755,7 +755,6 @@ class SwitchGroupWidget extends BaseWidget<
         maxDynamicHeight={this.props.maxDynamicHeight}
         onChange={this.handleSwitchStateChange}
         options={options}
-        ref={this.contentRef}
         required={isRequired}
         selected={selectedValues}
         valid={isValid}

--- a/app/client/src/widgets/SwitchWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/component/index.tsx
@@ -18,7 +18,6 @@ export interface SwitchComponentProps extends ComponentProps {
   labelPosition: LabelPosition;
   accentColor: string;
   inputRef?: (ref: HTMLInputElement | null) => any;
-  isDynamicHeightEnabled?: boolean;
   labelTextColor?: string;
   labelTextSize?: string;
   labelStyle?: string;
@@ -85,68 +84,56 @@ export const StyledSwitch = styled(Switch)<{
   }
 `;
 
-const SwitchComponent = React.forwardRef<HTMLDivElement, SwitchComponentProps>(
-  (
-    {
-      accentColor,
-      alignWidget,
-      inputRef,
-      isDisabled,
-      isDynamicHeightEnabled,
-      isLoading,
-      isSwitchedOn,
-      label,
-      labelPosition,
-      labelStyle,
-      labelTextColor,
-      labelTextSize,
-      onChange,
-    },
-    ref,
-  ) => {
-    const switchAlignClass =
-      alignWidget === AlignWidgetTypes.RIGHT ? Alignment.RIGHT : Alignment.LEFT;
+function SwitchComponent({
+  accentColor,
+  alignWidget,
+  inputRef,
+  isDisabled,
+  isLoading,
+  isSwitchedOn,
+  label,
+  labelPosition,
+  labelStyle,
+  labelTextColor,
+  labelTextSize,
+  onChange,
+}: SwitchComponentProps): JSX.Element {
+  const switchAlignClass =
+    alignWidget === AlignWidgetTypes.RIGHT ? Alignment.RIGHT : Alignment.LEFT;
 
-    return (
-      <SwitchComponentContainer
+  return (
+    <SwitchComponentContainer accentColor={accentColor}>
+      <StyledSwitch
         accentColor={accentColor}
-        ref={ref}
-        style={isDynamicHeightEnabled ? { height: "auto" } : undefined}
-      >
-        <StyledSwitch
-          accentColor={accentColor}
-          alignIndicator={switchAlignClass}
-          checked={isSwitchedOn}
-          className={
-            isLoading
-              ? `${Classes.SKELETON} t--switch-widget-loading`
-              : `${
-                  isSwitchedOn
-                    ? "t--switch-widget-active"
-                    : "t--switch-widget-inactive"
-                }`
-          }
-          disabled={isDisabled}
-          inputRef={inputRef}
-          labelElement={
-            <SwitchLabel
-              className="t--switch-widget-label"
-              disabled={isDisabled}
-              labelPosition={labelPosition}
-              labelStyle={labelStyle}
-              labelTextColor={labelTextColor}
-              labelTextSize={labelTextSize}
-            >
-              {label}
-            </SwitchLabel>
-          }
-          onChange={() => onChange(!isSwitchedOn)}
-        />
-      </SwitchComponentContainer>
-    );
-  },
-);
-
-SwitchComponent.displayName = "SwitchComponent";
+        alignIndicator={switchAlignClass}
+        checked={isSwitchedOn}
+        className={
+          isLoading
+            ? `${Classes.SKELETON} t--switch-widget-loading`
+            : `${
+                isSwitchedOn
+                  ? "t--switch-widget-active"
+                  : "t--switch-widget-inactive"
+              }`
+        }
+        disabled={isDisabled}
+        inputRef={inputRef}
+        labelElement={
+          <SwitchLabel
+            className="t--switch-widget-label"
+            disabled={isDisabled}
+            labelPosition={labelPosition}
+            labelStyle={labelStyle}
+            labelTextColor={labelTextColor}
+            labelTextSize={labelTextSize}
+          >
+            {label}
+          </SwitchLabel>
+        }
+        onChange={() => onChange(!isSwitchedOn)}
+      />
+    </SwitchComponentContainer>
+  );
+}
 
 export default SwitchComponent;

--- a/app/client/src/widgets/SwitchWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/widget/index.tsx
@@ -10,7 +10,7 @@ import { DerivedPropertiesMap } from "utils/WidgetFactory";
 
 import { LabelPosition } from "components/constants";
 import { AlignWidgetTypes } from "widgets/constants";
-import { isDynamicHeightEnabledForWidget } from "widgets/WidgetUtils";
+
 class SwitchWidget extends BaseWidget<SwitchWidgetProps, WidgetState> {
   static getPropertyPaneConfig() {
     return [

--- a/app/client/src/widgets/SwitchWidget/widget/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/widget/index.tsx
@@ -439,7 +439,6 @@ class SwitchWidget extends BaseWidget<SwitchWidgetProps, WidgetState> {
         accentColor={this.props.accentColor}
         alignWidget={this.props.alignWidget}
         isDisabled={this.props.isDisabled}
-        isDynamicHeightEnabled={isDynamicHeightEnabledForWidget(this.props)}
         isLoading={this.props.isLoading}
         isSwitchedOn={!!this.props.isSwitchedOn}
         key={this.props.widgetId}
@@ -449,7 +448,6 @@ class SwitchWidget extends BaseWidget<SwitchWidgetProps, WidgetState> {
         labelTextColor={this.props.labelTextColor}
         labelTextSize={this.props.labelTextSize}
         onChange={this.onChange}
-        ref={this.contentRef}
         widgetId={this.props.widgetId}
       />
     );
@@ -479,7 +477,6 @@ class SwitchWidget extends BaseWidget<SwitchWidgetProps, WidgetState> {
   }
 
   componentDidUpdate(prevProps: SwitchWidgetProps): void {
-    super.componentDidUpdate(prevProps);
     if (
       this.props.defaultSwitchState !== prevProps.defaultSwitchState &&
       this.props.isDirty

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -809,7 +809,6 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
             isVisibleHeaderOptions ? Math.max(1, pageSize) : pageSize + 1
           }
           prevPageClick={this.handlePrevPageClick}
-          ref={this.contentRef}
           searchKey={this.props.searchText}
           searchTableData={this.handleSearchTable}
           selectAllRow={this.handleAllRowSelect}

--- a/app/client/src/widgets/TextWidget/component/index.tsx
+++ b/app/client/src/widgets/TextWidget/component/index.tsx
@@ -213,7 +213,6 @@ export interface TextComponentProps extends ComponentProps {
   leftColumn?: number;
   rightColumn?: number;
   topRow?: number;
-  innerRef?: React.RefObject<HTMLDivElement>;
 }
 
 type State = {
@@ -303,17 +302,15 @@ class TextComponent extends React.Component<TextComponentProps, State> {
               textAlign={textAlign}
               textColor={textColor}
             >
-              <div className="dynamic-height-wrapper" ref={this.props.innerRef}>
-                <Interweave
-                  content={text}
-                  matchers={
-                    disableLink
-                      ? []
-                      : [new EmailMatcher("email"), new UrlMatcher("url")]
-                  }
-                  newWindow
-                />
-              </div>
+              <Interweave
+                content={text}
+                matchers={
+                  disableLink
+                    ? []
+                    : [new EmailMatcher("email"), new UrlMatcher("url")]
+                }
+                newWindow
+              />
             </StyledText>
             {this.state.isTruncated && (
               <StyledIcon
@@ -371,11 +368,4 @@ class TextComponent extends React.Component<TextComponentProps, State> {
   }
 }
 
-export default React.forwardRef<HTMLDivElement, TextComponentProps>(
-  (props, ref) => (
-    <TextComponent
-      {...props}
-      innerRef={ref as React.RefObject<HTMLDivElement>}
-    />
-  ),
-);
+export default TextComponent;

--- a/app/client/src/widgets/TextWidget/widget/index.tsx
+++ b/app/client/src/widgets/TextWidget/widget/index.tsx
@@ -644,10 +644,6 @@ class TextWidget extends BaseWidget<TextWidgetProps, WidgetState> {
     );
   };
 
-  componentDidUpdate(prevProps: TextWidgetProps): void {
-    super.componentDidUpdate(prevProps);
-  }
-
   getPageView() {
     const disableLink: boolean = this.props.disableLink
       ? true
@@ -673,7 +669,6 @@ class TextWidget extends BaseWidget<TextWidgetProps, WidgetState> {
           key={this.props.widgetId}
           leftColumn={this.props.leftColumn}
           overflow={this.props.overflow}
-          ref={this.contentRef}
           rightColumn={this.props.rightColumn}
           text={this.props.text}
           textAlign={this.props.textAlign ? this.props.textAlign : "LEFT"}


### PR DESCRIPTION
Since we are using ResizeObserver at the base widget level in the new DynamicHeightContainer, we can remove the dependency on ref passing down to widgets from base widget. This will make the API simpler for widgets as well.