### PR TITLE
feat: Support for proxy authentication

### DIFF
--- a/deploy/docker/scripts/run-java.sh
+++ b/deploy/docker/scripts/run-java.sh
@@ -21,7 +21,6 @@ match-proxy-url() {
   [[ -n $proxy_host ]]
 }
 
-echo "HTTP_PROXY = ${HTTP_PROXY-}"
 if match-proxy-url "${HTTP_PROXY-}"; then
   proxy_args+=(-Dhttp.proxyHost="$proxy_host" -Dhttp.proxyPort="$proxy_port")
   if [[ -n $proxy_user ]]; then


### PR DESCRIPTION
Appsmith supports running with a HTTP proxy, that can be configured with `HTTP_PROXY` or `HTTPS_PROXY` env variables. Like this:

```sh
HTTP_PROXY=http://myproxy:8080
HTTPS_PROXY=http://myproxy:8443
```

However, this proxy support didn't support authentication. This PR implements that. Now, proxy with authentication can be configured like this:

```sh
HTTP_PROXY=http://user:password@myproxy:8080
HTTPS_PROXY=http://user:password@myproxy:8080
```

This is not syntax or standards invented by Appsmith. This is the standard way proxy is usually configured.

Fixes #16330

🍰