### PR TITLE
fix: Log ChunkLoadError on Sentry only after 3rd failure

### DIFF
--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -1,6 +1,6 @@
 import { precacheAndRoute } from "workbox-precaching";
 import { clientsClaim, setCacheNameDetails, skipWaiting } from "workbox-core";
-import { registerRoute } from "workbox-routing";
+import { registerRoute, Route } from "workbox-routing";
 import {
   CacheFirst,
   NetworkOnly,
@@ -64,18 +64,8 @@ registerRoute(
   }),
 );
 
-registerRoute(({ url }) => {
-  return url.pathname.includes("index.html");
-}, new NetworkOnly());
-
-self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.keys().then(function(cacheNames) {
-      return Promise.all(
-        cacheNames.map(function(cacheName) {
-          return caches.delete(cacheName);
-        }),
-      );
-    }),
-  );
-});
+registerRoute(
+  new Route(({ request, sameOrigin }) => {
+    return sameOrigin && request.destination === "document";
+  }, new NetworkOnly()),
+);

--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -19,6 +19,24 @@ export const initializeAnalyticsAndTrackers = () => {
       window.Sentry = Sentry;
       Sentry.init({
         ...appsmithConfigs.sentry,
+        beforeSend(event) {
+          if (
+            event.exception &&
+            Array.isArray(event.exception.values) &&
+            event.exception.values[0].value &&
+            event.exception.values[0].type === "ChunkLoadError"
+          ) {
+            // Only log ChunkLoadErrors after the 2 retires
+            if (
+              !event.exception.values[0].value.includes(
+                "failed after 2 retries",
+              )
+            ) {
+              return null;
+            }
+          }
+          return event;
+        },
         beforeBreadcrumb(breadcrumb) {
           if (
             breadcrumb.category === "console" &&


### PR DESCRIPTION
## Description
We used to log sentry errors every time we faced a chunk load error. Now we will only do it after 3rd failure in the retry mechanism

Fixes #17258


Media
<img width="1690" alt="Screenshot 2022-11-16 at 5 07 29 PM" src="https://user-images.githubusercontent.com/12022471/202170698-42d526b5-1eda-4082-999b-cd31a275c3ba.png">
## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manually


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
