### PR TITLE
fix: widgets increase spacing 

### DIFF
--- a/app/client/src/utils/autoHeight/constants.ts
+++ b/app/client/src/utils/autoHeight/constants.ts
@@ -5,6 +5,7 @@ export type TreeNode = {
   bottomRow: number;
   originalTopRow: number;
   originalBottomRow: number;
+  distanceToNearestAbove: number;
 };
 
 export type NodeSpace = {

--- a/app/client/src/utils/autoHeight/generateTree.test.ts
+++ b/app/client/src/utils/autoHeight/generateTree.test.ts
@@ -17,6 +17,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 30,
         originalBottomRow: 30,
         originalTopRow: 0,
+        distanceToNearestAbove: 0,
       },
       "2": {
         aboves: [],
@@ -25,6 +26,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 30,
         originalBottomRow: 30,
         originalTopRow: 0,
+        distanceToNearestAbove: 0,
       },
     };
 
@@ -36,7 +38,7 @@ describe("Generate Auto Height Layout tree", () => {
   it("Does conflict when part of the boxes overlap horizontally", () => {
     const input: NodeSpace[] = [
       { left: 0, right: 100, top: 0, bottom: 30, id: "1" },
-      { left: 80, top: 30, bottom: 40, right: 120, id: "2" },
+      { left: 80, top: 40, bottom: 80, right: 120, id: "2" },
     ];
     const previousTree: Record<string, TreeNode> = {};
     const layoutUpdated = false;
@@ -48,14 +50,16 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 30,
         originalBottomRow: 30,
         originalTopRow: 0,
+        distanceToNearestAbove: 0,
       },
       "2": {
         aboves: ["1"],
         belows: [],
-        topRow: 30,
-        bottomRow: 40,
-        originalBottomRow: 40,
-        originalTopRow: 30,
+        topRow: 40,
+        bottomRow: 80,
+        originalBottomRow: 80,
+        originalTopRow: 40,
+        distanceToNearestAbove: 10,
       },
     };
 
@@ -77,6 +81,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 30,
         originalBottomRow: 20,
         originalTopRow: 0,
+        distanceToNearestAbove: 0,
       },
       "2": {
         aboves: ["1"],
@@ -85,6 +90,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 40,
         originalBottomRow: 30,
         originalTopRow: 20,
+        distanceToNearestAbove: 0,
       },
     };
     const layoutUpdated = false;
@@ -96,6 +102,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 30,
         originalBottomRow: 20,
         originalTopRow: 0,
+        distanceToNearestAbove: 0,
       },
       "2": {
         aboves: ["1"],
@@ -104,6 +111,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 40,
         originalBottomRow: 30,
         originalTopRow: 20,
+        distanceToNearestAbove: 0,
       },
     };
 
@@ -125,6 +133,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 30,
         originalBottomRow: 20,
         originalTopRow: 0,
+        distanceToNearestAbove: 0,
       },
       "2": {
         aboves: ["1"],
@@ -133,6 +142,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 40,
         originalBottomRow: 30,
         originalTopRow: 20,
+        distanceToNearestAbove: 0,
       },
     };
     const layoutUpdated = true;
@@ -144,6 +154,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 30,
         originalBottomRow: 30,
         originalTopRow: 0,
