### PR TITLE
fix: ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String 

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/PluginUtils.java
@@ -224,6 +224,10 @@ public class PluginUtils {
 
     }
 
+    public static String getValueSafelyFromFormDataAsString(Map<String, Object> formData, String field) {
+        return String.valueOf(getValueSafelyFromFormData(formData, field));
+    }
+
     public static void setDataValueSafelyInFormData(Map<String, Object> formData, String field, Object value) {
 
         // In case the formData has not been initialized before the fxn call, assign a new HashMap to the variable

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/PluginUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/PluginUtilsTest.java
@@ -4,6 +4,9 @@ import com.appsmith.external.constants.ConditionalOperator;
 import com.appsmith.external.models.Condition;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,8 +19,10 @@ import static com.appsmith.external.helpers.PluginUtils.STRING_TYPE;
 import static com.appsmith.external.helpers.PluginUtils.parseWhereClause;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Slf4j
 public class PluginUtilsTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -173,6 +178,29 @@ public class PluginUtilsTest {
 
         assertEquals(Map.of("k", "value"), data);
     }
+    
+
+    @Test
+    public void testGetValueSafelyInFormData_IncorrectParsingByCaller() {
+        final Map<String, Object> dataMap = Map.of("k", 1);
+
+        final Object data = PluginUtils.getValueSafelyFromFormData(dataMap, "k");
+
+        assertThrows(ClassCastException.class, () -> {
+            String result = (String) data;
+            log.info("Value of key : k as String casted from Integer is", result);
+        });
+    }
+
+    @Test
+    public void testGetValueSafelyInFormDataAsString() {
+        final Map<String, Object> dataMap = Map.of("k", 1);
+
+        final Object data = PluginUtils.getValueSafelyFromFormDataAsString(dataMap, "k");
+
+        String result = (String) data;
+        assertTrue(result instanceof String);
+    }
 
     @Test
     public void testSetDataValueSafelyInFormData_withNestedPath_createsInnermostDataKey() {
@@ -182,4 +210,5 @@ public class PluginUtilsTest {
 
         assertEquals(Map.of("key", Map.of("innerKey", Map.of("data", "value"))), dataMap);
     }
+
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/PluginUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/PluginUtilsTest.java
@@ -188,7 +188,6 @@ public class PluginUtilsTest {
 
         assertThrows(ClassCastException.class, () -> {
             String result = (String) data;
-            log.info("Value of key : k as String casted from Integer is", result);
         });
     }
 

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/config/MethodConfig.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 import static com.appsmith.external.helpers.PluginUtils.STRING_TYPE;
 import static com.appsmith.external.helpers.PluginUtils.getDataValueSafelyFromFormData;
 import static com.appsmith.external.helpers.PluginUtils.getTrimmedStringDataValueSafelyFromFormData;
-import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromFormData;
+import static com.appsmith.external.helpers.PluginUtils.getValueSafelyFromFormDataAsString;
 import static com.appsmith.external.helpers.PluginUtils.parseWhereClause;
 import static com.appsmith.external.helpers.PluginUtils.validDataConfigurationPresentInFormData;
 import static com.external.constants.FieldName.SHEET_NAME;
@@ -107,13 +107,13 @@ public class MethodConfig {
         switch (parameters.size()) {
             case 3:
             case 2:
-                this.tableHeaderIndex = (String) getValueSafelyFromFormData(parameters, TABLE_HEADER_INDEX);
+                this.tableHeaderIndex = getValueSafelyFromFormDataAsString(parameters, TABLE_HEADER_INDEX);
                 if (!StringUtils.hasLength(this.tableHeaderIndex)) {
                     this.tableHeaderIndex = "1";
                 }
-                this.sheetName = (String) getValueSafelyFromFormData(parameters, SHEET_NAME);
+                this.sheetName = getValueSafelyFromFormDataAsString(parameters, SHEET_NAME);
             case 1:
-                this.spreadsheetUrl = (String) getValueSafelyFromFormData(parameters, SHEET_URL);
+                this.spreadsheetUrl = getValueSafelyFromFormDataAsString(parameters, SHEET_URL);
                 setSpreadsheetUrlFromSpreadsheetId();
         }
     }


### PR DESCRIPTION


## Description





Fixes #16251

as per the suggestion
> [Apparently](https://app.smartlook.com/org/9b6c5c859e85745d01196fa4/project/e373e3a21d27278fd281d8b0/recordings?filter=ff5c57b6ed2be106f1ea85e57140fec16b4d51f5fee6aabb1d66950bcbfb4742&player=1&session=7WzknO24Dx&visitor=vesDHD7SFx) this user had bound the url string to a value that evaluated to a number. Possibly the same kind of error for other users before this. We shouldn't fail here in either case, can switch this to safer conversion.


- added a util method in PluginUtils which was earlier returning Object class, but is now returning a casted String.
- this method is a wrapper on the existing method only
- added junit to verify the error in casting in the existing method
- added junit to verify the correct casting behaviour in the new method

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?


- Added junit to test the bug as an exception case
- Added junit to test that bug to show correct behaviour

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
