### PR TITLE
fix: Add support for the shh url that does not contain domain name

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitUtils.java
@@ -30,7 +30,7 @@ public class GitUtils {
         }
         return sshUrl
                 .replaceFirst(".*git@", "https://")
-                .replaceFirst("(\\.[a-z]*):", "$1/")
+                .replaceFirst("(\\.[a-zA-Z0-9]*):", "$1/")
                 .replaceFirst("\\.git$", "");
     }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/GitUtilsTest.java
@@ -28,6 +28,8 @@ public class GitUtilsTest {
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
         assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("ssh://git@tim.tam.example.com:v3/sladeping/pyhe/SpaceJunk"))
                 .isEqualTo("https://tim.tam.example.com/v3/sladeping/pyhe/SpaceJunk");
+        assertThat(GitUtils.convertSshUrlToBrowserSupportedUrl("git@127.0.0.1:test/newRepo.git"))
+                .isEqualTo("https://127.0.0.1/test/newRepo");
     }
 
     @Test


### PR DESCRIPTION
## Description

> When the git service is self hosted, one can chose to not to set up a domain name. But this set up does not work with the current git sync feature. This PR fixes this bug by supporting such use cases. 

Fixes https://github.com/appsmithorg/appsmith/issues/19878

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual
- JUnit


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
