### PR TITLE
ci: flaky test validCloneApplicationWhenCancelledMidWay

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ApplicationServiceTest.java
@@ -2659,7 +2659,7 @@ public class ApplicationServiceTest {
 
         // Trigger the clone of application now.
         applicationPageService.cloneApplication(originalApplication.getId(), null)
-                .timeout(Duration.ofMillis(10))
+                .timeout(Duration.ofMillis(50))
                 .subscribe();
 
         // Wait for cloning to complete


### PR DESCRIPTION
## Description

> The `validCloneApplicationWhenCancelledMidWay` became flaky during the code changes due to https://github.com/appsmithorg/appsmith-ee/pull/843 so increasing the timeout in the test case for canceling midway.

Fixes # (issue)
> if no issue exists, please create an issue and ask the maintainers about this first


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Test case change for flaky tests.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
