### PR TITLE
fix: Select widget isOptionSelected > TypeError: Cannot read properties of null (reading 'value')

### DIFF
--- a/app/client/src/widgets/SelectWidget/component/index.tsx
+++ b/app/client/src/widgets/SelectWidget/component/index.tsx
@@ -117,13 +117,18 @@ class SelectComponent extends React.Component<
     if (this.state.isOpen) this.togglePopoverVisibility();
   };
 
-  isOptionSelected = (selectedOption: DropdownOption) => {
-    if (this.props.value) return selectedOption.value === this.props.value;
+  isOptionSelected = (currentOption: DropdownOption) => {
+    // if currentOption is null, then return false
+    if (isNil(currentOption)) return false;
+
+    if (this.props.value) return currentOption.value === this.props.value;
+
     const optionIndex = findIndex(this.props.options, (option) => {
-      return option.value === selectedOption.value;
+      return option.value === currentOption.value;
     });
     return optionIndex === this.props.selectedIndex;
   };
+
   onQueryChange = debounce((filterValue: string) => {
     if (equal(filterValue, this.props.filterText)) return;
     this.props.onFilterChange(filterValue);


### PR DESCRIPTION
This PR fixes an issue reported by a sentry in which the select widget was crashing due to null selected option.

## Description

Fixes #20875

## Type of change
- Bug fix

## How Has This Been Tested?
- Not sure how to reproduce it so just added the null check.

### Test Plan

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
