### PR TITLE
feat: separate health check api for redis and mongo (#19425)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -120,6 +120,7 @@ public class SecurityConfig {
                 .and()
                 .authorizeExchange()
                 .matchers(ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, Url.LOGIN_URL),
+                        ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, Url.HEALTH_CHECK),
                         ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL),
                         ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL + "/super"),
                         ServerWebExchangeMatchers.pathMatchers(HttpMethod.POST, USER_URL + "/forgotPassword"),

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Url.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Url.java
@@ -3,6 +3,7 @@ package com.appsmith.server.constants;
 public interface Url {
     String BASE_URL = "/api";
     String VERSION = "/v1";
+    String HEALTH_CHECK = BASE_URL + "/health";
     String LOGIN_URL = BASE_URL + VERSION + "/login";
     String LOGOUT_URL = BASE_URL + VERSION + "/logout";
     String WORKSPACE_URL = BASE_URL + VERSION + "/workspaces";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/HealthCheckController.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/HealthCheckController.java
@@ -1,0 +1,16 @@
+package com.appsmith.server.controllers;
+
+import com.appsmith.server.constants.Url;
+import com.appsmith.server.controllers.ce.HealthCheckControllerCE;
+import com.appsmith.server.services.HealthCheckService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(Url.HEALTH_CHECK)
+public class HealthCheckController extends HealthCheckControllerCE {
+
+    public HealthCheckController(HealthCheckService healthCheckService) {
+        super(healthCheckService);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/HealthCheckControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/HealthCheckControllerCE.java
@@ -1,0 +1,21 @@
+package com.appsmith.server.controllers.ce;
+
+import com.appsmith.server.constants.Url;
+import com.appsmith.server.dtos.ResponseDTO;
+import com.appsmith.server.services.HealthCheckService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import reactor.core.publisher.Mono;
+
+@RequestMapping(Url.HEALTH_CHECK)
+@AllArgsConstructor
+public class HealthCheckControllerCE {
+    private final HealthCheckService healthCheckService;
+
+    @GetMapping
+    public Mono<ResponseDTO<String>> getHealth() {
+        return healthCheckService.getHealth().map(health -> new ResponseDTO<>(HttpStatus.OK.value(), health, null));
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -101,6 +101,7 @@ public enum AppsmithError {
     PLUGIN_RUN_FAILED(500, 5003, "Plugin execution failed with error {0}", AppsmithErrorAction.DEFAULT, null, ErrorType.INTERNAL_ERROR, null),
     PLUGIN_EXECUTION_TIMEOUT(504, 5040, "Plugin execution exceeded the maximum allowed time. Please increase the timeout in your action settings or check your backend action endpoint",
             AppsmithErrorAction.DEFAULT, null, ErrorType.CONNECTIVITY_ERROR, null),
+    HEALTHCHECK_TIMEOUT(408, 4080, "{0} connection timed out.", AppsmithErrorAction.DEFAULT, null, ErrorType.CONNECTIVITY_ERROR, null),
     PLUGIN_LOAD_FORM_JSON_FAIL(500, 5004, "[{0}] Unable to load datasource form configuration. Details: {1}.",
             AppsmithErrorAction.LOG_EXTERNALLY, null, ErrorType.INTERNAL_ERROR, null),
     PLUGIN_LOAD_TEMPLATES_FAIL(500, 5005, "Unable to load datasource templates. Details: {0}.",

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/HealthCheckService.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/HealthCheckService.java
@@ -1,0 +1,6 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.services.ce.HealthCheckServiceCE;
+
+public interface HealthCheckService extends HealthCheckServiceCE {
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/HealthCheckServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/HealthCheckServiceImpl.java
@@ -1,0 +1,15 @@
+package com.appsmith.server.services;
+
+import com.appsmith.server.services.ce.HealthCheckServiceCEImpl;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class HealthCheckServiceImpl extends HealthCheckServiceCEImpl implements HealthCheckService {
+    public HealthCheckServiceImpl(ReactiveRedisConnectionFactory reactiveRedisConnectionFactory,
+                                  ReactiveMongoTemplate reactiveMongoTemplate) {
+        super(reactiveRedisConnectionFactory, reactiveMongoTemplate);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCE.java
@@ -1,0 +1,11 @@
+package com.appsmith.server.services.ce;
+
+import org.springframework.boot.actuate.health.Health;
+import reactor.core.publisher.Mono;
+
+public interface HealthCheckServiceCE {
+
+    Mono<String> getHealth();
+    Mono<Health> getRedisHealth();
+    Mono<Health> getMongoHealth();
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCEImpl.java
@@ -1,0 +1,58 @@
+package com.appsmith.server.services.ce;
+
+import com.appsmith.server.exceptions.AppsmithError;
+import com.appsmith.server.exceptions.AppsmithException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.data.mongo.MongoReactiveHealthIndicator;
+import org.springframework.boot.actuate.data.redis.RedisReactiveHealthIndicator;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+
+@Slf4j
+public class HealthCheckServiceCEImpl implements HealthCheckServiceCE {
+
+    private final ReactiveRedisConnectionFactory reactiveRedisConnectionFactory;
+    private final ReactiveMongoTemplate reactiveMongoTemplate;
+    public HealthCheckServiceCEImpl(ReactiveRedisConnectionFactory reactiveRedisConnectionFactory,
+                                    ReactiveMongoTemplate reactiveMongoTemplate) {
+        this.reactiveRedisConnectionFactory = reactiveRedisConnectionFactory;
+        this.reactiveMongoTemplate = reactiveMongoTemplate;
+    }
+
+    @Override
+    public Mono<String> getHealth() {
+        return Mono.zip(getRedisHealth(), getMongoHealth())
+                .map(tuple -> "All systems are Up");
+    }
+
+    @Override
+    public Mono<Health> getRedisHealth() {
+        Function<TimeoutException, Throwable> healthTimeout = error -> new AppsmithException(
+                AppsmithError.HEALTHCHECK_TIMEOUT, "Redis");
+        RedisReactiveHealthIndicator redisReactiveHealthIndicator = new RedisReactiveHealthIndicator(reactiveRedisConnectionFactory);
+        return redisReactiveHealthIndicator.health().timeout(Duration.ofSeconds(1)).onErrorMap(TimeoutException.class, healthTimeout);
+    }
+
+    @Override
+    public Mono<Health> getMongoHealth() {
+        Function<TimeoutException, Throwable> healthTimeout = error -> new AppsmithException(
+                AppsmithError.HEALTHCHECK_TIMEOUT, "Mongo");
+        MongoReactiveHealthIndicator mongoReactiveHealthIndicator = new MongoReactiveHealthIndicator(reactiveMongoTemplate);
+        return mongoReactiveHealthIndicator.health().timeout(Duration.ofSeconds(1)).onErrorMap(TimeoutException.class, healthTimeout);
+    }
+
+    private boolean isUp(Health health) {
+        if (Status.UP.equals(health.getStatus())) {
+            return Boolean.TRUE;
+        }
+        return Boolean.FALSE;
+    }
+}


### PR DESCRIPTION
Cherry picking health check API endpoint to be used to readiness and liveness probes in kubernetes.