### PR TITLE
ci: Remove PR from create run meta query

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -48,7 +48,14 @@ jobs:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
 
+      # Checkout the code in the current branch in case the workflow is called because of a branch push event
+      - name: Checkout the head commit of the branch
+        if: inputs.pr == 0
 
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
       # Create a run record exactly at the time of merge to release to  
       # ensure we compare run details with code at this point
       - name: Create Perf Meta
@@ -59,13 +66,6 @@ jobs:
           "INSERT INTO public.run_meta (gh_run_id, gh_run_attempt, pull_request_id, is_active) 
           VALUES ('${{github.run_id}}', '${{github.run_attempt}}', '${{ inputs.pr }}', FALSE)"
 
-      # Checkout the code in the current branch in case the workflow is called because of a branch push event
-      - name: Checkout the head commit of the branch
-        if: inputs.pr == 0
-
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -63,8 +63,8 @@ jobs:
         run: |
           PGPASSWORD='${{secrets.APPSMITH_PERFORMANCE_DB_PASSWORD}}' psql -h '${{secrets.APPSMITH_PERFORMANCE_DB_HOST}}' \
           -U aforce_admin -d perf-infra -c \
-          "INSERT INTO public.run_meta (gh_run_id, gh_run_attempt, pull_request_id, is_active) 
-          VALUES ('${{github.run_id}}', '${{github.run_attempt}}', '${{ inputs.pr }}', FALSE)"
+          "INSERT INTO public.run_meta (gh_run_id, gh_run_attempt, is_active) 
+          VALUES ('${{github.run_id}}', '${{github.run_attempt}}', FALSE)"
 
 
       - name: Figure out the PR number

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -63,8 +63,8 @@ jobs:
         run: |
           PGPASSWORD='${{secrets.APPSMITH_PERFORMANCE_DB_PASSWORD}}' psql -h '${{secrets.APPSMITH_PERFORMANCE_DB_HOST}}' \
           -U aforce_admin -d perf-infra -c \
-          "INSERT INTO public.run_meta (gh_run_id, gh_run_attempt, is_active) 
-          VALUES ('${{github.run_id}}', '${{github.run_attempt}}', FALSE)"
+          "INSERT INTO public.run_meta (repo, gh_run_id, gh_run_attempt, is_active) 
+          VALUES ('${{github.repository}}',${{github.run_id}}', '${{github.run_attempt}}', FALSE)"
 
 
       - name: Figure out the PR number


### PR DESCRIPTION
Remove PR from insert query as its sometimes not available and row can be uniquely identified with the run_id and attempt
Fixes: https://github.com/appsmithorg/appsmith/issues/17916