### PR TITLE
fix: auto height limits rich text editor min height

### DIFF
--- a/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/component/index.tsx
@@ -222,7 +222,7 @@ export const RichTextEditorInputWrapper = styled.div<{
   border-radius: ${({ borderRadius }) => borderRadius};
 
   ${({ isDynamicHeightEnabled }) =>
-    isDynamicHeightEnabled ? "&& { height: auto; min-height: 200px; }" : ""};
+    isDynamicHeightEnabled ? "&& { height: auto; min-height: 192px; }" : ""};
 `;
 
 export interface RichtextEditorComponentProps {


### PR DESCRIPTION
Fixed the position of the limits label to the right so that it will not intersect with the handle dot.