### PR TITLE
fix: Fetching page by id when new page is created via crud API

### DIFF
--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -28,6 +28,7 @@ import {
   fetchAllPageEntityCompletion,
   updatePageSuccess,
   updatePageError,
+  fetchPage,
 } from "actions/pageActions";
 import PageApi, {
   ClonePageRequest,
@@ -1072,6 +1073,8 @@ export function* generateTemplatePageSaga(
         pageId,
         isFirstLoad: true,
       });
+
+      yield put(fetchPage(pageId));
 
       // trigger evaluation after completion of page success & fetch actions for page + fetch jsobject for page
 


### PR DESCRIPTION
## Description

> Fetching page by id when new page is created via crud API to fix page error saying you do not have access to edit the page.

Fixes [#19222](https://github.com/appsmithorg/appsmith/issues/19222)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Tested it with the steps provided in the issue. It works fine now without any error.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
