### PR TITLE
fix: Add max dropdown height

### DIFF
--- a/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
+++ b/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
@@ -493,6 +493,7 @@ function WorkspaceInviteUsersForm(props: any) {
               allowDeselection={isMultiSelectDropdown}
               data-cy="t--invite-role-input"
               disabled={props.disableDropdown}
+              dropdownMaxHeight={props.dropdownMaxHeight}
               isMultiSelect={isMultiSelectDropdown}
               labelRenderer={(selected: Partial<DropdownOption>[]) =>
                 getLabel(selected)

--- a/app/client/src/components/editorComponents/form/FormDialogComponent.tsx
+++ b/app/client/src/components/editorComponents/form/FormDialogComponent.tsx
@@ -80,6 +80,8 @@ const getTabs = (
                   }
                 : {})}
               applicationId={applicationId}
+              dropdownMaxHeight={tab.dropdownMaxHeight}
+              dropdownPlaceholder={tab.dropdownPlaceholder}
               formName={`${INVITE_USERS_TO_WORKSPACE_FORM}_${tab.key}`}
               onCancel={() => setIsOpen(false)}
               options={tab.options}

--- a/app/client/src/components/editorComponents/form/fields/DropdownWrapper.tsx
+++ b/app/client/src/components/editorComponents/form/fields/DropdownWrapper.tsx
@@ -22,6 +22,7 @@ type DropdownWrapperProps = {
   fillOptions?: boolean;
   disabled?: boolean;
   renderOption?: RenderOption;
+  dropdownMaxHeight?: string;
 };
 
 function DropdownWrapper(props: DropdownWrapperProps) {
@@ -66,6 +67,7 @@ function DropdownWrapper(props: DropdownWrapperProps) {
     <Dropdown
       allowDeselection={props.allowDeselection}
       disabled={props.disabled}
+      dropdownMaxHeight={props.dropdownMaxHeight}
       fillOptions={props.fillOptions}
       isMultiSelect={props.isMultiSelect}
       labelRenderer={props.labelRenderer}

--- a/app/client/src/components/editorComponents/form/fields/SelectField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/SelectField.tsx
@@ -34,6 +34,7 @@ type SelectFieldProps = {
   fillOptions?: boolean;
   disabled?: boolean;
   renderOption?: RenderOption;
+  dropdownMaxHeight?: string;
 };
 
 export function SelectField(props: SelectFieldProps) {
@@ -42,6 +43,7 @@ export function SelectField(props: SelectFieldProps) {
       allowDeselection={props.allowDeselection}
       component={renderComponent}
       disabled={props.disabled}
+      dropdownMaxHeight={props.dropdownMaxHeight}
       fillOptions={props.fillOptions}
       isMultiSelect={props.isMultiSelect}
       labelRenderer={props.labelRenderer}


### PR DESCRIPTION
## Description

> Add max dropdown height to solve scrolling issue in dropdown on invite modal.

Fixes [#17804](https://github.com/appsmithorg/appsmith/issues/17804)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual
> Tested it out locally on the invite modal. If the dropdownMaxHeight prop is passed, then the max height of the dropdown has that value and is scrollable in that area.

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
