### PR TITLE
Fix potential race condition in sending email

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -559,8 +559,13 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
     public Mono<User> sendWelcomeEmail(User user, String originHeader) {
         Map<String, String> params = new HashMap<>();
         params.put("primaryLinkUrl", originHeader);
-        Mono<User> emailMono = emailSender
-                .sendMail(user.getEmail(), "Welcome to Appsmith", WELCOME_USER_EMAIL_TEMPLATE, params)
+
+        return updateTenantLogoInParams(params)
+                .flatMap(updatedParams -> emailSender.sendMail(
+                        user.getEmail(),
+                        "Welcome to Appsmith",
+                        WELCOME_USER_EMAIL_TEMPLATE,
+                        updatedParams))
                 .onErrorResume(error -> {
                     // Swallowing this exception because we don't want this to affect the rest of the flow.
                     log.error(
@@ -571,9 +576,6 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                     return Mono.just(TRUE);
                 })
                 .thenReturn(user);
-
-        return updateTenantLogoInParams(params)
-                .then(Mono.defer(() -> emailMono));
     }
 
     @Override


### PR DESCRIPTION
The call to `sendMail` is calling a reactor chain, that subscribes separately. This `sendMail` call is already finished, before the `updateTenantLogoInParams` function even starts running. The `defer` won't be able to protect here, unless we move the `emailMono` variable's value to be inside the `Mono.defer`.

This change is very similar to https://github.com/appsmithorg/appsmith-ee/pull/826.

