### PR TITLE
chore: send static anonymous id for anonymous users in usage pulse call

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/ApplicationURL_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/ApplicationURL_spec.js
@@ -154,7 +154,7 @@ describe("Slug URLs", () => {
     cy.url().then((url) => {
       cy.LogOut();
       cy.visit(url + "?embed=true&a=b");
-      cy.wait(6000);
+      //cy.wait(6000);
       cy.location().should((loc) => {
         expect(loc.search).to.eq(
           `?redirectUrl=${encodeURIComponent(url + "?embed=true&a=b")}`,

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/ForkApplication_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/OtherUIFeatures/ForkApplication_spec.js
@@ -83,9 +83,9 @@ describe("Fork application across workspaces", function() {
         cy.get(homePage.signOutIcon).click();
 
         cy.visit(forkableAppUrl);
-        cy.reload();
-        cy.visit(forkableAppUrl);
-        cy.wait(5000);
+        //cy.reload();
+        //cy.visit(forkableAppUrl);
+        cy.wait(4000);
         cy.get(applicationLocators.forkButton)
           .first()
           .click({ force: true });

--- a/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Workspace/ShareAppTests_spec.js
+++ b/app/client/cypress/integration/Smoke_TestSuite/ClientSideTests/Workspace/ShareAppTests_spec.js
@@ -153,7 +153,7 @@ describe("Create new workspace and share with a user", function() {
       "response.body.responseMeta.status",
       404,
     );
-    cy.wait(3000);
+    cy.wait(2000);
     cy.contains("Sign in to your account").should("be.visible");
   });
 

--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -55,10 +55,7 @@ import {
   getFirstTimeUserOnboardingApplicationId,
   getFirstTimeUserOnboardingIntroModalVisibility,
 } from "utils/storage";
-import {
-  initializeAnalyticsAndTrackers,
-  initializeSegmentWithoutTracking,
-} from "utils/AppsmithUtils";
+import { initializeAnalyticsAndTrackers } from "utils/AppsmithUtils";
 import { getAppsmithConfigs } from "ce/configs";
 import { getSegmentState } from "selectors/analyticsSelectors";
 import {

--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -161,7 +161,8 @@ export function* getCurrentUserSaga() {
          * We're initializing the segment api regardless of the enableTelemetry flag
          * So we can use segement Id to fingerprint anonymous user in usage pulse call
          */
-        yield initializeSegmentWithoutTracking();
+        //NOTE: commenting for now to fix a flaky cypress issue
+        // yield initializeSegmentWithoutTracking();
       }
 
       //To make sure that we're not tracking from previous session.
@@ -176,7 +177,7 @@ export function* getCurrentUserSaga() {
         //@ts-expect-error: response is of type unknown
         enableTelemetry && AnalyticsUtil.identifyUser(response.data);
       } else {
-        UsagePulse.userAnonymousId = AnalyticsUtil.getAnonymousId();
+        UsagePulse.userAnonymousId = "anonymousId";
 
         if (!enableTelemetry) {
           AnalyticsUtil.removeAnalytics();


### PR DESCRIPTION
## Description
The segment initialization for the anonymous user is creating a race condition and due to that two cypress test have become flaky(ShareAppTests_spec.js and ApplicationURL_spec.js). Temporarily commenting it out in this PR and will enable it after fixing the race condition.

Media
> A video or a GIF is preferred. when using Loom, don’t embed it because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
