### PR TITLE
fix: enforcing content-type header while registering the instance id

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/InstanceConfig.java
@@ -16,6 +16,7 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -128,6 +129,7 @@ public class InstanceConfig implements ApplicationListener<ApplicationReadyEvent
                         .create(baseUrl + "/api/v1/installations")
                         .post()
                         .body(BodyInserters.fromValue(Map.of("key", instanceId)))
+                        .headers(httpHeaders -> httpHeaders.set(HttpHeaders.CONTENT_TYPE, "application/json"))
                         .exchange())
                 .flatMap(clientResponse -> clientResponse.toEntity(new ParameterizedTypeReference<ResponseDTO<String>>() {
                 }))


### PR DESCRIPTION
## Description
In cloud services logs we are experiencing tons of `415 application/octet-stream `exceptions  related to the `api/v1/installation`. i.e when we register a new instance from the cloud services. as a consequence instance ids can't be registered.
This might be happening due to automatic setting of content-type to octet-stream, can't say for sure.
Here we are enforcing a "application/json" content-type.

- We are also experiencing unauthorised access exception logs thrown when we try to get remote plugins for the instance 
on endpoint `api/v1/plugins?instanceId={{instanceId}}` 
According to our hypothesis this one is thrown because the instance couldn't be registered in first place. hence the repo has no history of this particular instance id

> TL;DR enforced a application/json content type on api call for registering instance.

[Slack Thread](https://theappsmith.slack.com/archives/CGBPVEJ5C/p1677074154818309)

Fixes #20949 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This has been tested:
- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
