### PR TITLE
fix: Modal dropped inside a widget getting limited to parent size

### DIFF
--- a/app/client/src/pages/common/CanvasArenas/hooks/useBlocksToBeDraggedOnCanvas.ts
+++ b/app/client/src/pages/common/CanvasArenas/hooks/useBlocksToBeDraggedOnCanvas.ts
@@ -274,7 +274,9 @@ export const useBlocksToBeDraggedOnCanvas = ({
       payload: {
         dropPayload,
         newWidget: widgetPayload,
-        parentId: widgetId,
+        parentId: newWidget.detachFromLayout
+          ? MAIN_CONTAINER_WIDGET_ID
+          : widgetId,
         direction,
       },
     });


### PR DESCRIPTION
Regardless of where we drop the Modal widget, its parent should be MAIN_CONTAINER_WIDGET_ID
fixes: #19601 