### PR TITLE
chore: update import for ActionTriggerFunctionNames

### DIFF
--- a/app/client/src/workers/Linting/utils.ts
+++ b/app/client/src/workers/Linting/utils.ts
@@ -53,7 +53,7 @@ import { LintErrors } from "reducers/lintingReducers/lintErrorsReducers";
 import { Severity } from "entities/AppsmithConsole";
 import { JSLibraries } from "workers/common/JSLibrary";
 import { MessageType, sendMessage } from "utils/MessageUtil";
-import { ActionTriggerFunctionNames } from "ce/entities/DataTree/actionTriggers";
+import { ActionTriggerFunctionNames } from "@appsmith/entities/DataTree/actionTriggers";
 
 export function getlintErrorsFromTree(
   pathsToLint: string[],


### PR DESCRIPTION
Linting was broken in EE repo.

Since ActionTriggerFunctionName is imported from `ce/entities/DataTree/actionTriggers`.
Changed to `@appsmith/entities/DataTree/actionTriggers` namespace.