### PR TITLE
Fix: add back setup of ui environment in setup-test-ci workflow

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -220,7 +220,7 @@ jobs:
           APPSMITH_GOOGLE_MAPS_API_KEY: ${{ secrets.APPSMITH_GOOGLE_MAPS_API_KEY }}
           POSTGRES_PASSWORD: postgres
         run: |
-          ./cypress/setup-test.sh
+          ./cypress/setup-test-ci.sh
 
       - name: Get the performance-infra branch/ref
         id: perf_infra_ref

--- a/app/client/cypress/setup-test-ci.sh
+++ b/app/client/cypress/setup-test-ci.sh
@@ -18,6 +18,13 @@ touch ./docker/localhost ./docker/localhost.pem
 echo "$APPSMITH_SSL_CERTIFICATE" > ./docker/localhost.pem
 echo "$APPSMITH_SSL_KEY" > ./docker/localhost.pem
 
+sudo docker run --network host --name wildcard-nginx -d -p 80:80 -p 443:443 \
+	-v `pwd`/docker/nginx-root.conf:/etc/nginx/nginx.conf \
+    -v `pwd`/docker/nginx.conf:/etc/nginx/conf.d/app.conf \
+    -v `pwd`/docker/dev.appsmith.com.pem:/etc/certificate/dev.appsmith.com.pem \
+    -v `pwd`/docker/dev.appsmith.com-key.pem:/etc/certificate/dev.appsmith.com-key.pem \
+    nginx:latest
+
 sleep 10
 
 echo "Checking if the containers have started"

--- a/app/client/cypress/setup-test-ci.sh
+++ b/app/client/cypress/setup-test-ci.sh
@@ -18,6 +18,7 @@ touch ./docker/localhost ./docker/localhost.pem
 echo "$APPSMITH_SSL_CERTIFICATE" > ./docker/localhost.pem
 echo "$APPSMITH_SSL_KEY" > ./docker/localhost.pem
 
+# Setup UI environment from docker image for running UI tests and perf tests
 sudo docker run --network host --name wildcard-nginx -d -p 80:80 -p 443:443 \
 	-v `pwd`/docker/nginx-root.conf:/etc/nginx/nginx.conf \
     -v `pwd`/docker/nginx.conf:/etc/nginx/conf.d/app.conf \


### PR DESCRIPTION
## Description

> Add back setup of ui nginx environment using docker while setting up tests

Fixes # [(issue)](https://github.com/appsmithorg/appsmith/issues/20124)
> if no issue exists, please create an issue and ask the maintainers about this first


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
