### PR TITLE
feat: segregate datasource entity permissions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/PolicyUtils.java
@@ -21,6 +21,7 @@ import com.appsmith.server.repositories.DatasourceRepository;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.repositories.NewPageRepository;
 import com.appsmith.server.repositories.ThemeRepository;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
@@ -56,6 +57,7 @@ public class PolicyUtils {
     private final CommentThreadRepository commentThreadRepository;
     private final ActionCollectionRepository actionCollectionRepository;
     private final ThemeRepository themeRepository;
+    private final DatasourcePermission datasourcePermission;
 
     public <T extends BaseDomain> T addPoliciesToExistingObject(Map<String, Policy> policyMap, T obj) {
         // Making a deep copy here so we don't modify the `policyMap` object.
@@ -196,7 +198,7 @@ public class PolicyUtils {
 
         return datasourceRepository
                 // fetch datasources with execute permissions so that app viewers can invite other app viewers
-                .findAllByWorkspaceId(workspaceId, AclPermission.EXECUTE_DATASOURCES)
+                .findAllByWorkspaceId(workspaceId, datasourcePermission.getExecutePermission())
                 // In case we have come across a datasource for this workspace that the current user is not allowed to manage, move on.
                 .switchIfEmpty(Mono.empty())
                 .map(datasource -> {
@@ -213,7 +215,7 @@ public class PolicyUtils {
     public Flux<Datasource> updateWithNewPoliciesToDatasourcesByDatasourceIds(Set<String> ids, Map<String, Policy> datasourcePolicyMap, boolean addPolicyToObject) {
 
         return datasourceRepository
-                .findAllByIds(ids, MANAGE_DATASOURCES)
+                .findAllByIds(ids, datasourcePermission.getManagePermission())
                 // In case we have come across a datasource the current user is not allowed to manage, move on.
                 .switchIfEmpty(Mono.empty())
                 .flatMap(datasource -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ApplicationServiceImpl.java
@@ -6,6 +6,7 @@ import com.appsmith.server.repositories.ApplicationRepository;
 import com.appsmith.server.repositories.CommentThreadRepository;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.ce.ApplicationServiceCEImpl;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -32,10 +33,12 @@ public class ApplicationServiceImpl extends ApplicationServiceCEImpl implements 
                                   ResponseUtils responseUtils,
                                   PermissionGroupService permissionGroupService,
                                   TenantService tenantService,
-                                  UserRepository userRepository) {
+                                  UserRepository userRepository,
+                                  DatasourcePermission datasourcePermission) {
 
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService, policyUtils,
-                configService, commentThreadRepository, sessionUserService, responseUtils, permissionGroupService, tenantService, userRepository);
+                configService, commentThreadRepository, sessionUserService, responseUtils, permissionGroupService, tenantService, userRepository,
+                datasourcePermission);
 
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceContextServiceImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services;
 
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.services.ce.DatasourceContextServiceCEImpl;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -13,8 +14,9 @@ public class DatasourceContextServiceImpl extends DatasourceContextServiceCEImpl
     public DatasourceContextServiceImpl(@Lazy DatasourceService datasourceService,
                                         PluginService pluginService,
                                         PluginExecutorHelper pluginExecutorHelper,
-                                        ConfigService configService) {
+                                        ConfigService configService,
+                                        DatasourcePermission datasourcePermission) {
 
-        super(datasourceService, pluginService, pluginExecutorHelper, configService);
+        super(datasourceService, pluginService, pluginExecutorHelper, configService, datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/DatasourceServiceImpl.java
@@ -5,6 +5,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.DatasourceRepository;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.services.ce.DatasourceServiceCEImpl;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -30,11 +31,12 @@ public class DatasourceServiceImpl extends DatasourceServiceCEImpl implements Da
                                  PolicyGenerator policyGenerator,
                                  SequenceService sequenceService,
                                  NewActionRepository newActionRepository,
-                                 DatasourceContextService datasourceContextService) {
+                                 DatasourceContextService datasourceContextService,
+                                 DatasourcePermission datasourcePermission) {
 
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, workspaceService,
                 analyticsService, sessionUserService, pluginService, pluginExecutorHelper, policyGenerator,
-                sequenceService, newActionRepository, datasourceContextService);
+                sequenceService, newActionRepository, datasourceContextService, datasourcePermission);
 
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/GitServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/GitServiceImpl.java
@@ -9,6 +9,7 @@ import com.appsmith.server.helpers.GitFileUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.repositories.GitDeployKeysRepository;
 import com.appsmith.server.services.ce.GitServiceCEImpl;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Import;
@@ -35,11 +36,12 @@ public class GitServiceImpl extends GitServiceCEImpl implements GitService {
                           GitCloudServicesUtils gitCloudServicesUtils,
                           GitDeployKeysRepository gitDeployKeysRepository,
                           DatasourceService datasourceService,
-                          PluginService pluginService) {
+                          PluginService pluginService,
+                          DatasourcePermission datasourcePermission) {
 
         super(userService, userDataService, sessionUserService, applicationService, applicationPageService,
                 newPageService, newActionService, actionCollectionService, fileUtils, importExportApplicationService,
                 gitExecutor, responseUtils, emailConfig, analyticsService, gitCloudServicesUtils, gitDeployKeysRepository,
-                datasourceService, pluginService);
+                datasourceService, pluginService, datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/NewActionServiceImpl.java
@@ -6,6 +6,7 @@ import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.helpers.ResponseUtils;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.services.ce.NewActionServiceCEImpl;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -37,12 +38,13 @@ public class NewActionServiceImpl extends NewActionServiceCEImpl implements NewA
                                 AuthenticationValidator authenticationValidator,
                                 ConfigService configService,
                                 ResponseUtils responseUtils,
-                                PermissionGroupService permissionGroupService) {
+                                PermissionGroupService permissionGroupService,
+                                DatasourcePermission datasourcePermission) {
 
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService,
                 datasourceService, pluginService, datasourceContextService, pluginExecutorHelper, marketplaceService,
                 policyGenerator, newPageService, applicationService, sessionUserService, policyUtils,
-                authenticationValidator, configService, responseUtils, permissionGroupService);
+                authenticationValidator, configService, responseUtils, permissionGroupService, datasourcePermission);
 
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationServiceCEImpl.java
@@ -39,6 +39,7 @@ import com.appsmith.server.services.ConfigService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.TenantService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.mongodb.client.result.UpdateResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,6 +79,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
     private final TenantService tenantService;
 
     private final UserRepository userRepository;
+    private final DatasourcePermission datasourcePermission;
 
     @Autowired
     public ApplicationServiceCEImpl(Scheduler scheduler,
@@ -93,7 +95,8 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
                                     ResponseUtils responseUtils,
                                     PermissionGroupService permissionGroupService,
                                     TenantService tenantService,
-                                    UserRepository userRepository) {
+                                    UserRepository userRepository,
+                                    DatasourcePermission datasourcePermission) {
 
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
         this.policyUtils = policyUtils;
@@ -104,6 +107,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         this.permissionGroupService = permissionGroupService;
         this.tenantService = tenantService;
         this.userRepository = userRepository;
+        this.datasourcePermission = datasourcePermission;
     }
 
     @Override
@@ -376,7 +380,7 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         Map<String, Policy> actionPolicyMap = policyUtils
                 .generateInheritedPoliciesFromSourcePolicies(pagePolicyMap, Page.class, Action.class);
         Map<String, Policy> datasourcePolicyMap = policyUtils
-                .generatePolicyFromPermissionWithPermissionGroup(EXECUTE_DATASOURCES, permissionGroupId);
+                .generatePolicyFromPermissionWithPermissionGroup(datasourcePermission.getExecutePermission(), permissionGroupId);
         Map<String, Policy> themePolicyMap = policyUtils.generateInheritedPoliciesFromSourcePolicies(
                 applicationPolicyMap, Application.class, Theme.class
         );

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/GitServiceCEImpl.java
@@ -53,6 +53,7 @@ import com.appsmith.server.services.PluginService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.services.UserService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -131,6 +132,7 @@ public class GitServiceCEImpl implements GitServiceCE {
     private final GitDeployKeysRepository gitDeployKeysRepository;
     private final DatasourceService datasourceService;
     private final PluginService pluginService;
+    private final DatasourcePermission datasourcePermission;
 
     @Override
     public Mono<Application> updateGitMetadata(String applicationId, GitApplicationMetadata gitApplicationMetadata) {
@@ -1914,7 +1916,7 @@ public class GitServiceCEImpl implements GitServiceCE {
                     String defaultBranch = gitApplicationMetadata.getDefaultBranchName();
 
 
-                    Mono<List<Datasource>> datasourceMono = datasourceService.findAllByWorkspaceId(workspaceId, MANAGE_DATASOURCES).collectList();
+                    Mono<List<Datasource>> datasourceMono = datasourceService.findAllByWorkspaceId(workspaceId, datasourcePermission.getManagePermission()).collectList();
                     Mono<List<Plugin>> pluginMono = pluginService.getDefaultPlugins().collectList();
                     Mono<ApplicationJson> applicationJsonMono = fileUtils
                             .reconstructApplicationJsonFromGitRepo(workspaceId, application.getId(), gitApplicationMetadata.getRepoName(), defaultBranch)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/AuthenticationServiceImpl.java
@@ -19,8 +19,10 @@ public class AuthenticationServiceImpl extends AuthenticationServiceCEImpl imple
                                      RedirectHelper redirectHelper,
                                      NewPageService newPageService,
                                      CloudServicesConfig cloudServicesConfig,
-                                     ConfigService configService) {
+                                     ConfigService configService,
+                                     DatasourcePermission datasourcePermission) {
 
-        super(datasourceService, pluginService, redirectHelper, newPageService, cloudServicesConfig, configService);
+        super(datasourceService, pluginService, redirectHelper, newPageService, cloudServicesConfig, configService,
+                datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolutionImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/CreateDBTablePageSolutionImpl.java
@@ -27,9 +27,11 @@ public class CreateDBTablePageSolutionImpl extends CreateDBTablePageSolutionCEIm
                                          AnalyticsService analyticsService,
                                          SessionUserService sessionUserService,
                                          ResponseUtils responseUtils,
-                                         PluginExecutorHelper pluginExecutorHelper) {
+                                         PluginExecutorHelper pluginExecutorHelper,
+                                         DatasourcePermission datasourcePermission) {
 
         super(datasourceService, newPageService, layoutActionService, applicationPageService, applicationService,
-                pluginService, analyticsService, sessionUserService, responseUtils, pluginExecutorHelper);
+                pluginService, analyticsService, sessionUserService, responseUtils, pluginExecutorHelper,
+                datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourcePermission.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourcePermission.java
@@ -1,0 +1,6 @@
+package com.appsmith.server.solutions;
+
+import com.appsmith.server.solutions.ce.DatasourcePermissionCE;
+
+public interface DatasourcePermission extends DatasourcePermissionCE {
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourcePermissionImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourcePermissionImpl.java
@@ -1,0 +1,8 @@
+package com.appsmith.server.solutions;
+
+import com.appsmith.server.solutions.ce.DatasourcePermissionCEImpl;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DatasourcePermissionImpl extends DatasourcePermissionCEImpl implements DatasourcePermission {
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolutionImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceStructureSolutionImpl.java
@@ -19,9 +19,10 @@ public class DatasourceStructureSolutionImpl extends DatasourceStructureSolution
                                            PluginService pluginService,
                                            DatasourceContextService datasourceContextService,
                                            CustomDatasourceRepository datasourceRepository,
-                                           AuthenticationValidator authenticationValidator) {
+                                           AuthenticationValidator authenticationValidator,
+                                           DatasourcePermission datasourcePermission) {
 
         super(datasourceService, pluginExecutorHelper, pluginService, datasourceContextService, datasourceRepository,
-                authenticationValidator);
+                authenticationValidator, datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceTriggerSolutionImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/DatasourceTriggerSolutionImpl.java
@@ -18,13 +18,15 @@ public class DatasourceTriggerSolutionImpl extends DatasourceTriggerSolutionCEIm
                                          PluginService pluginService,
                                          DatasourceStructureSolution datasourceStructureSolution,
                                          AuthenticationValidator authenticationValidator,
-                                         DatasourceContextService datasourceContextService) {
+                                         DatasourceContextService datasourceContextService,
+                                         DatasourcePermission datasourcePermission) {
 
         super(datasourceService,
                 pluginExecutorHelper,
                 pluginService,
                 datasourceStructureSolution,
                 authenticationValidator,
-                datasourceContextService);
+                datasourceContextService,
+                datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ImportExportApplicationServiceImpl.java
@@ -42,11 +42,12 @@ public class ImportExportApplicationServiceImpl extends ImportExportApplicationS
                                               ActionCollectionService actionCollectionService,
                                               ThemeService themeService,
                                               PolicyUtils policyUtils,
-                                              AnalyticsService analyticsService) {
+                                              AnalyticsService analyticsService,
+                                              DatasourcePermission datasourcePermission) {
 
         super(datasourceService, sessionUserService, newActionRepository, datasourceRepository, pluginRepository,
                 workspaceService, applicationService, newPageService, applicationPageService, newPageRepository,
                 newActionService, sequenceService, examplesWorkspaceCloner, actionCollectionRepository,
-                actionCollectionService, themeService, policyUtils, analyticsService);
+                actionCollectionService, themeService, policyUtils, analyticsService, datasourcePermission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -37,6 +37,7 @@ import com.appsmith.server.services.LayoutActionService;
 import com.appsmith.server.services.NewPageService;
 import com.appsmith.server.services.PluginService;
 import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.RequiredArgsConstructor;
@@ -82,6 +83,7 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
     private final SessionUserService sessionUserService;
     private final ResponseUtils responseUtils;
     private final PluginExecutorHelper pluginExecutorHelper;
+    private final DatasourcePermission datasourcePermission;
 
     private static final String FILE_PATH = "CRUD-DB-Table-Template-Application.json";
 
@@ -181,7 +183,7 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
         Mono<NewPage> pageMono = getOrCreatePage(defaultApplicationId, defaultPageId, tableName, branchName);
 
         Mono<Datasource> datasourceMono = datasourceService
-                .findById(datasourceId, AclPermission.MANAGE_DATASOURCES)
+                .findById(datasourceId, datasourcePermission.getManagePermission())
                 .switchIfEmpty(Mono.error(
                         new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasourceId))
                 )

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCE.java
@@ -1,0 +1,10 @@
+package com.appsmith.server.solutions.ce;
+
+import com.appsmith.server.acl.AclPermission;
+
+public interface DatasourcePermissionCE {
+    AclPermission getReadPermission();
+    AclPermission getDeletePermission();
+    AclPermission getManagePermission();
+    AclPermission getExecutePermission();
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCEImpl.java
@@ -1,0 +1,25 @@
+package com.appsmith.server.solutions.ce;
+
+import com.appsmith.server.acl.AclPermission;
+
+public class DatasourcePermissionCEImpl implements DatasourcePermissionCE {
+    @Override
+    public AclPermission getReadPermission() {
+        return AclPermission.READ_DATASOURCES;
+    }
+
+    @Override
+    public AclPermission getDeletePermission() {
+        return AclPermission.DELETE_DATASOURCES;
+    }
+
+    @Override
+    public AclPermission getManagePermission() {
+        return AclPermission.MANAGE_DATASOURCES;
+    }
+
+    @Override
+    public AclPermission getExecutePermission() {
+        return AclPermission.EXECUTE_DATASOURCES;
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
@@ -19,6 +19,7 @@ import com.appsmith.server.services.AuthenticationValidator;
 import com.appsmith.server.services.DatasourceContextService;
 import com.appsmith.server.services.DatasourceService;
 import com.appsmith.server.services.PluginService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -41,6 +42,8 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
     private final DatasourceContextService datasourceContextService;
     private final CustomDatasourceRepository datasourceRepository;
     private final AuthenticationValidator authenticationValidator;
+    private final DatasourcePermission datasourcePermission;
+
 
     public Mono<DatasourceStructure> getStructure(String datasourceId, boolean ignoreCache) {
         return datasourceService.getById(datasourceId)
@@ -145,7 +148,7 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
             2. Check plugin is present
             3. Execute DB query from the information provided present in pluginSpecifiedTemplates
          */
-        Mono<Datasource> datasourceMono = datasourceService.findById(datasourceId, AclPermission.MANAGE_DATASOURCES)
+        Mono<Datasource> datasourceMono = datasourceService.findById(datasourceId, datasourcePermission.getManagePermission())
                 .switchIfEmpty(Mono.error(new AppsmithException(
                         AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasourceId
                 )))

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
@@ -14,6 +14,7 @@ import com.appsmith.server.services.AuthenticationValidator;
 import com.appsmith.server.services.DatasourceContextService;
 import com.appsmith.server.services.DatasourceService;
 import com.appsmith.server.services.PluginService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.DatasourceStructureSolution;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,10 +42,11 @@ public class DatasourceTriggerSolutionCEImpl implements DatasourceTriggerSolutio
     private final DatasourceStructureSolution datasourceStructureSolution;
     private final AuthenticationValidator authenticationValidator;
     private final DatasourceContextService datasourceContextService;
+    private final DatasourcePermission datasourcePermission;
 
     public Mono<TriggerResultDTO> trigger(String datasourceId, TriggerRequestDTO triggerRequestDTO) {
 
-        Mono<Datasource> datasourceMono = datasourceService.findById(datasourceId, READ_DATASOURCES)
+        Mono<Datasource> datasourceMono = datasourceService.findById(datasourceId, datasourcePermission.getReadPermission())
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, "datasourceId")))
                 .cache();
         final Mono<Plugin> pluginMono = datasourceMono

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -45,6 +45,7 @@ import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.solutions.ApplicationFetcher;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import com.appsmith.server.solutions.ReleaseNotesService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -197,6 +198,9 @@ public class ApplicationServiceTest {
 
     @Autowired
     SessionUserService sessionUserService;
+
+    @Autowired
+    DatasourcePermission datasourcePermission;
 
     String workspaceId;
 
@@ -1239,13 +1243,13 @@ public class ApplicationServiceTest {
                     PermissionGroup publicPermissionGroup = tuple.getT4();
                     final ActionCollection actionCollection1 = tuple.getT3();
 
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(),
                                     viewerPermissionGroup.getId(), publicPermissionGroup.getId()))
                             .build();
@@ -2880,7 +2884,7 @@ public class ApplicationServiceTest {
                 .collectList();
 
         Mono<Datasource> datasourceMono = applicationFromDbPostViewChange
-                .flatMap(application -> datasourceService.findById(savedDatasource.getId(), READ_DATASOURCES));
+                .flatMap(application -> datasourceService.findById(savedDatasource.getId(), datasourcePermission.getReadPermission()));
 
         List<PermissionGroup> permissionGroups = workspaceService.findById(workspaceId, READ_WORKSPACES)
                 .flatMapMany(savedWorkspace -> {
@@ -2953,7 +2957,7 @@ public class ApplicationServiceTest {
                     assertThat(datasource1
                             .getPolicies()
                             .stream()
-                            .filter(policy -> policy.getPermission().equals(EXECUTE_DATASOURCES.getValue()))
+                            .filter(policy -> policy.getPermission().equals(datasourcePermission.getExecutePermission().getValue()))
                             .findFirst()
                             .get()
                             .getPermissionGroups()

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -1,4 +1,4 @@
-package com.appsmith.server.services;
+ package com.appsmith.server.services;
 
 import com.appsmith.external.models.ApiKeyAuth;
 import com.appsmith.external.models.BasicAuth;
@@ -16,6 +16,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.DatasourceRepository;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,6 +75,9 @@ public class DatasourceContextServiceTest {
     @SpyBean
     DatasourceContextServiceImpl datasourceContextService;
 
+    @Autowired
+    DatasourcePermission datasourcePermission;
+
     @Test
     @WithUserDetails(value = "api_user")
     public void testDatasourceCache_afterDatasourceDeleted_doesNotReturnOldConnection() {
@@ -97,8 +101,8 @@ public class DatasourceContextServiceTest {
         Mono<DatasourceContext<?>> dsContextMono1 = datasourceContextService.getCachedDatasourceContextMono(datasource,
                 spyMockPluginExecutor, monitor);
 
-        doReturn(Mono.just(datasource)).when(datasourceRepository).findById("id1", MANAGE_DATASOURCES);
-        doReturn(Mono.just(datasource)).when(datasourceRepository).findById("id1", EXECUTE_DATASOURCES);
+        doReturn(Mono.just(datasource)).when(datasourceRepository).findById("id1", datasourcePermission.getManagePermission());
+        doReturn(Mono.just(datasource)).when(datasourceRepository).findById("id1", datasourcePermission.getExecutePermission());
         doReturn(Mono.just(new Plugin())).when(pluginService).findById("mockPlugin");
         doReturn(Mono.just(0L)).when(newActionRepository).countByDatasourceId("id1");
         doReturn(Mono.just(datasource)).when(datasourceRepository).archiveById("id1");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -29,6 +29,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,6 +105,8 @@ public class DatasourceServiceTest {
 
     @MockBean
     PluginExecutorHelper pluginExecutorHelper;
+    @Autowired
+    DatasourcePermission datasourcePermission;
 
     String workspaceId = "";
 
@@ -310,16 +313,16 @@ public class DatasourceServiceTest {
                     assertThat(createdDatasource.getUserPermissions()).isNotEmpty();
                     assertThat(createdDatasource.getPluginId()).isEqualTo(datasource.getPluginId());
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(), viewerPermissionGroup.getId()))
                             .build();
-                    Policy deleteDatasourcesPolicy = Policy.builder().permission(DELETE_DATASOURCES.getValue())
+                    Policy deleteDatasourcesPolicy = Policy.builder().permission(datasourcePermission.getDeletePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
 
@@ -1070,13 +1073,13 @@ public class DatasourceServiceTest {
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
                     assertThat(createdDatasource.getInvalids()).isEmpty();
 
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(),
                                     viewerPermissionGroup.getId()))
                             .build();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/MockDataServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/MockDataServiceTest.java
@@ -15,6 +15,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,6 +88,8 @@ public class MockDataServiceTest {
 
     @MockBean
     PluginExecutorHelper pluginExecutorHelper;
+    @Autowired
+    DatasourcePermission datasourcePermission;
 
     String workspaceId = "";
 
@@ -180,13 +183,13 @@ public class MockDataServiceTest {
                     assertThat(createdDatasource.getId()).isNotEmpty();
                     assertThat(createdDatasource.getPluginId()).isEqualTo(pluginMono.getId());
                     assertThat(createdDatasource.getName()).isEqualTo("Movies");
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(), viewerPermissionGroup.getId()))
                             .build();
 
@@ -244,13 +247,13 @@ public class MockDataServiceTest {
                     assertThat(createdDatasource.getId()).isNotEmpty();
                     assertThat(createdDatasource.getPluginId()).isEqualTo(pluginMono.getId());
                     assertThat(createdDatasource.getName()).isEqualTo("Users");
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(), viewerPermissionGroup.getId()))
                             .build();
 
@@ -313,13 +316,13 @@ public class MockDataServiceTest {
                     assertThat(createdDatasource.getId()).isNotEmpty();
                     assertThat(createdDatasource.getPluginId()).isEqualTo(pluginMono.getId());
                     assertThat(createdDatasource.getName()).isEqualTo("Movies (1)");
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(), viewerPermissionGroup.getId()))
                             .build();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
@@ -24,6 +24,7 @@ import com.appsmith.server.repositories.DatasourceRepository;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.UserAndAccessManagementService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -119,6 +120,8 @@ public class WorkspaceServiceTest {
 
     @Autowired
     private UserAndAccessManagementService userAndAccessManagementService;
+    @Autowired
+    DatasourcePermission datasourcePermission;
 
     Workspace workspace;
 
@@ -1003,7 +1006,7 @@ public class WorkspaceServiceTest {
                 .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, "workspace by name")));
 
         Mono<Datasource> readDatasourceByNameMono = workspaceMono.flatMap(workspace1 ->
-                datasourceRepository.findByNameAndWorkspaceId("test datasource", workspace1.getId(), READ_DATASOURCES)
+                datasourceRepository.findByNameAndWorkspaceId("test datasource", workspace1.getId(), datasourcePermission.getReadPermission())
                         .switchIfEmpty(Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, "Datasource")))
         );
 
@@ -1061,13 +1064,13 @@ public class WorkspaceServiceTest {
                     /*
                      * Check for datasource permissions after the user addition
                      */
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(), viewerPermissionGroup.getId()))
                             .build();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -59,6 +59,7 @@ import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.PluginService;
 import com.appsmith.server.services.UserService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -171,6 +172,8 @@ public class ActionServiceCE_Test {
 
     @SpyBean
     AstService astService;
+    @Autowired
+    DatasourcePermission datasourcePermission;
 
     Application testApp = null;
 
@@ -1322,13 +1325,13 @@ public class ActionServiceCE_Test {
                             .filter(permissionGroup -> permissionGroup.getName().startsWith(VIEWER))
                             .findFirst().get();
 
-                    Policy manageDatasourcePolicy = Policy.builder().permission(MANAGE_DATASOURCES.getValue())
+                    Policy manageDatasourcePolicy = Policy.builder().permission(datasourcePermission.getManagePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy readDatasourcePolicy = Policy.builder().permission(READ_DATASOURCES.getValue())
+                    Policy readDatasourcePolicy = Policy.builder().permission(datasourcePermission.getReadPermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId()))
                             .build();
-                    Policy executeDatasourcePolicy = Policy.builder().permission(EXECUTE_DATASOURCES.getValue())
+                    Policy executeDatasourcePolicy = Policy.builder().permission(datasourcePermission.getExecutePermission().getValue())
                             .permissionGroups(Set.of(adminPermissionGroup.getId(), developerPermissionGroup.getId(),
                                     viewerPermissionGroup.getId(), publicAppPermissionGroup.getId()))
                             .build();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/GitServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/GitServiceCEImplTest.java
@@ -17,6 +17,7 @@ import com.appsmith.server.services.PluginService;
 import com.appsmith.server.services.SessionUserService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.services.UserService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +75,8 @@ public class GitServiceCEImplTest {
     GitCloudServicesUtils gitCloudServicesUtils;
     @MockBean
     GitDeployKeysRepository gitDeployKeysRepository;
+    @MockBean
+    DatasourcePermission datasourcePermission;
 
     @BeforeEach
     public void setup() {
@@ -81,7 +84,7 @@ public class GitServiceCEImplTest {
                 userService, userDataService, sessionUserService, applicationService, applicationPageService,
                 newPageService, newActionService, actionCollectionService, gitFileUtils, importExportApplicationService,
                 gitExecutor, responseUtils, emailConfig, analyticsService, gitCloudServicesUtils, gitDeployKeysRepository,
-                datasourceService, pluginService
+                datasourceService, pluginService, datasourcePermission
         );
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceCEImplTest.java
@@ -25,6 +25,7 @@ import com.appsmith.server.services.NewPageService;
 import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.PluginService;
 import com.appsmith.server.services.SessionUserService;
+import com.appsmith.server.solutions.DatasourcePermission;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -120,6 +121,9 @@ public class NewActionServiceCEImplTest {
     @MockBean
     NewActionRepository newActionRepository;
 
+    @MockBean
+    DatasourcePermission datasourcePermission;
+
     private BodyExtractor.Context context;
 
     private Map<String, Object> hints;
@@ -145,7 +149,8 @@ public class NewActionServiceCEImplTest {
                 authenticationValidator,
                 configService,
                 responseUtils,
-                permissionGroupService);
+                permissionGroupService,
+                datasourcePermission);
     }
 
     @BeforeEach

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
@@ -156,6 +156,9 @@ public class ApplicationForkingServiceTests {
     @Autowired
     private UserAndAccessManagementService userAndAccessManagementService;
 
+    @Autowired
+    DatasourcePermission datasourcePermission;
+
     private static String sourceAppId;
 
     private static String testUserWorkspaceId;
@@ -294,7 +297,7 @@ public class ApplicationForkingServiceTests {
                                 .findByWorkspaceId(workspace.getId(), READ_APPLICATIONS)
                                 .map(data.applications::add),
                         datasourceService
-                                .findAllByWorkspaceId(workspace.getId(), READ_DATASOURCES)
+                                .findAllByWorkspaceId(workspace.getId(), datasourcePermission.getReadPermission())
                                 .map(data.datasources::add),
                         getActionsInWorkspace(workspace)
                                 .map(data.actions::add)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesWorkspaceClonerTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExamplesWorkspaceClonerTests.java
@@ -138,6 +138,8 @@ public class ExamplesWorkspaceClonerTests {
 
     @Autowired
     private LayoutCollectionService layoutCollectionService;
+    @Autowired
+    DatasourcePermission datasourcePermission;
 
     private static class WorkspaceData {
         Workspace workspace;
@@ -157,7 +159,7 @@ public class ExamplesWorkspaceClonerTests {
                                 .findByWorkspaceId(workspace.getId(), READ_APPLICATIONS)
                                 .map(data.applications::add),
                         datasourceService
-                                .findAllByWorkspaceId(workspace.getId(), READ_DATASOURCES)
+                                .findAllByWorkspaceId(workspace.getId(), datasourcePermission.getReadPermission())
                                 .map(data.datasources::add),
                         getActionsInWorkspace(workspace)
                                 .map(data.actions::add),

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ImportExportApplicationServiceTests.java
@@ -167,6 +167,8 @@ public class ImportExportApplicationServiceTests {
 
     @Autowired
     PermissionGroupService permissionGroupService;
+    @Autowired
+    DatasourcePermission datasourcePermission;
 
     private static final String INVALID_JSON_FILE = "invalid json file";
     private static Plugin installedPlugin;
@@ -835,7 +837,7 @@ public class ImportExportApplicationServiceTests {
                             Application application = applicationImportDTO.getApplication();
                             return Mono.zip(
                                     Mono.just(applicationImportDTO),
-                                    datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), MANAGE_DATASOURCES).collectList(),
+                                    datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), datasourcePermission.getManagePermission()).collectList(),
                                     newActionService.findAllByApplicationIdAndViewMode(application.getId(), false, READ_ACTIONS, null).collectList(),
                                     newPageService.findByApplicationId(application.getId(), MANAGE_PAGES, false).collectList(),
                                     actionCollectionService.findAllByApplicationIdAndViewMode(application.getId(), false, MANAGE_ACTIONS, null).collectList()
@@ -1040,7 +1042,7 @@ public class ImportExportApplicationServiceTests {
                 .create(resultMono
                         .flatMap(applicationImportDTO -> Mono.zip(
                                 Mono.just(applicationImportDTO),
-                                datasourceService.findAllByWorkspaceId(applicationImportDTO.getApplication().getWorkspaceId(), MANAGE_DATASOURCES).collectList(),
+                                datasourceService.findAllByWorkspaceId(applicationImportDTO.getApplication().getWorkspaceId(), datasourcePermission.getManagePermission()).collectList(),
                                 getActionsInApplication(applicationImportDTO.getApplication()).collectList(),
                                 newPageService.findByApplicationId(applicationImportDTO.getApplication().getId(), MANAGE_PAGES, false).collectList(),
                                 actionCollectionService.findAllByApplicationIdAndViewMode(applicationImportDTO.getApplication().getId(), false
@@ -1134,7 +1136,7 @@ public class ImportExportApplicationServiceTests {
                 .create(resultMono
                         .flatMap(applicationImportDTO -> Mono.zip(
                                 Mono.just(applicationImportDTO),
-                                datasourceService.findAllByWorkspaceId(applicationImportDTO.getApplication().getWorkspaceId(), MANAGE_DATASOURCES).collectList(),
+                                datasourceService.findAllByWorkspaceId(applicationImportDTO.getApplication().getWorkspaceId(), datasourcePermission.getManagePermission()).collectList(),
                                 getActionsInApplication(applicationImportDTO.getApplication()).collectList(),
                                 newPageService.findByApplicationId(applicationImportDTO.getApplication().getId(), MANAGE_PAGES, false).collectList(),
                                 actionCollectionService
@@ -1288,7 +1290,7 @@ public class ImportExportApplicationServiceTests {
                             Application application = applicationImportDTO.getApplication();
                             return Mono.zip(
                                     Mono.just(applicationImportDTO),
-                                    datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), MANAGE_DATASOURCES).collectList(),
+                                    datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), datasourcePermission.getManagePermission()).collectList(),
                                     newActionService.findAllByApplicationIdAndViewMode(application.getId(), false, READ_ACTIONS, null).collectList(),
                                     newPageService.findByApplicationId(application.getId(), MANAGE_PAGES, false).collectList(),
                                     actionCollectionService.findAllByApplicationIdAndViewMode(application.getId(), false, MANAGE_ACTIONS, null).collectList()
@@ -2423,7 +2425,7 @@ public class ImportExportApplicationServiceTests {
                 .create(resultMono
                         .flatMap(application -> Mono.zip(
                                 Mono.just(application),
-                                datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), MANAGE_DATASOURCES).collectList(),
+                                datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), datasourcePermission.getManagePermission()).collectList(),
                                 newActionService.findAllByApplicationIdAndViewMode(application.getId(), false, READ_ACTIONS, null).collectList()
                         )))
                 .assertNext(tuple -> {
@@ -2476,7 +2478,7 @@ public class ImportExportApplicationServiceTests {
                 .create(resultMono
                         .flatMap(application -> Mono.zip(
                                 Mono.just(application),
-                                datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), MANAGE_DATASOURCES).collectList(),
+                                datasourceService.findAllByWorkspaceId(application.getWorkspaceId(), datasourcePermission.getManagePermission()).collectList(),
                                 newActionService.findAllByApplicationIdAndViewMode(application.getId(), false, READ_ACTIONS, null).collectList()
                         )))
                 .assertNext(tuple -> {


### PR DESCRIPTION
## Description

> Currently we are using the Hardcoded Permissions mentioned in `AclPermission.java` for all Entities we have in Appsmith. But with the introduction of RBAC in the EE edition, we will need to have a better granular control over the 
> 
> Entities, and this is one such feature. Here we have introduced the concept of getting the Permission based on Instance and Entity which will help us  configure what permission should be used based on the Instance Type.

Fixes # (issue)
> if no issue exists, please create an issue and ask the maintainers about this first


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
> Updates have been made to the test cases in order to have no side effects.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
