### PR TITLE
fix: Reduces cloning by not adding platform functions

### DIFF
--- a/app/client/src/workers/Evaluation/JSObject/index.ts
+++ b/app/client/src/workers/Evaluation/JSObject/index.ts
@@ -98,7 +98,7 @@ export function saveResolvedFunctionsAndJSUpdates(
                 parsedElement.value,
                 unEvalDataTree,
                 {},
-                true,
+                false,
                 undefined,
                 undefined,
                 true,


### PR DESCRIPTION
## Description

Every time we load an application we parse each js object body using AST to get the key, value pair of functions, and variables. After parsing we get all functions in string format but to execute these functions we need them in function format. To convert string to function we use evaluateSync function but we were providing `isTriggred` as true which was adding all platform functions to GLOBAL_DATA. As part of this transformation, cloning of the data tree was happening internally which adds time for parseJSActions function. So to reduce this time, we are sending isTriggred as false. 


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual
- Jest
- Cypress



## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
