### PR TITLE
chore: Reducing the number of /new API calls

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/index.tsx
+++ b/app/client/src/ce/pages/AdminSettings/index.tsx
@@ -25,9 +25,6 @@ function Settings() {
     dispatch({
       type: ReduxActionTypes.FETCH_ADMIN_SETTINGS,
     });
-    dispatch({
-      type: ReduxActionTypes.FETCH_RELEASES,
-    });
   }, []);
 
   useEffect(() => {

--- a/app/client/src/pages/Applications/ProductUpdatesModal/index.tsx
+++ b/app/client/src/pages/Applications/ProductUpdatesModal/index.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useCallback, useContext, useRef } from "react";
+import React, {
+  useState,
+  useCallback,
+  useContext,
+  useRef,
+  useEffect,
+} from "react";
 import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
 import "@github/g-emoji-element";
@@ -9,6 +15,7 @@ import ReleasesAPI from "api/ReleasesAPI";
 import { resetReleasesCount } from "actions/releasesActions";
 import ReleaseComponent, { Release } from "./ReleaseComponent";
 import { DialogComponent as Dialog, ScrollIndicator } from "design-system";
+import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 
 const StyledDialog = styled(Dialog)`
   .bp3-dialog-body {
@@ -42,6 +49,15 @@ function ProductUpdatesModal(props: ProductUpdatesModalProps) {
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (props.hideTrigger && releaseItems.length === 0) {
+      dispatch({
+        type: ReduxActionTypes.FETCH_RELEASES,
+      });
+    }
+  }, []);
+
   const onOpening = useCallback(async () => {
     setIsOpen(true);
     dispatch(resetReleasesCount());


### PR DESCRIPTION
## Description

> Reducing the number of /new API calls by calling it on the Admin settings page only when a user tries to view the release notes in the Version tab.

Fixes [#17887](https://github.com/appsmithorg/appsmith/issues/17887)

## Type of change

- Reduce the number of API calls

## How Has This Been Tested?

> Tested that the /new API is getting called in the Admin settings page only when the user clicks on view release notes in the Version tab. Also, I checked that the home page what's new click is not affected by this change and neither is the number of /new API calls on the Home page.

- Manual

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
