### PR TITLE
fix: resolve issue of inconsistent color of select all label in disabled state.

### DIFF
--- a/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/CheckboxGroupWidget/component/index.tsx
@@ -86,7 +86,6 @@ export interface SelectAllProps {
   onChange: React.FormEventHandler<HTMLInputElement>;
   accentColor: string;
   borderRadius: string;
-  isDisabled?: boolean;
 }
 
 function SelectAll(props: SelectAllProps) {
@@ -97,7 +96,6 @@ function SelectAll(props: SelectAllProps) {
     disabled,
     indeterminate,
     inline,
-    isDisabled,
     onChange,
   } = props;
   return (
@@ -113,8 +111,7 @@ function SelectAll(props: SelectAllProps) {
         <CheckboxLabel
           alignment={AlignWidgetTypes.LEFT}
           className="t--checkbox-widget-label"
-          disabled={isDisabled}
-          labelTextColor={disabled ? Colors.GREY_8 : "inherit"}
+          disabled={disabled}
         >
           Select all
         </CheckboxLabel>


### PR DESCRIPTION
## Description

> This `SelectAll` component was using `isDisabled` prop internally, but the disabled state was passed in `disabled` prop. Although the internal `ChecboxLabel` component is using disabled prop, so to make `SelectAll`'s disabled prop name consistent, I used `disabled` prop, rather than `isDisabled`.

Fixes #18208 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)



## How Has This Been Tested?
- Manual


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
