### PR TITLE
fix: If the user has delete permission on the workspace, allow the user to delete the workspace and also delete the default roles (without permission)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCE.java
@@ -18,6 +18,8 @@ public interface PermissionGroupServiceCE extends CrudService<PermissionGroup, S
 
     Mono<PermissionGroup> bulkUnassignFromUsers(String permissionGroupId, List<User> users);
 
+    Mono<Boolean> bulkUnassignUsersFromPermissionGroupsWithoutPermission(Set<String> userIds, Set<String> permissionGroupIds);
+
     Flux<PermissionGroup> getByDefaultWorkspace(Workspace workspace, AclPermission permission);
 
     Mono<PermissionGroup> save(PermissionGroup permissionGroup);
@@ -35,6 +37,8 @@ public interface PermissionGroupServiceCE extends CrudService<PermissionGroup, S
     Flux<PermissionGroup> getAllByAssignedToUserAndDefaultWorkspace(User user, Workspace defaultWorkspace, AclPermission aclPermission);
     
     Mono<Void> delete(String id);
+
+    Mono<Void> deleteWithoutPermission(String id);
 
     Mono<PermissionGroup> findById(String permissionGroupId);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.external.models.BaseDomain;
 import com.appsmith.external.models.Policy;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.PermissionGroup;
+import com.appsmith.server.domains.QPermissionGroup;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.Permission;
@@ -20,6 +21,7 @@ import com.appsmith.server.services.TenantService;
 import com.appsmith.server.solutions.PermissionGroupPermission;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
@@ -35,6 +37,7 @@ import java.util.stream.Collectors;
 import static com.appsmith.server.acl.AclPermission.UNASSIGN_PERMISSION_GROUPS;
 import static com.appsmith.server.constants.FieldName.PERMISSION_GROUP_ID;
 import static com.appsmith.server.constants.FieldName.PUBLIC_PERMISSION_GROUP;
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.fieldName;
 import static java.lang.Boolean.TRUE;
 
 
@@ -126,6 +129,27 @@ public class PermissionGroupServiceCEImpl extends BaseService<PermissionGroupRep
     }
 
     @Override
+    public Mono<Void> deleteWithoutPermission(String id) {
+
+        return repository.findById(id)
+                .flatMap(permissionGroup -> {
+
+                    Mono<Void> returnMono = null;
+
+                    Set<String> assignedToUserIds = permissionGroup.getAssignedToUserIds();
+
+                    if (assignedToUserIds == null || assignedToUserIds.isEmpty()) {
+                        returnMono = repository.deleteById(id);
+                    } else {
+                        returnMono = bulkUnassignUsersFromPermissionGroupsWithoutPermission(assignedToUserIds, Set.of(id))
+                                .then(repository.deleteById(id));
+                    }
+
+                    return returnMono;
+                });
+    }
+
+    @Override
     public Mono<PermissionGroup> findById(String permissionGroupId) {
         return repository.findById(permissionGroupId);
     }
@@ -199,6 +223,22 @@ public class PermissionGroupServiceCEImpl extends BaseService<PermissionGroupRep
                         cleanPermissionGroupCacheForUsers(userIds).thenReturn(TRUE)
                 )
                 .map(tuple -> tuple.getT1());
+    }
+
+    @Override
+    public Mono<Boolean> bulkUnassignUsersFromPermissionGroupsWithoutPermission(Set<String> userIds, Set<String> permissionGroupIds) {
+        return repository.findAllById(permissionGroupIds)
+                .flatMap(pg -> {
+                    Set<String> assignedToUserIds = pg.getAssignedToUserIds();
+                    assignedToUserIds.removeAll(userIds);
+
+                    Update updateObj = new Update();
+                    String path = fieldName(QPermissionGroup.permissionGroup.assignedToUserIds);
+
+                    updateObj.set(path, assignedToUserIds);
+                    return repository.updateById(pg.getId(), updateObj);
+                })
+                .then(Mono.just(TRUE));
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/PermissionGroupServiceCEImpl.java
@@ -236,7 +236,12 @@ public class PermissionGroupServiceCEImpl extends BaseService<PermissionGroupRep
                     String path = fieldName(QPermissionGroup.permissionGroup.assignedToUserIds);
 
                     updateObj.set(path, assignedToUserIds);
-                    return repository.updateById(pg.getId(), updateObj);
+
+                    return Mono.zip(
+                                    repository.updateById(pg.getId(), updateObj),
+                                    cleanPermissionGroupCacheForUsers(List.copyOf(userIds))
+                            )
+                            .map(tuple -> tuple.getT1());
                 })
                 .then(Mono.just(TRUE));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -590,10 +590,13 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
                         .flatMap(workspace -> {
 
                             // Delete permission groups associated with this workspace before deleting the workspace
+                            // Since we have already asserted that the user has the delete permission on the workspace,
+                            // lets go ahead with the cleanup without permissions for the default permission groups (roles)
+                            // since we can't leave the permission groups in a state where they are not associated with any workspace
 
                             Set<String> defaultPermissionGroups = workspace.getDefaultPermissionGroups();
                             return Flux.fromIterable(defaultPermissionGroups)
-                                    .flatMap(permissionGroupService::delete)
+                                    .flatMap(permissionGroupService::deleteWithoutPermission)
                                     .then(Mono.just(workspace));
                         })
                         .flatMap(repository::archive)


### PR DESCRIPTION

Fixes #18216

Today, the workspace delete assumes that the user is a member of the workspace (which is indeed true for community editition). But with Granular Access Control, a non member could also be given the permission to delete the workspace. In that case, the user would not have access to the default workspace roles (since she isn't a member). During delete, the operation includes both delete of the workspace and doing a cleanup of default roles to which the user doesn't have any permission. To evade this, we are just checking for the user having the permission to delete the workspace. If she has the required permission on the workspace, we are letting the cleanup of the default roles without permission.

