### PR TITLE
fix: update JS Function async property after parsing 

### DIFF
--- a/app/client/src/workers/Evaluation/JSObject/test.ts
+++ b/app/client/src/workers/Evaluation/JSObject/test.ts
@@ -1,0 +1,189 @@
+import { DataTree } from "entities/DataTree/dataTreeFactory";
+import { getUpdatedLocalUnEvalTreeAfterJSUpdates } from ".";
+
+describe("updateJSCollectionInUnEvalTree", function() {
+  it("updates async value of jsAction", () => {
+    const jsUpdates = {
+      JSObject1: {
+        parsedBody: {
+          body:
+            "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t\t\n\t},\n\tmyFun2:  () => {\n\t\t//use async-await or promises\n\t\tyeso\n\t}\n}",
+          actions: [
+            {
+              name: "myFun1",
+              body: "() => {}",
+              arguments: [],
+              isAsync: false,
+            },
+            {
+              name: "myFun2",
+              body: "() => {\n  yeso;\n}",
+              arguments: [],
+              isAsync: true,
+            },
+          ],
+          variables: [
+            {
+              name: "myVar1",
+              value: "[]",
+            },
+            {
+              name: "myVar2",
+              value: "{}",
+            },
+          ],
+        },
+        id: "64013546b956c26882acc587",
+      },
+    };
+    const JSObject1Prototype = {
+      meta: {
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+      },
+      name: "JSObject1",
+      actionId: "64013546b956c26882acc587",
+      pluginType: "JS",
+      ENTITY_TYPE: "JSACTION",
+      bindingPaths: {
+        body: "SMART_SUBSTITUTE",
+        myVar1: "SMART_SUBSTITUTE",
+        myVar2: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+      },
+      reactivePaths: {
+        body: "SMART_SUBSTITUTE",
+        myVar1: "SMART_SUBSTITUTE",
+        myVar2: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myVar1",
+        },
+        {
+          key: "myVar2",
+        },
+        {
+          key: "myFun1",
+        },
+        {
+          key: "myFun2",
+        },
+      ],
+      variables: ["myVar1", "myVar2"],
+      dependencyMap: {
+        body: ["myFun1", "myFun2"],
+      },
+    };
+    const JSObject1 = {
+      myVar1: "[]",
+      myVar2: "{}",
+      myFun1: new String("() => {}"),
+      myFun2: new String("async () => {\n  yeso;\n}"),
+      body:
+        "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t\t\n\t},\n\tmyFun2:  () => {\n\t\t//use async-await or promises\n\t\tyeso\n\t}\n}",
+      ENTITY_TYPE: "JSACTION",
+    };
+    (JSObject1["myFun1"] as any).data = {};
+    (JSObject1["myFun2"] as any).data = {};
+    Object.setPrototypeOf(JSObject1, JSObject1Prototype);
+    const localUnEvalTree = ({
+      JSObject1,
+    } as unknown) as DataTree;
+
+    const actualResult = getUpdatedLocalUnEvalTreeAfterJSUpdates(
+      jsUpdates,
+      localUnEvalTree,
+    );
+
+    const expectedJSObjectPrototype = {
+      meta: {
+        myFun1: {
+          arguments: [],
+          isAsync: false,
+          confirmBeforeExecute: false,
+        },
+        myFun2: {
+          arguments: [],
+          isAsync: true,
+          confirmBeforeExecute: false,
+        },
+      },
+      name: "JSObject1",
+      actionId: "64013546b956c26882acc587",
+      pluginType: "JS",
+      ENTITY_TYPE: "JSACTION",
+      bindingPaths: {
+        body: "SMART_SUBSTITUTE",
+        myVar1: "SMART_SUBSTITUTE",
+        myVar2: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+      },
+      reactivePaths: {
+        body: "SMART_SUBSTITUTE",
+        myVar1: "SMART_SUBSTITUTE",
+        myVar2: "SMART_SUBSTITUTE",
+        myFun1: "SMART_SUBSTITUTE",
+        myFun2: "SMART_SUBSTITUTE",
+      },
+      dynamicBindingPathList: [
+        {
+          key: "body",
+        },
+        {
+          key: "myVar1",
+        },
+        {
+          key: "myVar2",
+        },
+        {
+          key: "myFun1",
+        },
+        {
+          key: "myFun2",
+        },
+      ],
+      variables: ["myVar1", "myVar2"],
+      dependencyMap: {
+        body: ["myFun1", "myFun2"],
+      },
+    };
+    const expectedJSObject = {
+      myVar1: "[]",
+      myVar2: "{}",
+      myFun1: new String("() => {}"),
+      myFun2: new String("() => {\n  yeso;\n}"),
+      body:
+        "export default {\n\tmyVar1: [],\n\tmyVar2: {},\n\tmyFun1: () => {\n\t\t//write code here\n\t\t\n\t},\n\tmyFun2:  () => {\n\t\t//use async-await or promises\n\t\tyeso\n\t}\n}",
+      ENTITY_TYPE: "JSACTION",
+      variables: ["myVar1", "myVar2"],
+    };
+    (expectedJSObject["myFun1"] as any).data = {};
+    (expectedJSObject["myFun2"] as any).data = {};
+    Object.setPrototypeOf(expectedJSObject, expectedJSObjectPrototype);
+    const expectedResult = {
+      JSObject1: expectedJSObject,
+    };
+
+    expect(Object.getPrototypeOf(actualResult["JSObject1"])).toStrictEqual(
+      Object.getPrototypeOf(expectedResult["JSObject1"]),
+    );
+
+    expect(expectedResult).toStrictEqual(actualResult);
+  });
+});

--- a/app/client/src/workers/Evaluation/JSObject/utils.ts
+++ b/app/client/src/workers/Evaluation/JSObject/utils.ts
@@ -67,6 +67,7 @@ export const updateJSCollectionInUnEvalTree = (
             `${jsCollection.name}.${action.name}.data`,
             data,
           );
+          set(oldConfig.meta[action.name], `isAsync`, action.isAsync);
         }
       } else {
         const reactivePaths = oldConfig.reactivePaths;


### PR DESCRIPTION
## Description
This PR updates the local unevalTree after parsing, to include changes in the `async` property of JS Functions

Fixes # (issue)
> if no issue exists, please create an issue and ask the maintainers about this first


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
