### PR TITLE
fix: remove parent list widget from child widget level data

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/ListV2_nested_List_widget_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/ListV2_nested_List_widget_spec.js
@@ -115,10 +115,10 @@ describe(" Nested List Widgets ", function() {
       cy.wrap($el).should("not.have.text", "triggeredItemView");
     });
 
-    cy.testJsontextclear("text");
-    cy.get(
-      ".t--property-control-text .CodeMirror textarea",
-    ).type("{{level_1.currentView.List1Copy.pageNo", { force: true });
+    cy.get(".CodeMirror-hints")
+      .contains("pageNo")
+      .first()
+      .click({ force: true });
 
     cy.get(`${widgetSelector("Text2")} .bp3-ui-text span`).should(
       "have.text",

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/ListV2_nested_List_widget_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/ListV2_nested_List_widget_spec.js
@@ -86,8 +86,43 @@ describe(" Nested List Widgets ", function() {
       },
     );
     checkAutosuggestion("Text1", "Object");
+    checkAutosuggestion("List1Copy", "Object");
+
+    cy.testJsontextclear("text");
+
+    cy.get(".t--property-control-text .CodeMirror textarea").type(
+      "{{level_1.currentView.List1Copy.",
+      {
+        force: true,
+      },
+    );
+    checkAutosuggestion("backgroundColor", "String");
+    checkAutosuggestion("itemSpacing", "Number");
+    checkAutosuggestion("isVisible", "Boolean");
+    checkAutosuggestion("listData", "Array");
+    checkAutosuggestion("pageNo", "Number");
+    checkAutosuggestion("pageSize", "Number");
+
     cy.get(".CodeMirror-hints").each(($el) => {
-      cy.wrap($el).should("not.have.text", "List1Copy");
+      cy.wrap($el).should("not.have.text", "currentViewItems");
     });
+
+    cy.get(".CodeMirror-hints").each(($el) => {
+      cy.wrap($el).should("not.have.text", "selectedItemView");
+    });
+
+    cy.get(".CodeMirror-hints").each(($el) => {
+      cy.wrap($el).should("not.have.text", "triggeredItemView");
+    });
+
+    cy.testJsontextclear("text");
+    cy.get(
+      ".t--property-control-text .CodeMirror textarea",
+    ).type("{{level_1.currentView.List1Copy.pageNo", { force: true });
+
+    cy.get(`${widgetSelector("Text2")} .bp3-ui-text span`).should(
+      "have.text",
+      "1",
+    );
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/ListV2_nested_List_widget_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/ListV2_nested_List_widget_spec.js
@@ -56,7 +56,7 @@ describe(" Nested List Widgets ", function() {
     cy.get(`${widgetSelector("List2Copy1")}`).should("not.exist");
   });
 
-  it("b. Not show parent list in level data autocomplete", () => {
+  it("b. No cyclic dependency when using levelData in a child widget", () => {
     cy.dragAndDropToWidgetBySelector(
       "textwidget",
       '[data-widgetname-cy="List1"] [type="CONTAINER_WIDGET"]',

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_BasicChildWidgetInteraction_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_BasicChildWidgetInteraction_spec.js
@@ -93,7 +93,7 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(3000);
+    cy.wait(4000);
 
     // open the select widget
     cy.get(publishLocators.selectwidget)
@@ -122,7 +122,7 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(3000);
+    cy.wait(4000);
 
     // select green
     cy.get(publishLocators.checkboxGroupWidget)
@@ -157,7 +157,7 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(3000);
+    cy.wait(4000);
 
     // Verify checked
     cy.get(publishLocators.switchwidget)
@@ -189,7 +189,7 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(3000);
+    cy.wait(4000);
 
     // Check radio with value=1 is selected
     checkSelectedRadioValue(publishLocators.radioWidget, "Y");

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_BasicChildWidgetInteraction_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_BasicChildWidgetInteraction_spec.js
@@ -93,7 +93,15 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(4000);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector("List1")} ${containerWidgetSelector} ${
+            publishLocators.selectwidget
+          }`,
+        )
+        .should("have.length", 3),
+    );
 
     // open the select widget
     cy.get(publishLocators.selectwidget)
@@ -122,7 +130,15 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(4000);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector("List1")} ${containerWidgetSelector} ${
+            publishLocators.checkboxGroupWidget
+          }`,
+        )
+        .should("have.length", 3),
+    );
 
     // select green
     cy.get(publishLocators.checkboxGroupWidget)
@@ -157,7 +173,15 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(4000);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector("List1")} ${containerWidgetSelector} ${
+            publishLocators.switchwidget
+          }`,
+        )
+        .should("have.length", 3),
+    );
 
     // Verify checked
     cy.get(publishLocators.switchwidget)
@@ -189,7 +213,15 @@ describe("List widget v2 - Basic Child Widget Interaction", () => {
 
     cy.PublishtheApp();
 
-    cy.wait(4000);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector("List1")} ${containerWidgetSelector} ${
+            publishLocators.radioWidget
+          }`,
+        )
+        .should("have.length", 3),
+    );
 
     // Check radio with value=1 is selected
     checkSelectedRadioValue(publishLocators.radioWidget, "Y");

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ClientSide_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ClientSide_spec.js
@@ -99,7 +99,17 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(3000);
+    cy.wait(200);
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
 
     //   SecondPage
     //   First Row
