### PR TITLE
chore: cloud hosting variable for worker

### DIFF
--- a/app/client/src/ce/workers/Evaluation/Actions.ts
+++ b/app/client/src/ce/workers/Evaluation/Actions.ts
@@ -4,7 +4,10 @@ import { EvalContext } from "workers/Evaluation/evaluate";
 import { EvaluationVersion } from "api/ApplicationApi";
 import { addFn } from "workers/Evaluation/fns/utils/fnGuard";
 import { set } from "lodash";
-import { entityFns, platformFns } from "@appsmith/workers/Evaluation/fns";
+import {
+  entityFns,
+  getPlatformFunctions,
+} from "@appsmith/workers/Evaluation/fns";
 declare global {
   /** All identifiers added to the worker global scope should also
    * be included in the DEDICATED_WORKER_GLOBAL_SCOPE_IDENTIFIERS in
@@ -62,13 +65,19 @@ export const addDataTreeToContext = (args: {
   }
 };
 
-export const addPlatformFunctionsToEvalContext = (context: any) => {
-  for (const fnDef of platformFns) {
+export const addPlatformFunctionsToEvalContext = (
+  context: any,
+  cloudHosting: boolean,
+) => {
+  for (const fnDef of getPlatformFunctions(cloudHosting)) {
     addFn(context, fnDef.name, fnDef.fn.bind(context));
   }
 };
 
-export const getAllAsyncFunctions = (dataTree: DataTree) => {
+export const getAllAsyncFunctions = (
+  dataTree: DataTree,
+  cloudHosting: boolean,
+) => {
   const asyncFunctionNameMap: Record<string, true> = {};
   const dataTreeEntries = Object.entries(dataTree);
   for (const [entityName, entity] of dataTreeEntries) {
@@ -78,7 +87,7 @@ export const getAllAsyncFunctions = (dataTree: DataTree) => {
       asyncFunctionNameMap[fullPath] = true;
     }
   }
-  for (const platformFn of platformFns) {
+  for (const platformFn of getPlatformFunctions(cloudHosting)) {
     asyncFunctionNameMap[platformFn.name] = true;
   }
   return asyncFunctionNameMap;

--- a/app/client/src/sagas/ActionExecution/errorUtils.ts
+++ b/app/client/src/sagas/ActionExecution/errorUtils.ts
@@ -13,10 +13,13 @@ import { ApiResponse } from "api/ApiResponses";
 import { isString } from "lodash";
 import { Types } from "utils/TypeHelpers";
 import {
-  ActionTriggerFunctionNames,
   ActionTriggerKeys,
+  getActionTriggerFunctionNames,
 } from "@appsmith/workers/Evaluation/fns/index";
 import DebugButton from "components/editorComponents/Debugger/DebugCTA";
+import { getAppsmithConfigs } from "@appsmith/configs";
+
+const APPSMITH_CONFIGS = getAppsmithConfigs();
 
 /*
  * The base trigger error that also logs the errors in the debugger.
@@ -49,7 +52,9 @@ export class ActionValidationError extends TriggerFailureError {
   ) {
     const errorMessage = createMessage(
       TRIGGER_ACTION_VALIDATION_ERROR,
-      ActionTriggerFunctionNames[functionName],
+      getActionTriggerFunctionNames(!!APPSMITH_CONFIGS.cloudHosting)[
+        functionName
+      ],
       argumentName,
       expectedType,
       received,

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -107,6 +107,9 @@ import {
 } from "workers/Evaluation/types";
 import { ActionDescription } from "@appsmith/workers/Evaluation/fns";
 import { handleEvalWorkerRequestSaga } from "./EvalWorkerActionSagas";
+import { getAppsmithConfigs } from "ce/configs";
+
+const APPSMITH_CONFIGS = getAppsmithConfigs();
 
 export const evalWorker = new GracefulWorkerService(
   new Worker(
@@ -159,6 +162,7 @@ export function* evaluateTreeSaga(
     requiresLinting: isEditMode && requiresLinting,
     forceEvaluation,
     metaWidgets,
+    cloudHosting: !!APPSMITH_CONFIGS.cloudHosting,
   };
 
   const workerResponse: EvalTreeResponseData = yield call(
@@ -273,6 +277,7 @@ export function* evaluateAndExecuteDynamicTrigger(
       globalContext,
       eventType,
       triggerMeta,
+      cloudHosting: !!APPSMITH_CONFIGS.cloudHosting,
     },
   );
   const { errors = [] } = response as any;
@@ -542,7 +547,9 @@ function* evaluationChangeListenerSaga(): any {
     call(lintWorker.start),
   ]);
 
-  yield call(evalWorker.request, EVAL_WORKER_ACTIONS.SETUP);
+  yield call(evalWorker.request, EVAL_WORKER_ACTIONS.SETUP, {
+    cloudHosting: !!APPSMITH_CONFIGS.cloudHosting,
+  });
   yield spawn(handleEvalWorkerRequestSaga, evalWorkerListenerChannel);
 
   widgetTypeConfigMap = WidgetFactory.getWidgetTypeConfigMap();

--- a/app/client/src/sagas/LintingSagas.ts
+++ b/app/client/src/sagas/LintingSagas.ts
@@ -15,6 +15,9 @@ import {
   LINT_WORKER_ACTIONS,
 } from "workers/Linting/types";
 import { logLatestLintPropertyErrors } from "./PostLintingSagas";
+import { getAppsmithConfigs } from "@appsmith/configs";
+
+const APPSMITH_CONFIGS = getAppsmithConfigs();
 
 export const lintWorker = new GracefulWorkerService(
   new Worker(new URL("../workers/Linting/lint.worker.ts", import.meta.url), {
@@ -43,6 +46,7 @@ export function* lintTreeSaga(action: ReduxAction<LintTreeSagaRequestData>) {
   const lintTreeRequestData: LintTreeRequest = {
     pathsToLint,
     unevalTree,
+    cloudHosting: !!APPSMITH_CONFIGS.cloudHosting,
   };
 
   const { errors }: LintTreeResponse = yield call(

--- a/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
+++ b/app/client/src/workers/Evaluation/__tests__/evaluate.test.ts
@@ -8,6 +8,7 @@ import { RenderModes } from "constants/WidgetConstants";
 import setupEvalEnv from "../handlers/setupEvalEnv";
 import { functionDeterminer } from "../functionDeterminer";
 import { resetJSLibraries } from "workers/common/JSLibrary";
+import { EVAL_WORKER_ACTIONS } from "ce/workers/Evaluation/evalWorkerActions";
 
 describe("evaluateSync", () => {
   const widget: DataTreeWidget = {
@@ -39,7 +40,12 @@ describe("evaluateSync", () => {
     Input1: widget,
   };
   beforeAll(() => {
-    setupEvalEnv();
+    setupEvalEnv({
+      method: EVAL_WORKER_ACTIONS.SETUP,
+      data: {
+        cloudHosting: false,
+      },
+    });
     resetJSLibraries();
   });
   it("unescapes string before evaluation", () => {

--- a/app/client/src/workers/Evaluation/errorModifier.ts
+++ b/app/client/src/workers/Evaluation/errorModifier.ts
@@ -18,8 +18,8 @@ class ErrorModifier {
 
   private asyncFunctionsNameMap: Record<string, true> = {};
 
-  updateAsyncFunctions(dataTree: DataTree) {
-    this.asyncFunctionsNameMap = getAllAsyncFunctions(dataTree);
+  updateAsyncFunctions(dataTree: DataTree, cloudHosting: boolean) {
+    this.asyncFunctionsNameMap = getAllAsyncFunctions(dataTree, cloudHosting);
   }
 
   run(error: Error) {

--- a/app/client/src/workers/Evaluation/fns/__tests__/interval.test.ts
+++ b/app/client/src/workers/Evaluation/fns/__tests__/interval.test.ts
@@ -46,9 +46,10 @@ jest.mock("workers/Evaluation/handlers/evalTree", () => ({
 describe("Tests for interval functions", () => {
   beforeAll(() => {
     self["$isDataField"] = false;
+    const cloudHosting = false;
     ExecutionMetaData.setExecutionMetaData({}, EventType.ON_PAGE_LOAD);
     overrideWebAPIs(evalContext);
-    addPlatformFunctionsToEvalContext(evalContext);
+    addPlatformFunctionsToEvalContext(evalContext, cloudHosting);
   });
 
   it("Should call the callback function after the interval", async () => {

--- a/app/client/src/workers/Evaluation/fns/index.ts
+++ b/app/client/src/workers/Evaluation/fns/index.ts
@@ -66,7 +66,13 @@ import {
 } from "./geolocationFns";
 import { isAsyncGuard } from "./utils/fnGuard";
 
-export const platformFns = [
+// cloudHosting -> to use in EE
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getPlatformFunctions = (cloudHosting: boolean) => {
+  return platformFns;
+};
+
+const platformFns = [
   {
     name: "navigateTo",
     fn: navigateTo,
@@ -168,7 +174,15 @@ export type ActionTriggerKeys =
   | TWatchGeoLocationActionType
   | TStopWatchGeoLocationActionType;
 
-export const ActionTriggerFunctionNames: Record<string, string> = {
+export const getActionTriggerFunctionNames = (
+  // cloudHosting -> to use in ee
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  cloudHosting: boolean,
+): Record<string, string> => {
+  return ActionTriggerFunctionNames;
+};
+
+const ActionTriggerFunctionNames: Record<string, string> = {
   CLEAR_INTERVAL: "clearInterval",
   CLEAR_PLUGIN_ACTION: "action.clear",
   CLOSE_MODAL: "closeModal",

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -83,7 +83,9 @@ export default function(request: EvalWorkerSyncRequest) {
         requiresLinting,
       );
 
-      const dataTreeResponse = dataTreeEvaluator.evalAndValidateFirstTree();
+      const dataTreeResponse = dataTreeEvaluator.evalAndValidateFirstTree(
+        request.data.cloudHosting,
+      );
       dataTree = makeEntityConfigsAsObjProperties(dataTreeResponse.evalTree, {
         evalProps: dataTreeEvaluator.evalProps,
       });
@@ -123,7 +125,9 @@ export default function(request: EvalWorkerSyncRequest) {
         requiresLinting,
       );
 
-      const dataTreeResponse = dataTreeEvaluator.evalAndValidateFirstTree();
+      const dataTreeResponse = dataTreeEvaluator.evalAndValidateFirstTree(
+        request.data.cloudHosting,
+      );
       dataTree = makeEntityConfigsAsObjProperties(dataTreeResponse.evalTree, {
         evalProps: dataTreeEvaluator.evalProps,
       });
@@ -160,6 +164,7 @@ export default function(request: EvalWorkerSyncRequest) {
         evalOrder,
         nonDynamicFieldValidationOrder,
         unEvalUpdates,
+        request.data.cloudHosting,
         Object.keys(metaWidgets),
       );
       dataTree = makeEntityConfigsAsObjProperties(dataTreeEvaluator.evalTree, {

--- a/app/client/src/workers/Evaluation/handlers/evalTrigger.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTrigger.ts
@@ -27,6 +27,7 @@ export default async function(request: EvalWorkerASyncRequest) {
     evalOrder,
     nonDynamicFieldValidationOrder,
     unEvalUpdates,
+    request.data.cloudHosting,
   );
   const evalTree = dataTreeEvaluator.evalTree;
   const resolvedFunctions = dataTreeEvaluator.resolvedFunctions;

--- a/app/client/src/workers/Evaluation/handlers/setupEvalEnv.ts
+++ b/app/client/src/workers/Evaluation/handlers/setupEvalEnv.ts
@@ -4,7 +4,7 @@ import { EvalWorkerSyncRequest } from "../types";
 import { addPlatformFunctionsToEvalContext } from "@appsmith/workers/Evaluation/Actions";
 import { overrideWebAPIs } from "../fns/overrides";
 
-export default function() {
+export default function(request: EvalWorkerSyncRequest) {
   self.$isDataField = false;
   ///// Remove all unsafe functions
   unsafeFunctionForEval.forEach((func) => {
@@ -13,7 +13,7 @@ export default function() {
   });
   setupDOM();
   overrideWebAPIs(self);
-  addPlatformFunctionsToEvalContext(self);
+  addPlatformFunctionsToEvalContext(self, request.data.cloudHosting);
   return true;
 }
 

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -34,6 +34,7 @@ export interface EvalTreeRequestData {
   requiresLinting: boolean;
   forceEvaluation: boolean;
   metaWidgets: MetaWidgetsReduxState;
+  cloudHosting: boolean;
 }
 
 export interface EvalTreeResponseData {

--- a/app/client/src/workers/Linting/lint.worker.ts
+++ b/app/client/src/workers/Linting/lint.worker.ts
@@ -65,8 +65,16 @@ function eventRequestHandler({
     case LINT_WORKER_ACTIONS.LINT_TREE: {
       const lintTreeResponse: LintTreeResponse = { errors: {} };
       try {
-        const { pathsToLint, unevalTree } = requestData as LintTreeRequest;
-        const lintErrors = getlintErrorsFromTree(pathsToLint, unevalTree);
+        const {
+          cloudHosting,
+          pathsToLint,
+          unevalTree,
+        } = requestData as LintTreeRequest;
+        const lintErrors = getlintErrorsFromTree(
+          pathsToLint,
+          unevalTree,
+          cloudHosting,
+        );
         lintTreeResponse.errors = lintErrors;
       } catch (e) {}
       return lintTreeResponse;

--- a/app/client/src/workers/Linting/types.ts
+++ b/app/client/src/workers/Linting/types.ts
@@ -14,6 +14,7 @@ export interface LintTreeResponse {
 export interface LintTreeRequest {
   pathsToLint: string[];
   unevalTree: DataTree;
+  cloudHosting: boolean;
 }
 
 export type LintWorkerRequest = WorkerRequest<

--- a/app/client/src/workers/Linting/utils.ts
+++ b/app/client/src/workers/Linting/utils.ts
@@ -52,12 +52,13 @@ import {
 import { LintErrors } from "reducers/lintingReducers/lintErrorsReducers";
 import { Severity } from "entities/AppsmithConsole";
 import { JSLibraries } from "workers/common/JSLibrary";
-import { ActionTriggerFunctionNames } from "@appsmith/workers/Evaluation/fns/index";
+import { getActionTriggerFunctionNames } from "@appsmith/workers/Evaluation/fns/index";
 import { WorkerMessenger } from "workers/Evaluation/fns/utils/Messenger";
 
 export function getlintErrorsFromTree(
   pathsToLint: string[],
   unEvalTree: DataTree,
+  cloudHosting: boolean,
 ): LintErrors {
   const lintTreeErrors: LintErrors = {};
 
@@ -68,7 +69,9 @@ export function getlintErrorsFromTree(
     skipEntityFunctions: true,
   });
 
-  const platformFnNamesMap = Object.values(ActionTriggerFunctionNames).reduce(
+  const platformFnNamesMap = Object.values(
+    getActionTriggerFunctionNames(cloudHosting),
+  ).reduce(
     (acc, name) => ({ ...acc, [name]: true }),
     {} as { [x: string]: boolean },
   );

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -287,7 +287,9 @@ export default class DataTreeEvaluator {
     };
   }
 
-  evalAndValidateFirstTree(): {
+  evalAndValidateFirstTree(
+    cloudHosting: boolean,
+  ): {
     evalTree: DataTree;
     evalMetaUpdates: EvalMetaUpdates;
     staleMetaIds: string[];
@@ -298,6 +300,7 @@ export default class DataTreeEvaluator {
       this.oldUnEvalTree,
       this.resolvedFunctions,
       this.sortedDependencies,
+      cloudHosting,
     );
     const evaluationEndTime = performance.now();
 
@@ -527,6 +530,7 @@ export default class DataTreeEvaluator {
     evaluationOrder: string[],
     nonDynamicFieldValidationOrder: string[],
     unevalUpdates: DataTreeDiff[],
+    cloudHosting: boolean,
     metaWidgetIds: string[] = [],
   ): {
     evalMetaUpdates: EvalMetaUpdates;
@@ -541,6 +545,7 @@ export default class DataTreeEvaluator {
       this.evalTree,
       this.resolvedFunctions,
       evaluationOrder,
+      cloudHosting,
       {
         skipRevalidation: false,
         isFirstTree: false,
@@ -670,6 +675,7 @@ export default class DataTreeEvaluator {
     oldUnevalTree: DataTree,
     resolvedFunctions: Record<string, any>,
     sortedDependencies: Array<string>,
+    cloudHosting: boolean,
     options: {
       skipRevalidation: boolean;
       isFirstTree: boolean;
@@ -687,7 +693,7 @@ export default class DataTreeEvaluator {
     staleMetaIds: string[];
   } {
     const tree = klona(oldUnevalTree);
-    errorModifier.updateAsyncFunctions(tree);
+    errorModifier.updateAsyncFunctions(tree, cloudHosting);
     const evalMetaUpdates: EvalMetaUpdates = [];
     const {
       isFirstTree,

--- a/app/client/src/workers/common/DataTreeEvaluator/test.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/test.ts
@@ -33,6 +33,8 @@ ALL_WIDGETS_AND_CONFIG.map(([, config]) => {
 
 const dataTreeEvaluator = new DataTreeEvaluator(widgetConfigMap);
 
+const cloudHosting = false;
+
 describe("DataTreeEvaluator", () => {
   describe("evaluateActionBindings", () => {
     it("handles this.params.property", () => {
@@ -139,7 +141,7 @@ describe("DataTreeEvaluator", () => {
   describe("test updateDependencyMap", () => {
     beforeEach(() => {
       dataTreeEvaluator.setupFirstTree((unEvalTree as unknown) as DataTree);
-      dataTreeEvaluator.evalAndValidateFirstTree();
+      dataTreeEvaluator.evalAndValidateFirstTree(cloudHosting);
     });
 
     it("initial dependencyMap computation", () => {
@@ -154,6 +156,7 @@ describe("DataTreeEvaluator", () => {
         evalOrder,
         nonDynamicFieldValidationOrder,
         unEvalUpdates,
+        cloudHosting,
       );
 
       expect(dataTreeEvaluator.dependencyMap).toStrictEqual({
@@ -213,7 +216,7 @@ describe("DataTreeEvaluator", () => {
     const postMessageMock = jest.fn();
     beforeEach(() => {
       dataTreeEvaluator.setupFirstTree(({} as unknown) as DataTree);
-      dataTreeEvaluator.evalAndValidateFirstTree();
+      dataTreeEvaluator.evalAndValidateFirstTree(cloudHosting);
       self.postMessage = postMessageMock;
     });
     it("set's isAsync tag for cross JsObject references", () => {
@@ -233,7 +236,7 @@ describe("DataTreeEvaluator", () => {
       dataTreeEvaluator.setupFirstTree(
         nestedArrayAccessorCyclicDependency.initUnEvalTree,
       );
-      dataTreeEvaluator.evalAndValidateFirstTree();
+      dataTreeEvaluator.evalAndValidateFirstTree(cloudHosting);
     });
     describe("array of objects", () => {
       // when Text1.text has a binding Api1.data[2].id
@@ -252,6 +255,7 @@ describe("DataTreeEvaluator", () => {
             evalOrder,
             nonDynamicFieldValidationOrder1,
             unEvalUpdates,
+            cloudHosting,
           );
           expect(dataTreeEvaluator.dependencyMap["Api1"]).toStrictEqual([
             "Api1.data",
@@ -278,6 +282,7 @@ describe("DataTreeEvaluator", () => {
             order,
             nonDynamicFieldValidationOrder2,
             unEvalUpdates2,
+            cloudHosting,
           );
 
           expect(dataTreeEvaluator.dependencyMap["Api1"]).toStrictEqual([
@@ -309,6 +314,7 @@ describe("DataTreeEvaluator", () => {
           order1,
           nonDynamicFieldValidationOrder3,
           unEvalUpdates,
+          cloudHosting,
         );
 
         // success: response -> [{...}, {...}]
@@ -323,6 +329,7 @@ describe("DataTreeEvaluator", () => {
           order2,
           nonDynamicFieldValidationOrder4,
           unEvalUpdates2,
+          cloudHosting,
         );
 
         expect(dataTreeEvaluator.dependencyMap["Api1"]).toStrictEqual([
@@ -353,6 +360,7 @@ describe("DataTreeEvaluator", () => {
             order,
             nonDynamicFieldValidationOrder5,
             unEvalUpdates,
+            cloudHosting,
           );
           expect(dataTreeEvaluator.dependencyMap["Api1"]).toStrictEqual([
             "Api1.data",
@@ -382,6 +390,7 @@ describe("DataTreeEvaluator", () => {
             order1,
             nonDynamicFieldValidationOrder,
             unEvalUpdates2,
+            cloudHosting,
           );
           expect(dataTreeEvaluator.dependencyMap["Api1"]).toStrictEqual([
             "Api1.data",
@@ -415,6 +424,7 @@ describe("DataTreeEvaluator", () => {
           order,
           nonDynamicFieldValidationOrder,
           unEvalUpdates,
+          cloudHosting,
         );
 
         // success: response -> [ [{...}, {...}, {...}], [{...}, {...}, {...}] ]
@@ -429,6 +439,7 @@ describe("DataTreeEvaluator", () => {
           order1,
           nonDynamicFieldValidationOrder2,
           unEvalUpdates2,
+          cloudHosting,
         );
 
         expect(dataTreeEvaluator.dependencyMap["Api1"]).toStrictEqual([
@@ -458,6 +469,7 @@ describe("DataTreeEvaluator", () => {
           order,
           nonDynamicFieldValidationOrder2,
           unEvalUpdates,
+          cloudHosting,
         );
 
         // success: response -> [ [{...}, {...}, {...}], [{...}, {...}, {...}], [] ]
@@ -472,6 +484,7 @@ describe("DataTreeEvaluator", () => {
           order1,
           nonDynamicFieldValidationOrder,
           unEvalUpdates2,
+          cloudHosting,
         );
         expect(dataTreeEvaluator.dependencyMap["Api1"]).toStrictEqual([
           "Api1.data",
@@ -495,7 +508,7 @@ describe("DataTreeEvaluator", () => {
       dataTreeEvaluator.setupFirstTree(
         (lintingUnEvalTree as unknown) as DataTree,
       );
-      dataTreeEvaluator.evalAndValidateFirstTree();
+      dataTreeEvaluator.evalAndValidateFirstTree(cloudHosting);
     });
     it("Creates correct triggerFieldDependencyMap", () => {
       expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
@@ -517,6 +530,7 @@ describe("DataTreeEvaluator", () => {
         evalOrder,
         nonDynamicFieldValidationOrder2,
         unEvalUpdates,
+        cloudHosting,
       );
       expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
         "Button3.onClick": ["Api1.run", "Button2.text"],
@@ -535,6 +549,7 @@ describe("DataTreeEvaluator", () => {
         order1,
         nonDynamicFieldValidationOrder3,
         unEvalUpdates2,
+        cloudHosting,
       );
       expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({
         "Button3.onClick": ["Api1.run", "Button2.text", "Api2.run"],
@@ -555,6 +570,7 @@ describe("DataTreeEvaluator", () => {
         order2,
         nonDynamicFieldValidationOrder,
         unEvalUpdates3,
+        cloudHosting,
       );
 
       // delete Button2
@@ -568,6 +584,7 @@ describe("DataTreeEvaluator", () => {
         order3,
         nonDynamicFieldValidationOrder4,
         unEvalUpdates4,
+        cloudHosting,
       );
 
       expect(dataTreeEvaluator.triggerFieldDependencyMap).toEqual({

--- a/app/client/src/workers/common/DependencyMap/test.ts
+++ b/app/client/src/workers/common/DependencyMap/test.ts
@@ -33,12 +33,14 @@ const widgetConfigMap = {};
 
 const dataTreeEvaluator = new DataTreeEvaluator(widgetConfigMap);
 
+const cloudHosting = false;
+
 describe("test validationDependencyMap", () => {
   beforeAll(() => {
     dataTreeEvaluator.setupFirstTree(
       (unEvalTreeWidgetSelectWidget as unknown) as DataTree,
     );
-    dataTreeEvaluator.evalAndValidateFirstTree();
+    dataTreeEvaluator.evalAndValidateFirstTree(cloudHosting);
   });
 
   it("initial validation dependencyMap computation", () => {
@@ -60,6 +62,7 @@ describe("test validationDependencyMap", () => {
       evalOrder,
       nonDynamicFieldValidationOrder,
       unEvalUpdates,
+      cloudHosting,
     );
 
     expect(dataTreeEvaluator.validationDependencyMap).toStrictEqual({});


### PR DESCRIPTION
## Description
Passed in `cloudHosting` env variable to worker for certain actions.
This will be used to filter `PlatformFunctions` and `ActionTriggerFunctionNames` in EE.
So we can have EE exclusive platform functions and the necessary linting for those.

eval worker actions:
- SETUP
- EVAL_TREE
- EVAL_TRIGGER

lint worker action(s):
- LINT_TREE

Fixes https://github.com/appsmithorg/appsmith-ee/issues/1024


## Type of change
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?
- Jest
- Cypress


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
