### PR TITLE
fix: Redis rdb persistance | User session persistance

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -248,8 +248,13 @@ configure_supervisord() {
     fi
     if [[ $APPSMITH_REDIS_URL == *"localhost"* || $APPSMITH_REDIS_URL == *"127.0.0.1"* ]]; then
       cp "$SUPERVISORD_CONF_PATH/redis.conf" /etc/supervisor/conf.d/
+      # Initialize Redis rdb directory
+      REDIS_DB_PATH="$stacks_path/data/redis"
+      mkdir -p "$REDIS_DB_PATH"
       # Enable saving Redis session data to disk more often, so recent sessions aren't cleared on restart.
-      sed -i 's/^# save 60 10000$/save 60 1/g' /etc/redis/redis.conf
+      sed -i 's/^save 60 10000$/save 15 1/g' /etc/redis/redis.conf
+      # Updating the default Redis rdb directory
+      sed -i "s|^dir /var/lib/redis$|dir ${REDIS_DB_PATH}|g" /etc/redis/redis.conf
     fi
     if ! [[ -e "/appsmith-stacks/ssl/fullchain.pem" ]] || ! [[ -e "/appsmith-stacks/ssl/privkey.pem" ]]; then
       cp "$SUPERVISORD_CONF_PATH/cron.conf" /etc/supervisor/conf.d/


### PR DESCRIPTION
## Description
- Updated redis.conf to set the Redis rdb directory to `/appsmith-stacks/data/redis` bind-mount directory, so that the data is persisted after the container restarts/updates. ( This was causing user sessions on Appsmith installations using the embedded Redis to reset after every container restart, since the redis data was not being persisted)
- Updated redis.conf for the embedded Redis to increase the snapshot frequency to dump after every 15 sec if at least 1 key changed

Fixes #19768

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual

