### PR TITLE
feat: appsmithctl version and mongo-eval utils

### DIFF
--- a/deploy/docker/utils/bin/backup.js
+++ b/deploy/docker/utils/bin/backup.js
@@ -83,7 +83,7 @@ async function createGitStorageArchive(destFolder) {
 }
 
 async function createManifestFile(path) {
-  const version = await getCurrentVersion()
+  const version = await utils.getCurrentAppsmithVersion()
   const manifest_data = { "appsmithVersion": version }
   await fsPromises.writeFile(path + '/manifest.json', JSON.stringify(manifest_data));
 }
@@ -183,10 +183,7 @@ function checkAvailableBackupSpace(availSpaceInBytes) {
   }
 }
 
-async function getCurrentVersion() {
-  const content = await fsPromises.readFile('/opt/appsmith/rts/version.js', { encoding: 'utf8' });
-  return content.match(/\bexports\.VERSION\s*=\s*["']([^"]+)["']/)[1];
-}
+
 
 module.exports = {
   run,
@@ -198,7 +195,6 @@ module.exports = {
   executeMongoDumpCMD,
   getGitRoot,
   executeCopyCMD,
-  getCurrentVersion,
   removeEncryptionEnvData,
   getBackupArchiveLimit,
   removeOldBackups

--- a/deploy/docker/utils/bin/backup.test.js
+++ b/deploy/docker/utils/bin/backup.test.js
@@ -83,7 +83,7 @@ it('Checks for the current Appsmith Version.', async () => {
   `Object.defineProperty(exports, "__esModule", { value: true });
   exports.VERSION = void 0;
   exports.VERSION = "v0.0.0-SNAPSHOT";`);
-  const res = await backup.getCurrentVersion()
+  const res = await utils.getCurrentAppsmithVersion()
   expect(res).toBe("v0.0.0-SNAPSHOT")
   console.log(res)
 })

--- a/deploy/docker/utils/bin/index.js
+++ b/deploy/docker/utils/bin/index.js
@@ -7,6 +7,8 @@ const import_db = require("./import_db.js");
 const migrate = require("./migrate.js");
 const check_replica_set = require("./check_replica_set.js");
 const estimate_billing = require("./estimate_billing.js");
+const version = require("./version.js");
+const mongo_shell_utils = require("./mongo_shell_utils.js");
 
 const APPLICATION_CONFIG_PATH = "/appsmith-stacks/configuration/docker.env";
 
@@ -50,6 +52,14 @@ if (["backup", "restore"].includes(command)) {
 
 if (["estimate-billing", "estimate_billing"].includes(command)) {
   estimate_billing.run(process.argv.slice(3));
+  return;
+}
+if (["appsmith-version", "appsmith_version", "version"].includes(command)) {
+  version.exec();
+  return;
+}
+if (["mongo-eval", "mongo_eval", "mongoEval"].includes(command)) {
+  mongo_shell_utils.exec(process.argv.slice(3));
   return;
 }
 

--- a/deploy/docker/utils/bin/mongo_shell_utils.js
+++ b/deploy/docker/utils/bin/mongo_shell_utils.js
@@ -20,7 +20,7 @@ async function execMongoEval(queryExpression, appsmithMongoURI) {
   if (command_args.includes('--pretty')) {
     queryExpression += '.pretty()';
   }
-  return await utils.execCommand(['mongo', `${appsmithMongoURI}`, `--eval=${queryExpression}`]);
+  return await utils.execCommand(['mongo', appsmithMongoURI, `--eval=${queryExpression}`]);
 }
 
 module.exports = {

--- a/deploy/docker/utils/bin/mongo_shell_utils.js
+++ b/deploy/docker/utils/bin/mongo_shell_utils.js
@@ -18,7 +18,7 @@ async function exec() {
 async function execMongoEval(queryExpression, appsmithMongoURI) {
   queryExpression = queryExpression.trim();
   if (command_args.includes('--pretty')) {
-    queryExpression = queryExpression + '.pretty()';
+    queryExpression += '.pretty()';
   }
   return await utils.execCommand(['mongo', `${appsmithMongoURI}`, `--eval=${queryExpression}`]);
 }

--- a/deploy/docker/utils/bin/mongo_shell_utils.js
+++ b/deploy/docker/utils/bin/mongo_shell_utils.js
@@ -1,0 +1,28 @@
+
+const utils = require('./utils');
+
+const command_args = process.argv.slice(3);
+
+async function exec() {
+  let errorCode = 0;
+  try {
+    await execMongoEval(command_args[0], process.env.APPSMITH_MONGODB_URI);
+  } catch (err) {
+    errorCode = 1;
+    console.error('Error evaluating the mongo query', err);
+  } finally {
+    process.exit(errorCode);
+  }
+}
+
+async function execMongoEval(queryExpression, appsmithMongoURI) {
+  queryExpression = queryExpression.trim();
+  if (command_args.includes('--pretty')) {
+    queryExpression = queryExpression + '.pretty()';
+  }
+  return await utils.execCommand(['mongo', `${appsmithMongoURI}`, `--eval=${queryExpression}`]);
+}
+
+module.exports = {
+  exec
+};

--- a/deploy/docker/utils/bin/utils.js
+++ b/deploy/docker/utils/bin/utils.js
@@ -58,7 +58,7 @@ function execCommand(cmd, options) {
         return;
       }
       isPromiseDone = true;
-      log.error("Error running command", err);
+      console.error("Error running command", err);
       reject();
     });
   });

--- a/deploy/docker/utils/bin/utils.js
+++ b/deploy/docker/utils/bin/utils.js
@@ -97,6 +97,11 @@ async function getLastBackupErrorMailSentInMilliSec() {
   }
 }
 
