### PR TITLE
chore: fix ingress fieldname in appsmith

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -44,8 +44,7 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  certManager: {{ .Values.ingress.certManager }}
-  className: {{ .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     {{- if not .Values.ingress.hosts }}
     - host:


### PR DESCRIPTION
These fields were supported earlier and with our new ingress template. 
we dont need certManager , we configure it with tls and kubernetes secret as follows.

```
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: ingress-resource
  annotations:
    kubernetes.io/ingress.class: nginx
spec:
  rules:
  - host: poc-helm3.bluekiri.tech
    http:
      paths:
      - path: /helloworld
        backend:
          serviceName: hello-app
          servicePort: 8080
```

and the field className has been changed to `ingressClassName`