### PR TITLE
fix: Lint editor only when lint error changes

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -144,7 +144,7 @@ export type EditorStyleProps = {
  *
  * element => HTML Element that gets added to line
  *
- * isFocusedAction => function called when focused
+ * isFocusedAction => function called when code editor is focused
  */
 export type GutterConfig = {
   line: number;
@@ -157,12 +157,6 @@ export type CodeEditorGutter = {
     | ((editorValue: string, cursorLineNumber: number) => GutterConfig | null)
     | null;
   gutterId: string;
-};
-
-export type CustomKeyMap = {
-  // combination of keys
-  combination: string;
-  onKeyDown: (cm: CodeMirror.Editor) => void;
 };
 
 export type EditorProps = EditorStyleProps &
@@ -381,6 +375,9 @@ class CodeEditor extends Component<Props, State> {
   }, 100);
 
   componentDidUpdate(prevProps: Props): void {
+    if (!isEqual(this.props.lintErrors, prevProps.lintErrors)) {
+      this.lintCode(this.editor);
+    }
     if (
       prevProps.containerHeight &&
       this.props.containerHeight &&
@@ -880,9 +877,6 @@ class CodeEditor extends Component<Props, State> {
     if (this.props.isInvalid !== undefined) {
       isInvalid = Boolean(this.props.isInvalid);
     }
-    /*  Evaluation results for snippet snippets */
-    this.lintCode(this.editor);
-
     const showEvaluatedValue =
       this.state.isFocused &&
       !hideEvaluatedValue &&


### PR DESCRIPTION
## Description

Previously, upon every re-render the code editor content was getting linted ( the `lintCode` function was getting called). To improve this, we now only lint when lint errors change.

Fixes # (issue)
> if no issue exists, please create an issue and ask the maintainers about this first


## Type of chang

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
