### PR TITLE
fix: datasource active tab options menu is not permission driven

### DIFF
--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -344,63 +344,60 @@ function DatasourceCard(props: DatasourceCardProps) {
                 plugin={plugin}
               />
             )}
-            {canDeleteDatasource ||
-              (canEditDatasource && (
-                <MenuWrapper
-                  className="t--datasource-menu-option"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                >
-                  <MenuComponent
-                    menuItemWrapperWidth="160px"
-                    position={Position.BOTTOM_RIGHT}
-                    target={
-                      <MoreOptionsContainer>
-                        <Icon
-                          fillColor={
-                            datasource.isConfigured
-                              ? Colors.GREY_8
-                              : Colors.GRAY2
-                          }
-                          name="comment-context-menu"
-                          size={IconSize.XXXL}
-                        />
-                      </MoreOptionsContainer>
-                    }
-                  >
-                    {canEditDatasource && (
-                      <MenuItem
-                        className="t--datasource-option-edit"
-                        icon="edit"
-                        onSelect={editDatasource}
-                        text="Edit"
-                      />
-                    )}
-                    {canDeleteDatasource && (
-                      <RedMenuItem
-                        className="t--datasource-option-delete"
-                        icon="delete"
-                        isLoading={isDeletingDatasource}
-                        onSelect={() => {
-                          if (!isDeletingDatasource) {
-                            confirmDelete
-                              ? deleteAction()
-                              : setConfirmDelete(true);
-                          }
-                        }}
-                        text={
-                          isDeletingDatasource
-                            ? createMessage(CONFIRM_CONTEXT_DELETING)
-                            : confirmDelete
-                            ? createMessage(CONFIRM_CONTEXT_DELETE)
-                            : createMessage(CONTEXT_DELETE)
+            {(canDeleteDatasource || canEditDatasource) && (
+              <MenuWrapper
+                className="t--datasource-menu-option"
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
+              >
+                <MenuComponent
+                  menuItemWrapperWidth="160px"
+                  position={Position.BOTTOM_RIGHT}
+                  target={
+                    <MoreOptionsContainer>
+                      <Icon
+                        fillColor={
+                          datasource.isConfigured ? Colors.GREY_8 : Colors.GRAY2
                         }
+                        name="comment-context-menu"
+                        size={IconSize.XXXL}
                       />
-                    )}
-                  </MenuComponent>
-                </MenuWrapper>
-              ))}
+                    </MoreOptionsContainer>
+                  }
+                >
+                  {canEditDatasource && (
+                    <MenuItem
+                      className="t--datasource-option-edit"
+                      icon="edit"
+                      onSelect={editDatasource}
+                      text="Edit"
+                    />
+                  )}
+                  {canDeleteDatasource && (
+                    <RedMenuItem
+                      className="t--datasource-option-delete"
+                      icon="delete"
+                      isLoading={isDeletingDatasource}
+                      onSelect={() => {
+                        if (!isDeletingDatasource) {
+                          confirmDelete
+                            ? deleteAction()
+                            : setConfirmDelete(true);
+                        }
+                      }}
+                      text={
+                        isDeletingDatasource
+                          ? createMessage(CONFIRM_CONTEXT_DELETING)
+                          : confirmDelete
+                          ? createMessage(CONFIRM_CONTEXT_DELETE)
+                          : createMessage(CONTEXT_DELETE)
+                      }
+                    />
+                  )}
+                </MenuComponent>
+              </MenuWrapper>
+            )}
           </ButtonsWrapper>
         </DatasourceCardHeader>
       </DatasourceCardMainBody>

--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -44,7 +44,11 @@ import {
   getCurrentPageId,
   getPagePermissions,
 } from "selectors/editorSelectors";
-import { hasCreateDatasourceActionPermission } from "@appsmith/utils/permissionHelpers";
+import {
+  hasCreateDatasourceActionPermission,
+  hasDeleteDatasourcePermission,
+  hasManageDatasourcePermission,
+} from "@appsmith/utils/permissionHelpers";
 
 const Wrapper = styled.div`
   padding: 15px;
@@ -209,6 +213,14 @@ function DatasourceCard(props: DatasourceCardProps) {
     ...pagePermissions,
   ]);
 
+  const canEditDatasource = hasManageDatasourcePermission(
+    datasourcePermissions,
+  );
+
+  const canDeleteDatasource = hasDeleteDatasourcePermission(
+    datasourcePermissions,
+  );
+
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const isDeletingDatasource = !!datasource.isDeleting;
@@ -332,52 +344,63 @@ function DatasourceCard(props: DatasourceCardProps) {
                 plugin={plugin}
               />
             )}
-            <MenuWrapper
-              className="t--datasource-menu-option"
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-            >
-              <MenuComponent
-                menuItemWrapperWidth="160px"
-                position={Position.BOTTOM_RIGHT}
-                target={
-                  <MoreOptionsContainer>
-                    <Icon
-                      fillColor={
-                        datasource.isConfigured ? Colors.GREY_8 : Colors.GRAY2
-                      }
-                      name="comment-context-menu"
-                      size={IconSize.XXXL}
-                    />
-                  </MoreOptionsContainer>
-                }
-              >
-                <MenuItem
-                  className="t--datasource-option-edit"
-                  icon="edit"
-                  onSelect={editDatasource}
-                  text="Edit"
-                />
-                <RedMenuItem
-                  className="t--datasource-option-delete"
-                  icon="delete"
-                  isLoading={isDeletingDatasource}
-                  onSelect={() => {
-                    if (!isDeletingDatasource) {
-                      confirmDelete ? deleteAction() : setConfirmDelete(true);
-                    }
+            {canDeleteDatasource ||
+              (canEditDatasource && (
+                <MenuWrapper
+                  className="t--datasource-menu-option"
+                  onClick={(e) => {
+                    e.stopPropagation();
                   }}
-                  text={
-                    isDeletingDatasource
-                      ? createMessage(CONFIRM_CONTEXT_DELETING)
-                      : confirmDelete
-                      ? createMessage(CONFIRM_CONTEXT_DELETE)
-                      : createMessage(CONTEXT_DELETE)
-                  }
-                />
-              </MenuComponent>
-            </MenuWrapper>
+                >
+                  <MenuComponent
+                    menuItemWrapperWidth="160px"
+                    position={Position.BOTTOM_RIGHT}
+                    target={
+                      <MoreOptionsContainer>
+                        <Icon
+                          fillColor={
+                            datasource.isConfigured
+                              ? Colors.GREY_8
+                              : Colors.GRAY2
+                          }
+                          name="comment-context-menu"
+                          size={IconSize.XXXL}
+                        />
+                      </MoreOptionsContainer>
+                    }
+                  >
+                    {canEditDatasource && (
+                      <MenuItem
+                        className="t--datasource-option-edit"
+                        icon="edit"
+                        onSelect={editDatasource}
+                        text="Edit"
+                      />
+                    )}
+                    {canDeleteDatasource && (
+                      <RedMenuItem
+                        className="t--datasource-option-delete"
+                        icon="delete"
+                        isLoading={isDeletingDatasource}
+                        onSelect={() => {
+                          if (!isDeletingDatasource) {
+                            confirmDelete
+                              ? deleteAction()
+                              : setConfirmDelete(true);
+                          }
+                        }}
+                        text={
+                          isDeletingDatasource
+                            ? createMessage(CONFIRM_CONTEXT_DELETING)
+                            : confirmDelete
+                            ? createMessage(CONFIRM_CONTEXT_DELETE)
+                            : createMessage(CONTEXT_DELETE)
+                        }
+                      />
+                    )}
+                  </MenuComponent>
+                </MenuWrapper>
+              ))}
           </ButtonsWrapper>
         </DatasourceCardHeader>
       </DatasourceCardMainBody>


### PR DESCRIPTION
## Description

Hide CTAs of datasource in active datasource options menu when there are no permissions.


Fixes #18786 

Media
[Loom video](https://www.loom.com/share/610fceaacdac4994b026f7ab82792901)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
