### PR TITLE
chore: Deny service, if not on MongoDB v5

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/UnsupportedMongoDBVersionException.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/UnsupportedMongoDBVersionException.java
@@ -1,0 +1,7 @@
+package com.appsmith.server.exceptions;
+
+public class UnsupportedMongoDBVersionException extends RuntimeException {
+    public UnsupportedMongoDBVersionException(String message) {
+        super(message);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog0.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog0.java
@@ -4,12 +4,15 @@ import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.Appsmith;
 import com.appsmith.server.domains.Config;
 import com.appsmith.server.domains.QConfig;
+import com.appsmith.server.exceptions.UnsupportedMongoDBVersionException;
 import com.github.cloudyrock.mongock.ChangeLog;
 import com.github.cloudyrock.mongock.ChangeSet;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
+import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.fieldName;
@@ -19,6 +22,22 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 @Slf4j
 @ChangeLog(order = "000")
 public class DatabaseChangelog0 {
+
+    public static final int MIN_MAJOR_VERSION = 5;
+
+    @ChangeSet(order = "000", id = "pre-start-checks", author = "", runAlways = true)
+    public void preStartChecks(MongoTemplate mongoTemplate) {
+        final Document buildInfo = mongoTemplate.executeCommand(new Document("buildInfo", 1));
+        final Object versionArrayObj = buildInfo.get("versionArray");
+        if (versionArrayObj instanceof List<?> versionArray) {
+            final Object majorVersion = versionArray.get(0);
+            if (majorVersion instanceof Integer majorVersionInt && majorVersionInt >= MIN_MAJOR_VERSION) {
+                return;
+            }
+        }
+        throw new UnsupportedMongoDBVersionException("Appsmith requires MongoDB v5. Please upgrade your MongoDB. " +
+                "You are running: '" + buildInfo.get("version") + "'.");
+    }
 
     /**
      * This migration initializes the correct version of instance schema migrations

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog0.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog0.java
@@ -35,7 +35,7 @@ public class DatabaseChangelog0 {
                 return;
             }
         }
-        throw new UnsupportedMongoDBVersionException("Appsmith requires MongoDB v5. Please upgrade your MongoDB. " +
+        throw new UnsupportedMongoDBVersionException("Appsmith requires MongoDB v" + MIN_MAJOR_VERSION + ". Please upgrade your MongoDB. " +
                 "You are running: '" + buildInfo.get("version") + "'.");
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog0.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog0.java
@@ -35,8 +35,9 @@ public class DatabaseChangelog0 {
                 return;
             }
         }
-        throw new UnsupportedMongoDBVersionException("Appsmith requires MongoDB v" + MIN_MAJOR_VERSION + ". Please upgrade your MongoDB. " +
-                "You are running: '" + buildInfo.get("version") + "'.");
+        throw new UnsupportedMongoDBVersionException("""
+                Appsmith requires MongoDB v%d. Please upgrade your MongoDB. " +
+                "You are running: '%s'.""".formatted(MIN_MAJOR_VERSION, buildInfo.get("version")));
     }
 
     /**


### PR DESCRIPTION
Adds a migration function, that checks the version of the MongoDB being used. If it's older than v5, we print an informative message like this:

```
Caused by: com.appsmith.server.exceptions.UnsupportedMongoDBVersionException: Appsmith requires MongoDB v5. Please upgrade your MongoDB. You are running: '4.4.16'.
```

Then deny service. No requests will be accepted. This is to avoid potential data loss/damage due to a change in the way queries are run in whatever old version is being run.