### PR TITLE
fix: incorrect jsfunction diff

### DIFF
--- a/app/client/src/ce/workers/Evaluation/evaluationUtils.test.ts
+++ b/app/client/src/ce/workers/Evaluation/evaluationUtils.test.ts
@@ -7,6 +7,7 @@ import { RenderModes } from "constants/WidgetConstants";
 import { ValidationTypes } from "constants/WidgetValidation";
 import {
   DataTreeEntity,
+  DataTreeJSAction,
   DataTreeWidget,
   ENTITY_TYPE,
   EvaluationSubstitutionType,
@@ -14,6 +15,7 @@ import {
 import { PrivateWidgets } from "entities/DataTree/types";
 import {
   addErrorToEntityProperty,
+  convertJSFunctionsToString,
   DataTreeDiff,
   DataTreeDiffEvent,
   getAllPaths,
@@ -25,7 +27,7 @@ import {
 } from "@appsmith/workers/Evaluation/evaluationUtils";
 import { warn as logWarn } from "loglevel";
 import { Diff } from "deep-diff";
-import _, { flatten } from "lodash";
+import _, { flatten, set } from "lodash";
 import {
   overrideWidgetProperties,
   findDatatype,
@@ -42,6 +44,7 @@ import { WidgetConfiguration } from "widgets/constants";
 import { createNewEntity } from "@appsmith/workers/Evaluation/dataTreeUtils";
 import DataTreeEvaluator from "workers/common/DataTreeEvaluator";
 import { Severity } from "entities/AppsmithConsole";
+import { PluginType } from "entities/Action";
 
 // to check if logWarn was called.
 // use jest.unmock, if the mock needs to be removed.
@@ -814,4 +817,214 @@ describe("7. Test addErrorToEntityProperty method", () => {
       dataTreeEvaluator.evalProps.Api1.__evaluation__?.errors.data[0],
     ).toEqual(error);
   });
+});
+
+describe("convertJSFunctionsToString", () => {
+  const JSObject1MyFun1 = new String('() => {\n  return "name";\n}');
+  set(JSObject1MyFun1, "data", {});
+  const JSObject2MyFun1 = new String("() => {}");
+  set(JSObject2MyFun1, "data", {});
+  const JSObject2MyFun2 = new String("async () => {}");
+  set(JSObject2MyFun2, "data", {});
+
+  const jsCollections: Record<string, DataTreeJSAction> = {
+    JSObject1: {
+      myFun1: JSObject1MyFun1,
+      body: 'export default {\nmyFun1:  ()=>{ \n\treturn "name"\n} \n}',
+      ENTITY_TYPE: ENTITY_TYPE.JSACTION,
+
+      meta: {
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+      },
+      name: "JSObject1",
+      actionId: "63ef4cb1a01b764626f2a6e5",
+      pluginType: PluginType.JS,
+      bindingPaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      reactivePaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myFun1",
+        },
+      ],
+      variables: [],
+      dependencyMap: {
+        body: ["myFun1"],
+      },
+    },
+    JSObject2: {
+      myVar1: "[]",
+      myVar2: "{}",
+      myFun1: JSObject2MyFun1,
+      myFun2: JSObject2MyFun2,
+      body:
+        "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+      ENTITY_TYPE: ENTITY_TYPE.JSACTION,
+
+      meta: {
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          arguments: [],
+          isAsync: true,
+          confirmBeforeExecute: false,
+        },
+      },
+      name: "JSObject2",
+      actionId: "63f78437d1a4ef55755952f1",
+      pluginType: PluginType.JS,
+      bindingPaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      reactivePaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myVar1",
+        },
+        {
+          key: "myVar2",
+        },
+        {
+          key: "myFun1",
+        },
+        {
+          key: "myFun2",
+        },
+      ],
+      variables: ["myVar1", "myVar2"],
+      dependencyMap: {
+        body: ["myFun1", "myFun2"],
+      },
+    },
+  };
+  const expectedResult = {
+    JSObject1: {
+      myFun1: '() => {\n  return "name";\n}',
+      body: 'export default {\nmyFun1:  ()=>{ \n\treturn "name"\n} \n}',
+      ENTITY_TYPE: "JSACTION",
+      "myFun1.data": {},
+      meta: {
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+      },
+      name: "JSObject1",
+      actionId: "63ef4cb1a01b764626f2a6e5",
+      pluginType: PluginType.JS,
+      bindingPaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      reactivePaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myFun1",
+        },
+      ],
+      variables: [],
+      dependencyMap: {
+        body: ["myFun1"],
+      },
+    },
+    JSObject2: {
+      myVar1: "[]",
+      myVar2: "{}",
+      myFun1: "() => {}",
+      myFun2: "async () => {}",
+      body:
+        "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t},\n\tmyFun2: async () => {\n\t\t//use async-await or promises\n\t}\n}",
+      ENTITY_TYPE: "JSACTION",
+      "myFun1.data": {},
+      "myFun2.data": {},
+      meta: {
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          arguments: [],
+          isAsync: true,
+          confirmBeforeExecute: false,
+        },
+      },
+      name: "JSObject2",
+      actionId: "63f78437d1a4ef55755952f1",
+      pluginType: PluginType.JS,
+      bindingPaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      reactivePaths: {
+        body: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myVar2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun1: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+        myFun2: EvaluationSubstitutionType.SMART_SUBSTITUTE,
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myVar1",
+        },
+        {
+          key: "myVar2",
+        },
+        {
+          key: "myFun1",
+        },
+        {
+          key: "myFun2",
+        },
+      ],
+      variables: ["myVar1", "myVar2"],
+      dependencyMap: {
+        body: ["myFun1", "myFun2"],
+      },
+    },
+  };
+  const actualResult = convertJSFunctionsToString(jsCollections);
+
+  expect(expectedResult).toStrictEqual(actualResult);
 });

