### PR TITLE
chore: Removing AST connection acquisition pool limit

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -37,9 +37,10 @@ public class AstServiceCEImpl implements AstServiceCE {
             .maxConnections(500)
             .maxIdleTime(Duration.ofSeconds(5))
             .maxLifeTime(Duration.ofSeconds(10))
-            .pendingAcquireTimeout(Duration.ofSeconds(10))
+            .pendingAcquireTimeout(Duration.ofMillis(1000))
             .pendingAcquireMaxCount(-1)
-            .evictInBackground(Duration.ofSeconds(20)).build());
+            .evictInBackground(Duration.ofSeconds(60)).
+            build());
 
     private final static long MAX_API_RESPONSE_TIME = 50;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -37,7 +37,7 @@ public class AstServiceCEImpl implements AstServiceCE {
             .maxConnections(500)
             .maxIdleTime(Duration.ofSeconds(5))
             .maxLifeTime(Duration.ofSeconds(10))
-            .pendingAcquireTimeout(Duration.ofMillis(1000))
+            .pendingAcquireTimeout(Duration.ofSeconds(5))
             .pendingAcquireMaxCount(-1)
             .evictInBackground(Duration.ofSeconds(60))
             .build());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -39,8 +39,8 @@ public class AstServiceCEImpl implements AstServiceCE {
             .maxLifeTime(Duration.ofSeconds(10))
             .pendingAcquireTimeout(Duration.ofMillis(1000))
             .pendingAcquireMaxCount(-1)
-            .evictInBackground(Duration.ofSeconds(60)).
-            build());
+            .evictInBackground(Duration.ofSeconds(60))
+            .build());
 
     private final static long MAX_API_RESPONSE_TIME = 50;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -38,6 +38,7 @@ public class AstServiceCEImpl implements AstServiceCE {
             .maxIdleTime(Duration.ofSeconds(5))
             .maxLifeTime(Duration.ofSeconds(10))
             .pendingAcquireTimeout(Duration.ofSeconds(10))
+            .pendingAcquireMaxCount(-1)
             .evictInBackground(Duration.ofSeconds(20)).build());
 
     private final static long MAX_API_RESPONSE_TIME = 50;

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -1,24 +1,31 @@
 server.port=${PORT:8080}
+
 # This property allows us to override beans during testing. This is useful when we want to set different configurations
 # and different parameters during test as compared to production. If this property is disabled, some tests will fail.
 spring.main.allow-bean-definition-overriding=true
+
 # This property allows the server to run behind a proxy server and still resolve all the urls correctly
 server.forward-headers-strategy=NATIVE
+
 spring.data.mongodb.auto-index-creation=false
 spring.data.mongodb.authentication-database=admin
 mongock.change-logs-scan-package=com.appsmith.server.migrations
 # Ensures that the size of the request object that we handle is controlled. By default it's 212KB.
 spring.codec.max-in-memory-size=100MB
 appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:100}
+
 # MongoDB Application Database
-spring.data.mongodb.uri=${APPSMITH_MONGODB_URI}
+spring.data.mongodb.uri = ${APPSMITH_MONGODB_URI}
+
 # embedded mongo DB version which is used during junit tests
 spring.mongodb.embedded.version=4.2.13
+
 # Log properties
 logging.level.root=info
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
 logging.pattern.console=[%d{ISO8601, UTC}] %X - %m%n
+
 #Spring security
 spring.security.oauth2.client.registration.google.client-id=${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:missing_value_sentinel}
 spring.security.oauth2.client.registration.google.client-secret=${APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET:}
@@ -26,22 +33,27 @@ spring.security.oauth2.client.provider.google.userNameAttribute=email
 spring.security.oauth2.client.registration.github.client-id=${APPSMITH_OAUTH2_GITHUB_CLIENT_ID:missing_value_sentinel}
 spring.security.oauth2.client.registration.github.client-secret=${APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET:}
 spring.security.oauth2.client.provider.github.userNameAttribute=login
+
 # Accounts from specific domains are allowed to login
 # DEPRECATED, in favor of signup.allowed-domains
 oauth2.allowed-domains=${APPSMITH_OAUTH2_ALLOWED_DOMAINS:}
