### PR TITLE
fix: Increased Nginx limit to 150 MB to allow 100 MB Base 64 encoded files

### DIFF
--- a/app/client/docker/templates/nginx-app-http.conf.template
+++ b/app/client/docker/templates/nginx-app-http.conf.template
@@ -2,7 +2,7 @@ server {
     listen 80;
     server_name $APPSMITH_DOMAIN;
 
-    client_max_body_size 100m;
+    client_max_body_size 150m;
 
     gzip on;
 

--- a/app/client/docker/templates/nginx-app-https.conf.template
+++ b/app/client/docker/templates/nginx-app-https.conf.template
@@ -12,7 +12,7 @@ server {
     ssl_certificate ${APPSMITH_SSL_CERT_PATH};
     ssl_certificate_key ${APPSMITH_SSL_CERT_KEY_PATH};
 
-    client_max_body_size 100m;
+    client_max_body_size 150m;
 
     gzip on;
 

--- a/app/client/docker/templates/nginx-app.conf.template
+++ b/app/client/docker/templates/nginx-app.conf.template
@@ -8,7 +8,7 @@ server {
 server {
     listen 443 ssl http2;
     server_name dev.appsmith.com;
-    client_max_body_size 100m;
+    client_max_body_size 150m;
 
     ssl_certificate /etc/certificate/dev.appsmith.com.pem;
     ssl_certificate_key /etc/certificate/dev.appsmith.com-key.pem;

--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -249,7 +249,7 @@ $(if [[ $use_https == 1 ]]; then echo "
         server_name _;
 "; fi)
 
-        client_max_body_size 100m;
+        client_max_body_size 150m;
         gzip on;
 
         proxy_ssl_server_name on;

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -19,8 +19,8 @@ server.forward-headers-strategy=NATIVE
 spring.data.mongodb.auto-index-creation=false
 spring.data.mongodb.authentication-database=admin
 # Ensures that the size of the request object that we handle is controlled. By default it's 212KB.
-spring.codec.max-in-memory-size=100MB
-appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:100}
+spring.codec.max-in-memory-size=150MB
+appsmith.codec.max-in-memory-size=${APPSMITH_CODEC_SIZE:150}
 
 # Log properties
 logging.level.root=info

--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -26,7 +26,7 @@ server {
   listen ${PORT:-80} default_server;
   server_name $CUSTOM_DOMAIN;
 
-  client_max_body_size 100m;
+  client_max_body_size 150m;
 
   gzip on;
   gzip_types *;

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -71,7 +71,7 @@ server {
   proxy_set_header X-Forwarded-Proto \$origin_scheme;
   proxy_set_header X-Forwarded-Host \$origin_host;
 
-  client_max_body_size 100m;
+  client_max_body_size 150m;
 
   gzip on;
   gzip_types *;

--- a/deploy/template/nginx_app.conf.sh
+++ b/deploy/template/nginx_app.conf.sh
@@ -19,7 +19,7 @@ map \$http_x_forwarded_proto \$origin_scheme {
 server {
     listen 80;
 $NGINX_SSL_CMNT    server_name $custom_domain ;
-    client_max_body_size 100m;
+    client_max_body_size 150m;
 
     gzip on;
 
@@ -77,7 +77,7 @@ $NGINX_SSL_CMNT    server_name $custom_domain ;
 $NGINX_SSL_CMNT server {
 $NGINX_SSL_CMNT    listen 443 ssl;
 $NGINX_SSL_CMNT    server_name $custom_domain;
-$NGINX_SSL_CMNT    client_max_body_size 100m;
+$NGINX_SSL_CMNT    client_max_body_size 150m;
 $NGINX_SSL_CMNT
 $NGINX_SSL_CMNT    ssl_certificate /etc/letsencrypt/live/$custom_domain/fullchain.pem;
 $NGINX_SSL_CMNT    ssl_certificate_key /etc/letsencrypt/live/$custom_domain/privkey.pem;


### PR DESCRIPTION
## Description

We're increasing the default limit of request payload on cloud so that 100 MB files that are base 64 encoded can also be uploaded via Appsmith.

Fixes #20424

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
