### PR TITLE
chore: Adding additional optional props to editable text component

### DIFF
--- a/app/client/src/components/editorComponents/EditableText.tsx
+++ b/app/client/src/components/editorComponents/EditableText.tsx
@@ -32,6 +32,10 @@ type EditableTextProps = {
   errorTooltipClass?: string;
   maxLength?: number;
   underline?: boolean;
+  multiline?: boolean;
+  maxLines?: number;
+  minLines?: number;
+  customErrorTooltip?: string;
 };
 
 const EditableTextWrapper = styled.div<{
@@ -102,6 +106,7 @@ export function EditableText(props: EditableTextProps) {
   const {
     beforeUnmount,
     className,
+    customErrorTooltip = "",
     defaultValue,
     editInteractionKind,
     errorTooltipClass,
@@ -110,7 +115,10 @@ export function EditableText(props: EditableTextProps) {
     isEditingDefault,
     isInvalid,
     maxLength,
+    maxLines,
     minimal,
+    minLines,
+    multiline,
     onBlur,
     onTextChanged,
     placeholder,
@@ -161,7 +169,7 @@ export function EditableText(props: EditableTextProps) {
         setIsEditing(false);
       } else {
         Toaster.show({
-          text: "Invalid name",
+          text: customErrorTooltip || "Invalid name",
           variant: Variant.danger,
         });
       }
@@ -208,6 +216,9 @@ export function EditableText(props: EditableTextProps) {
             disabled={!isEditing}
             isEditing={isEditing}
             maxLength={maxLength}
+            maxLines={maxLines}
+            minLines={minLines}
+            multiline={multiline}
             onCancel={onBlur}
             onChange={onInputchange}
             onConfirm={onChange}


### PR DESCRIPTION
## Description

> Adding additional optional props to editable text component

Fixes [#18543](https://github.com/appsmithorg/appsmith/issues/18543)

## Type of change

> New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
> These are additional optional props that are added and don't require testing unless being used.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
