### PR TITLE
chore: Add frame-ancestors CSP during dev time

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -259,6 +259,9 @@ $(if [[ $use_https == 1 ]]; then echo "
         proxy_set_header X-Forwarded-Host \$host;
         proxy_set_header Accept-Encoding '';
 
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
+        add_header Content-Security-Policy \"frame-ancestors ${APPSMITH_ALLOWED_FRAME_ANCESTORS-'self' *}\";
+
         sub_filter_once off;
         location / {
             proxy_pass $frontend;


### PR DESCRIPTION
We use `APPSMITH_ALLOWED_FRAME_ANCESTORS` env variable to determine the CSP value for `frame-ancestors` in the Docker container, but we don't do this in the `start-https.sh` script, which is used during development. This PR fixes this inconsistency.
