### PR TITLE
chore: Add version to analytics events

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ProjectProperties.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/ProjectProperties.java
@@ -16,6 +16,8 @@ import org.springframework.context.annotation.PropertySource;
 @Getter
 public class ProjectProperties {
 
+    public static final String EDITION = "CE";
+
     @Value("${version:UNKNOWN}")
     private String version;
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
@@ -55,13 +55,13 @@ public class UserUtilsCE {
     public Mono<Boolean> isSuperUser(User user) {
         return configRepository.findByNameAsUser(INSTANCE_CONFIG, user, AclPermission.MANAGE_INSTANCE_CONFIGURATION)
                 .map(config -> Boolean.TRUE)
-                .switchIfEmpty(Mono.just(Boolean.FALSE));
+                .defaultIfEmpty(false);
     }
 
     public Mono<Boolean> isCurrentUserSuperUser() {
         return configRepository.findByName(INSTANCE_CONFIG, AclPermission.MANAGE_INSTANCE_CONFIGURATION)
                 .map(config -> Boolean.TRUE)
-                .switchIfEmpty(Mono.just(Boolean.FALSE));
+                .defaultIfEmpty(false);
     }
 
     public Mono<Boolean> makeSuperUser(List<User> users) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ce/UserUtilsCE.java
@@ -55,13 +55,13 @@ public class UserUtilsCE {
     public Mono<Boolean> isSuperUser(User user) {
         return configRepository.findByNameAsUser(INSTANCE_CONFIG, user, AclPermission.MANAGE_INSTANCE_CONFIGURATION)
                 .map(config -> Boolean.TRUE)
-                .defaultIfEmpty(false);
+                .switchIfEmpty(Mono.just(Boolean.FALSE));
     }
 
     public Mono<Boolean> isCurrentUserSuperUser() {
         return configRepository.findByName(INSTANCE_CONFIG, AclPermission.MANAGE_INSTANCE_CONFIGURATION)
                 .map(config -> Boolean.TRUE)
-                .defaultIfEmpty(false);
+                .switchIfEmpty(Mono.just(Boolean.FALSE));
     }
 
     public Mono<Boolean> makeSuperUser(List<User> users) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCE.java
@@ -15,4 +15,7 @@ public interface CustomUserDataRepositoryCE extends AppsmithRepository<UserData>
     Mono<UpdateResult> removeIdFromRecentlyUsedList(String userId, String workspaceId, List<String> applicationIds);
 
     Flux<UserData> findPhotoAssetsByUserIds(Iterable<String> userId);
+
+    Mono<String> fetchMostRecentlyUsedWorkspaceId(String userId);
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomUserDataRepositoryCEImpl.java
@@ -9,6 +9,7 @@ import com.mongodb.client.result.UpdateResult;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
@@ -64,6 +65,19 @@ public class CustomUserDataRepositoryCEImpl extends BaseAppsmithRepositoryImpl<U
                 fieldName(QUserData.userData.userId)
         );
         return queryAll(List.of(criteria), Optional.of(fieldsToInclude), Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public Mono<String> fetchMostRecentlyUsedWorkspaceId(String userId) {
+        final Query query = query(where(fieldName(QUserData.userData.userId)).is(userId));
+
+        query.fields().include(fieldName(QUserData.userData.recentlyUsedWorkspaceIds));
+
+        return mongoOperations.findOne(query, UserData.class)
+                .map(userData -> {
+                    final List<String> recentlyUsedWorkspaceIds = userData.getRecentlyUsedWorkspaceIds();
+                    return CollectionUtils.isEmpty(recentlyUsedWorkspaceIds) ? "" : recentlyUsedWorkspaceIds.get(0);
+                });
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/AnalyticsServiceImpl.java
@@ -1,8 +1,10 @@
 package com.appsmith.server.services;
 
 import com.appsmith.server.configurations.CommonConfig;
+import com.appsmith.server.configurations.ProjectProperties;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.helpers.UserUtils;
+import com.appsmith.server.repositories.UserDataRepository;
 import com.appsmith.server.services.ce.AnalyticsServiceCEImpl;
 import com.google.gson.Gson;
 import com.segment.analytics.Analytics;
@@ -19,12 +21,10 @@ public class AnalyticsServiceImpl extends AnalyticsServiceCEImpl implements Anal
                                 SessionUserService sessionUserService,
                                 CommonConfig commonConfig,
                                 ConfigService configService,
-                                PolicyUtils policyUtils,
                                 UserUtils userUtils,
-                                Gson gson) {
-
-        super(analytics, sessionUserService, commonConfig, configService, policyUtils, userUtils, gson);
+                                ProjectProperties projectProperties,
+                                UserDataRepository userDataRepository) {
+        super(analytics, sessionUserService, commonConfig, configService, userUtils, projectProperties, userDataRepository);
     }
-
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCE.java
@@ -14,6 +14,8 @@ public interface AnalyticsServiceCE {
 
     Mono<User> identifyUser(User user, UserData userData);
 
+    Mono<User> identifyUser(User user, UserData userData, String recentlyUsedWorkspaceId);
+
     void identifyInstance(String instanceId, String role, String useCase);
 
     Mono<Void> sendEvent(String event, String userId, Map<String, ?> properties);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
@@ -51,4 +51,5 @@ public interface UserDataServiceCE {
 
     Mono<UpdateResult> removeRecentWorkspaceAndApps(String userId, String workspaceId);
 
+    Mono<String> fetchMostRecentlyUsedWorkspaceId(String userId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCE.java
@@ -50,6 +50,4 @@ public interface UserDataServiceCE {
     Mono<UserData> setCommentState(CommentOnboardingState commentOnboardingState);
 
     Mono<UpdateResult> removeRecentWorkspaceAndApps(String userId, String workspaceId);
-
-    Mono<String> fetchMostRecentlyUsedWorkspaceId(String userId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -22,6 +22,7 @@ import com.appsmith.server.solutions.ReleaseNotesService;
 import com.appsmith.server.solutions.UserChangedHandler;
 import com.mongodb.DBObject;
 import com.mongodb.client.result.UpdateResult;
+import org.apache.commons.collections.map.Flat3Map;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
@@ -36,6 +37,8 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 
 import jakarta.validation.Validator;
+import reactor.util.function.Tuple2;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -261,17 +264,25 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
      */
     @Override
     public Mono<UserData> updateLastUsedAppAndWorkspaceList(Application application) {
-        return this.getForCurrentUser().flatMap(userData -> {
-            // set recently used workspace ids
-            userData.setRecentlyUsedWorkspaceIds(
-                    addIdToRecentList(userData.getRecentlyUsedWorkspaceIds(), application.getWorkspaceId(), 10)
-            );
-            // set recently used application ids
-            userData.setRecentlyUsedAppIds(
-                    addIdToRecentList(userData.getRecentlyUsedAppIds(), application.getId(), 20)
-            );
-            return repository.save(userData);
-        });
+        return sessionUserService.getCurrentUser()
+                .zipWhen(this::getForUser)
+                .flatMap(tuple -> {
+                    final User user = tuple.getT1();
+                    final UserData userData = tuple.getT2();
+                    // set recently used workspace ids
+                    userData.setRecentlyUsedWorkspaceIds(
+                            addIdToRecentList(userData.getRecentlyUsedWorkspaceIds(), application.getWorkspaceId(), 10)
+                    );
+                    // set recently used application ids
+                    userData.setRecentlyUsedAppIds(
+                            addIdToRecentList(userData.getRecentlyUsedAppIds(), application.getId(), 20)
+                    );
+                    return Mono.zip(
+                        analyticsService.identifyUser(user, userData, application.getWorkspaceId()),
+                        repository.save(userData)
+                    );
+                })
+                .map(Tuple2::getT2);
     }
 
     @Override
@@ -330,4 +341,10 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
                 repository.removeIdFromRecentlyUsedList(userId, workspaceId, appIdsList)
         );
     }
+
+    @Override
+    public Mono<String> fetchMostRecentlyUsedWorkspaceId(String userId) {
+        return repository.fetchMostRecentlyUsedWorkspaceId(userId);
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -342,9 +342,4 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
         );
     }
 
-    @Override
-    public Mono<String> fetchMostRecentlyUsedWorkspaceId(String userId) {
-        return repository.fetchMostRecentlyUsedWorkspaceId(userId);
-    }
-
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ReleaseNotesServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ReleaseNotesServiceCEImpl.java
@@ -15,9 +15,12 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriBuilder;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.net.URI;
+import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +67,9 @@ public class ReleaseNotesServiceCEImpl implements ReleaseNotesServiceCE {
                                         // isCloudHosted should be true only for our cloud instance,
                                         // For docker images that burn the segment key with the image, the CE key will be present
                                         "&isSourceInstall=" + (commonConfig.isCloudHosting() || StringUtils.isEmpty(segmentConfig.getCeKey())) +
-                                        (StringUtils.isEmpty(commonConfig.getRepo()) ? "" : ("&repo=" + commonConfig.getRepo()))
+                                        (StringUtils.isEmpty(commonConfig.getRepo()) ? "" : ("&repo=" + commonConfig.getRepo())) +
+                                        "&version=" + projectProperties.getVersion() +
+                                        "&edition=" + ProjectProperties.EDITION
                         )
                         .get()
                         .exchange()


### PR DESCRIPTION
Currently, analytics events don't include Appsmith version information. This PR adds version, and edition information to all events.
