### PR TITLE
perf: Performance changes related to render and regenration

### DIFF
--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -6,7 +6,7 @@ GIT_SHA=$(eval git rev-parse HEAD)
 echo $GIT_SHA
 echo "Sentry Auth Token: $SENTRY_AUTH_TOKEN"
 
-REACT_APP_SENTRY_RELEASE=$GIT_SHA REACT_APP_CLIENT_LOG_LEVEL=ERROR EXTEND_ESLINT=true craco --max-old-space-size=4096 build --config craco.build.config.js --profile
+REACT_APP_SENTRY_RELEASE=$GIT_SHA REACT_APP_CLIENT_LOG_LEVEL=ERROR EXTEND_ESLINT=true craco --max-old-space-size=4096 build --config craco.build.config.js
 
-# rm ./build/static/js/*.js.map
+rm ./build/static/js/*.js.map
 echo "build finished"

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -6,7 +6,7 @@ GIT_SHA=$(eval git rev-parse HEAD)
 echo $GIT_SHA
 echo "Sentry Auth Token: $SENTRY_AUTH_TOKEN"
 
-REACT_APP_SENTRY_RELEASE=$GIT_SHA REACT_APP_CLIENT_LOG_LEVEL=ERROR EXTEND_ESLINT=true craco --max-old-space-size=4096 build --config craco.build.config.js
+REACT_APP_SENTRY_RELEASE=$GIT_SHA REACT_APP_CLIENT_LOG_LEVEL=ERROR EXTEND_ESLINT=true craco --max-old-space-size=4096 build --config craco.build.config.js --profile
 
-rm ./build/static/js/*.js.map
+# rm ./build/static/js/*.js.map
 echo "build finished"

--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useRef, useEffect, RefObject } from "react";
 import styled, { css } from "styled-components";
 import tinycolor from "tinycolor2";
+import fastdom from "fastdom";
 import { invisible } from "constants/DefaultTheme";
 import { Color } from "constants/Colors";
 import { generateClassName, getCanvasClassName } from "utils/generators";
@@ -60,13 +61,16 @@ function ContainerComponentWrapper(props: ContainerComponentProps) {
     if (!props.shouldScrollContents) {
       const supportsNativeSmoothScroll =
         "scrollBehavior" in document.documentElement.style;
-      if (supportsNativeSmoothScroll) {
-        containerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
-      } else {
-        if (containerRef.current) {
-          containerRef.current.scrollTop = 0;
+
+      fastdom.mutate(() => {
+        if (supportsNativeSmoothScroll) {
+          containerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+        } else {
+          if (containerRef.current) {
+            containerRef.current.scrollTop = 0;
+          }
         }
-      }
+      });
     }
   }, [props.shouldScrollContents]);
   return (

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -1018,7 +1018,7 @@ class MetaWidgetGenerator {
   private hasOptionsChanged = (nextOptions: GeneratorOptions) => {
     return (
       !equal(nextOptions.cacheIndexArr, this.cacheIndexArr) ||
-      nextOptions?.currTemplateWidgets !== this?.currTemplateWidgets ||
+      nextOptions?.currTemplateWidgets !== nextOptions?.prevTemplateWidgets ||
       nextOptions.data.length !== this.data.length ||
       nextOptions.infiniteScroll !== this.infiniteScroll ||
       nextOptions.itemGap !== this.itemGap ||

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -120,6 +120,7 @@ type AddDynamicPathsPropertiesOptions = {
 enum MODIFICATION_TYPE {
   UPDATE_CONTAINER = "UPDATE_CONTAINER",
   REGENERATE_META_WIDGETS = "REGENERATE_META_WIDGETS",
+  LEVEL_DATA_UPDATED = "LEVEL_DATA_UPDATED",
 }
 
 const ROOT_CONTAINER_PARENT_KEY = "__$ROOT_CONTAINER_PARENT$__";
@@ -938,6 +939,10 @@ class MetaWidgetGenerator {
     if (this.hasRegenerationOptionsChanged(nextOptions)) {
       this.modificationsQueue.add(MODIFICATION_TYPE.REGENERATE_META_WIDGETS);
     }
+
+    if (this.levelData !== nextOptions.levelData) {
+      this.modificationsQueue.add(MODIFICATION_TYPE.LEVEL_DATA_UPDATED);
+    }
   };
 
   private flushModificationQueue = () => {
@@ -988,6 +993,9 @@ class MetaWidgetGenerator {
     const containerUpdateRequired = this.modificationsQueue.has(
       MODIFICATION_TYPE.UPDATE_CONTAINER,
     );
+    const levelDataUpdated = this.modificationsQueue.has(
+      MODIFICATION_TYPE.LEVEL_DATA_UPDATED,
+    );
     const shouldMainContainerUpdate =
       templateWidgetsAddedOrRemoved || containerUpdateRequired;
 
@@ -1001,18 +1009,25 @@ class MetaWidgetGenerator {
      * or
      * if nested primary widget type (list widget) and templateWidgetsAddedOrRemoved
      * is true (levelData should be updated in this case).
+     * or
+     * if nested primary widget type (list widget) and levelData updated.
      */
 
     return (
       (isMainContainerWidget && shouldMainContainerUpdate) ||
       !isMetaWidgetPresentInCurrentView ||
       isTemplateWidgetChanged ||
-      (type === this.primaryWidgetType && templateWidgetsAddedOrRemoved)
+      (type === this.primaryWidgetType && templateWidgetsAddedOrRemoved) ||
+      (type === this.primaryWidgetType && levelDataUpdated)
     );
   };
 
   private hasRegenerationOptionsChanged = (nextOptions: GeneratorOptions) => {
     return (
+      nextOptions.containerParentId !== this.containerParentId ||
+      nextOptions.containerWidgetId !== this.containerWidgetId ||
+      nextOptions.widgetName !== this.widgetName ||
+      nextOptions.levelData !== this.levelData ||
       nextOptions?.currTemplateWidgets !== nextOptions?.prevTemplateWidgets ||
       nextOptions.data.length !== this.data.length ||
       nextOptions.infiniteScroll !== this.infiniteScroll ||


### PR DESCRIPTION
## Description

1. Container widget layout thrashing is avoided by using fastdom on direct DOM mutations in useEffect.
2. Avoid regeneration of widgets when none of the regeneration options are modified.
3. Memoize the renderChildren based on the change of `metaWidgetChildrenStructure`

Fixes #16786

Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change
- Performance

## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
