### PR TITLE
fix: Adding a check for execute permission to display the line gutter on the JS Object editor

### DIFF
--- a/app/client/src/pages/Editor/JSEditor/Form.tsx
+++ b/app/client/src/pages/Editor/JSEditor/Form.tsx
@@ -112,6 +112,16 @@ function JSEditorForm({ jsCollection: currentJSCollection }: Props) {
     ),
   );
 
+  const isChangePermitted = hasManageActionPermission(
+    currentJSCollection?.userPermissions || [],
+  );
+  const isExecutePermitted = hasExecuteActionPermission(
+    currentJSCollection?.userPermissions || [],
+  );
+  const isDeletePermitted = hasDeleteActionPermission(
+    currentJSCollection?.userPermissions || [],
+  );
+
   // Triggered when there is a change in the code editor
   const handleEditorChange = (valueOrEvent: ChangeEvent<any> | string) => {
     const value: string =
@@ -162,8 +172,9 @@ function JSEditorForm({ jsCollection: currentJSCollection }: Props) {
         executeJSAction,
         !parseErrors.length,
         handleActiveActionChange,
+        isExecutePermitted,
       ),
-    [jsActions, parseErrors, handleActiveActionChange],
+    [jsActions, parseErrors, handleActiveActionChange, isExecutePermitted],
   );
 
   const handleJSActionOptionSelection: DropdownOnSelect = (
@@ -219,16 +230,6 @@ function JSEditorForm({ jsCollection: currentJSCollection }: Props) {
     }
     return [];
   }, [selectedJSActionOption.label, currentJSCollection.name]);
-
-  const isChangePermitted = hasManageActionPermission(
-    currentJSCollection?.userPermissions || [],
-  );
-  const isExecutePermitted = hasExecuteActionPermission(
-    currentJSCollection?.userPermissions || [],
-  );
-  const isDeletePermitted = hasDeleteActionPermission(
-    currentJSCollection?.userPermissions || [],
-  );
 
   const selectedConfigTab = useSelector(getJSPaneConfigSelectedTabIndex);
 

--- a/app/client/src/pages/Editor/JSEditor/utils.ts
+++ b/app/client/src/pages/Editor/JSEditor/utils.ts
@@ -105,6 +105,7 @@ export const getJSFunctionLineGutter = (
   runFuction: (jsAction: JSAction, from: EventLocation) => void,
   showGutters: boolean,
   onFocusAction: (jsAction: JSAction) => void,
+  isExecutePermitted: boolean,
 ): CodeEditorGutter => {
   const gutter: CodeEditorGutter = {
     getGutterConfig: null,
@@ -116,7 +117,7 @@ export const getJSFunctionLineGutter = (
     getGutterConfig: (code: string, lineNumber: number) => {
       const config = getJSFunctionStartLineFromCode(code, lineNumber);
       const action = find(jsActions, ["name", config?.actionName]);
-      return config && action
+      return config && action && isExecutePermitted
         ? {
             line: config.line,
             element: createGutterMarker(() =>


### PR DESCRIPTION
## Description

> Adding a check for execute permission to display the line gutter on the JS Object editor

Fixes [#19183](https://github.com/appsmithorg/appsmith/issues/19183)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> This works as expected now and the line gutter icon is now seen only if you have execute access on the JS Object editor.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
