### PR TITLE
task: Dynamic height reflow fixes in Branch

### DIFF
--- a/app/client/src/reducers/entityReducers/autoHeightReducers/autoHeightLayoutTreeReducer.ts
+++ b/app/client/src/reducers/entityReducers/autoHeightReducers/autoHeightLayoutTreeReducer.ts
@@ -22,7 +22,7 @@ const autoHeightLayoutTreeReducer = createImmerReducer(initialState, {
     action: ReduxAction<AutoHeightLayoutTreePayload>,
   ) => {
     const { tree } = action.payload;
-    const diff = xor(Object.keys(state), ...Object.keys(tree));
+    const diff = xor(Object.keys(state), [...Object.keys(tree)]);
     for (const widgetId in diff) {
       delete state[widgetId];
     }
@@ -46,6 +46,8 @@ const autoHeightLayoutTreeReducer = createImmerReducer(initialState, {
 
         state[widgetId].topRow = tree[widgetId].topRow;
         state[widgetId].bottomRow = tree[widgetId].bottomRow;
+        state[widgetId].originalTopRow = tree[widgetId].originalTopRow;
+        state[widgetId].originalBottomRow = tree[widgetId].originalBottomRow;
       } else {
         state[widgetId] = tree[widgetId];
       }

--- a/app/client/src/utils/treeManipulationHelpers/dynamicHeightReflow.ts
+++ b/app/client/src/utils/treeManipulationHelpers/dynamicHeightReflow.ts
@@ -1,3 +1,4 @@
+import { uniq } from "lodash";
 import log from "loglevel";
 import { areIntersecting } from "utils/WidgetPropsUtils";
 
@@ -90,9 +91,10 @@ function getEffectedBoxes(
 ): string[] {
   const belows = tree[id].belows;
   belows.forEach((belowId) => {
+    getEffectedBoxes(belowId, tree, effectedBoxes);
     (effectedBoxes as string[]).push(belowId);
   });
-  return effectedBoxes;
+  return uniq(effectedBoxes);
 }
 
 // TODO: DEBUG(abhinav): This probably doesn't take in to account the following:


### PR DESCRIPTION
- [ ]  including all the belows, even the widgets below it's belows as effected boxes to reflow all of them
- [ ] fixing `xor` argument in reducer
- [ ] updating `originalBottomRow` and `originalTopRow` whenever layout updates to avoid any overlaps in reflow