### PR TITLE
fix: List v2 - Currency widget text trim of page change

### DIFF
--- a/app/client/cypress/fixtures/Listv2/simpleListWithCurrencyWidget.json
+++ b/app/client/cypress/fixtures/Listv2/simpleListWithCurrencyWidget.json
@@ -1,0 +1,397 @@
+{
+  "dsl": {
+    "widgetName": "MainContainer",
+    "backgroundColor": "none",
+    "rightColumn": 1224,
+    "snapColumns": 64,
+    "detachFromLayout": true,
+    "widgetId": "0",
+    "topRow": 0,
+    "bottomRow": 630,
+    "containerStyle": "none",
+    "snapRows": 56,
+    "parentRowSpace": 1,
+    "type": "CANVAS_WIDGET",
+    "canExtend": true,
+    "version": 75,
+    "minHeight": 570,
+    "parentColumnSpace": 1,
+    "dynamicBindingPathList": [],
+    "leftColumn": 0,
+    "children": [
+        {
+            "currentItemsView": "{{[]}}",
+            "triggeredItemView": "{{{}}}",
+            "widgetName": "List1",
+            "requiresFlatWidgetChildren": true,
+            "listData": "[\n  {\n    \"id\": \"000\",\n    \"name\": \"Yellow\",\n    \"img\": \"https://assets.appsmith.com/widgets/default.png\"\n  },\n  {\n    \"id\": \"001\",\n    \"name\": \"Blue\",\n    \"img\": \"https://assets.appsmith.com/widgets/default.png\"\n  },\n  {\n    \"id\": \"002\",\n    \"name\": \"Green\",\n    \"img\": \"https://assets.appsmith.com/widgets/default.png\"\n  },\n  {\n    \"id\": \"003\",\n    \"name\": \"Red\",\n    \"img\": \"https://assets.appsmith.com/widgets/default.png\"\n  },\n  {\n    \"id\": \"004\",\n    \"name\": \"Black\",\n    \"img\": \"https://assets.appsmith.com/widgets/default.png\"\n  },\n  {\n    \"id\": \"005\",\n    \"name\": \"Yellow\",\n    \"img\": \"https://assets.appsmith.com/widgets/default.png\"\n  },\n  {\n    \"id\": \"006\",\n    \"name\": \"Indigo\",\n    \"img\": \"https://assets.appsmith.com/widgets/default.png\"\n  }\n  ]",
+            "isCanvas": true,
+            "displayName": "List V2",
+            "iconSVG": "/static/media/icon.9925ee17dee37bf1ba7374412563a8a7.svg",
+            "topRow": 6,
+            "bottomRow": 55,
+            "pageSize": 3,
+            "parentRowSpace": 10,
+            "type": "LIST_WIDGET_V2",
+            "itemSpacing": 8,
+            "hideCard": false,
+            "templateBottomRow": 16,
+            "mainContainerId": "rwkr7nv4lg",
+            "animateLoading": true,
+            "primaryKeys": "{{List1.listData.map((currentItem, currentIndex) => currentItem[\"id\"] )}}",
+            "parentColumnSpace": 18.0625,
+            "dynamicTriggerPathList": [],
+            "dynamicBindingPathList": [
+                {
+                    "key": "currentItemsView"
+                },
+                {
+                    "key": "selectedItemView"
+                },
+                {
+                    "key": "triggeredItemView"
+                },
+                {
+                    "key": "primaryKeys"
+                }
+            ],
+            "leftColumn": 5,
+            "gridType": "vertical",
+            "enhancements": true,
+            "children": [
+                {
+                    "widgetName": "Canvas1",
+                    "displayName": "Canvas",
+                    "topRow": 0,
+                    "bottomRow": 490,
+                    "parentRowSpace": 1,
+                    "type": "CANVAS_WIDGET",
+                    "canExtend": false,
+                    "hideCard": true,
+                    "dropDisabled": true,
+                    "openParentPropertyPane": true,
+                    "minHeight": 490,
+                    "noPad": true,
+                    "parentColumnSpace": 1,
+                    "leftColumn": 0,
+                    "dynamicBindingPathList": [],
+                    "children": [
+                        {
+                            "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+                            "widgetName": "Container1",
+                            "borderColor": "#E0DEDE",
+                            "disallowCopy": true,
+                            "isCanvas": true,
+                            "displayName": "Container",
+                            "iconSVG": "/static/media/icon.1977dca3370505e2db3a8e44cfd54907.svg",
+                            "searchTags": [
+                                "div",
+                                "parent",
+                                "group"
+                            ],
+                            "topRow": 0,
+                            "bottomRow": 12,
+                            "dragDisabled": true,
+                            "type": "CONTAINER_WIDGET",
+                            "hideCard": false,
+                            "shouldScrollContents": false,
+                            "isDeletable": false,
+                            "animateLoading": true,
+                            "leftColumn": 0,
+                            "dynamicBindingPathList": [
+                                {
+                                    "key": "borderRadius"
+                                },
+                                {
+                                    "key": "boxShadow"
+                                }
+                            ],
+                            "children": [
+                                {
+                                    "widgetName": "Canvas2",
+                                    "isDeprecated": false,
+                                    "detachFromLayout": true,
+                                    "displayName": "Canvas",
+                                    "widgetId": "h51kxibkus",
+                                    "topRow": 0,
+                                    "containerStyle": "none",
+                                    "parentRowSpace": 1,
+                                    "isVisible": true,
+                                    "type": "CANVAS_WIDGET",
+                                    "canExtend": false,
+                                    "version": 1,
+                                    "hideCard": true,
+                                    "parentId": "rwkr7nv4lg",
+                                    "renderMode": "CANVAS",
+                                    "isLoading": false,
+                                    "parentColumnSpace": 1,
+                                    "leftColumn": 0,
+                                    "dynamicBindingPathList": [],
+                                    "children": [
+                                        {
+                                            "boxShadow": "none",
+                                            "widgetName": "Image1",
+                                            "displayName": "Image",
+                                            "iconSVG": "/static/media/icon.52d8fb963abcb95c79b10f1553389f22.svg",
+                                            "topRow": 0,
+                                            "bottomRow": 8,
+                                            "type": "IMAGE_WIDGET",
+                                            "hideCard": false,
+                                            "animateLoading": true,
+                                            "dynamicTriggerPathList": [],
+                                            "imageShape": "RECTANGLE",
+                                            "dynamicBindingPathList": [
+                                                {
+                                                    "key": "image"
+                                                },
+                                                {
+                                                    "key": "borderRadius"
+                                                }
+                                            ],
+                                            "leftColumn": 0,
+                                            "defaultImage": "https://assets.appsmith.com/widgets/default.png",
+                                            "key": "haq56bwf64",
+                                            "image": "{{currentItem.img}}",
+                                            "isDeprecated": false,
+                                            "rightColumn": 16,
+                                            "objectFit": "cover",
+                                            "widgetId": "sxtlg0j0ap",
+                                            "isVisible": true,
+                                            "version": 1,
+                                            "parentId": "h51kxibkus",
+                                            "renderMode": "CANVAS",
+                                            "isLoading": false,
+                                            "maxZoomLevel": 1,
+                                            "enableDownload": false,
+                                            "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                            "enableRotation": false
+                                        },
+                                        {
+                                            "boxShadow": "none",
+                                            "widgetName": "Text1",
+                                            "displayName": "Text",
+                                            "iconSVG": "/static/media/icon.97c59b523e6f70ba6f40a10fc2c7c5b5.svg",
+                                            "searchTags": [
+                                                "typography",
+                                                "paragraph",
+                                                "label"
+                                            ],
+                                            "topRow": 0,
+                                            "bottomRow": 4,
+                                            "type": "TEXT_WIDGET",
+                                            "hideCard": false,
+                                            "animateLoading": true,
+                                            "overflow": "NONE",
+                                            "dynamicTriggerPathList": [],
+                                            "fontFamily": "{{appsmith.theme.fontFamily.appFont}}",
+                                            "dynamicBindingPathList": [
+                                                {
+                                                    "key": "text"
+                                                },
+                                                {
+                                                    "key": "truncateButtonColor"
+                                                },
+                                                {
+                                                    "key": "fontFamily"
+                                                },
+                                                {
+                                                    "key": "borderRadius"
+                                                }
+                                            ],
+                                            "leftColumn": 16,
+                                            "shouldTruncate": false,
+                                            "truncateButtonColor": "{{appsmith.theme.colors.primaryColor}}",
+                                            "text": "{{currentItem.name}}",
+                                            "key": "8tp7d6smd7",
+                                            "isDeprecated": false,
+                                            "rightColumn": 28,
+                                            "textAlign": "LEFT",
+                                            "dynamicHeight": "AUTO_HEIGHT",
+                                            "widgetId": "60w0z5q6qy",
+                                            "isVisible": true,
+                                            "fontStyle": "BOLD",
+                                            "textColor": "#231F20",
+                                            "version": 1,
+                                            "parentId": "h51kxibkus",
+                                            "renderMode": "CANVAS",
+                                            "isLoading": false,
+                                            "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                            "maxDynamicHeight": 9000,
+                                            "fontSize": "1rem",
+                                            "textStyle": "HEADING",
+                                            "minDynamicHeight": 4
+                                        },
+                                        {
+                                            "boxShadow": "none",
+                                            "widgetName": "Text2",
+                                            "displayName": "Text",
+                                            "iconSVG": "/static/media/icon.97c59b523e6f70ba6f40a10fc2c7c5b5.svg",
+                                            "searchTags": [
+                                                "typography",
+                                                "paragraph",
+                                                "label"
+                                            ],
+                                            "topRow": 4,
+                                            "bottomRow": 8,
+                                            "type": "TEXT_WIDGET",
+                                            "hideCard": false,
+                                            "animateLoading": true,
+                                            "overflow": "NONE",
+                                            "dynamicTriggerPathList": [],
+                                            "fontFamily": "{{appsmith.theme.fontFamily.appFont}}",
+                                            "dynamicBindingPathList": [
+                                                {
+                                                    "key": "text"
+                                                },
+                                                {
+                                                    "key": "truncateButtonColor"
+                                                },
+                                                {
+                                                    "key": "fontFamily"
+                                                },
+                                                {
+                                                    "key": "borderRadius"
+                                                }
+                                            ],
+                                            "leftColumn": 16,
+                                            "shouldTruncate": false,
+                                            "truncateButtonColor": "{{appsmith.theme.colors.primaryColor}}",
+                                            "text": "{{currentItem.id}}",
+                                            "key": "8tp7d6smd7",
+                                            "isDeprecated": false,
+                                            "rightColumn": 24,
+                                            "textAlign": "LEFT",
+                                            "dynamicHeight": "AUTO_HEIGHT",
+                                            "widgetId": "rgk61cuepz",
+                                            "isVisible": true,
+                                            "fontStyle": "BOLD",
+                                            "textColor": "#231F20",
+                                            "version": 1,
+                                            "parentId": "h51kxibkus",
+                                            "renderMode": "CANVAS",
+                                            "isLoading": false,
+                                            "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                            "maxDynamicHeight": 9000,
+                                            "fontSize": "1rem",
+                                            "textStyle": "BODY",
+                                            "minDynamicHeight": 4
+                                        },
+                                        {
+                                            "boxShadow": "none",
+                                            "widgetName": "CurrencyInput1",
+                                            "displayName": "Currency Input",
+                                            "iconSVG": "/static/media/icon.f312efcb48ce4dafb08c20291635b30b.svg",
+                                            "searchTags": [
+                                                "amount",
+                                                "total"
+                                            ],
+                                            "topRow": 0,
+                                            "bottomRow": 7,
+                                            "defaultCurrencyCode": "USD",
+                                            "parentRowSpace": 10,
+                                            "labelWidth": 5,
+                                            "autoFocus": false,
+                                            "type": "CURRENCY_INPUT_WIDGET",
+                                            "hideCard": false,
+                                            "animateLoading": true,
+                                            "parentColumnSpace": 6.3359375,
+                                            "dynamicTriggerPathList": [],
+                                            "resetOnSubmit": true,
+                                            "leftColumn": 31,
+                                            "dynamicBindingPathList": [
+                                                {
+                                                    "key": "accentColor"
+                                                },
+                                                {
+                                                    "key": "borderRadius"
+                                                }
+                                            ],
+                                            "labelPosition": "Top",
+                                            "labelStyle": "",
+                                            "isDisabled": false,
+                                            "key": "e35bju0wd2",
+                                            "labelTextSize": "0.875rem",
+                                            "isRequired": false,
+                                            "isDeprecated": false,
+                                            "rightColumn": 51,
+                                            "dynamicHeight": "FIXED",
+                                            "widgetId": "hvo4i9pws4",
+                                            "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+                                            "showStepArrows": false,
+                                            "isVisible": true,
+                                            "label": "Label",
+                                            "allowCurrencyChange": false,
+                                            "version": 1,
+                                            "parentId": "h51kxibkus",
+                                            "labelAlignment": "left",
+                                            "renderMode": "CANVAS",
+                                            "isLoading": false,
+                                            "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                            "maxDynamicHeight": 9000,
+                                            "decimals": 0,
+                                            "iconAlign": "left",
+                                            "defaultText": "",
+                                            "minDynamicHeight": 4
+                                        }
+                                    ],
+                                    "key": "847xlt7tdq"
+                                }
+                            ],
+                            "borderWidth": "1",
+                            "key": "4i4xj3shn8",
+                            "backgroundColor": "white",
+                            "isDeprecated": false,
+                            "rightColumn": 64,
+                            "dynamicHeight": "FIXED",
+                            "widgetId": "rwkr7nv4lg",
+                            "containerStyle": "card",
+                            "isVisible": true,
+                            "version": 1,
+                            "parentId": "l6gb101tsq",
+                            "renderMode": "CANVAS",
+                            "isLoading": false,
+                            "noContainerOffset": true,
+                            "disabledWidgetFeatures": [
+                                "dynamicHeight"
+                            ],
+                            "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                            "maxDynamicHeight": 9000,
+                            "minDynamicHeight": 10
+                        }
+                    ],
+                    "key": "847xlt7tdq",
+                    "isDeprecated": false,
+                    "rightColumn": 433.5,
+                    "detachFromLayout": true,
+                    "widgetId": "l6gb101tsq",
+                    "containerStyle": "none",
+                    "isVisible": true,
+                    "version": 1,
+                    "parentId": "bicd8txs1t",
+                    "renderMode": "CANVAS",
+                    "isLoading": false
+                }
+            ],
+            "passThroughPropsKeys": [
+                "level",
+                "levelData",
+                "prefixMetaWidgetId",
+                "metaWidgetId"
+            ],
+            "key": "foegcys7mf",
+            "backgroundColor": "transparent",
+            "isDeprecated": false,
+            "rightColumn": 62,
+            "itemBackgroundColor": "#FFFFFF",
+            "widgetId": "bicd8txs1t",
+            "isVisible": true,
+            "parentId": "0",
+            "hasMetaWidgets": true,
+            "renderMode": "CANVAS",
+            "isLoading": false,
+            "mainCanvasId": "l6gb101tsq",
+            "selectedItemView": "{{{}}}"
+        }
+    ]
+  }
+}

--- a/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
@@ -296,7 +296,7 @@ class CurrencyInputWidget extends BaseInputWidget<
   }
 
   formatText() {
-    if (!!this.props.text) {
+    if (!!this.props.text && !this.isTextFormatted()) {
       try {
         /**
          * Since we are restricting default value to only have "." decimal separator,
@@ -344,6 +344,10 @@ class CurrencyInputWidget extends BaseInputWidget<
     if (!this.props.isDirty) {
       this.props.updateWidgetMetaProperty("isDirty", true);
     }
+  };
+
+  isTextFormatted = () => {
+    return this.props.text.includes(getLocaleThousandSeparator());
   };
 
   handleFocusChange = (isFocused?: boolean) => {


### PR DESCRIPTION
## Description

When a value is large, it is represented in formatted text i.e if value is 123456789 then it is shown as 123,456,789. Once a page is revisited, the meta prop `text` already has a value i.e `123,456,789` and on component mount of CurrencyWidget, the `formatText` is called by default. This in turn calls the function `parseFloat("123,456,789")` which trims everything.

Added a check to only format the text if it is in a non-formatted form. 

Fixes #19787 

Media
[LOOM](https://www.loom.com/share/b3c00efe6b8f48ad84b942bee7073afa)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
