### PR TITLE
fix: Usage pulse delivery for invalid user where manage user permission is missing 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UsagePulseControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UsagePulseControllerCE.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.controllers.ce;
 
+import com.appsmith.server.constants.Url;
 import com.appsmith.server.dtos.ResponseDTO;
 import com.appsmith.server.dtos.UsagePulseDTO;
 import com.appsmith.server.services.UsagePulseService;
@@ -8,10 +9,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
+@RequestMapping(Url.USAGE_PULSE_URL)
 public class UsagePulseControllerCE {
 
     private final UsagePulseService service;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -72,13 +72,14 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
                             // Hashed user email is stored to user for future mapping of user and pulses
                             User updateUser = new User();
                             updateUser.setHashedEmail(hashedEmail);
-                            updateUser.setPasswordResetInitiated(user.getPasswordResetInitiated());
-                            updateUser.setSource(user.getSource());
+
+                            // Avoid updating the ACL fields
                             updateUser.setGroupIds(null);
                             updateUser.setPolicies(null);
+                            updateUser.setPermissions(null);
 
-                            return Mono.zip(userService.update(user.getId(), updateUser),save(usagePulse))
-                                            .map(tuple1 -> tuple1.getT2());
+                            return userService.updateWithoutPermission(user.getId(), updateUser)
+                                    .then(save(usagePulse));
                         }
                         usagePulse.setUser(user.getHashedEmail());
                     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCE.java
@@ -47,4 +47,6 @@ public interface UserServiceCE extends CrudService<User, String> {
     Flux<User> getAllByEmails(Set<String> emails, AclPermission permission);
 
     Mono<Map<String, String>> updateTenantLogoInParams(Map<String, String> params);
+
+    Mono<User> updateWithoutPermission(String id, User update);
 }


### PR DESCRIPTION
## Description

> As we are using updateUser method within UsagePulse (`api/v1/usage-pulse`) API to update the hashedEmail. This requires the user to possess required permission but as this is a internal usecase it's safe to expose a method to perform the update operation.

Fixes https://github.com/appsmithorg/cloud-services/issues/226

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
