### PR TITLE
ci: Add APPSMITH_ENVFILE_PATH to server workflow

### DIFF
--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -133,6 +133,7 @@ jobs:
           APPSMITH_ENCRYPTION_SALT: "salt"
           APPSMITH_IS_SELF_HOSTED: false
           APPSMITH_AUDITLOG_ENABLED: true
+          APPSMITH_ENVFILE_PATH: /tmp/dummy.env
         run: |
           mvn --batch-mode versions:set \
             -DnewVersion=${{ steps.vars.outputs.version }} \


### PR DESCRIPTION
This is needed for writing tests using the Env API.
