### PR TITLE
chore: meta widget enable in view mode

### DIFF
--- a/app/client/src/components/editorComponents/EditorContextProvider.test.tsx
+++ b/app/client/src/components/editorComponents/EditorContextProvider.test.tsx
@@ -1,0 +1,84 @@
+import React, { useContext } from "react";
+import store from "store";
+import TestRenderer from "react-test-renderer";
+import { Provider } from "react-redux";
+
+import EditorContextProvider, {
+  EditorContext,
+  EditorContextType,
+} from "./EditorContextProvider";
+
+type TestChildProps = {
+  editorContext: EditorContextType;
+};
+
+const TestChild = (props: TestChildProps) => {
+  return <div>{Object.keys(props)}</div>;
+};
+
+const TestParent = () => {
+  const editorContext = useContext(EditorContext);
+
+  return <TestChild editorContext={editorContext} />;
+};
+
+describe("EditorContextProvider", () => {
+  it("it checks context methods in Edit mode", () => {
+    const expectedMethods = [
+      "batchUpdateWidgetProperty",
+      "executeAction",
+      "getWidgetCache",
+      "modifyMetaWidgets",
+      "resetChildrenMetaProperty",
+      "setWidgetCache",
+      "syncUpdateWidgetMetaProperty",
+      "triggerEvalOnMetaUpdate",
+      "deleteMetaWidgets",
+      "deleteWidgetProperty",
+      "disableDrag",
+      "updateWidget",
+      "updateWidgetProperty",
+    ].sort();
+
+    const testRenderer = TestRenderer.create(
+      <Provider store={store}>
+        <EditorContextProvider renderMode="CANVAS">
+          <TestParent />
+        </EditorContextProvider>
+      </Provider>,
+    );
+    const testInstance = testRenderer.root;
+    const result = (
+      Object.keys(testInstance.findByType(TestChild).props.editorContext) || []
+    ).sort();
+
+    expect(result).toEqual(expectedMethods);
+  });
+
+  it("it checks context methods in View mode", () => {
+    const expectedMethods = [
+      "batchUpdateWidgetProperty",
+      "executeAction",
+      "getWidgetCache",
+      "modifyMetaWidgets",
+      "resetChildrenMetaProperty",
+      "setWidgetCache",
+      "syncUpdateWidgetMetaProperty",
+      "triggerEvalOnMetaUpdate",
+    ].sort();
+
+    const testRenderer = TestRenderer.create(
+      <Provider store={store}>
+        <EditorContextProvider renderMode="PAGE">
+          <TestParent />
+        </EditorContextProvider>
+      </Provider>,
+    );
+    const testInstance = testRenderer.root;
+    const result = (
+      Object.keys(testInstance.findByType(TestChild).props.editorContext) || []
+    ).sort();
+
+    expect(result).toEqual(expectedMethods);
+  });
+});

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -36,12 +36,12 @@ export type RenderMode =
   | "PAGE"
   | "CANVAS_SELECTED";
 
-export const RenderModes: { [id: string]: RenderMode } = {
-  COMPONENT_PANE: "COMPONENT_PANE",
-  CANVAS: "CANVAS",
-  PAGE: "PAGE",
-  CANVAS_SELECTED: "CANVAS_SELECTED",
-};
+export enum RenderModes {
+  COMPONENT_PANE = "COMPONENT_PANE",
+  CANVAS = "CANVAS",
+  PAGE = "PAGE",
+  CANVAS_SELECTED = "CANVAS_SELECTED",
+}
 
 export const CSSUnits: { [id: string]: CSSUnit } = {
   PIXEL: "px",

--- a/app/client/src/pages/AppViewer/index.tsx
+++ b/app/client/src/pages/AppViewer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled, { ThemeProvider } from "styled-components";
 import { useDispatch } from "react-redux";
 import { withRouter, RouteComponentProps } from "react-router";
@@ -12,15 +12,8 @@ import {
   getIsInitialized,
   getAppViewHeaderHeight,
 } from "selectors/appViewSelectors";
-import { executeTrigger } from "actions/widgetActions";
-import { ExecuteTriggerPayload } from "constants/AppsmithActionConstants/ActionConstants";
-import { EditorContext } from "components/editorComponents/EditorContextProvider";
+import EditorContextProvider from "components/editorComponents/EditorContextProvider";
 import AppViewerPageContainer from "./AppViewerPageContainer";
-import {
-  resetChildrenMetaProperty,
-  syncUpdateWidgetMetaProperty,
-  triggerEvalOnMetaUpdate,
-} from "actions/metaActions";
 import { editorInitializer } from "utils/editor/EditorUtils";
 import * as Sentry from "@sentry/react";
 import { getViewModePageList } from "selectors/editorSelectors";
@@ -30,10 +23,6 @@ import { getSearchQuery } from "utils/helpers";
 import { getSelectedAppTheme } from "selectors/appThemingSelectors";
 import { useSelector } from "react-redux";
 import BrandingBadge from "./BrandingBadge";
-import {
-  BatchPropertyUpdatePayload,
-  batchUpdateWidgetProperty,
-} from "actions/controlActions";
 import { setAppViewHeaderHeight } from "actions/appViewActions";
 import { showPostCompletionMessage } from "selectors/onboardingSelectors";
 import { CANVAS_SELECTOR } from "constants/WidgetConstants";
@@ -182,62 +171,9 @@ function AppViewer(props: Props) {
     };
   }, [selectedTheme.properties.fontFamily.appFont]);
 
