### PR TITLE
chore: Remove usage pulse logging for Appsmith cloud

### DIFF
--- a/app/server/.run/ServerApplication.run.xml
+++ b/app/server/.run/ServerApplication.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ServerApplication" type="Application" factoryName="Application" nameIsGenerated="true">
-    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-17" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.appsmith.server.ServerApplication" />

--- a/app/server/.run/ServerApplication.run.xml
+++ b/app/server/.run/ServerApplication.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ServerApplication" type="Application" factoryName="Application" nameIsGenerated="true">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-17" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.appsmith.server.ServerApplication" />

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -12,6 +12,7 @@ import com.appsmith.external.models.QDatasource;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.acl.AppsmithRole;
 import com.appsmith.server.acl.PolicyGenerator;
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Action;
 import com.appsmith.server.domains.ActionCollection;
@@ -42,6 +43,7 @@ import com.appsmith.server.domains.QWorkspace;
 import com.appsmith.server.domains.Sequence;
 import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.domains.Theme;
+import com.appsmith.server.domains.UsagePulse;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.UserData;
 import com.appsmith.server.domains.UserRole;
@@ -2779,4 +2781,14 @@ public class DatabaseChangelog2 {
         update.set("datasourceConfiguration.connection.ssl.authType", "DEFAULT");
         mongoTemplate.updateMulti(queryToGetDatasources, update, Datasource.class);
     }
+
+    // Migration to drop usage pulse collection for Appsmith cloud as we will not be logging these pulses unless
+    // multi-tenancy is introduced
+    @ChangeSet(order = "040", id = "remove-usage-pulses-for-appsmith-cloud", author = "")
+    public void removeUsagePulsesForAppsmithCloud(MongoTemplate mongoTemplate, @NonLockGuarded CommonConfig commonConfig) {
+        if (Boolean.TRUE.equals(commonConfig.isCloudHosting())) {
+            mongoTemplate.dropCollection(UsagePulse.class);
+        }
+    }
+
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UsagePulseServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/UsagePulseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services;
 
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.repositories.UsagePulseRepository;
 import com.appsmith.server.services.ce.UsagePulseServiceCEImpl;
 import org.springframework.stereotype.Service;
@@ -11,8 +12,9 @@ public class UsagePulseServiceImpl extends UsagePulseServiceCEImpl implements Us
                                  SessionUserService sessionUserService,
                                  UserService userService,
                                  TenantService tenantService,
-                                 ConfigService configService) {
-        super(repository, sessionUserService, userService, tenantService, configService);
+                                 ConfigService configService,
+                                 CommonConfig commonConfig) {
+        super(repository, sessionUserService, userService, tenantService, configService, commonConfig);
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services.ce;
 
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.UsagePulse;
 import com.appsmith.server.domains.User;
@@ -29,6 +30,8 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
 
     private final ConfigService configService;
 
+    private final CommonConfig commonConfig;
+
     /**
      * To create a usage pulse
      * @param usagePulseDTO UsagePulseDTO
@@ -38,6 +41,11 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
     public Mono<UsagePulse> createPulse(UsagePulseDTO usagePulseDTO) {
         if (null == usagePulseDTO.getViewMode()) {
             return Mono.error(new AppsmithException(AppsmithError.INVALID_PARAMETER, FieldName.VIEW_MODE));
+        }
+
+        // Remove usage pulse logging for appsmith-cloud until multi-tenancy is introduced
+        if (Boolean.TRUE.equals(commonConfig.isCloudHosting())) {
+            return Mono.just(new UsagePulse());
         }
 
         UsagePulse usagePulse = new UsagePulse();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UsagePulseServiceCEImpl.java
@@ -44,6 +44,7 @@ public class UsagePulseServiceCEImpl implements UsagePulseServiceCE {
         }
 
         // Remove usage pulse logging for appsmith-cloud until multi-tenancy is introduced
+        // TODO remove this condition after multi-tenancy is introduced
         if (Boolean.TRUE.equals(commonConfig.isCloudHosting())) {
             return Mono.just(new UsagePulse());
         }


### PR DESCRIPTION
## Description

> We are working on usage and billing feature and as a part of usage calculation, we are recording the usage pulses at 1 hr intervals today. As the business cases are evolving we received a request to log the pulses for every 5mins instead of an hour. Just to provide the existing stats for the past month on our cloud alone we have received 155545 pulses with 1hr intervals between the pulses. Also going forward if are doing it with 5mins intervals this count is going to increase by 12 folds. Now considering we will not be monetising the cloud platform until multi-tenancy is out, do we have usecase where we still need the usage data? If not we would like to stop recording these usage pulses on Appsmith cloud and bring it back after multitenancy is live. Until then self-hosted EE instances will report the pulses as expected.

> TL;DR: Remove logging of usage pulses for Appsmith cloud not to bloat the cloud services DB, as these pulses will not be used unless the multi-tenancy is introduced 

Fixes https://github.com/appsmithorg/cloud-services/issues/400

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?

- Manual
- JUnit

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
