### PR TITLE
fix: Added JVM arg to opens java.time module to project

### DIFF
--- a/app/server/entrypoint.sh
+++ b/app/server/entrypoint.sh
@@ -12,4 +12,4 @@ if [ -n "$APPSMITH_MONGODB_URI" ]; then
 fi
 
 # Ref -Dlog4j2.formatMsgNoLookups=true https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot
-exec java -Djava.security.egd="file:/dev/./urandom" "$@" -Dlog4j2.formatMsgNoLookups=true -jar server.jar
+exec java -Djava.security.egd="file:/dev/./urandom" "$@" -Dlog4j2.formatMsgNoLookups=true --add-opens java.base/java.time=ALL-UNNAMED -jar server.jar


### PR DESCRIPTION
## Description

Since Spring 6/JDK 17 upgrade, our analytics code errors out unless we expose the `java.time` module to our project. This has been fixed for fat container scripts, but slim containers were not updated. This PR makes the same changes to slim containers.

Fixes #20323

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
