### PR TITLE
fix: update mongo cmd in evalMongo to use mongosh

### DIFF
--- a/deploy/docker/utils/bin/mongo_shell_utils.js
+++ b/deploy/docker/utils/bin/mongo_shell_utils.js
@@ -20,7 +20,7 @@ async function execMongoEval(queryExpression, appsmithMongoURI) {
   if (command_args.includes('--pretty')) {
     queryExpression += '.pretty()';
   }
-  return await utils.execCommand(['mongo', appsmithMongoURI, `--eval=${queryExpression}`]);
+  return await utils.execCommand(['mongosh', appsmithMongoURI, `--eval=${queryExpression}`]);
 }
 
 module.exports = {


### PR DESCRIPTION
The cmd util appsmithctl now used `mongosh` instead of the legacy `mongo` shell.
