### PR TITLE
fix: renamed rts port env to APPSMITH_RTS_PORT

### DIFF
--- a/app/rts/src/server.ts
+++ b/app/rts/src/server.ts
@@ -35,7 +35,7 @@ if (API_BASE_URL == null || API_BASE_URL === "") {
   process.exit(1);
 }
 
-const PORT = process.env.PORT || 8091;
+const APPSMITH_RTS_PORT = process.env.APPSMITH_RTS_PORT || 8091;
 
 //Disable x-powered-by header to prevent information disclosure
 const app = express();
@@ -62,8 +62,8 @@ app.use(`${RTS_BASE_API_PATH}`, health_check_routes);
 server.headersTimeout = 61000;
 server.keepAliveTimeout = 60000;
 // Run the server
-server.listen(PORT, () => {
-  log.info(`RTS version ${buildVersion} running at http://localhost:${PORT}`);
+server.listen(APPSMITH_RTS_PORT, () => {
+  log.info(`RTS version ${buildVersion} running at http://localhost:${APPSMITH_RTS_PORT}`);
 });
 
 export default server;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -67,7 +67,7 @@ public class CommonConfig {
     @Value("${appsmith.rts.port:8091}")
     private String rtsPort;
 
-    private String rtsBaseDomain = "http://127.0.0.1:" + rtsPort;
+    private String rtsBaseDomain;
 
     private List<String> allowedDomains;
 
@@ -131,5 +131,8 @@ public class CommonConfig {
         // If `true`, then disable signup. If anything else, including empty string, then signups will be enabled.
         isSignupDisabled = "true".equalsIgnoreCase(value);
     }
-
+    
+    public String getRtsBaseDomain() {
+     return "http://127.0.0.1:" + rtsPort;
+}
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -133,6 +133,6 @@ public class CommonConfig {
     }
     
     public String getRtsBaseDomain() {
-     return "http://127.0.0.1:" + rtsPort;
-}
+        return "http://127.0.0.1:" + rtsPort;
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -67,8 +67,6 @@ public class CommonConfig {
     @Value("${appsmith.rts.port:8091}")
     private String rtsPort;
 
-    private String rtsBaseDomain;
-
     private List<String> allowedDomains;
 
     @Bean

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -132,7 +132,7 @@ public class CommonConfig {
         isSignupDisabled = "true".equalsIgnoreCase(value);
     }
     
-    public String getRtsBaseDomain() {
+    public String getRtsBaseUrl() {
         return "http://127.0.0.1:" + rtsPort;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -64,7 +64,10 @@ public class CommonConfig {
     @Value("${disable.telemetry:true}")
     private boolean isTelemetryDisabled;
 
-    private String rtsBaseDomain = "http://127.0.0.1:8091";
+    @Value("${appsmith.rts.port:8091}")
+    private string rtsPort;
+
+    private String rtsBaseDomain = "http://127.0.0.1:" + rtsPort;
 
     private List<String> allowedDomains;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -65,7 +65,7 @@ public class CommonConfig {
     private boolean isTelemetryDisabled;
 
     @Value("${appsmith.rts.port:8091}")
-    private string rtsPort;
+    private String rtsPort;
 
     private String rtsBaseDomain = "http://127.0.0.1:" + rtsPort;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
@@ -149,7 +149,7 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
         log.debug("Performing RTS health check of this instance...");
 
         return WebClientUtils
-                .create(commonConfig.getRtsBaseDomain() + "/rts-api/v1/health-check")
+                .create(commonConfig.getRtsBaseUrl() + "/rts-api/v1/health-check")
                 .get()
                 .retrieve()
                 .toBodilessEntity()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AstServiceCEImpl.java
@@ -75,7 +75,7 @@ public class AstServiceCEImpl implements AstServiceCE {
         }
         return webClient
                 .post()
-                .uri(commonConfig.getRtsBaseDomain() + "/rts-api/v1/ast/multiple-script-data")
+                .uri(commonConfig.getRtsBaseUrl() + "/rts-api/v1/ast/multiple-script-data")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(BodyInserters.fromValue(new GetIdentifiersRequestBulk(bindingValues, evalVersion)))
                 .retrieve()
@@ -102,7 +102,7 @@ public class AstServiceCEImpl implements AstServiceCE {
                     EntityRefactorRequest entityRefactorRequest = new EntityRefactorRequest(bindingValue.getValue(), oldName, newName, evalVersion, isJSObject);
                     return webClient
                             .post()
-                            .uri(commonConfig.getRtsBaseDomain() + "/rts-api/v1/ast/entity-refactor")
+                            .uri(commonConfig.getRtsBaseUrl() + "/rts-api/v1/ast/entity-refactor")
                             .contentType(MediaType.APPLICATION_JSON)
                             .body(BodyInserters.fromValue(entityRefactorRequest))
                             .retrieve()

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -111,3 +111,6 @@ appsmith.admin.envfile=${APPSMITH_ENVFILE_PATH:/appsmith-stacks/configuration/do
 
 # Name of this instance
 appsmith.instance.name=${APPSMITH_INSTANCE_NAME:Appsmith}
+
+# RTS port
+appsmith.rts.port=${APPSMITH_RTS_PORT:8091}

--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -91,7 +91,7 @@ server {
   }
 
   location /rts {
-    proxy_pass http://localhost:8091;
+    proxy_pass http://localhost:${APPSMITH_RTS_PORT:-8091};
     proxy_http_version 1.1;
     proxy_set_header Host \$host;
     proxy_set_header Connection 'upgrade';

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -108,7 +108,7 @@ server {
   }
 
   location /rts {
-    proxy_pass http://localhost:8091;
+    proxy_pass http://localhost:${APPSMITH_RTS_PORT:-8091};
     proxy_http_version 1.1;
     proxy_set_header Host \$host;
     proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
Issue: Nginx and RTS used the same env PORT for binding it's service, while the backend server had the rts port hardcoded on its rts uri.
- Renamed env PORT to APPSMITH_RTS_PORT for starting the rts server.
- Updated nginx config templates to use env `APPSMITH_RTS_PORT`
- Added appsmith.rts.port property in server to use env APPSMITH_RTS_PORT
- Updated CommonConfig.java rtsBaseDomain to use appsmith.rts.port
