### PR TITLE
feat: InputTextControl enhanement

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -182,6 +182,10 @@ export type EditorProps = EditorStyleProps &
     containerHeight?: number;
     // Custom gutter
     customGutter?: CodeEditorGutter;
+
+    // On focus and blur event handler
+    onEditorBlur?: () => void;
+    onEditorFocus?: () => void;
   };
 
 interface Props extends ReduxStateProps, EditorProps, ReduxDispatchProps {}
@@ -547,6 +551,10 @@ class CodeEditor extends Component<Props, State> {
             hinter.showHint(cm, entityInformation, blockCompletions),
         );
     }
+
+    if (this.props.onEditorFocus) {
+      this.props.onEditorFocus();
+    }
   };
 
   handleEditorBlur = () => {
@@ -554,6 +562,10 @@ class CodeEditor extends Component<Props, State> {
     this.setState({ isFocused: false });
     this.editor.setOption("matchBrackets", false);
     this.handleCustomGutter(null);
+
+    if (this.props.onEditorBlur) {
+      this.props.onEditorBlur();
+    }
   };
 
   handleBeforeChange = (

--- a/app/client/src/components/propertyControls/InputTextControl.tsx
+++ b/app/client/src/components/propertyControls/InputTextControl.tsx
@@ -16,7 +16,9 @@ import CodeEditor from "../editorComponents/LazyCodeEditorWrapper";
 export function InputText(props: {
   label: string;
   value: string;
+  onBlur?: () => void;
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement> | string) => void;
+  onFocus?: () => void;
   evaluatedValue?: any;
   expected?: CodeEditorExpected;
   placeholder?: string;
@@ -30,7 +32,9 @@ export function InputText(props: {
     evaluatedValue,
     expected,
     hideEvaluatedValue,
+    onBlur,
     onChange,
+    onFocus,
     placeholder,
     value,
   } = props;
@@ -54,6 +58,8 @@ export function InputText(props: {
         }}
         isEditorHidden={!isOpen}
         mode={EditorModes.TEXT_WITH_BINDING}
+        onEditorBlur={onBlur}
+        onEditorFocus={onFocus}
         placeholder={placeholder}
         size={EditorSize.EXTENDED}
         tabBehaviour={TabBehaviour.INDENT}
@@ -72,6 +78,8 @@ class InputTextControl extends BaseControl<InputControlProps> {
       expected,
       hideEvaluatedValue,
       label,
+      onBlur,
+      onFocus,
       placeholderText,
       propertyValue,
     } = this.props;
@@ -83,7 +91,9 @@ class InputTextControl extends BaseControl<InputControlProps> {
         expected={expected}
         hideEvaluatedValue={hideEvaluatedValue}
         label={label}
+        onBlur={onBlur}
         onChange={this.onTextChange}
+        onFocus={onFocus}
         placeholder={placeholderText}
         theme={this.props.theme}
         value={propertyValue !== undefined ? propertyValue : defaultValue}
@@ -123,6 +133,8 @@ export interface InputControlProps extends ControlProps {
   validationMessage?: string;
   isDisabled?: boolean;
   defaultValue?: any;
+  onFocus?: () => void;
+  onBlur?: () => void;
 }
 
 export default InputTextControl;


### PR DESCRIPTION
Enhanced the InputTextControl to accept two more event handlers for focus and blur from the property pane config.
Now for any widget `INPUT_TEXT` control in it's property pane config can accept two more properties called `onBlur` and `onFocus` which will respond to focus and blur events from the field in the property pane.