### PR TITLE
chore: Fetch pages in editor with READ permissions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -235,7 +235,8 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
     @Override
     public Mono<PageDTO> getPageByBranchAndDefaultPageId(String defaultPageId, String branchName, boolean viewMode) {
 
-        AclPermission permission = viewMode ? pagePermission.getReadPermission() : pagePermission.getEditPermission();
+        // Fetch the page with read permission in both editor and in viewer.
+        AclPermission permission = pagePermission.getReadPermission();
         return newPageService.findByBranchNameAndDefaultPageId(branchName, defaultPageId, permission)
                 .flatMap(newPage -> {
                     return sendPageViewAnalyticsEvent(newPage, viewMode).then(getPage(newPage.getId(), viewMode));


### PR DESCRIPTION
Fixes #18371 

With GAC, it is possible now to take away edit permissions for a given page even though the user might have edit on the entire application (except a particular page). This change ensures that as long as the user has view permission on a page, they would still be able to open the said page in the editor. 