### PR TITLE
fix: send analytics event for role assigned instead of user invited

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserAndAccessManagementServiceCEImpl.java
@@ -153,21 +153,7 @@ public class UserAndAccessManagementServiceCEImpl implements UserAndAccessManage
                     return permissionGroupService.bulkAssignToUsers(permissionGroup, users);
                 }).cache();
 
-        // Send analytics event
-        Mono<Object> sendAnalyticsEventMono = Mono.zip(currentUserMono, inviteUsersMono)
-                .flatMap(tuple -> {
-                    User currentUser = tuple.getT1();
-                    List<User> users = tuple.getT2();
-                    Map<String, Object> analyticsProperties = new HashMap<>();
-                    long numberOfUsers = users.size();
-                    List<String> invitedUsers = users.stream().map(User::getEmail).collect(Collectors.toList());
-                    analyticsProperties.put("numberOfUsersInvited", numberOfUsers);
-                    analyticsProperties.put("userEmails", invitedUsers);
-                    analyticsProperties.put(FieldName.EVENT_DATA, eventData);
-                    return analyticsService.sendObjectEvent(AnalyticsEvents.EXECUTE_INVITE_USERS, currentUser, analyticsProperties);
-                });
-
-        return bulkAddUserResultMono.then(sendAnalyticsEventMono).then(inviteUsersMono);
+        return bulkAddUserResultMono.then(inviteUsersMono);
     }
 
 }


### PR DESCRIPTION
## Description

> Currently we are sending the `user.invite` event when a user in added to a Workspace.
> From now on, we want to send `role.assigned_users` event for specific Role to which the user has been assigned.

Fixes https://github.com/appsmithorg/appsmith/issues/19167


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
> Test for the same needs to be written in the Business Edition.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