@@ -122,7 +132,30 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginatePrevButton).click({
       force: true,
     });
-    cy.wait(3000);
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+        )
+        .first()
+        .invoke("text")
+        .then(($selectedValue) => {
+          expect($selectedValue).to.eq("Green");
+        }),
+    );
 
     //Validate values in FirstPage
     //   First Row
@@ -146,7 +179,30 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(3000);
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+        )
+        .first()
+        .invoke("text")
+        .then(($selectedValue) => {
+          expect($selectedValue).to.eq("Blue");
+        }),
+    );
 
     //Validate values in SecondPage
     //   First Row
@@ -194,7 +250,16 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(3000);
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
 
     //   SecondPage
     //   First Row
@@ -216,10 +281,34 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginatePrevButton).click({
       force: true,
     });
-    cy.wait(3000);
 
     //Validate values in FirstPage
     //   First Row
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+        )
+        .first()
+        .invoke("text")
+        .then(($selectedValue) => {
+          expect($selectedValue).to.eq("Green");
+        }),
+    );
+
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();
 
     verifyValueOfWidget("selectwidget", "Green", 0);
@@ -240,10 +329,34 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(3000);
 
     //Validate values in SecondPage
     //   First Row
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+        )
+        .first()
+        .invoke("text")
+        .then(($selectedValue) => {
+          expect($selectedValue).to.eq("Blue");
+        }),
+    );
+
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();
 
     verifyValueOfWidget("selectwidget", "Blue", 0);

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ClientSide_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ClientSide_spec.js
@@ -99,7 +99,7 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(2000);
+    cy.wait(3000);
 
     //   SecondPage
     //   First Row
@@ -194,7 +194,7 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(2000);
+    cy.wait(3000);
 
     //   SecondPage
     //   First Row

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
@@ -238,7 +238,6 @@ describe("List widget v2 - meta hydration tests", () => {
           }),
       {
         timeout: 10000,
-        interval: 500, // performs the check every 500 ms, default to 200
       },
     );
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();
@@ -394,7 +393,6 @@ describe("List widget v2 - meta hydration tests", () => {
           }),
       {
         timeout: 10000,
-        interval: 500, // performs the check every 500 ms, default to 200
       },
     );
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
@@ -176,7 +176,17 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(4000);
+    cy.wait(200);
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
 
     //   SecondPage
     //   First Row
