### PR TITLE
fix: Invisible Widgets Overlap while switching back and forth between edit and preview modes in rare cases

### DIFF
--- a/app/client/src/utils/autoHeight/generateTree.ts
+++ b/app/client/src/utils/autoHeight/generateTree.ts
@@ -11,7 +11,15 @@ export function generateTree(
   previousTree: Record<string, TreeNode>,
 ): Record<string, TreeNode> {
   // If widget doesn't exist in this DS, this means that its height changes does not effect any other sibling
-  spaces.sort((a, b) => a.top - b.top); // Sort based on position, top to bottom, so that we know which is above the other
+  spaces.sort((a, b) => {
+    //if both are of the same level and previous tree exists, check originalTops
+    if (a.top === b.top && previousTree[a.id] && previousTree[b.id]) {
+      return (
+        previousTree[a.id].originalTopRow - previousTree[b.id].originalTopRow
+      );
+    }
+    return a.top - b.top;
+  }); // Sort based on position, top to bottom, so that we know which is above the other
   const _spaces = [...spaces];
 
   const aboveMap: Record<string, string[]> = {};


### PR DESCRIPTION
## Description

Sort Space based on original position if dynamic positions are equal while generating tree.

Fixes #18399

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test


