### PR TITLE
ci: Add JAVA setup step to perf tests in test build workflow

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -497,6 +497,14 @@ jobs:
           name: client-build
           path: app/client/build
 
+      # Setup Java
+      - name: Set up JDK 17
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Download the server build artifact
         if: steps.run_result.outputs.run_result != 'success'
         uses: actions/download-artifact@v3
@@ -525,15 +533,7 @@ jobs:
           ls -l dist/
           # Run the server in the background and redirect logs to a log file
           ./scripts/start-dev-server.sh &> server-logs.log &
-      - name: Wait for 30 seconds for server to start
-        if: steps.run_result.outputs.run_result != 'success'
-        run: |
-          sleep 30s
-      - name: Installing Yarn serve
-        if: steps.run_result.outputs.run_result != 'success'
-        run: |
-          yarn global add serve
-          echo "$(yarn global bin)" >> $GITHUB_PATH
+
       # Start rts
       - name: Start RTS Server
         if: steps.run_result.outputs.run_result != 'success'
@@ -587,6 +587,18 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: app/client/perf
         run: chmod +x ./start-test.sh
+
+      - name: Wait for 10s and check if server is running
+        if: steps.run_result.outputs.run_result != 'success'
+        run: |
+          sleep 10s
+          if lsof -i :8080; then
+            echo "Server Found"
+          else
+            echo "Server Not Started. Printing logs from server process"
+            cat app/server/nohup.out
+            exit 1
+          fi
 
       - name: Run performance tests
         if: steps.run_result.outputs.run_result != 'success'


### PR DESCRIPTION
Add JAVA setup step to perf tests in test build workflow.
This is a possible fix for perf tests on running because backend server was not up.