### PR TITLE
fix: popover bug #19213

### DIFF
--- a/app/client/src/widgets/SelectWidget/component/index.tsx
+++ b/app/client/src/widgets/SelectWidget/component/index.tsx
@@ -383,7 +383,8 @@ class SelectComponent extends React.Component<
             popoverProps={{
               portalContainer:
                 document.getElementById("art-board") || undefined,
-              boundary: "window",
+              position: "auto",
+              boundary: "scrollParent",
               isOpen: this.state.isOpen,
               minimal: true,
               usePortal: true,

--- a/app/client/src/widgets/SelectWidget/component/index.tsx
+++ b/app/client/src/widgets/SelectWidget/component/index.tsx
@@ -383,6 +383,7 @@ class SelectComponent extends React.Component<
             popoverProps={{
               portalContainer:
                 document.getElementById("art-board") || undefined,
+              //check the boundaries of scroll parent to see where to position the options popopver
               position: "auto",
               boundary: "scrollParent",
               isOpen: this.state.isOpen,


### PR DESCRIPTION
## Description
Added an auto placement so that popover will reference the scrollParent boundary to decide the position of popover dropdown.
Fixes #19213 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
