### PR TITLE
chore: Updating the text from enterprise to business to maintain consistency

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/Omnibar_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/Omnibar_spec.js
@@ -197,8 +197,8 @@ describe("Omnibar functionality test cases", () => {
       .click()
       .wait(2000);
     cy.url().should(
-      "eq",
-      "https://docs.appsmith.com/core-concepts/connecting-to-data-sources/",
+      "contain",
+      "https://docs.appsmith.com/core-concepts/connecting-to-data-sources",
     ); // => true
     cy.go(-1);
   });

--- a/app/client/src/ce/constants/messages.test.ts
+++ b/app/client/src/ce/constants/messages.test.ts
@@ -464,7 +464,7 @@ describe("Audit logs messages", () => {
     const input = [INTRODUCING, EXCLUSIVE_TO_BUSINESS];
     const expected = [
       `Introducing XYZ`,
-      `The XYZ feature is exclusive to workspaces on the Enterprise Plan`,
+      `The XYZ feature is exclusive to workspaces on the Business Plan`,
     ];
     const actual = input.map((f) => createMessage(f, "XYZ"));
     expect(actual).toEqual(expected);

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1047,7 +1047,7 @@ export const INCIDENT_MANAGEMENT_DETAIL1 = () =>
   "Go back in time from an incident to see who did what, correlate events with breaking changes, and run RCAs to remediate incidents for now and the future.";
 export const AVAILABLE_ON_BUSINESS = () => "Available on a business plan only";
 export const EXCLUSIVE_TO_BUSINESS = (featureName: string) =>
-  `The ${featureName} feature is exclusive to workspaces on the Enterprise Plan`;
+  `The ${featureName} feature is exclusive to workspaces on the Business Plan`;
 // Audit logs Upgrade page end
 // Audit logs end
 

--- a/app/client/src/ce/pages/AdminSettings/LeftPane.tsx
+++ b/app/client/src/ce/pages/AdminSettings/LeftPane.tsx
@@ -143,7 +143,7 @@ export default function LeftPane() {
       </>
       <>
         <HeaderContainer>
-          <StyledHeader>Business Plan</StyledHeader>
+          <StyledHeader>Business</StyledHeader>
         </HeaderContainer>
         <CategoryList data-testid="t--enterprise-settings-category-list">
           {features.RBAC && (

--- a/app/client/src/ce/pages/AdminSettings/LeftPane.tsx
+++ b/app/client/src/ce/pages/AdminSettings/LeftPane.tsx
@@ -143,7 +143,7 @@ export default function LeftPane() {
       </>
       <>
         <HeaderContainer>
-          <StyledHeader>Enterprise</StyledHeader>
+          <StyledHeader>Business Plan</StyledHeader>
         </HeaderContainer>
         <CategoryList data-testid="t--enterprise-settings-category-list">
           {features.RBAC && (

--- a/app/client/src/ce/pages/AdminSettings/config/authentication/AuthPage.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication/AuthPage.tsx
@@ -107,10 +107,10 @@ const StyledAuthButton = styled(Button)`
   padding: 8px 16px;
 `;
 
-const Label = styled.span<{ enterprise?: boolean }>`
+const Label = styled.span<{ business?: boolean }>`
   display: inline;
   ${(props) =>
-    props.enterprise
+    props.business
       ? `
     border: 1px solid ${Colors.COD_GRAY};
     color: ${Colors.COD_GRAY};
@@ -177,7 +177,7 @@ export function AuthPage({ authMethods }: { authMethods: AuthMethodType[] }) {
                     {method.label}&nbsp;
                     {method.needsUpgrade && (
                       <>
-                        <Label enterprise>Enterprise</Label>
+                        <Label business>Business</Label>
                         &nbsp;
                       </>
                     )}


### PR DESCRIPTION
## Description

> Updating the text from enterprise to business to maintain consistency

Fixes [#18788](https://github.com/appsmithorg/appsmith/issues/18788)

Media
<img width="766" alt="image" src="https://user-images.githubusercontent.com/28362912/206464564-a60e6006-162b-4060-9c77-bf9475a62137.png">


## Type of change

- Renaming


## How Has This Been Tested?
> Checked pages using Enterprise text are now showing Business text.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
