### PR TITLE
fix: Add user permission in the response for update datasource api

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCEImpl.java
@@ -333,7 +333,8 @@ public class DatasourceServiceCEImpl extends BaseService<DatasourceRepository, D
                                 savedDatasource.setPluginName(unsavedDatasource.getPluginName());
                                 return savedDatasource;
                             });
-                });
+                })
+                .flatMap(repository::setUserPermissionsInObject);
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -392,7 +392,13 @@ public class DatasourceServiceTest {
                     assertThat(createdDatasource.getPluginId()).isEqualTo(datasource.getPluginId());
                     assertThat(createdDatasource.getName()).isEqualTo(datasource.getName());
                     assertThat(createdDatasource.getDatasourceConfiguration().getConnection().getSsl().getKeyFile().getName()).isEqualTo("ssl_key_file_id2");
-
+                    assertThat(createdDatasource.getUserPermissions()).isNotEmpty();
+                    assertThat(createdDatasource.getUserPermissions()).containsAll(
+                            Set.of(
+                                    READ_DATASOURCES.getValue(), EXECUTE_DATASOURCES.getValue(),
+                                    MANAGE_DATASOURCES.getValue(), DELETE_DATASOURCES.getValue()
+                            )
+                    );
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
When the datasource is updated, in the response the server did not set the current permissions of the user. This is now required as part of granular access control for the client to enable/disable actions on top of the datasource (like create a query, save, etc.). This PR adds the permissions in the response.

Fixes #18601 