### PR TITLE
fix: helm install values checks

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -21,6 +21,6 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
 - condition: mongodb.enabled
   name: mongodb
-  version: 10.31.5
-  appVersion: 4.4.11
+  version: 13.6.0
+  appVersion: 5.0.12
   repository: https://charts.bitnami.com/bitnami

--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
-  ingressClassName: {{ .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className |  default "nginx" }}
   {{- end }}
   rules:
     {{- if not .Values.ingress.hosts }}

--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -44,7 +44,9 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
+  {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     {{- if not .Values.ingress.hosts }}
     - host:

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -95,6 +95,10 @@ spec:
             - secretRef:
                 name: {{ .Values.secretName }}
             {{- end }}
+      {{- if .Values.image.pullSecrets}}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecrets }}
+      {{- end }}
       volumes:
   {{- if not .Values.persistence.enabled }}
       - name: data

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -55,6 +55,7 @@ image:
   registry: index.docker.io
   repository: appsmith/appsmith-ce
   pullPolicy: IfNotPresent
+  pullSecrets: ""
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 ## ServiceAccount

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -172,7 +172,7 @@ ingress:
   ## e.g:
   ## className: "nginx"
   ##
-  className: ""
+  className: "nginx"
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Description
- Updated ngnix as default ingress class in `values.yaml`
- Upgraded mongo's deployment image to `v5.0.12` as the previous 4.4.11 is deprecated
- Added `imagePullSecrets` to enable pulling images from private docker registries
- Added conditional to check for k8s version >=1.1.8 to handle both old and new k8s version scenarios for setting up the Ingress controller class name.
