### PR TITLE
fix: issues related to tabs widget in auto height

### DIFF
--- a/app/client/src/components/autoHeightOverlay/index.tsx
+++ b/app/client/src/components/autoHeightOverlay/index.tsx
@@ -27,6 +27,7 @@ import {
   AutoHeightOverlayUIStateReducer,
   createInitialAutoHeightUIState,
 } from "./store";
+import { previewModeSelector } from "selectors/editorSelectors";
 
 interface StyledAutoHeightOverlayProps {
   layerIndex: number;
@@ -378,11 +379,13 @@ const AutoHeightOverlayContainer: React.FC<AutoHeightOverlayContainerProps> = me
       selectedWidgets,
     } = useSelector((state: AppState) => state.ui.widgetDragResize);
 
+    const isPreviewMode = useSelector(previewModeSelector);
+
     const isWidgetSelected = selectedWidget === widgetId;
     const multipleWidgetsSelected = selectedWidgets.length > 1;
     const isHidden = multipleWidgetsSelected || isDragging || isResizing;
 
-    if (isWidgetSelected) {
+    if (isWidgetSelected && !isPreviewMode) {
       return <AutoHeightOverlay isHidden={isHidden} {...props} />;
     }
 

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -70,8 +70,11 @@ export const DropTargetContext: Context<{
 
 export function DropTargetComponent(props: DropTargetComponentProps) {
   const isPreviewMode = useSelector(previewModeSelector);
-  const canDropTargetExtend = props.canExtend && !isPreviewMode;
-  const snapRows = getCanvasSnapRows(props.bottomRow, props.canExtend);
+  const canDropTargetExtend = props.canExtend;
+  const snapRows = getCanvasSnapRows(
+    props.bottomRow,
+    props.canExtend && !isPreviewMode,
+  );
 
   const isResizing = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isResizing,
@@ -112,7 +115,10 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     isAutoHeightWithLimitsChanging;
 
   useEffect(() => {
-    const snapRows = getCanvasSnapRows(props.bottomRow, props.canExtend);
+    const snapRows = getCanvasSnapRows(
+      props.bottomRow,
+      props.canExtend && !isPreviewMode,
+    );
     if (rowRef.current !== snapRows) {
       rowRef.current = snapRows;
       updateHeight();
@@ -177,9 +183,12 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     e.preventDefault();
   };
 
-  const height = canDropTargetExtend
+  let height = canDropTargetExtend
     ? `${Math.max(rowRef.current * props.snapRowSpace, props.minHeight)}px`
     : "100%";
+  if (props.minHeight === rowRef.current * props.snapRowSpace && isPreviewMode)
+    height = `${props.minHeight - GridDefaults.DEFAULT_GRID_ROW_HEIGHT}px`;
+
   const boxShadow =
     (isResizing || isDragging || isAutoHeightWithLimitsChanging) &&
     props.widgetId === MAIN_CONTAINER_WIDGET_ID

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -68,20 +68,51 @@ export const DropTargetContext: Context<{
   ) => number | false;
 }> = createContext({});
 
+/**
+ * Gets the dropTarget height
+ * @param canDropTargetExtend boolean: Can we put widgets below the scrollview in this canvas?
+ * @param isPreviewMode boolean: Are we in the preview mode
+ * @param currentHeight number: Current height in the ref and what we have set in the dropTarget
+ * @param snapRowSpace number: This is a static value actually, GridDefaults.DEFAULT_GRID_ROW_HEIGHT
+ * @param minHeight number: The minHeight we've set to the widget in the reducer
+ * @returns number: A new height style to set in the dropTarget.
+ */
+function getDropTargetHeight(
+  canDropTargetExtend: boolean,
+  isPreviewMode: boolean,
+  currentHeight: number,
+  snapRowSpace: number,
+  minHeight: number,
+) {
+  let height = canDropTargetExtend
+    ? `${Math.max(currentHeight * snapRowSpace, minHeight)}px`
+    : "100%";
+  if (isPreviewMode && canDropTargetExtend)
+    height = `${currentHeight * snapRowSpace}px`;
+  return height;
+}
+
 export function DropTargetComponent(props: DropTargetComponentProps) {
+  // Get if this is in preview mode.
   const isPreviewMode = useSelector(previewModeSelector);
+  // Pretty much the shouldScrollContents from the parent container like widget
   const canDropTargetExtend = props.canExtend;
+  // If in preview mode, we don't need that extra row
+  // This gives us the number of rows
   const snapRows = getCanvasSnapRows(
     props.bottomRow,
     props.canExtend && !isPreviewMode,
   );
 
+  // Are we currently resizing?
   const isResizing = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isResizing,
   );
+  // Are we currently dragging?
   const isDragging = useSelector(
     (state: AppState) => state.ui.widgetDragResize.isDragging,
   );
+  // Are we changing the auto height limits by dragging the signifiers?
   const { isAutoHeightWithLimitsChanging } = useAutoHeightUIState();
 
   // dragDetails contains of info needed for a container jump:
@@ -93,40 +124,57 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
 
   const { draggedOn } = dragDetails;
 
+  // All the widgets in this canvas
   const childWidgets: string[] | undefined = useSelector(
     (state: AppState) => state.entities.canvasWidgets[props.widgetId]?.children,
   );
 
+  // The occupied spaces in this canvas. It is a data structure which has the rect values of each child.
   const selectOccupiedSpaces = useCallback(
     getOccupiedSpacesSelectorForContainer(props.widgetId),
     [props.widgetId],
   );
 
+  // Call the selector above.
   const occupiedSpacesByChildren = useSelector(selectOccupiedSpaces, equal);
 
+  // Put the existing snap rows in a ref.
   const rowRef = useRef(snapRows);
 
+  // This shows the property pane
   const showPropertyPane = useShowPropertyPane();
-  const { deselectAll, focusWidget } = useWidgetSelection();
-  const updateCanvasSnapRows = useCanvasSnapRowsUpdateHook();
-  const showDragLayer =
-    (isDragging && draggedOn === props.widgetId) ||
-    isResizing ||
-    isAutoHeightWithLimitsChanging;
 
+  const { deselectAll, focusWidget } = useWidgetSelection();
+
+  // This updates the bottomRow of this canvas, as simple as that
+  // This also doesn't cause an eval as it uses the action which is
+  // not registered to cause an eval
+  const updateCanvasSnapRows = useCanvasSnapRowsUpdateHook();
+
+  // Everytime we get a new bottomRow, or we toggle shouldScrollContents
+  // we call this effect
   useEffect(() => {
     const snapRows = getCanvasSnapRows(
       props.bottomRow,
       props.canExtend && !isPreviewMode,
     );
+    // If the current ref is not set to the new snaprows we've received (based on bottomRow)
     if (rowRef.current !== snapRows) {
       rowRef.current = snapRows;
+      // This sets the "height" property of the dropTarget div
+      // This makes the div change heights if new heights are different
       updateHeight();
-      if (canDropTargetExtend) {
+      // This sets the new rows in the reducer
+      // Not sure why, as we've just received the values from the props.
+      // seems like a potential way to cause recursive renders
+      // See this: https://github.com/appsmithorg/appsmith/pull/18457#issuecomment-1327615572
+      if (canDropTargetExtend && !isPreviewMode) {
         updateCanvasSnapRows(props.widgetId, snapRows);
       }
     }
-  }, [props.bottomRow, props.canExtend]);
+  }, [props.bottomRow, props.canExtend, isPreviewMode]);
+
+  // If we've stopped dragging, resizing or changing auto height limits
   useEffect(() => {
     if (!isDragging || !isResizing || !isAutoHeightWithLimitsChanging) {
       // bottom row of canvas can increase by any number as user moves/resizes any widget towards the bottom of the canvas
@@ -138,14 +186,38 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     }
   }, [isDragging, isResizing, isAutoHeightWithLimitsChanging]);
 
+  // Update the drop target height style directly.
   const updateHeight = () => {
     if (dropTargetRef.current) {
-      const height = canDropTargetExtend
-        ? `${Math.max(rowRef.current * props.snapRowSpace, props.minHeight)}px`
-        : "100%";
+      const height = getDropTargetHeight(
+        canDropTargetExtend,
+        isPreviewMode,
+        rowRef.current,
+        props.snapRowSpace,
+        props.minHeight,
+      );
+
       dropTargetRef.current.style.height = height;
     }
   };
+
+  const handleFocus = (e: any) => {
+    // Making sure that we don't deselect the widget
+    // after we are done dragging the limits in auto height with limits
+    if (!isResizing && !isDragging && !isAutoHeightWithLimitsChanging) {
+      if (!props.parentId) {
+        deselectAll();
+        focusWidget && focusWidget(props.widgetId);
+        showPropertyPane && showPropertyPane();
+      }
+    }
+    e.preventDefault();
+  };
+
+  /** PREPARE CONTEXT */
+
+  // Function which computes and updates the height of the dropTarget
+  // This is used in a context and hence in one of the children of this dropTarget
   const updateDropTargetRows = (
     widgetIdsToExclude: string[],
     widgetBottomRow: number,
@@ -167,27 +239,22 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     }
     return false;
   };
+  // memoizing context values
+  const contextValue = useMemo(() => {
+    return {
+      updateDropTargetRows,
+    };
+  }, [updateDropTargetRows, occupiedSpacesByChildren]);
 
-  const handleFocus = (e: any) => {
-    // Making sure that we don't deselect the widget
-    // after we are done dragging the limits in auto height with limits
-    if (!isResizing && !isDragging && !isAutoHeightWithLimitsChanging) {
-      if (!props.parentId) {
-        deselectAll();
-        focusWidget && focusWidget(props.widgetId);
-        showPropertyPane && showPropertyPane();
-      }
-    }
-    // commenting this out to allow propagation of click events
-    // e.stopPropagation();
-    e.preventDefault();
-  };
+  /** EO PREPARE CONTEXT */
 
-  let height = canDropTargetExtend
-    ? `${Math.max(rowRef.current * props.snapRowSpace, props.minHeight)}px`
-    : "100%";
-  if (props.minHeight === rowRef.current * props.snapRowSpace && isPreviewMode)
-    height = `${props.minHeight - GridDefaults.DEFAULT_GRID_ROW_HEIGHT}px`;
+  const height = getDropTargetHeight(
+    canDropTargetExtend,
+    isPreviewMode,
+    rowRef.current,
+    props.snapRowSpace,
+    props.minHeight,
+  );
 
   const boxShadow =
     (isResizing || isDragging || isAutoHeightWithLimitsChanging) &&
@@ -199,17 +266,19 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     height,
     boxShadow,
   };
-  const dropTargetRef = useRef<HTMLDivElement>(null);
-
-  // memoizing context values
-  const contextValue = useMemo(() => {
-    return {
-      updateDropTargetRows,
-    };
-  }, [updateDropTargetRows, occupiedSpacesByChildren]);
 
   const shouldOnboard =
     !(childWidgets && childWidgets.length) && !isDragging && !props.parentId;
+
+  // The drag layer is the one with the grid dots.
+  // They need to show in certain scenarios
+  const showDragLayer =
+    ((isDragging && draggedOn === props.widgetId) ||
+      isResizing ||
+      isAutoHeightWithLimitsChanging) &&
+    !isPreviewMode;
+
+  const dropTargetRef = useRef<HTMLDivElement>(null);
 
   return (
     <DropTargetContext.Provider value={contextValue}>

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -24,7 +24,10 @@ import {
   useShowPropertyPane,
   useCanvasSnapRowsUpdateHook,
 } from "utils/hooks/dragResizeHooks";
-import { getOccupiedSpacesSelectorForContainer } from "selectors/editorSelectors";
+import {
+  getOccupiedSpacesSelectorForContainer,
+  previewModeSelector,
+} from "selectors/editorSelectors";
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
 import { getDragDetails } from "sagas/selectors";
 import { useAutoHeightUIState } from "utils/hooks/autoHeightUIHooks";
@@ -66,7 +69,8 @@ export const DropTargetContext: Context<{
 }> = createContext({});
 
 export function DropTargetComponent(props: DropTargetComponentProps) {
-  const canDropTargetExtend = props.canExtend;
+  const isPreviewMode = useSelector(previewModeSelector);
+  const canDropTargetExtend = props.canExtend && !isPreviewMode;
   const snapRows = getCanvasSnapRows(props.bottomRow, props.canExtend);
 
   const isResizing = useSelector(
@@ -197,14 +201,6 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
 
   const shouldOnboard =
     !(childWidgets && childWidgets.length) && !isDragging && !props.parentId;
-
-  if (props.widgetId !== MAIN_CONTAINER_WIDGET_ID) {
-    // console.log(
-    //   "Dynamic height: Drop Target Height:",
-    //   { height },
-    //   { snapRows },
-    // );
-  }
 
   return (
     <DropTargetContext.Provider value={contextValue}>

--- a/app/client/src/sagas/autoHeightSagas/containers.ts
+++ b/app/client/src/sagas/autoHeightSagas/containers.ts
@@ -112,7 +112,15 @@ export function* dynamicallyUpdateContainersSaga() {
         let maxBottomRow = minDynamicHeightInRows;
 
         // For the child Canvas, use the value in pixels.
-        let canvasBottomRow = maxBottomRow;
+        let canvasBottomRow = maxBottomRow + 0;
+
+        // For widgets like Tabs Widget, some of the height is occupied by the
+        // tabs themselves, the child canvas as a result has less number of rows available
+        // To accommodate for this, we need to increase the new height by the offset amount.
+        const canvasHeightOffset: number = getCanvasHeightOffset(
+          parentContainerWidget.type,
+          parentContainerWidget,
+        );
 
         // If this canvas has children
         // we need to consider the bottom most child for the height
@@ -130,19 +138,14 @@ export function* dynamicallyUpdateContainersSaga() {
           maxBottomRowBasedOnChildren += GridDefaults.CANVAS_EXTENSION_OFFSET;
           // Set the canvas bottom row as a new variable with a new reference
           canvasBottomRow = maxBottomRowBasedOnChildren + 0;
-          // For widgets like Tabs Widget, some of the height is occupied by the
-          // tabs themselves, the child canvas as a result has less number of rows available
-          // To accommodate for this, we need to increase the new height by the offset amount.
-          const canvasHeightOffset: number = getCanvasHeightOffset(
-            parentContainerWidget.type,
-            parentContainerWidget,
-          );
 
           // Add the offset to the total height of the parent widget
           maxBottomRowBasedOnChildren += canvasHeightOffset;
 
           // Get the larger value between the minDynamicHeightInRows and bottomMostRowForChild
           maxBottomRow = Math.max(maxBottomRowBasedOnChildren, maxBottomRow);
+        } else {
+          canvasBottomRow = maxBottomRow - canvasHeightOffset;
         }
 
         // The following makes sure we stay within bounds
@@ -156,7 +159,7 @@ export function* dynamicallyUpdateContainersSaga() {
         }
 
         canvasBottomRow =
-          Math.max(maxBottomRow, canvasBottomRow) *
+          Math.max(maxBottomRow - canvasHeightOffset, canvasBottomRow) *
           GridDefaults.DEFAULT_GRID_ROW_HEIGHT;
 
         // If we have a new height to set and

--- a/app/client/src/sagas/autoHeightSagas/containers.ts
+++ b/app/client/src/sagas/autoHeightSagas/containers.ts
@@ -28,7 +28,7 @@ export function* dynamicallyUpdateContainersSaga() {
     const isCanvasWidget = widget.type === "CANVAS_WIDGET";
     const parent = widget.parentId ? stateWidgets[widget.parentId] : undefined;
     if (parent?.type === "LIST_WIDGET") return false;
-    if (!parent) return false;
+    if (parent === undefined) return false;
     return isCanvasWidget;
   });
 

--- a/app/client/src/sagas/autoHeightSagas/helpers.ts
+++ b/app/client/src/sagas/autoHeightSagas/helpers.ts
@@ -7,7 +7,10 @@ import {
 } from "reducers/entityReducers/canvasWidgetsReducer";
 import { select } from "redux-saga/effects";
 import { getWidgetMetaProps, getWidgets } from "sagas/selectors";
-import { previewModeSelector } from "selectors/editorSelectors";
+import {
+  getCanvasHeightOffset,
+  previewModeSelector,
+} from "selectors/editorSelectors";
 import { getAppMode } from "selectors/entitiesSelector";
 import { TreeNode } from "utils/autoHeight/constants";
 
@@ -84,6 +87,7 @@ export function* getMinHeightBasedOnChildren(
   const { children = [], parentId } = stateWidgets[widgetId];
   // If we need to consider the parent height
   if (parentId && !ignoreParent) {
+    const parent = stateWidgets[parentId];
     const parentHeightInRows = getParentCurrentHeightInRows(
       tree,
       parentId,
@@ -91,6 +95,14 @@ export function* getMinHeightBasedOnChildren(
     );
     // The canvas will be an extension smaller than the parent?
     minHeightInRows = parentHeightInRows - GridDefaults.CANVAS_EXTENSION_OFFSET;
+
+    // We will also remove any extra offsets the parent has
+    // As we're dealing with the child canvas widget here.
+    const canvasHeightOffset: number = getCanvasHeightOffset(
+      parent.type,
+      parent,
+    );
+    minHeightInRows = minHeightInRows - canvasHeightOffset;
     // If the canvas is empty return the parent's height in rows, without
     // the canvas extension offset
     if (!children.length) {

--- a/app/client/src/sagas/autoHeightSagas/index.ts
+++ b/app/client/src/sagas/autoHeightSagas/index.ts
@@ -8,7 +8,10 @@ import { updateWidgetAutoHeightSaga } from "./widgets";
 export default function* autoHeightSagas() {
   yield all([
     takeLatest(
-      ReduxActionTypes.CHECK_CONTAINERS_FOR_AUTO_HEIGHT,
+      [
+        ReduxActionTypes.CHECK_CONTAINERS_FOR_AUTO_HEIGHT,
+        ReduxActionTypes.SET_PREVIEW_MODE,
+      ],
       dynamicallyUpdateContainersSaga,
     ),
     takeEvery(

--- a/app/client/src/sagas/autoHeightSagas/widgets.ts
+++ b/app/client/src/sagas/autoHeightSagas/widgets.ts
@@ -298,6 +298,14 @@ export function* updateWidgetAutoHeightSaga() {
             // Add extra rows, this is to accommodate for padding and margins in the parent
             minCanvasHeightInRows += GridDefaults.CANVAS_EXTENSION_OFFSET;
 
+            // For widgets like Tabs Widget, some of the height is occupied by the
+            // tabs themselves, the child canvas as a result has less number of rows available
+            // To accommodate for this, we need to increase the new height by the offset amount.
+            const canvasHeightOffset: number = getCanvasHeightOffset(
+              parentContainerLikeWidget.type,
+              parentContainerLikeWidget,
+            );
+
             // Widgets need to consider changing heights, only if they have dynamic height
             // enabled.
             if (isAutoHeightEnabledForWidget(parentContainerLikeWidget)) {
@@ -333,13 +341,6 @@ export function* updateWidgetAutoHeightSaga() {
                 },
               ];
 
-              // For widgets like Tabs Widget, some of the height is occupied by the
-              // tabs themselves, the child canvas as a result has less number of rows available
-              // To accommodate for this, we need to increase the new height by the offset amount.
-              const canvasHeightOffset: number = getCanvasHeightOffset(
-                parentContainerLikeWidget.type,
-                parentContainerLikeWidget,
-              );
               minHeightInRows += canvasHeightOffset;
 
               // Make sure we're not overflowing the max height bounds
@@ -438,14 +439,22 @@ export function* updateWidgetAutoHeightSaga() {
                 }
               }
             } else {
-              const parentContinerHeightInRows = getParentCurrentHeightInRows(
+              let parentContainerHeightInRows = getParentCurrentHeightInRows(
                 dynamicHeightLayoutTree,
                 parentContainerLikeWidget.widgetId,
                 changesSoFar,
               );
+
+              parentContainerHeightInRows -= canvasHeightOffset;
+
+              console.log("Dynamic Height: Container Updates:", {
+                minCanvasHeightInRows,
+                parentContainerHeightInRows,
+              });
+
               // Setting this in a variable, as this will be the total scroll height in the canvas.
               const minCanvasHeightInPixels =
-                Math.max(minCanvasHeightInRows, parentContinerHeightInRows) *
+                Math.max(minCanvasHeightInRows, parentContainerHeightInRows) *
                 GridDefaults.DEFAULT_GRID_ROW_HEIGHT;
 
               // We need to make sure that the canvas widget doesn't have

--- a/app/client/src/sagas/autoHeightSagas/widgets.ts
+++ b/app/client/src/sagas/autoHeightSagas/widgets.ts
@@ -447,11 +447,6 @@ export function* updateWidgetAutoHeightSaga() {
 
               parentContainerHeightInRows -= canvasHeightOffset;
 
-              console.log("Dynamic Height: Container Updates:", {
-                minCanvasHeightInRows,
-                parentContainerHeightInRows,
-              });
-
               // Setting this in a variable, as this will be the total scroll height in the canvas.
               const minCanvasHeightInPixels =
                 Math.max(minCanvasHeightInRows, parentContainerHeightInRows) *

--- a/app/client/src/sagas/autoHeightSagas/widgets.ts
+++ b/app/client/src/sagas/autoHeightSagas/widgets.ts
@@ -317,12 +317,13 @@ export function* updateWidgetAutoHeightSaga() {
 
               minHeightInRows = Math.max(
                 minHeightInRows,
-                minCanvasHeightInRows,
+                minCanvasHeightInRows + canvasHeightOffset,
               );
 
               // Setting this in a variable, as this will be the total scroll height in the canvas.
               const minCanvasHeightInPixels =
-                minHeightInRows * GridDefaults.DEFAULT_GRID_ROW_HEIGHT;
+                (minHeightInRows - canvasHeightOffset) *
+                GridDefaults.DEFAULT_GRID_ROW_HEIGHT;
 
               // We need to make sure that the canvas widget doesn't have
               // any extra scroll, to this end, we need to add the `minHeight` update
@@ -340,8 +341,6 @@ export function* updateWidgetAutoHeightSaga() {
                   propertyValue: minCanvasHeightInPixels,
                 },
               ];
-
-              minHeightInRows += canvasHeightOffset;
 
               // Make sure we're not overflowing the max height bounds
               const maxDynamicHeight = getWidgetMaxAutoHeight(
@@ -540,8 +539,8 @@ export function* updateWidgetAutoHeightSaga() {
         );
 
         if (childWidgetId) {
-          const isCanvasWidget =
-            stateWidgets[childWidgetId]?.type === "CANVAS_WIDGET";
+          const childCanvasWidget = stateWidgets[childWidgetId];
+          const isCanvasWidget = childCanvasWidget?.type === "CANVAS_WIDGET";
           if (isCanvasWidget) {
             let canvasHeight: number = yield getMinHeightBasedOnChildren(
               childWidgetId,
@@ -551,11 +550,6 @@ export function* updateWidgetAutoHeightSaga() {
             );
             canvasHeight += GridDefaults.CANVAS_EXTENSION_OFFSET;
 
-            const canvasHeightOffset: number = getCanvasHeightOffset(
-              containerLikeWidget.type,
-              containerLikeWidget,
-            );
-            canvasHeight -= canvasHeightOffset;
             const propertyUpdates = [
               {
                 propertyPath: "minHeight",

--- a/app/client/src/sagas/autoHeightSagas/widgets.ts
+++ b/app/client/src/sagas/autoHeightSagas/widgets.ts
@@ -64,6 +64,7 @@ export function* updateWidgetAutoHeightSaga() {
   const updates = getAutoHeightUpdateQueue();
   log.debug("Dynamic Height: updates to process", { updates });
   const start = performance.now();
+  let shouldRecomputeContainers = false;
 
   const shouldCollapse: boolean = yield shouldWidgetsCollapse();
 
@@ -96,6 +97,8 @@ export function* updateWidgetAutoHeightSaga() {
       // Get the boundaries for possible min and max dynamic height.
       let minDynamicHeightInPixels =
         getWidgetMinAutoHeight(widget) * GridDefaults.DEFAULT_GRID_ROW_HEIGHT;
+
+      if (widget.type === "TABS_WIDGET") shouldRecomputeContainers = true;
 
       // In case of a widget going invisible in view mode
       if (updates[widgetId] === 0) {
@@ -582,7 +585,9 @@ export function* updateWidgetAutoHeightSaga() {
     // as we don't need to trigger an eval
     yield put(updateMultipleWidgetPropertiesAction(widgetsToUpdate));
     resetAutoHeightUpdateQueue();
-    yield put(generateAutoHeightLayoutTreeAction(false, false));
+    yield put(
+      generateAutoHeightLayoutTreeAction(shouldRecomputeContainers, false),
+    );
   }
 
   log.debug(

--- a/app/client/src/widgets/TabsWidget/component/index.tsx
+++ b/app/client/src/widgets/TabsWidget/component/index.tsx
@@ -42,21 +42,6 @@ const TAB_CONTAINER_HEIGHT = "44px";
 const CHILDREN_WRAPPER_HEIGHT_WITH_TABS = `calc(100% - ${TAB_CONTAINER_HEIGHT})`;
 const CHILDREN_WRAPPER_HEIGHT_WITHOUT_TABS = "100%";
 
-// const scrollNavControlContainerBaseStyle = css`
-//   display: flex;
-//   position: absolute;
-//   top: 0;
-//   bottom: 0;
-//   z-index: 2;
-//   background: white;
-
-//   button {
-//     z-index: 1;
-//     border-radius: 0px;
-//     border-bottom: ${(props) => `1px solid ${props.theme.colors.bodyBG}`};
-//   }
-// `;
-
 const scrollContents = css`
   overflow-y: auto;
   position: absolute;
@@ -111,39 +96,6 @@ export interface TabsContainerProps {
   isScrollable: boolean;
 }
 
-// const TabsContainer = styled.div<TabsContainerProps>`
-//   position: absolute;
-//   top: 0;
-//   overflow-x: auto;
-//   overflow-y: hidden;
-//   display: flex;
-//   height: ${TAB_CONTAINER_HEIGHT};
-//   background: ${(props) => props.theme.colors.builderBodyBG};
-//   overflow: hidden;
-//   border-bottom: ${(props) => `1px solid ${props.theme.colors.bodyBG}`};
-
-//   overflow-x: scroll;
-//   &::-webkit-scrollbar {
-//     display: none;
-//   }
-//   /* Hide scrollbar for IE, Edge and Firefox */
-//   -ms-overflow-style: none; /* IE and Edge */
-//   scrollbar-width: none; /* Firefox */
-
-//   && {
-//     width: 100%;
-//     display: flex;
-//     justify-content: flex-start;
-//     align-items: flex-end;
-//   }
-// `;
-
-// type TabProps = {
-//   selected?: boolean;
-//   onClick: (e: React.MouseEvent<HTMLDivElement>) => void;
-//   primaryColor: string;
-// };
-
 const Container = styled.div`
   width: 100%;
   align-items: flex-end;
@@ -194,19 +146,6 @@ export interface ScrollNavControlProps {
   className?: string;
 }
 
-// function ScrollNavControl(props: ScrollNavControlProps) {
-//   const { className, disabled, icon, onClick } = props;
-//   return (
-//     <Button
-//       className={className}
-//       disabled={disabled}
-//       icon={icon}
-//       minimal
-//       onClick={onClick}
-//     />
-//   );
-// }
-
 function TabsComponent(props: TabsComponentProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { onTabChange, tabs, width, ...remainingProps } = props;
@@ -251,14 +190,6 @@ function TabsComponent(props: TabsComponentProps) {
     },
     [tabsRef.current],
   );
-  // eslint-disable-next-line
-  // const [_intervalRef, _rafRef, requestAF] = useThrottledRAF(scroll, 10);
-
-  // useEffect(() => {
-  //   if (!props.shouldScrollContents) {
-  //     tabContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
-  //   }
-  // }, [props.shouldScrollContents]);
 
   return (
     <TabsContainerWrapper

--- a/app/client/src/widgets/TabsWidget/index.ts
+++ b/app/client/src/widgets/TabsWidget/index.ts
@@ -25,7 +25,7 @@ export const CONFIG = {
     },
   },
   defaults: {
-    rows: WidgetHeightLimits.MIN_CANVAS_HEIGHT_IN_ROWS,
+    rows: WidgetHeightLimits.MIN_CANVAS_HEIGHT_IN_ROWS + 5,
     columns: 24,
     shouldScrollContents: false,
     widgetName: "Tabs",
@@ -33,6 +33,7 @@ export const CONFIG = {
     borderWidth: 1,
     borderColor: Colors.GREY_5,
     backgroundColor: Colors.WHITE,
+    minDynamicHeight: WidgetHeightLimits.MIN_CANVAS_HEIGHT_IN_ROWS + 5,
     tabsObj: {
       tab1: {
         label: "Tab 1",

--- a/app/client/src/widgets/TabsWidget/index.ts
+++ b/app/client/src/widgets/TabsWidget/index.ts
@@ -66,6 +66,7 @@ export const CONFIG = {
             tabName: "Tab 1",
             children: [],
             version: 1,
+            bottomRow: WidgetHeightLimits.MIN_CANVAS_HEIGHT_IN_ROWS,
           },
         },
         {
@@ -81,6 +82,7 @@ export const CONFIG = {
             tabName: "Tab 2",
             children: [],
             version: 1,
+            bottomRow: WidgetHeightLimits.MIN_CANVAS_HEIGHT_IN_ROWS,
           },
         },
       ],

--- a/app/client/src/widgets/TabsWidget/widget/index.tsx
+++ b/app/client/src/widgets/TabsWidget/widget/index.tsx
@@ -172,9 +172,7 @@ class TabsWidget extends BaseWidget<
             controlType: "SWITCH",
             isBindProperty: false,
             isTriggerProperty: false,
-            postUpdateActions: [
-              ReduxActionTypes.CHECK_CONTAINERS_FOR_AUTO_HEIGHT,
-            ],
+            postUpdateAction: ReduxActionTypes.CHECK_CONTAINERS_FOR_AUTO_HEIGHT,
           },
         ],
       },

--- a/app/client/src/widgets/withWidgetProps.tsx
+++ b/app/client/src/widgets/withWidgetProps.tsx
@@ -136,13 +136,15 @@ function withWidgetProps(WrappedWidget: typeof BaseWidget) {
 
     // We don't render invisible widgets in view mode
     if (shouldCollapseWidgetInViewOrPreviewMode) {
-      dispatch({
-        type: ReduxActionTypes.UPDATE_WIDGET_AUTO_HEIGHT,
-        payload: {
-          widgetId: props.widgetId,
-          height: 0,
-        },
-      });
+      if (widgetProps.bottomRow !== widgetProps.topRow) {
+        dispatch({
+          type: ReduxActionTypes.UPDATE_WIDGET_AUTO_HEIGHT,
+          payload: {
+            widgetId: props.widgetId,
+            height: 0,
+          },
+        });
+      }
       return null;
     } else if (
       shouldResetCollapsedContainerHeightInViewOrPreviewMode ||


### PR DESCRIPTION
- [ ] Fixes issue where Tabs Widgets have scroll on drop
- [ ] Fixes issue where Signifiers and scroll shows up in preview mode
- [ ] Fixes issue where Tabs widget within tabs widget when width is changed, causes the auto height to stop working when switching tabs.