### PR TITLE
feat: wrap widgets into a component which listens to content height changes

### DIFF
--- a/app/client/src/components/dynamicHeight/DynamicHeightContainer.tsx
+++ b/app/client/src/components/dynamicHeight/DynamicHeightContainer.tsx
@@ -1,0 +1,74 @@
+import React, { PropsWithChildren, useRef, useState } from "react";
+import { GridDefaults } from "constants/WidgetConstants";
+import styled from "styled-components";
+import { DynamicHeight } from "utils/WidgetFeatures";
+
+const StyledDynamicHeightContainer = styled.div<{ isOverflow?: boolean }>`
+  overflow-y: ${(props) => (props.isOverflow ? "auto" : "unset")};
+  overflow-x: ${(props) => (props.isOverflow ? "hidden" : "unset")};
+`;
+
+interface DynamicHeightContainerProps {
+  maxDynamicHeight: number;
+  dynamicHeight: string;
+}
+
+function WithLimitsContainer({
+  children,
+  maxDynamicHeight,
+}: PropsWithChildren<{ maxDynamicHeight: number }>) {
+  const [expectedHeight, setExpectedHeight] = useState(0);
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const observer = React.useRef(
+    new ResizeObserver((entries) => {
+      setExpectedHeight(entries[0].contentRect.height);
+    }),
+  );
+
+  React.useEffect(() => {
+    if (ref.current) {
+      observer.current.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.current.unobserve(ref.current);
+      }
+    };
+  }, [observer]);
+
+  const expectedHeightInRows = Math.ceil(
+    expectedHeight / GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+  );
+
+  return (
+    <StyledDynamicHeightContainer
+      isOverflow={maxDynamicHeight < expectedHeightInRows}
+    >
+      <div ref={ref} style={{ height: "auto" }}>
+        {children}
+      </div>
+    </StyledDynamicHeightContainer>
+  );
+}
+
+export default function DynamicHeightContainer({
+  children,
+  dynamicHeight,
+  maxDynamicHeight,
+}: PropsWithChildren<DynamicHeightContainerProps>) {
+  const isAutoHeightWithLimits =
+    dynamicHeight === DynamicHeight.AUTO_HEIGHT_WITH_LIMITS;
+
+  if (isAutoHeightWithLimits) {
+    return (
+      <WithLimitsContainer maxDynamicHeight={maxDynamicHeight}>
+        {children}
+      </WithLimitsContainer>
+    );
+  }
+
+  return <div style={{ height: "auto" }}>{children}</div>;
+}

--- a/app/client/src/utils/WidgetFeatures.ts
+++ b/app/client/src/utils/WidgetFeatures.ts
@@ -6,8 +6,9 @@ export interface WidgetFeatures {
 }
 
 export enum DynamicHeight {
-  HUG_CONTENTS = "HUG_CONTENTS",
+  AUTO_HEIGHT = "AUTO_HEIGHT",
   FIXED = "FIXED",
+  AUTO_HEIGHT_WITH_LIMITS = "AUTO_HEIGHT_WITH_LIMITS",
 }
 
 /* This contains all properties which will be added 

--- a/app/client/src/widgets/BaseWidget.tsx
+++ b/app/client/src/widgets/BaseWidget.tsx
@@ -37,6 +37,7 @@ import PreviewModeComponent from "components/editorComponents/PreviewModeCompone
 import { CanvasWidgetStructure } from "./constants";
 import { DataTreeWidget } from "entities/DataTree/dataTreeFactory";
 import Skeleton from "./Skeleton";
+import DynamicHeightContainer from "components/dynamicHeight/DynamicHeightContainer";
 
 /***
  * BaseWidget
@@ -347,6 +348,17 @@ abstract class BaseWidget<
     return renderMode === RenderModes.CANVAS
       ? this.getCanvasView()
       : this.getPageView();
+  };
+
+  addDynamicHeightContainer = (content: ReactNode) => {
+    return (
+      <DynamicHeightContainer
+        dynamicHeight={this.props.dynamicHeight}
+        maxDynamicHeight={this.props.maxDynamicHeight}
+      >
+        {content}
+      </DynamicHeightContainer>
+    );
   };
 
   private getWidgetView(): ReactNode {


### PR DESCRIPTION
Added a new editor component for abstracting the whole dynamic height events in a container component.
This component will be inserted in the DOM tree of a widget just after the widget's own component tree. This component uses `ResizeObserver` API for listening to the height updates in a widget. How much widget wants to grow in height, this component receives events for that and further passes on to the `updateDynamicHeight` redux action.