### PR TITLE
chore: Added logging for WebClient provider

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -22,6 +22,8 @@ spring.mongodb.embedded.version=4.2.13
 
 # Log properties
 logging.level.root=info
+logging.level.reactor.netty.resources.PooledConnectionProvider=debug
+logging.level.reactor.netty.resources.DefaultPooledConnectionProvider=debug
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
 logging.pattern.console=[%d{ISO8601, UTC}] %X - %m%n


### PR DESCRIPTION
Enabled logging for WebClient client provider so that we're able to track the status of the connection pool over time.