### PR TITLE
fix: Added null check for action dependency edge

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ActionDependencyEdge.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/ActionDependencyEdge.java
@@ -4,13 +4,11 @@ import com.appsmith.external.models.EntityDependencyNode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 @Getter
 @Setter
-@ToString
 @AllArgsConstructor
 public class ActionDependencyEdge {
 
@@ -19,6 +17,10 @@ public class ActionDependencyEdge {
 
     @Override
     public int hashCode() {
+        if (sourceNode == null || targetNode == null) {
+            return 0;
+        }
+
         return new HashCodeBuilder()
                 .append(sourceNode.getReferenceString())
                 .append(targetNode.getReferenceString())
@@ -29,6 +31,10 @@ public class ActionDependencyEdge {
     public boolean equals(Object obj) {
         if (obj instanceof ActionDependencyEdge) {
             final ActionDependencyEdge actionDependencyEdge = (ActionDependencyEdge) obj;
+
+            if (sourceNode == null || targetNode == null || actionDependencyEdge.sourceNode == null || actionDependencyEdge.targetNode == null) {
+                return false;
+            }
 
             return new EqualsBuilder()
                     .append(sourceNode.getReferenceString(), actionDependencyEdge.sourceNode.getReferenceString())
@@ -41,6 +47,9 @@ public class ActionDependencyEdge {
 
     @Override
     public String toString() {
+        if (sourceNode == null || targetNode == null) {
+            return "";
+        }
         return sourceNode.getReferenceString() + " : " + targetNode.getReferenceString();
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
@@ -222,7 +222,8 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
                         }
                     }
                     return Mono.just(application);
-                }).flatMap(application -> {
+                })
+                .flatMap(application -> {
                     if (markApplicationAsRecentlyAccessed) {
                         // add this application and workspace id to the recently used list in UserData
                         return userDataService.updateLastUsedAppAndWorkspaceList(application)
@@ -581,8 +582,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
             return findApplicationPagesByApplicationIdViewModeAndBranch(applicationId, branchName, isViewMode, true);
         } else if (StringUtils.hasLength(pageId)) {
             return findRootApplicationIdFromNewPage(branchName, pageId)
-                    .flatMap(rootApplicationId -> findApplicationPagesByApplicationIdViewModeAndBranch(rootApplicationId, branchName, isViewMode, true))
-                    ;
+                    .flatMap(rootApplicationId -> findApplicationPagesByApplicationIdViewModeAndBranch(rootApplicationId, branchName, isViewMode, true));
         } else {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.APPLICATION_ID + " or " + FieldName.PAGE_ID));
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImpl.java
@@ -264,6 +264,10 @@ public class RefactoringSolutionCEImpl implements RefactoringSolutionCE {
                 });
     }
 
+    JSONObject refactorNameInDsl(JSONObject dsl, String oldName, String newName) {
+
+        return dsl;
+    }
 
     private JsonNode replaceStringInJsonNode(JsonNode jsonNode, Pattern oldNamePattern, String newName) {
         // If this is a text node, perform replacement directly

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImpl.java
@@ -264,10 +264,6 @@ public class RefactoringSolutionCEImpl implements RefactoringSolutionCE {
                 });
     }
 
-    JSONObject refactorNameInDsl(JSONObject dsl, String oldName, String newName) {
-
-        return dsl;
-    }
 
     private JsonNode replaceStringInJsonNode(JsonNode jsonNode, Pattern oldNamePattern, String newName) {
         // If this is a text node, perform replacement directly


### PR DESCRIPTION
Since the older way of storing on load actions does not conform to the new type, this PR adds null checks to simply ignore all of the older values. These values are not used today and will be overridden as soon as an update layout is performed on the page, so they are inconsequential.

Fixes #17494 