### PR TITLE
chore: Refactor DB changelog to install plugins in workspace with single query

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog.java
@@ -236,16 +236,13 @@ public class DatabaseChangelog {
     }
 
     public static void installPluginToAllWorkspaces(MongockTemplate mongockTemplate, String pluginId) {
-        Query queryToFetchAllWorkspaceIds = new Query();
+        Query queryToFetchAllWorkspaces = new Query();
         /* Filter in only those workspaces that don't have the plugin installed */
-        queryToFetchAllWorkspaceIds.addCriteria(Criteria.where("plugins.pluginId").ne(pluginId));
-        /* Only read the workspace id and leave out other fields */
-        queryToFetchAllWorkspaceIds.fields().include(fieldName(QWorkspace.workspace.id));
-        List<Workspace> workspacesWithOnlyId = mongockTemplate.find(queryToFetchAllWorkspaceIds, Workspace.class);
-        for (Workspace workspaceWithId : workspacesWithOnlyId) {
-            Workspace workspace =
-                    mongockTemplate.findOne(query(where(fieldName(QWorkspace.workspace.id)).is(workspaceWithId.getId())),
-                    Workspace.class);
+        queryToFetchAllWorkspaces.addCriteria(Criteria.where("plugins.pluginId").ne(pluginId));
+        /* Fetch complete details of the workspaces */
+        List<Workspace> workspacesWithNoPlugin = mongockTemplate.find(queryToFetchAllWorkspaces, Workspace.class);
+
+        for (Workspace workspace : workspacesWithNoPlugin) {
 
             if (CollectionUtils.isEmpty(workspace.getPlugins())) {
                 workspace.setPlugins(new HashSet<>());


### PR DESCRIPTION
## Description

> The method currently makes multiple DB calls
> 1) Fetch all workspace ids where the plugin id is not present
> 2) Fetch complete workspace details with these ids (1 query per workspace id)
> 3) Assign plugin and save each workspace

- Does not exactly fix the issue #16762 but does address it partially since the update happens in batches vs 1 by 1. Please check out the comment section to understand more. 

Fixes 

> The fix performs one single update query. The query adds the plugin to all workspaces where the plugin doesn't already exist.
> No data is fetched in java

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

> No tests found in the repo.
> Check if installation of plugin to all workspaces works when there are multiple workspaces and also when there are none.

- When there are no workspaces where the plugin is not installed
- There are multiple workspaces where the plugin is not installed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
