### PR TITLE
fix: show filter & show download should not control add new row link visibility in table widget

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/header/actions/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/header/actions/index.tsx
@@ -142,7 +142,9 @@ function Actions(props: ActionsPropsType) {
           />
         </SearchComponentWrapper>
       )}
-      {(props.isVisibleFilters || props.isVisibleDownload) && (
+      {(props.isVisibleFilters ||
+        props.isVisibleDownload ||
+        props.allowAddNewRow) && (
         <CommonFunctionsMenuWrapper tableSizes={props.tableSizes}>
           {props.isVisibleFilters && (
             <TableFilters


### PR DESCRIPTION
Fixes #18346

## Description
Now toggling the show filter and show download properties from the property pane should not hide/show the add new row link in the table header

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
