### PR TITLE
fix: add connection pool to MySQL plugin

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/mysqlPlugin/pom.xml
@@ -29,11 +29,15 @@
 
     <dependencies>
 
-        <dependency>
+        <!--<dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-r2dbc</artifactId>
             <version>1.1.5.RELEASE</version>
             <exclusions>
+                <exclusion>
+                    <groupId>io.r2dbc</groupId>
+                    <artifactId>r2dbc-spi</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
@@ -47,7 +51,7 @@
                     <artifactId>reactive-streams</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
+        </dependency>-->
 
         <dependency>
             <groupId>dev.miku</groupId>
@@ -92,8 +96,9 @@
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-pool</artifactId>
-            <version>0.9.2.RELEASE</version>
-            <scope>provided</scope>
+<!--            <version>0.9.2.RELEASE</version>-->
+            <version>0.8.8.RELEASE</version>
+            <!--<scope>provided</scope>-->
             <exclusions>
                 <exclusion>
                     <groupId>io.netty</groupId>
@@ -141,6 +146,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!--<dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-spi</artifactId>
+            <version>0.8.6.RELEASE</version>
+        </dependency>-->
+
     </dependencies>
 
     <build>

--- a/app/server/appsmith-plugins/mysqlPlugin/pom.xml
+++ b/app/server/appsmith-plugins/mysqlPlugin/pom.xml
@@ -89,6 +89,31 @@
             <version>4.1.75.Final</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-pool</artifactId>
+            <version>0.9.2.RELEASE</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.projectreactor</groupId>
+                    <artifactId>reactor-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.reactivestreams</groupId>
+                    <artifactId>reactive-streams</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>mysql</groupId>

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -74,6 +74,7 @@ import static com.appsmith.external.helpers.PluginUtils.MATCH_QUOTED_WORDS_REGEX
 import static com.appsmith.external.helpers.PluginUtils.getIdenticalColumns;
 import static com.appsmith.external.helpers.PluginUtils.getPSParamLabel;
 import static com.appsmith.external.helpers.SmartSubstitutionHelper.replaceQuestionMarkWithDollarIndex;
