### PR TITLE
ci: add release-portal url for deploy-previews

### DIFF
--- a/scripts/deploy_preview.sh
+++ b/scripts/deploy_preview.sh
@@ -64,6 +64,7 @@ helm upgrade -i $CHARTNAME appsmith/appsmith -n $NAMESPACE \
   --set image.pullSecrets=$SECRET --set redis.enabled=false --set mongodb.enabled=false --set ingress.enabled=true \
   --set "ingress.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-ssl-cert=$AWS_RELEASE_CERT" \
   --set "ingress.hosts[0].host=$DOMAINNAME, ingress.hosts[0].paths[0].path=/, ingress.hosts[0].paths[0].pathType=Prefix" \
-  --set ingress.className="nginx" --set image.pullPolicy="Always" --set autoupdate.enabled="true" --set persistence.size=4Gi \
+  --set ingress.className="nginx" --set applicationConfig.APPSMITH_CLOUD_SERVICES_BASE_URL="https://release-cs.appsmith.com" \
+  --set image.pullPolicy="Always" --set autoupdate.enabled="true" --set persistence.size=4Gi \
   --set applicationConfig.APPSMITH_MONGODB_URI="mongodb+srv://$DB_USERNAME:$DB_PASSWORD@$DB_URL/$DBNAME?retryWrites=true&minPoolSize=1&maxPoolSize=10&maxIdleTimeMS=900000&authSource=admin" \
   --version $HELMCHART_VERSION


### PR DESCRIPTION
Add env variable APPSMITH_CLOUD_SERVICES_BASE_URL to make sure the licence_key generation requests hit only release-cs i.e "https://release-cs.appsmith.com/" and not production-cs "https://cs.appsmith.com/"