### PR TITLE
feat: override helm chart images for init containers

### DIFF
--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -46,12 +46,24 @@ spec:
       initContainers:
       {{- if .Values.redis.enabled }}
       - name: redis-init-container
-        image: {{ .Values.redis.initImages | default "alpine" }}
+      {{- if .Values.initContainer.redis }}
+      {{- if .Values.initContainer.redis.image }}
+        image: {{ .Values.initContainer.redis.image }}
+      {{- end }}
+      {{- else }}
+        image: "alpine"
+      {{- end }}
         command: ['sh', '-c', "apk add redis; until redis-cli -h {{ include "appsmith.fullname" . }}-redis-master.{{.Release.Namespace}}.svc.cluster.local ping; do echo waiting for redis; sleep 2; done"]
       {{- end }}
       {{- if .Values.mongodb.enabled }}
       - name: mongo-init-container
-        image: {{ .Values.mongodb.initImages | default "docker.io/bitnami/mongodb:4.4.11-debian-10-r12" }}
+      {{- if .Values.initContainer.mongodb }}
+      {{- if .Values.initContainer.mongodb.image }}
+        image: {{ .Values.initContainer.mongodb.image }}
+      {{- end }}
+      {{- else }}
+        image:  "docker.io/bitnami/mongodb:4.4.11-debian-10-r12"
+      {{- end }}
         command: ['sh', '-c', "until mongo --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
       {{- end }}
       containers:

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -46,12 +46,12 @@ spec:
       initContainers:
       {{- if .Values.redis.enabled }}
       - name: redis-init-container
-        image: alpine
+        image: {{ .Values.redis.images | default "alpine" }}
         command: ['sh', '-c', "apk add redis; until redis-cli -h {{ include "appsmith.fullname" . }}-redis-master.{{.Release.Namespace}}.svc.cluster.local ping; do echo waiting for redis; sleep 2; done"]
       {{- end }}
       {{- if .Values.mongodb.enabled }}
       - name: mongo-init-container
-        image: docker.io/bitnami/mongodb:4.4.11-debian-10-r12
+        image: {{ .Values.mongodb.images | default "docker.io/bitnami/mongodb:4.4.11-debian-10-r12" }}
         command: ['sh', '-c', "until mongo --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
       {{- end }}
       containers:

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -46,12 +46,12 @@ spec:
       initContainers:
       {{- if .Values.redis.enabled }}
       - name: redis-init-container
-        image: {{ .Values.redis.images | default "alpine" }}
+        image: {{ .Values.redis.initImages | default "alpine" }}
         command: ['sh', '-c', "apk add redis; until redis-cli -h {{ include "appsmith.fullname" . }}-redis-master.{{.Release.Namespace}}.svc.cluster.local ping; do echo waiting for redis; sleep 2; done"]
       {{- end }}
       {{- if .Values.mongodb.enabled }}
       - name: mongo-init-container
-        image: {{ .Values.mongodb.images | default "docker.io/bitnami/mongodb:4.4.11-debian-10-r12" }}
+        image: {{ .Values.mongodb.initImages | default "docker.io/bitnami/mongodb:4.4.11-debian-10-r12" }}
         command: ['sh', '-c', "until mongo --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
       {{- end }}
       containers:

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -46,10 +46,8 @@ spec:
       initContainers:
       {{- if .Values.redis.enabled }}
       - name: redis-init-container
-      {{- if .Values.initContainer.redis }}
-      {{- if .Values.initContainer.redis.image }}
+      {{- if ((.Values.initContainer.redis).image) }}
         image: {{ .Values.initContainer.redis.image }}
-      {{- end }}
       {{- else }}
         image: "alpine"
       {{- end }}
@@ -57,10 +55,8 @@ spec:
       {{- end }}
       {{- if .Values.mongodb.enabled }}
       - name: mongo-init-container
-      {{- if .Values.initContainer.mongodb }}
-      {{- if .Values.initContainer.mongodb.image }}
+      {{- if ((.Values.initContainer.mongodb).image) }}
         image: {{ .Values.initContainer.mongodb.image }}
-      {{- end }}
       {{- else }}
         image:  "docker.io/bitnami/mongodb:4.4.11-debian-10-r12"
       {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,7 @@
 ## Redis parameters
 redis:
   enabled: true
+  images: alpine
   auth:
     enabled: false
   replica:
@@ -8,11 +9,12 @@ redis:
 
 mongodb:
   enabled: true
+  images: docker.io/bitnami/mongodb:4.4.11-debian-10-r12
   service:
     nameOverride: appsmith-mongodb
   auth:
     rootUser: root
-    rootPassword : password
+    rootPassword: password
   replicaCount: 2
   architecture: "replicaset"
   replicaSetName: rs0

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,7 +1,6 @@
 ## Redis parameters
 redis:
   enabled: true
-  initImages: alpine
   auth:
     enabled: false
   replica:
@@ -9,7 +8,6 @@ redis:
 
 mongodb:
   enabled: true
-  initImages: docker.io/bitnami/mongodb:4.4.11-debian-10-r12
   service:
     nameOverride: appsmith-mongodb
   auth:
@@ -51,6 +49,14 @@ schedulerName: ""
 ## It can be set to RollingUpdate or Recreate by default.
 ##
 strategyType: RollingUpdate
+##
+## Init containers for redis & mongodb
+##
+initContainer: {}
+  # redis:
+  #   image: alpine
+  # mongodb:
+  #   image:  docker.io/bitnami/mongodb:4.4.11-debian-10-r12
 ## Image
 ##
 image:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,7 +1,7 @@
 ## Redis parameters
 redis:
   enabled: true
-  images: alpine
+  initImages: alpine
   auth:
     enabled: false
   replica:
@@ -9,7 +9,7 @@ redis:
 
 mongodb:
   enabled: true
-  images: docker.io/bitnami/mongodb:4.4.11-debian-10-r12
+  initImages: docker.io/bitnami/mongodb:4.4.11-debian-10-r12
   service:
     nameOverride: appsmith-mongodb
   auth:


### PR DESCRIPTION
## Description

Small enhancement to permit usage of different image registries

Fixes #18833 


## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- Manual


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