-  /**
-   * callback for executing an action
-   */
-  const executeActionCallback = useCallback(
-    (actionPayload: ExecuteTriggerPayload) =>
-      dispatch(executeTrigger(actionPayload)),
-    [executeTrigger, dispatch],
-  );
-
-  /**
-   * callback for initializing app
-   */
-  const resetChildrenMetaPropertyCallback = useCallback(
-    (widgetId: string) => dispatch(resetChildrenMetaProperty(widgetId)),
-    [resetChildrenMetaProperty, dispatch],
-  );
-
-  /**
-   * callback for updating widget meta property in batch
-   */
-  const batchUpdateWidgetPropertyCallback = useCallback(
-    (widgetId: string, updates: BatchPropertyUpdatePayload) =>
-      dispatch(batchUpdateWidgetProperty(widgetId, updates)),
-    [batchUpdateWidgetProperty, dispatch],
-  );
-
-  /**
-   * callback for updating widget meta property
-   */
-  const syncUpdateWidgetMetaPropertyCallback = useCallback(
-    (widgetId: string, propertyName: string, propertyValue: unknown) =>
-      dispatch(
-        syncUpdateWidgetMetaProperty(widgetId, propertyName, propertyValue),
-      ),
-    [syncUpdateWidgetMetaProperty, dispatch],
-  );
-
-  /**
-   * callback for triggering evaluation
-   */
-  const triggerEvalOnMetaUpdateCallback = useCallback(
-    () => dispatch(triggerEvalOnMetaUpdate()),
-    [triggerEvalOnMetaUpdate, dispatch],
-  );
-
   return (
     <ThemeProvider theme={lightTheme}>
-      <EditorContext.Provider
-        value={{
-          executeAction: executeActionCallback,
-          resetChildrenMetaProperty: resetChildrenMetaPropertyCallback,
-          batchUpdateWidgetProperty: batchUpdateWidgetPropertyCallback,
-          syncUpdateWidgetMetaProperty: syncUpdateWidgetMetaPropertyCallback,
-          triggerEvalOnMetaUpdate: triggerEvalOnMetaUpdateCallback,
-        }}
-      >
+      <EditorContextProvider renderMode="PAGE">
         <WidgetGlobaStyles
           fontFamily={selectedTheme.properties.fontFamily.appFont}
           primaryColor={selectedTheme.properties.colors.primaryColor}
@@ -264,7 +200,7 @@ function AppViewer(props: Props) {
             </a>
           )}
         </AppViewerBodyContainer>
-      </EditorContext.Provider>
+      </EditorContextProvider>
     </ThemeProvider>
   );
 }

--- a/app/client/src/pages/Editor/WidgetsEditor/index.tsx
+++ b/app/client/src/pages/Editor/WidgetsEditor/index.tsx
@@ -102,7 +102,7 @@ function WidgetsEditor() {
 
   PerformanceTracker.stopTracking();
   return (
-    <EditorContextProvider>
+    <EditorContextProvider renderMode="CANVAS">
       {showOnboardingTasks ? (
         <OnboardingTasks />
       ) : (


### PR DESCRIPTION
## Description
Enables the meta widget API i.e `modifyMetaWidgets` in the view mode.

In View mode the `EditorContext` is set using the `EditorContext.Provider`.
In Edit mode the `EditorContext` is set using the `EditorContextProvider` component.

Due to this any new API introduced would have to be added to the view mode and edit mode separately even thought the methods are same.

This PR aims to the usage of the `EditorContextProvider` component in both view mode and edit mode.

Fixes #16847 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Jest

### Test Plan
All the API methods that are introduced in each modes (view/edit) are verified for the availability 

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
