### PR TITLE
fix: auto height limits label intersection with handle dot

### DIFF
--- a/app/client/src/components/editorComponents/DynamicHeightOverlay/ui/AutoHeightLimitHandleLabel.tsx
+++ b/app/client/src/components/editorComponents/DynamicHeightOverlay/ui/AutoHeightLimitHandleLabel.tsx
@@ -15,7 +15,8 @@ const AutoHeightLimitHandleLabel = styled.div<AutoHeightLimitHandleLabel>`
   color: #ffffff;
   text-align: center;
   white-space: nowrap;
-  left: 16px;
+  left: 0px;
+  transform: translate(calc(-100% - 4px), -2px);
   display: ${(props) => (props.isActive ? "initial" : "none")};
 `;
 


### PR DESCRIPTION
Fixed the position of the limits label to the right so that it will not intersect with the handle dot.