### PR TITLE
fix: Fixed an edge case with refactoring widget names similar to template widget names

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImpl.java
@@ -505,11 +505,11 @@ public class RefactoringSolutionCEImpl implements RefactoringSolutionCE {
         refactorBindingsMono = Flux.fromStream(StreamSupport.stream(bindingPathList.spliterator(), true))
                 .flatMap(bindingPath -> {
                     String key = bindingPath.get(FieldName.KEY).asText();
-                    // This is inside a list widget, and the path starts with template.<oldName>,
+                    // This is inside a list widget, and the path starts with template.<oldName>.,
                     // We need to update the binding path list entry itself as well
                     if (widgetDsl.has(FieldName.WIDGET_TYPE) &&
                             FieldName.LIST_WIDGET.equals(widgetDsl.get(FieldName.WIDGET_TYPE).asText()) &&
-                            key.startsWith("template." + oldName)) {
+                            key.startsWith("template." + oldName + ".")) {
                         key = key.replace(oldName, newName);
                         ((ObjectNode) bindingPath).set(FieldName.KEY, new TextNode(key));
                     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/RefactoringSolutionCEImplTest.java
@@ -92,7 +92,7 @@ class RefactoringSolutionCEImplTest {
              InputStream finalStream = this.getClass().getResourceAsStream("refactorDslWithOnlyWidgetsWithNewText.json")) {
             assert initialStream != null;
             JsonNode dslAsJsonNode = mapper.readTree(initialStream);
-            final String oldName = "Text3";
+            final String oldName = "Text";
             Mono<Set<String>> updatesMono = refactoringSolutionCE.refactorNameInDsl(
                     dslAsJsonNode,
                     oldName,
@@ -104,7 +104,7 @@ class RefactoringSolutionCEImplTest {
                     .assertNext(updatedPaths -> {
                         Assertions.assertThat(updatedPaths).hasSize(3);
                         Assertions.assertThat(updatedPaths).containsExactlyInAnyOrder(
-                                "Text3.widgetName",
+                                "Text.widgetName",
                                 "List1.template",
                                 "List1.onListItemClick");
                     })
@@ -139,7 +139,7 @@ class RefactoringSolutionCEImplTest {
                                 "List1.widgetName",
                                 "List1.template.Text4.text",
                                 "List1.template.Image1.image",
-                                "List1.template.Text3.text");
+                                "List1.template.Text.text");
                     })
                     .verifyComplete();
 

--- a/app/server/appsmith-server/src/test/resources/com/appsmith/server/solutions/ce/refactorDslWithOnlyWidgets.json
+++ b/app/server/appsmith-server/src/test/resources/com/appsmith/server/solutions/ce/refactorDslWithOnlyWidgets.json
@@ -59,9 +59,9 @@
           "widgetId": "bvixbymoxr",
           "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}"
         },
-        "Text3": {
+        "Text": {
           "text": "{{List1.listData.map((currentItem) => currentItem.name)}}",
-          "widgetName": "Text3",
+          "widgetName": "Text",
           "type": "TEXT_WIDGET",
           "key": "3pqpn28ba4",
           "dynamicBindingPathList": [
@@ -117,7 +117,7 @@
           "key": "template.Image1.image"
         },
         {
-          "key": "template.Text3.text"
+          "key": "template.Text.text"
         },
         {
           "key": "template.Text4.text"
@@ -128,7 +128,7 @@
           "key": "onListItemClick"
         }
       ],
-      "onListItemClick": "{{Text3.text}}",
+      "onListItemClick": "{{Text.text}}",
       "children": [
         {
           "widgetName": "Canvas1",
@@ -183,7 +183,7 @@
                       "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}"
                     },
                     {
-                      "widgetName": "Text3",
+                      "widgetName": "Text",
                       "type": "TEXT_WIDGET",
                       "fontFamily": "{{appsmith.theme.fontFamily.appFont}}",
                       "dynamicBindingPathList": [

--- a/app/server/appsmith-server/src/test/resources/com/appsmith/server/solutions/ce/refactorDslWithOnlyWidgetsWithNewList.json
+++ b/app/server/appsmith-server/src/test/resources/com/appsmith/server/solutions/ce/refactorDslWithOnlyWidgetsWithNewList.json
@@ -59,9 +59,9 @@
           "widgetId": "bvixbymoxr",
           "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}"
         },
-        "Text3": {
+        "Text": {
           "text": "{{newList.listData.map((currentItem) => currentItem.name)}}",
-          "widgetName": "Text3",
+          "widgetName": "Text",
           "type": "TEXT_WIDGET",
           "key": "3pqpn28ba4",
           "dynamicBindingPathList": [
@@ -117,7 +117,7 @@
           "key": "template.Image1.image"
         },
         {
-          "key": "template.Text3.text"
+          "key": "template.Text.text"
         },
         {
           "key": "template.Text4.text"
@@ -128,7 +128,7 @@
           "key": "onListItemClick"
         }
       ],
-      "onListItemClick": "{{Text3.text}}",
+      "onListItemClick": "{{Text.text}}",
       "children": [
         {
           "widgetName": "Canvas1",
@@ -183,7 +183,7 @@
                       "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}"
                     },
                     {
-                      "widgetName": "Text3",
+                      "widgetName": "Text",
                       "type": "TEXT_WIDGET",
                       "fontFamily": "{{appsmith.theme.fontFamily.appFont}}",
                       "dynamicBindingPathList": [


### PR DESCRIPTION
## Description

If a widget was being refactored from `Text1` to `Text2`, and the same application had a List widget with a template widget of the name `Text12`, then the refactor logic was breaking the recalculation of dynamic binding path list. This fix checks for the complete name instead of a partial match.

Reproduction and context:
https://theappsmith.slack.com/archives/C02JV8G1MP0/p1672388698340299?thread_ts=1671080059.752969&cid=C02JV8G1MP0

Fixes one cause of #10037 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Junit

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
