### PR TITLE
fix: Auto height breaks for fixed modal's children

### DIFF
--- a/app/client/src/reducers/entityReducers/autoHeightReducers/autoHeightLayoutTreeReducer.ts
+++ b/app/client/src/reducers/entityReducers/autoHeightReducers/autoHeightLayoutTreeReducer.ts
@@ -12,7 +12,7 @@ export type AutoHeightLayoutTreePayload = {
 };
 
 export type AutoHeightLayoutTreeReduxState = {
-  [widgetId: string]: TreeNode & { level?: number };
+  [widgetId: string]: TreeNode;
 };
 const initialState: AutoHeightLayoutTreeReduxState = {};
 

--- a/app/client/src/sagas/autoHeightSagas/widgets.ts
+++ b/app/client/src/sagas/autoHeightSagas/widgets.ts
@@ -441,8 +441,44 @@ export function* updateWidgetAutoHeightSaga() {
                 }
               }
             } else {
+              // Get the parent's topRow and bottomRow from the state
+              let parentBottomRow = parentContainerLikeWidget.bottomRow;
+              let parentTopRow = parentContainerLikeWidget.topRow;
+              // If we have the parent's dimensions in the tree
+              // and it is not a modal widget, then get the topRow
+              // and bottomRow from the tree.
+              if (
+                dynamicHeightLayoutTree[parentContainerLikeWidget.widgetId] &&
+                !parentContainerLikeWidget.detachFromLayout
+              ) {
+                parentBottomRow =
+                  dynamicHeightLayoutTree[parentContainerLikeWidget.widgetId]
+                    .bottomRow;
+                parentTopRow =
+                  dynamicHeightLayoutTree[parentContainerLikeWidget.widgetId]
+                    .topRow;
+              }
+
+              // If this is a modal widget, then get the bottomRow in rows
+              // as the height and bottomRow could be in pixels.
+              if (
+                parentContainerLikeWidget.detachFromLayout &&
+                parentContainerLikeWidget.height
+              ) {
+                parentBottomRow =
+                  parentTopRow +
+                  Math.ceil(
+                    parentContainerLikeWidget.height /
+                      GridDefaults.DEFAULT_GRID_ROW_HEIGHT,
+                  );
+              }
+
+              // Get the parent container's height in rows
+              // It is possible that some other update has changed this parent's
+              // dimensions.
               let parentContainerHeightInRows = getParentCurrentHeightInRows(
-                dynamicHeightLayoutTree,
+                parentBottomRow,
+                parentTopRow,
                 parentContainerLikeWidget.widgetId,
                 changesSoFar,
               );


### PR DESCRIPTION
## Description
Fix issue where auto height was throwing an error when a fixed modal widget's children were changing height automatically

Fixes #18681

Before:

https://user-images.githubusercontent.com/103687/205632585-9dc28071-7dbc-408e-9010-71cf5b2e2699.mov

After:

https://user-images.githubusercontent.com/103687/205632610-3b52e00e-f7cf-48dc-8bd4-4b316151a0c6.mov




## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual
- Cypress: [PENDING](https://www.notion.so/appsmith/Cypress-Test-scenarios-50557ff33f2745498396a4215b9a77ed)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
