### PR TITLE
fix: Fix assets not loading in supervisor UI

### DIFF
--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -74,7 +74,7 @@ server {
   }
 
   # If the path has an extension at the end, then respond with 404 status if the file not found.
-  location ~ \.[a-z]+$ {
+  location ~ ^/(?!supervisor/).*\.[a-z]+$ {
     try_files \$uri =404;
   }
 

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -91,7 +91,7 @@ server {
   }
 
   # If the path has an extension at the end, then respond with 404 status if the file not found.
-  location ~ \.[a-z]+$ {
+  location ~ ^/(?!supervisor/).*\.[a-z]+$ {
     try_files \$uri =404;
   }
 


### PR DESCRIPTION
Currently, supervisor UI shows up like this:

![Screenshot 2022-10-14 at 07 19 06](https://user-images.githubusercontent.com/120119/195743502-76d4173f-0f1a-4630-95e6-ea3902443d8e.png)

Instead of showing up as illustrated in the Documentation here: https://docs.appsmith.com/getting-started/setup/instance-management/supervisor.

This PR fixes that.


<img src="https://front.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_5akek)