### PR TITLE
fix: Internal server error in case of ARRAY type in MySQL (#17702)

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeServiceUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeServiceUtils.java
@@ -80,9 +80,11 @@ public class DataTypeServiceUtils {
      * @return         the corresponding AppsmithType from the clientDataType and the evaluated value
      */
     public static AppsmithType getAppsmithType(ClientDataType clientDataType, String value, Map<ClientDataType, List<AppsmithType>> pluginSpecificTypes) {
-        for (AppsmithType currentType : pluginSpecificTypes.get(clientDataType)) {
-            if (currentType.test(value)) {
-                return currentType;
+        if (pluginSpecificTypes.get(clientDataType) != null) {
+            for (AppsmithType currentType : pluginSpecificTypes.get(clientDataType)) {
+                if (currentType.test(value)) {
+                    return currentType;
+                }
             }
         }
         //TODO: Send analytics event to Mixpanel

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/datatypes/MySQLSpecificDataTypes.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/datatypes/MySQLSpecificDataTypes.java
@@ -39,6 +39,8 @@ public class MySQLSpecificDataTypes {
                 new MySQLDateTimeType(),
                 new StringType()
         ));
+
+        pluginSpecificTypes.put(ClientDataType.ARRAY, List.of(new StringType()));
     }
 
 }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySQLPluginDataTypeTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySQLPluginDataTypeTest.java
@@ -1,7 +1,6 @@
 package com.external.plugins;
 
 import com.appsmith.external.datatypes.AppsmithType;
-import com.appsmith.external.datatypes.BigDecimalType;
 import com.appsmith.external.datatypes.ClientDataType;
 import com.appsmith.external.datatypes.DoubleType;
 import com.appsmith.external.datatypes.FallbackType;
@@ -17,43 +16,13 @@ import com.external.plugins.datatypes.MySQLDateTimeType;
 import com.external.plugins.datatypes.MySQLDateType;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import static com.external.plugins.datatypes.MySQLSpecificDataTypes.pluginSpecificTypes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MySQLPluginDataTypeTest {
-    private static final Map<ClientDataType, List<AppsmithType>> pluginSpecificTypes;
-
-    static {
-        pluginSpecificTypes = new HashMap<>();
-        pluginSpecificTypes.put(ClientDataType.NULL, List.of(new NullType()));
-
-        pluginSpecificTypes.put(ClientDataType.BOOLEAN, List.of(new MySQLBooleanType()));
-
-        pluginSpecificTypes.put(ClientDataType.NUMBER, List.of(
-                new IntegerType(),
-                new LongType(),
-                new DoubleType(),
-                new BigDecimalType()
-        ));
-
-        /*
-            JsonObjectType is the preferred server-side data type when the client-side data type is of type OBJECT.
-            Fallback server-side data type for client-side OBJECT type is String.
-         */
-        pluginSpecificTypes.put(ClientDataType.OBJECT, List.of(new JsonObjectType()));
-
-        pluginSpecificTypes.put(ClientDataType.STRING, List.of(
-                new TimeType(),
-                new MySQLDateType(),
-                new MySQLDateTimeType(),
-                new StringType()
-        ));
-    }
-
     @Test
     public void shouldBeNullType() {
         String value = "null";
@@ -196,6 +165,18 @@ public class MySQLPluginDataTypeTest {
         for (String value : values) {
             AppsmithType appsmithType = DataTypeServiceUtils.getAppsmithType(ClientDataType.STRING, value, pluginSpecificTypes);
             assertTrue(appsmithType instanceof StringType);
+        }
+    }
+
+    @Test
+    public void arrayTypeShouldBeStringType() {
+        String[] values = {
+                "[3,31,12]",
+                "[]"
+        };
+        for (String value : values) {
+            AppsmithType appsmithType = DataTypeServiceUtils.getAppsmithType(ClientDataType.ARRAY, value, pluginSpecificTypes);
+            assertTrue(appsmithType instanceof StringType || appsmithType instanceof FallbackType);
         }
     }
 }


### PR DESCRIPTION
## Description

This commit adds support for handling array-like data in MySQL
- If the data type identified by the client side is of type ARRAY it will be treated as STRING as MySQL doesn't have support for ARRAY data type

Fixes #17702 


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual
- JUnit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
