### PR TITLE
fix: add datasource CTA in the query pane is not permission driven

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -1069,6 +1069,7 @@ export function EditorJSONtoForm(props: Props) {
                               {createMessage(NO_DATASOURCE_FOR_QUERY)}
                             </p>
                             <EditorButton
+                              disabled={!canCreateDatasource}
                               filled
                               icon="plus"
                               intent="primary"


### PR DESCRIPTION
## Description

The `Add datasource` CTA in query pane is not permission driven.

Fixes #19274


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual



## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
