### PR TITLE
fix: set current workspace id in redux store

### DIFF
--- a/app/client/src/sagas/ApplicationSagas.tsx
+++ b/app/client/src/sagas/ApplicationSagas.tsx
@@ -608,6 +608,12 @@ export function* forkApplicationSaga(
           application,
         },
       });
+      yield put({
+        type: ReduxActionTypes.SET_CURRENT_WORKSPACE_ID,
+        payload: {
+          id: action.payload.workspaceId,
+        },
+      });
       const pageURL = builderURL({
         pageId: application.defaultPageId as string,
       });


### PR DESCRIPTION
## Description

On forking application ( a hush hush operation ), workspace was not set up to the current one. The current one will be the one where the application is being forked.

Fixes #18045 


## Media

### bug

Notice the "Resource not found" error and that the /members response is error.

https://user-images.githubusercontent.com/1573771/199471301-b3803039-8940-47a6-bd00-e24309041102.mov

### fix

Notice that error pop up doesn't come up and the /members response is valid.

https://user-images.githubusercontent.com/1573771/199471455-78403152-de61-4961-b194-587fcff649bf.mov



## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

### Test Plan

### Issues raised during DP testing


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
