### PR TITLE
refac: Change deprecated Redis plan on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     ],
     "addons": [
         {
-            "plan": "heroku-redis:hobby-dev",
+            "plan": "heroku-redis:mini",
             "as": "APPSMITH_REDIS"
         }
     ],


### PR DESCRIPTION

## Description

Heroku deprecated the Hobby-dev plan for Redis, this prevents "deploying" AppSmith on Heroku by using the install Template. Instead now Heroku expects a Mini plan. 

Fixes # (issue)
Deployment issue. 


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
After changing the app.json to require: **heroku-redis:mini** i was able to install AppSmith on Heroku by using the template.


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
