### PR TITLE
chore: remove extra feature flags | FE

### DIFF
--- a/app/client/src/entities/FeatureFlags.ts
+++ b/app/client/src/entities/FeatureFlags.ts
@@ -3,11 +3,8 @@ type FeatureFlags = {
   JS_EDITOR?: boolean;
   MULTIPLAYER?: boolean;
   SNIPPET?: boolean;
-  GIT?: boolean;
-  GIT_IMPORT?: boolean;
   TEMPLATES_PHASE_2?: boolean;
   RBAC?: boolean;
-  AUDIT_LOGS?: boolean;
   CONTEXT_SWITCHING?: boolean;
 };
 

--- a/app/client/src/pages/Applications/ImportApplicationModal.tsx
+++ b/app/client/src/pages/Applications/ImportApplicationModal.tsx
@@ -20,8 +20,8 @@ import {
 import { Colors } from "constants/Colors";
 import {
   DialogComponent as Dialog,
-  FileType,
   FilePickerV2,
+  FileType,
   Icon,
   IconSize,
   SetProgress,
@@ -34,7 +34,6 @@ import { GitSyncModalTab } from "entities/GitSync";
 import { getIsImportingApplication } from "selectors/applicationSelectors";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { Classes } from "@blueprintjs/core";
-import { selectFeatureFlags } from "selectors/usersSelectors";
 import Statusbar from "pages/Editor/gitSync/components/Statusbar";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 
@@ -86,8 +85,8 @@ const Row = styled.div`
   }
 `;
 
-const FileImportCard = styled.div<{ gitEnabled?: boolean }>`
-  width: ${(props) => (props.gitEnabled ? "320px" : "100%")};
+const FileImportCard = styled.div`
+  width: 320px;
   height: 200px;
   border: 1px solid ${Colors.GREY_4};
   display: flex;
@@ -232,7 +231,6 @@ function GitImportCard(props: { children?: ReactNode; handler?: () => void }) {
 }
 
 type ImportApplicationModalProps = {
-  // import?: (file: any) => void;
   workspaceId?: string;
   isModalOpen?: boolean;
   onClose?: () => void;
@@ -296,9 +294,6 @@ function ImportApplicationModal(props: ImportApplicationModalProps) {
 
   const onRemoveFile = useCallback(() => setAppFileToBeUploaded(null), []);
 
-  const featureFlags = useSelector(selectFeatureFlags);
-  const { GIT_IMPORT: isGitImportFeatureEnabled } = featureFlags;
-
   return (
     <StyledDialog
       canOutsideClickClose
@@ -324,10 +319,7 @@ function ImportApplicationModal(props: ImportApplicationModalProps) {
       </TextWrapper>
       {!importingApplication && (
         <Row>
-          <FileImportCard
-            className="t--import-json-card"
-            gitEnabled={isGitImportFeatureEnabled}
-          >
+          <FileImportCard className="t--import-json-card">
             <FilePickerV2
               containerClickable
               description={createMessage(IMPORT_APP_FROM_FILE_MESSAGE)}
@@ -339,7 +331,7 @@ function ImportApplicationModal(props: ImportApplicationModalProps) {
               uploadIcon="file-line"
             />
           </FileImportCard>
-          {isGitImportFeatureEnabled && <GitImportCard handler={onGitImport} />}
+          <GitImportCard handler={onGitImport} />
         </Row>
       )}
       {importingApplication && (


### PR DESCRIPTION
## Description

Three flags GIT, GIT_IMPORT and AUDIT_LOGS are not being used in FE anymore. This PR removes those extra flags.
Continuation of https://github.com/appsmithorg/appsmith/pull/18029

Fixes #18036 

## Type of change

- Chore

## How Has This Been Tested?

- Manual

### Test Plan


### Issues raised during DP testing



## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
