### PR TITLE
fix: NO_PROXY not set correctly on backend server

### DIFF
--- a/deploy/docker/scripts/run-java.sh
+++ b/deploy/docker/scripts/run-java.sh
@@ -25,7 +25,7 @@ if [[ -z "${NO_PROXY-}" ]]; then
 fi
 
 if [[ $proxy_configured == 1 ]]; then
-  proxy_args+=(-Djava.net.useSystemProxies=true -Dhttp.nonProxyHosts="${NO_PROXY/,/|}")
+  proxy_args+=(-Djava.net.useSystemProxies=true -Dhttp.nonProxyHosts="${NO_PROXY//,/|}")
 fi
 
 # Wait until RTS started and listens on port 8091


### PR DESCRIPTION
When we have `NO_PROXY=localhost,one.com,two.com,three.com`, then the current implementation will pass the following to the backend server:

```
localhost|one.com,two.com,three.com
```

This will mean that only `localhost` will bypass the proxy, which is not what's expected.

This PR fixes this problem, so that the following is sent to the backend server:

```
localhost|one.com|two.com|three.com
```

This will mean that requests to all four of them, will bypass the proxy, as expected.
