### PR TITLE
fix:handle escape characters

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_EvaluatedPopup_spec.js
@@ -1,5 +1,5 @@
 describe("List widget v2 Evaluated Popup", () => {
-  it("1. List widget V2 with currentItem", () => {
+  it("1. List widget V2 with currentItem and escape characters", () => {
     cy.dragAndDropToCanvas("listwidgetv2", {
       x: 300,
       y: 300,
@@ -12,6 +12,15 @@ describe("List widget v2 Evaluated Popup", () => {
       ["{{currentItem.name}}_{{currentIndex}}", "Blue_0"],
       ["{{1000}}", "1000"],
       ['{{(() => "Text Widget")()}}', "Text Widget"],
+      ["NewLine\n{{currentItem.name}}", "NewLine\nBlue"],
+      [`\{{currentItem.name}}`, `\Blue`],
+      [
+        `{{
+          (function(){return true;})
+          ()}}
+        `,
+        "true",
+      ],
     ].forEach(([input, expected]) => {
       cy.updateCodeInput(".t--property-control-text", input);
       cy.wait(500);

--- a/app/client/src/utils/DynamicBindingUtils.ts
+++ b/app/client/src/utils/DynamicBindingUtils.ts
@@ -107,7 +107,7 @@ export const combineDynamicBindings = (
       if (jsSnippets[index] && jsSnippets[index].length > 0) {
         return jsSnippets[index];
       } else {
-        return `'${segment}'`;
+        return JSON.stringify(segment);
       }
     })
     .join(" + ");


### PR DESCRIPTION
## Description

The issue here was majorly handling escape characters.
I tried several methods and even templating the segmented string, but that didn't work.

Generally, `eval` fails with escape characters except we send them as template strings i.e. ```
```
`NewLine \n` rather than this "NewLine \n"
```
Stringifying gives us a way to turn the escape characters to a string which is also easier for eval to evaluate

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
