### PR TITLE
feat: Video Widget Reskinning

### DIFF
--- a/app/client/src/widgets/VideoWidget/index.ts
+++ b/app/client/src/widgets/VideoWidget/index.ts
@@ -15,6 +15,7 @@ export const CONFIG = {
     autoPlay: false,
     version: 1,
     animateLoading: true,
+    backgroundColor: "#000",
   },
   properties: {
     derived: Widget.getDerivedPropertiesMap(),


### PR DESCRIPTION
## Description

Add #000 default background color to the video widget. This enables the Video Widget borders to follow the theme even when the container is not the same size as the video.

Fixes #11021

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
