### PR TITLE
fix: Incorrect page count when number of records in page is different from page size

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/Table.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/Table.tsx
@@ -136,7 +136,13 @@ export function Table(props: TableProps) {
   );
   const pageCount =
     props.serverSidePaginationEnabled && props.totalRecordsCount
-      ? Math.ceil(props.totalRecordsCount / props.pageSize)
+      ? /*
+      For serverSidePaginationEnabled we are taking props.data.length as the page size.
+      As props.pageSize is being set by the visible number of rows in the table (without scrolling),
+      it will not give the correct count of records in the current page when query limit
+      is set higher/lower than the visible number of rows in the table
+    */
+        Math.ceil(props.totalRecordsCount / props.data.length)
       : Math.ceil(props.data.length / props.pageSize);
   const currentPageIndex = props.pageNo < pageCount ? props.pageNo : 0;
   const {


### PR DESCRIPTION
## Description

Total page count is incorrect when no. of records in a page is different from the visual page size of a table.

This is happening because we are calculating the total page count based on the page size of the table. The page size is calculated from the number of rows visible in the table without scrolling.

Fixed this by taking page size as the number of records in the current page.

Fixes #17187 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
