### PR TITLE
test: Fix to remove previous failing tests from Git Comment history

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -401,6 +401,7 @@ jobs:
         if: always()
         run: |
           mkdir -p  ~/failed_spec_ci
+          rm -rf ~/failed_spec_ci/*
           echo  "empty" >> ~/failed_spec_ci/dummy-${{ matrix.job }}
 
       # add list failed tests to a file


### PR DESCRIPTION
## Description

- This PR updates the ci-test.yml file to empty the failed_spec_ci folder which still holds the previoulsy (or attempt-1) failures & hence prints the attempt-1 failures also in the attempt-2 git comment in PRs.

## Type of change
- ci-test.yml file update


## Checklist:
### QA activity:
- [X] Added Test Plan Approved label after reviewing all changes
