### PR TITLE
chore: Re-adding the read permission group AclPermission

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/acl/AclPermission.java
@@ -118,6 +118,8 @@ public enum AclPermission {
     READ_PERMISSION_GROUP_MEMBERS("read:permissionGroupMembers", PermissionGroup.class),
     ASSIGN_PERMISSION_GROUPS("assign:permissionGroups", PermissionGroup.class),
     UNASSIGN_PERMISSION_GROUPS("unassign:permissionGroups", PermissionGroup.class),
+    @Deprecated
+    READ_PERMISSION_GROUPS("read:permissionGroups", PermissionGroup.class),
 
     // Manage tenant permissions
     MANAGE_TENANT("manage:tenants", Tenant.class),


### PR DESCRIPTION
This is a hot fix for the issue seen by a few instances which have manually upgraded Community Edition after a gap. This led to an old migration which relied on a deleted field for serialization failing leading to server not coming up. This issue was not seen by any instance which was on auto upgrade. This was faced only by a few instances who upgraded to the latest after a gap.