### PR TITLE
fix: evaluated popup value and error for list v2

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
@@ -1,0 +1,34 @@
+describe("List widget v2 Evaluated Popup", () => {
+  it("1. List widget V2 with currentItem", () => {
+    cy.dragAndDropToCanvas("listwidgetv2", {
+      x: 300,
+      y: 300,
+    });
+    cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+
+    [
+      ["{{currentItem.name}}", "Blue"],
+      ["{{currentItem.id}}", "001"],
+      ["{{currentItem.name}}_{{currentIndex}}", "Blue_0"],
+      ["{{1000}}", "1000"],
+      ['{{(() => "Text Widget")()}}', "Text Widget"],
+    ].forEach(([input, expected]) => {
+      cy.updateCodeInput(".t--property-control-text", input);
+      cy.wait(500);
+      cy.validateEvaluatedValue(expected);
+    });
+  });
+
+  it("2. List widget V2 with error input", () => {
+    cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+
+    [
+      ["{{currentItem}}", "This value does not evaluate to type string"],
+      ["{{Text}}", "ReferenceError: Text is not defined"],
+    ].forEach(([input, expected]) => {
+      cy.updateCodeInput(".t--property-control-text", input);
+      cy.wait(500);
+      cy.evaluateErrorMessage(expected);
+    });
+  });
+});


### PR DESCRIPTION

## Description

`logBlackList` prevented errors from getting to the Evaluation popup, also, the datapath has been changed, so we don't need `List1.template.Text1.text`. We just access it from the data tree directly. This introduced meta widget appearance in the debugger. This issue would be solved in https://github.com/appsmithorg/appsmith/issues/18382.


Fixes #16576


## Type of change

- Bug fix (non-breaking change which fixes an issue)



## How Has This Been Tested?
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