+import static io.r2dbc.pool.PoolingConnectionFactoryProvider.MAX_SIZE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
@@ -656,11 +657,12 @@ public class MySqlPlugin extends BasePlugin {
             ConnectionFactory cf = ConnectionFactories.get(ConnectionFactoryOptions.builder()
                     .option(DRIVER,"pool")
                     .option(PROTOCOL,"mysql") // driver identifier, PROTOCOL is delegated as DRIVER by the pool.
-                    .option(HOST, "test-db.cz8diybf9wdj.ap-south-1.rds.amazonaws.com")
-                    .option(PORT, 3306)
-                    .option(USER, "admin")
-                    .option(PASSWORD,"Appsmith2020#")
-                    .option(DATABASE,"testdb")
+                    .option(HOST, datasourceConfiguration.getEndpoints().get(0).getHost())
+                    .option(PORT, datasourceConfiguration.getEndpoints().get(0).getPort().intValue())
+                    .option(USER, authentication.getUsername())
+                    .option(PASSWORD, authentication.getPassword())
+                    .option(DATABASE,authentication.getDatabaseName())
+                    .option(MAX_SIZE, 3)
                     .build());
 
             ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(cf)

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -14,6 +14,7 @@ import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStructure;
+import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.PsParameterDTO;
@@ -24,9 +25,12 @@ import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.external.plugins.SmartSubstitutionInterface;
 import com.external.plugins.datatypes.MySQLSpecificDataTypes;
 import com.external.utils.QueryUtils;
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
 import io.r2dbc.spi.Result;
@@ -53,7 +57,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -62,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -140,7 +144,7 @@ public class MySqlPlugin extends BasePlugin {
     }
 
     @Extension
-    public static class MySqlPluginExecutor implements PluginExecutor<Connection>, SmartSubstitutionInterface {
+    public static class MySqlPluginExecutor implements PluginExecutor<ConnectionPool>, SmartSubstitutionInterface {
 
         private static final int PREPARED_STATEMENT_INDEX = 0;
         private final Scheduler scheduler = Schedulers.elastic();
@@ -160,7 +164,7 @@ public class MySqlPlugin extends BasePlugin {
          * @return
          */
         @Override
-        public Mono<ActionExecutionResult> executeParameterized(Connection connection,
+        public Mono<ActionExecutionResult> executeParameterized(ConnectionPool connection,
                                                                 ExecuteActionDTO executeActionDTO,
                                                                 DatasourceConfiguration datasourceConfiguration,
                                                                 ActionConfiguration actionConfiguration) {
@@ -221,7 +225,7 @@ public class MySqlPlugin extends BasePlugin {
             return executeCommon(connection, actionConfiguration, TRUE, mustacheKeysInOrder, executeActionDTO, requestData);
         }
 
-        public Mono<ActionExecutionResult> executeCommon(Connection connection,
+        public Mono<ActionExecutionResult> executeCommon(ConnectionPool connectionPool,
                                                          ActionConfiguration actionConfiguration,
                                                          Boolean preparedStatement,
                                                          List<String> mustacheValuesInOrder,
@@ -258,14 +262,21 @@ public class MySqlPlugin extends BasePlugin {
             List<RequestParamDTO> requestParams = List.of(new RequestParamDTO(ACTION_CONFIGURATION_BODY,
                     transformedQuery, null, null, psParams));
 
+            AtomicReference<Connection> connection = null;
             // TODO: need to write a JUnit TC for VALIDATION_CHECK_TIMEOUT
-            Flux<Result> resultFlux = Mono.from(connection.validate(ValidationDepth.REMOTE))
+            Flux<Result> resultFlux =
+                    connectionPool.create()
+                    .flatMap(conn -> {
+                        connection.set(conn);
+                        return Mono.from(conn.validate(ValidationDepth.REMOTE));
+                    })
+                    //Mono.from(connection.validate(ValidationDepth.REMOTE))
                     .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
                     .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
                     .flatMapMany(isValid -> {
                         if (isValid) {
                             return createAndExecuteQueryFromConnection(finalQuery,
-                                    connection,
+                                    connection.get(),
                                     preparedStatement,
                                     mustacheValuesInOrder,
                                     executeActionDTO,
@@ -337,6 +348,11 @@ public class MySqlPlugin extends BasePlugin {
                         result.setRequest(request);
                         return result;
                     })
+                    .zipWith(Mono.just(connection.get().close()))
+                    .map(t2 -> {
+                        ActionExecutionResult res = t2.getT1();
+                        return res;
+                    })
                     .subscribeOn(scheduler);
 
         }
@@ -384,6 +400,14 @@ public class MySqlPlugin extends BasePlugin {
 
             return Flux.from(connectionStatement.execute());
 
+        }
+
+        @Override
+        public Mono<DatasourceTestResult> testDatasource(ConnectionPool pool) {
+            return Mono.just(pool)
+                    .flatMap(p -> p.create())
+                    .flatMap(conn -> Mono.from(conn.close()))
+                    .then(Mono.just(new DatasourceTestResult()));
         }
 
         @Override
@@ -499,13 +523,14 @@ public class MySqlPlugin extends BasePlugin {
         }
 
         @Override
-        public Mono<ActionExecutionResult> execute(Connection connection, DatasourceConfiguration datasourceConfiguration, ActionConfiguration actionConfiguration) {
+        public Mono<ActionExecutionResult> execute(ConnectionPool connection,
+                                                   DatasourceConfiguration datasourceConfiguration, ActionConfiguration actionConfiguration) {
             // Unused function
             return Mono.error(new AppsmithPluginException(AppsmithPluginError.PLUGIN_ERROR, "Unsupported Operation"));
         }
 
         @Override
-        public Mono<Connection> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
+        public Mono<ConnectionPool> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
             DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
 
             StringBuilder urlBuilder = new StringBuilder();
@@ -540,6 +565,7 @@ public class MySqlPlugin extends BasePlugin {
             }
 
 
+            //ConnectionFactory pooledConnectionFactory = ConnectionFactories.get(urlBuilder.toString());
             ConnectionFactoryOptions baseOptions = ConnectionFactoryOptions.parse(urlBuilder.toString());
             ConnectionFactoryOptions.Builder ob = ConnectionFactoryOptions.builder().from(baseOptions)
                     .option(ConnectionFactoryOptions.USER, authentication.getUsername())
@@ -590,16 +616,25 @@ public class MySqlPlugin extends BasePlugin {
                     );
             }
 
-            return (Mono<Connection>) Mono.from(ConnectionFactories.get(ob.build()).create())
+            ConnectionFactory cf = ConnectionFactories.get(ob.build());
+            // Create a ConnectionPool for connectionFactory
+            ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(cf)
+                    .maxIdleTime(Duration.ofMillis(1000))
+                    .maxSize(20)
+                    .build();
+            ConnectionPool pool = new ConnectionPool(configuration);
+            return Mono.just(pool);
+
+            /*return (Mono<Connection>) Mono.from(ConnectionFactories.get(ob.build()).create())
                     .onErrorResume(exception -> Mono.error(new AppsmithPluginException(
                             AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
                             exception
                     )))
-                    .subscribeOn(scheduler);
+                    .subscribeOn(scheduler);*/
         }
 
         @Override
-        public void datasourceDestroy(Connection connection) {
+        public void datasourceDestroy(ConnectionPool connection) {
 
             if (connection != null) {
                 Mono.from(connection.close())
@@ -813,8 +848,9 @@ public class MySqlPlugin extends BasePlugin {
             }
         }
 
-        @Override
-        public Mono<DatasourceStructure> getStructure(Connection connection, DatasourceConfiguration datasourceConfiguration) {
+        /*@Override
+        public Mono<DatasourceStructure> getStructure(ConnectionPool connection,
+                                                      DatasourceConfiguration datasourceConfiguration) {
             final DatasourceStructure structure = new DatasourceStructure();
             final Map<String, DatasourceStructure.Table> tablesByName = new LinkedHashMap<>();
             final Map<String, DatasourceStructure.Key> keyRegistry = new HashMap<>();
@@ -847,7 +883,7 @@ public class MySqlPlugin extends BasePlugin {
                     })
                     .collectList()
                     .map(list -> {
-                        /* Get templates for each table and put those in. */
+                        *//* Get templates for each table and put those in. *//*
                         getTemplates(tablesByName);
                         structure.setTables(new ArrayList<>(tablesByName.values()));
                         for (DatasourceStructure.Table table : structure.getTables()) {
@@ -867,6 +903,6 @@ public class MySqlPlugin extends BasePlugin {
                         return e;
                     })
                     .subscribeOn(scheduler);
-        }
+        }*/
     }
 }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -19,11 +19,11 @@ import com.appsmith.external.models.Endpoint;
 import com.appsmith.external.models.Property;
 import com.appsmith.external.models.PsParameterDTO;
 import com.appsmith.external.models.RequestParamDTO;
-import com.appsmith.external.models.SSLDetails;
 import com.appsmith.external.plugins.BasePlugin;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.external.plugins.SmartSubstitutionInterface;
 import com.external.plugins.datatypes.MySQLSpecificDataTypes;
+import com.external.utils.MySqlDatasourceUtils;
 import com.external.utils.QueryUtils;
 import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.pool.ConnectionPoolConfiguration;
@@ -32,7 +32,6 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import io.r2dbc.spi.Option;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
@@ -48,6 +47,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.pool.PoolShutdownException;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -57,6 +57,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -65,7 +66,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -74,26 +74,22 @@ import static com.appsmith.external.helpers.PluginUtils.MATCH_QUOTED_WORDS_REGEX
 import static com.appsmith.external.helpers.PluginUtils.getIdenticalColumns;
 import static com.appsmith.external.helpers.PluginUtils.getPSParamLabel;
 import static com.appsmith.external.helpers.SmartSubstitutionHelper.replaceQuestionMarkWithDollarIndex;
-import static io.r2dbc.pool.PoolingConnectionFactoryProvider.MAX_SIZE;
-import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
-import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
-import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
-import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
-import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
-import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
-import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
-import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static com.external.utils.MySqlDatasourceUtils.MAX_CONNECTION_POOL_SIZE;
+import static com.external.utils.MySqlDatasourceUtils.addSslOptionsToBuilder;
+import static com.external.utils.MySqlDatasourceUtils.getBuilder;
+import static com.external.utils.MySqlGetStructureUtils.getKeyInfo;
+import static com.external.utils.MySqlGetStructureUtils.getTableInfo;
+import static com.external.utils.MySqlGetStructureUtils.getTemplates;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
 @Slf4j
 public class MySqlPlugin extends BasePlugin {
 
-    private static final String DATE_COLUMN_TYPE_NAME = "date";
-    private static final String DATETIME_COLUMN_TYPE_NAME = "datetime";
-    private static final String TIMESTAMP_COLUMN_TYPE_NAME = "timestamp";
     private static final int VALIDATION_CHECK_TIMEOUT = 4; // seconds
     private static final String IS_KEY = "is";
+
+    private static final Duration MAX_IDLE_TIME = Duration.ofMinutes(10);
 
     /**
      * Example output for COLUMNS_QUERY:
@@ -270,126 +266,95 @@ public class MySqlPlugin extends BasePlugin {
             List<RequestParamDTO> requestParams = List.of(new RequestParamDTO(ACTION_CONFIGURATION_BODY,
                     transformedQuery, null, null, psParams));
 
-            AtomicReference<Connection> connection = new AtomicReference<>();
-            // TODO: need to write a JUnit TC for VALIDATION_CHECK_TIMEOUT
-            Flux<Result> resultFlux =
-                    Flux.usingWhen(
-                            connectionPool.create(),
-                            connection1 -> {
-                                return createAndExecuteQueryFromConnection(finalQuery,
-                                        connection1,
-                                        preparedStatement,
-                                        mustacheValuesInOrder,
-                                        executeActionDTO,
-                                        requestData,
-                                        psParams);
-                            },
-                            Connection::close
-                    )
-                    /*connectionPool.create()
-                    .flatMap(conn -> {
-                        connection.set(conn);
-                        return Mono.from(conn.validate(ValidationDepth.REMOTE));
-                    })
-                    //Mono.from(connection.validate(ValidationDepth.REMOTE))
-                    //.timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
-                    .onErrorResume(error -> {
-                        return Mono.error(error);
-                    })
-                    .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
-                    .flatMapMany(isValid -> {
-                        if (isValid) {
-                            return createAndExecuteQueryFromConnection(finalQuery,
-                                    connection.get(),
-                                    preparedStatement,
-                                    mustacheValuesInOrder,
-                                    executeActionDTO,
-                                    requestData,
-                                    psParams);
-                        }
-                        return Flux.error(new StaleConnectionException());
-                    })*//*
-                            .zipWith(Mono.just(connection.get().close()), (res, empty) -> {
-                                return res;
-                            })*/;
+            return Mono.usingWhen(
+                    connectionPool.create(),
+                    connection -> {
+                        // TODO: add JUnit TC for the `connection.validate` check
+                        Flux<Result> resultFlux = Mono.from(connection.validate(ValidationDepth.REMOTE))
+                                .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
+                                .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
+                                .flatMapMany(isValid -> {
+                                    if (isValid) {
+                                        return createAndExecuteQueryFromConnection(finalQuery,
+                                                connection,
+                                                preparedStatement,
+                                                mustacheValuesInOrder,
+                                                executeActionDTO,
+                                                requestData,
+                                                psParams);
+                                    }
+                                    return Flux.error(new StaleConnectionException());
+                                });
 
-            Mono<List<Map<String, Object>>> resultMono;
+                        Mono<List<Map<String, Object>>> resultMono;
+                        if (isSelectOrShowOrDescQuery) {
+                            resultMono = resultFlux
+                                    .flatMap(result ->
+                                            result.map((row, meta) -> {
+                                                        rowsList.add(getRow(row, meta));
 
-            if (isSelectOrShowOrDescQuery) {
-                resultMono = resultFlux
-                        .flatMap(result ->
-                                result.map((row, meta) -> {
-                                            rowsList.add(getRow(row, meta));
+                                                        if (columnsList.isEmpty()) {
+                                                            columnsList.addAll(meta.getColumnNames());
+                                                        }
 
-                                            if (columnsList.isEmpty()) {
-                                                columnsList.addAll(meta.getColumnNames());
-                                            }
-
-                                            return result;
-                                        }
-                                )
-                        )
-                        .collectList()
-                        .thenReturn(rowsList);
-            } else {
-                resultMono = resultFlux
-                        .flatMap(Result::getRowsUpdated)
-                        .collectList()
-                        .flatMap(list -> Mono.just(list.get(list.size() - 1)))
-                        .map(rowsUpdated -> {
-                            rowsList.add(
-                                    Map.of(
-                                            "affectedRows",
-                                            ObjectUtils.defaultIfNull(rowsUpdated, 0)
+                                                        return result;
+                                                    }
+                                            )
                                     )
-                            );
-                            return rowsList;
-                        });
-            }
-
-            return resultMono
-                    .map(res -> {
-                        ActionExecutionResult result = new ActionExecutionResult();
-                        result.setBody(objectMapper.valueToTree(rowsList));
-                        result.setMessages(populateHintMessages(columnsList));
-                        result.setIsExecutionSuccess(true);
-                        log.debug("In the MySqlPlugin, got action execution result");
-                        return result;
-                    })
-                    .onErrorResume(error -> {
-                        if (error instanceof StaleConnectionException) {
-                            return Mono.error(error);
+                                    .collectList()
+                                    .thenReturn(rowsList);
+                        } else {
+                            resultMono = resultFlux
+                                    .flatMap(Result::getRowsUpdated)
+                                    .collectList()
+                                    .flatMap(list -> Mono.just(list.get(list.size() - 1)))
+                                    .map(rowsUpdated -> {
+                                        rowsList.add(
+                                                Map.of(
+                                                        "affectedRows",
+                                                        ObjectUtils.defaultIfNull(rowsUpdated, 0)
+                                                )
+                                        );
+                                        return rowsList;
+                                    });
                         }
-                        ActionExecutionResult result = new ActionExecutionResult();
-                        result.setIsExecutionSuccess(false);
-                        result.setErrorInfo(error);
-                        return Mono.just(result);
-                    })
-                    // Now set the request in the result to be returned back to the server
-                    .map(actionExecutionResult -> {
-                        ActionExecutionRequest request = new ActionExecutionRequest();
-                        request.setQuery(finalQuery);
-                        request.setProperties(requestData);
-                        request.setRequestParams(requestParams);
-                        ActionExecutionResult result = actionExecutionResult;
-                        result.setRequest(request);
 
-                        /*if (connection.get() != null) {
-                            Mono.from(connection.get().close()).block();
-                        }*/
+                        return resultMono
+                                .map(res -> {
+                                    ActionExecutionResult result = new ActionExecutionResult();
+                                    result.setBody(objectMapper.valueToTree(rowsList));
+                                    result.setMessages(populateHintMessages(columnsList));
+                                    result.setIsExecutionSuccess(true);
+                                    log.debug("In the MySqlPlugin, got action execution result");
+                                    return result;
+                                })
+                                .onErrorResume(error -> {
+                                    if (error instanceof StaleConnectionException) {
+                                        return Mono.error(error);
+                                    }
+                                    ActionExecutionResult result = new ActionExecutionResult();
+                                    result.setIsExecutionSuccess(false);
+                                    result.setErrorInfo(error);
+                                    return Mono.just(result);
+                                })
+                                // Now set the request in the result to be returned back to the server
+                                .map(actionExecutionResult -> {
+                                    ActionExecutionRequest request = new ActionExecutionRequest();
+                                    request.setQuery(finalQuery);
+                                    request.setProperties(requestData);
+                                    request.setRequestParams(requestParams);
+                                    ActionExecutionResult result = actionExecutionResult;
+                                    result.setRequest(request);
 
-                        return result;
-                    })
-                    /*.doFinally(signalType -> {
-                        connection.get().close().subscribe();
-                    })*/
-                    /*.zipWith(Mono.from(connection.get().close()))
-                    .map(t2 -> {
-                        ActionExecutionResult res = t2.getT1();
-                        return res;
-                    })*/
-                    .subscribeOn(scheduler);
-
+                                    return result;
+                                });
+                    },
+                    Connection::close
+            )
+            .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
+            .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
+            .onErrorMap(PoolShutdownException.class, error -> new StaleConnectionException())
+            .subscribeOn(scheduler);
         }
 
         boolean isIsOperatorUsed(String query) {
@@ -566,390 +531,104 @@ public class MySqlPlugin extends BasePlugin {
 
         @Override
         public Mono<ConnectionPool> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
-            DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
-
-           /* StringBuilder urlBuilder = new StringBuilder();
-            if (CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
-                urlBuilder.append(datasourceConfiguration.getUrl());
-            } else {
-                urlBuilder.append("r2dbc:pool:mysql://");
-                final List<String> hosts = new ArrayList<>();
-
-                for (Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
-                    hosts.add(endpoint.getHost() + ":" + ObjectUtils.defaultIfNull(endpoint.getPort(), 3306L));
-                }
-
-                urlBuilder.append(String.join(",", hosts)).append("/");
-
-                if (!StringUtils.isEmpty(authentication.getDatabaseName())) {
-                    urlBuilder.append(authentication.getDatabaseName());
-                }
-
+            ConnectionFactoryOptions.Builder ob = getBuilder(datasourceConfiguration);
+            try {
+                ob = addSslOptionsToBuilder(datasourceConfiguration, ob);
+            } catch (AppsmithPluginException e) {
+                return Mono.error(e);
             }
 
-            urlBuilder.append("?zeroDateTimeBehavior=convertToNull");
-            final List<Property> dsProperties = datasourceConfiguration.getProperties();
-
-            if (dsProperties != null) {
-                for (Property property : dsProperties) {
-                    if ("serverTimezone".equals(property.getKey()) && !StringUtils.isEmpty(property.getValue())) {
-                        urlBuilder.append("&serverTimezone=").append(property.getValue());
-                        break;
-                    }
-                }
-            }
-
-
-            //ConnectionFactory pooledConnectionFactory = ConnectionFactories.get(urlBuilder.toString());
-            ConnectionFactoryOptions baseOptions = ConnectionFactoryOptions.parse(urlBuilder.toString());
-            ConnectionFactoryOptions.Builder ob = ConnectionFactoryOptions.builder().from(baseOptions)
-                    .option(ConnectionFactoryOptions.USER, authentication.getUsername())
-                    .option(ConnectionFactoryOptions.PASSWORD, authentication.getPassword());
-
-            *//*
-             * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
-             *//*
-            if (datasourceConfiguration.getConnection() == null
-                    || datasourceConfiguration.getConnection().getSsl() == null
-                    || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
-                return Mono.error(
-                        new AppsmithPluginException(
-                                AppsmithPluginError.PLUGIN_ERROR,
-                                "Appsmith server has failed to fetch SSL configuration from datasource configuration form. " +
-                                        "Please reach out to Appsmith customer support to resolve this."
-                        )
-                );
-            }
-
-            *//*
-             * - By default, the driver configures SSL in the preferred mode.
-             *//*
-            SSLDetails.AuthType sslAuthType = datasourceConfiguration.getConnection().getSsl().getAuthType();
-            switch (sslAuthType) {
-                case PREFERRED:
-                case REQUIRED:
-                    ob = ob
-                            .option(SSL, true)
-                            .option(Option.valueOf("sslMode"), sslAuthType.toString().toLowerCase());
-
-                    break;
-                case DISABLED:
-                    ob = ob.option(SSL, false);
-
-                    break;
-                case DEFAULT:
-                    *//* do nothing - accept default driver setting*//*
-
-                    break;
-                default:
-                    return Mono.error(
-                            new AppsmithPluginException(
-                                    AppsmithPluginError.PLUGIN_ERROR,
-                                    "Appsmith server has found an unexpected SSL option: " + sslAuthType + ". Please reach out to" +
-                                            " Appsmith customer support to resolve this."
-                            )
-                    );
-            }
-*/
-            //ConnectionFactory cf = ConnectionFactories.get(ob.build());
-            // Create a ConnectionPool for connectionFactory
-
-            ConnectionFactory cf = ConnectionFactories.get(ConnectionFactoryOptions.builder()
-                    .option(DRIVER,"pool")
-                    .option(PROTOCOL,"mysql") // driver identifier, PROTOCOL is delegated as DRIVER by the pool.
-                    .option(HOST, datasourceConfiguration.getEndpoints().get(0).getHost())
-                    .option(PORT, datasourceConfiguration.getEndpoints().get(0).getPort().intValue())
-                    .option(USER, authentication.getUsername())
-                    .option(PASSWORD, authentication.getPassword())
-                    .option(DATABASE,authentication.getDatabaseName())
-                    .option(MAX_SIZE, 3)
-                    .build());
-
+            ConnectionFactory cf = ConnectionFactories.get(ob.build());
             ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(cf)
-                    .maxIdleTime(Duration.ofMillis(1000))
-                    .maxSize(3)
+                    .maxIdleTime(MAX_IDLE_TIME)
+                    .maxSize(MAX_CONNECTION_POOL_SIZE)
                     .build();
             ConnectionPool pool = new ConnectionPool(configuration);
             return Mono.just(pool);
-
-            /*return (Mono<Connection>) Mono.from(ConnectionFactories.get(ob.build()).create())
-                    .onErrorResume(exception -> Mono.error(new AppsmithPluginException(
-                            AppsmithPluginError.PLUGIN_DATASOURCE_ARGUMENT_ERROR,
-                            exception
-                    )))
-                    .subscribeOn(scheduler);*/
         }
 
         @Override
-        public void datasourceDestroy(ConnectionPool connection) {
-
-            /*if (connection != null) {
-                Mono.from(connection.close())
+        public void datasourceDestroy(ConnectionPool connectionPool) {
+            if (connectionPool != null) {
+                Mono.just(connectionPool.disposeLater())
                         .onErrorResume(exception -> {
                             log.debug("In datasourceDestroy function error mode.", exception);
                             return Mono.empty();
                         })
                         .subscribeOn(scheduler)
                         .subscribe();
-            }*/
+            }
         }
 
         @Override
         public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
-
-            Set<String> invalids = new HashSet<>();
-
-            if (datasourceConfiguration.getConnection() != null
-                    && datasourceConfiguration.getConnection().getMode() == null) {
-                invalids.add("Missing Connection Mode.");
-            }
-
-            if (StringUtils.isEmpty(datasourceConfiguration.getUrl()) &&
-                    CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
-                invalids.add("Missing endpoint and url");
-            } else if (!CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
-                for (final Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
-                    if (endpoint.getHost() == null || endpoint.getHost().isBlank()) {
-                        invalids.add("Host value cannot be empty");
-                    } else if (endpoint.getHost().contains("/") || endpoint.getHost().contains(":")) {
-                        invalids.add("Host value cannot contain `/` or `:` characters. Found `" + endpoint.getHost() + "`.");
-                    }
-                }
-            }
-
-            if (datasourceConfiguration.getAuthentication() == null) {
-                invalids.add("Missing authentication details.");
-            } else {
-                DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
-                if (StringUtils.isEmpty(authentication.getUsername())) {
-                    invalids.add("Missing username for authentication.");
-                }
-
-                if (StringUtils.isEmpty(authentication.getPassword()) && StringUtils.isEmpty(authentication.getUsername())) {
-                    invalids.add("Missing password for authentication.");
-                } else if (StringUtils.isEmpty(authentication.getPassword())) {
-                    // it is valid if it has the username but not the password
-                    authentication.setPassword("");
-                }
-
-                if (StringUtils.isEmpty(authentication.getDatabaseName())) {
-                    invalids.add("Missing database name.");
-                }
-            }
-
-            /*
-             * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
-             */
-            if (datasourceConfiguration.getConnection() == null
-                    || datasourceConfiguration.getConnection().getSsl() == null
-                    || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
-                invalids.add("Appsmith server has failed to fetch SSL configuration from datasource configuration form. " +
-                        "Please reach out to Appsmith customer support to resolve this.");
-            }
-
-            return invalids;
+            return MySqlDatasourceUtils.validateDatasource(datasourceConfiguration);
         }
 
-        /**
-         * 1. Parse results obtained by running COLUMNS_QUERY defined on top of the page.
-         * 2. A sample mysql output for the query is also given near COLUMNS_QUERY definition on top of the page.
-         */
-        private void getTableInfo(Row row, RowMetadata meta, Map<String, DatasourceStructure.Table> tablesByName) {
-            final String tableName = row.get("table_name", String.class);
-
-            if (!tablesByName.containsKey(tableName)) {
-                tablesByName.put(tableName, new DatasourceStructure.Table(
-                        DatasourceStructure.TableType.TABLE,
-                        null,
-                        tableName,
-                        new ArrayList<>(),
-                        new ArrayList<>(),
-                        new ArrayList<>()
-                ));
-            }
-
-            final DatasourceStructure.Table table = tablesByName.get(tableName);
-            table.getColumns().add(new DatasourceStructure.Column(
-                    row.get("column_name", String.class),
-                    row.get("column_type", String.class),
-                    null,
-                    row.get("extra", String.class).contains("auto_increment")
-            ));
-
-            return;
-        }
-
-        /**
-         * 1. Parse results obtained by running KEYS_QUERY defined on top of the page.
-         * 2. A sample mysql output for the query is also given near KEYS_QUERY definition on top of the page.
-         */
-        private void getKeyInfo(Row row, RowMetadata meta, Map<String, DatasourceStructure.Table> tablesByName,
-                                Map<String, DatasourceStructure.Key> keyRegistry) {
-            final String constraintName = row.get("constraint_name", String.class);
-            final char constraintType = row.get("constraint_type", String.class).charAt(0);
-            final String selfSchema = row.get("self_schema", String.class);
-            final String tableName = row.get("self_table", String.class);
-
-
-            if (!tablesByName.containsKey(tableName)) {
-                /* do nothing */
-                return;
-            }
-
-            final DatasourceStructure.Table table = tablesByName.get(tableName);
-            final String keyFullName = tableName + "." + row.get("constraint_name", String.class);
-
-            if (constraintType == 'p') {
-                if (!keyRegistry.containsKey(keyFullName)) {
-                    final DatasourceStructure.PrimaryKey key = new DatasourceStructure.PrimaryKey(
-                            constraintName,
-                            new ArrayList<>()
-                    );
-                    keyRegistry.put(keyFullName, key);
-                    table.getKeys().add(key);
-                }
-                ((DatasourceStructure.PrimaryKey) keyRegistry.get(keyFullName)).getColumnNames()
-                        .add(row.get("self_column", String.class));
-            } else if (constraintType == 'f') {
-                final String foreignSchema = row.get("foreign_schema", String.class);
-                final String prefix = (foreignSchema.equalsIgnoreCase(selfSchema) ? "" : foreignSchema + ".")
-                        + row.get("foreign_table", String.class) + ".";
-
-                if (!keyRegistry.containsKey(keyFullName)) {
-                    final DatasourceStructure.ForeignKey key = new DatasourceStructure.ForeignKey(
-                            constraintName,
-                            new ArrayList<>(),
-                            new ArrayList<>()
-                    );
-                    keyRegistry.put(keyFullName, key);
-                    table.getKeys().add(key);
-                }
-
-                ((DatasourceStructure.ForeignKey) keyRegistry.get(keyFullName)).getFromColumns()
-                        .add(row.get("self_column", String.class));
-                ((DatasourceStructure.ForeignKey) keyRegistry.get(keyFullName)).getToColumns()
-                        .add(prefix + row.get("foreign_column", String.class));
-            }
-
-            return;
-        }
-
-        /**
-         * 1. Generate template for all tables in the database.
-         */
-        private void getTemplates(Map<String, DatasourceStructure.Table> tablesByName) {
-            for (DatasourceStructure.Table table : tablesByName.values()) {
-                final List<DatasourceStructure.Column> columnsWithoutDefault = table.getColumns()
-                        .stream()
-                        .filter(column -> column.getDefaultValue() == null)
-                        .collect(Collectors.toList());
-
-                final List<String> columnNames = new ArrayList<>();
-                final List<String> columnValues = new ArrayList<>();
-                final StringBuilder setFragments = new StringBuilder();
-
-                for (DatasourceStructure.Column column : columnsWithoutDefault) {
-                    final String name = column.getName();
-                    final String type = column.getType();
-                    String value;
-
-                    if (type == null) {
-                        value = "null";
-                    } else if ("text".equals(type) || "varchar".equals(type)) {
-                        value = "''";
-                    } else if (type.startsWith("int")) {
-                        value = "1";
-                    } else if (type.startsWith("double")) {
-                        value = "1.0";
-                    } else if (DATE_COLUMN_TYPE_NAME.equals(type)) {
-                        value = "'2019-07-01'";
-                    } else if (DATETIME_COLUMN_TYPE_NAME.equals(type)
-                            || TIMESTAMP_COLUMN_TYPE_NAME.equals(type)) {
-                        value = "'2019-07-01 10:00:00'";
-                    } else {
-                        value = "''";
-                    }
-
-                    columnNames.add(name);
-                    columnValues.add(value);
-                    setFragments.append("\n    ").append(name).append(" = ").append(value).append(",");
-                }
-
-                // Delete the last comma
-                if (setFragments.length() > 0) {
-                    setFragments.deleteCharAt(setFragments.length() - 1);
-                }
-
-                final String tableName = table.getName();
-                table.getTemplates().addAll(List.of(
-                        new DatasourceStructure.Template("SELECT", "SELECT * FROM " + tableName + " LIMIT 10;"),
-                        new DatasourceStructure.Template("INSERT", "INSERT INTO " + tableName
-                                + " (" + String.join(", ", columnNames) + ")\n"
-                                + "  VALUES (" + String.join(", ", columnValues) + ");"),
-                        new DatasourceStructure.Template("UPDATE", "UPDATE " + tableName + " SET"
-                                + setFragments + "\n"
-                                + "  WHERE 1 = 0; -- Specify a valid condition here. Removing the condition may update every row in the table!"),
-                        new DatasourceStructure.Template("DELETE", "DELETE FROM " + tableName
-                                + "\n  WHERE 1 = 0; -- Specify a valid condition here. Removing the condition may delete everything in the table!")
-                ));
-            }
-        }
-
-        /*@Override
-        public Mono<DatasourceStructure> getStructure(ConnectionPool connection,
+        @Override
+        public Mono<DatasourceStructure> getStructure(ConnectionPool connectionPool,
                                                       DatasourceConfiguration datasourceConfiguration) {
             final DatasourceStructure structure = new DatasourceStructure();
             final Map<String, DatasourceStructure.Table> tablesByName = new LinkedHashMap<>();
             final Map<String, DatasourceStructure.Key> keyRegistry = new HashMap<>();
 
-            return Mono.from(connection.validate(ValidationDepth.REMOTE))
+            return Mono.usingWhen(
+                    connectionPool.create(),
+                    connection -> {
+                        return Mono.from(connection.validate(ValidationDepth.REMOTE))
+                                .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
+                                .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
+                                .flatMapMany(isValid -> {
+                                    if (isValid) {
+                                        return connection.createStatement(COLUMNS_QUERY).execute();
+                                    } else {
+                                        return Flux.error(new StaleConnectionException());
+                                    }
+                                })
+                                .flatMap(result -> {
+                                    return result.map((row, meta) -> {
+                                        getTableInfo(row, meta, tablesByName);
+
+                                        return result;
+                                    });
+                                })
+                                .collectList()
+                                .thenMany(Flux.from(connection.createStatement(KEYS_QUERY).execute()))
+                                .flatMap(result -> {
+                                    return result.map((row, meta) -> {
+                                        getKeyInfo(row, meta, tablesByName, keyRegistry);
+
+                                        return result;
+                                    });
+                                })
+                                .collectList()
+                                .map(list -> {
+                                    /* Get templates for each table and put those in. */
+                                    getTemplates(tablesByName);
+                                    structure.setTables(new ArrayList<>(tablesByName.values()));
+                                    for (DatasourceStructure.Table table : structure.getTables()) {
+                                        table.getKeys().sort(Comparator.naturalOrder());
+                                    }
+
+                                    return structure;
+                                })
+                                .onErrorMap(e -> {
+                                    if (!(e instanceof AppsmithPluginException) && !(e instanceof StaleConnectionException)) {
+                                        return new AppsmithPluginException(
+                                                AppsmithPluginError.PLUGIN_ERROR,
+                                                e.getMessage()
+                                        );
+                                    }
+
+                                    return e;
+                                });
+                    },
+                    Connection::close
+                    )
                     .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
                     .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
-                    .flatMapMany(isValid -> {
-                        if (isValid) {
-                            return connection.createStatement(COLUMNS_QUERY).execute();
-                        } else {
-                            return Flux.error(new StaleConnectionException());
-                        }
-                    })
-                    .flatMap(result -> {
-                        return result.map((row, meta) -> {
-                            getTableInfo(row, meta, tablesByName);
-
-                            return result;
-                        });
-                    })
-                    .collectList()
-                    .thenMany(Flux.from(connection.createStatement(KEYS_QUERY).execute()))
-                    .flatMap(result -> {
-                        return result.map((row, meta) -> {
-                            getKeyInfo(row, meta, tablesByName, keyRegistry);
-
-                            return result;
-                        });
-                    })
-                    .collectList()
-                    .map(list -> {
-                        *//* Get templates for each table and put those in. *//*
-                        getTemplates(tablesByName);
-                        structure.setTables(new ArrayList<>(tablesByName.values()));
-                        for (DatasourceStructure.Table table : structure.getTables()) {
-                            table.getKeys().sort(Comparator.naturalOrder());
-                        }
-
-                        return structure;
-                    })
-                    .onErrorMap(e -> {
-                        if (!(e instanceof AppsmithPluginException) && !(e instanceof StaleConnectionException)) {
-                            return new AppsmithPluginException(
-                                    AppsmithPluginError.PLUGIN_ERROR,
-                                    e.getMessage()
-                            );
-                        }
-
-                        return e;
-                    })
+                    .onErrorMap(PoolShutdownException.class, error -> new StaleConnectionException())
                     .subscribeOn(scheduler);
-        }*/
+        }
     }
 }

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -74,7 +74,14 @@ import static com.appsmith.external.helpers.PluginUtils.MATCH_QUOTED_WORDS_REGEX
 import static com.appsmith.external.helpers.PluginUtils.getIdenticalColumns;
 import static com.appsmith.external.helpers.PluginUtils.getPSParamLabel;
 import static com.appsmith.external.helpers.SmartSubstitutionHelper.replaceQuestionMarkWithDollarIndex;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
@@ -271,7 +278,7 @@ public class MySqlPlugin extends BasePlugin {
                         return Mono.from(conn.validate(ValidationDepth.REMOTE));
                     })
                     //Mono.from(connection.validate(ValidationDepth.REMOTE))
-                    .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
+                    //.timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
                     .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
                     .flatMapMany(isValid -> {
                         if (isValid) {
@@ -346,13 +353,18 @@ public class MySqlPlugin extends BasePlugin {
                         request.setRequestParams(requestParams);
                         ActionExecutionResult result = actionExecutionResult;
                         result.setRequest(request);
+
+                        /*if (connection.get() != null) {
+                            connection.get().close();
+                        }*/
+
                         return result;
                     })
-                    .zipWith(Mono.just(connection.get().close()))
-                    .map(t2 -> {
-                        ActionExecutionResult res = t2.getT1();
-                        return res;
-                    })
+//                    .zipWith(Mono.just(connection.get().close()))
+//                    .map(t2 -> {
+//                        ActionExecutionResult res = t2.getT1();
+//                        return res;
+//                    })
                     .subscribeOn(scheduler);
 
         }
@@ -533,11 +545,11 @@ public class MySqlPlugin extends BasePlugin {
         public Mono<ConnectionPool> datasourceCreate(DatasourceConfiguration datasourceConfiguration) {
             DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
 
-            StringBuilder urlBuilder = new StringBuilder();
+           /* StringBuilder urlBuilder = new StringBuilder();
             if (CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
                 urlBuilder.append(datasourceConfiguration.getUrl());
             } else {
-                urlBuilder.append("r2dbc:mysql://");
+                urlBuilder.append("r2dbc:pool:mysql://");
                 final List<String> hosts = new ArrayList<>();
 
                 for (Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
@@ -571,9 +583,9 @@ public class MySqlPlugin extends BasePlugin {
                     .option(ConnectionFactoryOptions.USER, authentication.getUsername())
                     .option(ConnectionFactoryOptions.PASSWORD, authentication.getPassword());
 
-            /*
+            *//*
              * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
-             */
+             *//*
             if (datasourceConfiguration.getConnection() == null
                     || datasourceConfiguration.getConnection().getSsl() == null
                     || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
@@ -586,9 +598,9 @@ public class MySqlPlugin extends BasePlugin {
                 );
             }
 
-            /*
+            *//*
              * - By default, the driver configures SSL in the preferred mode.
-             */
+             *//*
             SSLDetails.AuthType sslAuthType = datasourceConfiguration.getConnection().getSsl().getAuthType();
             switch (sslAuthType) {
                 case PREFERRED:
@@ -603,7 +615,7 @@ public class MySqlPlugin extends BasePlugin {
 
                     break;
                 case DEFAULT:
-                    /* do nothing - accept default driver setting*/
+                    *//* do nothing - accept default driver setting*//*
 
                     break;
                 default:
@@ -615,9 +627,20 @@ public class MySqlPlugin extends BasePlugin {
                             )
                     );
             }
-
-            ConnectionFactory cf = ConnectionFactories.get(ob.build());
+*/
+            //ConnectionFactory cf = ConnectionFactories.get(ob.build());
             // Create a ConnectionPool for connectionFactory
+
+            ConnectionFactory cf = ConnectionFactories.get(ConnectionFactoryOptions.builder()
+                    .option(DRIVER,"pool")
+                    .option(PROTOCOL,"mysql") // driver identifier, PROTOCOL is delegated as DRIVER by the pool.
+                    .option(HOST, "test-db.cz8diybf9wdj.ap-south-1.rds.amazonaws.com")
+                    .option(PORT, 3306)
+                    .option(USER, "admin")
+                    .option(PASSWORD,"Appsmith2020#")
+                    .option(DATABASE,"testdb")
+                    .build());
+
             ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(cf)
                     .maxIdleTime(Duration.ofMillis(1000))
                     .maxSize(20)
@@ -636,7 +659,7 @@ public class MySqlPlugin extends BasePlugin {
         @Override
         public void datasourceDestroy(ConnectionPool connection) {
 
-            if (connection != null) {
+            /*if (connection != null) {
                 Mono.from(connection.close())
                         .onErrorResume(exception -> {
                             log.debug("In datasourceDestroy function error mode.", exception);
@@ -644,7 +667,7 @@ public class MySqlPlugin extends BasePlugin {
                         })
                         .subscribeOn(scheduler)
                         .subscribe();
-            }
+            }*/
         }
 
         @Override

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlDatasourceUtils.java
@@ -1,0 +1,170 @@
+package com.external.utils;
+
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
+import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginException;
+import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.Endpoint;
+import com.appsmith.external.models.Property;
+import com.appsmith.external.models.SSLDetails;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import org.apache.commons.lang.ObjectUtils;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+import javax.xml.crypto.Data;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static io.r2dbc.pool.PoolingConnectionFactoryProvider.MAX_SIZE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
+
+public class MySqlDatasourceUtils {
+
+    public static int MAX_CONNECTION_POOL_SIZE = 5;
+
+    public static ConnectionFactoryOptions.Builder getBuilder(DatasourceConfiguration datasourceConfiguration) {
+        DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
+
+        StringBuilder urlBuilder = new StringBuilder();
+        if (CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
+            urlBuilder.append(datasourceConfiguration.getUrl());
+        } else {
+            urlBuilder.append("r2dbc:pool:mysql://");
+            final List<String> hosts = new ArrayList<>();
+
+            for (Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
+                hosts.add(endpoint.getHost() + ":" + ObjectUtils.defaultIfNull(endpoint.getPort(), 3306L));
+            }
+
+            urlBuilder.append(String.join(",", hosts)).append("/");
+
+            if (!StringUtils.isEmpty(authentication.getDatabaseName())) {
+                urlBuilder.append(authentication.getDatabaseName());
+            }
+
+        }
+
+        urlBuilder.append("?zeroDateTimeBehavior=convertToNull");
+        final List<Property> dsProperties = datasourceConfiguration.getProperties();
+
+        if (dsProperties != null) {
+            for (Property property : dsProperties) {
+                if ("serverTimezone".equals(property.getKey()) && !StringUtils.isEmpty(property.getValue())) {
+                    urlBuilder.append("&serverTimezone=").append(property.getValue());
+                    break;
+                }
+            }
+        }
+
+        ConnectionFactoryOptions baseOptions = ConnectionFactoryOptions.parse(urlBuilder.toString());
+        ConnectionFactoryOptions.Builder ob = ConnectionFactoryOptions.builder().from(baseOptions)
+                .option(ConnectionFactoryOptions.USER, authentication.getUsername())
+                .option(ConnectionFactoryOptions.PASSWORD, authentication.getPassword())
+                .option(MAX_SIZE, MAX_CONNECTION_POOL_SIZE);
+
+        return ob;
+    }
+
+    public static ConnectionFactoryOptions.Builder addSslOptionsToBuilder(DatasourceConfiguration datasourceConfiguration,
+                                                                          ConnectionFactoryOptions.Builder ob) {
+        /*
+         * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
+         */
+        if (datasourceConfiguration.getConnection() == null
+                || datasourceConfiguration.getConnection().getSsl() == null
+                || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
+            throw new AppsmithPluginException(
+                            AppsmithPluginError.PLUGIN_ERROR,
+                            "Appsmith server has failed to fetch SSL configuration from datasource configuration form. " +
+                                    "Please reach out to Appsmith customer support to resolve this.");
+        }
+
+        /*
+         * - By default, the driver configures SSL in the preferred mode.
+         */
+        SSLDetails.AuthType sslAuthType = datasourceConfiguration.getConnection().getSsl().getAuthType();
+        switch (sslAuthType) {
+            case PREFERRED:
+            case REQUIRED:
+                ob = ob
+                        .option(SSL, true)
+                        .option(Option.valueOf("sslMode"), sslAuthType.toString().toLowerCase());
+
+                break;
+            case DISABLED:
+                ob = ob.option(SSL, false);
+
+                break;
+            case DEFAULT:
+                /* do nothing - accept default driver setting*/
+
+                break;
+            default:
+                        throw new AppsmithPluginException(
+                                AppsmithPluginError.PLUGIN_ERROR,
+                                "Appsmith server has found an unexpected SSL option: " + sslAuthType + ". Please reach out to" +
+                                        " Appsmith customer support to resolve this.");
+        }
+
+        return ob;
+    }
+
+    public static Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
+        Set<String> invalids = new HashSet<>();
+
+        if (datasourceConfiguration.getConnection() != null
+                && datasourceConfiguration.getConnection().getMode() == null) {
+            invalids.add("Missing Connection Mode.");
+        }
+
+        if (StringUtils.isEmpty(datasourceConfiguration.getUrl()) &&
+                CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
+            invalids.add("Missing endpoint and url");
+        } else if (!CollectionUtils.isEmpty(datasourceConfiguration.getEndpoints())) {
+            for (final Endpoint endpoint : datasourceConfiguration.getEndpoints()) {
+                if (endpoint.getHost() == null || endpoint.getHost().isBlank()) {
+                    invalids.add("Host value cannot be empty");
+                } else if (endpoint.getHost().contains("/") || endpoint.getHost().contains(":")) {
+                    invalids.add("Host value cannot contain `/` or `:` characters. Found `" + endpoint.getHost() + "`.");
+                }
+            }
+        }
+
+        if (datasourceConfiguration.getAuthentication() == null) {
+            invalids.add("Missing authentication details.");
+        } else {
+            DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();
+            if (StringUtils.isEmpty(authentication.getUsername())) {
+                invalids.add("Missing username for authentication.");
+            }
+
+            if (StringUtils.isEmpty(authentication.getPassword()) && StringUtils.isEmpty(authentication.getUsername())) {
+                invalids.add("Missing password for authentication.");
+            } else if (StringUtils.isEmpty(authentication.getPassword())) {
+                // it is valid if it has the username but not the password
+                authentication.setPassword("");
+            }
+
+            if (StringUtils.isEmpty(authentication.getDatabaseName())) {
+                invalids.add("Missing database name.");
+            }
+        }
+
+        /*
+         * - Ideally, it is never expected to be null because the SSL dropdown is set to a initial value.
+         */
+        if (datasourceConfiguration.getConnection() == null
+                || datasourceConfiguration.getConnection().getSsl() == null
+                || datasourceConfiguration.getConnection().getSsl().getAuthType() == null) {
+            invalids.add("Appsmith server has failed to fetch SSL configuration from datasource configuration form. " +
+                    "Please reach out to Appsmith customer support to resolve this.");
+        }
+
+        return invalids;
+    }
+}

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlGetStructureUtils.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/utils/MySqlGetStructureUtils.java
@@ -1,0 +1,162 @@
+package com.external.utils;
+
+import com.appsmith.external.models.DatasourceStructure;
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MySqlGetStructureUtils {
+
+    private static final String DATE_COLUMN_TYPE_NAME = "date";
+    private static final String DATETIME_COLUMN_TYPE_NAME = "datetime";
+    private static final String TIMESTAMP_COLUMN_TYPE_NAME = "timestamp";
+
+    /**
+     * 1. Parse results obtained by running COLUMNS_QUERY defined on top of the page.
+     * 2. A sample mysql output for the query is also given near COLUMNS_QUERY definition on top of the page.
+     */
+    public static void getTableInfo(Row row, RowMetadata meta, Map<String, DatasourceStructure.Table> tablesByName) {
+        final String tableName = row.get("table_name", String.class);
+
+        if (!tablesByName.containsKey(tableName)) {
+            tablesByName.put(tableName, new DatasourceStructure.Table(
+                    DatasourceStructure.TableType.TABLE,
+                    null,
+                    tableName,
+                    new ArrayList<>(),
+                    new ArrayList<>(),
+                    new ArrayList<>()
+            ));
+        }
+
+        final DatasourceStructure.Table table = tablesByName.get(tableName);
+        table.getColumns().add(new DatasourceStructure.Column(
+                row.get("column_name", String.class),
+                row.get("column_type", String.class),
+                null,
+                row.get("extra", String.class).contains("auto_increment")
+        ));
+
+        return;
+    }
+
+    /**
+     * 1. Parse results obtained by running KEYS_QUERY defined on top of the page.
+     * 2. A sample mysql output for the query is also given near KEYS_QUERY definition on top of the page.
+     */
+    public static void getKeyInfo(Row row, RowMetadata meta, Map<String, DatasourceStructure.Table> tablesByName,
+                            Map<String, DatasourceStructure.Key> keyRegistry) {
+        final String constraintName = row.get("constraint_name", String.class);
+        final char constraintType = row.get("constraint_type", String.class).charAt(0);
+        final String selfSchema = row.get("self_schema", String.class);
+        final String tableName = row.get("self_table", String.class);
+
+
+        if (!tablesByName.containsKey(tableName)) {
+            /* do nothing */
+            return;
+        }
+
+        final DatasourceStructure.Table table = tablesByName.get(tableName);
+        final String keyFullName = tableName + "." + row.get("constraint_name", String.class);
+
+        if (constraintType == 'p') {
+            if (!keyRegistry.containsKey(keyFullName)) {
+                final DatasourceStructure.PrimaryKey key = new DatasourceStructure.PrimaryKey(
+                        constraintName,
+                        new ArrayList<>()
+                );
+                keyRegistry.put(keyFullName, key);
+                table.getKeys().add(key);
+            }
+            ((DatasourceStructure.PrimaryKey) keyRegistry.get(keyFullName)).getColumnNames()
+                    .add(row.get("self_column", String.class));
+        } else if (constraintType == 'f') {
+            final String foreignSchema = row.get("foreign_schema", String.class);
+            final String prefix = (foreignSchema.equalsIgnoreCase(selfSchema) ? "" : foreignSchema + ".")
+                    + row.get("foreign_table", String.class) + ".";
+
+            if (!keyRegistry.containsKey(keyFullName)) {
+                final DatasourceStructure.ForeignKey key = new DatasourceStructure.ForeignKey(
+                        constraintName,
+                        new ArrayList<>(),
+                        new ArrayList<>()
+                );
+                keyRegistry.put(keyFullName, key);
+                table.getKeys().add(key);
+            }
+
+            ((DatasourceStructure.ForeignKey) keyRegistry.get(keyFullName)).getFromColumns()
+                    .add(row.get("self_column", String.class));
+            ((DatasourceStructure.ForeignKey) keyRegistry.get(keyFullName)).getToColumns()
+                    .add(prefix + row.get("foreign_column", String.class));
+        }
+
+        return;
+    }
+
+    /**
+     * 1. Generate template for all tables in the database.
+     */
+    public static void getTemplates(Map<String, DatasourceStructure.Table> tablesByName) {
+        for (DatasourceStructure.Table table : tablesByName.values()) {
+            final List<DatasourceStructure.Column> columnsWithoutDefault = table.getColumns()
+                    .stream()
+                    .filter(column -> column.getDefaultValue() == null)
+                    .collect(Collectors.toList());
+
+            final List<String> columnNames = new ArrayList<>();
+            final List<String> columnValues = new ArrayList<>();
+            final StringBuilder setFragments = new StringBuilder();
+
+            for (DatasourceStructure.Column column : columnsWithoutDefault) {
+                final String name = column.getName();
+                final String type = column.getType();
+                String value;
+
+                if (type == null) {
+                    value = "null";
+                } else if ("text".equals(type) || "varchar".equals(type)) {
+                    value = "''";
+                } else if (type.startsWith("int")) {
+                    value = "1";
+                } else if (type.startsWith("double")) {
+                    value = "1.0";
+                } else if (DATE_COLUMN_TYPE_NAME.equals(type)) {
+                    value = "'2019-07-01'";
+                } else if (DATETIME_COLUMN_TYPE_NAME.equals(type)
+                        || TIMESTAMP_COLUMN_TYPE_NAME.equals(type)) {
+                    value = "'2019-07-01 10:00:00'";
+                } else {
+                    value = "''";
+                }
+
+                columnNames.add(name);
+                columnValues.add(value);
+                setFragments.append("\n    ").append(name).append(" = ").append(value).append(",");
+            }
+
+            // Delete the last comma
+            if (setFragments.length() > 0) {
+                setFragments.deleteCharAt(setFragments.length() - 1);
+            }
+
+            final String tableName = table.getName();
+            table.getTemplates().addAll(List.of(
+                    new DatasourceStructure.Template("SELECT", "SELECT * FROM " + tableName + " LIMIT 10;"),
+                    new DatasourceStructure.Template("INSERT", "INSERT INTO " + tableName
+                            + " (" + String.join(", ", columnNames) + ")\n"
+                            + "  VALUES (" + String.join(", ", columnValues) + ");"),
+                    new DatasourceStructure.Template("UPDATE", "UPDATE " + tableName + " SET"
+                            + setFragments + "\n"
+                            + "  WHERE 1 = 0; -- Specify a valid condition here. Removing the condition may update every row in the table!"),
+                    new DatasourceStructure.Template("DELETE", "DELETE FROM " + tableName
+                            + "\n  WHERE 1 = 0; -- Specify a valid condition here. Removing the condition may delete everything in the table!")
+            ));
+        }
+    }
+}

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -56,8 +56,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-@Slf4j
-@Testcontainers
+//@Slf4j
+//@Testcontainers
+/*
 public class MySqlPluginTest {
 
         MySqlPlugin.MySqlPluginExecutor pluginExecutor = new MySqlPlugin.MySqlPluginExecutor();
@@ -166,11 +167,15 @@ public class MySqlPluginTest {
 
                 DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
 
-                /* set endpoint */
+                */
+/* set endpoint *//*
+
                 datasourceConfiguration.setAuthentication(authDTO);
                 datasourceConfiguration.setEndpoints(List.of(endpoint));
 
-                /* set ssl mode */
+                */
+/* set ssl mode *//*
+
                 datasourceConfiguration.setConnection(new com.appsmith.external.models.Connection());
                 datasourceConfiguration.getConnection().setSsl(new SSLDetails());
                 datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.DEFAULT);
@@ -206,14 +211,18 @@ public class MySqlPluginTest {
         public void testTestDatasource() {
                 dsConfig = createDatasourceConfiguration();
 
-                /* Expect no error */
+                */
+/* Expect no error *//*
+
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> {
                                         assertEquals(0, datasourceTestResult.getInvalids().size());
                                 })
                                 .verifyComplete();
 
-                /* Create bad datasource configuration and expect error */
+                */
+/* Create bad datasource configuration and expect error *//*
+
                 dsConfig.getEndpoints().get(0).setHost("badHost");
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> {
@@ -221,7 +230,9 @@ public class MySqlPluginTest {
                                 })
                                 .verifyComplete();
 
-                /* Reset dsConfig */
+                */
+/* Reset dsConfig *//*
+
                 dsConfig = createDatasourceConfiguration();
         }
 
@@ -238,11 +249,15 @@ public class MySqlPluginTest {
 
                 final DatasourceConfiguration dsConfig = new DatasourceConfiguration();
 
-                /* set endpoint */
+                */
+/* set endpoint *//*
+
                 dsConfig.setAuthentication(authDTO);
                 dsConfig.setEndpoints(List.of(endpoint));
 
-                /* set ssl mode */
+                */
+/* set ssl mode *//*
+
 
                 dsConfig.setConnection(new com.appsmith.external.models.Connection());
                 dsConfig.getConnection().setMode(com.appsmith.external.models.Connection.Mode.READ_WRITE);
@@ -290,7 +305,9 @@ public class MySqlPluginTest {
                                 .assertNext(Assertions::assertNotNull)
                                 .verifyComplete();
 
-                /* Expect no error */
+                */
+/* Expect no error *//*
+
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> assertEquals(0,
                                                 datasourceTestResult.getInvalids().size()))
@@ -316,7 +333,9 @@ public class MySqlPluginTest {
                                 .assertNext(Assertions::assertNotNull)
                                 .verifyComplete();
 
-                /* Expect no error */
+                */
+/* Expect no error *//*
+
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> assertEquals(0,
                                                 datasourceTestResult.getInvalids().size()))
@@ -391,12 +410,14 @@ public class MySqlPluginTest {
                                         assertEquals("18:32:45", node.get("time1").asText());
                                         assertEquals("2018-11-30T20:45:15Z", node.get("created_on").asText());
 
-                                        /*
+                                        */
+/*
                                          * - RequestParamDTO object only have attributes configProperty and value at
                                          * this point.
                                          * - The other two RequestParamDTO attributes - label and type are null at this
                                          * point.
-                                         */
+                                         *//*
+
                                         List<RequestParamDTO> expectedRequestParams = new ArrayList<>();
                                         expectedRequestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_BODY,
                                                         actionConfiguration.getBody(), null, null, new HashMap<>()));
@@ -509,7 +530,8 @@ public class MySqlPluginTest {
                 Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
-                /**
+                */
+/**
                  * - MySQL r2dbc driver is not able to substitute the `True/False` value
                  * properly after the IS keyword.
                  * Converting `True/False` to integer 1 or 0 also does not work in this case as
@@ -517,7 +539,8 @@ public class MySqlPluginTest {
                  * integers with IS keyword.
                  * - I have raised an issue with r2dbc to track it:
                  * https://github.com/mirromutth/r2dbc-mysql/issues/200
-                 */
+                 *//*
+
                 actionConfiguration.setBody("SELECT id FROM test_boolean_type WHERE c_boolean IS {{binding1}};");
 
                 List<Property> pluginSpecifiedTemplates = new ArrayList<>();
@@ -566,14 +589,16 @@ public class MySqlPluginTest {
                 Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
-                /**
+                */
+/**
                  * - For mysql float / double / real types the actual values that are stored in
                  * the db my differ by a very
                  * thin margin as long as they are approximately same. Hence adding comparison
                  * based check instead of direct
                  * equality.
                  * - Ref: https://dev.mysql.com/doc/refman/8.0/en/problems-with-float.html
-                 */
+                 *//*
+
                 actionConfiguration.setBody(
                                 "SELECT id FROM test_real_types WHERE ABS(c_float - {{binding1}}) < 0.1 AND ABS" +
                                                 "(c_double - {{binding2}}) < 0.1 AND ABS(c_real - {{binding3}}) < 0.1;");
@@ -724,12 +749,14 @@ public class MySqlPluginTest {
                                         // Verify value
                                         assertEquals(1, node.get("id").asInt());
 
-                                        /*
+                                        */
+/*
                                          * - Check if request params are sent back properly.
                                          * - Not replicating the same to other tests as the overall flow remains the
                                          * same w.r.t. request
                                          * params.
-                                         */
+                                         *//*
+
 
                                         // Check if '?' is replaced by $i.
                                         assertEquals("SELECT id FROM users WHERE id = $1 limit 1 offset $2;",
@@ -808,7 +835,8 @@ public class MySqlPluginTest {
                                 .verifyComplete();
         }
 
-        /**
+        */
+/**
          * 1. Add a test to check that mysql driver can interpret and read all the
          * regular data types used in mysql.
          * 2. List of the data types is taken is from
@@ -818,7 +846,8 @@ public class MySqlPluginTest {
          * DATE, DATETIME, TIMESTAMP, TIME, YEAR, CHAR, VARCHAR, BINARY, VARBINARY,
          * TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB,
          * TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, ENUM, SET, JSON, GEOMETRY, POINT
-         */
+         *//*
+
         @Test
         public void testExecuteDataTypesExtensive() throws AppsmithPluginException {
                 String query_create_table_numeric_types = "create table test_numeric_types (c_integer INTEGER, c_smallint "
@@ -887,15 +916,25 @@ public class MySqlPluginTest {
                                 .flatMapMany(batch -> Flux.from(batch.execute()))
                                 .blockLast(); // wait until completion of all the queries
 
-                /* Test numeric types */
+                */
+/* Test numeric types *//*
+
                 testExecute(query_select_from_test_numeric_types);
-                /* Test date time types */
+                */
+/* Test date time types *//*
+
                 testExecute(query_select_from_test_date_time_types);
-                /* Test data types */
+                */
+/* Test data types *//*
+
                 testExecute(query_select_from_test_data_types);
-                /* Test data types */
+                */
+/* Test data types *//*
+
                 testExecute(query_select_from_test_json_data_type);
-                /* Test data types */
+                */
+/* Test data types *//*
+
                 testExecute(query_select_from_test_geometry_types);
 
                 return;
@@ -1214,9 +1253,11 @@ public class MySqlPluginTest {
                                                                         .anyMatch(message -> message
                                                                                         .contains(expectedMessage)));
 
-                                        /*
+                                        */
+/*
                                          * - Check if all of the duplicate column names are reported.
-                                         */
+                                         *//*
+
                                         Set<String> expectedColumnNames = Stream.of("id", "password")
                                                         .collect(Collectors.toCollection(HashSet::new));
                                         Set<String> foundColumnNames = new HashSet<>();
@@ -1476,4 +1517,4 @@ public class MySqlPluginTest {
                                 })
                                 .verifyComplete();
         }
-}
+}*/

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactoryOptions;
@@ -56,9 +57,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-//@Slf4j
-//@Testcontainers
-/*
+@Slf4j
+@Testcontainers
+
 public class MySqlPluginTest {
 
         MySqlPlugin.MySqlPluginExecutor pluginExecutor = new MySqlPlugin.MySqlPluginExecutor();
@@ -167,15 +168,13 @@ public class MySqlPluginTest {
 
                 DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
 
-                */
-/* set endpoint *//*
 
+                /* set endpoint */
                 datasourceConfiguration.setAuthentication(authDTO);
                 datasourceConfiguration.setEndpoints(List.of(endpoint));
 
-                */
-/* set ssl mode *//*
 
+                /* set ssl mode */
                 datasourceConfiguration.setConnection(new com.appsmith.external.models.Connection());
                 datasourceConfiguration.getConnection().setSsl(new SSLDetails());
                 datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.DEFAULT);
@@ -185,9 +184,7 @@ public class MySqlPluginTest {
 
         @Test
         public void testConnectMySQLContainer() {
-
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
-
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
                 StepVerifier.create(dsConnectionMono)
                                 .assertNext(Assertions::assertNotNull)
                                 .verifyComplete();
@@ -195,13 +192,11 @@ public class MySqlPluginTest {
 
         @Test
         public void testConnectMySQLContainerWithInvalidTimezone() {
-
                 final DatasourceConfiguration dsConfig = createDatasourceConfigForContainerWithInvalidTZ();
                 dsConfig.setProperties(List.of(
                                 new Property("serverTimezone", "UTC")));
 
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
-
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
                 StepVerifier.create(dsConnectionMono)
                                 .assertNext(Assertions::assertNotNull)
                                 .verifyComplete();
@@ -211,18 +206,14 @@ public class MySqlPluginTest {
         public void testTestDatasource() {
                 dsConfig = createDatasourceConfiguration();
 
-                */
-/* Expect no error *//*
-
+                /* Expect no error */
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> {
                                         assertEquals(0, datasourceTestResult.getInvalids().size());
                                 })
                                 .verifyComplete();
 
-                */
-/* Create bad datasource configuration and expect error *//*
-
+                /* Create bad datasource configuration and expect error */
                 dsConfig.getEndpoints().get(0).setHost("badHost");
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> {
@@ -230,9 +221,8 @@ public class MySqlPluginTest {
                                 })
                                 .verifyComplete();
 
-                */
-/* Reset dsConfig *//*
 
+                /* Reset dsConfig */
                 dsConfig = createDatasourceConfiguration();
         }
 
@@ -249,16 +239,11 @@ public class MySqlPluginTest {
 
                 final DatasourceConfiguration dsConfig = new DatasourceConfiguration();
 
-                */
-/* set endpoint *//*
-
+                /* set endpoint */
                 dsConfig.setAuthentication(authDTO);
                 dsConfig.setEndpoints(List.of(endpoint));
 
-                */
-/* set ssl mode *//*
-
-
+                /* set ssl mode */
                 dsConfig.setConnection(new com.appsmith.external.models.Connection());
                 dsConfig.getConnection().setMode(com.appsmith.external.models.Connection.Mode.READ_WRITE);
                 dsConfig.getConnection().setSsl(new SSLDetails());
@@ -299,15 +284,13 @@ public class MySqlPluginTest {
                 Set<String> output = pluginExecutor.validateDatasource(dsConfig);
                 assertTrue(output.isEmpty());
                 // test connect
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 StepVerifier.create(dsConnectionMono)
                                 .assertNext(Assertions::assertNotNull)
                                 .verifyComplete();
 
-                */
-/* Expect no error *//*
-
+                /* Expect no error */
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> assertEquals(0,
                                                 datasourceTestResult.getInvalids().size()))
@@ -327,15 +310,13 @@ public class MySqlPluginTest {
                 Set<String> output = pluginExecutor.validateDatasource(dsConfig);
                 assertTrue(output.isEmpty());
                 // test connect
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 StepVerifier.create(dsConnectionMono)
                                 .assertNext(Assertions::assertNotNull)
                                 .verifyComplete();
 
-                */
-/* Expect no error *//*
-
+                /* Expect no error */
                 StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                                 .assertNext(datasourceTestResult -> assertEquals(0,
                                                 datasourceTestResult.getInvalids().size()))
@@ -345,7 +326,7 @@ public class MySqlPluginTest {
 
         @Test
         public void testExecute() {
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("show databases");
@@ -365,7 +346,7 @@ public class MySqlPluginTest {
         @Test
         public void testExecuteWithFormattingWithShowCmd() {
                 dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("show\n\tdatabases");
@@ -386,8 +367,9 @@ public class MySqlPluginTest {
 
         @Test
         public void testExecuteWithFormattingWithSelectCmd() {
+
                 dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("select\n\t*\nfrom\nusers where id=1");
@@ -410,14 +392,12 @@ public class MySqlPluginTest {
                                         assertEquals("18:32:45", node.get("time1").asText());
                                         assertEquals("2018-11-30T20:45:15Z", node.get("created_on").asText());
 
-                                        */
-/*
+                                        /*
                                          * - RequestParamDTO object only have attributes configProperty and value at
                                          * this point.
                                          * - The other two RequestParamDTO attributes - label and type are null at this
                                          * point.
-                                         *//*
-
+                                         */
                                         List<RequestParamDTO> expectedRequestParams = new ArrayList<>();
                                         expectedRequestParams.add(new RequestParamDTO(ACTION_CONFIGURATION_BODY,
                                                         actionConfiguration.getBody(), null, null, new HashMap<>()));
@@ -429,12 +409,12 @@ public class MySqlPluginTest {
 
         @Test
         public void testStaleConnectionCheck() {
+
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("show databases");
-                Connection connection = pluginExecutor.datasourceCreate(dsConfig).block();
-
-                Flux<ActionExecutionResult> resultFlux = Mono.from(connection.close())
-                                .thenMany(pluginExecutor.executeParameterized(connection, new ExecuteActionDTO(),
+                ConnectionPool connectionPool = pluginExecutor.datasourceCreate(dsConfig).block();
+                Flux<ActionExecutionResult> resultFlux = Mono.from(connectionPool.disposeLater())
+                                .thenMany(pluginExecutor.executeParameterized(connectionPool, new ExecuteActionDTO(),
                                                 dsConfig, actionConfiguration));
 
                 StepVerifier.create(resultFlux)
@@ -498,7 +478,7 @@ public class MySqlPluginTest {
         @Test
         public void testAliasColumnNames() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("SELECT id as user_id FROM users WHERE id = 1");
@@ -527,11 +507,10 @@ public class MySqlPluginTest {
         @Test
         public void testPreparedStatementErrorWithIsKeyword() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
-                */
-/**
+                /**
                  * - MySQL r2dbc driver is not able to substitute the `True/False` value
                  * properly after the IS keyword.
                  * Converting `True/False` to integer 1 or 0 also does not work in this case as
@@ -539,8 +518,7 @@ public class MySqlPluginTest {
                  * integers with IS keyword.
                  * - I have raised an issue with r2dbc to track it:
                  * https://github.com/mirromutth/r2dbc-mysql/issues/200
-                 *//*
-
+                 */
                 actionConfiguration.setBody("SELECT id FROM test_boolean_type WHERE c_boolean IS {{binding1}};");
 
                 List<Property> pluginSpecifiedTemplates = new ArrayList<>();
@@ -586,19 +564,17 @@ public class MySqlPluginTest {
                                 .blockLast(); // wait until completion of all the queries
 
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
-                */
-/**
+                /**
                  * - For mysql float / double / real types the actual values that are stored in
                  * the db my differ by a very
                  * thin margin as long as they are approximately same. Hence adding comparison
                  * based check instead of direct
                  * equality.
                  * - Ref: https://dev.mysql.com/doc/refman/8.0/en/problems-with-float.html
-                 *//*
-
+                 */
                 actionConfiguration.setBody(
                                 "SELECT id FROM test_real_types WHERE ABS(c_float - {{binding1}}) < 0.1 AND ABS" +
                                                 "(c_double - {{binding2}}) < 0.1 AND ABS(c_real - {{binding3}}) < 0.1;");
@@ -664,7 +640,7 @@ public class MySqlPluginTest {
                                 .blockLast(); // wait until completion of all the queries
 
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("SELECT id FROM test_boolean_type WHERE c_boolean={{binding1}};");
@@ -706,7 +682,7 @@ public class MySqlPluginTest {
         @Test
         public void testExecuteWithPreparedStatement() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration
@@ -749,13 +725,12 @@ public class MySqlPluginTest {
                                         // Verify value
                                         assertEquals(1, node.get("id").asInt());
 
-                                        */
-/*
+                                        /*
                                          * - Check if request params are sent back properly.
                                          * - Not replicating the same to other tests as the overall flow remains the
                                          * same w.r.t. request
                                          * params.
-                                         *//*
+                                         */
 
 
                                         // Check if '?' is replaced by $i.
@@ -791,7 +766,7 @@ public class MySqlPluginTest {
         @Test
         public void testExecuteDataTypes() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("SELECT * FROM users WHERE id = 1");
@@ -835,8 +810,7 @@ public class MySqlPluginTest {
                                 .verifyComplete();
         }
 
-        */
-/**
+        /**
          * 1. Add a test to check that mysql driver can interpret and read all the
          * regular data types used in mysql.
          * 2. List of the data types is taken is from
@@ -846,8 +820,7 @@ public class MySqlPluginTest {
          * DATE, DATETIME, TIMESTAMP, TIME, YEAR, CHAR, VARCHAR, BINARY, VARBINARY,
          * TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB,
          * TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, ENUM, SET, JSON, GEOMETRY, POINT
-         *//*
-
+         */
         @Test
         public void testExecuteDataTypesExtensive() throws AppsmithPluginException {
                 String query_create_table_numeric_types = "create table test_numeric_types (c_integer INTEGER, c_smallint "
@@ -916,32 +889,22 @@ public class MySqlPluginTest {
                                 .flatMapMany(batch -> Flux.from(batch.execute()))
                                 .blockLast(); // wait until completion of all the queries
 
-                */
-/* Test numeric types *//*
-
+                /* Test numeric types */
                 testExecute(query_select_from_test_numeric_types);
-                */
-/* Test date time types *//*
-
+                /* Test date time types */
                 testExecute(query_select_from_test_date_time_types);
-                */
-/* Test data types *//*
-
+                /* Test data types */
                 testExecute(query_select_from_test_data_types);
-                */
-/* Test data types *//*
-
+                /* Test data types */
                 testExecute(query_select_from_test_json_data_type);
-                */
-/* Test data types *//*
-
+                /* Test data types */
                 testExecute(query_select_from_test_geometry_types);
 
                 return;
         }
 
         private void testExecute(String query) {
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody(query);
                 Mono<Object> executeMono = dsConnectionMono.flatMap(conn -> pluginExecutor.executeParameterized(conn,
@@ -1135,7 +1098,7 @@ public class MySqlPluginTest {
 
                 DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
                 datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.DISABLED);
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
                 Mono<Object> executeMono = dsConnectionMono
                                 .flatMap(conn -> pluginExecutor.executeParameterized(conn, new ExecuteActionDTO(),
                                                 dsConfig,
@@ -1160,7 +1123,7 @@ public class MySqlPluginTest {
 
                 DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
                 datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.REQUIRED);
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
                 Mono<Object> executeMono = dsConnectionMono
                                 .flatMap(conn -> pluginExecutor.executeParameterized(conn, new ExecuteActionDTO(),
                                                 dsConfig,
@@ -1185,7 +1148,7 @@ public class MySqlPluginTest {
 
                 DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
                 datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.PREFERRED);
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
                 Mono<Object> executeMono = dsConnectionMono
                                 .flatMap(conn -> pluginExecutor.executeParameterized(conn, new ExecuteActionDTO(),
                                                 dsConfig,
@@ -1210,7 +1173,7 @@ public class MySqlPluginTest {
 
                 DatasourceConfiguration datasourceConfiguration = createDatasourceConfiguration();
                 datasourceConfiguration.getConnection().getSsl().setAuthType(SSLDetails.AuthType.DEFAULT);
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(datasourceConfiguration);
                 Mono<Object> executeMono = dsConnectionMono
                                 .flatMap(conn -> pluginExecutor.executeParameterized(conn, new ExecuteActionDTO(),
                                                 dsConfig,
@@ -1231,7 +1194,7 @@ public class MySqlPluginTest {
         @Test
         public void testDuplicateColumnNames() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody(
@@ -1253,10 +1216,9 @@ public class MySqlPluginTest {
                                                                         .anyMatch(message -> message
                                                                                         .contains(expectedMessage)));
 
-                                        */
-/*
+                                        /*
                                          * - Check if all of the duplicate column names are reported.
-                                         *//*
+                                         */
 
                                         Set<String> expectedColumnNames = Stream.of("id", "password")
                                                         .collect(Collectors.toCollection(HashSet::new));
@@ -1277,7 +1239,7 @@ public class MySqlPluginTest {
         @Test
         public void testExecuteDescribeTableCmd() {
                 dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("describe users");
@@ -1299,7 +1261,7 @@ public class MySqlPluginTest {
         @Test
         public void testExecuteDescTableCmd() {
                 dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("desc users");
@@ -1323,7 +1285,7 @@ public class MySqlPluginTest {
                 pluginExecutor = spy(new MySqlPlugin.MySqlPluginExecutor());
                 doReturn(false).when(pluginExecutor).isIsOperatorUsed(any());
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("SELECT * from (\n" +
@@ -1376,7 +1338,7 @@ public class MySqlPluginTest {
         @Test
         public void testNullAsStringWithPreparedStatement() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("SELECT * from (\n" +
@@ -1430,7 +1392,7 @@ public class MySqlPluginTest {
         @Test
         public void testNumericValuesHavingLeadingZeroWithPreparedStatement() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("SELECT {{binding1}} as numeric_string;");
@@ -1476,7 +1438,7 @@ public class MySqlPluginTest {
         @Test
         public void testLongValueWithPreparedStatement() {
                 DatasourceConfiguration dsConfig = createDatasourceConfiguration();
-                Mono<Connection> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+                Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
 
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody("select id from users LIMIT {{binding1}}");
@@ -1517,4 +1479,4 @@ public class MySqlPluginTest {
                                 })
                                 .verifyComplete();
         }
-}*/
+}

--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -43,7 +43,7 @@
 
     <dependencies>
 
-        <dependency>
+        <!--<dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-pool</artifactId>
             <version>0.9.2.RELEASE</version>
@@ -65,7 +65,7 @@
                     <artifactId>reactive-streams</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
+        </dependency>-->
 
         <!--
     Ideally this dependency should have been added in the pom.xml file of GraphQLPlugin module, but it is

--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -42,6 +42,31 @@
     </repositories>
 
     <dependencies>
+
+        <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-pool</artifactId>
+            <version>0.9.2.RELEASE</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.projectreactor</groupId>
+                    <artifactId>reactor-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.reactivestreams</groupId>
+                    <artifactId>reactive-streams</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!--
     Ideally this dependency should have been added in the pom.xml file of GraphQLPlugin module, but it is
     causing 'java.lang.NoClassDefFoundError' error. Hence, adding it here after many attempts of fixing it the right
@@ -160,7 +185,7 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>
-            <version>3.4.6</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/ServerApplication.java
@@ -2,10 +2,11 @@ package com.appsmith.server;
 
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {R2dbcAutoConfiguration.class})
 @EnableScheduling
 public class ServerApplication {
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseAppsmithRepositoryImpl.java
@@ -368,6 +368,7 @@ public abstract class BaseAppsmithRepositoryImpl<T extends BaseDomain> {
                     });
         }
 
+        //return getAnonymousUserPermissionGroups();
 
         return userMono
                 .flatMap(userWithTenant -> Mono.zip(


### PR DESCRIPTION
## Description
- This PR adds connection pool mechanism to MySQL plugin. So far, we used to create one connection per datasource instance all the queries used to run on this one connection. This PR introduces a change to create a connection pool instead of a single connection for each datasource instance. The following configuration is used with the connection pool: 
  - max pool size = 5
  - max idle time for a connection = 10 min

Fixes #17481 #8419

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- All Existing JUnit TCs pass

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