--- a/app/client/src/ce/workers/Evaluation/evaluationUtils.test.ts
+++ b/app/client/src/ce/workers/Evaluation/evaluationUtils.test.ts
@@ -450,12 +450,6 @@ describe("4. translateDiffEvent", () => {
 
     const expectedTranslations: DataTreeDiff[] = [
       {
-        event: DataTreeDiffEvent.DELETE,
-        payload: {
-          propertyPath: "JsObject.myFun1.data",
-        },
-      },
-      {
         event: DataTreeDiffEvent.EDIT,
         payload: {
           propertyPath: "JsObject.myFun1",

--- a/app/client/src/ce/workers/Evaluation/evaluationUtils.ts
+++ b/app/client/src/ce/workers/Evaluation/evaluationUtils.ts
@@ -18,7 +18,7 @@ import {
   DataTreeJSAction,
 } from "entities/DataTree/dataTreeFactory";
 
-import _, { difference, find, get, set } from "lodash";
+import _, { difference, find, get, has, set } from "lodash";
 import { WidgetTypeConfigMap } from "utils/WidgetFactory";
 import { PluginType } from "entities/Action";
 import { klona } from "klona/full";
@@ -185,32 +185,7 @@ export const translateDiffEventToDataTreeDiffEvent = (
         typeof difference.lhs === "string" &&
         (isDynamicValue(difference.lhs) || isJsAction);
 
-      // JsObject function renaming
-      // remove .data from a String instance manually
-      // since it won't be identified when calculating diffs
-      // source for .data in a String instance -> `updateLocalUnEvalTree`
-      if (
-        isJsAction &&
-        rhsChange &&
-        difference.lhs instanceof String &&
-        _.get(difference.lhs, "data")
-      ) {
-        result = [
-          {
-            event: DataTreeDiffEvent.DELETE,
-            payload: {
-              propertyPath: `${propertyPath}.data`,
-            },
-          },
-          {
-            event: DataTreeDiffEvent.EDIT,
-            payload: {
-              propertyPath,
-              value: difference.rhs,
-            },
-          },
-        ];
-      } else if (rhsChange || lhsChange) {
+      if (rhsChange || lhsChange) {
         result = [
           {
             event: DataTreeDiffEvent.EDIT,
@@ -929,4 +904,24 @@ export function getStaleMetaStateIds(args: {
     isMetaWidgetTemplate(entity)
     ? difference(entity.siblingMetaWidgets, metaWidgets)
     : [];
+}
+
+export function convertJSFunctionsToString(
+  jscollections: Record<string, DataTreeJSAction>,
+) {
+  const collections = klona(jscollections);
+  Object.keys(collections).forEach((collectionName) => {
+    const jsCollection = collections[collectionName];
+    const jsFunctions = jsCollection.meta;
+    for (const funcName in jsFunctions) {
+      if (jsCollection[funcName] instanceof String) {
+        if (has(jsCollection, [funcName, "data"])) {
+          set(jsCollection, [`${funcName}.data`], jsCollection[funcName].data);
+        }
+        set(jsCollection, funcName, jsCollection[funcName].toString());
+      }
+    }
+  });
+
+  return collections;
 }

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -45,6 +45,7 @@ import {
   isValidEntity,
   isNewEntity,
   getStaleMetaStateIds,
+  convertJSFunctionsToString,
 } from "@appsmith/workers/Evaluation/evaluationUtils";
 import {
   difference,
@@ -396,8 +397,30 @@ export default class DataTreeEvaluator {
       localUnEvalTree,
     );
 
+    const stringifiedOldUnEvalTreeJSCollections = convertJSFunctionsToString(
+      oldUnEvalTreeJSCollections,
+    );
+    const stringifiedLocalUnEvalTreeJSCollection = convertJSFunctionsToString(
+      localUnEvalTreeJSCollection,
+    );
+
+    const oldUnEvalTreeWithStrigifiedJSFunctions = Object.assign(
+      {},
+      this.oldUnEvalTree,
+      stringifiedOldUnEvalTreeJSCollections,
+    );
+
+    const localUnEvalTreeWithStrigifiedJSFunctions = Object.assign(
+      {},
+      localUnEvalTree,
+      stringifiedLocalUnEvalTreeJSCollection,
+    );
+
     const differences: Diff<DataTree, DataTree>[] =
-      diff(this.oldUnEvalTree, localUnEvalTree) || [];
+      diff(
+        oldUnEvalTreeWithStrigifiedJSFunctions,
+        localUnEvalTreeWithStrigifiedJSFunctions,
+      ) || [];
     // Since eval tree is listening to possible events that don't cause differences
     // We want to check if no diffs are present and bail out early
     if (differences.length === 0) {


### PR DESCRIPTION
## Description

Cause of issue
During evaluation, JS Functions are stored as String objects, rather than string literals. This was done to allow us to add a ".data" property to it.

Solution
Before translating diffs, String objects should be converted to literals, and separated from the ".data" field



Fixes #20893 


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
-WIP

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
