### PR TITLE
fix: Logout user, if session deserialization fails

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.boot.web.reactive.error.ErrorAttributes;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -31,6 +32,10 @@ import static org.springframework.web.reactive.function.server.RouterFunctions.r
 @Component
 @Order(-2)
 public class AppSmithErrorWebExceptionHandler extends DefaultErrorWebExceptionHandler {
+
+    public static final String DESERIALIZATION_ERROR_MESSAGE =
+            "Failed to deserialize payload. Is the byte array a result of corresponding serialization for DefaultDeserializer";
+
     @Autowired
     public AppSmithErrorWebExceptionHandler(ErrorAttributes errorAttributes, WebProperties webProperties,
                                             ServerProperties serverProperties, ApplicationContext applicationContext,
@@ -52,9 +57,22 @@ public class AppSmithErrorWebExceptionHandler extends DefaultErrorWebExceptionHa
         Map<String, Object> error = getErrorAttributes(request, ErrorAttributeOptions.of(ErrorAttributeOptions.Include.STACK_TRACE));
         int errorCode = getHttpStatus(error);
 
-        return ServerResponse.status(errorCode).
-                contentType(MediaType.APPLICATION_JSON).
-                body(BodyInserters.
-                        fromValue(new ResponseDTO<>(errorCode, new ErrorDTO(errorCode, String.valueOf(error.get("error"))))));
+        ServerResponse.BodyBuilder responseBuilder = ServerResponse.status(errorCode)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        if (errorCode == 500 && String.valueOf(error.get("trace")).contains(DESERIALIZATION_ERROR_MESSAGE)) {
+            responseBuilder = responseBuilder.cookie(
+                    ResponseCookie.from("SESSION", "")
+                            .httpOnly(true)
+                            .path("/")
+                            .maxAge(0)
+                            .build()
+            );
+        }
+
+        return responseBuilder.body(
+                BodyInserters
+                        .fromValue(new ResponseDTO<>(errorCode, new ErrorDTO(errorCode, String.valueOf(error.get("error")))))
+        );
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppSmithErrorWebExceptionHandler.java
@@ -61,6 +61,9 @@ public class AppSmithErrorWebExceptionHandler extends DefaultErrorWebExceptionHa
                 .contentType(MediaType.APPLICATION_JSON);
 
         if (errorCode == 500 && String.valueOf(error.get("trace")).contains(DESERIALIZATION_ERROR_MESSAGE)) {
+            // If the error is regarding a deserialization error in the session data, then the user is essentially locked out.
+            // They have to use a different browser, or Incognito, or clear their cookies to get back in. So, we'll delete
+            // the SESSION cookie here, so that the user gets sent back to the Login page, and they can unblock themselves.
             responseBuilder = responseBuilder.cookie(
                     ResponseCookie.from("SESSION", "")
                             .httpOnly(true)


### PR DESCRIPTION
We handle this in the global error handler, looking for the error message that indicates this cause, and include a cookie deletion header, so the user can recover by logging in again.
