### PR TITLE
fix: Check for AVX instruction, and produce a warning

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -5,17 +5,6 @@ set -o xtrace
 
 stacks_path=/appsmith-stacks
 
-system_check() {
-  if [[ -f /proc/cpuinfo ]] && ! grep --quiet avx /proc/cpuinfo; then
-    echo "===================================================================================================="
-    echo "=="
-    echo "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
-    echo "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
-    echo "=="
-    echo "===================================================================================================="
-  fi
-}
-
 function get_maximum_heap() {
     resource=$(ulimit -u)
     echo "Resource : $resource"
@@ -184,6 +173,15 @@ init_replica_set() {
   fi
 
   if [[ $isUriLocal -gt 0 ]]; then
+    if [[ -f /proc/cpuinfo ]] && ! grep --quiet avx /proc/cpuinfo; then
+      echo "===================================================================================================="
+      echo "=="
+      echo "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
+      echo "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
+      echo "=="
+      echo "===================================================================================================="
+    fi
+
     echo "Checking Replica Set of external MongoDB"
 
     if appsmithctl check-replica-set; then
@@ -301,7 +299,6 @@ check_redis_compatible_page_size() {
 }
 
 # Main Section
-system_check
 init_env_file
 setup_proxy_variables
 unset_unused_variables

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -174,12 +174,12 @@ init_replica_set() {
 
   if [[ $isUriLocal -gt 0 ]]; then
     if [[ -f /proc/cpuinfo ]] && ! grep --quiet avx /proc/cpuinfo; then
-      echo "===================================================================================================="
-      echo "=="
+      echo "====================================================================================================" >&2
+      echo "==" >&2
       echo "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
       echo "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
-      echo "=="
-      echo "===================================================================================================="
+      echo "==" >&2
+      echo "====================================================================================================" >&2
     fi
 
     echo "Checking Replica Set of external MongoDB"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -5,6 +5,17 @@ set -o xtrace
 
 stacks_path=/appsmith-stacks
 
+system_check() {
+  if [[ -f /proc/cpuinfo ]] && ! grep --quiet avx /proc/cpuinfo; then
+    echo "===================================================================================================="
+    echo "=="
+    echo "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
+    echo "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
+    echo "=="
+    echo "===================================================================================================="
+  fi
+}
+
 function get_maximum_heap() {
     resource=$(ulimit -u)
     echo "Resource : $resource"
@@ -290,6 +301,7 @@ check_redis_compatible_page_size() {
 }
 
 # Main Section
+system_check
 init_env_file
 setup_proxy_variables
 unset_unused_variables


### PR DESCRIPTION
When running on CPUs without an AVX instruction, the embedded MongoDB cannot run. It fails to run with a cryptic error message, and they are forced to reach out to support for help.

This PR adds a check, and a warning message, if trying to use embedded MongoDB on a CPU without the AVX instruction.
