### PR TITLE
feat: Add feature for widgets to have non-serialisable properties

### DIFF
--- a/app/client/src/selectors/editorSelectors.tsx
+++ b/app/client/src/selectors/editorSelectors.tsx
@@ -18,6 +18,7 @@ import {
 import {
   MAIN_CONTAINER_WIDGET_ID,
   RenderModes,
+  WidgetType,
 } from "constants/WidgetConstants";
 import CanvasWidgetsNormalizer from "normalizers/CanvasWidgetsNormalizer";
 import { DataTree, DataTreeWidget } from "entities/DataTree/dataTreeFactory";
@@ -35,6 +36,9 @@ import {
   createLoadingWidget,
 } from "utils/widgetRenderUtils";
 import { LOCAL_STORAGE_KEYS } from "utils/localStorage";
+import WidgetFactory, {
+  NonSerialisableWidgetConfigs,
+} from "utils/WidgetFactory";
 
 const getIsDraggingOrResizing = (state: AppState) =>
   state.ui.widgetDragResize.isResizing || state.ui.widgetDragResize.isDragging;
@@ -615,3 +619,30 @@ export const showCanvasTopSectionSelector = createSelector(
     return true;
   },
 );
+
+/**
+ * This returns the number of rows which is not occupied by a Canvas Widget within
+ * a parent container like widget of type widgetType
+ * For example, the Tabs Widget takes 4 rows for the tabs
+ * @param widgetType Type of widget
+ * @param props Widget properties
+ * @returns the offset in rows
+ */
+export const getCanvasHeightOffset = (
+  widgetType: WidgetType,
+  props: WidgetProps,
+) => {
+  // Get the non serialisable configs for the widget type
+  const config:
+    | Record<NonSerialisableWidgetConfigs, unknown>
+    | undefined = WidgetFactory.nonSerialisableWidgetConfigMap.get(widgetType);
+  let offset = 0;
+  // If this widget has a registered canvasHeightOffset function
+  if (config?.canvasHeightOffset) {
+    // Run the function to get the offset value
+    offset = (config.canvasHeightOffset as (props: WidgetProps) => number)(
+      props,
+    );
+  }
+  return offset;
+};

--- a/app/client/src/utils/WidgetFactory.tsx
+++ b/app/client/src/utils/WidgetFactory.tsx
@@ -17,6 +17,9 @@ type WidgetDerivedPropertyType = any;
 export type DerivedPropertiesMap = Record<string, string>;
 export type WidgetType = typeof WidgetFactory.widgetTypes[number];
 
+export enum NonSerialisableWidgetConfigs {
+  CANVAS_HEIGHT_OFFSET = "canvasHeightOffset",
+}
 class WidgetFactory {
   static widgetTypes: Record<string, string> = {};
   static widgetMap: Map<
@@ -53,6 +56,11 @@ class WidgetFactory {
   static widgetConfigMap: Map<
     WidgetType,
     Partial<WidgetProps> & WidgetConfigProps & { type: string }
+  > = new Map();
+
+  static nonSerialisableWidgetConfigMap: Map<
+    WidgetType,
+    Record<NonSerialisableWidgetConfigs, unknown>
   > = new Map();
 
   static registerWidgetBuilder(
@@ -143,6 +151,13 @@ class WidgetFactory {
     config: Partial<WidgetProps> & WidgetConfigProps & { type: string },
   ) {
     this.widgetConfigMap.set(widgetType, Object.freeze(config));
+  }
+
+  static storeNonSerialisablewidgetConfig(
+    widgetType: string,
+    config: Record<NonSerialisableWidgetConfigs, unknown>,
+  ) {
+    this.nonSerialisableWidgetConfigMap.set(widgetType, config);
   }
 
   static createWidget(

--- a/app/client/src/utils/WidgetRegisterHelpers.tsx
+++ b/app/client/src/utils/WidgetRegisterHelpers.tsx
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/react";
 import store from "store";
 
 import BaseWidget from "widgets/BaseWidget";
-import WidgetFactory from "./WidgetFactory";
+import WidgetFactory, { NonSerialisableWidgetConfigs } from "./WidgetFactory";
 
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import withMeta from "widgets/MetaHOC";
@@ -55,8 +55,8 @@ export const configureWidget = (config: WidgetConfiguration) => {
     features = Object.assign({}, WidgetFeatureProps.DYNAMIC_HEIGHT);
   }
   const _config = {
-    ...features,
     ...config.defaults,
+    ...features,
     searchTags: config.searchTags,
     type: config.type,
     hideCard: !!config.hideCard || !config.iconSVG,
@@ -66,7 +66,21 @@ export const configureWidget = (config: WidgetConfiguration) => {
     key: generateReactKey(),
     iconSVG: config.iconSVG,
     isCanvas: config.isCanvas,
+    canvasHeightOffset: config.canvasHeightOffset,
   };
+
+  const nonSerialisableWidgetConfigs: Record<string, unknown> = {};
+  Object.values(NonSerialisableWidgetConfigs).forEach((entry) => {
+    if (_config[entry] !== undefined) {
+      nonSerialisableWidgetConfigs[entry] = _config[entry];
+    }
+    delete _config[entry];
+  });
+
+  WidgetFactory.storeNonSerialisablewidgetConfig(
+    config.type,
+    nonSerialisableWidgetConfigs,
+  );
 
   store.dispatch({
     type: ReduxActionTypes.ADD_WIDGET_CONFIG,

--- a/app/client/src/widgets/constants.ts
+++ b/app/client/src/widgets/constants.ts
@@ -21,6 +21,7 @@ export interface WidgetConfiguration {
   needsMeta?: boolean;
   features?: WidgetFeatures;
   searchTags?: string[];
+  canvasHeightOffset?: (props: WidgetProps) => number;
   properties: {
     config: PropertyPaneConfig[];
     contentConfig?: PropertyPaneConfig[];


### PR DESCRIPTION
## Description
Adds feature for widgets to have non-serialisable widget configuration
This allows us to have these properties, while also not having to send it to the workers

- [ ] Add WidgetConfiguration property `canvasHeightOffset`
- [ ] Add a non-serialisable widget config registry (enum)
- [ ] Skip adding this to the redux store when registering a widget
- [ ] Store in memory, these properties as a part of the `WidgetFactory`


Fixes #18118

## Type of change
- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
- Internal change: Needs existing tests to pass


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [NA] I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
~~- [NA] I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
~~- [NA] PR is being merged under a feature flag~~


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organised project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reviewing all Cypress test
