### PR TITLE
fix: Appsmith version update dialog showing up when no version is set

### DIFF
--- a/app/client/src/sagas/WebsocketSagas/handleAppLevelSocketEvents.tsx
+++ b/app/client/src/sagas/WebsocketSagas/handleAppLevelSocketEvents.tsx
@@ -20,7 +20,7 @@ export default function* handleAppLevelSocketEvents(event: any) {
     // notification on release version
     case APP_LEVEL_SOCKET_EVENTS.RELEASE_VERSION_NOTIFICATION: {
       const { appVersion } = getAppsmithConfigs();
-      if (appVersion.id != event.payload[0]) {
+      if (appVersion.id && appVersion.id != event.payload[0]) {
         Toaster.show({
           text: createMessage(INFO_VERSION_MISMATCH_FOUND_RELOAD_REQUEST),
           variant: Variant.info,


### PR DESCRIPTION
## Description
We have added a check to confirm if an Appsmith version is set. That way when building an instance without an version number will not keep failing the version check.

> We will not show an Appsmith update dialog when no version is set

Fixes #18485

More context
https://theappsmith.slack.com/archives/CGBPVEJ5C/p1669193068825349


## Type of change

- Bug fix (non-breaking change which fixes an issue)

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
