### PR TITLE
fix: list v2 nested list container widget reference

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Childwigets/List_Modal_Stats_Check_Radio_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Childwigets/List_Modal_Stats_Check_Radio_spec.js
@@ -12,9 +12,11 @@ describe("Modal, Radio, Checkbox widget", function() {
       .first()
       .should("have.text", "");
 
+    cy.wait(1000);
+
     cy.get(`${widgetSelector("Input1")} textarea`)
       .first()
-      .type("Leo Messi");
+      .type("Leo Messi", { force: true });
 
     cy.get(`${widgetSelector("Text4")} ${commonlocators.bodyTextStyle}`)
       .first()

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_event_bindings.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_event_bindings.js
@@ -40,7 +40,7 @@ describe("Listv2 - Event bindings", () => {
       .find("button")
       .click({ force: true });
 
-    cy.get(commonlocators.toastmsg).contains("Input _ 001 _ 0");
+    cy.get(commonlocators.toastmsg).contains("Input _ 000 _ 0");
   });
 
   it("2. simple list widget should get updated values of currentView", () => {
@@ -57,7 +57,7 @@ describe("Listv2 - Event bindings", () => {
 
     cy.wait(1000);
 
-    cy.get(commonlocators.toastmsg).contains("Updated Input _ 001 _ 0");
+    cy.get(commonlocators.toastmsg).contains("Updated Input _ 000 _ 0");
   });
 
   it("3. nested list - inner widget should have access to currentItem, currentIndex, currentView and level_1", () => {

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -57,6 +57,12 @@ type UpdateSiblingsOptions = {
   metaWidget: MetaWidget;
 };
 
+type GenerateDefaultCacheOptions = {
+  lookupId: string;
+  templateWidget: FlattenedWidgetProps;
+  generateEntityDefinition: boolean;
+};
+
 export type HookOptions = {
   childMetaWidgets: MetaWidgets;
   rowReferences: Record<string, string | undefined>;
@@ -596,7 +602,11 @@ class MetaWidgetGenerator {
     if (templateWidget.type === this.primaryWidgetType) {
       this.addLevelData(metaWidget, rowIndex, key);
       metaWidget.prefixMetaWidgetId = this.prefixMetaWidgetId;
-      metaWidget.nestedViewIndex = viewIndex;
+      /**
+       * If nestedViewIndex is present then it comes from the outermost listwidget
+       * and that value should ideally be continued to the nested list widgets.
+       *  */
+      metaWidget.nestedViewIndex = this.nestedViewIndex || viewIndex;
     }
 
     if (this.isRowNonConfigurable(metaCacheProps)) {
@@ -684,21 +694,17 @@ class MetaWidgetGenerator {
     const updatedRowCache: MetaWidgetCache[string] = {};
 
     templateWidgets.forEach((templateWidget) => {
-      const {
-        type,
-        widgetId: templateWidgetId,
-        widgetName: templateWidgetName,
-      } = templateWidget;
+      const { widgetId: templateWidgetId } = templateWidget;
 
       if (templateWidgetId === this.containerParentId) return;
 
-      const currentCache = rowCache[templateWidgetId] || {};
-      const metaWidgetId =
-        currentCache.metaWidgetId || this.generateMetaWidgetId();
-      const metaWidgetName = `${this.widgetName}_${templateWidgetName}_${metaWidgetId}`;
-      const entityDefinition =
-        currentCache.entityDefinition ||
-        this.getPropertiesOfWidget(metaWidgetName, type);
+      const defaultCache = this.generateDefaultCache(key, {
+        lookupId: templateWidgetId,
+        templateWidget,
+        generateEntityDefinition: true,
+      });
+
+      const { metaWidgetId } = defaultCache;
 
       if (!isClonedItem) {
         this.templateWidgetCandidates.add(metaWidgetId);
@@ -713,18 +719,9 @@ class MetaWidgetGenerator {
       this.metaIdToTemplateIdMap[metaWidgetId] = templateWidgetId;
 
       updatedRowCache[templateWidgetId] = {
-        entityDefinition,
-        prevRowIndex: currentCache.rowIndex,
+        ...defaultCache,
         rowIndex,
-        metaWidgetId,
-        metaWidgetName,
         viewIndex,
-        prevViewIndex: currentCache.viewIndex,
-        templateWidgetId,
-        templateWidgetName,
-        type,
-        originalMetaWidgetId: metaWidgetId,
-        originalMetaWidgetName: metaWidgetName,
       };
     });
 
@@ -739,40 +736,64 @@ class MetaWidgetGenerator {
   ) => {
     if (templateWidget) {
       const rowCache = this.getRowCache(ROOT_ROW_KEY) || {};
-      const currentCache = rowCache[ROOT_CONTAINER_PARENT_KEY] || {};
       const updatedRowCache: MetaWidgetCache[string] = {};
-      const {
-        type,
-        widgetId: containerParentId,
-        widgetName: containerParentName,
-      } = templateWidget;
 
-      const metaWidgetId = this.isListCloned
-        ? currentCache.metaWidgetId || this.generateMetaWidgetId()
-        : containerParentId;
+      const defaultCache = this.generateDefaultCache(ROOT_ROW_KEY, {
+        lookupId: ROOT_CONTAINER_PARENT_KEY,
+        templateWidget,
+        generateEntityDefinition: false,
+      });
 
-      const metaWidgetName = this.isListCloned
-        ? `${this.widgetName}_${containerParentName}_${metaWidgetId}`
-        : containerParentName;
+      if (this.nestedViewIndex === undefined || this.nestedViewIndex === 0) {
+        this.templateWidgetCandidates.add(defaultCache.metaWidgetId);
+      }
 
-      updatedRowCache[ROOT_CONTAINER_PARENT_KEY] = {
-        metaWidgetId,
-        metaWidgetName,
-        type,
-        rowIndex: -1,
-        viewIndex: -1,
-        entityDefinition: {},
-        templateWidgetId: containerParentId,
-        templateWidgetName: containerParentName,
-        originalMetaWidgetId: metaWidgetId,
-        originalMetaWidgetName: metaWidgetName,
-      };
+      updatedRowCache[ROOT_CONTAINER_PARENT_KEY] = defaultCache;
 
       this.setRowCache(ROOT_ROW_KEY, {
         ...rowCache,
         ...updatedRowCache,
       });
     }
+  };
+
+  private generateDefaultCache = (
+    key: string,
+    options: GenerateDefaultCacheOptions,
+  ) => {
+    const { generateEntityDefinition, lookupId, templateWidget } = options;
+    const rowCache = this.getRowCache(key) || {};
+    const currentCache = rowCache[lookupId] || {};
+
+    const {
+      type,
+      widgetId: templateWidgetId,
+      widgetName: templateWidgetName,
+    } = templateWidget;
+
+    const metaWidgetId =
+      currentCache.metaWidgetId || this.generateMetaWidgetId();
+
+    const metaWidgetName = `${this.widgetName}_${templateWidgetId}_${metaWidgetId}`;
+    const entityDefinition = generateEntityDefinition
+      ? currentCache.entityDefinition ||
+        this.getPropertiesOfWidget(metaWidgetName, type)
+      : {};
+
+    return {
+      entityDefinition,
+      metaWidgetId,
+      metaWidgetName,
+      originalMetaWidgetId: metaWidgetId,
+      originalMetaWidgetName: metaWidgetName,
+      prevRowIndex: currentCache.rowIndex,
+      prevViewIndex: currentCache.viewIndex,
+      rowIndex: -1,
+      templateWidgetId,
+      templateWidgetName,
+      type,
+      viewIndex: -1,
+    };
   };
 
   private generatePrimaryKeys = (options: GeneratorOptions) => {
@@ -996,12 +1017,18 @@ class MetaWidgetGenerator {
      * Calling this here as all references in all the dynamicBindingPathList has to
      * be collected first in the above loop and then added at last.
      */
-    if (pathTypes.has(DynamicPathType.CURRENT_VIEW)) {
-      this.addCurrentViewProperty(
-        metaWidget,
-        Object.values(referencesEntityDef),
-      );
-    }
+    // if (pathTypes.has(DynamicPathType.CURRENT_VIEW)) {
+    //   this.addCurrentViewProperty(
+    //     metaWidget,
+    //     Object.values(referencesEntityDef),
+    //   );
+    // }
+    /**
+     * The above commented out code should be used instead of this
+     * only after the following issue is resolved
+     * https://github.com/appsmithorg/appsmith/issues/20401
+     */
+    this.addCurrentViewProperty(metaWidget, Object.values(referencesEntityDef));
   };
 
   /**


### PR DESCRIPTION
## Description

The new logic to asses if a particular item is template item was not implemented in case of the parent container cache calculation. This resulted in incorrect value population in the cache.

Refactored the cache generation to DRY the code.

https://docs.google.com/spreadsheets/d/1kWosVCH622m9hohVKyFRdrr7TUa_exO8thwjo8Aqe2M/edit?pli=1#gid=1460346791&range=12:12

Fixes #20344

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual
- Jests
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
