### PR TITLE
fix: Table breaks on adding binding to column name

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
@@ -13,6 +13,7 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
     ).clear();
     cy.get(
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+      // For escaping "{" in cypress refer to https://docs.cypress.io/api/commands/type#Arguments
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}appsmith.mode{}}{}}");
     cy.contains(

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
@@ -1,7 +1,5 @@
 const dsl = require("../../../../../fixtures/tableV2NewDsl.json");
-import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
-
-const table = ObjectsRegistry.TableV2;
+import { DEFAULT_COLUMN_NAME } from "../../../../../../src/widgets/TableWidgetV2/constants";
 
 describe("tests bug 20663 TypeError: Cannot read properties of undefined", function() {
   before(() => {
@@ -17,8 +15,8 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}appsmith.mode{}}{}}");
-    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
-      "contain.text",
+    cy.contains(
+      ".tableWrap .thead .tr div[role='columnheader']:first-child",
       "EDIT",
     );
   });
@@ -32,9 +30,9 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}false{}}{}}");
-    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
-      "contain.text",
-      "tableColumn",
+    cy.contains(
+      ".tableWrap .thead .tr div[role='columnheader']:first-child",
+      DEFAULT_COLUMN_NAME,
     );
   });
 
@@ -47,9 +45,9 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}0{}}{}}");
-    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
-      "contain.text",
-      "tableColumn",
+    cy.contains(
+      ".tableWrap .thead .tr div[role='columnheader']:first-child",
+      DEFAULT_COLUMN_NAME,
     );
 
     cy.get(
@@ -59,9 +57,9 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}982{}}{}}");
-    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
-      "contain.text",
-      "tableColumn",
+    cy.contains(
+      ".tableWrap .thead .tr div[role='columnheader']:first-child",
+      DEFAULT_COLUMN_NAME,
     );
   });
 
@@ -74,9 +72,9 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}appsmith{}}{}}");
-    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
-      "contain.text",
-      "tableColumn",
+    cy.contains(
+      ".tableWrap .thead .tr div[role='columnheader']:first-child",
+      DEFAULT_COLUMN_NAME,
     );
   });
 
@@ -89,6 +87,9 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}ap{}}{}}");
-    cy.get(table._tableRow(0, 0)).should("exist");
+    cy.contains(
+      ".tableWrap .thead .tr div[role='columnheader']:first-child",
+      DEFAULT_COLUMN_NAME,
+    );
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
@@ -3,12 +3,12 @@ import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
 
 const table = ObjectsRegistry.TableV2;
 
