### PR TITLE
fix: Error deleting application when soft-deleted entities are present in the application

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
@@ -148,7 +148,7 @@ public class BaseRepositoryImpl<T extends BaseDomain, ID extends Serializable> e
         Assert.notNull(entity.getId(), "The given entity's id must not be null!");
         // Entity is already deleted
         if (entity.isDeleted()) {
-            return Mono.empty();
+            return Mono.just(entity);
         }
 
         entity.setDeleted(true);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
@@ -146,7 +146,10 @@ public class BaseRepositoryImpl<T extends BaseDomain, ID extends Serializable> e
     public Mono<T> archive(T entity) {
         Assert.notNull(entity, "The given entity must not be null!");
         Assert.notNull(entity.getId(), "The given entity's id must not be null!");
-        Assert.isTrue(!entity.isDeleted(), "The given entity is already deleted");
+        // Entity is already deleted
+        if (entity.isDeleted()) {
+            return Mono.empty();
+        }
 
         entity.setDeleted(true);
         entity.setDeletedAt(Instant.now());


### PR DESCRIPTION
## Description

Deleting the application throws a 500 error if there are soft-deleted JSObjects present. This happens when apps are exported from older versions of Appsmith and imported to new versions and if there are soft-deleted JSObjects present in the exported JSON.

Fixes #18181 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
