### PR TITLE
chore: Improved metadata on logs when reading DSL fails

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -46,11 +46,13 @@ public enum AppsmithError {
     INVALID_DYNAMIC_BINDING_REFERENCE(400, 4022,
             "  \"widgetType\" : \"{0}\"," +
                     "  \"bindingPath\" : \"{3}\"," +
+                    "  \"currentKey\" : \"{7}\"," +
                     "  \"message\" : \"Binding path in the widget not found. Please reach out to Appsmith customer support to resolve this.\"," +
                     "  \"widgetName\" : \"{1}\"," +
                     "  \"widgetId\" : \"{2}\"," +
                     "  \"pageId\" : \"{4}\"," +
                     "  \"layoutId\" : \"{5}\"," +
+                    "  \"errorDetail\" : \"{8}\"," +
                     "  \"dynamicBinding\" : {6}",
             AppsmithErrorAction.LOG_EXTERNALLY, null, ErrorType.BAD_REQUEST, null),
     USER_ALREADY_EXISTS_IN_WORKSPACE(400, 4021, "The user {0} has already been added to the workspace with role {1}. To change the role, please navigate to `Manage Users` page.",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -76,17 +76,12 @@ public class AstServiceCEImpl implements AstServiceCE {
                 .retrieve()
                 .bodyToMono(GetIdentifiersResponseBulk.class)
                 .retryWhen(Retry.max(3))
-                .elapsed()
-                .map(tuple -> {
-                    log.debug("Time elapsed since AST get identifiers call: {} ms, for size: {}", tuple.getT1(), bindingValues.size());
-                    return tuple.getT2().data;
-                })
-                .flatMapIterable(getIdentifiersResponseDetails -> getIdentifiersResponseDetails)
+                .flatMapIterable(getIdentifiersResponseDetails -> getIdentifiersResponseDetails.data)
                 .index()
                 .flatMap(tuple2 -> {
-                        long currentIndex = tuple2.getT1();
-                        Set<String> references = tuple2.getT2().getReferences();
-                        return Mono.zip(Mono.just(bindingValues.get((int) currentIndex)), Mono.just(references));
+                    long currentIndex = tuple2.getT1();
+                    Set<String> references = tuple2.getT2().getReferences();
+                    return Mono.zip(Mono.just(bindingValues.get((int) currentIndex)), Mono.just(references));
                 });
         // TODO: add error handling scenario for when RTS is not accessible in fat container
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -63,9 +63,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
-import static com.appsmith.server.acl.AclPermission.MANAGE_ACTIONS;
-import static com.appsmith.server.acl.AclPermission.MANAGE_PAGES;
-import static com.appsmith.server.acl.AclPermission.READ_PAGES;
 import static com.appsmith.server.services.ce.ApplicationPageServiceCEImpl.EVALUATION_VERSION;
 import static java.lang.Boolean.FALSE;
 import static java.util.stream.Collectors.toSet;
@@ -300,6 +297,7 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                 // root.field.list[index].childField.anotherList.indexWithDotOperator.multidimensionalList[index1][index2]
                 while (fieldsIterator.hasNext()) {
                     String nextKey = fieldsIterator.next();
+                    Object oldParent = parent;
                     if (parent instanceof JSONObject) {
                         parent = ((JSONObject) parent).get(nextKey);
                     } else if (parent instanceof Map) {
@@ -311,17 +309,17 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                             } catch (IndexOutOfBoundsException e) {
                                 // The index being referred does not exist. Hence the path would not exist.
                                 throw new AppsmithException(AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE, widgetType,
-                                        widgetName, widgetId, fieldPath, pageId, layoutId, null);
+                                        widgetName, widgetId, fieldPath, pageId, layoutId, oldParent, nextKey, "Index out of bounds for list");
                             }
                         } else {
                             throw new AppsmithException(AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE, widgetType,
-                                    widgetName, widgetId, fieldPath, pageId, layoutId, null);
+                                    widgetName, widgetId, fieldPath, pageId, layoutId, oldParent, nextKey, "Child of list is not in an indexed path");
                         }
                     }
                     // After updating the parent, check for the types
                     if (parent == null) {
                         throw new AppsmithException(AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE, widgetType,
-                                widgetName, widgetId, fieldPath, pageId, layoutId, null);
+                                widgetName, widgetId, fieldPath, pageId, layoutId, oldParent, nextKey, "New element is null");
                     } else if (parent instanceof String) {
                         // If we get String value, then this is a leaf node
                         isLeafNode = true;
@@ -335,7 +333,7 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                             try {
                                 String bindingAsString = objectMapper.writeValueAsString(parent);
                                 throw new AppsmithException(AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE, widgetType,
-                                        widgetName, widgetId, fieldPath, pageId, layoutId, bindingAsString);
+                                        widgetName, widgetId, fieldPath, pageId, layoutId, bindingAsString, nextKey, "Binding path has no mustache bindings");
                             } catch (JsonProcessingException e) {
                                 throw new AppsmithException(AppsmithError.JSON_PROCESSING_ERROR, parent);
                             }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -292,12 +292,13 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                 Object parent = dsl;
                 Iterator<String> fieldsIterator = Arrays.stream(fields).filter(fieldToken -> !fieldToken.isBlank()).iterator();
                 boolean isLeafNode = false;
