### PR TITLE
test: TED support for GITEA (stop ssh revert)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -187,10 +187,7 @@ jobs:
         run: |
           mkdir -p ~/git-server/keys
           mkdir -p ~/git-server/repos
-      # systemctl stop ssh
-      # systemctl disable ssh
-      # /etc/init.d/sshd stop
-          docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
+          docker run --name test-event-driver -d -p 2222:22 -p 5001:5001 -p 3306:3306 \
           -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3000:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal


### PR DESCRIPTION
## Description

- This PR reverts https://github.com/appsmithorg/appsmith/pull/20471

## Type of change
- ci-test yml file update

## Checklist:
### QA activity:
- [X] Added Test Plan Approved label after reviewing all changes
