### PR TITLE
fix: Do not replace binding with `null` if no value found (#11688)

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
@@ -325,7 +325,10 @@ public class MustacheHelper {
 
         for (MustacheBindingToken token : tokenize(template)) {
             if (token.getValue().startsWith("{{") && token.getValue().endsWith("}}")) {
-                rendered.append(keyValueMap.get(token.getValue().substring(2, token.getValue().length() - 2).trim()));
+                //If there is no entry found for the current token in keyValueMap that means the binding is part of the text
+                //and hence reflecting the value in the rendered string as is.
+                // Example: {{Input.text}} = "This whole string is the value of Input1.text. Even this {{one}}."
+                rendered.append(keyValueMap.getOrDefault(token.getValue().substring(2, token.getValue().length() - 2).trim(), token.getValue()));
             } else {
                 rendered.append(token.getValue());
             }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/MustacheHelper.java
@@ -328,7 +328,12 @@ public class MustacheHelper {
                 //If there is no entry found for the current token in keyValueMap that means the binding is part of the text
                 //and hence reflecting the value in the rendered string as is.
                 // Example: {{Input.text}} = "This whole string is the value of Input1.text. Even this {{one}}."
-                rendered.append(keyValueMap.getOrDefault(token.getValue().substring(2, token.getValue().length() - 2).trim(), token.getValue()));
+                String bindingValue = keyValueMap.get(token.getValue().substring(2, token.getValue().length() - 2).trim());
+                if (bindingValue != null) {
+                    rendered.append(bindingValue);
+                } else {
+                    rendered.append(token.getValue());
+                }
             } else {
                 rendered.append(token.getValue());
             }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/helpers/MustacheHelperTest.java
@@ -670,4 +670,15 @@ public class MustacheHelperTest {
         assertThat(rendered).isEqualTo("leading value1 and then value2 tailing.");
     }
 
+    @Test
+    public void whenBindingFoundWithoutValue_doNotReplaceWithNull() {
+        final String rendered = render(
+                "HL7 Result: CODE 5 - {{severity}} - {{institution}} {{accessionNumber}}",
+                Map.of(
+                        "severity", "CRITICAL VALUE"
+                )
+        );
+        assertThat(rendered).isEqualTo("HL7 Result: CODE 5 - CRITICAL VALUE - {{institution}} {{accessionNumber}}");
+    }
+
 }

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -1480,5 +1480,45 @@ public class RestApiPluginTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    public void whenBindingFoundWithoutValue_doNotReplaceWithNull() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        dsConfig.setUrl("https://postman-echo.com/post");
+
+        ActionConfiguration actionConfig = new ActionConfiguration();
+        final List<Property> headers = List.of(new Property("content-type", "application/json"));
+        actionConfig.setHeaders(headers);
+        actionConfig.setHttpMethod(HttpMethod.POST);
+        String requestBody = "{\"inputValue\":\"{{Input1.text}}\"}";
+        actionConfig.setBody(requestBody);
+        ExecuteActionDTO executeActionDTO = new ExecuteActionDTO();
+        Param param = new Param();
+        param.setKey("Input1.text");
+        param.setValue("This TC is for this {{bug11688}}. HL7 Result: CODE 5 - CRITICAL VALUE - {{institution}} {{accessionNumber}}");
+        param.setClientDataType(ClientDataType.STRING);
+        List<Param> params = new ArrayList<>();
+        params.add(param);
+        executeActionDTO.setParams(params);
+
+        Mono<ActionExecutionResult> resultMono = pluginExecutor.executeParameterized(null, executeActionDTO, dsConfig, actionConfig);
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+                    JsonNode data = ((ObjectNode) result.getBody()).get("data");
+                    assertEquals(requestBody.replace("{{Input1.text}}", param.getValue()), data.toString());
+                    final ActionExecutionRequest request = result.getRequest();
+                    assertEquals("https://postman-echo.com/post", request.getUrl());
+                    assertEquals(HttpMethod.POST, request.getHttpMethod());
+                    final Iterator<Map.Entry<String, JsonNode>> fields = ((ObjectNode) result.getRequest().getHeaders()).fields();
+                    fields.forEachRemaining(field -> {
+                        if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(field.getKey())) {
+                            assertEquals("application/json", field.getValue().get(0).asText());
+                        }
+                    });
+                })
+                .verifyComplete();
+    }
 }
 


### PR DESCRIPTION
## Description
Appsmith always treats something as dynamic binding if it follows this pattern `{{.*}}`. This behavior leads to experiencing some edge cases when the value of the binding contains a pattern like the above. Before this fix, if the no value is found for binding it would get replaced by `null`.

In this PR it won't get replaced by `null` rather the original string prevails.


Fixes #11688 


Media


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- JUnit

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
