### PR TITLE
fix: fetching the plugin form config for queries if datasource is not viewable

### DIFF
--- a/app/client/src/components/editorComponents/Button.tsx
+++ b/app/client/src/components/editorComponents/Button.tsx
@@ -57,7 +57,15 @@ const buttonStyles = css<Partial<ButtonProps>>`
 `;
 const StyledButton = styled((props: IButtonProps & Partial<ButtonProps>) => (
   <BlueprintButton
-    {...omit(props, ["iconAlignment", "fluid", "filled", "outline"])}
+    {...omit(props, [
+      "borderRadius",
+      "boxShadow",
+      "boxShadowColor",
+      "iconAlignment",
+      "fluid",
+      "filled",
+      "outline",
+    ])}
   />
 ))`
   ${buttonStyles}

--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -32,7 +32,7 @@ import {
 } from "@appsmith/constants/ReduxActionConstants";
 import { addBranchParam } from "constants/routes";
 import { APP_MODE } from "entities/App";
-import { all, call, put, select } from "redux-saga/effects";
+import { call, put, select } from "redux-saga/effects";
 import { failFastApiCalls } from "sagas/InitSagas";
 import { getCurrentApplication } from "selectors/editorSelectors";
 import { getCurrentGitBranch } from "selectors/gitSyncSelectors";
@@ -172,10 +172,8 @@ export default class AppEditorEngine extends AppEngine {
   }
 
   public *loadAppEntities(toLoadPageId: string, applicationId: string): any {
-    yield all([
-      call(this.loadPageThemesAndActions, toLoadPageId, applicationId),
-      call(this.loadPluginsAndDatasources),
-    ]);
+    yield call(this.loadPageThemesAndActions, toLoadPageId, applicationId);
+    yield call(this.loadPluginsAndDatasources);
   }
 
   public *completeChore() {

--- a/app/client/src/pages/Editor/Explorer/Files/index.tsx
+++ b/app/client/src/pages/Editor/Explorer/Files/index.tsx
@@ -65,7 +65,7 @@ function Files() {
           return (
             <div
               className={`text-sm text-[${Colors.CODE_GRAY}] pl-8 bg-trueGray-50 overflow-hidden overflow-ellipsis whitespace-nowrap`}
-              key={entity.name}
+              key={entity.name || "Queries"}
             >
               {entity.name}
             </div>

--- a/app/client/src/sagas/PluginSagas.ts
+++ b/app/client/src/sagas/PluginSagas.ts
@@ -8,6 +8,7 @@ import PluginsApi, { DefaultPlugin, PluginFormPayload } from "api/PluginApi";
 import { validateResponse } from "sagas/ErrorSagas";
 import { getCurrentWorkspaceId } from "@appsmith/selectors/workspaceSelectors";
 import {
+  getActions,
   getDatasources,
   getPlugin,
   getPluginForm,
@@ -36,6 +37,7 @@ import {
   FormDependencyConfigs,
   FormDatasourceButtonConfigs,
 } from "utils/DynamicBindingUtils";
+import { ActionDataState } from "reducers/entityReducers/actionsReducer";
 
 function* fetchPluginsSaga(
   action: ReduxAction<{ workspaceId?: string } | undefined>,
@@ -84,6 +86,12 @@ function* fetchPluginFormConfigsSaga() {
 
     if (graphqlPlugin) {
       pluginIdFormsToFetch.add(graphqlPlugin.id);
+    }
+
+    const actions: ActionDataState = yield select(getActions);
+    const actionPluginIds = actions.map((action) => action.config.pluginId);
+    for (const pluginId of actionPluginIds) {
+      pluginIdFormsToFetch.add(pluginId);
     }
 
     const pluginFormData: PluginFormPayload[] = [];


### PR DESCRIPTION
## Description

> Fetching the plugin form config for queries if datasource is not viewable.

> TL;DR: Change is being done for GAC. Shouldn't impact users.

Fixes [#18372](https://github.com/appsmithorg/appsmith/issues/18372)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Tested this on the GAC feature branch and now its working as expected.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
