### PR TITLE
fix: Removed on page load edges from layout model

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Layout.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Layout.java
@@ -58,9 +58,6 @@ public class Layout extends BaseDomain {
     Set<String> allOnPageLoadActionNames;
 
     @JsonIgnore
-    Set<ActionDependencyEdge> allOnPageLoadActionEdges;
-
-    @JsonIgnore
     Set<String> actionsUsedInDynamicBindings;
 
     @JsonIgnore
@@ -90,7 +87,6 @@ public class Layout extends BaseDomain {
         this.setAllOnPageLoadActionNames(null);
         this.setCreatedAt(null);
         this.setUpdatedAt(null);
-        this.setAllOnPageLoadActionEdges(null);
         this.setActionsUsedInDynamicBindings(null);
         this.setWidgetNames(null);
         List<Set<DslActionDTO>> layoutOnLoadActions = this.getLayoutOnLoadActions();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration004ResetOnPageLoadEdgesInLayouts.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration004ResetOnPageLoadEdgesInLayouts.java
@@ -9,7 +9,15 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.core.query.UpdateDefinition;
 
-
+/**
+ * Since an Appsmith application is not limited by the number of interconnections it can make,
+ * it is possible for users to create graphs so complex that we end up having MBs of data in a
+ * relatively simple page as well.
+ * This was causing failures in a user's app since they were now unable to update their app
+ * any further. We do not really use this property anywhere in our logic today,
+ * and this is essentially redundant information.
+ * This migration gets rid of the edges property from the layout in all existing pages.
+ */
 @ChangeUnit(order = "004", id = "reset-on-page-load-edges-in-layouts")
 public class Migration004ResetOnPageLoadEdgesInLayouts {
     private final MongoTemplate mongoTemplate;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration004ResetOnPageLoadEdgesInLayouts.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration004ResetOnPageLoadEdgesInLayouts.java
@@ -1,0 +1,33 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.server.domains.NewPage;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
+
+
+@ChangeUnit(order = "004", id = "reset-on-page-load-edges-in-layouts")
+public class Migration004ResetOnPageLoadEdgesInLayouts {
+    private final MongoTemplate mongoTemplate;
+
+    public Migration004ResetOnPageLoadEdgesInLayouts(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void demoRollbackExecution() {
+    }
+
+    @Execution
+    public void executeMigration() {
+        UpdateDefinition updateQuery = new Update()
+                .unset("unpublishedPage.layouts.0.allOnPageLoadActionEdges")
+                .unset("publishedPage.layouts.0.allOnPageLoadActionEdges");
+
+        mongoTemplate.updateMulti(new Query(), updateQuery, NewPage.class);
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/models/export/LayoutMetadata.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/models/export/LayoutMetadata.java
@@ -1,19 +1,16 @@
 package com.appsmith.server.models.export;
 
-import java.util.List;
-import java.util.Set;
-
-import org.json.JSONObject;
-
 import com.appsmith.external.exceptions.ErrorDTO;
-import com.appsmith.server.domains.ActionDependencyEdge;
 import com.appsmith.server.domains.ScreenType;
 import com.appsmith.server.dtos.DslActionDTO;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Set;
 
 import static java.lang.Boolean.TRUE;
-
-import lombok.Data;
 
 @Data
 public class LayoutMetadata {
@@ -28,7 +25,6 @@ public class LayoutMetadata {
     private List<Set<DslActionDTO>> publishedLayoutOnLoadActions;
     private Set<String> widgetNames;
     private Set<String> allOnPageLoadActionNames;
-    private Set<ActionDependencyEdge> allOnPageLoadActionEdges;
     private Set<String> actionsUsedInDynamicBindings;
     private Set<String> mongoEscapedWidgetNames;
     private Boolean validOnPageLoadActions = TRUE;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/LayoutActionServiceCEImpl.java
@@ -707,7 +707,6 @@ public class LayoutActionServiceCEImpl implements LayoutActionServiceCE {
                             // in the layout for re-use to avoid computing DAG unnecessarily.
                             layout.setLayoutOnLoadActions(onLoadActions);
                             layout.setAllOnPageLoadActionNames(actionNames);
-                            layout.setAllOnPageLoadActionEdges(edges);
                             layout.setActionsUsedInDynamicBindings(actionsUsedInDSL);
                             // The below field is to ensure that we record if the page load actions computation was valid
                             // when last stored in the database.

--- a/app/server/appsmith-server/src/test/resources/test_assets/ActionCollectionServiceTest/mockObjects.json
+++ b/app/server/appsmith-server/src/test/resources/test_assets/ActionCollectionServiceTest/mockObjects.json
@@ -20,7 +20,6 @@
             "MainContainer"
           ],
           "allOnPageLoadActionNames": [],
-          "allOnPageLoadActionEdges": [],
           "actionsUsedInDynamicBindings": [],
           "deleted": false,
           "policies": []


### PR DESCRIPTION
## Description

Since an Appsmith application is not limited by the number of interconnections it can make, it is possible for users to create graphs so complex that we end up having MBs of data in a relatively simple page as well. This was causing failures in a user's app since they were now unable to update their app any further. We do not really use this property anywhere in our logic today, and this is essentially redundant information. This PR gets rid of the edges property from the layout and runs a migrations to clean up all existing pages as well. 

If we do find a need for this property in the future, a simple update layout on each of these pages would do the trick.

Fixes #20680 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
