### PR TITLE
ci: Add java setup step to perf-test workflow

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -121,6 +121,14 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         run: yarn install --frozen-lockfile
 
+      # Setup Java
+      - name: Set up JDK 17
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Download the react build artifact
         if: steps.run_result.outputs.run_result != 'success'
         uses: actions/download-artifact@v3
@@ -238,7 +246,6 @@ jobs:
       - name: Exit if Server hasnt started
         if: steps.run_result.outputs.run_result != 'success'
         run: |
-          sleep 30s
           if lsof -i :8080; then
             echo "Server Found"
           else

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -238,6 +238,7 @@ jobs:
       - name: Exit if Server hasnt started
         if: steps.run_result.outputs.run_result != 'success'
         run: |
+          sleep 30s
           if lsof -i :8080; then
             echo "Server Found"
           else


### PR DESCRIPTION
With the latest build, we’ve upgraded to Java 17.   By default, Ubuntu ships with Java 11.