### PR TITLE
fix: update permission driven ctas to handle auto save update changes

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/SaveOrDiscardDatasourceModal.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/SaveOrDiscardDatasourceModal.tsx
@@ -10,16 +10,33 @@ import {
   DialogComponent as Dialog,
   Size,
 } from "design-system";
+import { TEMP_DATASOURCE_ID } from "constants/Datasource";
+import { hasManageDatasourcePermission } from "@appsmith/utils/permissionHelpers";
 
 interface SaveOrDiscardModalProps {
   isOpen: boolean;
   onDiscard(): void;
   onSave?(): void;
   onClose(): void;
+  datasourceId: string;
+  datasourcePermissions: string[];
 }
 
 function SaveOrDiscardDatasourceModal(props: SaveOrDiscardModalProps) {
-  const { isOpen, onClose, onDiscard, onSave } = props;
+  const {
+    datasourceId,
+    datasourcePermissions,
+    isOpen,
+    onClose,
+    onDiscard,
+    onSave,
+  } = props;
+
+  const createMode = datasourceId === TEMP_DATASOURCE_ID;
+  const canManageDatasources = hasManageDatasourcePermission(
+    datasourcePermissions,
+  );
+  const disableSaveButton = !createMode && !canManageDatasources;
 
   return (
     <Dialog
@@ -43,7 +60,8 @@ function SaveOrDiscardDatasourceModal(props: SaveOrDiscardModalProps) {
           />
           <Button
             category={Category.primary}
-            onClick={onSave}
+            disabled={disableSaveButton}
+            onClick={!disableSaveButton && onSave}
             size={Size.medium}
             text="SAVE"
           />

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -383,6 +383,8 @@ class DatasourceEditorRouter extends React.Component<Props, State> {
   renderSaveDisacardModal() {
     return (
       <SaveOrDiscardDatasourceModal
+        datasourceId={this.props.datasourceId}
+        datasourcePermissions={this.props.datasource?.userPermissions || []}
         isOpen={this.state.showDialog}
         onClose={this.closeDialog}
         onDiscard={this.onDiscard}

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -321,6 +321,8 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
           )}
         </form>
         <SaveOrDiscardDatasourceModal
+          datasourceId={datasourceId}
+          datasourcePermissions={datasource?.userPermissions || []}
           isOpen={this.state.showDialog}
           onClose={this.closeDialog}
           onDiscard={this.onDiscard}

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -261,13 +261,15 @@ function DatasourceAuth({
     }
   };
 
+  const createMode = datasourceId === TEMP_DATASOURCE_ID;
+
   const datasourceButtonsComponentMap = (buttonType: string): JSX.Element => {
     return {
       [DatasourceButtonType.DELETE]: (
         <ActionButton
           category={Category.primary}
           className="t--delete-datasource"
-          disabled={!canDeleteDatasource || datasourceId === TEMP_DATASOURCE_ID}
+          disabled={createMode || !canDeleteDatasource}
           key={buttonType}
           loading={isDeleting}
           onClick={() => {
@@ -300,7 +302,9 @@ function DatasourceAuth({
         <ActionButton
           category={Category.primary}
           className="t--save-datasource"
-          disabled={isInvalid || !isFormDirty || !canManageDatasource}
+          disabled={
+            isInvalid || !isFormDirty || (!createMode && !canManageDatasource)
+          }
           filled
           key={buttonType}
           loading={isSaving}
@@ -315,7 +319,7 @@ function DatasourceAuth({
         <StyledButton
           category={Category.primary}
           className="t--save-datasource"
-          disabled={isInvalid || !canManageDatasource}
+          disabled={isInvalid || (!createMode && !canManageDatasource)}
           filled
           fluidWidth
           isLoading={isSaving}


### PR DESCRIPTION
## Description
There has been some change to the datasource create flow. Before as soon as the user click the `+` next to the datasource entity, it creates a datasource and then let the user edit the datasource form. But now, we only create datasource only when the user saves the datasource. 

Since the datasource only gets created on save, there will be no permissions. So the CTAs which are permission driven will all be disabled in EE.  So fixed that and handled it for the scenarios mentioned in the linked issue.


Fixes #18600 



Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag

