### PR TITLE
fix: remove padding from state used in OIDC authorise

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
@@ -230,11 +230,11 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
         String state = exchange.getRequest().getQueryParams().getFirst(Security.QUERY_PARAMETER_STATE);
         String redirectUrl = RedirectHelper.DEFAULT_REDIRECT_URL;
         if (state != null && !state.isEmpty()) {
-            String[] stateArray = state.split(",");
+            String[] stateArray = state.split("@");
             for (String stateVar : stateArray) {
                 if (stateVar != null && stateVar.startsWith(Security.STATE_PARAMETER_ORIGIN)) {
                     // This is the origin of the request that we want to redirect to
-                    redirectUrl = stateVar.split("=", 2)[1];
+                    redirectUrl = stateVar.split("-", 2)[1];
                 }
             }
         }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/CustomServerOAuth2AuthorizationRequestResolverCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/CustomServerOAuth2AuthorizationRequestResolverCE.java
@@ -64,7 +64,7 @@ public class CustomServerOAuth2AuthorizationRequestResolverCE implements ServerO
 
     private final ReactiveClientRegistrationRepository clientRegistrationRepository;
 
-    private final StringKeyGenerator stateGenerator = new Base64StringKeyGenerator(Base64.getUrlEncoder());
+    private final StringKeyGenerator stateGenerator = new Base64StringKeyGenerator(Base64.getUrlEncoder().withoutPadding());
 
     private final StringKeyGenerator secureKeyGenerator = new Base64StringKeyGenerator(Base64.getUrlEncoder().withoutPadding(), 96);
 
@@ -200,7 +200,7 @@ public class CustomServerOAuth2AuthorizationRequestResolverCE implements ServerO
         return redirectHelper.getRedirectUrl(request)
                 .map(redirectUrl -> {
                     String stateKey = this.stateGenerator.generateKey();
-                    stateKey = stateKey + "," + Security.STATE_PARAMETER_ORIGIN + redirectUrl;
+                    stateKey = stateKey + "@" + Security.STATE_PARAMETER_ORIGIN + redirectUrl;
                     return stateKey;
                 });
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Security.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/Security.java
@@ -4,5 +4,5 @@ public interface Security {
     String USER_ROLE = "USER_ROLE";
     String QUERY_PARAMETER_STATE = "state";
     String REFERER_HEADER = "Referer";
-    String STATE_PARAMETER_ORIGIN = "origin=";
+    String STATE_PARAMETER_ORIGIN = "origin-";
 }


### PR DESCRIPTION
## Description

> Cognito returns **Malformed URI** for redirect when User tries to Login. Due to this, browser ends up throwing `400 Bad Request`. In order to fix this, we have removed the padding from the `state` query parameter which we send to the OIDC, in order to avoid the cases where the additional `=` will lead to malformed URIs being created. Read [here](https://stackoverflow.com/questions/6916805/why-does-a-base64-encoded-string-have-an-sign-at-the-end) for Additional information on the Base64 encoding and padding.
> Also, we are changing the delimiter from `=` to `-` when server tries to find the redirect URI for other use cases.
> Server uses `,` in order to split the state to get the `origin value`. Now we will use `@` instead of `,`.

> TL;DR, remove `=` and `,` in order to avoid malformed URI strings.

Fixes https://github.com/appsmithorg/appsmith/issues/19692

Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?
> Tested manually with different use case scenarios.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
