### PR TITLE
fix: Adding permission checks on save & edit datasource buttons next to API field

### DIFF
--- a/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
+++ b/app/client/src/components/editorComponents/form/fields/EmbeddedDatasourcePathField.tsx
@@ -55,6 +55,11 @@ import {
   getDatasourcesByPluginId,
 } from "selectors/entitiesSelector";
 import { extractApiUrlPath } from "transformers/RestActionTransformer";
+import { getCurrentAppWorkspace } from "@appsmith/selectors/workspaceSelectors";
+import {
+  hasCreateDatasourcePermission,
+  hasManageDatasourcePermission,
+} from "@appsmith/utils/permissionHelpers";
 
 type ReduxStateProps = {
   workspaceId: string;
@@ -64,6 +69,7 @@ type ReduxStateProps = {
   dataTree: DataTree;
   actionName: string;
   formName: string;
+  userWorkspacePermissions: string[];
 };
 
 type ReduxDispatchProps = {
@@ -443,6 +449,7 @@ class EmbeddedDatasourcePathComponent extends React.Component<
       codeEditorVisibleOverflow,
       datasource,
       input: { value },
+      userWorkspacePermissions,
     } = this.props;
     const datasourceUrl = get(datasource, "datasourceConfiguration.url", "");
     const displayValue = `${datasourceUrl}${value}`;
@@ -451,6 +458,22 @@ class EmbeddedDatasourcePathComponent extends React.Component<
       value: displayValue,
       onChange: this.handleOnChange,
     };
+
+    const shouldSave = datasource && !("id" in datasource);
+
+    const canCreateDatasource = hasCreateDatasourcePermission(
+      userWorkspacePermissions,
+    );
+
+    const datasourcePermissions = datasource?.userPermissions || [];
+
+    const canManageDatasource = hasManageDatasourcePermission(
+      datasourcePermissions,
+    );
+
+    const isEnabled =
+      (shouldSave && canCreateDatasource) ||
+      (!shouldSave && canManageDatasource);
 
     const props: EditorProps = {
       ...this.props,
@@ -508,8 +531,8 @@ class EmbeddedDatasourcePathComponent extends React.Component<
             datasourceId={
               datasource && "id" in datasource ? datasource.id : undefined
             }
-            enable
-            shouldSave={datasource && !("id" in datasource)}
+            enable={isEnabled}
+            shouldSave={shouldSave}
           />
         )}
       </DatasourceContainer>
@@ -547,6 +570,8 @@ const mapStateToProps = (
     dataTree: getDataTree(state),
     actionName: ownProps.actionName,
     formName: ownProps.formName,
+    userWorkspacePermissions:
+      getCurrentAppWorkspace(state)?.userPermissions ?? [],
   };
 };
 


### PR DESCRIPTION
## Description

> Adding permission checks on save & edit datasource buttons next to API field

Fixes #19248 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Works now based on permission.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
