### PR TITLE
fix: Prevent JS error message printing in browser console

### DIFF
--- a/app/client/src/utils/WidgetFactory.tsx
+++ b/app/client/src/utils/WidgetFactory.tsx
@@ -220,7 +220,8 @@ class WidgetFactory {
     const map = this.propertyPaneConfigsMap.get(type);
     if (!map || (map && map.length === 0)) {
       const config = WidgetFactory.getWidgetPropertyPaneCombinedConfig(type);
-      if (config.length === 0) {
+      // CANVAS_WIDGET has no property pane config
+      if (config.length === 0 && type !== "CANVAS_WIDGET") {
         log.error("Widget property pane config not defined", type);
       }
       return config;

--- a/app/client/src/widgets/TabsWidget/widget/index.tsx
+++ b/app/client/src/widgets/TabsWidget/widget/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { find } from "lodash";
+import { find, isEmpty } from "lodash";
 import TabsComponent from "../component";
 import BaseWidget, { WidgetState } from "../../BaseWidget";
 import WidgetFactory from "utils/WidgetFactory";
@@ -321,7 +321,7 @@ class TabsWidget extends BaseWidget<
         return selectedTabWidgetId === item.widgetId;
       })[0],
     };
-    if (!childWidgetData) {
+    if (isEmpty(childWidgetData)) {
       return null;
     }
 


### PR DESCRIPTION
Fixes #17747