### PR TITLE
fix: PostgreSQL Trust Authentication Login

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/EmptyDataSource_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/QueryPane/EmptyDataSource_spec.js
@@ -28,7 +28,7 @@ describe("Create a query with a empty datasource, run, save the query", function
     cy.EvaluateCurrentValue("select * from users limit 10");
     cy.runQuery(false);
     cy.get(".t--query-error").contains(
-      "[Missing endpoint., Missing username for authentication., Missing password for authentication.]",
+      "[Missing endpoint., Missing username for authentication.]",
     );
   });
 });

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -567,9 +567,13 @@ public class PostgresPlugin extends BasePlugin {
                     invalids.add("Missing username for authentication.");
                 }
 
-                if (StringUtils.isEmpty(authentication.getPassword())) {
-                    invalids.add("Missing password for authentication.");
-                }
+                /*
+                    Commenting the below check to allow the user to connect to
+                    postgresql without password
+                 */
+//                if (StringUtils.isEmpty(authentication.getPassword())) {
+//                    invalids.add("Missing password for authentication.");
+//                }
 
                 if (StringUtils.isEmpty(authentication.getDatabaseName())) {
                     invalids.add("Missing database name.");

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/java/com/external/plugins/PostgresPlugin.java
@@ -567,14 +567,6 @@ public class PostgresPlugin extends BasePlugin {
                     invalids.add("Missing username for authentication.");
                 }
 
-                /*
-                    Commenting the below check to allow the user to connect to
-                    postgresql without password
-                 */
-//                if (StringUtils.isEmpty(authentication.getPassword())) {
-//                    invalids.add("Missing password for authentication.");
-//                }
-
                 if (StringUtils.isEmpty(authentication.getDatabaseName())) {
                     invalids.add("Missing database name.");
                 }

--- a/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
+++ b/app/server/appsmith-plugins/postgresPlugin/src/test/java/com/external/plugins/PostgresPluginTest.java
@@ -85,16 +85,18 @@ public class PostgresPluginTest {
             .withPassword("password");
 
     @Container
-    public static final PostgreSQLContainer pgsqlContainerNoPwdAuth = new PostgreSQLContainer<>("postgres:alpine")
+    public static final PostgreSQLContainer pgsqlContainerNoPwdAuth =
+            new PostgreSQLContainer<>("postgres:alpine")
             .withExposedPorts(5432)
-            .withUsername("postgres_no_pwd_auth").withEnv("POSTGRES_HOST_AUTH_METHOD","trust");
+            .withUsername("postgres_no_pwd_auth")
+            .withEnv("POSTGRES_HOST_AUTH_METHOD","trust");
 
     private static String address;
     private static Integer port;
     private static String username, password;
-    private static String address_no_pwd_auth;
-    private static String username_no_pwd_auth;
-    private static Integer port_no_pwd_auth;
+    private static String addressNoPwdAuth;
+    private static String usernameNoPwdAuth;
+    private static Integer portNoPwdAuth;
 
     @BeforeAll
     public static void setUp() {
@@ -107,9 +109,9 @@ public class PostgresPluginTest {
         username = pgsqlContainer.getUsername();
         password = pgsqlContainer.getPassword();
 
-        address_no_pwd_auth = pgsqlContainerNoPwdAuth.getContainerIpAddress();
-        username_no_pwd_auth = pgsqlContainerNoPwdAuth.getUsername();
-        port_no_pwd_auth = pgsqlContainerNoPwdAuth.getFirstMappedPort();
+        addressNoPwdAuth = pgsqlContainerNoPwdAuth.getContainerIpAddress();
+        usernameNoPwdAuth = pgsqlContainerNoPwdAuth.getUsername();
+        portNoPwdAuth = pgsqlContainerNoPwdAuth.getFirstMappedPort();
 
         Properties properties = new Properties();
         properties.putAll(Map.of(
@@ -268,12 +270,12 @@ public class PostgresPluginTest {
 
     private DatasourceConfiguration createDatasourceConfigurationWithoutPwd() {
         DBAuth authDTO = new DBAuth();
-        authDTO.setUsername(username_no_pwd_auth);
+        authDTO.setUsername(usernameNoPwdAuth);
         authDTO.setDatabaseName("postgres");
 
         Endpoint endpoint = new Endpoint();
-        endpoint.setHost(address_no_pwd_auth);
-        endpoint.setPort(port_no_pwd_auth.longValue());
+        endpoint.setHost(addressNoPwdAuth);
+        endpoint.setPort(portNoPwdAuth.longValue());
 
         DatasourceConfiguration dsConfig = new DatasourceConfiguration();
         dsConfig.setAuthentication(authDTO);


### PR DESCRIPTION
### **Description**

- The PR removes the empty password validation check for PostgreSQL while creating a new data source.
- The JUnit test case is added for the same. Implemented using a separate PostgreSQL container with Trust Authentication enabled for the Same.
- Please note for testing from UI perspective we have to create a user with Trust auth enabled to validate the above changes.

Fixes  #14003

### **Type of Change**

- Bug Fix(non-breaking change which adds functionality)

### **How Has This Been Tested?**
- Manual
- JUnit TC added 

### **Checklist**:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [ ]  My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [ ]  PR is being merged under a feature flag

### **QA activity:**

- [ ]  Test plan has been approved by relevant developers
- [ ]  Test plan has been peer reviewed by QA
- [ ]  Cypress test cases have been added and approved by either SDET or manual QA
- [ ]  Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ]  Added Test Plan Approved label after reveiwing all Cypress test
