### PR TITLE
fix: resolve issue of double click to select all in checkbox group

### DIFF
--- a/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
@@ -73,9 +73,6 @@ export const CheckboxGroupContainer = styled.div<CheckboxGroupContainerProps>`
     ${({ labelPosition }) =>
       labelPosition === LabelPosition.Left && "min-height: 30px"};
   }
-  & .select-all {
-    white-space: nowrap;
-  }
 `;
 
 export interface SelectAllProps {
@@ -105,7 +102,7 @@ function SelectAll(props: SelectAllProps) {
       accentColor={accentColor}
       borderRadius={borderRadius}
       checked={checked}
-      className="select-all"
+      className="whitespace-nowrap"
       disabled={disabled}
       indeterminate={indeterminate}
       inline={inline}


### PR DESCRIPTION
## Description

> In CheckBoxGroupComponent, when `isSelectAll` is enabled, it takes two clicks to check/uncheck it rather then one. The reason for this issue was, the custom className `select-all` given to `StyledCheckbox` component. The same className is available from tailwind which adds the `user-select: all` property, making the label text of select all option to be selectable. So it used to select the text on first click, and then used to check the select all option on second click.

> Add a TL;DR when description is extra long (helps content team)

Fixes #18880 


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
