### PR TITLE
fix: canvas height not enough to drop widgets

### DIFF
--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -197,14 +197,6 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
   const shouldOnboard =
     !(childWidgets && childWidgets.length) && !isDragging && !props.parentId;
 
-  if (props.widgetId !== MAIN_CONTAINER_WIDGET_ID) {
-    // console.log(
-    //   "Dynamic height: Drop Target Height:",
-    //   { height },
-    //   { snapRows },
-    // );
-  }
-
   return (
     <DropTargetContext.Provider value={contextValue}>
       <StyledDropTarget

--- a/app/client/src/sagas/autoHeightSagas/widgets.ts
+++ b/app/client/src/sagas/autoHeightSagas/widgets.ts
@@ -291,7 +291,7 @@ export function* updateWidgetAutoHeightSaga() {
             let minCanvasHeightInRows: number = yield getMinHeightBasedOnChildren(
               parentCanvasWidget.widgetId,
               changesSoFar,
-              true,
+              false,
               dynamicHeightLayoutTree,
             );
 


### PR DESCRIPTION
## Description

Issue:-
Whenever we drop a widget into a container and enable Auto Height then the height of the child canvas is set to the max bottom row of the children, this results in a very low droppable canvas area inside the container and does not allow to drop further widgets.

Fix:-
We calculate the canvas height now to be max of Container height or the max bottom row of the children it has.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
