### PR TITLE
fix: missing reference to installed libraries when an application is deployed

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/JSLibrary/Library_spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/JSLibrary/Library_spec.ts
@@ -5,6 +5,7 @@ const explorer = ObjectsRegistry.EntityExplorer;
 const installer = ObjectsRegistry.LibraryInstaller;
 const aggregateHelper = ObjectsRegistry.AggregateHelper;
 const homePage = ObjectsRegistry.HomePage;
+const deployMode = ObjectsRegistry.DeployMode;
 
 describe("Tests JS Libraries", () => {
   it("1. Validates Library install/uninstall", () => {
@@ -31,6 +32,12 @@ describe("Tests JS Libraries", () => {
   it("4. Checks installation in duplicated app", () => {
     homePage.NavigateToHome();
     homePage.DuplicateApplication("Library_export");
+    aggregateHelper.AssertContains("true");
+  });
+  it("5. Deploy app and check installation", () => {
+    deployMode.DeployApp();
+    aggregateHelper.AssertContains("true");
+    deployMode.NavigateBacktoEditor();
     aggregateHelper.AssertContains("true");
   });
 });

--- a/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
+++ b/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
@@ -6,8 +6,8 @@ import {
 } from "entities/DataTree/dataTreeFactory";
 import { RenderModes } from "constants/WidgetConstants";
 import setupEvalEnv from "../handlers/setupEvalEnv";
-import { addPlatformFunctionsToEvalContext } from "@appsmith/workers/Evaluation/Actions";
 import { functionDeterminer } from "../functionDeterminer";
+import { resetJSLibraries } from "workers/common/JSLibrary";
 
 describe("evaluateSync", () => {
   const widget: DataTreeWidget = {
@@ -40,6 +40,7 @@ describe("evaluateSync", () => {
   };
   beforeAll(() => {
     setupEvalEnv();
+    resetJSLibraries();
   });
   it("unescapes string before evaluation", () => {
     const js = '\\"Hello!\\"';

--- a/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
+++ b/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
@@ -7,6 +7,7 @@ import { Def } from "tern";
 import {
   JSLibraries,
   libraryReservedIdentifiers,
+  resetJSLibraries,
 } from "../../common/JSLibrary";
 import { makeTernDefs } from "../../common/JSLibrary/ternDefinitionGenerator";
 import { EvalWorkerSyncRequest } from "../types";
@@ -139,6 +140,7 @@ export function uninstallLibrary(request: EvalWorkerSyncRequest) {
 }
 
 export function loadLibraries(request: EvalWorkerSyncRequest) {
+  resetJSLibraries();
   //Add types
   const { data } = request;
   const urls = data.map((lib: any) => lib.url);

--- a/app/client/src/workers/Evaluation/handlers/setupEvalEnv.ts
+++ b/app/client/src/workers/Evaluation/handlers/setupEvalEnv.ts
@@ -9,13 +9,6 @@ import { addPlatformFunctionsToEvalContext } from "@appsmith/workers/Evaluation/
 import initLocalStorage from "../fns/LocalStorage";
 
 export default function() {
-  const libraries = resetJSLibraries();
-  ///// Adding extra libraries separately
-  libraries.forEach((library) => {
-    // @ts-expect-error: Types are not available
-    self[library.accessor] = library.lib;
-  });
-
   ///// Remove all unsafe functions
   unsafeFunctionForEval.forEach((func) => {
     // @ts-expect-error: Types are not available
@@ -35,7 +28,5 @@ export function setEvaluationVersion(request: EvalWorkerSyncRequest) {
   const { data } = request;
   const { version } = data;
   self.evaluationVersion = version || 1;
-  // TODO: Move this to setup
-  resetJSLibraries();
   return true;
 }

--- a/app/client/src/workers/Evaluation/handlers/setupEvalEnv.ts
+++ b/app/client/src/workers/Evaluation/handlers/setupEvalEnv.ts
@@ -1,6 +1,5 @@
 import { unsafeFunctionForEval } from "utils/DynamicBindingUtils";
 import interceptAndOverrideHttpRequest from "../HTTPRequestOverride";
-import { resetJSLibraries } from "../../common/JSLibrary";
 import setupDOM from "../SetupDOM";
 import overrideTimeout from "../TimeoutOverride";
 import { EvalWorkerSyncRequest } from "../types";

--- a/app/client/src/workers/common/JSLibrary/index.ts
+++ b/app/client/src/workers/common/JSLibrary/index.ts
@@ -70,5 +70,8 @@ export function resetJSLibraries() {
     }
     delete libraryReservedIdentifiers[key];
   }
-  return JSLibraries;
+  JSLibraries.forEach((library) => {
+    // @ts-expect-error: Types are not available
+    self[library.accessor] = library.lib;
+  });
 }


### PR DESCRIPTION
## Description
Fixes a bug where application in edit mode loses references to installed libraries immediately after it is deployed.

Fixes #20245 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Cypress

### Test Plan
Add a test case to the existing [test plan](https://github.com/appsmithorg/TestSmith/issues/2125) on custom libraries

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [x] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [x] Added Test Plan Approved label after reveiwing all Cypress test
