### PR TITLE
fix: flaky tests due to startup happening async

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
@@ -57,14 +57,16 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
                 .then(performRtsHealthCheck())
                 .doFinally(ignored -> this.printReady());
 
-        checkInstanceSchemaVersion()
+        Mono<?> startupProcess = checkInstanceSchemaVersion()
                 .flatMap(signal -> registrationAndRtsCheckMono)
                 // Prefill the server cache with anonymous user permission group ids.
-                .then(cacheableRepositoryHelper.preFillAnonymousUserPermissionGroupIdsCache())
-                .subscribe(null, e -> {
-                    log.debug("Application start up encountered an error: {}", e.getMessage());
-                    Sentry.captureException(e);
-                });
+                .then(cacheableRepositoryHelper.preFillAnonymousUserPermissionGroupIdsCache());
+        try {
+            startupProcess.block();
+        } catch(Exception e) {
+            log.debug("Application start up encountered an error: {}", e.getMessage());
+            Sentry.captureException(e);
+        }
     }
 
     private Mono<Void> checkInstanceSchemaVersion() {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExampleApplicationsAreMarked.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ExampleApplicationsAreMarked.java
@@ -17,6 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -50,10 +52,10 @@ public class ExampleApplicationsAreMarked {
     @Autowired
     private SessionUserService sessionUserService;
 
-    @MockBean
+    @SpyBean
     private ConfigService configService;
 
-    @MockBean
+    @SpyBean
     private InstanceConfig instanceConfig;
 
     @Test
@@ -71,9 +73,7 @@ public class ExampleApplicationsAreMarked {
 
                     assert workspace.getId() != null;
                     Mockito.when(configService.getTemplateWorkspaceId()).thenReturn(Mono.just(workspace.getId()));
-                    Mockito.doNothing().when(instanceConfig).onApplicationEvent(
-                            Mockito.any(ApplicationReadyEvent.class)
-                    );
+
                     // Create 4 applications inside the example workspace but only mark three applications as example
                     final Application app1 = new Application();
                     app1.setName("first application");


### PR DESCRIPTION
Testcases were flaky because loading cache after application is ready is happening in async with testcases, so sometimes testcases fails if cache is not loaded by the time testcase executes.
Testcases fail and gives the following error message `Appsmith server is not ready. Please try again in some time`

This fixes the issue by running startup process in sync after application is ready.

And there is a genuine failure of testcase `exampleApplicationsAreMarked` which is fixed.
