### PR TITLE
chore: Update NavigateTo tests to verify params

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/NavigateTo_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/NavigateTo_spec.ts
@@ -32,7 +32,11 @@ describe("Navigate To feature", () => {
       .contains("Query Params")
       .siblings()
       .find(".CodeEditorTarget")
-      .then(($el) => cy.updateCodeInput($el, "{{ { test: '123' } }}"));
+      .then(($el) => cy.updateCodeInput($el, "{{{ test: '123' }}}"));
+    agHelper.ClickButton("Submit");
+    cy.url().should("include", "a=b");
+    cy.url().should("include", "test=123");
+    ee.SelectEntityByName("Page1");
     deployMode.DeployApp();
     agHelper.ClickButton("Submit");
     cy.get(".bp3-heading").contains("This page seems to be blank");

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/NavigateTo_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/ActionExecution/NavigateTo_spec.ts
@@ -8,7 +8,6 @@ const {
 } = ObjectsRegistry;
 
 describe("Navigate To feature", () => {
-
   beforeEach(() => {
     agHelper.RestoreLocalStorageCache();
   });
@@ -29,9 +28,16 @@ describe("Navigate To feature", () => {
     cy.get(".t--open-dropdown-Select-Page").click();
     agHelper.AssertElementLength(".bp3-menu-item", 2);
     cy.get(locator._dropDownValue("Page2")).click();
+    cy.get("label")
+      .contains("Query Params")
+      .siblings()
+      .find(".CodeEditorTarget")
+      .then(($el) => cy.updateCodeInput($el, "{{ { test: '123' } }}"));
     deployMode.DeployApp();
     agHelper.ClickButton("Submit");
     cy.get(".bp3-heading").contains("This page seems to be blank");
+    cy.url().should("include", "a=b");
+    cy.url().should("include", "test=123");
     deployMode.NavigateBacktoEditor();
   });
 

--- a/app/server/appsmith-server/src/main/resources/features/init-flags.yml
+++ b/app/server/appsmith-server/src/main/resources/features/init-flags.yml
@@ -57,10 +57,10 @@ ff4j:
       enable: true
       description: Restoring old context while navigating across the app
       flipstrategy:
-        class: com.appsmith.server.featureflags.strategies.EmailBasedRolloutStrategy
+        class: org.ff4j.strategy.PonderationStrategy
         param:
-          - name: emailDomains
-            value: appsmith.com,moolya.com
+          - name: weight
+            value: 1
 
     - uid: DATASOURCE_ENVIRONMENTS
       enable: true


### PR DESCRIPTION
## Description

Recently, navigation broke where params were not retained when using the navigateTo function. Adding an assertion here to make sure it does not break again


