### PR TITLE
test: Change mapping port for GITEA to 3001

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -187,7 +187,7 @@ jobs:
           mkdir -p ~/git-server/keys
           mkdir -p ~/git-server/repos
           docker run --name test-event-driver -d -p 22:22 -p 5001:5001 -p 3306:3306 \
-          -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3000:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
+          -p 5432:5432 -p 28017:27017 -p 25:25 -p 5000:5000 -p 3001:3000 --privileged --pid=host --ipc=host --volume /:/host -v ~/git-server/keys:/git-server/keys \
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
           docker run -d --name appsmith -p 80:80 -p 9001:9001 \

--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -51,6 +51,6 @@
   "authenticatedApiUrl": "https://fakeapi.com",
   "graphqlApiUrl": "https://spacex-production.up.railway.app",
   "GITEA_API_BASE_TED" : "localhost",
-  "GITEA_API_PORT_TED": "3000",
+  "GITEA_API_PORT_TED": "3001",
   "GITEA_API_URL_TED": "git@host.docker.internal:Cypress"
 }


### PR DESCRIPTION
## Description

- This PR changes the mapping port of GITEA TED form 3000 to 3001 because while building client/server locally Appsmith uses localhost:3000

## Type of change

- Script yml update (non-breaking change which fixes an issue)

## Checklist:
### QA activity:
- [X] Added Test Plan Approved label after reviewing the changes
