### PR TITLE
ci: Add replicate set to the mongodb url for transaction PR

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -585,7 +585,7 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: app/server
         env:
-          APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
+          APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools?replicaSet=mobtools-test-cluster-shard-0"
           APPSMITH_REDIS_URL: "redis://127.0.0.1:6379"
           APPSMITH_ENCRYPTION_PASSWORD: "password"
           APPSMITH_ENCRYPTION_SALT: "salt"

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -131,7 +131,7 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: app/server
         env:
-          APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
+          APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools?replicaSet=mobtools-test-cluster-shard-0"
           APPSMITH_REDIS_URL: "redis://127.0.0.1:6379"
           APPSMITH_ENCRYPTION_PASSWORD: "password"
           APPSMITH_ENCRYPTION_SALT: "salt"

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -504,7 +504,7 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: app/server
         env:
-          APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools"
+          APPSMITH_MONGODB_URI: "mongodb://localhost:27017/mobtools?replicaSet=mobtools-test-cluster-shard-0"
           APPSMITH_REDIS_URL: "redis://127.0.0.1:6379"
           APPSMITH_ENCRYPTION_PASSWORD: "password"
           APPSMITH_ENCRYPTION_SALT: "salt"


### PR DESCRIPTION
This PR adds replicaSet to the mongodb url used in the CI. This is to support the mongoDB transaction PR - https://github.com/appsmithorg/appsmith/pull/14939