### PR TITLE
chore: Reduce size of payload to data sent to Segment

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SegmentConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SegmentConfig.java
@@ -59,7 +59,6 @@ public class SegmentConfig {
             final Throwable error = logData.getError();
             // TODO remove this log statement once the issue with analytics is resolved
             log.error(" UserId is null or empty inside error. Message from log data {}, stack trace {}, message from error {}, args {}", logData.getMessage(), error == null ? "null" : ExceptionUtils.getStackTrace(error), error == null ? "" : error.getMessage(), ObjectUtils.defaultIfNull(logData.getArgs(), Collections.emptyList()));
-            // TODO set the userId before calling the segment build function
             analyticsOnAnalytics.enqueue(TrackMessage.builder("segment_error").userId("segmentError")
                     .properties(Map.of(
                             "message", logData.getMessage(),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -135,12 +135,6 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
         // at java.base/java.util.ImmutableCollections$AbstractImmutableMap.put(ImmutableCollections.java)
         Map<String, Object> analyticsProperties = properties == null ? new HashMap<>() : new HashMap<>(properties);
 
-        // To debug the issue with userId empty error from segment
-        // TODO remove the code block once the issue is fixed
-        if (StringUtils.isEmpty(userId)) {
-            log.error(" UserId is null or empty. event Name is {}, analyticProperties is {}, hashUserId is {}", String.valueOf(userId), event, convertWithStream(properties), hashUserId);
-        }
-
         // Hash usernames at all places for self-hosted instance
         if (userId != null
                 && hashUserId

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -597,7 +597,6 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                             "appId", t2.getApplicationId(),
                             "pageId", pageId,
                             "layoutId", layoutId,
-                            "dsl", dsl.toJSONString(),
                             "isSuccessfulExecution", isSuccess,
                             "error", error == null ? "" : error.getMessage()
                     );


### PR DESCRIPTION
## Description

> This PR fixes the issue of the Segment - `IllegalArgumentException : Either anonymousId or userId must be provided.`
> We were passing the entire dsl on the update layout call to the segment. This was more than the 32KB limit of the segment. When we hit this error we have an onError method which catches all the segment call failures and tries to send the error details back to the segment with details. This is present in `SegmentConfig` class. But with the Segment library upgrade from 2.1.1 to 3.3.1, Segment expects either userId or anonymousId to be present always. It can't be an empty string. 
So adding the `segmentError` as user details in case of the Segment call failures. 