+                Object oldParent;
                 // This loop will end at either a leaf node, or the last identified JSON field (by throwing an exception)
                 // Valid forms of the fieldPath for this search could be:
                 // root.field.list[index].childField.anotherList.indexWithDotOperator.multidimensionalList[index1][index2]
                 while (fieldsIterator.hasNext()) {
+                    oldParent = parent;
                     String nextKey = fieldsIterator.next();
-                    Object oldParent = parent;
                     if (parent instanceof JSONObject) {
                         parent = ((JSONObject) parent).get(nextKey);
                     } else if (parent instanceof Map) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
@@ -1203,7 +1203,7 @@ public class LayoutServiceTest {
                 .expectErrorMatches(throwable -> {
                     assertThat(throwable).isInstanceOf(AppsmithException.class);
                     assertThat(throwable.getMessage()).isEqualTo(
-                            AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE.getMessage("test_type", "testWidget", "id", "dynamicGet_IncorrectKey", pageId, layoutId.get(), null)
+                            AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE.getMessage("test_type", "testWidget", "id", "dynamicGet_IncorrectKey", pageId, layoutId.get(), "dynamicGet_IncorrectKey", "New element is null")
                     );
                     return true;
                 })

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/LayoutServiceTest.java
@@ -20,9 +20,12 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.PluginRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1202,8 +1205,15 @@ public class LayoutServiceTest {
                 .create(testMono)
                 .expectErrorMatches(throwable -> {
                     assertThat(throwable).isInstanceOf(AppsmithException.class);
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    Object oldParent = null;
+                    try {
+                        oldParent = objectMapper.readTree("{\"widgetName\":\"testWidget\",\"dynamicBindingPathList\":[{\"key\":\"dynamicGet_IncorrectKey\"}],\"widgetId\":\"id\",\"another\":\"Hello people of the {{input1.text}} planet!\",\"dynamicGet\":\"some dynamic {{aGetAction.data}}\",\"type\":\"test_type\",\"key\":\"value-updated\"}");
+                    } catch (JsonProcessingException e) {
+                        Assertions.fail("Incorrect initialization of expected DSL");
+                    }
                     assertThat(throwable.getMessage()).isEqualTo(
-                            AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE.getMessage("test_type", "testWidget", "id", "dynamicGet_IncorrectKey", pageId, layoutId.get(), "dynamicGet_IncorrectKey", "New element is null")
+                            AppsmithError.INVALID_DYNAMIC_BINDING_REFERENCE.getMessage("test_type", "testWidget", "id", "dynamicGet_IncorrectKey", pageId, layoutId.get(), oldParent,  "dynamicGet_IncorrectKey", "New element is null")
                     );
                     return true;
                 })


### PR DESCRIPTION
## Description

This PR adds two new attributes to invalid binding errors. These are:
- oldParent: The DSL object before this iteration
- currentKey: The path component that this iteration is currently at

These two additions will help us better understand what the state of the app was during failure.

## Type of change
- Chore


## How Has This Been Tested?
- Manual


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
