### PR TITLE
fix: Updating profile image API url for members page and invite modal

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/general.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/general.tsx
@@ -62,12 +62,11 @@ export const APPSMITH_DOWNLOAD_DOCKER_COMPOSE_FILE_SETTING: Setting = {
 
 export const APPSMITH_DISABLE_TELEMETRY_SETTING: Setting = {
   id: "APPSMITH_DISABLE_TELEMETRY",
+  name: "APPSMITH_DISABLE_TELEMETRY",
   category: SettingCategories.GENERAL,
-  controlType: SettingTypes.TOGGLE,
-  label: "Share anonymous usage data",
-  subText: "Share anonymous usage data to help improve the product",
-  toggleText: (value: boolean) =>
-    value ? "Don't share any data" : "Share Anonymous Telemetry",
+  controlType: SettingTypes.CHECKBOX,
+  label: "Anonymous Usage Data",
+  text: "Share anonymous usage data to help improve the product",
 };
 
 export const APPSMITH_HIDE_WATERMARK_SETTING: Setting = {

--- a/app/client/src/ce/pages/workspace/Members.tsx
+++ b/app/client/src/ce/pages/workspace/Members.tsx
@@ -32,7 +32,7 @@ import DeleteConfirmationModal from "pages/workspace/DeleteConfirmationModal";
 import { useMediaQuery } from "react-responsive";
 import { Card } from "@blueprintjs/core";
 import ProfileImage from "pages/common/ProfileImage";
-import { USER_PHOTO_URL } from "constants/userConstants";
+import { USER_PHOTO_ASSET_URL } from "constants/userConstants";
 import { Colors } from "constants/Colors";
 import { WorkspaceUser } from "@appsmith/constants/workspaceConstants";
 import {
@@ -342,7 +342,11 @@ export default function MemberSettings(props: PageProps) {
               <ProfileImage
                 className="user-icons"
                 size={20}
-                source={`/api/v1/users/photo/${member.username}`}
+                source={
+                  member.photoId
+                    ? `/api/${USER_PHOTO_ASSET_URL}/${member.photoId}`
+                    : undefined
+                }
                 userName={member.username}
               />
               <HighlightText highlight={searchValue} text={member.username} />
@@ -465,7 +469,11 @@ export default function MemberSettings(props: PageProps) {
                     <ProfileImage
                       className="avatar"
                       size={71}
-                      source={`/api/${USER_PHOTO_URL}/${member.username}`}
+                      source={
+                        member.photoId
+                          ? `/api/${USER_PHOTO_ASSET_URL}/${member.photoId}`
+                          : undefined
+                      }
                       userName={member.username}
                     />
                     <HighlightText

--- a/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
+++ b/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
@@ -58,12 +58,12 @@ import {
 import { getInitialsAndColorCode } from "utils/AppsmithUtils";
 import ProfileImage from "pages/common/ProfileImage";
 import ManageUsers from "pages/workspace/ManageUsers";
-import UserApi from "@appsmith/api/UserApi";
 import { Colors } from "constants/Colors";
 import { fetchWorkspace } from "@appsmith/actions/workspaceActions";
 import { useHistory } from "react-router-dom";
 import { Tooltip } from "@blueprintjs/core";
 import { isEllipsisActive } from "utils/helpers";
+import { USER_PHOTO_ASSET_URL } from "constants/userConstants";
 
 const { cloudHosting, mailEnabled } = getAppsmithConfigs();
 
@@ -458,8 +458,10 @@ function WorkspaceInviteUsersForm(props: any) {
             .filter((user: any) => isEmail(user))
             .join(",");
           AnalyticsUtil.logEvent("INVITE_USER", {
-            users: usersAsStringsArray,
-            role: values.role,
+            ...(cloudHosting ? { users: usersAsStringsArray } : {}),
+            role: isMultiSelectDropdown
+              ? selectedOption.map((group: any) => group.id).join(",")
+              : [selectedOption[0].id],
             numberOfUsersInvited: usersAsStringsArray.length,
           });
           return inviteUsersToWorkspace(
@@ -546,13 +548,18 @@ function WorkspaceInviteUsersForm(props: any) {
                     permissionGroupId: string;
                     permissionGroupName: string;
                     initials: string;
+                    photoId?: string;
                   }) => {
                     return (
                       <Fragment key={user.username}>
                         <User>
                           <UserInfo>
                             <ProfileImage
-                              source={`/api/${UserApi.photoURL}/${user.username}`}
+                              source={
+                                user.photoId
+                                  ? `/api/${USER_PHOTO_ASSET_URL}/${user.photoId}`
+                                  : undefined
+                              }
                               userName={user.name || user.username}
                             />
                             <UserName>


### PR DESCRIPTION
## Description

> Updating profile image API URL for members page and invite modal. 
> Also, changing the telemetry setting on the Admin settings page from toggle to checkbox for better UX.
> Updating invite user event payload.

Fixes [#19453](https://github.com/appsmithorg/appsmith/issues/19453) [#20492](https://github.com/appsmithorg/appsmith/issues/20492)


Media
<img width="463" alt="image" src="https://user-images.githubusercontent.com/28362912/220900112-511b79b1-8290-4fcf-9329-40a6a72eef91.png">

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?
> Tested both the above changes manually on local and it works as expected.

- Manual
- Jest
- Cypress

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
