### PR TITLE
fix: Allow country code change text gets wrapped and makes the UI looks ugly

### DIFF
--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -113,7 +113,7 @@ class PhoneInputWidget extends BaseInputWidget<
             },
             {
               propertyName: "allowDialCodeChange",
-              label: "Allow Country Code Change",
+              label: "Change Country Code",
               helpText: "Search by country",
               controlType: "SWITCH",
               isJSConvertible: true,


### PR DESCRIPTION
## Description

The "Allow Country Code Change" text was getting wrapped, making the UI look ugly.
Fixed it by changing the copy to "Change Country Code"

![Screenshot 2022-11-17 at 11 49 35 AM](https://user-images.githubusercontent.com/10436935/202371283-8431f497-e263-4beb-a67a-a594e8188521.png)
