### PR TITLE
feat: Add `instanceId` in tenant response

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Tenant.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Tenant.java
@@ -1,15 +1,12 @@
 package com.appsmith.server.domains;
 
 import com.appsmith.external.models.BaseDomain;
-import com.appsmith.server.constants.ConfigNames;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.util.Map;
 
 @Getter
 @Setter
@@ -22,6 +19,8 @@ public class Tenant extends BaseDomain {
     String slug;
 
     String displayName;
+
+    String instanceId;
 
     PricingPlan pricingPlan;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/TenantServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/TenantServiceImpl.java
@@ -17,7 +17,8 @@ public class TenantServiceImpl extends TenantServiceCEImpl implements TenantServ
                              MongoConverter mongoConverter,
                              ReactiveMongoTemplate reactiveMongoTemplate,
                              TenantRepository repository,
-                             AnalyticsService analyticsService) {
-        super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
+                             AnalyticsService analyticsService,
+                             ConfigService configService) {
+        super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService, configService);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
@@ -10,6 +10,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.repositories.TenantRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.BaseService;
+import com.appsmith.server.services.ConfigService;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.util.StringUtils;
@@ -24,14 +25,17 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
 
     private String tenantId = null;
 
+    private final ConfigService configService;
+
     public TenantServiceCEImpl(Scheduler scheduler,
                                Validator validator,
                                MongoConverter mongoConverter,
                                ReactiveMongoTemplate reactiveMongoTemplate,
                                TenantRepository repository,
-                               AnalyticsService analyticsService) {
-
+                               AnalyticsService analyticsService,
+                               ConfigService configService) {
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
+        this.configService = configService;
     }
 
     @Override
@@ -72,11 +76,16 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
     }
 
     /*
-     *  For now, returning an empty tenantConfiguration object in this class. Will enhance this function once we
-     *  start saving other pertinent environment variables in the tenant collection
+     * For now, returning just the instance-id, with an empty tenantConfiguration object in this class. Will enhance
+     * this function once we start saving other pertinent environment variables in the tenant collection.
      */
     @Override
     public Mono<Tenant> getTenantConfiguration() {
-        return Mono.just(new Tenant());
+        return configService.getInstanceId()
+                .map(instanceId -> {
+                    final Tenant tenant = new Tenant();
+                    tenant.setInstanceId(instanceId);
+                    return tenant;
+                });
     }
 }


### PR DESCRIPTION
In the tenant response, this PR adds the current `instanceId` to the tenant response.

Why do we need it? This will be used to power the `Upgrade` buttons in Admin Settings to start the U&B flow.

Why add it to the tenant API? So that for U&B flows on the cloud, we can add something like a `tenantId` there, in the same request, so this felt like the right place.

Potential performance impact? Unlikely. The `instanceId` is permanently cached in the process memory, so this is a one-time DB-call, in the lifetime of the server process.
