### PR TITLE
feat: Resize Image option in Table Widget v2

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/Constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/component/Constants.ts
@@ -36,9 +36,9 @@ export enum VerticalAlignmentTypes {
 }
 
 export enum ImageSizes {
-  DEFAULT = "32",
-  MEDIUM = "64",
-  LARGE = "128",
+  DEFAULT = "32px",
+  MEDIUM = "64px",
+  LARGE = "128px",
 }
 
 export const TABLE_SIZES: { [key: string]: TableSizes } = {

--- a/app/client/src/widgets/TableWidgetV2/component/Constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/component/Constants.ts
@@ -35,6 +35,12 @@ export enum VerticalAlignmentTypes {
   CENTER = "CENTER",
 }
 
+export enum ImageSizes {
+  DEFAULT = "32",
+  MEDIUM = "64",
+  LARGE = "128",
+}
+
 export const TABLE_SIZES: { [key: string]: TableSizes } = {
   [CompactModeTypes.DEFAULT]: {
     COLUMN_HEADER_HEIGHT: 32,
@@ -86,6 +92,7 @@ export type Condition = keyof typeof ConditionFunctions | "";
 export type Operator = keyof typeof OperatorTypes;
 export type CellAlignment = keyof typeof CellAlignmentTypes;
 export type VerticalAlignment = keyof typeof VerticalAlignmentTypes;
+export type ImageSize = keyof typeof ImageSizes;
 
 export interface ReactTableFilter {
   column: string;
@@ -138,6 +145,7 @@ export interface CellLayoutProperties {
   discardActionIconName?: IconName;
   isDiscardVisible?: boolean;
   isDiscardDisabled?: boolean;
+  imageSize: ImageSize;
 }
 
 export type MenuItems = Record<
@@ -274,6 +282,7 @@ export interface ColumnProperties
   iconAlign?: Alignment;
   onItemClicked?: (onClick: string | undefined) => void;
   iconButtonStyle?: ButtonStyleType;
+  imageSize?: ImageSize;
 }
 
 export const ConditionFunctions: {
@@ -371,15 +380,15 @@ export enum ALIGN_ITEMS {
 }
 
 export enum IMAGE_HORIZONTAL_ALIGN {
-  LEFT = "left",
+  LEFT = "flex-start",
   CENTER = "center",
-  RIGHT = "right",
+  RIGHT = "flex-end",
 }
 
 export enum IMAGE_VERTICAL_ALIGN {
-  TOP = "top",
+  TOP = "flex-start",
   CENTER = "center",
-  BOTTOM = "bottom",
+  BOTTOM = "flex-end",
 }
 
 export type BaseCellComponentProps = {
@@ -393,6 +402,7 @@ export type BaseCellComponentProps = {
   fontStyle?: string;
   textColor?: string;
   textSize?: string;
+  imageSize?: ImageSize;
 };
 
 export enum CheckboxState {

--- a/app/client/src/widgets/TableWidgetV2/component/Table.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/Table.tsx
@@ -21,6 +21,7 @@ import {
   TABLE_SIZES,
   CompactMode,
   CompactModeTypes,
+  ImageSize,
 } from "./Constants";
 import { Colors } from "constants/Colors";
 
@@ -85,6 +86,7 @@ interface TableProps {
   boxShadow?: string;
   onBulkEditDiscard: () => void;
   onBulkEditSave: () => void;
+  imageSize?: ImageSize;
 }
 
 const defaultColumn = {

--- a/app/client/src/widgets/TableWidgetV2/component/TableStyledWrappers.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/TableStyledWrappers.tsx
@@ -390,7 +390,7 @@ export const CellWrapper = styled.div<{
   .image-cell {
     // width: 100%;
     height: ${(props) =>
-      props.imageSize ? `${ImageSizes[props.imageSize]}px` : "64px"};
+      props.imageSize ? ImageSizes[props.imageSize] : ImageSizes.DEFAULT};
     margin: 0 5px 0 0;
     ${BORDER_RADIUS}
     object-fit: contain;

--- a/app/client/src/widgets/TableWidgetV2/component/TableStyledWrappers.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/TableStyledWrappers.tsx
@@ -11,6 +11,8 @@ import {
   CellAlignment,
   VerticalAlignment,
   scrollbarOnHoverCSS,
+  ImageSize,
+  ImageSizes,
 } from "./Constants";
 import { Colors, Color } from "constants/Colors";
 import { hideScrollbar, invisible } from "constants/DefaultTheme";
@@ -330,6 +332,7 @@ export const CellWrapper = styled.div<{
   textColor?: string;
   cellBackground?: string;
   textSize?: string;
+  imageSize?: ImageSize;
 }>`
   display: ${(props) => (props.isCellVisible !== false ? "flex" : "none")};
   align-items: center;
@@ -356,7 +359,7 @@ export const CellWrapper = styled.div<{
   font-size: ${(props) => props.textSize};
 
   padding: ${(props) =>
-    props.compactMode ? TABLE_SIZES[props.compactMode].VERTICAL_PADDING : 0}px
+      props.compactMode ? TABLE_SIZES[props.compactMode].VERTICAL_PADDING : 0}px
     10px;
   line-height: ${CELL_WRAPPER_LINE_HEIGHT}px;
   .${Classes.POPOVER_WRAPPER} {
@@ -377,19 +380,20 @@ export const CellWrapper = styled.div<{
   .image-cell-wrapper {
     width: 100%;
     height: 100%;
-  }
-  .image-cell {
-    width: 100%;
-    height: 100%;
-    margin: 0 5px 0 0;
-    ${BORDER_RADIUS}
-    background-position-x: ${(props) =>
+    display: flex;
+    align-items: ${(props) =>
+      props.verticalAlignment && IMAGE_VERTICAL_ALIGN[props.verticalAlignment]};
+    justify-content: ${(props) =>
       props.horizontalAlignment &&
       IMAGE_HORIZONTAL_ALIGN[props.horizontalAlignment]};
-    background-position-y: ${(props) =>
-      props.verticalAlignment && IMAGE_VERTICAL_ALIGN[props.verticalAlignment]};
-    background-repeat: no-repeat;
-    background-size: contain;
+  }
+  .image-cell {
+    // width: 100%;
+    height: ${(props) =>
+      props.imageSize ? `${ImageSizes[props.imageSize]}px` : "64px"};
+    margin: 0 5px 0 0;
+    ${BORDER_RADIUS}
+    object-fit: contain;
   }
   video {
     ${BORDER_RADIUS}

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/ImageCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/ImageCell.tsx
@@ -42,6 +42,7 @@ export function ImageCell(props: renderImageType) {
     fontStyle,
     textColor,
     textSize,
+    imageSize,
   } = props;
 
   if (!value) {
@@ -52,6 +53,7 @@ export function ImageCell(props: renderImageType) {
         compactMode={compactMode}
         fontStyle={fontStyle}
         horizontalAlignment={horizontalAlignment}
+        imageSize={imageSize}
         isCellVisible={isCellVisible}
         isHidden={isHidden}
         textColor={textColor}
@@ -67,6 +69,7 @@ export function ImageCell(props: renderImageType) {
         compactMode={compactMode}
         fontStyle={fontStyle}
         horizontalAlignment={horizontalAlignment}
+        imageSize={imageSize}
         isCellVisible={isCellVisible}
         isHidden={isHidden}
         textColor={textColor}
@@ -87,6 +90,7 @@ export function ImageCell(props: renderImageType) {
       compactMode={compactMode}
       fontStyle={fontStyle}
       horizontalAlignment={horizontalAlignment}
+      imageSize={imageSize}
       isCellVisible={isCellVisible}
       isHidden={isHidden}
       textColor={textColor}
@@ -104,10 +108,7 @@ export function ImageCell(props: renderImageType) {
                 onClick();
               }}
             >
-              <div
-                className="image-cell"
-                style={{ backgroundImage: `url("${item}")` }}
-              />
+              <img className="image-cell" src={item} />
             </div>
           );
         } else {

--- a/app/client/src/widgets/TableWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import Table from "./Table";
 import {
   CompactMode,
+  ImageSize,
   ReactTableColumnProps,
   ReactTableFilter,
 } from "./Constants";
@@ -83,6 +84,7 @@ interface ReactTableComponentProps {
   borderRadius: string;
   boxShadow?: string;
   isEditableCellValid?: boolean;
+  imageSize?: ImageSize;
 }
 
 function ReactTableComponent(props: ReactTableComponentProps) {
@@ -99,6 +101,7 @@ function ReactTableComponent(props: ReactTableComponentProps) {
     handleReorderColumn,
     handleResizeColumn,
     height,
+    imageSize,
     isLoading,
     isSortable,
     isVisibleDownload,
@@ -280,6 +283,7 @@ function ReactTableComponent(props: ReactTableComponentProps) {
       filters={filters}
       handleResizeColumn={handleResizeColumn}
       height={height}
+      imageSize={imageSize}
       isLoading={isLoading}
       isSortable={isSortable}
       isVisibleDownload={isVisibleDownload}

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -1456,6 +1456,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
             compactMode={compactMode}
             fontStyle={cellProperties.fontStyle}
             horizontalAlignment={cellProperties.horizontalAlignment}
+            imageSize={cellProperties.imageSize}
             isCellVisible={cellProperties.isCellVisible ?? true}
             isHidden={isHidden}
             isSelected={isSelected}

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/General.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/General.ts
@@ -136,6 +136,33 @@ export default {
         return !isColumnTypeEditable(columnType) || isDerived;
       },
     },
+    {
+      propertyName: "imageSize",
+      dependencies: ["primaryColumns", "columnType"],
+      label: "Image Size",
+      defaultValue: "DEFAULT",
+      controlType: "DROP_DOWN",
+      options: [
+        {
+          label: "Default",
+          value: "DEFAULT",
+        },
+        {
+          label: "Medium",
+          value: "MEDIUM",
+        },
+        {
+          label: "Large",
+          value: "LARGE",
+        },
+      ],
+      isBindProperty: false,
+      isTriggerProperty: false,
+      validation: { type: ValidationTypes.TEXT },
+      hidden: (props: TableWidgetProps, propertyPath: string) => {
+        return hideByColumnType(props, propertyPath, [ColumnTypes.IMAGE]);
+      },
+    },
   ],
 };
 

--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
@@ -420,6 +420,7 @@ export const getCellProperties = (
         columnProperties.isDiscardDisabled,
         rowIndex,
       ),
+      imageSize: getPropertyValue(columnProperties.imageSize, rowIndex, true),
     } as CellLayoutProperties;
   }
   return {} as CellLayoutProperties;


### PR DESCRIPTION
## Description
Introduces Image Resize option under column settings for Image type columns.

Note:

- Default Row Height property (in Style tab for Table widget) does not clash with this feature
- When cell wrapping is turned on for a column then the final row height will be the bigger one among Image height and Wrapped cell height
- On reducing column width of an image column, the image covers all available width of the column while maintaining the aspect ratio

Fixes #9815 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Cypress tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
