### PR TITLE
fix: MySQL Plugin: update handling of JSON DB type

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -893,20 +893,25 @@ public class MySqlPluginTest {
                         .blockLast(); // wait until completion of all the queries
 
                 /* Test numeric types */
-                testExecute(query_select_from_test_numeric_types);
+                testExecute(query_select_from_test_numeric_types, null);
                 /* Test date time types */
-                testExecute(query_select_from_test_date_time_types);
+                testExecute(query_select_from_test_date_time_types, null);
                 /* Test data types */
-                testExecute(query_select_from_test_data_types);
-                /* Test data types */
-                testExecute(query_select_from_test_json_data_type);
-                /* Test data types */
-                testExecute(query_select_from_test_geometry_types);
+                testExecute(query_select_from_test_data_types, null);
+                /* Test json type */
+                /**
+                 * TBD: add check for other data types as well.
+                 * Tracked here: https://github.com/appsmithorg/appsmith/issues/20069
+                 */
+                String expectedJsonResult = "[{\"c_json\":\"{\\\"key1\\\": \\\"value1\\\", \\\"key2\\\": \\\"value2\\\"}\"}]";
+                testExecute(query_select_from_test_json_data_type, expectedJsonResult);
+                /* Test geometry types */
+                testExecute(query_select_from_test_geometry_types, null);
 
                 return;
         }
 
-        private void testExecute(String query) {
+        private void testExecute(String query, String expectedResult) {
                 Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
                 ActionConfiguration actionConfiguration = new ActionConfiguration();
                 actionConfiguration.setBody(query);
@@ -918,6 +923,9 @@ public class MySqlPluginTest {
                                 assertNotNull(result);
                                 assertTrue(result.getIsExecutionSuccess());
                                 assertNotNull(result.getBody());
+                                if (expectedResult != null) {
+                                        assertEquals(expectedResult, result.getBody().toString());
+                                }
                         })
                         .verifyComplete();
         }


### PR DESCRIPTION
## Description
- In case of MySQL the JSON DB type is stored as a binary object in the DB. This is different from MariaDB where it is stored as a text.Since we currently use MariaDB driver for MySQL plugin as well the driver reads the JSON DB type data as byte array. This PR adds change to convert this byte array to string before sending back the response. 
- Currently, we assume utf-8 encoding when reading the data back into JSON string (since MySQL uses a subset by default ie. utf-8mb3/4), however other encodings can be configured. I have created a new feature request to track it: https://github.com/appsmithorg/appsmith/issues/20088

Fixes #19867 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- JUnit

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