+        distanceToNearestAbove: 0,
       },
       "2": {
         aboves: ["1"],
@@ -152,6 +163,7 @@ describe("Generate Auto Height Layout tree", () => {
         bottomRow: 40,
         originalBottomRow: 40,
         originalTopRow: 30,
+        distanceToNearestAbove: 0,
       },
     };
 

--- a/app/client/src/utils/autoHeight/generateTree.ts
+++ b/app/client/src/utils/autoHeight/generateTree.ts
@@ -1,6 +1,7 @@
 import { areIntersecting } from "utils/boxHelpers";
 import { pushToArray } from "utils/helpers";
 import { MAX_BOX_SIZE, NodeSpace, TreeNode } from "./constants";
+import { getNearestAbove } from "./helpers";
 
 // This function uses the spaces occupied by sibling boxes and provides us with
 // a data structure which defines the relative vertical positioning of the boxes
@@ -76,6 +77,7 @@ export function generateTree(
       if (originalBottomRow === undefined || layoutUpdated) {
         originalBottomRow = currentSpace.bottom - MAX_BOX_SIZE;
       }
+
       tree[currentSpace.id] = {
         aboves: aboveMap[currentSpace.id] || [],
         belows: belowMap[currentSpace.id] || [],
@@ -83,7 +85,16 @@ export function generateTree(
         bottomRow: currentSpace.bottom - MAX_BOX_SIZE,
         originalTopRow,
         originalBottomRow,
+        distanceToNearestAbove: 0,
       };
+    }
+  }
+
+  for (const boxId in tree) {
+    const nearestAbove = getNearestAbove(tree, boxId, {});
+    if (nearestAbove.length > 0) {
+      tree[boxId].distanceToNearestAbove =
+        tree[boxId].topRow - tree[nearestAbove[0]].bottomRow;
     }
   }
 

--- a/app/client/src/utils/autoHeight/helpers.ts
+++ b/app/client/src/utils/autoHeight/helpers.ts
@@ -1,0 +1,58 @@
+import { TreeNode } from "./constants";
+
+/**
+ * Gets the nearest above box for the current box. Including the aboves which have changes so far.
+ *
+ * @param tree: Auto Height Layout Tree
+ * @param effectedBoxId: Current box in consideration
+ * @param repositionedBoxes: Boxes repositioned so far
+ * @returns An array of boxIds which are above and nearest the effectedBoxId
+ */
+export function getNearestAbove(
+  tree: Record<string, TreeNode>,
+  effectedBoxId: string,
+  repositionedBoxes: Record<string, { topRow: number; bottomRow: number }>,
+) {
+  // Get all the above boxes
+  const aboves = tree[effectedBoxId].aboves;
+  // We're trying to find the nearest boxes above this box
+
+  return aboves.reduce((prev: string[], next: string) => {
+    if (!prev[0]) return [next];
+    // Get the bottomRow of the above box
+    let nextBottomRow = tree[next].bottomRow;
+    let prevBottomRow = tree[prev[0]].bottomRow;
+    // If we've already repositioned this, use the new bottomRow of the box
+    if (repositionedBoxes[next]) {
+      nextBottomRow = repositionedBoxes[next].bottomRow;
+    }
+    if (repositionedBoxes[prev[0]]) {
+      prevBottomRow = repositionedBoxes[prev[0]].bottomRow;
+    }
+
+    // If the current box's (next) bottomRow is larger than the previous
+    // This (next) box is the bottom most above so far
+    if (nextBottomRow > prevBottomRow) return [next];
+    // If this (next) box's bottom row is the same as the previous
+    // We have two bottom most boxes
+    else if (nextBottomRow === prevBottomRow) {
+      if (
+        repositionedBoxes[prev[0]] &&
+        repositionedBoxes[prev[0]].bottomRow ===
+          repositionedBoxes[prev[0]].topRow
+      ) {
+        return prev;
+      }
+      if (
+        repositionedBoxes[next] &&
+        repositionedBoxes[next].bottomRow === repositionedBoxes[next].topRow
+      ) {
+        return [next];
+      }
+      return [...prev, next];
+    }
+    // This (next) box's bottom row is lower than the boxes selected so far
+    // so, we ignore it.
+    else return prev;
+  }, []);
+}

--- a/app/client/src/utils/autoHeight/reflow.test.ts
+++ b/app/client/src/utils/autoHeight/reflow.test.ts
@@ -27,7 +27,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2TopRow,
           originalBottomRow: box2BottomRow,
-          distanceToNearestAbove: 0,
+          distanceToNearestAbove: 10,
         },
       };
 
