### PR TITLE
chore: update import path for messages in cypress to ee path

### DIFF
--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -17,7 +17,7 @@
 import "cypress-real-events/support";
 import "cypress-wait-until";
 import "cypress-xpath";
-import * as MESSAGES from "../../../client/src/ce/constants/messages.ts";
+import * as MESSAGES from "../../../client/src/ee/constants/messages.ts";
 import "./ApiCommands";
 // Import commands.js using ES2015 syntax:
 import "./commands";


### PR DESCRIPTION
## Description
 
 Updates the import path to get messages from `ee/constants` where we have both re exported ce messages and added ee messages.


Fixes # 



## Type of change

> Please delete options that are not relevant.

- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
