### PR TITLE
feat: set user permissions to objects when creating

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutCollectionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/LayoutCollectionServiceImpl.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.services;
 
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.services.ce.LayoutCollectionServiceCEImpl;
 import com.appsmith.server.solutions.RefactoringSolution;
 import lombok.extern.slf4j.Slf4j;
@@ -16,9 +17,10 @@ public class LayoutCollectionServiceImpl extends LayoutCollectionServiceCEImpl i
                                        ActionCollectionService actionCollectionService,
                                        NewActionService newActionService,
                                        AnalyticsService analyticsService,
-                                       ResponseUtils responseUtils) {
+                                       ResponseUtils responseUtils,
+                                       ActionCollectionRepository actionCollectionRepository) {
 
         super(newPageService, layoutActionService, refactoringSolution, actionCollectionService, newActionService, analyticsService,
-                responseUtils);
+                responseUtils, actionCollectionRepository);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCEImpl.java
@@ -133,7 +133,8 @@ public class DatasourceServiceCEImpl extends BaseService<DatasourceRepository, D
                 .flatMap(savedDatasource ->
                         analyticsService.sendCreateEvent(savedDatasource, getAnalyticsProperties(savedDatasource))
                 )
-                .flatMap(this::populateHintMessages); // For REST API datasource create flow.
+                .flatMap(this::populateHintMessages)  // For REST API datasource create flow.
+                .flatMap(repository::setUserPermissionsInObject);
     }
 
     private Mono<Datasource> generateAndSetDatasourcePolicies(Mono<User> userMono, Datasource datasource) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutCollectionServiceCEImpl.java
@@ -19,6 +19,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.helpers.DefaultResourcesUtils;
 import com.appsmith.server.helpers.ResponseUtils;
+import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.services.ActionCollectionService;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.LayoutActionService;
@@ -59,6 +60,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
     private final NewActionService newActionService;
     private final AnalyticsService analyticsService;
     private final ResponseUtils responseUtils;
