### PR TITLE
chore: use `typography` and `getTypographyFromKey` from the design-system

### DIFF
--- a/app/client/src/ce/pages/UserAuth/ThirdPartyAuth.tsx
+++ b/app/client/src/ce/pages/UserAuth/ThirdPartyAuth.tsx
@@ -4,7 +4,7 @@ import {
   getSocialLoginButtonProps,
   SocialLoginType,
 } from "@appsmith/constants/SocialLogin";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import AnalyticsUtil, { EventName } from "utils/AnalyticsUtil";
 import { useLocation } from "react-router-dom";
 import PerformanceTracker, {
@@ -34,7 +34,7 @@ const StyledSocialLoginButton = styled.a`
   }
 
   & .login-method {
-    ${(props) => getTypographyByKey(props, "btnLarge")}
+    ${getTypographyByKey("btnLarge")}
     color: ${(props) => props.theme.colors.auth.socialBtnText};
     text-transform: uppercase;
   }

--- a/app/client/src/components/TabItemBackgroundFill.tsx
+++ b/app/client/src/components/TabItemBackgroundFill.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
-import { TabProp } from "design-system";
-import { getTypographyByKey, Theme } from "constants/DefaultTheme";
+import { getTypographyByKey, TabProp } from "design-system";
+import { Theme } from "constants/DefaultTheme";
 
 type WrapperProps = {
   selected: boolean;
@@ -17,13 +17,13 @@ const getFocusedStyles = (props: WrapperProps) => `
 
 const Wrapper = styled.div<WrapperProps>`
   display: flex;
-  ${(props) => getTypographyByKey(props, "p1")}
+  ${getTypographyByKey("p1")}
 
   ${(props) =>
     props.selected
       ? getFocusedStyles(props)
       : `
-      color: ${props.theme.colors.tabItemBackgroundFill.textColor};  
+      color: ${props.theme.colors.tabItemBackgroundFill.textColor};
     `};
 
   &:hover,

--- a/app/client/src/components/editorComponents/ActionRightPane/Connections.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/Connections.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { Collapsible } from ".";
-import { Classes, Icon, IconSize, Text, TextType } from "design-system";
+import {
+  Classes,
+  getTypographyByKey,
+  Icon,
+  IconSize,
+  Text,
+  TextType,
+} from "design-system";
 import styled from "styled-components";
 import LongArrowSVG from "assets/images/long-arrow-bottom.svg";
 import { useEntityLink } from "../Debugger/hooks/debuggerHooks";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import {
   createMessage,
@@ -57,7 +63,7 @@ const ConnectionsContainer = styled.span`
       ${(props) => props.theme.colors.actionSidePane.connectionBorder};
     padding: ${(props) => props.theme.spaces[0] + 2}px
       ${(props) => props.theme.spaces[1]}px;
-    ${(props) => getTypographyByKey(props, "p3")}
+    ${getTypographyByKey("p3")}
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/client/src/components/editorComponents/ActionRightPane/SuggestedWidgets.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/SuggestedWidgets.tsx
@@ -1,10 +1,9 @@
-import { getTypographyByKey } from "constants/DefaultTheme";
 import React, { memo } from "react";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { generateReactKey } from "utils/generators";
 import { Collapsible } from ".";
-import { TooltipComponent as Tooltip } from "design-system";
+import { getTypographyByKey, TooltipComponent as Tooltip } from "design-system";
 import { addSuggestedWidget } from "actions/widgetActions";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import {
@@ -21,7 +20,7 @@ import { getWidgets } from "sagas/selectors";
 import { getNextWidgetName } from "sagas/WidgetOperationUtils";
 
 const WidgetList = styled.div`
-  ${(props) => getTypographyByKey(props, "p1")}
+  ${getTypographyByKey("p1")}
   margin-left: ${(props) => props.theme.spaces[2] + 1}px;
 
   img {

--- a/app/client/src/components/editorComponents/ActionRightPane/index.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/index.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Category,
   Classes,
+  getTypographyByKey,
   Icon,
   IconSize,
   Size,
@@ -14,7 +15,6 @@ import {
 } from "design-system";
 import { useState } from "react";
 import history from "utils/history";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import Connections from "./Connections";
 import SuggestedWidgets from "./SuggestedWidgets";
 import { ReactNode } from "react";
@@ -60,7 +60,7 @@ const SideBar = styled.div`
     margin-left: ${(props) => props.theme.spaces[2] + 1}px;
 
     .connection-type {
-      ${(props) => getTypographyByKey(props, "p1")}
+      ${getTypographyByKey("p1")}
     }
   }
 
@@ -69,7 +69,7 @@ const SideBar = styled.div`
   }
 
   .description {
-    ${(props) => getTypographyByKey(props, "p1")}
+    ${getTypographyByKey("p1")}
     margin-left: ${(props) => props.theme.spaces[2] + 1}px;
     padding-bottom: ${(props) => props.theme.spaces[7]}px;
   }
@@ -107,7 +107,7 @@ const CollapsibleWrapper = styled.div<{ isOpen: boolean }>`
 
   & > .icon-text:first-child {
     color: ${(props) => props.theme.colors.actionSidePane.collapsibleIcon};
-    ${(props) => getTypographyByKey(props, "h4")}
+    ${getTypographyByKey("h4")}
     cursor: pointer;
     .${Classes.ICON} {
       ${(props) => !props.isOpen && `transform: rotate(-90deg);`}
@@ -120,7 +120,7 @@ const CollapsibleWrapper = styled.div<{ isOpen: boolean }>`
 `;
 
 const SnipingWrapper = styled.div`
-  ${(props) => getTypographyByKey(props, "p1")}
+  ${getTypographyByKey("p1")}
   margin-left: ${(props) => props.theme.spaces[2] + 1}px;
 
   img {

--- a/app/client/src/components/editorComponents/Debugger/DebugCTA.tsx
+++ b/app/client/src/components/editorComponents/Debugger/DebugCTA.tsx
@@ -7,8 +7,14 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import { getAppMode } from "selectors/applicationSelectors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
-import { getTypographyByKey } from "constants/DefaultTheme";
-import { Button, Classes, Icon, IconSize, Variant } from "design-system";
+import {
+  Button,
+  Classes,
+  getTypographyByKey,
+  Icon,
+  IconSize,
+  Variant,
+} from "design-system";
 import { Message } from "entities/AppsmithConsole";
 import ContextualMenu from "./ContextualMenu";
 import { Position } from "@blueprintjs/core";
@@ -17,7 +23,7 @@ import { Colors } from "constants/Colors";
 import { FieldEntityInformation } from "../CodeEditor/EditorConfig";
 
 const EVDebugButton = styled.button`
-  ${(props) => getTypographyByKey(props, "btnSmall")};
+  ${getTypographyByKey("btnSmall")};
   display: flex;
   padding: ${(props) => props.theme.spaces[1]}px;
   border: 1px solid
@@ -93,7 +99,7 @@ const StyledButton = styled(Button)`
     margin-top: 4px;
     text-transform: none;
     height: 26px;
-    ${(props) => getTypographyByKey(props, "p2")}
+    ${getTypographyByKey("p2")}
     .${Classes.ICON} {
       margin-right: 5px;
     }

--- a/app/client/src/components/editorComponents/Debugger/EntityDependecies.tsx
+++ b/app/client/src/components/editorComponents/Debugger/EntityDependecies.tsx
@@ -5,6 +5,7 @@ import { AppState } from "@appsmith/reducers";
 import styled from "styled-components";
 import {
   Classes,
+  getTypographyByKey,
   Icon,
   IconSize,
   Text,
@@ -24,7 +25,7 @@ import {
 import { getDependenciesFromInverseDependencies } from "./helpers";
 import { useSelectedEntity, useEntityLink } from "./hooks/debuggerHooks";
 import AnalyticsUtil from "utils/AnalyticsUtil";
-import { getTypographyByKey, thinScrollbar } from "constants/DefaultTheme";
+import { thinScrollbar } from "constants/DefaultTheme";
 import { ENTITY_TYPE } from "entities/AppsmithConsole";
 import { useGetEntityInfo } from "./hooks/useGetEntityInfo";
 
@@ -52,7 +53,7 @@ const ConnectionsContainer = styled.span`
       ${(props) => props.theme.colors.actionSidePane.connectionBorder};
     padding: ${(props) => props.theme.spaces[0] + 2}px
       ${(props) => props.theme.spaces[1]}px;
-    ${(props) => getTypographyByKey(props, "p3")}
+    ${getTypographyByKey("p3")}
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -103,7 +104,7 @@ const Wrapper = styled.div`
     margin-left: ${(props) => props.theme.spaces[2] + 1}px;
 
     .connection-type {
-      ${(props) => getTypographyByKey(props, "p1")}
+      ${getTypographyByKey("p1")}
     }
   }
 

--- a/app/client/src/components/editorComponents/Debugger/LogItem.tsx
+++ b/app/client/src/components/editorComponents/Debugger/LogItem.tsx
@@ -16,6 +16,7 @@ import { getLogIcon } from "./helpers";
 import {
   AppIcon,
   Classes,
+  getTypographyByKey,
   Icon,
   IconName,
   IconSize,
@@ -23,7 +24,6 @@ import {
   TextType,
   TooltipComponent,
 } from "design-system";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import {
   createMessage,
   TROUBLESHOOT_ISSUE,
@@ -76,7 +76,7 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
         : `transform: rotate(0deg); `};
     }
   .debugger-time {
-    ${(props) => getTypographyByKey(props, "h6")}
+    ${getTypographyByKey("h6")}
     line-height: 16px;
     margin-left: 8px;
     margin-right: 18px;
@@ -110,7 +110,7 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
     &.${Severity.WARNING} {
       background-color: ${Colors.WARNING_DEBUGGER_GROUPING_BADGE};
     }
-    ${(props) => getTypographyByKey(props, "u2")}
+    ${getTypographyByKey("u2")}
   }
   .debugger-description {
     display: flex;
@@ -121,7 +121,7 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
 
     .debugger-label {
       color: ${(props) => props.theme.colors.debugger.label};
-      ${(props) => getTypographyByKey(props, "p1")}
+      ${getTypographyByKey("p1")}
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
@@ -132,7 +132,7 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
     }
     .debugger-entity {
       color: ${(props) => props.theme.colors.debugger.entity};
-      ${(props) => getTypographyByKey(props, "h6")}
+      ${getTypographyByKey("h6")}
       margin-left: 6px;
 
       & > span {
@@ -149,13 +149,13 @@ const Wrapper = styled.div<{ collapsed: boolean }>`
   .debugger-timetaken {
     color: ${(props) => props.theme.colors.debugger.entity};
     margin-left: 5px;
-    ${(props) => getTypographyByKey(props, "p2")}
+    ${getTypographyByKey("p2")}
     line-height: 19px;
   }
 
   .debugger-entity-link {
     margin-left: auto;
-    ${(props) => getTypographyByKey(props, "btnMedium")}
+    ${getTypographyByKey("btnMedium")}
     color: ${(props) => props.theme.colors.debugger.entityLink};
     text-transform: uppercase;
     cursor: pointer;
@@ -187,7 +187,7 @@ margin-top:${(props) =>
   margin-left: 120px;
 
   .debugger-message {
-    ${(props) => getTypographyByKey(props, "p2")}
+    ${getTypographyByKey("p2")}
     color: ${(props) => props.theme.colors.debugger.message};
     text-decoration-line: underline;
     cursor: pointer;

--- a/app/client/src/components/editorComponents/Debugger/helpers.tsx
+++ b/app/client/src/components/editorComponents/Debugger/helpers.tsx
@@ -1,7 +1,7 @@
 import { Log, LOG_CATEGORY, Severity } from "entities/AppsmithConsole";
 import React from "react";
 import styled from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import {
   createMessage,
   OPEN_THE_DEBUGGER,
@@ -24,11 +24,11 @@ const BlankStateWrapper = styled.div`
   justify-content: center;
   align-items: center;
   color: ${(props) => props.theme.colors.debugger.blankState.color};
-  ${(props) => getTypographyByKey(props, "p1")}
+  ${getTypographyByKey("p1")}
 
   .debugger-shortcut {
     color: ${(props) => props.theme.colors.debugger.blankState.shortcut};
-    ${(props) => getTypographyByKey(props, "h5")}
+    ${getTypographyByKey("h5")}
   }
 `;
 

--- a/app/client/src/components/editorComponents/Debugger/index.tsx
+++ b/app/client/src/components/editorComponents/Debugger/index.tsx
@@ -11,14 +11,13 @@ import {
 } from "actions/debuggerActions";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { stopEventPropagation } from "utils/AppsmithUtils";
 import {
   getMessageCount,
   hideDebuggerIconSelector,
 } from "selectors/debuggerSelectors";
 import { matchBuilderPath } from "constants/routes";
-import { TooltipComponent } from "design-system";
+import { getTypographyByKey, TooltipComponent } from "design-system";
 import { DEBUGGER_TAB_KEYS } from "./helpers";
 
 function Debugger() {
@@ -40,7 +39,7 @@ const TriggerContainer = styled.div<{
 
   .debugger-count {
     color: ${Colors.WHITE};
-    ${(props) => getTypographyByKey(props, "btnSmall")}
+    ${getTypographyByKey("btnSmall")}
     height: 16px;
     width: 16px;
     background-color: ${(props) =>

--- a/app/client/src/components/editorComponents/GlobalSearch/Description.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/Description.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import ActionLink from "./ActionLink";
 import Highlight from "./Highlight";
 import { algoliaHighlightTag, getItemTitle, SEARCH_ITEM_TYPES } from "./utils";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import { SearchItem } from "./utils";
 import parseDocumentationContent from "./parseDocumentationContent";
 import { retryPromise } from "utils/AppsmithUtils";
@@ -31,9 +31,9 @@ const Container = styled.div`
   color: ${(props) => props.theme.colors.globalSearch.searchItemText};
   overflow: auto;
 
-  ${(props) => getTypographyByKey(props, "spacedOutP1")};
+  ${getTypographyByKey("spacedOutP1")};
   [class^="ais-"] {
-    ${(props) => getTypographyByKey(props, "spacedOutP1")};
+    ${getTypographyByKey("spacedOutP1")};
   }
 
   img {
@@ -41,13 +41,13 @@ const Container = styled.div`
   }
 
   h1 {
-    ${(props) => getTypographyByKey(props, "docHeader")}
+    ${getTypographyByKey("docHeader")}
     word-break: break-word;
   }
 
   h2,
   h3 {
-    ${(props) => getTypographyByKey(props, "h5")}
+    ${getTypographyByKey("h5")}
     font-weight: 600;
   }
 
@@ -72,7 +72,7 @@ const Container = styled.div`
   }
 
   .documentation-cta {
-    ${(props) => getTypographyByKey(props, "p3")}
+    ${getTypographyByKey("p3")}
     white-space: nowrap;
     background: ${(props) =>
       props.theme.colors.globalSearch.documentationCtaBackground};
@@ -194,7 +194,7 @@ const StyledHitEnterMessageContainer = styled.div`
     `${props.theme.spaces[6]}px ${props.theme.spaces[3]}px`};
   border: 1px solid
     ${(props) => props.theme.colors.globalSearch.snippets.codeContainerBorder};
-  ${(props) => getTypographyByKey(props, "p3")};
+  ${getTypographyByKey("p3")};
 `;
 
 const StyledKey = styled.span`

--- a/app/client/src/components/editorComponents/GlobalSearch/HelpBar.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/HelpBar.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
-import { Text, TextType } from "design-system";
+import { getTypographyByKey, Text, TextType } from "design-system";
 import { setGlobalSearchCategory } from "actions/globalSearchActions";
 import { HELPBAR_PLACEHOLDER } from "@appsmith/constants/messages";
 import AnalyticsUtil from "utils/AnalyticsUtil";
@@ -13,7 +12,7 @@ const StyledHelpBar = styled.div`
   padding: 0 ${(props) => props.theme.spaces[4]}px;
   margin: ${(props) => props.theme.spaces[2]}px;
   .placeholder-text {
-    ${(props) => getTypographyByKey(props, "p2")}
+    ${getTypographyByKey("p2")}
   }
   display: flex;
   justify-content: space-between;

--- a/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/ResultsNotFound.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import NoSearchDataImage from "assets/images/no_search_data.png";
 import { NO_SEARCH_DATA_TEXT } from "@appsmith/constants/messages";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import { ReactComponent as DiscordIcon } from "assets/icons/help/discord.svg";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 
@@ -14,7 +14,7 @@ const Container = styled.div`
   align-items: center;
   flex-direction: column;
 
-  ${(props) => getTypographyByKey(props, "spacedOutP1")}
+  ${getTypographyByKey("spacedOutP1")}
   color: ${(props) => props.theme.colors.globalSearch.emptyStateText};
 
   .no-data-title {

--- a/app/client/src/components/editorComponents/GlobalSearch/SearchBox.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/SearchBox.tsx
@@ -3,8 +3,7 @@ import { useSelector } from "react-redux";
 import styled from "styled-components";
 import { connectSearchBox } from "react-instantsearch-dom";
 import { SearchBoxProvided } from "react-instantsearch-core";
-import { getTypographyByKey } from "constants/DefaultTheme";
-import { Icon } from "design-system";
+import { getTypographyByKey, Icon } from "design-system";
 import { AppState } from "@appsmith/reducers";
 import {
   createMessage,
@@ -21,7 +20,7 @@ import { ReactComponent as SearchIcon } from "assets/icons/ads/search.svg";
 const Container = styled.div`
   background: #ffffff;
   & input {
-    ${(props) => getTypographyByKey(props, "p1")}
+    ${getTypographyByKey("p1")}
     background: transparent;
     color: ${(props) => props.theme.colors.globalSearch.searchInputText};
     border: none;
@@ -58,7 +57,7 @@ const CategoryDisplay = styled.div`
   border: 1px solid
     ${(props) => props.theme.colors.globalSearch.primaryBorderColor};
   margin-right: ${(props) => props.theme.spaces[4]}px;
-  ${(props) => getTypographyByKey(props, "categoryBtn")}
+  ${getTypographyByKey("categoryBtn")}
   svg {
     cursor: pointer;
     margin-left: ${(props) => `${props.theme.spaces[4]}px`};

--- a/app/client/src/components/editorComponents/GlobalSearch/SearchResults.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/SearchResults.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { Highlight as AlgoliaHighlight } from "react-instantsearch-dom";
 import { Hit as IHit } from "react-instantsearch-core";
 import styled, { css } from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import Highlight from "./Highlight";
 import ActionLink, { StyledActionLink } from "./ActionLink";
 import scrollIntoView from "scroll-into-view-if-needed";
@@ -105,9 +105,9 @@ export const SearchItemContainer = styled.div<{
     }
   }
 
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   [class^="ais-"] {
-    ${(props) => getTypographyByKey(props, "p1")};
+    ${getTypographyByKey("p1")};
   }
 `;
 
@@ -117,9 +117,9 @@ const ItemTitle = styled.div`
   justify-content: space-between;
   flex: 1;
   align-items: center;
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   font-w [class^="ais-"] {
-    ${(props) => getTypographyByKey(props, "p1")};
+    ${getTypographyByKey("p1")};
   }
 `;
 
@@ -352,17 +352,17 @@ const CategoryListItem = styled.div<{ isActiveItem: boolean }>`
     display: flex;
     flex-direction: column;
     .category-title {
-      ${(props) => getTypographyByKey(props, "h5")}
+      ${getTypographyByKey("h5")}
       color: ${(props) => props.theme.colors.globalSearch.primaryTextColor};
     }
     .category-desc {
-      ${(props) => getTypographyByKey(props, "p3")}
+      ${getTypographyByKey("p3")}
       color: ${(props) => props.theme.colors.globalSearch.secondaryTextColor};
     }
   }
   .action-msg {
     color: ${(props) => props.theme.colors.globalSearch.secondaryTextColor};
-    ${(props) => getTypographyByKey(props, "p3")}
+    ${getTypographyByKey("p3")}
     flex-shrink: 0;
   }
 `;

--- a/app/client/src/components/editorComponents/GlobalSearch/SnippetsDescription.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/SnippetsDescription.tsx
@@ -36,10 +36,9 @@ import {
   SNIPPET_INSERT,
 } from "@appsmith/constants/messages";
 import { getExpectedValue } from "utils/validation/common";
-import { Toaster, Variant } from "design-system";
+import { getTypographyByKey, Toaster, Variant } from "design-system";
 import { ReactComponent as CopyIcon } from "assets/icons/menu/copy-snippet.svg";
 import AnalyticsUtil from "utils/AnalyticsUtil";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { SnippetAction } from "reducers/uiReducers/globalSearchReducer";
 import { Layers } from "constants/Layers";
 
@@ -85,7 +84,7 @@ const SnippetContainer = styled.div`
   }
   .snippet-title {
     color: ${(props) => props.theme.colors.globalSearch.primaryTextColor};
-    ${(props) => getTypographyByKey(props, "h3")}
+    ${getTypographyByKey("h3")}
     font-size: 1.5rem;
     line-height: 1.5rem;
     display: flex;
@@ -99,17 +98,17 @@ const SnippetContainer = styled.div`
   }
   .snippet-desc {
     color: ${(props) => props.theme.colors.globalSearch.secondaryTextColor};
-    ${(props) => getTypographyByKey(props, "p1")}
+    ${getTypographyByKey("p1")}
     margin: 10px 0;
   }
   .snippet-group {
     margin: 5px 0;
     .header {
-      ${(props) => getTypographyByKey(props, "p1")}
+      ${getTypographyByKey("p1")}
       font-weight: 500;
     }
     .content {
-      ${(props) => getTypographyByKey(props, "p1")}
+      ${getTypographyByKey("p1")}
     }
     .argument {
       display: flex;

--- a/app/client/src/globalStyles/CodemirrorHintStyles.ts
+++ b/app/client/src/globalStyles/CodemirrorHintStyles.ts
@@ -1,6 +1,7 @@
 import { createGlobalStyle } from "styled-components";
 import { EditorTheme } from "components/editorComponents/CodeEditor/EditorConfig";
-import { getTypographyByKey, Theme } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
+import { Theme } from "constants/DefaultTheme";
 import { LINT_TOOLTIP_JUSTIFIED_LEFT_CLASS } from "components/editorComponents/CodeEditor/constants";
 
 export const CodemirrorHintStyles = createGlobalStyle<{
@@ -51,7 +52,7 @@ export const CodemirrorHintStyles = createGlobalStyle<{
     color: #716e6e;
     pointer-events: none !important;
     font-family: ${(props) => props.theme.fonts.text};
-    ${(props) => getTypographyByKey(props, "p3")}
+    ${getTypographyByKey("p3")}
     font-weight: 600;
   }
 
@@ -61,7 +62,7 @@ export const CodemirrorHintStyles = createGlobalStyle<{
     padding: 0 ${(props) => props.theme.spaces[3]}px !important;
     height: 25px;
     font-family: ${(props) => props.theme.fonts.text};
-    ${(props) => getTypographyByKey(props, "p3")}
+    ${getTypographyByKey("p3")}
     &.CodeMirror-hint-active {
       .shortcut {
         color: #ffffff;
@@ -258,11 +259,11 @@ export const CodemirrorHintStyles = createGlobalStyle<{
     box-shadow: 0px 12px 28px -6px rgba(0, 0, 0, 0.32);
     padding: 7px 12px;
     border-radius: 0;
-    
+
     &.${LINT_TOOLTIP_JUSTIFIED_LEFT_CLASS}{
     transform: translate(-100%);
   }
-  
+
   }
   .CodeMirror-lint-message {
     margin-top: 5px;

--- a/app/client/src/pages/AppViewer/PageTabs.tsx
+++ b/app/client/src/pages/AppViewer/PageTabs.tsx
@@ -7,8 +7,7 @@ import {
   Page,
 } from "@appsmith/constants/ReduxActionConstants";
 import { isEllipsisActive, trimQueryString } from "utils/helpers";
-import { TooltipComponent } from "design-system";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey, TooltipComponent } from "design-system";
 
 import { getAppMode } from "selectors/applicationSelectors";
 import { useSelector } from "react-redux";
@@ -48,7 +47,7 @@ const StyleTabText = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  ${(props) => getTypographyByKey(props, "h6")}
+  ${getTypographyByKey("h6")}
   color: ${(props) => props.theme.colors.header.tabText};
   height: ${(props) => `calc(${props.theme.smallHeaderHeight})`};
   & span {

--- a/app/client/src/pages/Applications/ForkModalStyles.ts
+++ b/app/client/src/pages/Applications/ForkModalStyles.ts
@@ -2,13 +2,13 @@ import styled from "styled-components";
 import {
   Button,
   DialogComponent as Dialog,
+  getTypographyByKey,
   RadioComponent,
 } from "design-system";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { Classes } from "@blueprintjs/core";
 
 const TriggerButton = styled(Button)`
-  ${(props) => getTypographyByKey(props, "btnLarge")}
+  ${getTypographyByKey("btnLarge")}
   height: 100%;
 `;
 

--- a/app/client/src/pages/Editor/EditorAppName/NavigationMenuItem.tsx
+++ b/app/client/src/pages/Editor/EditorAppName/NavigationMenuItem.tsx
@@ -4,9 +4,8 @@ import styled from "styled-components";
 import { Classes, MenuItem } from "@blueprintjs/core";
 import _, { noop } from "lodash";
 
-import { CommonComponentProps } from "design-system";
+import { getTypographyByKey, CommonComponentProps } from "design-system";
 import AnalyticsUtil from "utils/AnalyticsUtil";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { HeaderIcons } from "icons/HeaderIcons";
 
 const ShareIcon = HeaderIcons.SHARE;
@@ -43,7 +42,7 @@ const StyledMenuItem = styled((props) => {
     props.theme.colors.navigationMenu.backgroundInactive};
   color: ${(props) => props.theme.colors.navigationMenu.contentInactive};
   border-radius: 0;
-  ${(props) => getTypographyByKey(props, "h5")};
+  ${getTypographyByKey("h5")};
   height: ${(props) => props.theme.navbarMenuHeight};
   line-height: ${(props) => props.theme.navbarMenuLineHeight};
   padding: 5px 10px;

--- a/app/client/src/pages/Editor/EditorAppName/index.tsx
+++ b/app/client/src/pages/Editor/EditorAppName/index.tsx
@@ -7,13 +7,13 @@ import { noop } from "lodash";
 import {
   CommonComponentProps,
   EditInteractionKind,
+  getTypographyByKey,
   Icon,
   IconSize,
   SavingState,
   Toaster,
   Variant,
 } from "design-system";
-import { getTypographyByKey } from "constants/DefaultTheme";
 
 import EditableAppName from "./EditableAppName";
 import { GetNavigationMenuData } from "./NavigationMenuData";
@@ -71,7 +71,7 @@ const Container = styled.div<{ isPopoverOpen: boolean }>`
   }
   &&&& .${Classes.EDITABLE_TEXT_CONTENT}, &&&& .${Classes.EDITABLE_TEXT_INPUT} {
     display: block;
-    ${(props) => getTypographyByKey(props, "h4")};
+    ${getTypographyByKey("h4")};
     line-height: ${(props) => props.theme.smallHeaderHeight} !important;
     padding: 0 ${(props) => props.theme.spaces[2]}px;
   }
@@ -90,7 +90,7 @@ const StyledMenu = styled(Menu)`
   background: ${(props) =>
     props.theme.colors.navigationMenu.backgroundInactive};
   color: ${(props) => props.theme.colors.navigationMenu.contentInactive};
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   border-radius: 0;
   padding: 0;
 

--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -37,9 +37,15 @@ import EditorAppName from "./EditorAppName";
 import ProfileDropdown from "pages/common/ProfileDropdown";
 import { getCurrentUser } from "selectors/usersSelectors";
 import { ANONYMOUS_USERNAME, User } from "constants/userConstants";
-import { Button, Icon, IconSize, Size, TooltipComponent } from "design-system";
+import {
+  Button,
+  getTypographyByKey,
+  Icon,
+  IconSize,
+  Size,
+  TooltipComponent,
+} from "design-system";
 import { Profile } from "pages/common/ProfileImage";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import HelpBar from "components/editorComponents/GlobalSearch/HelpBar";
 import HelpButton from "./HelpButton";
 import { getTheme, ThemeMode } from "selectors/themeSelectors";
@@ -93,7 +99,7 @@ const HeaderWrapper = styled.div`
   box-shadow: none;
   border-bottom: 1px solid ${(props) => props.theme.colors.menuBorder};
   & .editable-application-name {
-    ${(props) => getTypographyByKey(props, "h4")}
+    ${getTypographyByKey("h4")}
     color: ${(props) => props.theme.colors.header.appName};
   }
   & ${Profile} {
@@ -147,7 +153,7 @@ const ProfileDropdownContainer = styled.div``;
 const StyledInviteButton = styled(Button)`
   margin-right: ${(props) => props.theme.spaces[9]}px;
   height: ${(props) => props.theme.smallHeaderHeight};
-  ${(props) => getTypographyByKey(props, "btnLarge")}
+  ${getTypographyByKey("btnLarge")}
   padding: ${(props) => props.theme.spaces[2]}px;
 `;
 

--- a/app/client/src/pages/Editor/FirstTimeUserOnboarding/Statusbar.tsx
+++ b/app/client/src/pages/Editor/FirstTimeUserOnboarding/Statusbar.tsx
@@ -32,7 +32,7 @@ import {
   createMessage,
   ONBOARDING_STATUS_STEPS_THIRD_ALT,
 } from "@appsmith/constants/messages";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import { Colors } from "constants/Colors";
 import { onboardingCheckListUrl } from "RouteBuilder";
 
@@ -64,7 +64,7 @@ const Wrapper = styled.div<{ active: boolean }>`
 
 const TitleWrapper = styled.p`
   color: ${Colors.GREY_10};
-  ${(props) => getTypographyByKey(props, "p4")}
+  ${getTypographyByKey("p4")}
 `;
 
 const StatusText = styled.p`

--- a/app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/CrudInfoModal.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Category,
   DialogComponent as Dialog,
+  getTypographyByKey,
   Size,
   Text,
   TextType,
@@ -21,7 +22,6 @@ import {
   GEN_CRUD_SUCCESS_MESSAGE,
   createMessage,
 } from "@appsmith/constants/messages";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { getInfoImage, getInfoThumbnail } from "constants/ImagesURL";
 import {
   ProgressiveImage,
@@ -38,7 +38,7 @@ const Heading = styled.div`
   color: ${Colors.CODE_GRAY};
   display: flex;
   justify-content: center;
-  ${(props) => getTypographyByKey(props, "h1")}
+  ${getTypographyByKey("h1")}
 `;
 
 const ActionButtonWrapper = styled.div`

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import styled from "styled-components";
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { useSelector, useDispatch } from "react-redux";
 import {
   getDatasources,
@@ -28,6 +27,7 @@ import {
   Category,
   Dropdown,
   DropdownOption,
+  getTypographyByKey,
   IconName,
   IconSize,
   RenderDropdownOptionType,
@@ -105,7 +105,7 @@ const FormWrapper = styled.div`
 `;
 
 const FormSubmitButton = styled(Button)<{ disabled?: boolean }>`
-  ${(props) => getTypographyByKey(props, "btnLarge")};
+  ${getTypographyByKey("btnLarge")};
   color: ${Colors.DOVE_GRAY2};
   margin: 10px 0px;
 `;
@@ -122,7 +122,7 @@ const DescWrapper = styled.div`
 `;
 
 const Title = styled.p`
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   font-weight: 500;
   color: ${Colors.CODE_GRAY};
   font-size: 24px;

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GoogleSheetForm.tsx
@@ -16,6 +16,7 @@ import {
   Dropdown,
   DropdownOption,
   FontWeight,
+  getTypographyByKey,
   Icon,
   IconSize,
   Text,
@@ -24,7 +25,6 @@ import {
   TooltipComponent as Tooltip,
 } from "design-system";
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { debounce } from "lodash";
 import {
   createMessage,
@@ -72,7 +72,7 @@ const Row = styled.div`
 `;
 
 const ColumnName = styled.span`
-  ${(props) => `${getTypographyByKey(props, "p3")}`};
+  ${getTypographyByKey("p3")};
   color: ${Colors.GRAY};
   text-align: center;
   white-space: nowrap;
@@ -101,7 +101,7 @@ const TooltipWrapper = styled.div`
 `;
 
 const RowHeading = styled.p`
-  ${(props) => `${getTypographyByKey(props, "p1")}`};
+  ${getTypographyByKey("p1")};
   margin-right: 10px;
 `;
 

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/styles.ts
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 
 export const SelectWrapper = styled.div<{ width: string }>`
   display: inline-block;
@@ -10,7 +10,7 @@ export const SelectWrapper = styled.div<{ width: string }>`
 
 export const Label = styled.p`
   flex: 1;
-  ${(props) => `${getTypographyByKey(props, "p1")}`};
+  ${getTypographyByKey("p1")};
   white-space: nowrap;
 `;
 

--- a/app/client/src/pages/Editor/GeneratePage/index.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/index.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import styled from "styled-components";
 import PageContent from "./components/PageContent";
-import { getTypographyByKey } from "../../../constants/DefaultTheme";
 import { Colors } from "constants/Colors";
 import { Icon } from "@blueprintjs/core";
-import { Text, TextType } from "design-system";
+import { getTypographyByKey, Text, TextType } from "design-system";
 
 const Container = styled.div`
   display: flex;
@@ -32,7 +31,7 @@ const Heading = styled.h1`
 `;
 
 const SubHeading = styled.p`
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   margin: 20px 0px;
   color: ${Colors.BLACK};
   text-align: center;

--- a/app/client/src/pages/Editor/GuidedTour/EndTour.tsx
+++ b/app/client/src/pages/Editor/GuidedTour/EndTour.tsx
@@ -1,5 +1,5 @@
 import { enableGuidedTour } from "actions/onboardingActions";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import { createMessage, END_TUTORIAL } from "@appsmith/constants/messages";
 import React from "react";
 import { useDispatch } from "react-redux";
@@ -8,7 +8,7 @@ import AnalyticsUtil from "utils/AnalyticsUtil";
 
 const EndTutorial = styled.span`
   color: ${(props) => props.theme.colors.guidedTour.endTourButton.color};
-  ${(props) => getTypographyByKey(props, "btnMedium")}
+  ${getTypographyByKey("btnMedium")}
   cursor: pointer;
 
   &:hover {

--- a/app/client/src/pages/Editor/GuidedTour/Guide.tsx
+++ b/app/client/src/pages/Editor/GuidedTour/Guide.tsx
@@ -3,7 +3,7 @@ import {
   showInfoMessage,
   toggleLoader,
 } from "actions/onboardingActions";
-import { Button, Icon, IconSize } from "design-system";
+import { Button, getTypographyByKey, Icon, IconSize } from "design-system";
 import { isArray } from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -19,7 +19,6 @@ import {
 } from "selectors/onboardingSelectors";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { GUIDED_TOUR_STEPS, Steps } from "./constants";
 import useComputeCurrentStep from "./useComputeCurrentStep";
 import {
@@ -57,7 +56,7 @@ const TitleWrapper = styled.div`
 `;
 
 const Title = styled.span`
-  ${(props) => getTypographyByKey(props, "h2")}
+  ${getTypographyByKey("h2")}
   font-weight: 600;
   color: #000000;
   display: flex;
@@ -71,7 +70,7 @@ const Title = styled.span`
 const StepCount = styled.div`
   background: ${(props) => props.theme.colors.guidedTour.stepCountBackground};
   color: white;
-  ${(props) => getTypographyByKey(props, "h5")};
+  ${getTypographyByKey("h5")};
   height: 24px;
   width: 24px;
   border-radius: 12px;
@@ -109,7 +108,7 @@ const GuideButton = styled(Button)<{ isVisible?: boolean }>`
   padding: ${(props) => props.theme.spaces[0]}px
     ${(props) => props.theme.spaces[6]}px;
   height: 38px;
-  ${(props) => getTypographyByKey(props, "btnMedium")};
+  ${getTypographyByKey("btnMedium")};
   visibility: ${({ isVisible = true }) => (isVisible ? "visible" : "hidden")};
 `;
 

--- a/app/client/src/pages/Editor/GuidedTour/TourCompletionMessage.tsx
+++ b/app/client/src/pages/Editor/GuidedTour/TourCompletionMessage.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Rating from "react-rating";
-import { Button, Icon, IconSize, Size } from "design-system";
+import {
+  Button,
+  getTypographyByKey,
+  Icon,
+  IconSize,
+  Size,
+} from "design-system";
 import {
   getPostWelcomeTourState,
   setPostWelcomeTourState,
@@ -19,7 +25,6 @@ import {
   RATING_TEXT,
   RATING_TITLE,
 } from "@appsmith/constants/messages";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { Colors } from "constants/Colors";
 import history from "utils/history";
 import { APPLICATIONS_URL } from "constants/routes";
@@ -44,7 +49,7 @@ const Confetti = styled.span`
 
 const Title = styled.div`
   color: #000000;
-  ${(props) => getTypographyByKey(props, "h2")}
+  ${getTypographyByKey("h2")}
   font-weight: 600;
 `;
 
@@ -55,7 +60,7 @@ const Description = styled.div`
 `;
 
 const RatingText = styled.span`
-  ${(props) => getTypographyByKey(props, "h4")}
+  ${getTypographyByKey("h4")}
   color: #000000;
   padding-bottom: ${(props) => props.theme.spaces[2]}px;
   margin-right: ${(props) => props.theme.spaces[7]}px;

--- a/app/client/src/pages/Editor/PropertyPane/ConnectDataCTA.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/ConnectDataCTA.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Button, Category, Size } from "design-system";
+import { Button, Category, getTypographyByKey, Size } from "design-system";
 import { AppState } from "@appsmith/reducers";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
@@ -10,14 +10,13 @@ import {
   toggleShowGlobalSearchModal,
 } from "actions/globalSearchActions";
 import AnalyticsUtil from "utils/AnalyticsUtil";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { WidgetType } from "constants/WidgetConstants";
 import { integrationEditorURL } from "RouteBuilder";
 import { getCurrentPageId } from "selectors/editorSelectors";
 
 const StyledDiv = styled.div`
   color: ${(props) => props.theme.colors.propertyPane.ctaTextColor};
-  ${(props) => getTypographyByKey(props, "p1")}
+  ${getTypographyByKey("p1")}
   background-color: ${(props) =>
     props.theme.colors.propertyPane.ctaBackgroundColor};
   padding: ${(props) => props.theme.spaces[3]}px ${(props) =>
@@ -35,7 +34,7 @@ const StyledDiv = styled.div`
     justify-content: flex-start;
     padding: 0px;
     color: ${(props) => props.theme.colors.propertyPane.ctaLearnMoreTextColor};
-    ${(props) => getTypographyByKey(props, "p3")}
+    ${getTypographyByKey("p3")}
     margin-top: ${(props) => props.theme.spaces[2]}px;
 
     :hover, :focus {

--- a/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyPaneConnections.tsx
@@ -9,6 +9,7 @@ import {
   Dropdown,
   DefaultDropDownValueNodeProps,
   DropdownOption,
+  getTypographyByKey,
   Icon,
   IconSize,
   Text,
@@ -26,7 +27,6 @@ import { getFilteredErrors } from "selectors/debuggerSelectors";
 import { ENTITY_TYPE, Log } from "entities/AppsmithConsole";
 import { DebugButton } from "components/editorComponents/Debugger/DebugCTA";
 import { showDebugger } from "actions/debuggerActions";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { Colors } from "constants/Colors";
 import { inGuidedTour } from "selectors/onboardingSelectors";
@@ -76,7 +76,7 @@ const SelectedNodeWrapper = styled.div<{
     props.hasError
       ? props.theme.colors.propertyPane.connections.error
       : props.theme.colors.propertyPane.connections.connectionsCount};
-  ${(props) => getTypographyByKey(props, "p3")}
+  ${getTypographyByKey("p3")}
   opacity: ${(props) => (!!props.entityCount ? 1 : 0.5)};
 
   & > *:nth-child(2) {

--- a/app/client/src/pages/Editor/gitSync/QuickGitActions/BranchButton.tsx
+++ b/app/client/src/pages/Editor/gitSync/QuickGitActions/BranchButton.tsx
@@ -4,13 +4,17 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { Popover2 } from "@blueprintjs/popover2";
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
-import { getTypographyByKey } from "constants/DefaultTheme";
 
 import { Colors } from "constants/Colors";
 import { getCurrentAppGitMetaData } from "selectors/applicationSelectors";
 import BranchList from "../components/BranchList";
 import { fetchBranchesInit } from "actions/gitSyncActions";
-import { Icon, IconSize, TooltipComponent as Tooltip } from "design-system";
+import {
+  getTypographyByKey,
+  Icon,
+  IconSize,
+  TooltipComponent as Tooltip,
+} from "design-system";
 import { isEllipsisActive } from "utils/helpers";
 import { getGitStatus } from "selectors/gitSyncSelectors";
 import AnalyticsUtil from "utils/AnalyticsUtil";
@@ -21,7 +25,7 @@ const ButtonContainer = styled.div`
 
   & .label {
     color: ${(props) => props.theme.colors.editorBottomBar.branchBtnText};
-    ${(props) => getTypographyByKey(props, "p1")};
+    ${getTypographyByKey("p1")};
     line-height: 18px;
   }
 

--- a/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
+++ b/app/client/src/pages/Editor/gitSync/QuickGitActions/index.tsx
@@ -21,7 +21,6 @@ import {
 } from "@appsmith/constants/messages";
 
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { useDispatch, useSelector } from "react-redux";
 import { ReactComponent as GitCommitLine } from "assets/icons/ads/git-commit-line.svg";
 import {
@@ -43,6 +42,7 @@ import { inGuidedTour } from "selectors/onboardingSelectors";
 import {
   Button,
   Category,
+  getTypographyByKey,
   Icon,
   IconName,
   IconSize,
@@ -86,7 +86,7 @@ const QuickActionButtonContainer = styled.div<{ disabled?: boolean }>`
     top: ${(props) => -1 * props.theme.spaces[3]}px;
     left: ${(props) => props.theme.spaces[8]}px;
     border-radius: ${(props) => props.theme.spaces[3]}px;
-    ${(props) => getTypographyByKey(props, "p3")};
+    ${getTypographyByKey("p3")};
     z-index: 1;
     padding: ${(props) => props.theme.spaces[1]}px
       ${(props) => props.theme.spaces[2]}px;
@@ -224,7 +224,7 @@ const PlaceholderButton = styled.div`
   padding: ${(props) =>
     `${props.theme.spaces[1]}px ${props.theme.spaces[3]}px`};
   border: solid 1px ${Colors.MERCURY};
-  ${(props) => getTypographyByKey(props, "btnSmall")};
+  ${getTypographyByKey("btnSmall")};
   text-transform: uppercase;
   background-color: ${Colors.ALABASTER_ALT};
   color: ${Colors.GRAY};

--- a/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
+++ b/app/client/src/pages/Editor/gitSync/Tabs/Deploy.tsx
@@ -18,6 +18,7 @@ import styled, { useTheme } from "styled-components";
 import {
   Button,
   Category,
+  getTypographyByKey,
   LabelContainer,
   Size,
   TextInput,
@@ -37,7 +38,7 @@ import {
 } from "selectors/gitSyncSelectors";
 import { useDispatch, useSelector } from "react-redux";
 import { Colors } from "constants/Colors";
-import { getTypographyByKey, Theme } from "constants/DefaultTheme";
+import { Theme } from "constants/DefaultTheme";
 
 import { getCurrentAppGitMetaData } from "selectors/applicationSelectors";
 import DeployPreview from "../components/DeployPreview";
@@ -90,7 +91,7 @@ const Row = styled.div`
 `;
 
 const SectionTitle = styled.div`
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   color: ${Colors.CHARCOAL};
   display: inline-flex;
 

--- a/app/client/src/pages/Editor/gitSync/components/BetaTag.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BetaTag.tsx
@@ -1,5 +1,5 @@
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import React from "react";
 import styled from "styled-components";
 
@@ -9,7 +9,7 @@ const StyledTag = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  ${(props) => getTypographyByKey(props, "btnSmall")};
+  ${getTypographyByKey("btnSmall")};
   border: 1px solid ${Colors.COD_GRAY};
   color: ${Colors.COD_GRAY};
 `;

--- a/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BranchList.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { TextInput } from "design-system";
+import { getTypographyByKey, TextInput } from "design-system";
 import styled, { useTheme } from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { Colors } from "constants/Colors";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -57,7 +56,7 @@ const BranchDropdownContainer = styled.div`
   flex-direction: column;
 
   & .title {
-    ${(props) => getTypographyByKey(props, "p1")};
+    ${getTypographyByKey("p1")};
   }
 
   padding: ${(props) => props.theme.spaces[5]}px;
@@ -85,12 +84,12 @@ const CreateNewBranchContainer = styled.div`
   }
 
   & .large-text {
-    ${(props) => getTypographyByKey(props, "p1")};
+    ${getTypographyByKey("p1")};
     color: ${Colors.BLACK};
   }
 
   & .small-text {
-    ${(props) => getTypographyByKey(props, "p3")};
+    ${getTypographyByKey("p3")};
     color: ${Colors.GREY_7};
   }
 `;

--- a/app/client/src/pages/Editor/gitSync/components/BranchListItemContainer.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BranchListItemContainer.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { Colors } from "constants/Colors";
-import { Classes } from "design-system";
+import { Classes, getTypographyByKey } from "design-system";
 
 export const BranchListItemContainer = styled.div<{
   selected?: boolean;
@@ -11,7 +10,7 @@ export const BranchListItemContainer = styled.div<{
   padding: ${(props) =>
     `${props.theme.spaces[5]}px ${props.theme.spaces[5]}px`};
   margin: ${(props) => `${props.theme.spaces[1]} 0`};
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   cursor: pointer;
 
   &:hover {

--- a/app/client/src/pages/Editor/gitSync/components/LocalBranchList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/LocalBranchList.tsx
@@ -26,7 +26,6 @@ export function LocalBranchList(
       {localBranches?.length > 0 && (
         <SegmentHeader
           data-testid="t--branch-list-header-local"
-          hideStyledHr
           title={createMessage(LOCAL_BRANCHES)}
         />
       )}

--- a/app/client/src/pages/Editor/gitSync/components/RemoteBranchList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/RemoteBranchList.tsx
@@ -17,7 +17,6 @@ export function RemoteBranchList(
       {remoteBranches?.length > 0 && (
         <SegmentHeader
           data-testid="t--branch-list-header-remote"
-          hideStyledHr
           title={createMessage(REMOTE_BRANCHES)}
         />
       )}

--- a/app/client/src/pages/Editor/gitSync/components/StyledComponents.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/StyledComponents.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import { Colors } from "constants/Colors";
 
 export const Title = styled.p`
-  ${(props) => getTypographyByKey(props, "h1")};
+  ${getTypographyByKey("h1")};
   margin: ${(props) =>
     `${props.theme.spaces[7]}px 0px ${props.theme.spaces[3]}px 0px`};
   color: ${Colors.GREY_900};
@@ -11,12 +11,12 @@ export const Title = styled.p`
 
 export const Subtitle = styled.div`
   margin-top: 8px;
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
   color: ${Colors.GREY_900};
 `;
 
 export const Caption = styled.span`
-  ${(props) => getTypographyByKey(props, "p1")};
+  ${getTypographyByKey("p1")};
 `;
 
 type sizeType =

--- a/app/client/src/pages/Editor/gitSync/components/TabItem.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/TabItem.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
-import { getTypographyByKey, Theme } from "constants/DefaultTheme";
-import { TabProp } from "design-system";
+import { Theme } from "constants/DefaultTheme";
+import { getTypographyByKey, TabProp } from "design-system";
 import { Colors } from "constants/Colors";
 
 type WrapperProps = {
@@ -22,7 +22,7 @@ const getSelectedStyles = (props: WrapperProps) =>
 
 const Wrapper = styled.div<WrapperProps>`
   display: flex;
-  ${(props) => getTypographyByKey(props, "p0")};
+  ${getTypographyByKey("p0")};
   ${(props) => getSelectedStyles(props)};
 
   &:hover,

--- a/app/client/src/pages/Editor/gitSync/components/UserGitProfileSettings.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/UserGitProfileSettings.tsx
@@ -10,14 +10,18 @@ import {
   createMessage,
 } from "@appsmith/constants/messages";
 import styled from "styled-components";
-import { Checkbox, emailValidator, TextInput } from "design-system";
+import {
+  Checkbox,
+  emailValidator,
+  getTypographyByKey,
+  TextInput,
+} from "design-system";
 import { Colors } from "constants/Colors";
 import { useSelector } from "react-redux";
 import {
   getIsFetchingGlobalGitConfig,
   getIsFetchingLocalGitConfig,
 } from "selectors/gitSyncSelectors";
-import { getTypographyByKey } from "constants/DefaultTheme";
 
 const LabelContainer = styled.div`
   display: flex;
@@ -50,7 +54,7 @@ const DefaultConfigContainer = styled.div`
 `;
 
 const SectionTitle = styled.span`
-  ${(props) => getTypographyByKey(props, "u1")};
+  ${getTypographyByKey("u1")};
   text-transform: uppercase;
   color: ${Colors.GRAY_900};
 `;

--- a/app/client/src/pages/Settings/DisconnectService.tsx
+++ b/app/client/src/pages/Settings/DisconnectService.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { Button, CalloutV2, Variant } from "design-system";
+import { Button, CalloutV2, getTypographyByKey, Variant } from "design-system";
 import {
   createMessage,
   DANGER_ZONE,
@@ -8,7 +8,6 @@ import {
   DISCONNECT_CONFIRMATION,
 } from "@appsmith/constants/messages";
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
 
 export const Container = styled.div`
   width: 100%;
@@ -31,7 +30,7 @@ export const DisconnectButton = styled(Button)`
 `;
 
 export const Header = styled.h2`
-  ${(props) => getTypographyByKey(props, "dangerHeading")}
+  ${getTypographyByKey("dangerHeading")}
   text-align: left;
 `;
 
@@ -41,7 +40,7 @@ export const HeaderDanger = styled(Header)`
 
 export const Info = styled.h3`
   display: block;
-  ${(props) => getTypographyByKey(props, "p3")}
+  ${getTypographyByKey("p3")}
   text-align: left;
   margin: 8px 0;
 `;

--- a/app/client/src/pages/Settings/FormGroup/Common.tsx
+++ b/app/client/src/pages/Settings/FormGroup/Common.tsx
@@ -1,9 +1,12 @@
-import { TooltipComponent as Tooltip } from "design-system";
 import { createMessage } from "@appsmith/constants/messages";
 import React from "react";
 import styled from "styled-components";
-import { Icon, IconSize } from "design-system";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import {
+  getTypographyByKey,
+  Icon,
+  IconSize,
+  TooltipComponent as Tooltip,
+} from "design-system";
 import { Setting } from "@appsmith/pages/AdminSettings/config/types";
 import { Colors } from "constants/Colors";
 
@@ -40,7 +43,7 @@ export const StyledFormGroup = styled.div`
 export const StyledLabel = styled.label`
   margin-bottom: ${(props) => props.theme.spaces[3]}px;
   display: inline-block;
-  ${(props) => getTypographyByKey(props, "h5")}
+  ${getTypographyByKey("h5")}
   color: ${(props) => props.theme.colors.textInput.normal.text};
 `;
 

--- a/app/client/src/pages/Templates/DatasourceChip.tsx
+++ b/app/client/src/pages/Templates/DatasourceChip.tsx
@@ -1,5 +1,5 @@
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import React from "react";
 import { useSelector } from "react-redux";
 import { AppState } from "@appsmith/reducers";
@@ -20,7 +20,7 @@ const StyledDatasourceChip = styled.div`
   }
   span {
     margin-left: ${(props) => props.theme.spaces[2]}px;
-    ${(props) => getTypographyByKey(props, "h6")}
+    ${getTypographyByKey("h6")}
     letter-spacing: -0.221538px;
     color: var(--appsmith-color-black-900);
   }

--- a/app/client/src/pages/Templates/Template/LargeTemplate.tsx
+++ b/app/client/src/pages/Templates/Template/LargeTemplate.tsx
@@ -1,5 +1,5 @@
 import { Colors } from "constants/Colors";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 import styled from "styled-components";
 import { TemplateLayout } from "./index";
 
@@ -16,14 +16,14 @@ const LargeTemplate = styled(TemplateLayout)`
 
   && {
     .title {
-      ${(props) => getTypographyByKey(props, "h1")}
+      ${getTypographyByKey("h1")}
     }
     .categories {
-      ${(props) => getTypographyByKey(props, "h4")}
+      ${getTypographyByKey("h4")}
       font-weight: normal;
     }
     .description {
-      ${(props) => getTypographyByKey(props, "p1")}
+      ${getTypographyByKey("p1")}
       flex: 1;
     }
   }

--- a/app/client/src/pages/Templates/Template/TemplateDescription.tsx
+++ b/app/client/src/pages/Templates/Template/TemplateDescription.tsx
@@ -2,12 +2,12 @@ import { Template } from "api/TemplatesApi";
 import React from "react";
 import { useHistory, useParams } from "react-router";
 import styled from "styled-components";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import DatasourceChip from "../DatasourceChip";
 import { Colors } from "constants/Colors";
 import {
   Button,
   FontWeight,
+  getTypographyByKey,
   IconPositions,
   Size,
   Text,
@@ -63,7 +63,7 @@ export const StyledDatasourceChip = styled(DatasourceChip)`
     width: 25px;
   }
   span {
-    ${(props) => getTypographyByKey(props, "h4")}
+    ${getTypographyByKey("h4")}
     color: ${Colors.EBONY_CLAY};
   }
 `;

--- a/app/client/src/pages/Templates/Template/index.tsx
+++ b/app/client/src/pages/Templates/Template/index.tsx
@@ -2,11 +2,15 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import history from "utils/history";
 import { Template as TemplateInterface } from "api/TemplatesApi";
-import { Button, Size, TooltipComponent as Tooltip } from "design-system";
+import {
+  Button,
+  getTypographyByKey,
+  Size,
+  TooltipComponent as Tooltip,
+} from "design-system";
 import ForkTemplateDialog from "../ForkTemplate";
 import DatasourceChip from "../DatasourceChip";
 import LargeTemplate from "./LargeTemplate";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { Colors } from "constants/Colors";
 import {
   createMessage,
@@ -48,11 +52,11 @@ const TemplateContent = styled.div`
   flex: 1;
 
   .title {
-    ${(props) => getTypographyByKey(props, "h1")}
+    ${getTypographyByKey("h1")}
     color: ${Colors.EBONY_CLAY};
   }
   .categories {
-    ${(props) => getTypographyByKey(props, "h4")}
+    ${getTypographyByKey("h4")}
     font-weight: normal;
     color: var(--appsmith-color-black-800);
     margin-top: ${(props) => props.theme.spaces[1]}px;
@@ -60,7 +64,7 @@ const TemplateContent = styled.div`
   .description {
     margin-top: ${(props) => props.theme.spaces[2]}px;
     color: var(--appsmith-color-black-700);
-    ${(props) => getTypographyByKey(props, "p1")}
+    ${getTypographyByKey("p1")}
   }
 `;
 

--- a/app/client/src/pages/Templates/index.tsx
+++ b/app/client/src/pages/Templates/index.tsx
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/react";
 import { ControlGroup } from "@blueprintjs/core";
 import { debounce, noop, isEmpty } from "lodash";
 import { Switch, Route, useRouteMatch } from "react-router-dom";
-import { SearchInput, SearchVariant } from "design-system";
+import { getTypographyByKey, SearchInput, SearchVariant } from "design-system";
 import TemplateList from "./TemplateList";
 import TemplateView from "./TemplateView";
 import Filters from "pages/Templates/Filters";
@@ -29,7 +29,6 @@ import {
   getUserApplicationsWorkspacesList,
 } from "selectors/applicationSelectors";
 import { getAllApplications } from "actions/applicationActions";
-import { getTypographyByKey } from "constants/DefaultTheme";
 import { Colors } from "constants/Colors";
 import { createMessage, SEARCH_TEMPLATES } from "@appsmith/constants/messages";
 import LeftPaneBottomSection from "pages/Home/LeftPaneBottomSection";
@@ -70,7 +69,7 @@ export const TemplateListWrapper = styled.div`
 `;
 
 export const ResultsCount = styled.div`
-  ${(props) => getTypographyByKey(props, "h1")}
+  ${getTypographyByKey("h1")}
   color: ${Colors.CODE_GRAY};
   margin-top: ${(props) => props.theme.spaces[5]}px;
   margin-left: ${(props) => props.theme.spaces[12]}px;

--- a/app/client/src/pages/UserAuth/StyledComponents.tsx
+++ b/app/client/src/pages/UserAuth/StyledComponents.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { Link } from "react-router-dom";
 import Form from "components/editorComponents/Form";
 import { Card } from "@blueprintjs/core";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey } from "design-system";
 
 export const AuthContainer = styled.section`
   position: absolute;
@@ -36,7 +36,7 @@ export const AuthCard = styled(Card)`
     text-align: center;
     padding: 0;
     margin: 0;
-    ${(props) => getTypographyByKey(props, "cardHeader")}
+    ${getTypographyByKey("cardHeader")}
     color: ${(props) => props.theme.colors.auth.headingText};
   }
   & .form-message-container {
@@ -120,13 +120,13 @@ export const FormActions = styled.div`
 `;
 
 export const SignUpLinkSection = styled.div`
-  ${(props) => getTypographyByKey(props, "cardSubheader")}
+  ${getTypographyByKey("cardSubheader")}
   color: ${(props) => props.theme.colors.auth.text};
   text-align: center;
 `;
 
 export const ForgotPasswordLink = styled.div`
-  ${(props) => getTypographyByKey(props, "cardSubheader")}
+  ${getTypographyByKey("cardSubheader")}
   color: ${(props) => props.theme.colors.auth.text};
   text-align: center;
   margin-top: ${(props) => props.theme.spaces[11]}px;

--- a/app/client/src/widgets/TabsWidget/component/PageTabs.tsx
+++ b/app/client/src/widgets/TabsWidget/component/PageTabs.tsx
@@ -2,8 +2,7 @@ import React, { useRef, useEffect, useState } from "react";
 import styled from "styled-components";
 import { get } from "lodash";
 import { isEllipsisActive } from "utils/helpers";
-import { TooltipComponent } from "design-system";
-import { getTypographyByKey } from "constants/DefaultTheme";
+import { getTypographyByKey, TooltipComponent } from "design-system";
 
 import { useSelector } from "react-redux";
 
@@ -44,7 +43,7 @@ const StyleTabText = styled.div<{
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  ${(props) => getTypographyByKey(props, "h6")}
+  ${getTypographyByKey("h6")}
   color: ${(props) => getComplementaryGrayscaleColor(props.backgroundColor)};
   font-weight: normal;
   height: 32px;


### PR DESCRIPTION
## Description

Change typography imports for `typography` and `getTypographyFromKey`. We do this in order to have a single source of truth for the typography. 

Fixes https://github.com/appsmithorg/appsmith/issues/18049

This PR does not have an EE equivalent.

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have run the build on my branch.

### Test Plan
 
 A general regression over the places where TextType has been used is required. 
 https://docs.google.com/spreadsheets/d/1np7jQdiQa0nyryOBnNa927NkGDplG9M2gb7qnoZIIyM/edit#gid=1871619967

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [x] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
