### PR TITLE
perf: Listv2 regeneration of meta canvas widget for every re-render

### DIFF
--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -338,7 +338,7 @@ class ListWidget extends BaseWidget<ListWidgetProps, WidgetState> {
     }
 
     if (!equal(this.prevMetaMainCanvasWidget, mainCanvasWidget)) {
-      this.prevMetaMainCanvasWidget = mainCanvasWidget;
+      this.prevMetaMainCanvasWidget = klona(mainCanvasWidget);
       return mainCanvasWidget;
     }
   };


### PR DESCRIPTION
## Description

This a perf only PR.

The meta canvas widget which has the individual item's containers id as children was re-generated for every render cycle even when it wasn't required. This lead to un-necessary re-renders in the child widgets.

Problem:
The `this.prevMetaMainCanvasWidget` was getting mutated as it got the value from `mainCanvasWidget` in line 341 (widget/index.tsx). The mutation was that the base widget adds `creatorId` to the meta widgets before calling the action. This addition of createdId gets mutated to the `this.prevMetaMainCanvasWidget` and thus when deep equaled in re-render, `this.prevMetaMainCanvasWidget` has `creatorId` and `mainCanvasWidget` does not as it is re-generated.

The above fix led to another problem of the main canvas widget getting removed when page changed for a server side enabled list. 
When page is changed, the primary keys array also change, this led to the removal of all the meta widgets in the cache.
Solution for this was to never reset the cache and when the primary keys change by updating the property pane, the metaWidgetGenerator will automatically start using the new keys and the stale meta widgets (generated by old keys) would get removed from view.

Fixes #18106 

Note: QA not required

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

### Test Plan

### Issues raised during DP testing


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
