### PR TITLE
chore: correct the casing of url to URL in the REST API editor

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/Pagination.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Pagination.tsx
@@ -176,7 +176,7 @@ export default function Pagination(props: PaginationProps) {
                   </Text>
                 </StepTitle>
                 <Step type={TextType.P1}>Configure Next and Previous URL </Step>
-                <Step type={TextType.P1}>Previous url</Step>
+                <Step type={TextType.P1}>Previous URL</Step>
                 <PaginationFieldWrapper
                   data-replay-id={btoa("actionConfiguration.prev")}
                 >
@@ -202,7 +202,7 @@ export default function Pagination(props: PaginationProps) {
                     type="button"
                   />
                 </PaginationFieldWrapper>
-                <Step type={TextType.P1}>Next url</Step>
+                <Step type={TextType.P1}>Next URL</Step>
                 <PaginationFieldWrapper
                   data-replay-id={btoa("actionConfiguration.next")}
                 >


### PR DESCRIPTION
## Description

Change `url` to `URL` in REST API Editor

Fixes #19550 

<!--
Media
 > A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video  -->

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

### Test Plan

-

### Issues raised during DP testing

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
