### PR TITLE
fix: Switches mongo field type from dynamic input text to dynamic text

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/find.json
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/resources/editor/find.json
@@ -25,8 +25,7 @@
         {
           "label": "Query",
           "configProperty": "actionConfiguration.formData.find.query.data",
-          "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
-          "inputType": "JSON",
+          "controlType": "QUERY_DYNAMIC_TEXT",
           "evaluationSubstitutionType": "TEMPLATE",
           "placeholderText": "{rating : {$gte : 9}}"
         },


### PR DESCRIPTION
This PR increases the size of MongoDB's Query field by changing the Query field form control to `QUERY_DYNAMIC_TEXT`.

Fixes #17265 

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
