### PR TITLE
fix: Ends with operator not working as expected

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV1/TableFilter2_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV1/TableFilter2_Spec.ts
@@ -359,7 +359,7 @@ describe("Verify various Table_Filter combinations", function() {
     filterOnlyCondition("starts with", "1");
 
     //Ends with - Open Bug 13334
-    //filterOnlyCondition('ends with', '1')
+    filterOnlyCondition("ends with", "1");
 
     filterOnlyCondition("is exactly", "1");
     filterOnlyCondition("empty", "0");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV2/TableV2Filter2_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/TableV2/TableV2Filter2_Spec.ts
@@ -366,8 +366,8 @@ describe("Verify various Table_Filter combinations", function() {
     filterOnlyCondition("does not contain", "49");
     filterOnlyCondition("starts with", "1");
 
-    //Ends with - Open Bug 13334
-    //filterOnlyCondition('ends with', '1')
+    // Ends with - Open Bug 13334
+    filterOnlyCondition("ends with", "1");
 
     filterOnlyCondition("is exactly", "1");
     filterOnlyCondition("empty", "0");

--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -444,9 +444,10 @@ export default {
         try {
           const _a = a.toString().toLowerCase();
           const _b = b.toString().toLowerCase();
-          return _a.lastIndexOf(_b) >= 0
-            ? _a.length === _a.lastIndexOf(_b) + _b.length
-            : false;
+          return (
+            _a.lastIndexOf(_b) >= 0 &&
+            _a.length === _a.lastIndexOf(_b) + _b.length
+          );
         } catch (e) {
           return false;
         }

--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -444,8 +444,9 @@ export default {
         try {
           const _a = a.toString().toLowerCase();
           const _b = b.toString().toLowerCase();
-
-          return _a.length === _a.lastIndexOf(_b) + _b.length;
+          return _a.lastIndexOf(_b) >= 0
+            ? _a.length === _a.lastIndexOf(_b) + _b.length
+            : false;
         } catch (e) {
           return false;
         }


### PR DESCRIPTION
## Description

Ends with operator not working in certain scenarios.
Here the issue is that we are using `lastIndexOf` without considering the edge case where this method might return a `-1`. When `lastIndexOf` returns -1 the condition for endsWith operation returns true for certain string lengths where it should have returned false.

Handled this by updating the endsWith checking logic.

Fixes #13334 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Cypress tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
