### PR TITLE
Fix for using charset from response headers instead of default UTF-8

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/RestAPIActivateUtils.java
@@ -37,6 +37,7 @@ import javax.crypto.SecretKey;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -123,7 +124,11 @@ public class RestAPIActivateUtils {
                          */
                         if (contentType.includes(MediaType.APPLICATION_JSON)) {
                             try {
-                                String jsonBody = new String(body, StandardCharsets.UTF_8);
+                                Charset charset = contentType.getCharset();
+                                if(charset==null) {
+                                    charset = StandardCharsets.UTF_8;
+                                }
+                                String jsonBody = new String(body, charset);
                                 result.setBody(objectMapper.readTree(jsonBody));
                                 responseDataType = ResponseDataType.JSON;
                             } catch (IOException e) {


### PR DESCRIPTION

## Description

> The REST-API response content are by default parsed in UTF-8 irrespective of what the response content-type header charset is sent. 

Fixes # 
> Checks for any charset mentioned in response headers, if mentioned, it used the charset otherwise defaults to UTF-8



## Type of change


- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual
 


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
