### PR TITLE
poc: scroll canvas horizontally when widgets overflow.

### DIFF
--- a/app/client/src/components/designSystems/appsmith/autoLayout/FlexBoxComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/autoLayout/FlexBoxComponent.tsx
@@ -51,8 +51,6 @@ export const FlexContainer = styled.div<{
   width: 100%;
   height: ${({ stretchHeight }) => (stretchHeight ? "100%" : "auto")};
 
-  overflow: hidden;
-
   padding: ${({ leaveSpaceForWidgetName }) =>
     leaveSpaceForWidgetName
       ? `${FLEXBOX_PADDING}px ${FLEXBOX_PADDING}px 22px ${FLEXBOX_PADDING}px;`

--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -26,7 +26,8 @@ const StyledContainerComponent = styled.div<
 >`
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow-y: hidden;
+  
   ${(props) => (!!props.dropDisabled ? `position: relative;` : ``)}
 
   ${(props) => (props.shouldScrollContents ? scrollCSS : ``)}
@@ -135,7 +136,9 @@ function ContainerComponentWrapper(
       backgroundColor={props.backgroundColor}
       className={`${
         props.shouldScrollContents ? getCanvasClassName() : ""
-      } ${generateClassName(props.widgetId)} container-with-scrollbar ${
+      } ${generateClassName(
+        props.widgetId,
+      )} hidden-scrollbar container-with-scrollbar ${
         appPositioningType === AppPositioningTypes.AUTO &&
         props.widgetId === MAIN_CONTAINER_WIDGET_ID
           ? "auto-layout"


### PR DESCRIPTION
## Description
- Add a horizontal scroll to the canvas when the widgets overflow the canvas width.

Fixes # (issue)
> if no issue exists, please create an issue and ask the maintainers about this first


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
