### PR TITLE
fix: Issue with filter not working with IPs

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RequestCaptureFilter.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RequestCaptureFilter.java
@@ -52,8 +52,14 @@ public class RequestCaptureFilter implements ExchangeFilterFunction {
     }
 
     public ActionExecutionRequest populateRequestFields(ActionExecutionRequest existing) {
-
         final ActionExecutionRequest actionExecutionRequest = new ActionExecutionRequest();
+
+        if (request == null) {
+            // The `request` can be null, if there's another filter function before `this.filter`,
+            // which returns a `Mono.error` instead of the request object.
+            return actionExecutionRequest;
+        }
+
         actionExecutionRequest.setUrl(request.url().toString());
         actionExecutionRequest.setHttpMethod(request.method());
         MultiValueMap<String, String> headers = CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));

--- a/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
+++ b/app/server/appsmith-plugins/restApiPlugin/src/test/java/com/external/plugins/RestApiPluginTest.java
@@ -1330,7 +1330,14 @@ public class RestApiPluginTest {
 
         Mono<ActionExecutionResult> resultMono = pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);
         StepVerifier.create(resultMono)
-                .assertNext(result -> assertFalse(result.getIsExecutionSuccess()))
+                .assertNext(result -> {
+                    assertFalse(result.getIsExecutionSuccess());
+                    assertEquals(
+                            "Host not allowed.",
+                            result.getBody(),
+                            "Unexpected error message. Did this fail for a different reason?"
+                    );
+                })
                 .verifyComplete();
     }
 
@@ -1344,7 +1351,10 @@ public class RestApiPluginTest {
 
         Mono<ActionExecutionResult> resultMono = pluginExecutor.executeParameterized(null, new ExecuteActionDTO(), dsConfig, actionConfig);
         StepVerifier.create(resultMono)
-                .assertNext(result -> assertFalse(result.getIsExecutionSuccess()))
+                .assertNext(result -> {
+                    assertFalse(result.getIsExecutionSuccess());
+                    assertEquals("Host not allowed.", result.getBody());
+                })
                 .verifyComplete();
     }
 


### PR DESCRIPTION
We're missing a filter to check for requests that contain a direct IP address, that's listed in the disallow-list. This PR fixes that.
