### PR TITLE
fix: dropping of canvas widget issue.

### DIFF
--- a/app/client/src/widgets/ListWidgetV2/index.ts
+++ b/app/client/src/widgets/ListWidgetV2/index.ts
@@ -5,6 +5,7 @@ import Widget from "./widget";
 import { BlueprintOperationTypes } from "widgets/constants";
 import { RegisteredWidgetFeatures } from "utils/WidgetFeatures";
 import { WidgetProps } from "widgets/BaseWidget";
+import { GridDefaults } from "constants/WidgetConstants";
 
 const DEFAULT_LIST_DATA = [
   {
@@ -101,12 +102,13 @@ export const CONFIG = {
                     isDeletable: false,
                     disallowCopy: true,
                     noContainerOffset: true,
+
                     disabledWidgetFeatures: [
                       RegisteredWidgetFeatures.DYNAMIC_HEIGHT,
                     ],
                     shouldScrollContents: false,
                     // Removed dynamicHeight to enable dropping of widgets on the container
-                    // dynamicHeight: "FIXED",
+                    dynamicHeight: "FIXED",
                     children: [],
                     blueprint: {
                       view: [

--- a/app/client/src/widgets/withWidgetProps.tsx
+++ b/app/client/src/widgets/withWidgetProps.tsx
@@ -121,7 +121,11 @@ function withWidgetProps(WrappedWidget: typeof BaseWidget) {
           props.noPad && props.dropDisabled && props.openParentPropertyPane;
 
         widgetProps.rightColumn = props.rightColumn;
-        if (widgetProps.bottomRow === undefined || isListWidgetCanvas) {
+        if (
+          widgetProps.bottomRow === undefined ||
+          isListWidgetCanvas ||
+          Number.isNaN(widgetProps.bottomRow)
+        ) {
           widgetProps.bottomRow = props.bottomRow;
           widgetProps.minHeight = props.minHeight;
         }


### PR DESCRIPTION

## Description

widgetProps of BottomRow, RightColumn, and minHeight all had values of `NaN` but the props had their correct value.

So switching this when it's either `undefined` or `NaN` fixed the issue.
Although, further investigation should be done why it gets `NaN` or `undefined`

Fixes #19498


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
