### PR TITLE
feat: Split `/me` to only return basic user information and use `/profile` used in home page for detailed view of the current user

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UserControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/UserControllerCE.java
@@ -140,6 +140,12 @@ public class UserControllerCE extends BaseController<UserService, User, String> 
     }
 
     @GetMapping("/me")
+    public Mono<ResponseDTO<User>> getCurrentUser() {
+        return sessionUserService.getCurrentUser()
+                .map(profile -> new ResponseDTO<>(HttpStatus.OK.value(), profile, null));
+    }
+
+    @GetMapping("/profile")
     public Mono<ResponseDTO<UserProfileDTO>> getUserProfile() {
         return sessionUserService.getCurrentUser()
                 .flatMap(service::buildUserProfileDTO)


### PR DESCRIPTION
`/me` has become a very heavy API due to overloading of different functions into a single api since it gets called from all the pages. Splitting this API to make this faster and introducing a new `/profile` endpoint which should be used on the homepage (and only if required, on the edit user profile page.). 