### PR TITLE
fix: update chart.lock and app versions

### DIFF
--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.0.10
+  version: 16.11.2
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.31.5
-digest: sha256:d1759068c26d23269da82e349b9744e395f2e3ed4dce5cdbd9137580632e3f67
-generated: "2022-09-28T15:45:22.795613+05:30"
+  version: 12.1.16
+digest: sha256:5c331a59e883c66893d2896c24aa2c4edf53423b12d440d1ec832e2c18637805
+generated: "2023-01-26T10:40:02.874578+05:30"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,6 @@
 annotations:
   category: Application
 apiVersion: v2
-appVersion: "1.16.0"
 name: appsmith
 type: application
 description: Appsmith is an open source framework to build admin panels, CRUD apps and workflows. Build everything you need, 10x faster.
@@ -16,11 +15,11 @@ version: 2.0.0
 dependencies:
 - condition: redis.enabled
   name: redis
-  version: 17.0.10
-  appVersion: 6.0.2
+  version: 16.11.2
+  appVersion: 6.2.7
   repository: https://charts.bitnami.com/bitnami
 - condition: mongodb.enabled
   name: mongodb
-  version: 13.6.0
-  appVersion: 5.0.12
+  version: 12.1.16
+  appVersion: 5.0.9
   repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Fixes: [20000](https://github.com/appsmithorg/appsmith/issues/20000)

- [Bug]: Update appsmith version from 1.16.0 to the current 1.9.4 version
  * Though we deploy the latest appsmith version. In the helm chart we show that we are deploying appsmith version as 1.16.0 and its confusing . We are now fixing it with this PR
- Correct helm chart versions for redis and mongo. This, helps in deploying the desired versions of redis and mongo which appsmith supports. 
  *  Previously, When we deploy appsmith along with redis and mongo . It used to deploy redis v7.0.4 and mongo v6.0.3.
with this changes we deploy the supported versions of redis and mongo which is v6 and v5 respectively.

### Mongo

before:
```
I have no name!@tempappsmith-mongodb-0:/$ mongosh

Current Mongosh Log ID:	63d2128c2e4dabde5a68f8f8
Connecting to:		mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+1.6.0
Using MongoDB:		6.0.3
Using Mongosh:		1.6.0

For mongosh info see: https://docs.mongodb.com/mongodb-shell/

rs0 [direct: primary] test>

rs0 [direct: primary] test> db.version()
6.0.3
```

After the proposed changes:
```
I have no name!@tempappsmith-mongodb-0:/$ mongo
MongoDB shell version v5.0.9
connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb
Implicit session: session { "id" : UUID("d75e90e4-cbff-4b52-a7ab-22755ab43ec1") }
MongoDB server version: 5.0.9
================
Warning: the "mongo" shell has been superseded by "mongosh",
which delivers improved usability and compatibility.The "mongo" shell has been deprecated and will be removed in
an upcoming release.
For installation instructions, see
https://docs.mongodb.com/mongodb-shell/install/
================
rs0:PRIMARY> db.version()
5.0.9
```

### Redis

Before
```
I have no name!@tempappsmith-redis-master-0:/$ redis-server
19:C 26 Jan 2023 05:40:42.232 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
19:C 26 Jan 2023 05:40:42.232 # Redis version=7.0.4, bits=64, commit=00000000, modified=0, pid=19, just started
19:C 26 Jan 2023 05:40:42.232 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
19:M 26 Jan 2023 05:40:42.233 * monotonic clock: POSIX clock_gettime
19:M 26 Jan 2023 05:40:42.233 # Warning: Could not create server TCP listening socket *:6379: bind: Address already in use
19:M 26 Jan 2023 05:40:42.233 # Failed listening on port 6379 (TCP), aborting.
```

After the proposed changes
```
I have no name!@tempappsmith-redis-master-0:/$ redis-server
4728:C 26 Jan 2023 05:35:07.745 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
4728:C 26 Jan 2023 05:35:07.745 # Redis version=6.2.7, bits=64, commit=00000000, modified=0, pid=4728, just started
4728:C 26 Jan 2023 05:35:07.745 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
4728:M 26 Jan 2023 05:35:07.746 * monotonic clock: POSIX clock_gettime
4728:M 26 Jan 2023 05:35:07.746 # Warning: Could not create server TCP listening socket *:6379: bind: Address already in use
4728:M 26 Jan 2023 05:35:07.746 # Failed listening on port 6379 (TCP), aborting.
```