### PR TITLE
fix: Removing temporarily copied action to a page when API responds with an error

### DIFF
--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -374,7 +374,10 @@ const actionsReducer = createReducer(initialState, {
   ): ActionDataState =>
     state.filter((a) => {
       if (a.config.pageId === action.payload.destinationPageId) {
-        if (a.config.id === action.payload.id) {
+        if (
+          a.config.id === action.payload.id ||
+          a.config.id === "TEMP_COPY_ID"
+        ) {
           return a.config.name !== action.payload.name;
         }
         return true;


### PR DESCRIPTION
## Description

> Removing temporarily copied action to a page when API responds with an error.

Fixes [#19159](https://github.com/appsmithorg/appsmith/issues/19159)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Tested the same scenario locally. The issue was with coping an action to another page that doesn't have a create action permission. Fixed that in this PR and it reverts to the old state without page refresh when API responds with an error. Moving the action works fine with an error response from API. Didn't need any fixing.

- Manual


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
