### PR TITLE
chore: restrict when /usage-pulse can be fired

### DIFF
--- a/app/client/public/logger.js
+++ b/app/client/public/logger.js
@@ -15,22 +15,31 @@ function getCurrentUTCHourTimestamp() {
 
 const PULSE_API_ENDPOINT = "/api/v1/usage-pulse";
 
-// Use standard fetch to POST (fire and forget)
+/**
+ * Sends HTTP pulse to the server, when beaconAPI is not available.
+ * Fire and forget.
+ */
 function sendHTTPPulse() {
   fetch(PULSE_API_ENDPOINT, {
     method: "POST",
     credentials: "same-origin",
-  });
+  })
+    .then(() => {
+      // Fire and forget
+    })
+    .catch(() => {
+      // Ignore errors; fire and forget
+    });
 }
 
-// Use the Beacon API to POST (fire and forget)
+/**
+ * Sends a usage-pulse to the server using the Beacon API.
+ * If the Beacon API is not available, falls back to a standard fetch.
+ * Note: Only sends pulse when user is on "/app/" pages: editor and viewer.
+ */
 function sendPulse() {
-  const url = PULSE_API_ENDPOINT;
-
-  // In case the beacon fails to queue, use HTTPRequest
-  // TODO(abhinav): What about when the request itself fails?
-  if (!navigator.sendBeacon(url)) {
-    sendHTTPPulse();
+  if (window.location.href.includes("/app/")) {
+    navigator.sendBeacon(PULSE_API_ENDPOINT, "") || sendHTTPPulse();
   }
 }
 


### PR DESCRIPTION
## Description

Restricts /usage-pulse call only to urls containing "/app/". 

`sendPulse` fires a call to /usage-pulse endpoint in the server. Tracking metions of sendPulse:

1. [client/public/logger.js#L84 DOMContentLoaded](https://github.com/appsmithorg/appsmith/blob/release/app/client/public/logger.js#L84)
2. [client/public/logger.js#L44 pointerDown](https://github.com/appsmithorg/appsmith/blob/release/app/client/public/logger.js#L44)
3. Here we remove the event listener added on the line 44 (above). [client/public/logger.js#L47](https://github.com/appsmithorg/appsmith/blob/release/app/client/public/logger.js#L47)

First two result in calling `punchIn`, which calls `sendPulse` [here](https://github.com/appsmithorg/appsmith/blob/release/app/client/public/logger.js#L80)

It is defined [here](https://github.com/appsmithorg/appsmith/blob/release/app/client/public/logger.js#L27-L35)

sendPulse internally calls `sendHTTPPulse` [here](https://github.com/appsmithorg/appsmith/blob/release/app/client/public/logger.js#L27-L35)

It is just a POST `fetch` request.

Problematic /usage-pulse

1. login page
2. signup page
3. applications page

Instead of a blocklist, I am going with an allowlist that contains only one input: `/app/` in url.

Fixes #19025 

## Type of change

- Chore

## How Has This Been Tested?

- Manually

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
