### PR TITLE
chore: Increase Redis timeout in /health from 1s to 3s

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCEImpl.java
@@ -46,7 +46,7 @@ public class HealthCheckServiceCEImpl implements HealthCheckServiceCE {
         Function<TimeoutException, Throwable> healthTimeout = error -> new AppsmithException(
                 AppsmithError.HEALTHCHECK_TIMEOUT, "Mongo");
         MongoReactiveHealthIndicator mongoReactiveHealthIndicator = new MongoReactiveHealthIndicator(reactiveMongoTemplate);
-        return mongoReactiveHealthIndicator.health().timeout(Duration.ofSeconds(3)).onErrorMap(TimeoutException.class, healthTimeout);
+        return mongoReactiveHealthIndicator.health().timeout(Duration.ofSeconds(1)).onErrorMap(TimeoutException.class, healthTimeout);
     }
 
     private boolean isUp(Health health) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/HealthCheckServiceCEImpl.java
@@ -38,7 +38,7 @@ public class HealthCheckServiceCEImpl implements HealthCheckServiceCE {
         Function<TimeoutException, Throwable> healthTimeout = error -> new AppsmithException(
                 AppsmithError.HEALTHCHECK_TIMEOUT, "Redis");
         RedisReactiveHealthIndicator redisReactiveHealthIndicator = new RedisReactiveHealthIndicator(reactiveRedisConnectionFactory);
-        return redisReactiveHealthIndicator.health().timeout(Duration.ofSeconds(1)).onErrorMap(TimeoutException.class, healthTimeout);
+        return redisReactiveHealthIndicator.health().timeout(Duration.ofSeconds(3)).onErrorMap(TimeoutException.class, healthTimeout);
     }
 
     @Override
@@ -46,7 +46,7 @@ public class HealthCheckServiceCEImpl implements HealthCheckServiceCE {
         Function<TimeoutException, Throwable> healthTimeout = error -> new AppsmithException(
                 AppsmithError.HEALTHCHECK_TIMEOUT, "Mongo");
         MongoReactiveHealthIndicator mongoReactiveHealthIndicator = new MongoReactiveHealthIndicator(reactiveMongoTemplate);
-        return mongoReactiveHealthIndicator.health().timeout(Duration.ofSeconds(1)).onErrorMap(TimeoutException.class, healthTimeout);
+        return mongoReactiveHealthIndicator.health().timeout(Duration.ofSeconds(3)).onErrorMap(TimeoutException.class, healthTimeout);
     }
 
     private boolean isUp(Health health) {


### PR DESCRIPTION
The current Redis timeout of 1s is triggering a lot of false-positives, where we report as down, but operate just fine. In this PR, we change this to 3s, in an attempt to reduce the number of such false-positives.

We increase it to 3s _only_, just so we don't change too much too fast. If this also creates too many false-positives, we revisit.
