### PR TITLE
fix: flicker issue when both the min max values collide

### DIFF
--- a/app/client/src/components/autoHeightOverlay/index.tsx
+++ b/app/client/src/components/autoHeightOverlay/index.tsx
@@ -159,6 +159,9 @@ const AutoHeightOverlay: React.FC<AutoHeightOverlayProps> = memo(
     const finalMinY = minY + mindY;
 
     useEffect(() => {
+      // reset the diff on backend update
+      setMindY(0);
+      setMaxdY(0);
       setMaxY(maxDynamicHeight * GridDefaults.DEFAULT_GRID_ROW_HEIGHT);
     }, [maxDynamicHeight]);
 
@@ -220,8 +223,6 @@ const AutoHeightOverlay: React.FC<AutoHeightOverlayProps> = memo(
 
       if (heightToSet === minY + mindY) {
         batchUpdate(heightToSet);
-        setMindY(0);
-        setMaxdY(0);
       } else {
         updateMaxHeight(heightToSet);
         setMaxdY(0);
@@ -231,6 +232,9 @@ const AutoHeightOverlay: React.FC<AutoHeightOverlayProps> = memo(
     }
 
     useEffect(() => {
+      // reset the diff on backend update
+      setMindY(0);
+      setMaxdY(0);
       setMinY(minDynamicHeight * GridDefaults.DEFAULT_GRID_ROW_HEIGHT);
     }, [minDynamicHeight]);
 
@@ -258,8 +262,6 @@ const AutoHeightOverlay: React.FC<AutoHeightOverlayProps> = memo(
 
       if (heightToSet === maxY + maxdY) {
         batchUpdate(heightToSet);
-        setMindY(0);
-        setMaxdY(0);
       } else {
         updateMinHeight(heightToSet);
         setMindY(0);


### PR DESCRIPTION
## Description

### Issue
When we drag the min/max to each other and make them equal, we see a flicker to the past value in the one we are dragging.

### Solution
We do a batch update when the two values collide, and then set the diff to 0 therefore it goes back to its previous value but then the batch completes and resets the value which we wanted to set hence the flicker. Now we set the diff after the batch update completes.

Fixes #18548


Media
-- Before

https://user-images.githubusercontent.com/17961105/204501044-6c062a75-9f76-444c-bee3-5e9c1d365815.mov


-- After

https://user-images.githubusercontent.com/17961105/204501270-0cb17733-8321-4644-a151-d349473a07e6.mov



## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
