### PR TITLE
fix: date settings visibility for different column types

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/DateProperties.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyConfig/PanelConfig/DateProperties.ts
@@ -1,22 +1,15 @@
 import { ValidationTypes } from "constants/WidgetValidation";
 import { ColumnTypes, TableWidgetProps } from "widgets/TableWidgetV2/constants";
 import { get } from "lodash";
-import {
-  allowedFirstDayOfWeekRange,
-  showByColumnType,
-} from "../../propertyUtils";
+import { allowedFirstDayOfWeekRange } from "../../propertyUtils";
 import { AutocompleteDataType } from "utils/autocomplete/CodemirrorTernService";
 
 export default {
   sectionName: "Date Settings",
   hidden: (props: TableWidgetProps, propertyPath: string) => {
-    if (showByColumnType(props, propertyPath, [ColumnTypes.IMAGE], true)) {
-      return false;
-    } else {
-      const columnType = get(props, `${propertyPath}.columnType`, "");
-      const isEditable = get(props, `${propertyPath}.isEditable`, "");
-      return columnType !== ColumnTypes.DATE || !isEditable;
-    }
+    const columnType = get(props, `${propertyPath}.columnType`, "");
+    const isEditable = get(props, `${propertyPath}.isEditable`, "");
+    return columnType !== ColumnTypes.DATE || !isEditable;
   },
   children: [
     {


### PR DESCRIPTION
## Description

This PR removes the condition where on Image date column type hidden property is false


Fixes #20173

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual
     - Make sure that date settings is not available in any other column type
     - Make sure that date settings is only available when column type is date and editable is true

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
