### PR TITLE
fix: redirection to HomePage when CREATE WORKSPACE permission revoked from Default Role

### DIFF
--- a/app/client/src/utils/helpers.tsx
+++ b/app/client/src/utils/helpers.tsx
@@ -619,7 +619,10 @@ export const getCanCreateApplications = (currentWorkspace: Workspace) => {
 
 export const getIsSafeRedirectURL = (redirectURL: string) => {
   try {
-    return new URL(redirectURL).origin === window.location.origin;
+    return (
+      new URL(redirectURL, window.location.origin).origin ===
+      window.location.origin
+    );
   } catch (e) {
     return false;
   }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
@@ -32,6 +32,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import java.net.URI;
 import java.net.URLEncoder;
@@ -85,46 +87,11 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
             String defaultWorkspaceId
     ) {
         log.debug("Login succeeded for user: {}", authentication.getPrincipal());
-        Mono<Void> redirectionMono;
-        User user = (User) authentication.getPrincipal();
+        Tuple2<Boolean, Mono<Void>> redirectionMonoAndIsFromSignUp = setRedirectionMonoAndSignup(webFilterExchange,
+                authentication, createDefaultApplication, isFromSignup, defaultWorkspaceId);
+        Mono<Void> redirectionMono = redirectionMonoAndIsFromSignUp.getT2();
+        final Boolean isFromSignupFinal = redirectionMonoAndIsFromSignUp.getT1();
 
-        if (authentication instanceof OAuth2AuthenticationToken) {
-            // In case of OAuth2 based authentication, there is no way to identify if this was a user signup (new user
-            // creation) or if this was a login (existing user). What we do here to identify this, is an approximation.
-            // If and when we find a better way to do identify this, let's please move away from this approximation.
-            // If the user object was created within the last 5 seconds, we treat it as a new user.
-            isFromSignup = user.getCreatedAt().isAfter(Instant.now().minusSeconds(5));
-            // If user has previously signed up using password and now using OAuth as a sign in method we are removing
-            // form login method henceforth. This step is taken to avoid any security vulnerability in the login flow
-            // as we are not verifying the user emails at first sign up. In future if we implement the email
-            // verification this can be eliminated safely
-            if (user.getPassword() != null) {
-                user.setPassword(null);
-                user.setSource(
-                        LoginSource.fromString(((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId())
-                );
-                // Update the user in separate thread
-                userRepository.save(user).subscribeOn(Schedulers.boundedElastic()).subscribe();
-            }
-            if (isFromSignup) {
-                boolean finalIsFromSignup = isFromSignup;
-                redirectionMono = createDefaultApplication(defaultWorkspaceId, authentication)
-                        .flatMap(defaultApplication -> handleOAuth2Redirect(webFilterExchange, defaultApplication, finalIsFromSignup));
-            } else {
-                redirectionMono = handleOAuth2Redirect(webFilterExchange, null, isFromSignup);
-            }
-        } else {
-            boolean finalIsFromSignup = isFromSignup;
-            if (createDefaultApplication && isFromSignup) {
-                redirectionMono = createDefaultApplication(defaultWorkspaceId, authentication).flatMap(
-                        defaultApplication -> handleRedirect(webFilterExchange, defaultApplication, finalIsFromSignup)
-                );
-            } else {
-                redirectionMono = handleRedirect(webFilterExchange, null, finalIsFromSignup);
-            }
-        }
-
-        final boolean isFromSignupFinal = isFromSignup;
         return sessionUserService.getCurrentUser()
                 .flatMap(currentUser -> {
                     List<Mono<?>> monos = new ArrayList<>();
@@ -170,6 +137,52 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
                     return Mono.whenDelayError(monos);
                 })
                 .then(redirectionMono);
+    }
+
+    protected Tuple2<Boolean, Mono<Void>> setRedirectionMonoAndSignup(WebFilterExchange webFilterExchange,
+                                                                      Authentication authentication,
+                                                                      boolean createDefaultApplication,
+                                                                      boolean isFromSignup,
+                                                                      String defaultWorkspaceId) {
+        Mono<Void> redirectionMono;
+        User user = (User) authentication.getPrincipal();
+
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            // In case of OAuth2 based authentication, there is no way to identify if this was a user signup (new user
+            // creation) or if this was a login (existing user). What we do here to identify this, is an approximation.
+            // If and when we find a better way to do identify this, let's please move away from this approximation.
+            // If the user object was created within the last 5 seconds, we treat it as a new user.
+            isFromSignup = user.getCreatedAt().isAfter(Instant.now().minusSeconds(5));
+            // If user has previously signed up using password and now using OAuth as a sign in method we are removing
+            // form login method henceforth. This step is taken to avoid any security vulnerability in the login flow
+            // as we are not verifying the user emails at first sign up. In future if we implement the email
+            // verification this can be eliminated safely
+            if (user.getPassword() != null) {
+                user.setPassword(null);
+                user.setSource(
+                        LoginSource.fromString(((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId())
+                );
+                // Update the user in separate thread
+                userRepository.save(user).subscribeOn(Schedulers.boundedElastic()).subscribe();
+            }
+            if (isFromSignup) {
+                boolean finalIsFromSignup = isFromSignup;
+                redirectionMono = createDefaultApplication(defaultWorkspaceId, authentication)
+                        .flatMap(defaultApplication -> handleOAuth2Redirect(webFilterExchange, defaultApplication, finalIsFromSignup));
+            } else {
+                redirectionMono = handleOAuth2Redirect(webFilterExchange, null, isFromSignup);
+            }
+        } else {
+            boolean finalIsFromSignup = isFromSignup;
+            if (createDefaultApplication && isFromSignup) {
+                redirectionMono = createDefaultApplication(defaultWorkspaceId, authentication).flatMap(
+                        defaultApplication -> handleRedirect(webFilterExchange, defaultApplication, finalIsFromSignup)
+                );
+            } else {
+                redirectionMono = handleRedirect(webFilterExchange, null, finalIsFromSignup);
+            }
+        }
+        return Tuples.of(isFromSignup, redirectionMono);
     }
 
     protected Mono<Application> createDefaultApplication(String defaultWorkspaceId, Authentication authentication) {
@@ -225,7 +238,7 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
             // Disabling this because although the reference in the Javadoc is to a private method, it is still useful.
             "JavadocReference"
     )
-    private Mono<Void> handleOAuth2Redirect(WebFilterExchange webFilterExchange, Application defaultApplication, boolean isFromSignup) {
+    protected Mono<Void> handleOAuth2Redirect(WebFilterExchange webFilterExchange, Application defaultApplication, boolean isFromSignup) {
         ServerWebExchange exchange = webFilterExchange.getExchange();
         String state = exchange.getRequest().getQueryParams().getFirst(Security.QUERY_PARAMETER_STATE);
         String redirectUrl = RedirectHelper.DEFAULT_REDIRECT_URL;
@@ -269,7 +282,7 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
         }
     }
 
-    private Mono<Void> handleRedirect(WebFilterExchange webFilterExchange, Application defaultApplication, boolean isFromSignup) {
+    protected Mono<Void> handleRedirect(WebFilterExchange webFilterExchange, Application defaultApplication, boolean isFromSignup) {
         ServerWebExchange exchange = webFilterExchange.getExchange();
 
         // On authentication success, we send a redirect to the client's home page. This ensures that the session

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
@@ -108,12 +108,14 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
             }
             if (isFromSignup) {
                 boolean finalIsFromSignup = isFromSignup;
-                redirectionMono = workspaceService.isCreateWorkspaceAllowed(Boolean.TRUE).flatMap(isCreateWorkspaceAllowed -> {
-                    if (isCreateWorkspaceAllowed) {
-                        return createDefaultApplication(defaultWorkspaceId, authentication).flatMap(defaultApplication ->
-                                handleOAuth2Redirect(webFilterExchange, defaultApplication, finalIsFromSignup));
-                    }
-                    return handleOAuth2Redirect(webFilterExchange, null, finalIsFromSignup);
+                redirectionMono = workspaceService.isCreateWorkspaceAllowed(Boolean.TRUE)
+                        .flatMap(isCreateWorkspaceAllowed -> {
+                            if (isCreateWorkspaceAllowed) {
+                                return createDefaultApplication(defaultWorkspaceId, authentication)
+                                        .flatMap(defaultApplication ->
+                                                handleOAuth2Redirect(webFilterExchange, defaultApplication, finalIsFromSignup));
+                            }
+                            return handleOAuth2Redirect(webFilterExchange, null, finalIsFromSignup);
                 });
             } else {
                 redirectionMono = handleOAuth2Redirect(webFilterExchange, null, isFromSignup);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
@@ -44,4 +44,5 @@ public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
     Flux<Workspace> getAll();
 
     Mono<Workspace> archiveById(String s);
+    Mono<Boolean> isCreateWorkspaceAllowed(Boolean isDefaultWorkspace);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -241,7 +241,8 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
         return repository.save(createdWorkspace);
     }
 
-    protected Mono<Boolean> isCreateWorkspaceAllowed(Boolean isDefaultWorkspace) {
+    @Override
+    public Mono<Boolean> isCreateWorkspaceAllowed(Boolean isDefaultWorkspace) {
         return Mono.just(TRUE);
     }
 


### PR DESCRIPTION
## Description

> Updating the SignUp success flow to take into account, if the new User can create Workspace or not.
> Issue: 
> When the admin revokes the Create Workspace permission, the existing flow is still trying to create the workflow post the signup, which throws an Internal Server Error.
> Solution:
> A check has been introduced which will skip the Workspace Creation step, if the admin has blocked Workspace Creation from the **Default Role for All Users** role.
> Also, another change in behaviour is the redirection strategy.
> When the Create Permission is revoked, the user will land on the HomePage.
> When the permission is not revoked, user will land on a new Application with the Onboarding tutorial (this exists).

Fixes https://github.com/appsmithorg/appsmith/issues/20980

Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This has been tested manually on the local setups, and a QA has been done on the same on the Deploy Preview.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
