### PR TITLE
chore: update gitignore with yalc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ deploy/ansible/appsmith_playbook/inventory
 app/client/perf/traces/*
 .history
 stacks
+
+# yalc files
+## This is for integrating design-system changes during development
+app/client/.yalc/
+app/client/yalc.lock


### PR DESCRIPTION
## Description

Ignore `yalc` files when developing; `yalc` helps in integrating design-system changes in development.
