### PR TITLE
chore: Upgrade test MongoDB to v5

### DIFF
--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -18,7 +18,7 @@ appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:100}
 spring.data.mongodb.uri = ${APPSMITH_MONGODB_URI}
 
 # embedded mongo DB version which is used during junit tests
-spring.mongodb.embedded.version=4.2.13
+spring.mongodb.embedded.version=5.0.16
 
 # Log properties
 logging.level.root=info


### PR DESCRIPTION
This should upgrade the MongoDB we use for running server tests to v5.
