### PR TITLE
fix: Updating the input field placeholder on app invite users modal

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -46,7 +46,7 @@
     "cypress-log-to-output": "^1.1.2",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",
-    "design-system": "npm:@appsmithorg/design-system@1.0.43",
+    "design-system": "npm:@appsmithorg/design-system@1.0.44",
     "downloadjs": "^1.4.7",
     "draft-js": "^0.11.7",
     "exceljs-lightweight": "^1.14.0",

--- a/app/client/src/pages/workspace/AppInviteUsersForm.tsx
+++ b/app/client/src/pages/workspace/AppInviteUsersForm.tsx
@@ -26,6 +26,9 @@ import {
   MAKE_APPLICATION_PUBLIC,
   MAKE_APPLICATION_PUBLIC_TOOLTIP,
 } from "@appsmith/constants/messages";
+import { getAppsmithConfigs } from "@appsmith/configs";
+
+const { cloudHosting } = getAppsmithConfigs();
 
 const ShareToggle = styled.div`
   flex-basis: 46px;
@@ -86,7 +89,7 @@ function AppInviteUsersForm(props: any) {
       {canInviteToWorkspace && (
         <WorkspaceInviteUsersForm
           isApplicationInvite
-          placeholder={createMessage(INVITE_USERS_PLACEHOLDER)}
+          placeholder={createMessage(INVITE_USERS_PLACEHOLDER, cloudHosting)}
           workspaceId={props.workspaceId}
         />
       )}

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -6202,10 +6202,10 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
 
-"design-system@npm:@appsmithorg/design-system@1.0.43":
-  version "1.0.43"
-  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system/-/design-system-1.0.43.tgz#f52380e44259ec11f9159be10977d2d6b94a9449"
-  integrity sha512-hn+8EYtDEUwwVFSS76yBWdMlmUOtvXVb+7eimNOVIS5ml9rLiT+bQC7sq3hd9h5cDw0MME2BHMrpWdBx3SlfwA==
+"design-system@npm:@appsmithorg/design-system@1.0.44":
+  version "1.0.44"
+  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system/-/design-system-1.0.44.tgz#22c061dada942ff947933bc92e96fff55fc006ba"
+  integrity sha512-HjqKtvIAdW2TkaG7iRc5HB4ieG+V1zTp9b2N98DCsNXjMzBUCvCH2afBzlDYYoL3r5GHAeMvZlTDFVME41I2yQ==
   dependencies:
     emoji-mart "3.0.1"
 


### PR DESCRIPTION
## Description

> Updating the input field placeholder on app invite users modal

Fixes [#19506](https://github.com/appsmithorg/appsmith/issues/19506)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Visited the edit page of an application and clicked on the share modal to check the input field placeholder on the invite modal. Group(s) is no longer seen on the release cloud, as expected.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
