### PR TITLE
chore: Undo the git actions queue changes

### DIFF
--- a/app/client/src/sagas/GitSyncSagas.ts
+++ b/app/client/src/sagas/GitSyncSagas.ts
@@ -6,13 +6,14 @@ import {
   ReduxActionWithCallbacks,
 } from "@appsmith/constants/ReduxActionConstants";
 import {
-  all,
+  actionChannel,
   call,
+  fork,
   put,
   select,
-  takeLatest,
-  throttle,
+  take,
 } from "redux-saga/effects";
+import { TakeableChannel } from "@redux-saga/core";
 import GitSyncAPI, {
   MergeBranchPayload,
   MergeStatusPayload,
@@ -898,53 +899,54 @@ function* discardChanges() {
   }
 }
 
+const gitRequestActions: Record<
+  typeof ReduxActionTypes[keyof typeof ReduxActionTypes],
+  (...args: any[]) => any
+> = {
+  [ReduxActionTypes.COMMIT_TO_GIT_REPO_INIT]: commitToGitRepoSaga,
+  [ReduxActionTypes.CONNECT_TO_GIT_INIT]: connectToGitSaga,
+  [ReduxActionTypes.FETCH_GLOBAL_GIT_CONFIG_INIT]: fetchGlobalGitConfig,
+  [ReduxActionTypes.UPDATE_GLOBAL_GIT_CONFIG_INIT]: updateGlobalGitConfig,
+  [ReduxActionTypes.SWITCH_GIT_BRANCH_INIT]: switchBranch,
+  [ReduxActionTypes.FETCH_BRANCHES_INIT]: fetchBranches,
+  [ReduxActionTypes.CREATE_NEW_BRANCH_INIT]: createNewBranch,
+  [ReduxActionTypes.FETCH_LOCAL_GIT_CONFIG_INIT]: fetchLocalGitConfig,
+  [ReduxActionTypes.UPDATE_LOCAL_GIT_CONFIG_INIT]: updateLocalGitConfig,
+  [ReduxActionTypes.FETCH_GIT_STATUS_INIT]: fetchGitStatusSaga,
+  [ReduxActionTypes.MERGE_BRANCH_INIT]: mergeBranchSaga,
+  [ReduxActionTypes.FETCH_MERGE_STATUS_INIT]: fetchMergeStatusSaga,
+  [ReduxActionTypes.GIT_PULL_INIT]: gitPullSaga,
+  [ReduxActionTypes.SHOW_CONNECT_GIT_MODAL]: showConnectGitModal,
+  [ReduxActionTypes.REVOKE_GIT]: disconnectGitSaga,
+  [ReduxActionTypes.IMPORT_APPLICATION_FROM_GIT_INIT]: importAppFromGitSaga,
+  [ReduxActionTypes.GENERATE_SSH_KEY_PAIR_INIT]: generateSSHKeyPairSaga,
+  [ReduxActionTypes.FETCH_SSH_KEY_PAIR_INIT]: getSSHKeyPairSaga,
+  [ReduxActionTypes.DELETE_BRANCH_INIT]: deleteBranch,
+  [ReduxActionTypes.GIT_DISCARD_CHANGES]: discardChanges,
+};
+
+/**
+ * All git actions on the server are behind a lock,
+ * that means that only one action can be performed at once.
+ *
+ * To follow the same principle, we will queue all actions from the client
+ * as well and only perform one action at a time.
+ *
+ * This will ensure that client is not running parallel requests to the server for git
+ * */
+function* watchGitRequests() {
+  const gitActionChannel: TakeableChannel<unknown> = yield actionChannel(
+    Object.keys(gitRequestActions),
+  );
+
+  while (true) {
+    const { type, ...args }: ReduxAction<unknown> = yield take(
+      gitActionChannel,
+    );
+    yield call(gitRequestActions[type], { type, ...args });
+  }
+}
+
 export default function* gitSyncSagas() {
-  yield all([
-    takeLatest(ReduxActionTypes.COMMIT_TO_GIT_REPO_INIT, commitToGitRepoSaga),
-    takeLatest(ReduxActionTypes.CONNECT_TO_GIT_INIT, connectToGitSaga),
-    takeLatest(
-      ReduxActionTypes.FETCH_GLOBAL_GIT_CONFIG_INIT,
-      fetchGlobalGitConfig,
-    ),
-    takeLatest(
-      ReduxActionTypes.UPDATE_GLOBAL_GIT_CONFIG_INIT,
-      updateGlobalGitConfig,
-    ),
-    takeLatest(ReduxActionTypes.SWITCH_GIT_BRANCH_INIT, switchBranch),
-    throttle(5 * 1000, ReduxActionTypes.FETCH_BRANCHES_INIT, fetchBranches),
-    takeLatest(ReduxActionTypes.CREATE_NEW_BRANCH_INIT, createNewBranch),
-    takeLatest(
-      ReduxActionTypes.FETCH_LOCAL_GIT_CONFIG_INIT,
-      fetchLocalGitConfig,
-    ),
-    takeLatest(
-      ReduxActionTypes.UPDATE_LOCAL_GIT_CONFIG_INIT,
-      updateLocalGitConfig,
-    ),
-    throttle(
-      5 * 1000,
-      ReduxActionTypes.FETCH_GIT_STATUS_INIT,
-      fetchGitStatusSaga,
-    ),
-    takeLatest(ReduxActionTypes.MERGE_BRANCH_INIT, mergeBranchSaga),
-    throttle(
-      5 * 1000,
-      ReduxActionTypes.FETCH_MERGE_STATUS_INIT,
-      fetchMergeStatusSaga,
-    ),
-    takeLatest(ReduxActionTypes.GIT_PULL_INIT, gitPullSaga),
-    takeLatest(ReduxActionTypes.SHOW_CONNECT_GIT_MODAL, showConnectGitModal),
-    takeLatest(ReduxActionTypes.REVOKE_GIT, disconnectGitSaga),
-    takeLatest(
-      ReduxActionTypes.IMPORT_APPLICATION_FROM_GIT_INIT,
-      importAppFromGitSaga,
-    ),
-    takeLatest(
-      ReduxActionTypes.GENERATE_SSH_KEY_PAIR_INIT,
-      generateSSHKeyPairSaga,
-    ),
-    takeLatest(ReduxActionTypes.FETCH_SSH_KEY_PAIR_INIT, getSSHKeyPairSaga),
-    takeLatest(ReduxActionTypes.DELETE_BRANCH_INIT, deleteBranch),
-    takeLatest(ReduxActionTypes.GIT_DISCARD_CHANGES, discardChanges),
-  ]);
+  yield fork(watchGitRequests);
 }


### PR DESCRIPTION
Changes made in the PR - https://github.com/appsmithorg/appsmith/pull/20258 were reverted by file lock PR to test a few scenarios but forgot to undo them and got merged to release. 
So this PR adds the changes done by the original PR