### PR TITLE
fix: datasource autosave git issue fixed

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Git/GitDatasourceChange/CreateBranch_DiscardDatasource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Git/GitDatasourceChange/CreateBranch_DiscardDatasource_spec.js
@@ -1,0 +1,45 @@
+import commonLocators from "../../../../../locators/commonlocators.json";
+import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+import gitSyncLocators from "../../../../../locators/gitSyncLocators";
+
+let dataSources = ObjectsRegistry.DataSources;
+let testBranchName = "Test";
+
+let repoName;
+describe("Bug 18665: Git sync:", function() {
+  before(() => {
+    cy.NavigateToHome();
+    cy.createWorkspace();
+    cy.wait("@createWorkspace").then((interception) => {
+      const newWorkspaceName = interception.response.body.data.name;
+      cy.CreateAppForWorkspace(newWorkspaceName, newWorkspaceName);
+    });
+
+    cy.generateUUID().then((uid) => {
+      repoName = "test" + uid;
+      cy.createTestGithubRepo(repoName);
+      cy.connectToGitRepo(repoName);
+    });
+  });
+
+  it("1. creates a new branch", function() {
+    cy.get(commonLocators.canvas).click({ force: true });
+    cy.generateUUID().then((uid) => {
+      testBranchName += uid;
+      cy.createGitBranch(testBranchName + uid);
+    });
+  });
+
+  it("2. Create datasource, discard it and check current branch", function() {
+    dataSources.NavigateToDSCreateNew();
+    dataSources.CreatePlugIn("PostgreSQL");
+    dataSources.SaveDSFromDialog(false);
+    cy.get(gitSyncLocators.branchButton)
+      .contains(testBranchName)
+      .should("be.visible");
+  });
+
+  after(() => {
+    cy.deleteTestGithubRepo(repoName);
+  });
+});

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -376,6 +376,7 @@ class DatasourceEditorRouter extends React.Component<Props, State> {
       unblock: this.props?.history?.block((tx: any) => {
         this.setState(
           {
+            // need to pass in query params as well as state, when user navigates away from ds form page
             navigation: () =>
               this.props.history.push(tx.pathname + tx.search, tx.state),
             showDialog: true,

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -376,7 +376,8 @@ class DatasourceEditorRouter extends React.Component<Props, State> {
       unblock: this.props?.history?.block((tx: any) => {
         this.setState(
           {
-            navigation: () => this.props.history.push(tx.pathname),
+            navigation: () =>
+              this.props.history.push(tx.pathname + tx.search, tx.state),
             showDialog: true,
             routesBlocked: true,
           },

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -193,7 +193,8 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
       unblock: this.props?.history?.block((tx: any) => {
         this.setState(
           {
-            navigation: () => this.props.history.push(tx.pathname),
+            navigation: () =>
+              this.props.history.push(tx.pathname + tx.search, tx.state),
             showDialog: true,
             routesBlocked: true,
           },

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -193,6 +193,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
       unblock: this.props?.history?.block((tx: any) => {
         this.setState(
           {
+            // need to pass in query params as well as state, when user navigates away from ds form page
             navigation: () =>
               this.props.history.push(tx.pathname + tx.search, tx.state),
             showDialog: true,


### PR DESCRIPTION
## Description

From a new branch in a git connected application (say "Test"), when I create new datasource, and in the new datasource page, I click on Back, and click on Don't Save, the branch gets changed from Test to Main.

> Add a TL;DR when description is extra long (helps content team)

Fixes #18665 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
