### PR TITLE
fix: gsheet save and authorize redirect issue fixed

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
@@ -49,7 +49,7 @@ describe("Authenticated API Datasource", function() {
     cy.deleteDatasource("FakeAuthenticatedApi");
   });
 
-  it.only("4. Bug: 18051 - Save and Authorise should return to datasource page in view mode and not new datasource page", () => {
+  it("4. Bug: 18051 - Save and Authorise should return to datasource page in view mode and not new datasource page", () => {
     cy.NavigateToAPI_Panel();
     cy.get(apiwidget.createAuthApiDatasource).click();
     cy.generateUUID().then((uuid) => {

--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/AuthenticatedApiDatasource_spec.js
@@ -1,6 +1,10 @@
 const apiwidget = require("../../../../locators/apiWidgetslocator.json");
 const datasourceFormData = require("../../../../fixtures/datasources.json");
 const datasourceEditor = require("../../../../locators/DatasourcesEditor.json");
+const testdata = require("../../../../fixtures/testdata.json");
+
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+let dataSources = ObjectsRegistry.DataSources;
 
 describe("Authenticated API Datasource", function() {
   const URL = datasourceFormData["authenticatedApiUrl"];
@@ -43,5 +47,29 @@ describe("Authenticated API Datasource", function() {
     cy.contains(headers).should("not.exist");
     cy.contains(queryParams).should("not.exist");
     cy.deleteDatasource("FakeAuthenticatedApi");
+  });
+
+  it.only("4. Bug: 18051 - Save and Authorise should return to datasource page in view mode and not new datasource page", () => {
+    cy.NavigateToAPI_Panel();
+    cy.get(apiwidget.createAuthApiDatasource).click();
+    cy.generateUUID().then((uuid) => {
+      cy.renameDatasource(uuid);
+      cy.fillAuthenticatedAPIForm();
+      cy.addOAuth2AuthorizationCodeDetails(
+        testdata.accessTokenUrl,
+        testdata.clientID,
+        testdata.clientSecret,
+        testdata.authorizationURL,
+      );
+      dataSources.AuthAPISaveAndAuthorize();
+      cy.xpath('//input[@name="email"]').type("Test@email.com");
+      cy.xpath('//input[@name="email"]').type("Test");
+      cy.xpath("//input[@name='password']").type("Test@123");
+      cy.xpath("//input[@id='login-submit']").click();
+      cy.wait(2000);
+      cy.reload();
+      cy.get(".t--edit-datasource").should("be.visible");
+      dataSources.DeleteDatasouceFromActiveTab(uuid);
+    });
   });
 });

--- a/app/client/cypress/support/Pages/DataSources.ts
+++ b/app/client/cypress/support/Pages/DataSources.ts
@@ -28,6 +28,7 @@ export class DataSources {
     "input[name = 'datasourceConfiguration.authentication.password']";
   private _testDs = ".t--test-datasource";
   private _saveDs = ".t--save-datasource";
+  private _saveAndAuthorizeDS = ".t--save-and-authorize-datasource";
   private _datasourceCard = ".t--datasource";
   _activeDS = "[data-testid='active-datasource-name']";
   _templateMenu = ".t--template-menu";
@@ -329,6 +330,11 @@ export class DataSources {
     //     .then((xhr) => {
     //         cy.log(JSON.stringify(xhr.response!.body));
     //     }).should("have.nested.property", "response.body.responseMeta.status", 200);
+  }
+
+  public AuthAPISaveAndAuthorize() {
+    cy.get(this._saveAndAuthorizeDS).click();
+    this.agHelper.ValidateNetworkStatus("@saveDatasource", 200);
   }
 
   public DeleteDatasouceFromActiveTab(

--- a/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/RestAPIDatasourceForm.tsx
@@ -547,6 +547,7 @@ class DatasourceRestAPIEditor extends React.Component<
             GrantType.AuthorizationCode && (
             <FormInputContainer>
               <AuthorizeButton
+                className="t--save-and-authorize-datasource"
                 disabled={this.disableSave()}
                 filled
                 intent="primary"

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Entity.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Entity.java
@@ -7,4 +7,5 @@ public interface Entity {
     String DATASOURCES = "datasources";
     String S3_PLUGIN_PACKAGE_NAME = "amazons3-plugin";
     String POSTGRES_PLUGIN_PACKAGE_NAME = "postgres-plugin";
+    String DATASOURCE = "datasource";
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCEImpl.java
@@ -287,7 +287,7 @@ public class AuthenticationServiceCEImpl implements AuthenticationServiceCE {
                         Entity.PAGES + Entity.SLASH +
                         newPage.getId() + Entity.SLASH +
                         "edit" + Entity.SLASH +
-                        Entity.DATASOURCES + Entity.SLASH +
+                        Entity.DATASOURCE + Entity.SLASH +
                         datasourceId +
                         "?response_status=" + responseStatus +
                         "&view_mode=true")


### PR DESCRIPTION
## Description

When I save and authorize a new authenticated api datasource successfully, I expect to see the overview of that datasource, but instead I see the new datasources pane.

Fixes #18051

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
