### PR TITLE
fix: labels switch checkbox widget

### DIFF
--- a/app/client/src/widgets/CheckboxWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxWidget/component/index.tsx
@@ -32,6 +32,7 @@ export const CheckboxLabel = styled.div<{
   labelTextColor?: string;
   labelTextSize?: string;
   labelStyle?: string;
+  isDynamicHeightEnabled?: boolean;
 }>`
   width: 100%;
   display: inline-block;
@@ -47,6 +48,9 @@ export const CheckboxLabel = styled.div<{
     labelStyle?.includes(FontStyleTypes.ITALIC) ? "italic" : "normal"
   };
   `}
+
+  ${({ isDynamicHeightEnabled }) =>
+    isDynamicHeightEnabled ? "&& { word-break: break-all; }" : ""};
 `;
 
 export const StyledCheckbox = Checkbox;
@@ -92,6 +96,7 @@ class CheckboxComponent extends React.Component<CheckboxComponentProps> {
             <CheckboxLabel
               className="t--checkbox-widget-label"
               disabled={this.props.isDisabled}
+              isDynamicHeightEnabled={this.props.isDynamicHeightEnabled}
               labelPosition={this.props.labelPosition}
               labelStyle={this.props.labelStyle}
               labelTextColor={this.props.labelTextColor}

--- a/app/client/src/widgets/SwitchWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/component/index.tsx
@@ -40,6 +40,7 @@ const SwitchLabel = styled.div<{
   labelTextColor?: string;
   labelTextSize?: string;
   labelStyle?: string;
+  isDynamicHeightEnabled?: boolean;
 }>`
   width: 100%;
   display: inline-block;
@@ -53,6 +54,9 @@ const SwitchLabel = styled.div<{
     labelStyle?.includes(FontStyleTypes.ITALIC) ? "italic" : "normal"
   };
   `}
+
+  ${({ isDynamicHeightEnabled }) =>
+    isDynamicHeightEnabled ? "&& { word-break: break-all; }" : ""};
 `;
 
 export const StyledSwitch = styled(Switch)<{
@@ -132,6 +136,7 @@ const SwitchComponent = React.forwardRef<HTMLDivElement, SwitchComponentProps>(
             <SwitchLabel
               className="t--switch-widget-label"
               disabled={isDisabled}
+              isDynamicHeightEnabled={isDynamicHeightEnabled}
               labelPosition={labelPosition}
               labelStyle={labelStyle}
               labelTextColor={labelTextColor}


### PR DESCRIPTION
Word-break CSS rules added for Switch and Checkbox widget when Dynamic Height is enabled.