### PR TITLE
fix: App Version issue where the app was getting reset to old url after the template was merged to existing application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -2022,7 +2022,6 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
             // setting some properties to null so that target application is not updated by these properties
             applicationJson.getExportedApplication().setName(null);
             applicationJson.getExportedApplication().setSlug(null);
-            applicationJson.getExportedApplication().setApplicationVersion(null);
             applicationJson.getExportedApplication().setForkingEnabled(null);
             applicationJson.getExportedApplication().setClonedFromApplicationId(null);
         }


### PR DESCRIPTION

## Description

> When a template is imported. The app is reset to the old URL format. Because the applicationVersion is reset to 1. This currently breaks deployed apps.

Fixes #17428 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
