### PR TITLE
ci: Make perf tests a blocking check

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -825,8 +825,18 @@ jobs:
       # Set status = success
       - run: echo "::set-output name=run_result::success" > ~/run_result
 
+  perf-test:
+    needs: [client-build, server-build, rts-build]
+    # Only run if the build step is successful
+    if: success()
+    name: perf-test
+    uses: ./.github/workflows/perf-test.yml
+    secrets: inherit
+    with:
+      pr: ${{ github.event.client_payload.pull_request.number }}
+
   ui-test-result:
-    needs: [ui-test, fat-container-test]
+    needs: [ui-test, fat-container-test, perf-test]
     # Only run if the ui-test with matrices step is successful
     if: always()
     runs-on: ubuntu-latest
@@ -975,7 +985,7 @@ jobs:
         run: echo "$PAYLOAD_CONTEXT"
 
       - name: Check ui-test set status
-        if: needs.ui-test.result != 'success' || needs.fat-container-test.result != 'success'
+        if: needs.ui-test.result != 'success' || needs.fat-container-test.result != 'success' || needs.perf-test.result != 'success'
         run: exit 1
 
   package:
@@ -1046,12 +1056,3 @@ jobs:
 
             return result;
             }
-  perf-test:
-    needs: [client-build, server-build, rts-build]
-    # Only run if the build step is successful
-    if: success()
-    name: perf-test
-    uses: ./.github/workflows/perf-test.yml
-    secrets: inherit
-    with:
-      pr: ${{ github.event.client_payload.pull_request.number }}


### PR DESCRIPTION
Makes perf tests a blocking check and doesn't let the PR get merged until the perf tests have passed.