### PR TITLE
fix: Corrected usage of old soft deleted filter in BaseAppsmithRepository

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -95,9 +95,17 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
     }
 
     public static final Criteria notDeleted() {
-        return new Criteria().orOperator(
-                where(fieldName(QBaseDomain.baseDomain.deleted)).exists(false),
-                where(fieldName(QBaseDomain.baseDomain.deleted)).is(false)
+        return new Criteria().andOperator(
+                //Older check for deleted
+                new Criteria().orOperator(
+                        where(FieldName.DELETED).exists(false),
+                        where(FieldName.DELETED).is(false)
+                ),
+                //New check for deleted
+                new Criteria().orOperator(
+                        where(FieldName.DELETED_AT).exists(false),
+                        where(FieldName.DELETED_AT).is(null)
+                )
         );
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ActionCollectionServiceTest.java
@@ -24,6 +24,7 @@ import com.appsmith.server.dtos.RefactorActionNameDTO;
 import com.appsmith.server.dtos.WorkspacePluginStatus;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
+import com.appsmith.server.repositories.ActionCollectionRepository;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
@@ -45,6 +46,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -100,6 +102,9 @@ public class ActionCollectionServiceTest {
 
     @Autowired
     PluginRepository pluginRepository;
+
+    @Autowired
+    ActionCollectionRepository actionCollectionRepository;
 
     @Autowired
     UserWorkspaceService userWorkspaceService;
@@ -216,6 +221,42 @@ public class ActionCollectionServiceTest {
                 })
                 .verifyComplete();
     }
+
+    /**
+     * Test to verify soft-deleted actionCollections are not retrieved in repository find methods.
+     * This issue was observed when deprecated soft-delete field "deleted" is set to "false" and current field "deletedAt"
+     * contains a non-null value.
+     * Here deletedAt field is manually set to a non-null value instead of deleting actionCollection since that would
+     * update both fields.
+     */
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testCreateActionCollection_verifySoftDeletedCollectionIsNotLoaded() {
+        Application application = new Application();
+        application.setName(UUID.randomUUID().toString());
+
+        Application createdApplication = applicationPageService.createApplication(application, workspaceId).block();
+
+        assert createdApplication != null;
+        final String pageId = createdApplication.getPages().get(0).getId();
+
+        ActionCollectionDTO actionCollectionDTO = new ActionCollectionDTO();
+        actionCollectionDTO.setName("testActionCollectionSoftDeleted");
+        actionCollectionDTO.setApplicationId(createdApplication.getId());
+        actionCollectionDTO.setWorkspaceId(createdApplication.getWorkspaceId());
+        actionCollectionDTO.setPageId(pageId);
+        actionCollectionDTO.setPluginId(datasource.getPluginId());
+        actionCollectionDTO.setPluginType(PluginType.JS);
+        actionCollectionDTO.setDeletedAt(Instant.now());
+        layoutCollectionService.createCollection(actionCollectionDTO).block();
+        ActionCollection createdActionCollection = actionCollectionRepository.findByApplicationId(createdApplication.getId(), READ_ACTIONS, null).blockFirst();
+        createdActionCollection.setDeletedAt(Instant.now());
+        actionCollectionRepository.save(createdActionCollection).block();
+
+        StepVerifier.create(actionCollectionRepository.findByApplicationId(createdApplication.getId(), READ_ACTIONS, null))
+                .verifyComplete();
+    }
+
 
     @Test
     @WithUserDetails(value = "api_user")


### PR DESCRIPTION
## Description

Recently we found there were issues happening because of the deprecated `deleted` param in entities for soft-delete operation. In the latest version, we only use `deletedAt` field for soft-delete. This PR correct the usage of old `deleted` field only filter and adds the current field to the filter.

Fixes #18161

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- JUnit

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