+    private final ActionCollectionRepository actionCollectionRepository;
 
     /**
      * Called by ActionCollection controller to create ActionCollection
@@ -190,6 +192,7 @@ public class LayoutCollectionServiceCEImpl implements LayoutCollectionServiceCE 
                                 }
                                 return actionCollectionService.save(savedActionCollection);
                             })
+                            .flatMap(actionCollectionRepository::setUserPermissionsInObject)
                             .cache();
 
                     return actionCollectionMono

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -419,6 +419,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                     }
                     return Mono.just(savedAction);
                 })
+                .flatMap(repository::setUserPermissionsInObject)
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.REPOSITORY_SAVE_FAILED)))
                 .flatMap(this::setTransientFieldsInUnpublishedAction);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
@@ -173,6 +173,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
                     }
                     return Mono.just(savedPage);
                 })
+                .flatMap(repository::setUserPermissionsInObject)
                 .flatMap(page -> getPageByViewMode(page, false));
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -115,7 +115,8 @@ public class ActionCollectionServiceImplTest {
                 actionCollectionService,
                 newActionService,
                 analyticsService,
-                responseUtils
+                responseUtils,
+                actionCollectionRepository
         );
 
         Mockito

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceImplTest.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @Slf4j
@@ -267,12 +268,21 @@ public class ActionCollectionServiceImplTest {
                     argument.setId("testActionCollectionId");
                     return Mono.just(argument);
                 });
+        Mockito
+                .when(actionCollectionRepository.setUserPermissionsInObject(Mockito.any()))
+                .thenAnswer(invocation -> {
+                    final ActionCollection argument = (ActionCollection) invocation.getArguments()[0];
+                    argument.setId("testActionCollectionId");
+                    argument.setUserPermissions(Set.of("test-user-permission1", "test-user-permission2"));
+                    return Mono.just(argument);
+                });
 
         final Mono<ActionCollectionDTO> actionCollectionDTOMono = layoutCollectionService.createCollection(actionCollectionDTO);
 
         StepVerifier.create(actionCollectionDTOMono)
                 .assertNext(actionCollectionDTO1 -> {
                     assertTrue(actionCollectionDTO1.getActions().isEmpty());
+                    assertThat(actionCollectionDTO1.getUserPermissions()).hasSize(2);
                 })
                 .verifyComplete();
     }
@@ -337,11 +347,21 @@ public class ActionCollectionServiceImplTest {
                     return Mono.just(argument);
                 });
 
+        Mockito
+                .when(actionCollectionRepository.setUserPermissionsInObject(Mockito.any()))
+                .thenAnswer(invocation -> {
+                    final ActionCollection argument = (ActionCollection) invocation.getArguments()[0];
+                    argument.setId("testActionCollectionId");
+                    argument.setUserPermissions(Set.of("test-user-permission1", "test-user-permission2"));
+                    return Mono.just(argument);
+                });
+
         final Mono<ActionCollectionDTO> actionCollectionDTOMono = layoutCollectionService.createCollection(actionCollectionDTO);
 
         StepVerifier.create(actionCollectionDTOMono)
                 .assertNext(actionCollectionDTO1 -> {
                     assertEquals(1, actionCollectionDTO1.getActions().size());
+                    assertThat(actionCollectionDTO1.getUserPermissions()).hasSize(2);
                     final ActionDTO actionDTO = actionCollectionDTO1.getActions().get(0);
                     assertEquals("testAction", actionDTO.getName());
                     assertEquals("testActionId", actionDTO.getId());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
@@ -197,6 +197,28 @@ public class ActionCollectionServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
+    public void testCreateActionCollection() {
+        ActionCollectionDTO actionCollectionDTO = new ActionCollectionDTO();
+        actionCollectionDTO.setName("testActionCollection");
+        actionCollectionDTO.setApplicationId(testApp.getId());
+        actionCollectionDTO.setWorkspaceId(testApp.getWorkspaceId());
+        actionCollectionDTO.setPageId(testPage.getId());
+        actionCollectionDTO.setPluginId(datasource.getPluginId());
+        actionCollectionDTO.setPluginType(PluginType.JS);
+
+        StepVerifier.create(layoutCollectionService.createCollection(actionCollectionDTO))
+                .assertNext(actionCollectionDTO1 -> {
+                    assertThat(actionCollectionDTO1.getApplicationId()).isEqualTo(testApp.getId());
+                    assertThat(actionCollectionDTO1.getWorkspaceId()).isEqualTo(testApp.getWorkspaceId());
+                    assertThat(actionCollectionDTO1.getPageId()).isEqualTo(testPage.getId());
+                    assertThat(actionCollectionDTO1.getPluginId()).isEqualTo(datasource.getPluginId());
+                    assertThat(actionCollectionDTO1.getUserPermissions()).isNotEmpty();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
     public void createValidActionCollectionAndCheckPermissions() {
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any())).thenReturn(Mono.just(new MockPluginExecutor()));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -149,8 +149,10 @@ public class DatasourceServiceTest {
                 .assertNext(datasource -> {
                     assertThat(datasource.getT1().getName()).isEqualTo("Untitled Datasource");
                     assertThat(datasource.getT1().getWorkspaceId()).isEqualTo("random-org-id-1");
+                    assertThat(datasource.getT1().getUserPermissions()).isNotEmpty();
                     assertThat(datasource.getT2().getName()).isEqualTo("Untitled Datasource");
                     assertThat(datasource.getT2().getWorkspaceId()).isEqualTo("random-org-id-2");
+                    assertThat(datasource.getT2().getUserPermissions()).isNotEmpty();
                 })
                 .verifyComplete();
     }
@@ -176,6 +178,7 @@ public class DatasourceServiceTest {
                 .assertNext(createdDatasource -> {
                     assertThat(createdDatasource.getId()).isNotEmpty();
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
+                    assertThat(createdDatasource.getUserPermissions()).isNotEmpty();
                     assertThat(createdDatasource.getIsValid()).isFalse();
                     assertThat(createdDatasource.getInvalids()).containsExactlyInAnyOrder("Missing plugin id. Please enter one.");
                 })
@@ -244,6 +247,7 @@ public class DatasourceServiceTest {
                     assertThat(createdDatasource.getId()).isNotEmpty();
                     assertThat(createdDatasource.getPluginId()).isEqualTo(datasource.getPluginId());
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
+                    assertThat(createdDatasource.getUserPermissions()).isNotEmpty();
                     assertThat(createdDatasource.getIsValid()).isFalse();
                     assertThat(createdDatasource.getInvalids()).contains("Plugin " + datasource.getPluginId() + " not installed");
                 })
@@ -303,6 +307,7 @@ public class DatasourceServiceTest {
                 .create(datasourceMono)
                 .assertNext(createdDatasource -> {
                     assertThat(createdDatasource.getId()).isNotEmpty();
+                    assertThat(createdDatasource.getUserPermissions()).isNotEmpty();
                     assertThat(createdDatasource.getPluginId()).isEqualTo(datasource.getPluginId());
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
                     Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -318,9 +318,7 @@ public class ActionServiceCE_Test {
         action.setActionConfiguration(actionConfiguration);
         action.setDatasource(datasource);
 
-        Mono<ActionDTO> actionMono = layoutActionService.createSingleAction(action)
-                .flatMap(createdAction -> newActionService.findById(createdAction.getId(), READ_ACTIONS))
-                .flatMap(newAction -> newActionService.generateActionByViewMode(newAction, false));
+        Mono<ActionDTO> actionMono = layoutActionService.createSingleAction(action);
 
         StepVerifier
                 .create(Mono.zip(actionMono, defaultPermissionGroupsMono))
@@ -329,6 +327,7 @@ public class ActionServiceCE_Test {
                     assertThat(createdAction.getId()).isNotEmpty();
                     assertThat(createdAction.getName()).isEqualTo(action.getName());
                     assertThat(createdAction.getExecuteOnLoad()).isFalse();
+                    assertThat(createdAction.getUserPermissions()).isNotEmpty();
 
                     List<PermissionGroup> permissionGroups = tuple.getT2();
                     PermissionGroup adminPermissionGroup = permissionGroups.stream()
@@ -381,17 +380,15 @@ public class ActionServiceCE_Test {
         action.setActionConfiguration(actionConfiguration);
         action.setDatasource(datasource);
 
-        Mono<ActionDTO> actionMono = layoutActionService.createSingleActionWithBranch(action, branchName)
-                .flatMap(createdAction -> newActionService.findByBranchNameAndDefaultActionId(branchName, createdAction.getId(), READ_ACTIONS))
-                .flatMap(newAction -> newActionService.generateActionByViewMode(newAction, false));
+        Mono<ActionDTO> actionMono = layoutActionService.createSingleActionWithBranch(action, branchName);
 
         StepVerifier
                 .create(Mono.zip(actionMono, defaultPermissionGroupsMono))
                 .assertNext(tuple -> {
                     ActionDTO createdAction = tuple.getT1();
                     assertThat(createdAction.getExecuteOnLoad()).isFalse();
-
                     assertThat(createdAction.getDefaultResources()).isNotNull();
+                    assertThat(createdAction.getUserPermissions()).isNotEmpty();
                     assertThat(createdAction.getDefaultResources().getActionId()).isEqualTo(createdAction.getId());
                     assertThat(createdAction.getDefaultResources().getPageId()).isEqualTo(gitConnectedPage.getId());
                     assertThat(createdAction.getDefaultResources().getApplicationId()).isEqualTo(gitConnectedPage.getApplicationId());
@@ -449,6 +446,7 @@ public class ActionServiceCE_Test {
                     ActionMoveDTO actionMoveDTO = new ActionMoveDTO();
                     actionMoveDTO.setAction(savedAction);
                     actionMoveDTO.setDestinationPageId(destinationPage.getId());
+                    assertThat(savedAction.getUserPermissions()).isNotEmpty();
                     return layoutActionService.moveAction(actionMoveDTO);
                 });
 


### PR DESCRIPTION
## Description

> Set the user permissions for Datasources, Pages, Actions and JS Objects

Fixes https://github.com/appsmithorg/appsmith/issues/17870

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> This has been tested manually with running POST API calls.
> JUnit Test cases updated/added
> - ActionCollectionServiceTest$testCreateActionCollection
> - DatasourceServiceTest$datasourceDefaultNameCounterAsPerWorkspaceId
> - DatasourceServiceTest$createDatasourceWithNullPluginId
> - DatasourceServiceTest$createDatasourceNotInstalledPlugin
> - DatasourceServiceTest$createDatasourceValid
> - NewPageServiceTest$testCreateDefault
> - ActionServiceCE_Test$createValidActionAndCheckPermissions
> - ActionServiceCE_Test$createValidAction_forGitConnectedApp_getValidPermissionAndDefaultIds
> - ActionServiceCE_Test$validMoveAction
> - ActionCollectionServiceImplTest$testCreateCollection_createActionFailure_returnsWithIncompleteCollection
> - ActionCollectionServiceImplTest$testCreateCollection_validCollection_returnsPopulatedCollection

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
