### PR TITLE
fix: Fix api url binding params

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug16683_Spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/BugTests/Bug16683_Spec.ts
@@ -1,0 +1,21 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+import {
+  ERROR_ACTION_EXECUTE_FAIL,
+  createMessage,
+} from "../../../../support/Objects/CommonErrorMessages";
+
+const locator = ObjectsRegistry.CommonLocators,
+  apiPage = ObjectsRegistry.ApiPage,
+  agHelper = ObjectsRegistry.AggregateHelper;
+
+describe("Binding Expressions should not be truncated in Url Query Param", function() {
+  it("Bug 16683, When Api url has dynamic binding expressions, ensures the query params is not truncated", function() {
+    const apiUrl = `https://echo.hoppscotch.io/v6/deployments?limit=4{{Math.random() > 0.5 ? '&param1=5' : '&param2=6'}}`;
+
+    apiPage.CreateAndFillApi(apiUrl, "BindingExpressions");
+    apiPage.ValidateQueryParams({
+      key: "limit",
+      value: "4{{Math.random() > 0.5 ? '&param1=5' : '&param2=6'}}",
+    });
+  });
+});

--- a/app/client/cypress/support/Pages/ApiPage.ts
+++ b/app/client/cypress/support/Pages/ApiPage.ts
@@ -195,9 +195,8 @@ export class ApiPage {
 
   ToggleOnPageLoadRun(enable = true || false) {
     this.SelectPaneTab("Settings");
-    if (enable)
-      this.agHelper.CheckUncheck(this._onPageLoad, true);
-      else this.agHelper.CheckUncheck(this._onPageLoad, false);
+    if (enable) this.agHelper.CheckUncheck(this._onPageLoad, true);
+    else this.agHelper.CheckUncheck(this._onPageLoad, false);
   }
 
   ToggleConfirmBeforeRunningApi(enable = true || false) {

--- a/app/client/src/utils/ApiPaneUtils.tsx
+++ b/app/client/src/utils/ApiPaneUtils.tsx
@@ -1,4 +1,8 @@
 import { CONTENT_TYPE_HEADER_KEY } from "constants/ApiEditorConstants/CommonApiConstants";
+import {
+  getDynamicStringSegments,
+  isDynamicValue,
+} from "./DynamicBindingUtils";
 
 /**
  * This function updates the header at a given index.
@@ -25,19 +29,47 @@ export const queryParamsRegEx = /([\s\S]*?)(\?(?![^{]*})[\s\S]*)?$/;
 export function parseUrlForQueryParams(url: string) {
   const padQueryParams = { key: "", value: "" };
   let params = Array(2).fill(padQueryParams);
+  const dynamicValuesDetected: string[] = [];
   const matchGroup = url.match(queryParamsRegEx) || [];
   const parsedUrlWithQueryParams = matchGroup[2] || "";
+
+  const dynamicStringSegments = getDynamicStringSegments(
+    parsedUrlWithQueryParams,
+  );
+
+  const templateStringSegments = dynamicStringSegments.map((segment) => {
+    if (isDynamicValue(segment)) {
+      dynamicValuesDetected.push(segment);
+      return "~";
+    }
+    return segment;
+  });
+
   if (parsedUrlWithQueryParams.indexOf("?") > -1) {
-    const paramsString = parsedUrlWithQueryParams.slice(
-      parsedUrlWithQueryParams.indexOf("?") + 1,
-    );
-    params = paramsString.split("&").map((p) => {
+    const paramsString = templateStringSegments
+      .join("")
+      .slice(parsedUrlWithQueryParams.indexOf("?") + 1);
+
+    const paramsWithDynamicValues = paramsString.split("&").map((p) => {
       const firstEqualPos = p.indexOf("=");
       const keyValue =
         firstEqualPos > -1
           ? [p.substring(0, firstEqualPos), p.substring(firstEqualPos + 1)]
           : [];
       return { key: keyValue[0] || "", value: keyValue[1] || "" };
+    });
+
+    params = paramsWithDynamicValues.map((queryParam, index) => {
+      if (queryParam.value.includes("~")) {
+        const newVal = queryParam?.value?.replace(
+          /~/,
+          dynamicValuesDetected[index],
+        );
+
+        return { key: queryParam.key, value: newVal };
+      }
+
+      return queryParam;
     });
   }
   return params;

--- a/app/client/src/utils/ApiPaneUtils.tsx
+++ b/app/client/src/utils/ApiPaneUtils.tsx
@@ -59,13 +59,15 @@ export function parseUrlForQueryParams(url: string) {
       return { key: keyValue[0] || "", value: keyValue[1] || "" };
     });
 
-    params = paramsWithDynamicValues.map((queryParam, index) => {
+    params = paramsWithDynamicValues.map((queryParam) => {
       if (queryParam.value.includes("~")) {
         const newVal = queryParam?.value?.replace(
           /~/,
-          dynamicValuesDetected[index],
+          dynamicValuesDetected[0],
         );
 
+        // remove the first index from detected dynamic values.
+        dynamicValuesDetected.shift();
         return { key: queryParam.key, value: newVal };
       }
 


### PR DESCRIPTION
This PR fixes API query params from being truncated when a dynamic binding expression is added to the API Url.

Fixes #16683 

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
