### PR TITLE
test: fix merge_spec.js cypress test

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Git/GitSync/Merge_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Git/GitSync/Merge_spec.js
@@ -32,6 +32,7 @@ describe("Git sync modal: merge tab", function() {
       .should("eq", "true");
 
     cy.get(gitSyncLocators.mergeButton).should("be.disabled");
+    cy.wait(3000);
     cy.get(gitSyncLocators.mergeBranchDropdownDestination).click();
     cy.get(commonLocators.dropdownmenu)
       .contains(mainBranch)


### PR DESCRIPTION
## Description

Fixes merge_spec.js by adding wait before clicking the branch dropdown in git modal.

## How Has This Been Tested?

locally

## Checklist:
### Dev activity
- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


