### PR TITLE
fix: MongoPlugin Update Command : parsing valid document or array of valid documents

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
@@ -84,7 +84,7 @@ public class UpdateMany extends MongoCommand {
 
         Document queryDocument = parseSafely("Query", this.query);
 
-        Document updateDocument = parseSafely("Update", this.update);
+        Object updateDocument = parseSafely("Update", this.update);
 
         Document update = new Document();
         update.put("q", queryDocument);

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/commands/UpdateMany.java
@@ -26,6 +26,7 @@ import static com.external.plugins.constants.FieldName.UPDATE_LIMIT;
 import static com.external.plugins.constants.FieldName.UPDATE_OPERATION;
 import static com.external.plugins.constants.FieldName.UPDATE_QUERY;
 import static com.external.plugins.utils.MongoPluginUtils.parseSafely;
+import static com.external.plugins.utils.MongoPluginUtils.parseSafelyDocumentAndArrayOfDocuments;
 
 @Getter
 @Setter
@@ -84,7 +85,7 @@ public class UpdateMany extends MongoCommand {
 
         Document queryDocument = parseSafely("Query", this.query);
 
-        Object updateDocument = parseSafely("Update", this.update);
+        Object updateDocument = parseSafelyDocumentAndArrayOfDocuments("Update", this.update);
 
         Document update = new Document();
         update.put("q", queryDocument);

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
@@ -15,6 +15,8 @@ import com.external.plugins.commands.Find;
 import com.external.plugins.commands.Insert;
 import com.external.plugins.commands.MongoCommand;
 import com.external.plugins.commands.UpdateMany;
+
+import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.bson.json.JsonParseException;
 import org.bson.types.Decimal128;
@@ -46,16 +48,15 @@ public class MongoPluginUtils {
     public static Document parseSafely(String fieldName, String input) {
         try {
             return Document.parse(input);
-        } catch (Exception e) {
+        } catch (JsonParseException | BsonInvalidOperationException e) {
             throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, fieldName + " could not be parsed into expected JSON format.");
         }
     }
 
     public static Object parseSafelyDocumentAndArrayOfDocuments(String fieldName, String input){
         try {
-            new JSONObject(input);
             return parseSafely(fieldName, input);
-        } catch (JSONException e) {
+        } catch (AppsmithPluginException e) {
             try {
                 List<Document> parsedDocumentList = new ArrayList<>();
                 JSONArray rawInputJsonArray  = new JSONArray(input);

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/utils/MongoPluginUtils.java
@@ -51,18 +51,18 @@ public class MongoPluginUtils {
         }
     }
 
-    public static Object parseSafelyRawInput(String fieldName, String input){
+    public static Object parseSafelyDocumentAndArrayOfDocuments(String fieldName, String input){
         try {
             new JSONObject(input);
             return parseSafely(fieldName, input);
         } catch (JSONException e) {
             try {
-                List<Document> jsonList = new ArrayList<>();
-                JSONArray jsonArray = new JSONArray(input);
-                for (int i=0; i < jsonArray.length(); i++) {
-                    jsonList.add(parseSafely(fieldName, jsonArray.getJSONObject(i).toString()));
+                List<Document> parsedDocumentList = new ArrayList<>();
+                JSONArray rawInputJsonArray  = new JSONArray(input);
+                for (int i=0; i < rawInputJsonArray.length(); i++) {
+                    parsedDocumentList.add(parseSafely(fieldName, rawInputJsonArray.getJSONObject(i).toString()));
                 }
-                return jsonList;
+                return parsedDocumentList;
             } catch (JSONException ne) {
                 throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_EXECUTE_ARGUMENT_ERROR, fieldName + " could not be parsed into expected JSON format.");
             }

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/utils/MongoPluginUtilsTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/utils/MongoPluginUtilsTest.java
@@ -5,18 +5,58 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MongoPluginUtilsTest {
 
     @Test
-    public void testGetDatabaseName_withoutDatabaseName_throwsDatasourceError() {
+    void testGetDatabaseName_withoutDatabaseName_throwsDatasourceError() {
         final AppsmithPluginException exception = assertThrows(
                 AppsmithPluginException.class,
-                () -> MongoPluginUtils.getDatabaseName(new DatasourceConfiguration())
-        );
+                () -> MongoPluginUtils.getDatabaseName(new DatasourceConfiguration()));
 
         assertEquals("Missing default database name.", exception.getMessage());
 
     }
+
+    @Test
+    void testParseSafely_Success() {
+        assertNotNull(MongoPluginUtils.parseSafely("field", "{\"$set\":{name: \"Ram singh\"}}"));
+    }
+
+    @Test
+    void testParseSafely_FailureOnArrayValues() {
+        assertThrows(AppsmithPluginException.class,
+                () -> MongoPluginUtils.parseSafely("field", "[{\"$set\":{name: \"Ram singh\"}},{\"$set\":{age: 40}}]"));
+    }
+
+    @Test
+    void testParseSafelyRawInput_Success() {
+        assertNotNull(MongoPluginUtils.parseSafelyRawInput("field", "{\"$set\":{name: \"Ram singh\"}}"));
+    }
+
+    @Test
+    void testParseSafelyRawInput_FailureOnNonJsonValue() {
+        assertThrows(AppsmithPluginException.class,
+                () -> MongoPluginUtils.parseSafelyRawInput("field", "{abc, pqr}"));
+    }
+
+    @Test
+    void testParseSafelyRawInput_OnArrayValues_Success() {
+        assertNotNull(MongoPluginUtils.parseSafelyRawInput("field",
+                "[{\"$set\":{name: \"Ram singh\"}},{\"$set\":{age: 40}}]"));
+    }
+
+    @Test
+    void testParseSafelyRawInput_OnArrayValues_EmptyArray_Success() {
+        assertNotNull(MongoPluginUtils.parseSafelyRawInput("field", "[]"));
+    }
+
+    @Test
+    void testParseSafelyRawInput_onArrayValues_FailureOnNonJsonValue() {
+        assertThrows(AppsmithPluginException.class,
+                () -> MongoPluginUtils.parseSafelyRawInput("field", "[abc, pqr]"));
+    }
+
 }

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/utils/MongoPluginUtilsTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/utils/MongoPluginUtilsTest.java
@@ -32,31 +32,31 @@ public class MongoPluginUtilsTest {
     }
 
     @Test
-    void testParseSafelyRawInput_Success() {
-        assertNotNull(MongoPluginUtils.parseSafelyRawInput("field", "{\"$set\":{name: \"Ram singh\"}}"));
+    void testParseSafelyDocumentAndArrayOfDocuments_Success() {
+        assertNotNull(MongoPluginUtils.parseSafelyDocumentAndArrayOfDocuments("field", "{\"$set\":{name: \"Ram singh\"}}"));
     }
 
     @Test
-    void testParseSafelyRawInput_FailureOnNonJsonValue() {
+    void testParseSafelyDocumentAndArrayOfDocumentst_FailureOnNonJsonValue() {
         assertThrows(AppsmithPluginException.class,
-                () -> MongoPluginUtils.parseSafelyRawInput("field", "{abc, pqr}"));
+                () -> MongoPluginUtils.parseSafelyDocumentAndArrayOfDocuments("field", "{abc, pqr}"));
     }
 
     @Test
-    void testParseSafelyRawInput_OnArrayValues_Success() {
-        assertNotNull(MongoPluginUtils.parseSafelyRawInput("field",
+    void testParseSafelyDocumentAndArrayOfDocuments_OnArrayValues_Success() {
+        assertNotNull(MongoPluginUtils.parseSafelyDocumentAndArrayOfDocuments("field",
                 "[{\"$set\":{name: \"Ram singh\"}},{\"$set\":{age: 40}}]"));
     }
 
     @Test
-    void testParseSafelyRawInput_OnArrayValues_EmptyArray_Success() {
-        assertNotNull(MongoPluginUtils.parseSafelyRawInput("field", "[]"));
+    void testParseSafelyDocumentAndArrayOfDocuments_OnArrayValues_EmptyArray_Success() {
+        assertNotNull(MongoPluginUtils.parseSafelyDocumentAndArrayOfDocuments("field", "[]"));
     }
 
     @Test
-    void testParseSafelyRawInput_onArrayValues_FailureOnNonJsonValue() {
+    void testParseSafelyDocumentAndArrayOfDocuments_onArrayValues_FailureOnNonJsonValue() {
         assertThrows(AppsmithPluginException.class,
-                () -> MongoPluginUtils.parseSafelyRawInput("field", "[abc, pqr]"));
+                () -> MongoPluginUtils.parseSafelyDocumentAndArrayOfDocuments("field", "[abc, pqr]"));
     }
 
 }


### PR DESCRIPTION


## Description


Fixes #11419

Based on the suggestion : https://github.com/appsmithorg/appsmith/pull/12241#discussion_r844997566
> Hi @devnamrits , this approach has a drawback. If we do this, then we can never validate any input as valid or invalid. e.g. If `this.update` is `"abc"` then this will be parsed as a valid input which is not intended. Essentially this change converts any input into a valid input. However, what we want is to be able to detect if the user input is valid or not. Up until now we have only tried to check if the input is a valid `Document` or not, which in this case is not sufficient since MongoDB 4.2 onwards it also accepts an array of Documents (pipleine) as well. Hence, IMO, the correct approach here should be to parse for two things - (1) valid Document (2) valid array of Documents. To achieve this one good way would be create a new method `parseSafely(fieldName, input., boolean)` along the lines of `parseSafely` method that already exists and use the last parameter to check if we need to validate for array of Documents as well.

- Added a method parseSafelyRawInput : parsing valid document or array of valid documents
- Added junit to check the existing error on the existing parseSafely method
- Added junits to check success and failures for the new method.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added junit to check the existing error on the existing parseSafely method
- Added junits to check success and failures for the new method.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
