### PR TITLE
fix: list v2 loading state

### DIFF
--- a/app/client/src/widgets/ListWidgetV2/component/Loader.tsx
+++ b/app/client/src/widgets/ListWidgetV2/component/Loader.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import styled from "styled-components";
+import { range } from "lodash";
+import { WIDGET_PADDING } from "constants/WidgetConstants";
+
+type LoaderProps = {
+  pageSize: number;
+  gridGap?: number;
+  templateHeight: number;
+};
+
+type LoaderItemProps = Pick<LoaderProps, "templateHeight" | "gridGap">;
+type StyledWrapperProps = Pick<LoaderProps, "gridGap">;
+
+const StyledWrapper = styled.div<StyledWrapperProps>`
+  height: 100%;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0px 0px 0px 1px #e7e7e7;
+`;
+
+const StyledLoaderItem = styled.div<LoaderItemProps>`
+  height: ${({ templateHeight }) => templateHeight - WIDGET_PADDING * 2}px;
+  margin: ${WIDGET_PADDING}px;
+  margin-bottom: ${({ gridGap = 0 }) => gridGap + WIDGET_PADDING}px;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+`;
+
+function LoaderItem({ gridGap, templateHeight }: LoaderItemProps) {
+  return (
+    <StyledLoaderItem
+      className="bp3-card bp3-skeleton"
+      gridGap={gridGap}
+      templateHeight={templateHeight}
+    />
+  );
+}
+
+function Loader({ gridGap, pageSize, templateHeight }: LoaderProps) {
+  return (
+    <StyledWrapper>
+      {range(pageSize).map((index) => (
+        <LoaderItem
+          gridGap={gridGap}
+          key={index}
+          templateHeight={templateHeight}
+        />
+      ))}
+    </StyledWrapper>
+  );
+}
+
+export default Loader;

--- a/app/client/src/widgets/ListWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/component/index.tsx
@@ -21,6 +21,23 @@ const StyledListContainer = styled.div<StyledListContainerProps>`
   overflow-y: auto;
 `;
 
+export const ListComponentEmpty = styled.div<{
+  backgroundColor?: string;
+}>`
+  height: 100%;
+  width: 100%;
+  position: relative;
+  background: ${(props) => props.backgroundColor ?? "white"};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: Verdana, sans;
+  font-size: 10px;
+  text-anchor: middle;
+  color: rgb(102, 102, 102);
+  box-shadow: ${(props) => `0px 0px 0px 1px ${props.theme.borders[2].color}`};
+`;
+
 function ListComponent(props: ListComponentProps) {
   const {
     backgroundColor,
@@ -42,37 +59,5 @@ function ListComponent(props: ListComponentProps) {
     </StyledListContainer>
   );
 }
-
-export const ListComponentEmpty = styled.div<{
-  backgroundColor?: string;
-}>`
-  height: 100%;
-  width: 100%;
-  position: relative;
-  background: ${(props) => props.backgroundColor ?? "white"};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: Verdana, sans;
-  font-size: 10px;
-  text-anchor: middle;
-  color: rgb(102, 102, 102);
-  box-shadow: ${(props) => `0px 0px 0px 1px ${props.theme.borders[2].color}`};
-`;
-
-export const ListComponentLoading = styled.div<{
-  backgroundColor?: string;
-}>`
-  height: 100%;
-  width: 100%;
-  position: relative;
-  overflow: hidden;
-  box-shadow: 0px 0px 0px 1px #e7e7e7;
-
-  & > div {
-    background: ${(props) => props.backgroundColor ?? "white"};
-    margin: 8px;
-  }
-`;
 
 export default ListComponent;


### PR DESCRIPTION
## Description

- Fixes the loading state of the list widget when data changes in server side paginated list. 
- Isolates the loader to a separate component

Note: This has a monkey patch of `isDataLoading` which fails in multiple scenarios.
For for a simple use case where the list data is just the query, the patch should work fine
The actual fix is expected in #12308 and the fix we are introducing can be reverted after that.

Fixes #18105

Media
Please check issue for loom video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
### Test Plan

> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