+
 # Segment
 segment.writeKey=${APPSMITH_SEGMENT_KEY:}
 # Is this instance hosted on Appsmith cloud?
-is.cloud-hosting=${APPSMITH_CLOUD_HOSTING:false}
-disable.telemetry=${APPSMITH_DISABLE_TELEMETRY:true}
-segment.ce.key=${APPSMITH_SEGMENT_CE_KEY:}
+is.cloud-hosting = ${APPSMITH_CLOUD_HOSTING:false}
+disable.telemetry = ${APPSMITH_DISABLE_TELEMETRY:true}
+segment.ce.key = ${APPSMITH_SEGMENT_CE_KEY:}
+
 # Sentry
 sentry.dsn=${APPSMITH_SENTRY_DSN:}
 sentry.send-default-pii=true
 sentry.debug=off
 sentry.environment=${APPSMITH_SENTRY_ENVIRONMENT:}
+
 # Redis Properties
 spring.redis.url=${APPSMITH_REDIS_URL}
+
 # Mail Properties
 # Email defaults to false, because, when true and the other SMTP properties are not set, Spring will try to use a
 #   default localhost:25 SMTP server and throw an error. If false, this error won't happen because there's no attempt
@@ -56,18 +68,22 @@ spring.mail.username=${APPSMITH_MAIL_USERNAME:}
 spring.mail.password=${APPSMITH_MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=${APPSMITH_MAIL_SMTP_AUTH:}
 spring.mail.properties.mail.smtp.starttls.enable=${APPSMITH_MAIL_SMTP_TLS_ENABLED:}
-admin.emails=${APPSMITH_ADMIN_EMAILS:}
+admin.emails = ${APPSMITH_ADMIN_EMAILS:}
+
 # Configuring individual emails
-emails.welcome.enabled=${APPSMITH_EMAILS_WELCOME_ENABLED:true}
+emails.welcome.enabled = ${APPSMITH_EMAILS_WELCOME_ENABLED:true}
+
 # Appsmith Cloud Services
-appsmith.cloud_services.base_url=${APPSMITH_CLOUD_SERVICES_BASE_URL:https://cs.appsmith.com}
-appsmith.cloud_services.username=${APPSMITH_CLOUD_SERVICES_USERNAME:}
-appsmith.cloud_services.password=${APPSMITH_CLOUD_SERVICES_PASSWORD:}
-github_repo=${APPSMITH_GITHUB_REPO:}
+appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:https://cs.appsmith.com}
+appsmith.cloud_services.username = ${APPSMITH_CLOUD_SERVICES_USERNAME:}
+appsmith.cloud_services.password = ${APPSMITH_CLOUD_SERVICES_PASSWORD:}
+github_repo = ${APPSMITH_GITHUB_REPO:}
+
 # MANDATORY!! No default properties are being provided for encryption password and salt for security.
 # The server would not come up without these values provided through the environment variables.
 encrypt.password=${APPSMITH_ENCRYPTION_PASSWORD:}
 encrypt.salt=${APPSMITH_ENCRYPTION_SALT:}
+
 # The following configurations are to help support prometheus scraping for monitoring
 management.endpoints.web.exposure.include=prometheus
 management.metrics.web.server.request.autotime.enabled=true
@@ -76,15 +92,20 @@ management.metrics.web.server.request.ignore-trailing-slash=true
 management.metrics.web.server.request.autotime.percentiles=0.5, 0.9, 0.95, 0.99
 management.metrics.web.server.request.autotime.percentiles-histogram=true
 management.metrics.distribution.sla.[http.server.requests]=1s
+
 # Support disabling signup with an environment variable
-signup.disabled=${APPSMITH_SIGNUP_DISABLED:false}
+signup.disabled = ${APPSMITH_SIGNUP_DISABLED:false}
 signup.allowed-domains=${APPSMITH_SIGNUP_ALLOWED_DOMAINS:}
+
 # Google recaptcha config
-google.recaptcha.key.site=${APPSMITH_RECAPTCHA_SITE_KEY:}
-google.recaptcha.key.secret=${APPSMITH_RECAPTCHA_SECRET_KEY:}
+google.recaptcha.key.site = ${APPSMITH_RECAPTCHA_SITE_KEY:}
+google.recaptcha.key.secret= ${APPSMITH_RECAPTCHA_SECRET_KEY:}
+
 # Plugin Interface level settings
 appsmith.plugin.response.size.max=${APPSMITH_PLUGIN_MAX_RESPONSE_SIZE_MB:5}
+
 # Location env file with environment variables, that can be configured from the UI.
 appsmith.admin.envfile=${APPSMITH_ENVFILE_PATH:/appsmith-stacks/configuration/docker.env}
+
 # Name of this instance
 appsmith.instance.name=${APPSMITH_INSTANCE_NAME:Appsmith}

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -22,6 +22,8 @@ spring.mongodb.embedded.version=4.2.13
 
 # Log properties
 logging.level.root=info
+logging.level.reactor.netty.resources.PooledConnectionProvider=debug
+logging.level.reactor.netty.resources.DefaultPooledConnectionProvider=debug
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
 logging.pattern.console=[%d{ISO8601, UTC}] %X - %m%n

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -1,33 +1,24 @@
 server.port=${PORT:8080}
-
 # This property allows us to override beans during testing. This is useful when we want to set different configurations
 # and different parameters during test as compared to production. If this property is disabled, some tests will fail.
 spring.main.allow-bean-definition-overriding=true
-
 # This property allows the server to run behind a proxy server and still resolve all the urls correctly
 server.forward-headers-strategy=NATIVE
-
 spring.data.mongodb.auto-index-creation=false
 spring.data.mongodb.authentication-database=admin
 mongock.change-logs-scan-package=com.appsmith.server.migrations
 # Ensures that the size of the request object that we handle is controlled. By default it's 212KB.
 spring.codec.max-in-memory-size=100MB
 appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:100}
-
 # MongoDB Application Database
-spring.data.mongodb.uri = ${APPSMITH_MONGODB_URI}
-
+spring.data.mongodb.uri=${APPSMITH_MONGODB_URI}
 # embedded mongo DB version which is used during junit tests
 spring.mongodb.embedded.version=4.2.13
-
 # Log properties
 logging.level.root=info
-logging.level.reactor.netty.resources.PooledConnectionProvider=debug
-logging.level.reactor.netty.resources.DefaultPooledConnectionProvider=debug
 logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
 logging.pattern.console=[%d{ISO8601, UTC}] %X - %m%n
-
 #Spring security
 spring.security.oauth2.client.registration.google.client-id=${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:missing_value_sentinel}
 spring.security.oauth2.client.registration.google.client-secret=${APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET:}
@@ -35,27 +26,22 @@ spring.security.oauth2.client.provider.google.userNameAttribute=email
 spring.security.oauth2.client.registration.github.client-id=${APPSMITH_OAUTH2_GITHUB_CLIENT_ID:missing_value_sentinel}
 spring.security.oauth2.client.registration.github.client-secret=${APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET:}
 spring.security.oauth2.client.provider.github.userNameAttribute=login
-
 # Accounts from specific domains are allowed to login
 # DEPRECATED, in favor of signup.allowed-domains
 oauth2.allowed-domains=${APPSMITH_OAUTH2_ALLOWED_DOMAINS:}
-
 # Segment
 segment.writeKey=${APPSMITH_SEGMENT_KEY:}
 # Is this instance hosted on Appsmith cloud?
-is.cloud-hosting = ${APPSMITH_CLOUD_HOSTING:false}
-disable.telemetry = ${APPSMITH_DISABLE_TELEMETRY:true}
-segment.ce.key = ${APPSMITH_SEGMENT_CE_KEY:}
-
+is.cloud-hosting=${APPSMITH_CLOUD_HOSTING:false}
+disable.telemetry=${APPSMITH_DISABLE_TELEMETRY:true}
+segment.ce.key=${APPSMITH_SEGMENT_CE_KEY:}
 # Sentry
 sentry.dsn=${APPSMITH_SENTRY_DSN:}
 sentry.send-default-pii=true
 sentry.debug=off
 sentry.environment=${APPSMITH_SENTRY_ENVIRONMENT:}
-
 # Redis Properties
 spring.redis.url=${APPSMITH_REDIS_URL}
-
 # Mail Properties
 # Email defaults to false, because, when true and the other SMTP properties are not set, Spring will try to use a
 #   default localhost:25 SMTP server and throw an error. If false, this error won't happen because there's no attempt
@@ -70,22 +56,18 @@ spring.mail.username=${APPSMITH_MAIL_USERNAME:}
 spring.mail.password=${APPSMITH_MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=${APPSMITH_MAIL_SMTP_AUTH:}
 spring.mail.properties.mail.smtp.starttls.enable=${APPSMITH_MAIL_SMTP_TLS_ENABLED:}
-admin.emails = ${APPSMITH_ADMIN_EMAILS:}
-
+admin.emails=${APPSMITH_ADMIN_EMAILS:}
 # Configuring individual emails
-emails.welcome.enabled = ${APPSMITH_EMAILS_WELCOME_ENABLED:true}
-
+emails.welcome.enabled=${APPSMITH_EMAILS_WELCOME_ENABLED:true}
 # Appsmith Cloud Services
-appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:https://cs.appsmith.com}
-appsmith.cloud_services.username = ${APPSMITH_CLOUD_SERVICES_USERNAME:}
-appsmith.cloud_services.password = ${APPSMITH_CLOUD_SERVICES_PASSWORD:}
-github_repo = ${APPSMITH_GITHUB_REPO:}
-
+appsmith.cloud_services.base_url=${APPSMITH_CLOUD_SERVICES_BASE_URL:https://cs.appsmith.com}
+appsmith.cloud_services.username=${APPSMITH_CLOUD_SERVICES_USERNAME:}
+appsmith.cloud_services.password=${APPSMITH_CLOUD_SERVICES_PASSWORD:}
+github_repo=${APPSMITH_GITHUB_REPO:}
 # MANDATORY!! No default properties are being provided for encryption password and salt for security.
 # The server would not come up without these values provided through the environment variables.
 encrypt.password=${APPSMITH_ENCRYPTION_PASSWORD:}
 encrypt.salt=${APPSMITH_ENCRYPTION_SALT:}
-
 # The following configurations are to help support prometheus scraping for monitoring
 management.endpoints.web.exposure.include=prometheus
 management.metrics.web.server.request.autotime.enabled=true
@@ -94,20 +76,15 @@ management.metrics.web.server.request.ignore-trailing-slash=true
 management.metrics.web.server.request.autotime.percentiles=0.5, 0.9, 0.95, 0.99
 management.metrics.web.server.request.autotime.percentiles-histogram=true
 management.metrics.distribution.sla.[http.server.requests]=1s
-
 # Support disabling signup with an environment variable
-signup.disabled = ${APPSMITH_SIGNUP_DISABLED:false}
+signup.disabled=${APPSMITH_SIGNUP_DISABLED:false}
 signup.allowed-domains=${APPSMITH_SIGNUP_ALLOWED_DOMAINS:}
-
 # Google recaptcha config
-google.recaptcha.key.site = ${APPSMITH_RECAPTCHA_SITE_KEY:}
-google.recaptcha.key.secret= ${APPSMITH_RECAPTCHA_SECRET_KEY:}
-
+google.recaptcha.key.site=${APPSMITH_RECAPTCHA_SITE_KEY:}
+google.recaptcha.key.secret=${APPSMITH_RECAPTCHA_SECRET_KEY:}
 # Plugin Interface level settings
 appsmith.plugin.response.size.max=${APPSMITH_PLUGIN_MAX_RESPONSE_SIZE_MB:5}
-
 # Location env file with environment variables, that can be configured from the UI.
 appsmith.admin.envfile=${APPSMITH_ENVFILE_PATH:/appsmith-stacks/configuration/docker.env}
-
 # Name of this instance
 appsmith.instance.name=${APPSMITH_INSTANCE_NAME:Appsmith}


### PR DESCRIPTION
We'll make use of a generous timeout of 1 second instead so that these attempts do have an end.