### PR TITLE
ci: Updated the pat to access appsmithorg/ci-oldstack

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           ref: main
           repository: appsmithorg/ci-oldstack
-          token: ${{ secrets.CYPRESS_GITHUB_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.APPSMITH_DEPLOY_PREVIEW_PAT }}
           submodules: 'recursive'
           path: cicontainerlocal/oldstack
 


### PR DESCRIPTION
## Description
- Updated the pat to access appsmithorg/ci-oldstack

## How Has This Been Tested?
- Cypress

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
