### PR TITLE
fix: Switch and Radio group widget height fix

### DIFF
--- a/app/client/src/widgets/RadioGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/component/index.tsx
@@ -32,11 +32,13 @@ export interface StyledRadioGroupProps {
   labelPosition?: LabelPosition;
   optionCount: number;
   accentColor: string;
+  isDynamicHeightEnabled?: boolean;
 }
 
 const StyledRadioGroup = styled(RadioGroup)<StyledRadioGroupProps>`
   ${BlueprintRadioSwitchGroupTransform}
-  height: ${({ inline }) => (inline ? "32px" : "100%")};
+  height: ${({ inline, isDynamicHeightEnabled }) =>
+    inline && !isDynamicHeightEnabled ? "32px" : "100%"};
 
   .${Classes.CONTROL} {
     & input:checked ~ .${Classes.CONTROL_INDICATOR} {
@@ -122,6 +124,7 @@ function RadioGroupComponent(props: RadioGroupComponentProps) {
         disabled={disabled}
         height={height}
         inline={inline}
+        isDynamicHeightEnabled={isDynamicHeightEnabled}
         labelPosition={labelPosition}
         onChange={handleChange}
         optionCount={options.length}

--- a/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchGroupWidget/component/index.tsx
@@ -33,11 +33,13 @@ export interface InputContainerProps {
   labelPosition?: LabelPosition;
   optionCount: number;
   valid?: boolean;
+  isDynamicHeightEnabled?: boolean;
 }
 
 export const InputContainer = styled.div<ThemeProp & InputContainerProps>`
   ${BlueprintRadioSwitchGroupTransform}
-  height: ${({ inline }) => (inline ? "32px" : "100%")};
+  height: ${({ inline, isDynamicHeightEnabled }) =>
+    inline && !isDynamicHeightEnabled ? "32px" : "100%"};
   border: 1px solid transparent;
   ${({ theme, valid }) =>
     !valid &&
@@ -103,6 +105,7 @@ function SwitchGroupComponent(props: SwitchGroupComponentProps) {
         compactMode={compactMode}
         height={height}
         inline={inline}
+        isDynamicHeightEnabled={isDynamicHeightEnabled}
         labelPosition={labelPosition}
         optionCount={optionCount}
         valid={valid}


### PR DESCRIPTION
Used the isDynamicHeightEnabled prop to set the height of SwitchGroup and RadioGroup widgets from 32px to 100% in case of inline mode.