### PR TITLE
fix: Response Pane height context restore issue in some cases

### DIFF
--- a/app/client/src/components/editorComponents/Debugger/Resizer/index.tsx
+++ b/app/client/src/components/editorComponents/Debugger/Resizer/index.tsx
@@ -1,6 +1,7 @@
 import { Layers } from "constants/Layers";
 import React, { useState, useEffect, RefObject } from "react";
 import styled, { css } from "styled-components";
+import { ActionExecutionResizerHeight } from "pages/Editor/APIEditor/constants";
 
 export const ResizerCSS = css`
   width: 100%;
@@ -30,15 +31,20 @@ type ResizerProps = {
 function Resizer(props: ResizerProps) {
   const [mouseDown, setMouseDown] = useState(false);
   const [height, setHeight] = useState(
-    props.panelRef.current?.getBoundingClientRect().height || 0,
+    props.initialHeight ||
+      props.panelRef.current?.getBoundingClientRect().height ||
+      ActionExecutionResizerHeight,
   );
 
+  // On mount and update, set the initial height of the component
   useEffect(() => {
     if (!props.initialHeight) return;
     const panel = props.panelRef.current;
     if (!panel) return;
     panel.style.height = `${props.initialHeight}px`;
-    setHeight(props.initialHeight);
+    if (height !== props.initialHeight) {
+      setHeight(props.initialHeight);
+    }
   }, [props.initialHeight]);
 
   const handleResize = (movementY: number) => {


### PR DESCRIPTION
## Description
We were getting some storing some wrong states when switching between certain action entities 
This would mess up context restore of Response pane heights. This PR makes sure that response pane
is mounted with correct values

Fixes #17749

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
