### PR TITLE
fix: remove file references on click of cancel button

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Filepicker/FilePickerV2_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Filepicker/FilePickerV2_spec.js
@@ -55,4 +55,18 @@ describe("File picker widget v2", () => {
     );
     cy.get(".t--widget-textwidget").should("contain", "testFile.mov");
   });
+
+  it("Check if the uploaded file is removed on click of cancel button", () => {
+    cy.get(widgetsPage.filepickerwidgetv2).click();
+    cy.get(widgetsPage.filepickerwidgetv2CancelBtn).click();
+    cy.get(widgetsPage.filepickerwidgetv2).should("contain", "Select Files");
+    cy.get(widgetsPage.filepickerwidgetv2CloseModalBtn).click();
+    cy.get(widgetsPage.explorerSwitchId).click();
+    cy.get(".t--entity-item:contains(Api1)").click();
+    cy.get("[class*='t--actionConfiguration']")
+      .eq(0)
+      .click();
+    cy.wait(1000);
+    cy.validateEvaluatedValue("[]");
+  });
 });

--- a/app/client/cypress/locators/Widgets.json
+++ b/app/client/cypress/locators/Widgets.json
@@ -191,5 +191,7 @@
     "colorPickerV2Color": ".t--colorpicker-v2-color",
     "modalCloseButton": ".t--draggable-iconbuttonwidget .bp3-button",
     "filepickerwidgetv2": ".t--widget-filepickerwidgetv2",
+    "filepickerwidgetv2CancelBtn": "button.uppy-DashboardContent-back",
+    "filepickerwidgetv2CloseModalBtn": "button.uppy-Dashboard-close",
     "codescannerwidget": ".t--widget-codescannerwidget"
 }

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -568,6 +568,7 @@ class FilePickerWidget extends BaseWidget<
         showLinkToFileUploadResult: true,
         showProgressDetails: false,
         hideUploadButton: false,
+        hideCancelButton: true,
         hideProgressAfterFinish: false,
         note: null,
         closeAfterFinish: true,

--- a/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/FilePickerWidgetV2/widget/index.tsx
@@ -205,8 +205,11 @@ class FilePickerWidget extends BaseWidget<
   FilePickerWidgetProps,
   FilePickerWidgetState
 > {
+  private isWidgetUnmounting: boolean;
+
   constructor(props: FilePickerWidgetProps) {
     super(props);
+    this.isWidgetUnmounting = false;
     this.state = {
       isLoading: false,
       uppy: this.initializeUppy(),
@@ -568,7 +571,6 @@ class FilePickerWidget extends BaseWidget<
         showLinkToFileUploadResult: true,
         showProgressDetails: false,
         hideUploadButton: false,
-        hideCancelButton: true,
         hideProgressAfterFinish: false,
         note: null,
         closeAfterFinish: true,
@@ -637,6 +639,10 @@ class FilePickerWidget extends BaseWidget<
           "selectedFiles",
           updatedFiles ?? [],
         );
+      }
+
+      if (reason === "cancel-all" && !this.isWidgetUnmounting) {
+        this.props.updateWidgetMetaProperty("selectedFiles", []);
       }
     });
 
@@ -797,6 +803,7 @@ class FilePickerWidget extends BaseWidget<
   }
 
   componentWillUnmount() {
+    this.isWidgetUnmounting = true;
     this.state.uppy.close();
   }
 


### PR DESCRIPTION
## Description

To remove the `selectedFiles` meta property whenever the cancel button is clicked. This will make sure to remove the files from the redux store and also from the uppy's instance. 

Fixes #17659

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Updated the `FilePickerV2_spec.js` with the following scenario:

- Click on cancel button
- Check the file picker button for the file count text. Since all files are deleted the text inside the file picker button becomes "Select Files"
- Check the API page and check the evaluated value inside the binding


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