+async function getCurrentAppsmithVersion() {
+  const content = await fsPromises.readFile('/opt/appsmith/rts/version.js', { encoding: 'utf8' });
+  return content.match(/\bexports\.VERSION\s*=\s*["']([^"]+)["']/)[1];
+}
+
 module.exports = {
   showHelp,
   start,
@@ -105,4 +110,5 @@ module.exports = {
   listLocalBackupFiles,
   updateLastBackupErrorMailSentInMilliSec,
   getLastBackupErrorMailSentInMilliSec,
+  getCurrentAppsmithVersion
 };

--- a/deploy/docker/utils/bin/version.js
+++ b/deploy/docker/utils/bin/version.js
@@ -1,9 +1,9 @@
-const bk = require('./backup');
+const utils = require('./utils');
 
 async function exec() {
   let version = null;
   try {
-    version = await bk.getCurrentVersion();
+    version = await utils.getCurrentAppsmithVersion();
   } catch (err) {
     console.error("Error fetching current Appsmith version", err);
     process.exit(1);

--- a/deploy/docker/utils/bin/version.js
+++ b/deploy/docker/utils/bin/version.js
@@ -1,0 +1,22 @@
+const bk = require('./backup');
+
+async function exec() {
+  let version = null;
+  try {
+    version = await bk.getCurrentVersion();
+  } catch (err) {
+    console.error("Error fetching current Appsmith version", err);
+    process.exit(1);
+  }
+  if (version) {
+    console.log(version);
+  }
+  else {
+    console.log("Error: could not find the current Appsmith version")
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  exec,
+};

--- a/deploy/docker/utils/bin/version.js
+++ b/deploy/docker/utils/bin/version.js
@@ -12,7 +12,7 @@ async function exec() {
     console.log(version);
   }
   else {
-    console.log("Error: could not find the current Appsmith version")
+    console.error("Error: could not find the current Appsmith version")
     process.exit(1);
   }
 }


### PR DESCRIPTION
`appsmithctl version` - Util to display current Appsmith version
`appsmithctl mongo-eval '<mongo query>'  [--pretty]` - Util to run mongo queries