### PR TITLE
chore: Updating the tenant API to return the complete object instead of just the configuration

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DataUtils.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 
 public class DataUtils {
 
-    public  static String FIELD_API_CONTENT_TYPE = "apiContentType";
+    public static String FIELD_API_CONTENT_TYPE = "apiContentType";
 
     private final ObjectMapper objectMapper;
 
@@ -194,12 +194,6 @@ public class DataUtils {
                                         }
                                     } catch (JsonProcessingException e) {
                                         bodyBuilder.part(key, value);
-                                    } catch (IOException e) {
-                                        e.printStackTrace();
-                                        throw new AppsmithPluginException(
-                                                AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
-                                                "Unable to parse content. Expected to receive an array or object of multipart data"
-                                        );
                                     }
                                 } else {
                                     bodyBuilder.part(key, property.getValue());
@@ -290,7 +284,7 @@ public class DataUtils {
     }
 
     public Object getRequestBodyObject(ActionConfiguration actionConfiguration, String reqContentType,
-                                              boolean encodeParamsToggle, HttpMethod httpMethod) {
+                                       boolean encodeParamsToggle, HttpMethod httpMethod) {
         // We initialize this object to an empty string because body can never be empty
         // Based on the content-type, this Object may be of type MultiValueMap or String
         Object requestBodyObj = "";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/TenantControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/TenantControllerCE.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.controllers.ce;
 
 import com.appsmith.server.constants.Url;
+import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.domains.TenantConfiguration;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.services.TenantService;
@@ -30,7 +31,7 @@ public class TenantControllerCE {
      * @return
      */
     @GetMapping("/current")
-    public Mono<ResponseDTO<TenantConfiguration>> getTenantConfig() {
+    public Mono<ResponseDTO<Tenant>> getTenantConfig() {
         return service.getTenantConfiguration()
                 .map(resource -> new ResponseDTO<>(HttpStatus.OK.value(), resource, null));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCE.java
@@ -18,5 +18,5 @@ public interface TenantServiceCE extends CrudService<Tenant, String> {
      *  For now, returning an empty tenantConfiguration object in this class. Will enhance this function once we
      *  start saving other pertinent environment variables in the tenant collection
      */
-    Mono<TenantConfiguration> getTenantConfiguration();
+    Mono<Tenant> getTenantConfiguration();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
@@ -76,7 +76,7 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
      *  start saving other pertinent environment variables in the tenant collection
      */
     @Override
-    public Mono<TenantConfiguration> getTenantConfiguration() {
-        return Mono.just(new TenantConfiguration());
+    public Mono<Tenant> getTenantConfiguration() {
+        return Mono.just(new Tenant());
     }
 }


### PR DESCRIPTION
## Description

Return the tenant object so that the `userPermissions` are part of the object.
## Type of change

- New feature (non-breaking change which adds functionality)
- 
## How Has This Been Tested?

- Manual

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
