### PR TITLE
fix: add new button is always visible as long as it is enabled (#19762)

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/Add_new_row_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/Add_new_row_spec.js
@@ -166,6 +166,34 @@ describe("Table widget Add new row feature's", () => {
       });
       cy.get(".t--property-pane-back-btn").click();
     });
+    it("1.11. should not hide the header section when add new row button is enabled and another header element is disabled", () => {
+      cy.get(".t--discard-new-row").click({ force: true });
+      //disable all header widgets for the table
+      [
+        "Show Pagination",
+        "Allow Searching",
+        "Allow Download",
+        "Allow Filtering",
+        "Allow adding a row",
+      ].forEach((val) => {
+        propPane.ToggleOnOrOff(val, "Off");
+      });
+      cy.wait(1000);
+
+      //intially enable 2 sections show pagination and add a row header section
+      propPane.ToggleOnOrOff("Show Pagination", "On");
+      propPane.ToggleOnOrOff("Allow adding a row", "On");
+
+      //add new row button should be present
+      cy.get(".t--add-new-row").should("exist");
+      //turn off pagination and now add new row button should be the only section left
+      propPane.ToggleOnOrOff("Show Pagination", "Off");
+      //add new row button should continue to be present
+      cy.get(".t--add-new-row").should("exist");
+      //finally turn off add new row button should be removed from the widget
+      propPane.ToggleOnOrOff("Allow adding a row", "Off");
+      cy.get(".t--add-new-row").should("not.exist");
+    });
   });
 
   describe("Validation flow", () => {

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/Add_new_row_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/Add_new_row_spec.js
@@ -180,17 +180,17 @@ describe("Table widget Add new row feature's", () => {
       });
       cy.wait(1000);
 
-      //intially enable 2 sections show pagination and add a row header section
+      //intially enable 2 sections to show pagination and "add new row" button to the header section
       propPane.ToggleOnOrOff("Show Pagination", "On");
       propPane.ToggleOnOrOff("Allow adding a row", "On");
 
-      //add new row button should be present
+      //"add new row" button should be present
       cy.get(".t--add-new-row").should("exist");
-      //turn off pagination and now add new row button should be the only section left
+      //turn off pagination and now the "add new row" button should be the only component left in the header section
       propPane.ToggleOnOrOff("Show Pagination", "Off");
-      //add new row button should continue to be present
+      //"add new row" should continue to be present
       cy.get(".t--add-new-row").should("exist");
-      //finally turn off add new row button should be removed from the widget
+      //finally turn off allow adding a row then the "add new row" button should be removed from the header section
       propPane.ToggleOnOrOff("Allow adding a row", "Off");
       cy.get(".t--add-new-row").should("not.exist");
     });

--- a/app/client/src/widgets/TableWidgetV2/component/Table.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/Table.tsx
@@ -236,7 +236,8 @@ export function Table(props: TableProps) {
     props.isVisibleSearch ||
     props.isVisibleFilters ||
     props.isVisibleDownload ||
-    props.isVisiblePagination;
+    props.isVisiblePagination ||
+    props.allowAddNewRow;
 
   const style = useMemo(
     () => ({


### PR DESCRIPTION
## Description
An enabled add new button was hidden when other header components are disabled, this PR fixes it. 

Fixes  #19762
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
