### PR TITLE
fix: remove scroll from container widgets

### DIFF
--- a/app/client/src/widgets/ContainerWidget/widget/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/widget/index.tsx
@@ -64,9 +64,6 @@ class ContainerWidget extends BaseWidget<
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
-            hidden: (props: WidgetProps) =>
-              isDynamicHeightEnabledForWidget(props),
-            dependencies: ["dynamicHeight"],
           },
         ],
       },

--- a/app/client/src/widgets/ContainerWidget/widget/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/widget/index.tsx
@@ -20,6 +20,7 @@ import WidgetsMultiSelectBox from "pages/Editor/WidgetsMultiSelectBox";
 
 import { CanvasDraggingArena } from "pages/common/CanvasArenas/CanvasDraggingArena";
 import { getCanvasSnapRows } from "utils/WidgetPropsUtils";
+import { isDynamicHeightEnabledForWidget } from "widgets/WidgetUtils";
 
 class ContainerWidget extends BaseWidget<
   ContainerWidgetProps<WidgetProps>,
@@ -63,6 +64,9 @@ class ContainerWidget extends BaseWidget<
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
+            hidden: (props: WidgetProps) =>
+              isDynamicHeightEnabledForWidget(props),
+            dependencies: ["dynamicHeight"],
           },
         ],
       },
@@ -149,6 +153,9 @@ class ContainerWidget extends BaseWidget<
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
+            hidden: (props: WidgetProps) =>
+              isDynamicHeightEnabledForWidget(props),
+            dependencies: ["dynamicHeight"],
           },
           {
             propertyName: "animateLoading",

--- a/app/client/src/widgets/ModalWidget/widget/index.tsx
+++ b/app/client/src/widgets/ModalWidget/widget/index.tsx
@@ -112,6 +112,9 @@ export class ModalWidget extends BaseWidget<ModalWidgetProps, WidgetState> {
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
+            hidden: (props: WidgetProps) =>
+              isDynamicHeightEnabledForWidget(props),
+            dependencies: ["dynamicHeight"],
           },
           {
             propertyName: "animateLoading",

--- a/app/client/src/widgets/StatboxWidget/widget/index.tsx
+++ b/app/client/src/widgets/StatboxWidget/widget/index.tsx
@@ -2,6 +2,8 @@ import { WidgetType } from "constants/WidgetConstants";
 import ContainerWidget from "widgets/ContainerWidget";
 
 import { ValidationTypes } from "constants/WidgetValidation";
+import { WidgetProps } from "widgets/BaseWidget";
+import { isDynamicHeightEnabledForWidget } from "widgets/WidgetUtils";
 
 class StatboxWidget extends ContainerWidget {
   static getPropertyPaneConfig() {
@@ -124,6 +126,9 @@ class StatboxWidget extends ContainerWidget {
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
+            hidden: (props: WidgetProps) =>
+              isDynamicHeightEnabledForWidget(props),
+            dependencies: ["dynamicHeight"],
           },
           {
             propertyName: "animateLoading",

--- a/app/client/src/widgets/TabsWidget/widget/index.tsx
+++ b/app/client/src/widgets/TabsWidget/widget/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { find } from "lodash";
 import TabsComponent from "../component";
-import BaseWidget, { WidgetState } from "../../BaseWidget";
+import BaseWidget, { WidgetProps, WidgetState } from "../../BaseWidget";
 import WidgetFactory from "utils/WidgetFactory";
 import {
   ValidationResponse,
@@ -13,6 +13,7 @@ import { AutocompleteDataType } from "utils/autocomplete/TernServer";
 import { WidgetProperties } from "selectors/propertyPaneSelectors";
 import { WIDGET_PADDING } from "constants/WidgetConstants";
 import derivedProperties from "./parseDerivedProperties";
+import { isDynamicHeightEnabledForWidget } from "widgets/WidgetUtils";
 
 export function selectedTabValidation(
   value: unknown,
@@ -143,6 +144,9 @@ class TabsWidget extends BaseWidget<
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
+            hidden: (props: WidgetProps) =>
+              isDynamicHeightEnabledForWidget(props),
+            dependencies: ["dynamicHeight"],
           },
           {
             propertyName: "isVisible",
@@ -329,6 +333,9 @@ class TabsWidget extends BaseWidget<
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
+            hidden: (props: WidgetProps) =>
+              isDynamicHeightEnabledForWidget(props),
+            dependencies: ["dynamicHeight"],
           },
           {
             propertyName: "animateLoading",


### PR DESCRIPTION
Removed scroll contents option in property pane from container widgets when Dynamic Height is enabled.