### PR TITLE
fix: Return undefined for nonexistent action headers

### DIFF
--- a/app/client/src/sagas/ApiPaneSagas.ts
+++ b/app/client/src/sagas/ApiPaneSagas.ts
@@ -203,7 +203,7 @@ function* handleUpdateBodyContentType(
 
   const headers = cloneDeep(values.actionConfiguration.headers);
 
-  const contentTypeHeaderIndex = headers.findIndex(
+  const contentTypeHeaderIndex = headers?.findIndex(
     (element: { key: string; value: string }) =>
       element &&
       element.key &&
@@ -411,7 +411,7 @@ export function* updateFormFields(
     if (!actionConfiguration.headers) return;
 
     const actionConfigurationHeaders = cloneDeep(actionConfiguration.headers);
-    const contentTypeHeaderIndex = actionConfigurationHeaders.findIndex(
+    const contentTypeHeaderIndex = actionConfigurationHeaders?.findIndex(
       (header: { key: string; value: string }) =>
         header?.key?.trim().toLowerCase() === CONTENT_TYPE_HEADER_KEY,
     );
@@ -466,7 +466,7 @@ function* formValueChangeSaga(
       });
     }
 
-    const contentTypeHeaderIndex = values.actionConfiguration.headers.findIndex(
+    const contentTypeHeaderIndex = values?.actionConfiguration?.headers?.findIndex(
       (header: { key: string; value: string }) =>
         header?.key?.trim().toLowerCase() === CONTENT_TYPE_HEADER_KEY,
     );
@@ -493,6 +493,7 @@ function* formValueChangeSaga(
       // when user types a content type value, update actionConfiguration.formData.apiContent type as well.
       // we don't do this initally because we want to specifically catch user editing the content-type value
       if (
+        contentTypeHeaderIndex &&
         field === `actionConfiguration.headers[${contentTypeHeaderIndex}].value`
       ) {
         yield put(

--- a/app/client/src/utils/ApiPaneUtils.tsx
+++ b/app/client/src/utils/ApiPaneUtils.tsx
@@ -9,7 +9,7 @@ import { CONTENT_TYPE_HEADER_KEY } from "constants/ApiEditorConstants/CommonApiC
  * @returns
  */
 export const getIndextoUpdate = (headers: any, headerIndexToUpdate: number) => {
-  const firstEmptyHeaderRowIndex: number = headers.findIndex(
+  const firstEmptyHeaderRowIndex: number = headers?.findIndex(
     (element: { key: string; value: string }) =>
       element && element.key === "" && element.value === "",
   );


### PR DESCRIPTION
This issue occurs when users switch the datasource of an API action, and the actionConfiguration headers is empty. This PR adds conditional checks to prevent an error from happening.

Fixes #18682

Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video

- Bug fix (non-breaking change which fixes an issue)

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
