### PR TITLE
fix: bottomRow undefined for auto height sagas

### DIFF
--- a/app/client/src/sagas/autoHeightSagas/helpers.ts
+++ b/app/client/src/sagas/autoHeightSagas/helpers.ts
@@ -86,7 +86,7 @@ export function* getMinHeightBasedOnChildren(
 
   const { children = [], parentId } = stateWidgets[widgetId];
   // If we need to consider the parent height
-  if (parentId && !ignoreParent) {
+  if (parentId && !ignoreParent && parentId in tree) {
     const parent = stateWidgets[parentId];
     const parentHeightInRows = getParentCurrentHeightInRows(
       tree,


### PR DESCRIPTION
## Description

-- Issue
Somehow a parent of a widget is not present in the auto height layout tree during the computations in getParentCurrentHeightInRows.

-- Fix
Added a check for the existence of the parent in the tree before calling, getParentCurrentHeightInRows.

Fixes #18681 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
