### PR TITLE
fix: Updating UI for icons and import modal content height

### DIFF
--- a/app/client/src/pages/Editor/DataSourceEditor/JSONtoForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/JSONtoForm.tsx
@@ -21,6 +21,8 @@ export const PluginImageWrapper = styled.div`
   justify-content: center;
   background: ${Colors.GREY_200};
   border-radius: 100%;
+  margin-right: 8px;
+  flex-shrink: 0;
   img {
     height: 100%;
     width: auto;

--- a/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
@@ -99,7 +99,7 @@ const TabsContainer = styled.div`
 `;
 
 const ContentWrapper = styled.div`
-  height: calc(100% - 76px);
+  height: calc(100% - 96px);
   display: flex;
   margin-left: -${(props) => props.theme.spaces[8]}px;
 


### PR DESCRIPTION
## Description

> Updating UI for icons and import modal content height

Fixes #19111 #19112 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Checked the UI locally and looks fine now - icons + scrollable height of the import modal content. 

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
