### PR TITLE
fix: update local_testing.sh to build image for external contributor PRs

### DIFF
--- a/scripts/local_testing.sh
+++ b/scripts/local_testing.sh
@@ -10,10 +10,12 @@ display_help()
   echo "If --local or -l is passed, it will build with local changes"
   echo "---------------------------------------------------------------------------------------"
   echo
-  echo "Syntax: $0 [-h] [-l] [branchName]"
+  echo "Syntax: $0 [-h] [-l] [-r [remote_url]] [branch_name]"
   echo "options:"
-  echo "h     Print this help"
-  echo "local"    Use the local codebase and not git
+  echo "-h     			Print this help"
+  echo "-l or --local    	Use the local codebase and not git"
+  echo "-r or --remote    	Use the branch from a remote repository"
+  echo "For more info please check: https://www.notion.so/appsmith/Test-an-Appsmith-branch-locally-c39ad68aea0d42bf94a149ea22e86820#9cee16c7e2054b5980513ec6f351ace2"
   echo
 }
 
@@ -38,12 +40,28 @@ then
   LOCAL=true
 fi
 
-BRANCH=${1:-release}
+REMOTE=false
+if [[ ($1 == "--remote" || $1 == "-r")]]
+then
+  REMOTE=true
+fi
 
 if [[ ($LOCAL == true) ]]
 then
   pretty_print "Setting up instance with local changes"
+  BRANCH=release
+elif [[ ($REMOTE == true) ]]
+then
+  pretty_print "Setting up instance with remote repository branch ..."	
+  REMOTE_REPOSITORY_URL=$2
+  REMOTE_BRANCH=$3
+  pretty_print "Please ignore if the following error occurs: remote remote_origin_for_local_test already exists."	
+  git remote add remote_origin_for_local_test $REMOTE_REPOSITORY_URL || git remote set-url remote_origin_for_local_test $REMOTE_REPOSITORY_URL
+  git fetch remote_origin_for_local_test 
+  git checkout $REMOTE_BRANCH
+  git pull remote_origin_for_local_test $REMOTE_BRANCH
 else
+  BRANCH=$1
   pretty_print "Setting up instance to run on branch: $BRANCH"
   cd "$(dirname "$0")"/..
   git fetch origin $BRANCH


### PR DESCRIPTION
## Description
- Currently, the `local_testing.sh` script fails when building external contributor PRs because the source branch belongs to a non-Appsmith repository. `local_testing.sh` is used by the QA team to manually test PR changes before merge. This PR updates the script to include any non-Appsmith repository as a `remote` reference to the local Git context which would allow us to pull the related external contributor branch on our local setup for manual test. 
- New usage example : `/scripts/local_testing.sh -r https://github.com/lifeneedspassion/appsmith.git fix/17747-js-error`

Fixes #18023 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Automated test does not seem feasible at the moment

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
