### PR TITLE
ci: Specifying the branch name to pull from ci-oldstack in ci-test.yml

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -171,6 +171,7 @@ jobs:
       - name: Download the oldstack
         uses: actions/checkout@v3
         with:
+          ref: main
           repository: appsmithorg/ci-oldstack
           token: ${{ secrets.CYPRESS_GITHUB_PERSONAL_ACCESS_TOKEN }}
           submodules: 'recursive'


### PR DESCRIPTION
## Description
- Specifying the branch name to pull from ci-oldstack in ci-test.yml

## Type of change
- ci-test.yml

## How Has This Been Tested?
- Cypress

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
