### PR TITLE
fix: auto height tabs double scroll

### DIFF
--- a/app/client/src/widgets/TabsWidget/widget/index.tsx
+++ b/app/client/src/widgets/TabsWidget/widget/index.tsx
@@ -337,7 +337,7 @@ class TabsWidget extends BaseWidget<
       return null;
     }
 
-    childWidgetData.shouldScrollContents = this.props.shouldScrollContents;
+    // childWidgetData.shouldScrollContents = this.props.shouldScrollContents;
     childWidgetData.canExtend = this.props.shouldScrollContents;
     const { componentHeight, componentWidth } = this.getComponentDimensions();
     childWidgetData.rightColumn = componentWidth;


### PR DESCRIPTION
Solved the issue by disabling the scroll for the child canvas widget in the tabs widget.