### PR TITLE
feat: Total Record Count field for Server-side pagination in List widget

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -1138,6 +1138,8 @@ export const TABLE_WIDGET_TOTAL_RECORD_TOOLTIP = () =>
   "It stores the total no. of rows in the table. Helps in calculating the no. of pages that further allows to enable or disable the next/previous control in pagination.";
 export const CREATE_DATASOURCE_TOOLTIP = () => "Add a new datasource";
 export const ADD_QUERY_JS_TOOLTIP = () => "Add a new query / JS Object";
+export const LIST_WIDGET_V2_TOTAL_RECORD_TOOLTIP = () =>
+  "It stores the total no. of items in the list. Helps in calculating the no. of pages that further allows to enable or disable the next/previous control in pagination.";
 
 // Add datasource
 export const GENERATE_APPLICATION_TITLE = () => "Generate Page";

--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -786,6 +786,18 @@ class ListWidget extends BaseWidget<
     this.resetTriggeredItemView();
   };
 
+  getPageCount = () => {
+    const defaultValue = 0;
+    const { serverSidePagination, totalRecordsCount } = this.props;
+
+    if (!serverSidePagination) return (this.props.listData || []).length;
+
+    if (typeof totalRecordsCount === "number" && totalRecordsCount > 0)
+      return totalRecordsCount;
+
+    return defaultValue;
+  };
+
   shouldPaginate = () => {
     /**
      * if client side pagination and not infinite scroll and data is more than page size
@@ -943,7 +955,7 @@ class ListWidget extends BaseWidget<
     const disableNextPage = this.shouldDisableNextPage();
     return (
       this.shouldPaginate() &&
-      (serverSidePagination ? (
+      (serverSidePagination && !this.getPageCount() ? (
         <ServerSideListPagination
           accentColor={this.props.accentColor}
           borderRadius={this.props.borderRadius}
@@ -965,7 +977,7 @@ class ListWidget extends BaseWidget<
           onChange={this.onPageChange}
           pageNo={this.props.pageNo}
           pageSize={this.pageSize}
-          total={(this.props.listData || []).length}
+          total={this.getPageCount()}
         />
       ))
     );
@@ -1089,6 +1101,7 @@ export interface ListWidgetProps<T extends WidgetProps = WidgetProps>
   primaryKeys?: (string | number)[];
   serverSidePagination?: boolean;
   nestedViewIndex?: number;
+  totalRecordsCount?: number | string;
 }
 
 export default ListWidget;

--- a/app/client/src/widgets/ListWidgetV2/widget/propertyConfig.ts
+++ b/app/client/src/widgets/ListWidgetV2/widget/propertyConfig.ts
@@ -8,9 +8,15 @@ import { WidgetProps } from "widgets/BaseWidget";
 import { ListWidgetProps } from ".";
 import { getBindingTemplate } from "../constants";
 import { AutocompleteDataType } from "utils/autocomplete/CodemirrorTernService";
+import {
+  LIST_WIDGET_V2_TOTAL_RECORD_TOOLTIP,
+  createMessage,
+} from "@appsmith/constants/messages";
 
 const MIN_ITEM_SPACING = 0;
 const MAX_ITEM_SPACING = 16;
+const MIN_TOTAL_RECORD_COUNT = 0;
+const MAX_TOTAL_RECORD_COUNT = Number.MAX_SAFE_INTEGER;
 
 const isValidListData = (
   value: unknown,
@@ -239,6 +245,23 @@ export const PropertyPaneContentConfig = [
         controlType: "SWITCH",
         isBindProperty: false,
         isTriggerProperty: false,
+      },
+      {
+        propertyName: "totalRecordsCount",
+        helpText: createMessage(LIST_WIDGET_V2_TOTAL_RECORD_TOOLTIP),
+        label: "Total Records",
+        controlType: "INPUT_TEXT",
+        inputType: "INTEGER",
+        isBindProperty: true,
+        isTriggerProperty: false,
+        placeholderText: "Enter total record count",
+        validation: {
+          type: ValidationTypes.NUMBER,
+          params: { min: MIN_TOTAL_RECORD_COUNT, max: MAX_TOTAL_RECORD_COUNT },
+        },
+        hidden: (props: ListWidgetProps<WidgetProps>) =>
+          !props.serverSidePagination,
+        dependencies: ["serverSidePagination"],
       },
       {
         propertyName: "onPageChange",


### PR DESCRIPTION
## Description

Created a new property, Total Record Count. This helps the user navigate the list items.
It prevents landing on an empty page since the app developer sets a Total Record Count.


Fixes #14551 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


## How Has This Been Tested?
- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