@@ -202,7 +212,35 @@ describe("List widget v2 - meta hydration tests", () => {
 
     //Validate values in FirstPage
     //   First Row
-    cy.wait(10000);
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(
+      () =>
+        cy
+          .get(
+            `${widgetSelector(
+              "List1",
+            )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+          )
+          .first()
+          .invoke("text")
+          .then(($selectedValue) => {
+            expect($selectedValue).to.eq("Green");
+          }),
+      {
+        timeout: 10000,
+        interval: 500, // performs the check every 500 ms, default to 200
+      },
+    );
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();
     verifyValueOfWidget("selectwidget", "Green", 0);
     verifyValueOfWidget("inputwidgetv2", "First", 0);
@@ -222,10 +260,37 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
+    cy.wait(300);
 
     //Validate values in SecondPage
     //   First Row
-    cy.wait(10000);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(
+      () =>
+        cy
+          .get(
+            `${widgetSelector(
+              "List1",
+            )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+          )
+          .first()
+          .invoke("text")
+          .then(($selectedValue) => {
+            expect($selectedValue).to.eq("Blue");
+          }),
+      {
+        timeout: 10000,
+      },
+    );
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();
     verifyValueOfWidget("selectwidget", "Blue", 0);
     verifyValueOfWidget("inputwidgetv2", "Fourth", 0);
@@ -268,7 +333,17 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(4000);
+    cy.wait(200);
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
 
     //   SecondPage
     //   First Row
@@ -293,7 +368,35 @@ describe("List widget v2 - meta hydration tests", () => {
 
     //Validate values in FirstPage
     //   First Row
-    cy.wait(10000);
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(
+      () =>
+        cy
+          .get(
+            `${widgetSelector(
+              "List1",
+            )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+          )
+          .first()
+          .invoke("text")
+          .then(($selectedValue) => {
+            expect($selectedValue).to.eq("Green");
+          }),
+      {
+        timeout: 10000,
+        interval: 500, // performs the check every 500 ms, default to 200
+      },
+    );
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();
     verifyValueOfWidget("selectwidget", "Green", 0);
     verifyValueOfWidget("inputwidgetv2", "First", 0);
@@ -316,7 +419,34 @@ describe("List widget v2 - meta hydration tests", () => {
 
     //Validate values in SecondPage
     //   First Row
-    cy.wait(10000);
+    cy.wait(300);
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-selectwidget button`,
+        )
+        .should("have.length", 3),
+    );
+
+    cy.waitUntil(
+      () =>
+        cy
+          .get(
+            `${widgetSelector(
+              "List1",
+            )} ${containerWidgetSelector} .t--widget-selectwidget button span.bp3-button-text`,
+          )
+          .first()
+          .invoke("text")
+          .then(($selectedValue) => {
+            expect($selectedValue).to.eq("Green");
+          }),
+      {
+        timeout: 10000,
+      },
+    );
     cy.get(`${widgetSelector("List1")}`).scrollIntoView();
     verifyValueOfWidget("selectwidget", "Blue", 0);
     verifyValueOfWidget("inputwidgetv2", "Fourth", 0);

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
@@ -176,7 +176,7 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(2000);
+    cy.wait(4000);
 
     //   SecondPage
     //   First Row
@@ -268,7 +268,7 @@ describe("List widget v2 - meta hydration tests", () => {
     cy.get(commonlocators.listPaginateNextButton).click({
       force: true,
     });
-    cy.wait(2000);
+    cy.wait(4000);
 
     //   SecondPage
     //   First Row

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_Meta_Hydration_ServerSide_spec.js
@@ -439,7 +439,7 @@ describe("List widget v2 - meta hydration tests", () => {
           .first()
           .invoke("text")
           .then(($selectedValue) => {
-            expect($selectedValue).to.eq("Green");
+            expect($selectedValue).to.eq("Blue");
           }),
       {
         timeout: 10000,

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_autocomplete_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_autocomplete_spec.js
@@ -105,18 +105,14 @@ describe("List v2 - Property autocomplete", () => {
     cy.get(
       ".t--property-control-text .CodeMirror textarea",
     ).type("{{level_1.currentView.List2.", { force: true });
-    cy.get(".CodeMirror-hints")
-      .contains("currentItemsView")
-      .should("not.exist");
+    cy.get(".CodeMirror-hints").should("not.exist");
 
     // level_2 List currentItemsView should not exist
     cy.testJsontext("text", "");
     cy.get(
       ".t--property-control-text .CodeMirror textarea",
     ).type("{{level_2.currentView.List3.", { force: true });
-    cy.get(".CodeMirror-hints")
-      .contains("currentItemsView")
-      .should("not.exist");
+    cy.get(".CodeMirror-hints").should("not.exist");
   });
 
   it("8. currentItem should reflect appropriate data types", () => {
@@ -144,7 +140,6 @@ describe("List v2 - Property autocomplete", () => {
     ).type("{{level_1.currentView.", { force: true });
     checkAutosuggestion("Text1", "Object");
     checkAutosuggestion("Text2", "Object");
-    checkAutosuggestion("List2", "Object");
 
     // level_1.currentView.Text1
     cy.testJsontext("text", "");
@@ -166,12 +161,9 @@ describe("List v2 - Property autocomplete", () => {
     cy.testJsontext("text", "");
     cy.get(
       ".t--property-control-text .CodeMirror textarea",
-    ).type("{{level_1.currentView.List2.", { force: true });
-    checkAutosuggestion("backgroundColor", "String");
-    checkAutosuggestion("itemSpacing", "Number");
-    checkAutosuggestion("isVisible", "Boolean");
-    checkAutosuggestion("listData", "Array");
-    checkAutosuggestion("pageNo", "Number");
-    checkAutosuggestion("pageSize", "Number");
+    ).type("{{level_1.currentView.", { force: true });
+    cy.get(".CodeMirror-hints").each(($el) => {
+      cy.wrap($el).should("not.have.text", "List2");
+    });
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_autocomplete_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_autocomplete_spec.js
@@ -105,14 +105,18 @@ describe("List v2 - Property autocomplete", () => {
     cy.get(
       ".t--property-control-text .CodeMirror textarea",
     ).type("{{level_1.currentView.List2.", { force: true });
-    cy.get(".CodeMirror-hints").should("not.exist");
+    cy.get(".CodeMirror-hints")
+      .contains("currentItemsView")
+      .should("not.exist");
 
     // level_2 List currentItemsView should not exist
     cy.testJsontext("text", "");
     cy.get(
       ".t--property-control-text .CodeMirror textarea",
     ).type("{{level_2.currentView.List3.", { force: true });
-    cy.get(".CodeMirror-hints").should("not.exist");
+    cy.get(".CodeMirror-hints")
+      .contains("currentItemsView")
+      .should("not.exist");
   });
 
   it("8. currentItem should reflect appropriate data types", () => {
@@ -140,6 +144,7 @@ describe("List v2 - Property autocomplete", () => {
     ).type("{{level_1.currentView.", { force: true });
     checkAutosuggestion("Text1", "Object");
     checkAutosuggestion("Text2", "Object");
+    checkAutosuggestion("List2", "Object");
 
     // level_1.currentView.Text1
     cy.testJsontext("text", "");
@@ -161,9 +166,12 @@ describe("List v2 - Property autocomplete", () => {
     cy.testJsontext("text", "");
     cy.get(
       ".t--property-control-text .CodeMirror textarea",
-    ).type("{{level_1.currentView.", { force: true });
-    cy.get(".CodeMirror-hints").each(($el) => {
-      cy.wrap($el).should("not.have.text", "List2");
-    });
+    ).type("{{level_1.currentView.List2.", { force: true });
+    checkAutosuggestion("backgroundColor", "String");
+    checkAutosuggestion("itemSpacing", "Number");
+    checkAutosuggestion("isVisible", "Boolean");
+    checkAutosuggestion("listData", "Array");
+    checkAutosuggestion("pageNo", "Number");
+    checkAutosuggestion("pageSize", "Number");
   });
 });

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -785,6 +785,25 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  "dragAndDropToWidgetBySelector",
+  (widgetType, destinationSelector, { x, y }) => {
+    const selector = `.t--widget-card-draggable-${widgetType}`;
+    cy.wait(800);
+    cy.get(selector)
+      .scrollIntoView()
+      .trigger("dragstart", { force: true })
+      .trigger("mousemove", x, y, { force: true });
+    cy.get(destinationSelector)
+      .first()
+      .scrollIntoView()
+      .scrollTo("top", { ensureScrollable: false })
+      .trigger("mousemove", x, y, { eventConstructor: "MouseEvent" })
+      .trigger("mousemove", x, y, { eventConstructor: "MouseEvent" })
+      .trigger("mouseup", x, y, { eventConstructor: "MouseEvent" });
+  },
+);
+
 Cypress.Commands.add("changeButtonColor", (buttonColor) => {
   cy.get(widgetsPage.buttonColor)
     .click({ force: true })

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
@@ -727,7 +727,7 @@ describe("#generate", () => {
           },
           List6: {
             entityDefinition:
-              "backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItem: List6.triggeredItem,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize",
+              "backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,triggeredItem: List6.triggeredItem,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize",
             rowIndex: 0,
             metaWidgetId: "fs2d2lqjgd",
             metaWidgetName: "List6",
@@ -927,7 +927,7 @@ describe("#generate", () => {
     };
 
     const expectedDataBinding =
-      "{{\n      {\n        \n          Image1: { image: Image1.image,isVisible: Image1.isVisible }\n        ,\n          Text1: { isVisible: Text1.isVisible,text: Text1.text }\n        ,\n          Text2: { isVisible: Text2.isVisible,text: Text2.text }\n        ,\n          List6: { backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,selectedItemView: List6.selectedItemView,triggeredItem: List6.triggeredItem,triggeredItemView: List6.triggeredItemView,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize }\n        \n      }\n    }}";
+      "{{\n      {\n        \n          Image1: { image: Image1.image,isVisible: Image1.isVisible }\n        ,\n          Text1: { isVisible: Text1.isVisible,text: Text1.text }\n        ,\n          Text2: { isVisible: Text2.isVisible,text: Text2.text }\n        ,\n          List6: { backgroundColor: List6.backgroundColor,isVisible: List6.isVisible,itemSpacing: List6.itemSpacing,selectedItem: List6.selectedItem,triggeredItem: List6.triggeredItem,listData: List6.listData,pageNo: List6.pageNo,pageSize: List6.pageSize }\n        \n      }\n    }}";
 
     const count = Object.keys(metaWidgets).length;
     expect(count).toEqual(18);

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
@@ -764,8 +764,7 @@ describe("#generate", () => {
             id: 1,
             name: "Blue",
           },
-          currentView:
-            '{{((data, name) => Object.keys(data).filter((widgetName) => widgetName !== name).reduce((obj, key) => {obj[key] = data[key];return obj;}, {}))(Container1.data, "List6")}}',
+          currentView: "{{Container1.data}}",
         },
       },
     };

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.test.ts
@@ -764,7 +764,8 @@ describe("#generate", () => {
             id: 1,
             name: "Blue",
           },
-          currentView: "{{Container1.data}}",
+          currentView:
+            '{{((data, name) => Object.keys(data).filter((widgetName) => widgetName !== name).reduce((obj, key) => {obj[key] = data[key];return obj;}, {}))(Container1.data, "List6")}}',
         },
       },
     };

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -178,6 +178,12 @@ enum MODIFICATION_TYPE {
   GENERATE_CACHE_WIDGETS = "GENERATE_CACHE_WIDGETS",
 }
 
+const getLevelDataCurrentView = (
+  metaContainerName: string,
+  widgetName: string,
+) =>
+  `{{((data, name) => Object.keys(data).filter((widgetName) => widgetName !== name).reduce((obj, key) => {obj[key] = data[key];return obj;}, {}))(${metaContainerName}.data, "${widgetName}")}}`;
+
 const ROOT_CONTAINER_PARENT_KEY = "__$ROOT_CONTAINER_PARENT$__";
 const ROOT_ROW_KEY = "__$ROOT_KEY$__";
 const BLACKLISTED_ENTITY_DEFINITION: Record<string, string[] | undefined> = {
@@ -858,7 +864,7 @@ class MetaWidgetGenerator {
     rowIndex: number,
     key: string,
   ) => {
-    const { metaWidgetId, widgetId } = metaWidget;
+    const { metaWidgetId, widgetId, widgetName } = metaWidget;
     const currentViewData = this.getCurrentViewData();
     const shouldAddDataCacheToBinding = this.shouldAddDataCacheToBinding(
       metaWidgetId ?? widgetId,
@@ -904,7 +910,7 @@ class MetaWidgetGenerator {
           currentItem: currentViewData?.[0],
           // Uses any one of the row's container present on the List widget to
           // get the object of current row for autocomplete
-          currentView: `{{${metaContainerName}.data}}`,
+          currentView: getLevelDataCurrentView(metaContainerName, widgetName),
         },
       },
     };

--- a/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
+++ b/app/client/src/widgets/ListWidgetV2/MetaWidgetGenerator.ts
@@ -178,16 +178,10 @@ enum MODIFICATION_TYPE {
   GENERATE_CACHE_WIDGETS = "GENERATE_CACHE_WIDGETS",
 }
 
-const getLevelDataCurrentView = (
-  metaContainerName: string,
-  widgetName: string,
-) =>
-  `{{((data, name) => Object.keys(data).filter((widgetName) => widgetName !== name).reduce((obj, key) => {obj[key] = data[key];return obj;}, {}))(${metaContainerName}.data, "${widgetName}")}}`;
-
 const ROOT_CONTAINER_PARENT_KEY = "__$ROOT_CONTAINER_PARENT$__";
 const ROOT_ROW_KEY = "__$ROOT_KEY$__";
 const BLACKLISTED_ENTITY_DEFINITION: Record<string, string[] | undefined> = {
-  LIST_WIDGET_V2: ["currentItemsView"],
+  LIST_WIDGET_V2: ["currentItemsView", "selectedItemView", "triggeredItemView"],
 };
 /**
  * LEVEL_PATH_REGEX gives out following matches:
@@ -864,7 +858,7 @@ class MetaWidgetGenerator {
     rowIndex: number,
     key: string,
   ) => {
-    const { metaWidgetId, widgetId, widgetName } = metaWidget;
+    const { metaWidgetId, widgetId } = metaWidget;
     const currentViewData = this.getCurrentViewData();
     const shouldAddDataCacheToBinding = this.shouldAddDataCacheToBinding(
       metaWidgetId ?? widgetId,
@@ -910,7 +904,7 @@ class MetaWidgetGenerator {
           currentItem: currentViewData?.[0],
           // Uses any one of the row's container present on the List widget to
           // get the object of current row for autocomplete
-          currentView: getLevelDataCurrentView(metaContainerName, widgetName),
+          currentView: `{{${metaContainerName}.data}}`,
         },
       },
     };


### PR DESCRIPTION
## Description

Avoid cyclic dependency in child widget when using level data to reference Parent List widget

Fixes #20793 

## Type of change
- Bug fix (non-breaking change which fixes an issue)



## How Has This Been Tested?

- Cypress

### Test Plan
> https://github.com/appsmithorg/TestSmith/issues/2187

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
