### PR TITLE
fix: modal widget close on new widget drop

### DIFF
--- a/app/client/src/sagas/WidgetSelectionSagas.ts
+++ b/app/client/src/sagas/WidgetSelectionSagas.ts
@@ -39,8 +39,8 @@ import { getCurrentPageId } from "selectors/editorSelectors";
 import { builderURL } from "RouteBuilder";
 import { CanvasWidgetsStructureReduxState } from "reducers/entityReducers/canvasWidgetsStructureReducer";
 import {
-  getAllWidgetsMap,
   getCanvasWidgetsWithParentId,
+  getParentModalId,
 } from "selectors/entitiesSelector";
 const WidgetTypes = WidgetFactory.widgetTypes;
 // The following is computed to be used in the entity explorer
@@ -413,16 +413,15 @@ function* openOrCloseModalSaga(
     yield put(showModal(action.payload.widgetId));
     return;
   }
-  const widgetMap: Record<string, FlattenedWidgetProps> = yield select(
-    getAllWidgetsMap,
-  );
 
+  const widgetMap: CanvasWidgetsReduxState = yield select(getWidgets);
   const widget = widgetMap[action.payload.widgetId];
 
   if (widget && widget.parentId) {
-    const widgetInModal = modalWidgetIds.includes(widget.parentModalId);
+    const parentModalId = getParentModalId(widget, widgetMap);
+    const widgetInModal = modalWidgetIds.includes(parentModalId);
     if (widgetInModal) {
-      yield put(showModal(widget.parentModalId));
+      yield put(showModal(parentModalId));
       return;
     }
   }

--- a/app/client/src/selectors/entitiesSelector.ts
+++ b/app/client/src/selectors/entitiesSelector.ts
@@ -480,7 +480,10 @@ export const getCurrentPageWidgets = createSelector(
     currentPageId ? widgetsByPage[currentPageId] : {},
 );
 
-const getParentModalId = (widget: any, pageWidgets: Record<string, any>) => {
+export const getParentModalId = (
+  widget: any,
+  pageWidgets: Record<string, any>,
+) => {
   let parentModalId;
   let { parentId } = widget;
   let parentWidget = pageWidgets[parentId];


### PR DESCRIPTION
## Description

Issue:
Modal widget was getting closed after dropping a new widget.

Problem:
After the merge of this feature #18326 in the `openOrCloseModalSaga` we were using `state.ui.pageWidgets` which is not giving us an updated map of the new widgets added to the Modal, hence it was not able to check whether that widget parent is a Modal Widget.

Solution:-
Replaced `state.ui.pageWidgets` map with `state.entities.canvasWidgets` in the `openOrCloseModalSaga` which gives us the information of the newly dropped widget and solve the isse.

Fixes #18952


Media


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
