### PR TITLE
chore: Add dependency to start backend only if rts is ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,9 @@ COPY ./deploy/docker/templates/nginx/* \
   templates/
 
 # Add bootstrapfile
-COPY ./deploy/docker/entrypoint.sh ./deploy/docker/scripts/* ./
+COPY ./deploy/docker/entrypoint.sh ./deploy/docker/scripts/* ./scripts/start-backend.sh ./
 
-# Add uitl tools
+# Add util tools
 COPY ./deploy/docker/utils ./utils
 RUN cd ./utils && npm install && npm install -g .
 
@@ -81,7 +81,7 @@ COPY ./deploy/docker/templates/supervisord/ templates/supervisord/
 COPY ./deploy/docker/templates/cron.d /etc/cron.d/
 RUN chmod 0644 /etc/cron.d/*
 
-RUN chmod +x entrypoint.sh renew-certificate.sh healthcheck.sh
+RUN chmod +x entrypoint.sh renew-certificate.sh healthcheck.sh start-backend.sh
 
 # Disable setuid/setgid bits for the files inside container.
 RUN find / \( -path /proc -prune \) -o \( \( -perm -2000 -o -perm -4000 \) -print -exec chmod -s '{}' + \) || true

--- a/deploy/docker/templates/supervisord/application_process/backend.conf
+++ b/deploy/docker/templates/supervisord/application_process/backend.conf
@@ -1,7 +1,7 @@
 [program:backend]
 directory=/opt/appsmith/backend
-command=/opt/appsmith/run-with-env.sh /opt/appsmith/run-java.sh
-priority=15
+command=/opt/appsmith/start_backend.sh
+priority=20
 autostart=true
 autorestart=true
 startsecs=10

--- a/deploy/docker/templates/supervisord/application_process/backend.conf
+++ b/deploy/docker/templates/supervisord/application_process/backend.conf
@@ -1,6 +1,6 @@
 [program:backend]
 directory=/opt/appsmith/backend
-command=/opt/appsmith/start_backend.sh
+command=/opt/appsmith/start-backend.sh
 priority=20
 autostart=true
 autorestart=true

--- a/deploy/docker/templates/supervisord/application_process/rts.conf
+++ b/deploy/docker/templates/supervisord/application_process/rts.conf
@@ -1,7 +1,7 @@
 [program:rts]
 directory=/opt/appsmith/rts
 command=/opt/appsmith/run-with-env.sh node server.js
-priority=20
+priority=15
 autostart=true
 autorestart=true
 startsecs=0

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+
+# Wait until RTS started and listens on port 8091
+while ! curl --fail --silent localhost/rts-api/v1/health-check; do
+  echo 'Waiting for RTS to start ...'
+  sleep 1
+done
+echo 'RTS started.'
+
+# Start server.
+echo 'Starting Backend server...'
+exec /opt/appsmith/run-with-env.sh /opt/appsmith/run-java.sh


### PR DESCRIPTION
Fixes: [19207](https://github.com/appsmithorg/appsmith/issues/19207)

**By default on start-up**

```
root@ab348246fff8:/appsmith-stacks/logs# head backend/backend-ab348246fff8.log
Waiting for RTS to start ...
RTS started.
Starting Backend server...
Load environment configuration
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/appsmith/backend/server.jar!/BOOT-INF/lib/logback-classic-1.2.11.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/appsmith/backend/server.jar!/BOOT-INF/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
[2022-12-26 11:39:34,962]  - Starting ServerApplication vv1.8.14.1 using Java 11.0.17 on ab348246fff8 with PID 1543 (/opt/appsmith/backend/server.jar started by root in /opt/appsmith/backend)
```
**Upon stopping RTS manually** 

```
root@ab348246fff8:/appsmith-stacks/logs# supervisorctl stop rts
rts: stopped
root@ab348246fff8:/appsmith-stacks/logs# supervisorctl status
backend                          RUNNING   pid 1497, uptime 0:01:21
cron                             RUNNING   pid 1505, uptime 0:01:21
editor                           RUNNING   pid 1502, uptime 0:01:21
mongodb                          RUNNING   pid 1491, uptime 0:01:21
redis                            RUNNING   pid 1490, uptime 0:01:21
rts                              STOPPED   Dec 26 11:40 AM
stdout                           RUNNING   pid 1489, uptime 0:01:21
```

**Restart Backend service to check if backend service starts** 

```
root@ab348246fff8:/appsmith-stacks/logs# supervisorctl restart backend
backend: stopped
backend: started
root@ab348246fff8:/appsmith-stacks/logs# supervisorctl status
backend                          RUNNING   pid 1802, uptime 0:00:12
cron                             RUNNING   pid 1505, uptime 0:01:43
editor                           RUNNING   pid 1502, uptime 0:01:43
mongodb                          RUNNING   pid 1491, uptime 0:01:43
redis                            RUNNING   pid 1490, uptime 0:01:43
rts                              STOPPED   Dec 26 11:40 AM
stdout                           RUNNING   pid 1489, uptime 0:01:43
root@ab348246fff8:/appsmith-stacks/logs# supervisorctl ^C
root@ab348246fff8:/appsmith-stacks/logs# tail -f backend/backend-ab348246fff8.log
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
Waiting for RTS to start ...
^C
```

**Upon starting RTS the behaviour of backend immediately**
 
```
root@ab348246fff8:/appsmith-stacks/logs# supervisorctl start rts
rts: started
root@ab348246fff8:/appsmith-stacks/logs# tail -f backend/backend-ab348246fff8.log
Starting Backend server...
Load environment configuration
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/appsmith/backend/server.jar!/BOOT-INF/lib/logback-classic-1.2.11.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/appsmith/backend/server.jar!/BOOT-INF/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
[2022-12-26 11:41:33,796]  - Starting ServerApplication vv1.8.14.1 using Java 11.0.17 on ab348246fff8 with PID 1968 (/opt/appsmith/backend/server.jar started by root in /opt/appsmith/backend)
[2022-12-26 11:41:33,799]  - Running with Spring Boot v2.6.5, Spring v5.3.17
[2022-12-26 11:41:33,803]  - No active profile set, falling back to 1 default profile: "default"
[2022-12-26 11:41:34,615]  - Multiple Spring Data modules found, entering strict repository configuration mode!
[2022-12-26 11:41:34,616]  - Bootstrapping Spring Data Reactive MongoDB repositories in DEFAULT mode.
[2022-12-26 11:41:34,859]  - Finished Spring Data repository scanning in 239 ms. Found 55 Reactive MongoDB repository interfaces.
[2022-12-26 11:41:35,220]  - Multiple Spring Data modules found, entering strict repository configuration mode!
[2022-12-26 11:41:35,221]  - Bootstrapping Spring Data Redis repositories in DEFAULT mode.
```