### PR TITLE
fix: Change watchtower to latest

### DIFF
--- a/deploy/aws_ami/docker-compose.yml
+++ b/deploy/aws_ami/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     #  com.centurylinklabs.watchtower.enable: "true"
 
   #auto_update:
-  #  image: containrrr/watchtower:latest-dev
+  #  image: containrrr/watchtower
   #  volumes:
   #    - /var/run/docker.sock:/var/run/docker.sock
   #  # Update check interval in seconds.

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -54,7 +54,7 @@ services:
   #     com.centurylinklabs.watchtower.enable: "true"
 
   # auto_update:
-  #   image: containrrr/watchtower:latest-dev
+  #   image: containrrr/watchtower
   #   volumes:
   #     - /var/run/docker.sock:/var/run/docker.sock
   #   # Update check interval in seconds.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     #  com.centurylinklabs.watchtower.enable: "true"
 
   #auto_update:
-  #  image: containrrr/watchtower:latest-dev
+  #  image: containrrr/watchtower
   #  volumes:
   #    - /var/run/docker.sock:/var/run/docker.sock
   #  # Update check interval in seconds.


### PR DESCRIPTION
We're `watchtower:latest-dev` image for the `--schedule` support. This was only available in the `latest-dev` version of Watchtower.

Now, this feature is available in the `latest` version of Watchtower, so we should be fine switching back to `latest`.

More importantly, the `latest-dev` version of Watchtower, doesn't have ARM images built. It only has AMD images built today. So this watchtower service fails to start on ARM architectures. This PR fixes that.

