### PR TITLE
fix: old DSL container collapse

### DIFF
--- a/app/client/src/utils/WidgetFeatures.ts
+++ b/app/client/src/utils/WidgetFeatures.ts
@@ -266,7 +266,7 @@ function updateMinMaxDynamicHeight(
         propertyValue: props.topRow,
       });
     }
-    if (props.shouldScrollContents === false) {
+    if (!props.shouldScrollContents) {
       updates.push({
         propertyPath: "shouldScrollContents",
         propertyValue: true,

--- a/app/client/src/utils/hooks/useWidgetConfig.ts
+++ b/app/client/src/utils/hooks/useWidgetConfig.ts
@@ -1,0 +1,11 @@
+import { AppState } from "@appsmith/reducers";
+
+import { useSelector } from "react-redux";
+import { WidgetType } from "utils/WidgetFactory";
+
+export default function useWidgetConfig(type: WidgetType, attr: string) {
+  const config = useSelector(
+    (state: AppState) => state.entities.widgetConfig.config[type],
+  );
+  return config[attr];
+}

--- a/app/client/src/widgets/DynamicHeightContainerWrapper.tsx
+++ b/app/client/src/widgets/DynamicHeightContainerWrapper.tsx
@@ -1,0 +1,43 @@
+import { WidgetProps } from "./BaseWidget";
+import {
+  getWidgetMaxDynamicHeight,
+  getWidgetMinDynamicHeight,
+} from "./WidgetUtils";
+import DynamicHeightContainer from "./DynamicHeightContainer";
+import React, { ReactNode } from "react";
+import useWidgetConfig from "utils/hooks/useWidgetConfig";
+
+export type DynamicHeightWrapperProps = {
+  widgetProps: WidgetProps;
+  children: ReactNode;
+  onUpdateDynamicHeight: (height: number) => void;
+};
+
+export function DynamicHeightContainerWrapper(
+  props: DynamicHeightWrapperProps,
+) {
+  const { children, widgetProps } = props;
+  const isCanvas = useWidgetConfig(widgetProps.type, "isCanvas");
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  if (isCanvas) return <>{children}</>;
+
+  const onHeightUpdate = (height: number) => {
+    requestAnimationFrame(() => {
+      props.onUpdateDynamicHeight(height);
+    });
+  };
+
+  const maxDynamicHeight = getWidgetMaxDynamicHeight(widgetProps);
+  const minDynamicHeight = getWidgetMinDynamicHeight(widgetProps);
+
+  return (
+    <DynamicHeightContainer
+      dynamicHeight={widgetProps.dynamicHeight}
+      maxDynamicHeight={maxDynamicHeight}
+      minDynamicHeight={minDynamicHeight}
+      onHeightUpdate={onHeightUpdate}
+    >
+      {children}
+    </DynamicHeightContainer>
+  );
+}


### PR DESCRIPTION
## Description
The DynamicHeightContainer is added all widgets which donot have `isCanvas` property. This means that widgets like container widgets should not have this container wrapper. Unfortunately, with the current mechanism things this may not work, as old DSLs may not have the `isCanvas` property properly defined. 

To get around this we'll get the `isCanvas` value from the widget configs in the reducers.
This makes us convert the `addDynamicHeightContainer` function into a React component, which uses hooks to fetch the config.
