### PR TITLE
Fix list widget height update issue.

### DIFF
--- a/app/client/src/utils/widgetRenderUtils.tsx
+++ b/app/client/src/utils/widgetRenderUtils.tsx
@@ -22,6 +22,7 @@ export const createCanvasWidget = (
   const widgetStaticProps = pick(canvasWidget, [
     ...Object.keys(WIDGET_STATIC_PROPS),
     ...(canvasWidget.additionalStaticProps || []),
+    ...["hasMetaWidgets", "requiresFlatWidgetChildren"],
   ]);
 
   //Pick required only contents for specific widgets

--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -231,7 +231,10 @@ class ListWidget extends BaseWidget<
 
     this.pageSize = this.getPageSize();
 
-    if (this.shouldUpdatePageSize()) {
+    if (
+      this.shouldUpdatePageSize() &&
+      this.props.pageSize !== prevProps.pageSize
+    ) {
       this.updatePageSize();
       if (this.props.serverSidePagination && this.pageSize) {
         this.executeOnPageChange();


### PR DESCRIPTION
## Description

Issue: Increasing height of a list widget, when inside a form widget, causes the app to crash due to an infinite loop.
Fix: Update componentDidUpdate check to compare the new and old values before calling the update.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
