### PR TITLE
fix: Updates for DS components to consume branding colors

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -46,7 +46,7 @@
     "cypress-log-to-output": "^1.1.2",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",
-    "design-system": "npm:@appsmithorg/design-system@1.0.39",
+    "design-system": "npm:@appsmithorg/design-system@0.0.0-alpha-20221221085108",
     "downloadjs": "^1.4.7",
     "draft-js": "^0.11.7",
     "exceljs-lightweight": "^1.14.0",

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -6197,10 +6197,10 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
 
-"design-system@npm:@appsmithorg/design-system@1.0.39":
-  version "1.0.39"
-  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system/-/design-system-1.0.39.tgz#8f735ddca6768d647bb6187c8754e07b98a56f1b"
-  integrity sha512-ronzjAJyR1nc0Amya1jD1vsyrWKf+iSgOSg9mfRLfWBO52gn6fOStEAs9h+7FS8qvlXnww1MDGWfeK69pIXYRQ==
+"design-system@npm:@appsmithorg/design-system@0.0.0-alpha-20221221085108":
+  version "0.0.0-alpha-20221221085108"
+  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system/-/design-system-0.0.0-alpha-20221221085108.tgz#a78347880190743b28c76f580c64a8a3cb2bc754"
+  integrity sha512-ZeT32/EQ42bGvX+134gx7qGmlhsOkEatc6/X2940EOASyBMrP4k3TEeoU2ojMTshmUHcuBo/pAyjZ9N+Z18Pbw==
   dependencies:
     emoji-mart "3.0.1"
 


### PR DESCRIPTION
## Description

As part of rebranding, button component from DS was modified to use the branding color but other components was not using branding colors. This PR contains changes for all components that uses brand color to consume rebranding colors as well. Below are the components which got updated.

- Checkbox
- Date Range Picker
- Dropdown - multiselect
- Tabs
- Rectangular switch
- Showcase carousal
- Statusbar
- Toggle
- Toast undo redo

Fixes #19093


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
