### PR TITLE
ci: Moving the runners to use Github large runners instead of Buildjet

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -23,7 +23,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-latest-8-cores
     # Only run this workflow for internally triggered events
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||
@@ -55,8 +55,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
-      # Create a run record exactly at the time of merge to release to  
+
+      # Create a run record exactly at the time of merge to release to
       # ensure we compare run details with code at this point
       - name: Create Perf Meta
         continue-on-error: true
@@ -65,7 +65,6 @@ jobs:
           -U aforce_admin -d perf-infra -c \
           "INSERT INTO public.run_meta (repo, gh_run_id, gh_run_attempt, is_active) 
           VALUES ('${{github.repository}}', '${{github.run_id}}', '${{github.run_attempt}}', FALSE)"
-
 
       - name: Figure out the PR number
         run: echo ${{ inputs.pr }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -44,7 +44,7 @@ jobs:
     needs:
       - prelude
 
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-latest-8-cores
 
     defaults:
       run:

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -23,7 +23,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-latest-8-cores
     # Only run this workflow for internally triggered events
     if: |
       github.event.pull_request.head.repo.full_name == github.repository ||

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -23,7 +23,7 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-latest-8-cores
     defaults:
       run:
         working-directory: app/client
@@ -172,7 +172,7 @@ jobs:
     defaults:
       run:
         working-directory: app/server
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     # Only run this workflow for internally triggered events
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -1483,7 +1483,7 @@ jobs:
         with:
           name: failed-spec
           path: ~/failed_spec
-      
+
       # Download failed_spec_fat list for all fat container jobs
       - uses: actions/download-artifact@v2
         if: needs.fat-container-test.result
@@ -1496,7 +1496,7 @@ jobs:
       - name: "combine all specs"
         if: needs.ui-test.result != 'success'
         run: cat ~/failed_spec/failed_spec* >> ~/combined_failed_spec
-      
+
       # Incase for any fat-container job failure, create combined failed spec
       - name: "combine all specs for fat"
         if: needs.fat-container-test.result != 'success'
@@ -1532,7 +1532,7 @@ jobs:
         with:
           name: combined_failed_spec
           path: ~/combined_failed_spec
-      
+
       # Upload combined failed fat spec list to a file
       # This is done for debugging.
       - name: upload combined failed spec


### PR DESCRIPTION
This PR moves the Github runners from Buildjet to Github large runners because of concurrency concerns.