-describe("Table Widget V2 row multi select validation", function() {
+describe("tests bug 20663 TypeError: Cannot read properties of undefined", function() {
   before(() => {
     cy.addDsl(dsl);
   });
 
-  it("tests bug 20663 TypeError: Cannot read properties of undefined", function() {
+  it("test bug when the evaluated column label value is an object", function() {
     cy.openPropertyPane("tablewidgetv2");
     cy.get(
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
@@ -17,6 +17,18 @@ describe("Table Widget V2 row multi select validation", function() {
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}appsmith{}}{}}");
+    cy.get(table._tableRow(0, 0)).should("exist");
+  });
+
+  it("test bug when the evaluated column label value is undefined", function() {
+    cy.openPropertyPane("tablewidgetv2");
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+    ).clear();
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+      // eslint-disable-next-line prettier/prettier
+    ).type("{{}{{}ap{}}{}}");
     cy.get(table._tableRow(0, 0)).should("exist");
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
@@ -8,7 +8,64 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
     cy.addDsl(dsl);
   });
 
-  it("test bug when the evaluated column label value is an object", function() {
+  it("when the column label value is a valid string should show the evaluated string", function() {
+    cy.openPropertyPane("tablewidgetv2");
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+    ).clear();
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+      // eslint-disable-next-line prettier/prettier
+    ).type("{{}{{}appsmith.mode{}}{}}");
+    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
+      "contain.text",
+      "EDIT",
+    );
+  });
+
+  it("when the column label value is a boolean replace column name with default column name", function() {
+    cy.openPropertyPane("tablewidgetv2");
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+    ).clear();
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+      // eslint-disable-next-line prettier/prettier
+    ).type("{{}{{}false{}}{}}");
+    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
+      "contain.text",
+      "tableColumn",
+    );
+  });
+
+  it("when the column label value is a number replace column name with default column name", function() {
+    cy.openPropertyPane("tablewidgetv2");
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+    ).clear();
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+      // eslint-disable-next-line prettier/prettier
+    ).type("{{}{{}0{}}{}}");
+    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
+      "contain.text",
+      "tableColumn",
+    );
+
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+    ).clear();
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+      // eslint-disable-next-line prettier/prettier
+    ).type("{{}{{}982{}}{}}");
+    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
+      "contain.text",
+      "tableColumn",
+    );
+  });
+
+  it("when the column label value is an object replace column name with default column name", function() {
     cy.openPropertyPane("tablewidgetv2");
     cy.get(
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
@@ -17,10 +74,13 @@ describe("tests bug 20663 TypeError: Cannot read properties of undefined", funct
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
       // eslint-disable-next-line prettier/prettier
     ).type("{{}{{}appsmith{}}{}}");
-    cy.get(table._tableRow(0, 0)).should("exist");
+    cy.get(".tableWrap .thead .tr div[role='columnheader']:first-child").should(
+      "contain.text",
+      "tableColumn",
+    );
   });
 
-  it("test bug when the evaluated column label value is undefined", function() {
+  it("when the column label value is undefined replace column name with default column name", function() {
     cy.openPropertyPane("tablewidgetv2");
     cy.get(
       ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_misc.js
@@ -1,0 +1,22 @@
+const dsl = require("../../../../../fixtures/tableV2NewDsl.json");
+import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+
+const table = ObjectsRegistry.TableV2;
+
+describe("Table Widget V2 row multi select validation", function() {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("tests bug 20663 TypeError: Cannot read properties of undefined", function() {
+    cy.openPropertyPane("tablewidgetv2");
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+    ).clear();
+    cy.get(
+      ".tablewidgetv2-primarycolumn-list div[data-rbd-draggable-id='id'] input[type=text]",
+      // eslint-disable-next-line prettier/prettier
+    ).type("{{}{{}appsmith{}}{}}");
+    cy.get(table._tableRow(0, 0)).should("exist");
+  });
+});

--- a/app/client/src/widgets/TableWidgetV2/constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/constants.ts
@@ -210,3 +210,5 @@ export const defaultEditableCell = {
   value: "",
   initialValue: "",
 };
+
+export const defaultColumnName = "tableColumn";

--- a/app/client/src/widgets/TableWidgetV2/constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/constants.ts
@@ -211,4 +211,4 @@ export const defaultEditableCell = {
   initialValue: "",
 };
 
-export const defaultColumnName = "tableColumn";
+export const DEFAULT_COLUMN_NAME = "Table Column";

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -209,7 +209,8 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
         const isHidden = !column.isVisible;
         const columnData = {
           id: column.id,
-          Header: column.label,
+          Header:
+            typeof column.label === "string" ? column.label : "customColumn",
           alias: column.alias,
           accessor: (row: any) => row[column.alias],
           width: columnWidthMap[column.id] || DEFAULT_COLUMN_WIDTH,

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -211,7 +211,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
         const columnData = {
           id: column.id,
           Header:
-            typeof column.label === "string"
+            column.hasOwnProperty("label") && typeof column.label === "string"
               ? column.label
               : DEFAULT_COLUMN_NAME,
           alias: column.alias,

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -47,6 +47,7 @@ import {
   ORIGINAL_INDEX_KEY,
   TableWidgetProps,
   TransientDataPayload,
+  defaultColumnName,
 } from "../constants";
 import derivedProperties from "./parseDerivedProperties";
 import {
@@ -210,7 +211,7 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
         const columnData = {
           id: column.id,
           Header:
-            typeof column.label === "string" ? column.label : "customColumn",
+            typeof column.label === "string" ? column.label : defaultColumnName,
           alias: column.alias,
           accessor: (row: any) => row[column.alias],
           width: columnWidthMap[column.id] || DEFAULT_COLUMN_WIDTH,

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -47,7 +47,7 @@ import {
   ORIGINAL_INDEX_KEY,
   TableWidgetProps,
   TransientDataPayload,
-  defaultColumnName,
+  DEFAULT_COLUMN_NAME,
 } from "../constants";
 import derivedProperties from "./parseDerivedProperties";
 import {
@@ -211,7 +211,9 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
         const columnData = {
           id: column.id,
           Header:
-            typeof column.label === "string" ? column.label : defaultColumnName,
+            typeof column.label === "string"
+              ? column.label
+              : DEFAULT_COLUMN_NAME,
           alias: column.alias,
           accessor: (row: any) => row[column.alias],
           width: columnWidthMap[column.id] || DEFAULT_COLUMN_WIDTH,


### PR DESCRIPTION
## Description

When user adds any sort of binding to the column name of a table from property pane Columns section, the table breaks.
This was happening because of the column label getting stored as undefined or as an object that the binding evaluates to.
Only string values are expected in column label. Hence the table was breaking for non string values of column label.

This PR fixes this issue by replacing the column name with a default text "customColumn" whenever the column label is not of type string

https://www.loom.com/share/1c5feab1aafa43abaac757d853a02770

Fixes #20663 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress

### Test Plan
> https://github.com/appsmithorg/TestSmith/issues/2188

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [x] Test plan has been approved by relevant developers
- [x] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
