### PR TITLE
feat: set default workspace for instance config permission group

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
@@ -146,6 +146,7 @@ public class UserUtilsCE {
     private Mono<PermissionGroup> createInstanceAdminPermissionGroupWithoutPermissions() {
         PermissionGroup instanceAdminPermissionGroup = new PermissionGroup();
         instanceAdminPermissionGroup.setName(FieldName.INSTANCE_ADMIN_ROLE);
+        instanceAdminPermissionGroup.setDefaultWorkspaceId(FieldName.DEFAULT);
 
         return permissionGroupRepository.save(instanceAdminPermissionGroup)
                 .flatMap(savedPermissionGroup -> {


### PR DESCRIPTION
## Description

> Set the default workspace id in permission groups which are created for Instance Config.

Fixes #17798 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Not yet tested.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
