### PR TITLE
fix: Using an html tag within a Text widget to access a web page, without the https:// appended causes application to crash

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Text/Text_new_feature_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/Text/Text_new_feature_spec.js
@@ -13,6 +13,15 @@ describe("Text Widget color/font/alignment Functionality", function() {
   });
   it("Test to validate parsing link", function() {
     // Add link to text widget
+    cy.testCodeMirror("app.appsmith.com");
+    // check if it's a link when no http or https is passed,
+    cy.get(`${commonlocators.headingTextStyle} a`).should(
+      "have.attr",
+      "href",
+      "http://app.appsmith.com",
+    );
+
+    // Add link to text widget
     cy.testCodeMirror("https://app.appsmith.com");
     // check if it's parsed as link
     cy.get(commonlocators.headingTextStyle);

--- a/app/client/src/widgets/TextWidget/component/filters/LinkFilter.ts
+++ b/app/client/src/widgets/TextWidget/component/filters/LinkFilter.ts
@@ -1,0 +1,22 @@
+import { Filter } from "interweave";
+import { addHttpIfMissing } from "../helpers";
+
+class LinkFilter extends Filter {
+  attribute(name: string, value: string): string {
+    if (name === "href") {
+      return addHttpIfMissing(value);
+    }
+
+    return value;
+  }
+
+  node(name: string, node: HTMLElement): HTMLElement {
+    if (name === "a") {
+      node.setAttribute("target", "_blank");
+    }
+
+    return node;
+  }
+}
+
+export default LinkFilter;

--- a/app/client/src/widgets/TextWidget/component/filters/LinkFilter.ts
+++ b/app/client/src/widgets/TextWidget/component/filters/LinkFilter.ts
@@ -9,14 +9,6 @@ class LinkFilter extends Filter {
 
     return value;
   }
-
-  node(name: string, node: HTMLElement): HTMLElement {
-    if (name === "a") {
-      node.setAttribute("target", "_blank");
-    }
-
-    return node;
-  }
 }
 
 export default LinkFilter;

--- a/app/client/src/widgets/TextWidget/component/helpers.tsx
+++ b/app/client/src/widgets/TextWidget/component/helpers.tsx
@@ -1,0 +1,15 @@
+/**
+ * add http if missing
+ *
+ * @param url
+ * @returns
+ */
+export const addHttpIfMissing = (url: string) => {
+  if (!url) {
+    return url;
+  }
+  if (url.indexOf("http") === 0) {
+    return url;
+  }
+  return `http://${url}`;
+};

--- a/app/client/src/widgets/TextWidget/component/index.tsx
+++ b/app/client/src/widgets/TextWidget/component/index.tsx
@@ -352,6 +352,7 @@ class TextComponent extends React.Component<TextComponentProps, State> {
             >
               <Interweave
                 content={text}
+                filters={[new LinkFilter()]}
                 matchers={
                   disableLink
                     ? []

--- a/app/client/src/widgets/TextWidget/component/index.tsx
+++ b/app/client/src/widgets/TextWidget/component/index.tsx
@@ -17,6 +17,7 @@ import { Color, Colors } from "constants/Colors";
 import FontLoader from "./FontLoader";
 import { fontSizeUtility } from "widgets/WidgetUtils";
 import { OverflowTypes } from "../constants";
+import LinkFilter from "./filters/LinkFilter";
 
 export type TextAlign = "LEFT" | "CENTER" | "RIGHT" | "JUSTIFY";
 
@@ -301,6 +302,7 @@ class TextComponent extends React.Component<TextComponentProps, State> {
             >
               <Interweave
                 content={text}
+                filters={[new LinkFilter()]}
                 matchers={
                   disableLink
                     ? []


### PR DESCRIPTION
## Description
On using anchor with href without `https` or `http`, It creates invalid URL which leads to 404 page. This PR fixes that invalid URL.

Fixes #18204 

## Type of change

- Bug fix

## How Has This Been Tested?
- Manual

### Issues raised during DP testing

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
