### PR TITLE
test: Skipping GraphQL tests until endpoint responds to unblock CI

### DIFF
--- a/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/GraphQL_spec.ts
+++ b/app/client/cypress/integration/Smoke_TestSuite/ServerSideTests/Datasources/GraphQL_spec.ts
@@ -65,7 +65,7 @@ describe("GraphQL Datasource Implementation", function() {
     agHelper.RenameWithInPane(apiName, true);
   });
 
-  it("3. Should execute the API and validate the response", function() {
+  it.skip("3. Should execute the API and validate the response", function() {
     /* Create an API */
     dataSources.NavigateFromActiveDS(datasourceName, true);
 
@@ -81,7 +81,7 @@ describe("GraphQL Datasource Implementation", function() {
     });
   });
 
-  it("4. Pagination for limit based should work without offset", function() {
+  it.skip("4. Pagination for limit based should work without offset", function() {
     /* Create an API */
     dataSources.NavigateFromActiveDS(datasourceName, true);
     apiPage.SelectPaneTab("Body");
@@ -108,7 +108,7 @@ describe("GraphQL Datasource Implementation", function() {
     });
   });
 
-  it("5. Pagination for limit based should work with offset", function() {
+  it.skip("5. Pagination for limit based should work with offset", function() {
     /* Create an API */
     dataSources.NavigateFromActiveDS(datasourceName, true);
     apiPage.SelectPaneTab("Body");


### PR DESCRIPTION
## Description

- This PR skips the GraphQL cases until the endpoint used in the spec responds or is changed to point to TED GraphQL

## Type of change

- Script update


## How Has This Been Tested?
- Cypress local run

## Checklist:
### QA activity:
- [X] Test plan has been peer reviewed by QA
- [X] Cypress test cases have been added and approved by either SDET or manual QA