### PR TITLE
fix: incorrect currentItem value

### DIFF
--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -742,7 +742,7 @@ class MetaWidgetGenerator {
       : rowIndex;
     const dataBinding =
       this.serverSidePagination && this.cachedRows.curr.has(key)
-        ? this.rowDataCache[key]
+        ? `{{${JSON.stringify(this.rowDataCache[key])}}}`
         : `{{${this.widgetName}.listData[${currentIndex}]}}`;
     const currentItem = dataBinding;
     const currentRowCache = this.getRowCacheGroupByTemplateWidgetName(key);

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -875,7 +875,7 @@ class MetaWidgetGenerator {
 
     const dataBinding =
       this.serverSidePagination && this.cachedRows.curr.has(key)
-        ? this.rowDataCache[key]
+        ? `{{${JSON.stringify(this.rowDataCache[key])}}}`
         : `{{${this.widgetName}.listData[${metaWidgetName}.currentIndex]}}`;
 
     metaWidget.currentItem = dataBinding;


### PR DESCRIPTION
## Description

since `currentItem` uses `TEMPLATE` as `evaluationSubstitutionType` and can't be made to be dynamic depending on its value, passing the stringified value in `{{ }}` would evaluate the string back to it's original value

Fixes #19652 


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Cypress


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
