### PR TITLE
ci: Ship source maps + fix perf test failures on EE

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -140,6 +140,8 @@ jobs:
           APPSMITH_CLOUD_SERVICES_USERNAME: ""
           APPSMITH_CLOUD_SERVICES_PASSWORD: ""
           APPSMITH_GIT_ROOT: "./container-volumes/git-storage"
+          APPSMITH_LICENSE_KEY: ${{ secrets.APPSMITH_LICENSE_KEY }}
+          APPSMITH_ENVFILE_PATH: /tmp/dummy.env
         run: |
           ls -l
           ls -l scripts/

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -126,6 +126,43 @@ jobs:
           name: build
           path: app/server/dist
 
+      - name: Download the rts build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: rts-dist
+          path: app/rts/dist
+
+      - name: Untar the rts folder
+        run: |
+          tar -xvf app/rts/dist/rts-dist.tar -C app/rts/
+          echo "Cleaning up the tar files"
+          rm app/rts/dist/rts-dist.tar
+      # We don't use Depot Docker builds because it's faster for local Docker images to be built locally.
+      # It's slower and more expensive to build these Docker images on Depot and download it back to the CI node.
+      - name: Build  docker image
+        if: steps.run_result.outputs.run_result != 'success'
+        working-directory: "."
+        run: |
+          docker build -t fatcontainer .
+      - name: Create folder
+        if: steps.run_result.outputs.run_result != 'success'
+        env:
+          APPSMITH_LICENSE_KEY: ${{ secrets.APPSMITH_LICENSE_KEY }}
+        working-directory: "."
+        run: |
+          mkdir -p fatcontainerlocal/stacks/configuration/
+          mkdir -p fatcontainerlocal/oldstack
+      - name: Download S3 image
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: s3://ci-assets--appsmith/
+          destination: /home/runner/work/appsmith/appsmith/fatcontainerlocal/oldstack
+          aws_access_key_id: ${{ secrets.S3_CI_ASSETS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.S3_CI_ASSETS_SECRET_ACCESS_KEY }}
+          aws_region: ap-south-1
+          flags: --recursive
+
       # Start server
       - name: start server
         if: steps.run_result.outputs.run_result != 'success'
@@ -149,10 +186,11 @@ jobs:
           # Run the server in the background and redirect logs to a log file
           ./scripts/start-dev-server.sh &> server-logs.log &
 
-      - name: Wait for 30 seconds for server to start
+      - name: Installing Yarn serve
         if: steps.run_result.outputs.run_result != 'success'
         run: |
-          sleep 30s
+          yarn global add serve
+          echo "$(yarn global bin)" >> $GITHUB_PATH
 
       - name: Exit if Server hasnt started
         if: steps.run_result.outputs.run_result != 'success'
@@ -163,12 +201,6 @@ jobs:
            else
              echo "Server Found";
            fi
-
-      - name: Installing Yarn serve
-        if: steps.run_result.outputs.run_result != 'success'
-        run: |
-          yarn global add serve
-          echo "$(yarn global bin)" >> $GITHUB_PATH
 
       - name: Load docker image
         if: steps.run_result.outputs.run_result != 'success'
@@ -181,7 +213,13 @@ jobs:
           docker run --name test-event-driver -d -p 2222:22 -p 5001:5001 -p 3306:3306 \
           -p 5432:5432 -p 28017:27017 -p 25:25 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
-            
+          cd fatcontainerlocal
+          docker run -d --name appsmith -p 80:80 -p 9001:9001 \
+            -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
+            -e APPSMITH_AUDITLOG_ENABLED=true \
+            -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
+            fatcontainer
+
       - name: Setting up the perf tests
         if: steps.run_result.outputs.run_result != 'success'
         shell: bash

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -8,5 +8,11 @@ echo "Sentry Auth Token: $SENTRY_AUTH_TOKEN"
 
 REACT_APP_SENTRY_RELEASE=$GIT_SHA REACT_APP_CLIENT_LOG_LEVEL=ERROR EXTEND_ESLINT=true craco --max-old-space-size=4096 build --config craco.build.config.js
 
-rm ./build/static/js/*.js.map
+
+if [ "$CI" ] && [ "$GITHUB_REPOSITORY" == "appsmithorg/appsmith-ee" ]; then
+    echo "Deleting sourcemaps for EE"
+    rm ./build/static/js/*.js.map
+    rm ./build/static/js/*.js.map.gz
+fi
+
 echo "build finished"


### PR DESCRIPTION
## Description

- Perf tests were failing on EE because the EE license key was not available. 
- Delete source maps only on EE
- Remove the wait for the server to start, instead install the performance infra dependencies in that time. 

Fixes #18687 #18688


## Type of change
Non breaking change to CI


## How Has This Been Tested?




## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
