### PR TITLE
fix: JS option missing for Label Font Style in Input widget

### DIFF
--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -342,7 +342,7 @@ class BaseInputWidget<
                 value: "ITALIC",
               },
             ],
-            isJSConvertible: true,
+
             isBindProperty: false,
             isTriggerProperty: false,
             validation: { type: ValidationTypes.TEXT },

--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -343,7 +343,7 @@ class BaseInputWidget<
               },
             ],
             isJSConvertible: true,
-            isBindProperty: false,
+            isBindProperty: true,
             isTriggerProperty: false,
             validation: { type: ValidationTypes.TEXT },
           },

--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -342,7 +342,7 @@ class BaseInputWidget<
                 value: "ITALIC",
               },
             ],
-
+            isJSConvertible: true,
             isBindProperty: false,
             isTriggerProperty: false,
             validation: { type: ValidationTypes.TEXT },

--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -342,6 +342,7 @@ class BaseInputWidget<
                 value: "ITALIC",
               },
             ],
+            isJSConvertible: true,
             isBindProperty: false,
             isTriggerProperty: false,
             validation: { type: ValidationTypes.TEXT },


### PR DESCRIPTION
## Description

> Made changes to baseinputwidget label style - Emphasis Property
Fixes #15542 


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

This has been tested locally on my Computer

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