@@ -81,7 +81,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2OriginalTopRow,
           originalBottomRow: box2OriginalBottomRow,
-          distanceToNearestAbove: 0,
+          distanceToNearestAbove: 10,
         },
       };
 
@@ -135,7 +135,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2OriginalTopRow,
           originalBottomRow: box2OriginalBottomRow,
-          distanceToNearestAbove: 0,
+          distanceToNearestAbove: 40,
         },
       };
 
@@ -199,7 +199,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2OriginalTopRow,
           originalBottomRow: box2OriginalBottomRow,
-          distanceToNearestAbove: 0,
+          distanceToNearestAbove: 20,
         },
         "3": box3,
       };
@@ -217,8 +217,8 @@ describe("reflow", () => {
           bottomRow: box1BottomRow + box1DeltaHeight,
         },
         "2": {
-          topRow: 130,
-          bottomRow: 170,
+          topRow: 140,
+          bottomRow: 180,
         },
       };
 

--- a/app/client/src/utils/autoHeight/reflow.test.ts
+++ b/app/client/src/utils/autoHeight/reflow.test.ts
@@ -18,6 +18,7 @@ describe("reflow", () => {
           bottomRow: box1BottomRow,
           originalTopRow: box1TopRow,
           originalBottomRow: box1BottomRow,
+          distanceToNearestAbove: 0,
         },
         "2": {
           aboves: ["1"],
@@ -26,6 +27,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2TopRow,
           originalBottomRow: box2BottomRow,
+          distanceToNearestAbove: 0,
         },
       };
 
@@ -70,6 +72,7 @@ describe("reflow", () => {
           bottomRow: box1BottomRow,
           originalTopRow: box1OriginalTopRow,
           originalBottomRow: box1OriginalBottomRow,
+          distanceToNearestAbove: 0,
         },
         "2": {
           aboves: ["1"],
@@ -78,6 +81,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2OriginalTopRow,
           originalBottomRow: box2OriginalBottomRow,
+          distanceToNearestAbove: 0,
         },
       };
 
@@ -122,6 +126,7 @@ describe("reflow", () => {
           bottomRow: box1BottomRow,
           originalTopRow: box1OriginalTopRow,
           originalBottomRow: box1OriginalBottomRow,
+          distanceToNearestAbove: 0,
         },
         "2": {
           aboves: ["1"],
@@ -130,6 +135,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2OriginalTopRow,
           originalBottomRow: box2OriginalBottomRow,
+          distanceToNearestAbove: 0,
         },
       };
 
@@ -173,6 +179,7 @@ describe("reflow", () => {
         bottomRow: 120,
         originalBottomRow: 20,
         originalTopRow: 10,
+        distanceToNearestAbove: 0,
       };
 
       const tree: Record<string, TreeNode> = {
@@ -183,6 +190,7 @@ describe("reflow", () => {
           bottomRow: box1BottomRow,
           originalTopRow: box1OriginalTopRow,
           originalBottomRow: box1OriginalBottomRow,
+          distanceToNearestAbove: 0,
         },
         "2": {
           aboves: ["1", "3"],
@@ -191,6 +199,7 @@ describe("reflow", () => {
           bottomRow: box2BottomRow,
           originalTopRow: box2OriginalTopRow,
           originalBottomRow: box2OriginalBottomRow,
+          distanceToNearestAbove: 0,
         },
         "3": box3,
       };


### PR DESCRIPTION
## Description
Fixes issue where widget spacing keeps increasing when moving widgets and updating auto height
This change maintains the distance to be the same as the one with the nearest above widget before the update.

### Before:

https://user-images.githubusercontent.com/103687/204091036-5f2c15d8-5951-4993-98c1-e76209b5a7bf.mov

### After

https://user-images.githubusercontent.com/103687/204092362-57f69e99-0d6d-4bc6-855d-5b5053fbfbda.mov




## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?
- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
