### PR TITLE
fix: modal autofocus fix issue #19957

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Modal/Modal_focus_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Modal/Modal_focus_spec.js
@@ -1,0 +1,90 @@
+const dsl = require("../../../../../fixtures/ModalDsl.json");
+const explorer = require("../../../../../locators/explorerlocators.json");
+const widgets = require("../../../../../locators/Widgets.json");
+import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+const agHelper = ObjectsRegistry.AggregateHelper,
+  ee = ObjectsRegistry.EntityExplorer;
+
+describe("Modal focus", function() {
+  const someInputText = "some text";
+
+  function setupModalWithInputWidget() {
+    //drag a button to open modal
+    cy.dragAndDropToCanvas("buttonwidget", { x: 400, y: 550 });
+    cy.openPropertyPane("buttonwidget");
+    cy.get(widgets.toggleOnClick).click();
+
+    cy.updateCodeInput(
+      ".t--property-control-onclick",
+      `{{showModal('Modal1')}}`,
+    );
+    //add modal
+    ee.SelectEntityByName("Modal1", "Widgets");
+    cy.get(widgets.modalWidget).should("exist");
+
+    cy.get(explorer.addWidget).click();
+
+    cy.wait(500);
+    //drag input field into modal
+    cy.get(".t--widget-card-draggable-inputwidgetv2").trigger("dragstart", {
+      force: true,
+    });
+
+    cy.get(widgets.modalWidget)
+      .scrollIntoView()
+      .trigger("mousemove", 50, 100, { eventConstructor: "MouseEvent" })
+      .trigger("mousemove", 50, 100, { eventConstructor: "MouseEvent" })
+      .trigger("mouseup", 50, 100, { eventConstructor: "MouseEvent" });
+  }
+
+  after(() => {
+    agHelper.SaveLocalStorageCache();
+  });
+
+  before(() => {
+    agHelper.RestoreLocalStorageCache();
+    cy.addDsl(dsl);
+  });
+
+  it("should focus on the input field when autofocus for the input field is enabled", () => {
+    setupModalWithInputWidget();
+    cy.openPropertyPane("inputwidgetv2");
+
+    // autofocus for input field is enabled
+    cy.get(".t--property-control-autofocus")
+      .find(".bp3-switch input")
+      .click({ force: true });
+    //enter some text to the input field
+    cy.get(`${widgets.modalWidget} .t--widget-inputwidgetv2 input`)
+      .click()
+      .type(someInputText);
+
+    //close Modal
+    cy.get(widgets.modalCloseButton).click({ force: true });
+
+    //open the modal
+    cy.get(widgets.widgetBtn)
+      .contains("Submit")
+      .click({ force: true });
+    //check if the focus is on the input field
+    cy.focused().should("have.value", someInputText);
+  });
+  it("should not focus on the input field if autofocus is disabled", () => {
+    cy.openPropertyPane("inputwidgetv2");
+
+    // autofocus for input field is disabled
+    cy.get(".t--property-control-autofocus")
+      .find(".bp3-switch input")
+      .click({ force: true });
+    //close Modal
+
+    cy.get(widgets.modalCloseButton).click({ force: true });
+    //open the modal
+
+    cy.get(widgets.widgetBtn)
+      .contains("Submit")
+      .click({ force: true });
+    //check if the focus is not on the input field
+    cy.focused().should("not.have.value", someInputText);
+  });
+});

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Modal/Modal_functionaliy_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Modal/Modal_functionaliy_spec.js
@@ -1,8 +1,8 @@
-const dsl = require("../../../../fixtures/ModalDsl.json");
-const commonlocators = require("../../../../locators/commonlocators.json");
-const explorer = require("../../../../locators/explorerlocators.json");
-const widgets = require("../../../../locators/Widgets.json");
-import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+const dsl = require("../../../../../fixtures/ModalDsl.json");
+const commonlocators = require("../../../../../locators/commonlocators.json");
+const explorer = require("../../../../../locators/explorerlocators.json");
+const widgets = require("../../../../../locators/Widgets.json");
+import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
 const agHelper = ObjectsRegistry.AggregateHelper,
   ee = ObjectsRegistry.EntityExplorer;
 

--- a/app/client/src/widgets/ModalWidget/component/index.tsx
+++ b/app/client/src/widgets/ModalWidget/component/index.tsx
@@ -177,8 +177,6 @@ export default function ModalComponent(props: ModalComponentProps) {
       setModalPosition("unset");
     }, 100);
 
-    modalContentRef.current?.focus();
-
     return () => {
       // handle modal close events when this component unmounts
       // will be called in all cases :-


### PR DESCRIPTION
## Description

This fix checks the modal's content and check if any of the input widgets state has autofocused enabled. If it does it allows the html autoofocus attribute to resolve the focus state and if not the focus is shifted to the modal.

Fixes #19957 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual
- cypress


### Test Plan
> https://github.com/appsmithorg/TestSmith/issues/2183

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
