### PR TITLE
chore: code split changes for license error page for non admin user

### DIFF
--- a/app/client/src/pages/common/PageHeader.tsx
+++ b/app/client/src/pages/common/PageHeader.tsx
@@ -99,6 +99,7 @@ type PageHeaderProps = {
   user?: User;
   hideShadow?: boolean;
   showSeparator?: boolean;
+  hideEditProfileLink?: boolean;
 };
 
 export function PageHeader(props: PageHeaderProps) {
@@ -196,6 +197,7 @@ export function PageHeader(props: PageHeaderProps) {
             />
           ) : (
             <ProfileDropdown
+              hideEditProfileLink={props.hideEditProfileLink}
               name={user.name}
               photoId={user?.photoId}
               userName={user.username}

--- a/app/client/src/pages/common/ProfileDropdown.tsx
+++ b/app/client/src/pages/common/ProfileDropdown.tsx
@@ -32,6 +32,7 @@ type TagProps = CommonComponentProps & {
   name: string;
   modifiers?: PopperModifiers;
   photoId?: string;
+  hideEditProfileLink?: boolean;
 };
 
 const StyledMenuItem = styled(MenuItem)`
@@ -134,16 +135,18 @@ export default function ProfileDropdown(props: TagProps) {
         </UserNameWrapper>
       </UserInformation>
       <MenuDivider />
-      <StyledMenuItem
-        className={`t--edit-profile ${BlueprintClasses.POPOVER_DISMISS}`}
-        icon="edit-underline"
-        onSelect={() => {
-          getOnSelectAction(DropdownOnSelectActions.REDIRECT, {
-            path: PROFILE,
-          });
-        }}
-        text="Edit Profile"
-      />
+      {!props.hideEditProfileLink && (
+        <StyledMenuItem
+          className={`t--edit-profile ${BlueprintClasses.POPOVER_DISMISS}`}
+          icon="edit-underline"
+          onSelect={() => {
+            getOnSelectAction(DropdownOnSelectActions.REDIRECT, {
+              path: PROFILE,
+            });
+          }}
+          text="Edit Profile"
+        />
+      )}
       <StyledMenuItem
         className="t--logout-icon"
         icon="logout"


### PR DESCRIPTION
## Description
 license error page for non-admin users. Added an option to hide the edit profile link from the profile dropdown in the header.

Fixes https://github.com/appsmithorg/cloud-services/issues/209

## Type of change

> Please delete options that are not relevant.

- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
