### PR TITLE
fix: force auto height on no drop

### DIFF
--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -149,6 +149,7 @@ function useUpdateRows(bottomRow: number, widgetId: string, parentId?: string) {
         // We can't update the height of the "Canvas" or "dropTarget" using this function
         // in the previous if clause, because, there could be more "dropTargets" updating
         // and this information can only be computed using auto height
+
         updateHeight(dropTargetRef, rowRef.current);
       }
       return newRows;
@@ -187,6 +188,8 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
   // Are we changing the auto height limits by dragging the signifiers?
   const { isAutoHeightWithLimitsChanging } = useAutoHeightUIState();
 
+  const dispatch = useDispatch();
+
   // dragDetails contains of info needed for a container jump:
   // which parent the dragging widget belongs,
   // which canvas is active(being dragged on),
@@ -215,8 +218,19 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
     if (rowRef.current !== snapRows && !isDragging && !isResizing) {
       rowRef.current = snapRows;
       updateHeight(dropTargetRef, snapRows);
+
+      // If we're done dragging, and the parent has auto height enabled
+      // It is possible that the auto height has not triggered yet
+      // because the user has released the mouse button but not placed the widget
+      // In these scenarios, the parent's height needs to be updated
+      // in the same way as the auto height would have done
+      if (props.parentId) {
+        dispatch(
+          updateDOMDirectlyBasedOnAutoHeightAction(props.parentId, snapRows),
+        );
+      }
     }
-  }, [props.widgetId, props.bottomRow, isDragging, isResizing]);
+  }, [props.widgetId, props.bottomRow, isDragging, isResizing, props.parentId]);
 
   const handleFocus = (e: any) => {
     // Making sure that we don't deselect the widget

--- a/app/client/src/components/editorComponents/DropTargetComponent.tsx
+++ b/app/client/src/components/editorComponents/DropTargetComponent.tsx
@@ -27,7 +27,10 @@ import {
 import { useWidgetSelection } from "utils/hooks/useWidgetSelection";
 import { getDragDetails } from "sagas/selectors";
 import { useAutoHeightUIState } from "utils/hooks/autoHeightUIHooks";
-import { updateDOMDirectlyBasedOnAutoHeightAction } from "actions/autoHeightActions";
+import {
+  checkContainersForAutoHeightAction,
+  updateDOMDirectlyBasedOnAutoHeightAction,
+} from "actions/autoHeightActions";
 import { isAutoHeightEnabledForWidget } from "widgets/WidgetUtils";
 
 type DropTargetComponentProps = PropsWithChildren<{
@@ -225,9 +228,7 @@ export function DropTargetComponent(props: DropTargetComponentProps) {
       // In these scenarios, the parent's height needs to be updated
       // in the same way as the auto height would have done
       if (props.parentId) {
-        dispatch(
-          updateDOMDirectlyBasedOnAutoHeightAction(props.parentId, snapRows),
-        );
+        dispatch(checkContainersForAutoHeightAction());
       }
     }
   }, [props.widgetId, props.bottomRow, isDragging, isResizing, props.parentId]);


### PR DESCRIPTION
## Description
When we drag a widget within a container like widget, the container expands instantly. However, when we don't drop the widget and bring the mouse point outside the canvas, the auto height fails to kick in, as no action has been performed. This results in the container like widget's  height to remain as it was. This leads to incorrect height for the container like widget. 

This PR fixes it by forcing a new computation when the container like widget's internal canvas receives a new height.

Fixes #20907 



Media
Before

https://user-images.githubusercontent.com/103687/220900648-81cb5a0e-9aea-4d21-901e-29a8aa99c6b2.mov


After

https://user-images.githubusercontent.com/103687/220900630-725929dc-ce87-4b92-aec4-1305acd79e18.mov


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual

### Test Plan

### Issues raised during DP testing


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [NA] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
