### PR TITLE
chore: rename_triggerUtils

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
@@ -47,7 +47,7 @@ import java.util.Set;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @NoArgsConstructor
-public class TriggerUtils {
+public class RestAPIActivateUtils {
 
     public static String SIGNATURE_HEADER_NAME = "X-APPSMITH-SIGNATURE";
     public static String RESPONSE_DATA_TYPE = "X-APPSMITH-DATATYPE";

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
@@ -10,7 +10,7 @@ import com.appsmith.external.helpers.restApiUtils.helpers.HeaderUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.InitUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.SmartSubstitutionUtils;
-import com.appsmith.external.helpers.restApiUtils.helpers.TriggerUtils;
+import com.appsmith.external.helpers.restApiUtils.helpers.RestAPIActivateUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.URIUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionResult;
@@ -36,7 +36,7 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
     protected SmartSubstitutionUtils smartSubstitutionUtils;
     protected URIUtils uriUtils;
     protected DatasourceUtils datasourceUtils;
-    protected TriggerUtils triggerUtils;
+    protected RestAPIActivateUtils restAPIActivateUtils;
     protected InitUtils initUtils;
     protected HeaderUtils headerUtils;
     protected HintMessageUtils hintMessageUtils;
@@ -51,7 +51,7 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
         this.dataUtils = new DataUtils();
         this.smartSubstitutionUtils = new SmartSubstitutionUtils();
         this.uriUtils = new URIUtils();
-        this.triggerUtils = new TriggerUtils();
+        this.restAPIActivateUtils = new RestAPIActivateUtils();
         this.initUtils = new InitUtils();
         this.headerUtils = new HeaderUtils();
         this.datasourceUtils = new DatasourceUtils();

--- a/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
+++ b/app/server/appsmith-plugins/graphqlPlugin/src/main/java/com/external/plugins/GraphQLPlugin.java
@@ -186,7 +186,7 @@ public class GraphQLPlugin extends BasePlugin {
             ActionExecutionRequest actionExecutionRequest =
                     RequestCaptureFilter.populateRequestFields(actionConfiguration, uri, insertedParams, objectMapper);
 
-            WebClient.Builder webClientBuilder = triggerUtils.getWebClientBuilder(actionConfiguration,
+            WebClient.Builder webClientBuilder = restAPIActivateUtils.getWebClientBuilder(actionConfiguration,
                     datasourceConfiguration);
 
             String reqContentType = headerUtils.getRequestContentType(actionConfiguration, datasourceConfiguration);
@@ -266,12 +266,12 @@ public class GraphQLPlugin extends BasePlugin {
             Object requestBodyObj = dataUtils.getRequestBodyObject(actionConfiguration, reqContentType,
                     encodeParamsToggle,
                     httpMethod);
-            WebClient client = triggerUtils.getWebClient(webClientBuilder, apiConnection, reqContentType, objectMapper,
+            WebClient client = restAPIActivateUtils.getWebClient(webClientBuilder, apiConnection, reqContentType, objectMapper,
                     EXCHANGE_STRATEGIES, requestCaptureFilter);
 
             /* Triggering the actual REST API call */
             Set<String> hintMessages = new HashSet<>();
-            return triggerUtils.triggerApiCall(client, httpMethod, uri, requestBodyObj, actionExecutionRequest,
+            return restAPIActivateUtils.triggerApiCall(client, httpMethod, uri, requestBodyObj, actionExecutionRequest,
                     objectMapper,
                     hintMessages, errorResult, requestCaptureFilter);
         }

--- a/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/main/java/com/external/plugins/RestApiPlugin.java
@@ -149,7 +149,7 @@ public class RestApiPlugin extends BasePlugin {
             ActionExecutionRequest actionExecutionRequest =
                     RequestCaptureFilter.populateRequestFields(actionConfiguration, uri, insertedParams, objectMapper);
 
-            WebClient.Builder webClientBuilder = triggerUtils.getWebClientBuilder(actionConfiguration,
+            WebClient.Builder webClientBuilder = restAPIActivateUtils.getWebClientBuilder(actionConfiguration,
                     datasourceConfiguration);
             String reqContentType = headerUtils.getRequestContentType(actionConfiguration, datasourceConfiguration);
 
@@ -172,11 +172,11 @@ public class RestApiPlugin extends BasePlugin {
             Object requestBodyObj = dataUtils.getRequestBodyObject(actionConfiguration, reqContentType,
                     encodeParamsToggle,
                     httpMethod);
-            WebClient client = triggerUtils.getWebClient(webClientBuilder, apiConnection, reqContentType, objectMapper,
+            WebClient client = restAPIActivateUtils.getWebClient(webClientBuilder, apiConnection, reqContentType, objectMapper,
                     EXCHANGE_STRATEGIES, requestCaptureFilter);
 
             /* Triggering the actual REST API call */
-            return triggerUtils.triggerApiCall(client, httpMethod, uri, requestBodyObj, actionExecutionRequest,
+            return restAPIActivateUtils.triggerApiCall(client, httpMethod, uri, requestBodyObj, actionExecutionRequest,
                     objectMapper, hintMessages, errorResult, requestCaptureFilter);
         }
 


### PR DESCRIPTION
**Description**

Rename file.
Fixes https://github.com/appsmithorg/appsmith/issues/16670

Just a renaming class name, its usage and associated object names from RestAPITriggerUtils to RestAPIActivateUtils
Reason: Name "Trigger" context has been used to denote dynamic calls. This class is to performs the built api call on execute command

Ref #16687

Checklist:
- [x] My code follows the style guidelines of this project
- [ ]  I have performed a self-review of my own code
- [ ]  My changes generate no new warnings
- [ ]  New and existing unit tests pass locally with my changes