### PR TITLE
chore: Fix Installation complete event not being sent

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
@@ -21,6 +21,7 @@ public class ExchangeUtils {
                         contextView.get(ServerWebExchange.class).getRequest().getHeaders().getFirst(HEADER_ANONYMOUS_USER_ID),
                         FieldName.ANONYMOUS_USER
                 ))
+                // An error is thrown when the context is not available. We don't want to fail the request in this case.
                 .onErrorResume(error -> Mono.empty())
                 .defaultIfEmpty(FieldName.ANONYMOUS_USER);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
@@ -21,6 +21,7 @@ public class ExchangeUtils {
                         contextView.get(ServerWebExchange.class).getRequest().getHeaders().getFirst(HEADER_ANONYMOUS_USER_ID),
                         FieldName.ANONYMOUS_USER
                 ))
+                .onErrorResume(error -> Mono.empty())
                 .defaultIfEmpty(FieldName.ANONYMOUS_USER);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -225,7 +225,7 @@ public class UserSignupCEImpl implements UserSignupCE {
                     return Mono.when(
                             userDataService.updateForUser(user, userData),
                             configService.getInstanceId()
-                                    .map(instanceId -> {
+                                    .flatMap(instanceId -> {
                                         log.debug("Installation setup complete.");
                                         analyticsService.identifyInstance(instanceId, userData.getRole(), userData.getUseCase());
                                         return analyticsService.sendEvent(
@@ -239,7 +239,7 @@ public class UserSignupCEImpl implements UserSignupCE {
                                                         "goal", ObjectUtils.defaultIfNull(userData.getUseCase(), "")
                                                 ),
                                                 false
-                                        ).thenReturn(instanceId);
+                                        );
                                     }),
                             envManager.applyChanges(Map.of(
                                     APPSMITH_DISABLE_TELEMETRY.name(),


### PR DESCRIPTION
The problem was that the Mono returned by `analyticsService.sendEvent` was returned inside a `.map` call, which, (almost) always results in a bug.

This PR fixes that.
