### PR TITLE
fix: List widget with serverside enabled, resetting should re-trigger page change query

### DIFF
--- a/app/client/cypress/fixtures/Listv2/listWithServerSideData.json
+++ b/app/client/cypress/fixtures/Listv2/listWithServerSideData.json
@@ -583,6 +583,57 @@
             "isLoading": false,
             "mainCanvasId": "fzoe28dkhl",
             "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}"
+        },
+        {
+            "resetFormOnClick": false,
+            "boxShadow": "none",
+            "widgetName": "Button1",
+            "onClick": "",
+            "buttonColor": "{{appsmith.theme.colors.primaryColor}}",
+            "displayName": "Button",
+            "iconSVG": "/static/media/icon.cca026338f1c8eb6df8ba03d084c2fca.svg",
+            "searchTags": [
+                "click",
+                "submit"
+            ],
+            "topRow": 73,
+            "bottomRow": 77,
+            "parentRowSpace": 10,
+            "type": "BUTTON_WIDGET",
+            "hideCard": false,
+            "animateLoading": true,
+            "parentColumnSpace": 10.375,
+            "dynamicTriggerPathList": [
+                {
+                    "key": "onClick"
+                }
+            ],
+            "leftColumn": 25,
+            "dynamicBindingPathList": [
+                {
+                    "key": "buttonColor"
+                },
+                {
+                    "key": "borderRadius"
+                }
+            ],
+            "text": "Submit",
+            "isDisabled": false,
+            "key": "2yau3vob7i",
+            "isDeprecated": false,
+            "rightColumn": 41,
+            "isDefaultClickDisabled": true,
+            "widgetId": "gxyrbodx7e",
+            "isVisible": true,
+            "recaptchaType": "V3",
+            "version": 1,
+            "parentId": "0",
+            "renderMode": "CANVAS",
+            "isLoading": false,
+            "disabledWhenInvalid": false,
+            "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+            "buttonVariant": "PRIMARY",
+            "placement": "CENTER"
         }
     ]
   }

--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -130,6 +130,7 @@ class ListWidget extends BaseWidget<
   prevMetaContainerNames: string[];
   prevMetaMainCanvasWidget?: MetaWidget;
   pageSize: number;
+  pageChangeEventTriggerFromPageNo?: number | null;
 
   static getPropertyPaneContentConfig() {
     return PropertyPaneContentConfig;
@@ -236,6 +237,13 @@ class ListWidget extends BaseWidget<
       );
 
       this.onPageChange(maxPageNo);
+    }
+
+    if (this.hasPageNoReset(prevProps.pageNo, this.props.pageNo)) {
+      this.executeOnPageChange();
+
+      // Reset
+      this.pageChangeEventTriggerFromPageNo = null;
     }
 
     if (this.shouldUpdateCacheKeys(prevProps)) {
@@ -469,6 +477,27 @@ class ListWidget extends BaseWidget<
     return isNaN(pageSize) ? 0 : floor(pageSize);
   };
 
+  /**
+   * If this object has some value then the onPageChange event was triggered
+   * and the prev and curr properties in it represent what was the transition
+   * when the event was triggered.
+   * This helps in ensuring that during a page change onPageChange event was
+   * successfully triggered.
+   *
+   * Page no can be changed in 2 ways
+   * 1. On clicking of page number in the pagination controls
+   * 2. The widget is reset and the page no resets to 1.
+   * 3. If current page is higher than the max page available.
+   *  */
+  hasPageNoReset = (prevPageNo: number, currPageNo: number) => {
+    return (
+      prevPageNo > 1 &&
+      currPageNo === 1 &&
+      (!this.pageChangeEventTriggerFromPageNo ||
+        this.pageChangeEventTriggerFromPageNo !== prevPageNo)
+    );
+  };
+
   updatePageSize = () => {
     super.updateWidgetProperty("pageSize", this.pageSize);
   };
@@ -544,9 +573,21 @@ class ListWidget extends BaseWidget<
           type: eventType,
         },
       });
+
+      this.pageChangeEventTriggerFromPageNo = currentPage;
     } else {
       this.props.updateWidgetMetaProperty("pageNo", page);
     }
+  };
+
+  executeOnPageChange = () => {
+    super.executeAction({
+      triggerPropertyName: "onPageChange",
+      dynamicString: this.props.onPageChange,
+      event: {
+        type: EventType.ON_PREV_PAGE,
+      },
+    });
   };
 
   getCurrDataCache = () => this.metaWidgetGenerator.getRowDataCache();


### PR DESCRIPTION
## Description

When the server side list widget is reset, the page no resets to 1 and if it resets from a higher page; the `On Page Change` query should re-trigger to get the latest data for page 1.

Fixes #19940
Fixes issue 17 in the [tracker](https://docs.google.com/spreadsheets/d/1kWosVCH622m9hohVKyFRdrr7TUa_exO8thwjo8Aqe2M/edit#gid=0)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
