### PR TITLE
chore: send anonymous id from segment for anonymous users in usage pulse call

### DIFF
--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -1,4 +1,4 @@
-import { call, put, race, select, take } from "redux-saga/effects";
+import { call, fork, put, race, select, take } from "redux-saga/effects";
 import {
   ReduxAction,
   ReduxActionWithPromise,
@@ -55,7 +55,10 @@ import {
   getFirstTimeUserOnboardingApplicationId,
   getFirstTimeUserOnboardingIntroModalVisibility,
 } from "utils/storage";
-import { initializeAnalyticsAndTrackers } from "utils/AppsmithUtils";
+import {
+  initializeAnalyticsAndTrackers,
+  initializeSegmentWithoutTracking,
+} from "utils/AppsmithUtils";
 import { getAppsmithConfigs } from "ce/configs";
 import { getSegmentState } from "selectors/analyticsSelectors";
 import {
@@ -124,6 +127,32 @@ export function* waitForSegmentInit(skipWithAnonymousId: boolean) {
   }
 }
 
+/*
+ * Function to initiate usage tracking
+ *  - For anonymous users we need segement id, so if telemetry is off
+ *    we're intiating segment without tracking and once we get the id,
+ *    analytics object is purged.
+ */
+export function* initiateUsageTracking(payload: {
+  isAnonymousUser: boolean;
+  enableTelemetry: boolean;
+}) {
+  //To make sure that we're not tracking from previous session.
+  UsagePulse.stopTrackingActivity();
+
+  if (payload.isAnonymousUser) {
+    if (payload.enableTelemetry) {
+      UsagePulse.userAnonymousId = AnalyticsUtil.getAnonymousId();
+    } else {
+      yield initializeSegmentWithoutTracking();
+      UsagePulse.userAnonymousId = AnalyticsUtil.getAnonymousId();
+      AnalyticsUtil.removeAnalytics();
+    }
+  }
+
+  UsagePulse.startTrackingActivity();
+}
+
 export function* getCurrentUserSaga() {
   try {
     PerformanceTracker.startAsyncTracking(
@@ -132,6 +161,7 @@ export function* getCurrentUserSaga() {
     const response: ApiResponse = yield call(UserApi.getCurrentUser);
 
     const isValidResponse: boolean = yield validateResponse(response);
+
     if (isValidResponse) {
       //@ts-expect-error: response is of type unknown
       const { enableTelemetry } = response.data;
@@ -148,22 +178,7 @@ export function* getCurrentUserSaga() {
             yield put(segmentInitUncertain());
           }
         }
-      } else if (
-        //@ts-expect-error: response is of type unknown
-        response.data.isAnonymous &&
-        //@ts-expect-error: response is of type unknown
-        response.data.username === ANONYMOUS_USERNAME
-      ) {
-        /*
-         * We're initializing the segment api regardless of the enableTelemetry flag
-         * So we can use segement Id to fingerprint anonymous user in usage pulse call
-         */
-        //NOTE: commenting for now to fix a flaky cypress issue
-        // yield initializeSegmentWithoutTracking();
       }
-
-      //To make sure that we're not tracking from previous session.
-      UsagePulse.stopTrackingActivity();
 
       if (
         //@ts-expect-error: response is of type unknown
@@ -173,16 +188,16 @@ export function* getCurrentUserSaga() {
       ) {
         //@ts-expect-error: response is of type unknown
         enableTelemetry && AnalyticsUtil.identifyUser(response.data);
-      } else {
-        UsagePulse.userAnonymousId = "anonymousId";
-
-        if (!enableTelemetry) {
-          AnalyticsUtil.removeAnalytics();
-        }
       }
 
-      UsagePulse.startTrackingActivity();
-
+      /*
+       * Forking it as we don't want to block application flow
+       */
+      yield fork(initiateUsageTracking, {
+        //@ts-expect-error: response is of type unknown
+        isAnonymousUser: response.data.isAnonymous,
+        enableTelemetry,
+      });
       yield put(initAppLevelSocketConnection());
       yield put(initPageLevelSocketConnection());
       yield put({

--- a/app/client/src/ce/sagas/userSagas.tsx
+++ b/app/client/src/ce/sagas/userSagas.tsx
@@ -137,11 +137,13 @@ export function* initiateUsageTracking(payload: {
   isAnonymousUser: boolean;
   enableTelemetry: boolean;
 }) {
+  const appsmithConfigs = getAppsmithConfigs();
+
   //To make sure that we're not tracking from previous session.
   UsagePulse.stopTrackingActivity();
 
   if (payload.isAnonymousUser) {
-    if (payload.enableTelemetry) {
+    if (payload.enableTelemetry && appsmithConfigs.segment.enabled) {
       UsagePulse.userAnonymousId = AnalyticsUtil.getAnonymousId();
     } else {
       yield initializeSegmentWithoutTracking();


### PR DESCRIPTION
## Description

For anonymous users, we need segment id, so if telemetry is off we're initiating the segment without tracking and once we get the id, the analytics object is purged.

Fixes https://github.com/appsmithorg/cloud-services/issues/231

## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
