### PR TITLE
fix: add certmanager and classname fields in ingress

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -44,6 +44,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
+  certManager: {{ .Values.ingress.certManager }}
+  className: {{ .Values.ingress.className }}
   rules:
     {{- if not .Values.ingress.hosts }}
     - host:


### PR DESCRIPTION
fixes: [18207](https://github.com/appsmithorg/appsmith/issues/18207)