### PR TITLE
fix: Revert container-internal communication when using IPv6

### DIFF
--- a/app/client/docker/templates/nginx-app-http.conf.template
+++ b/app/client/docker/templates/nginx-app-http.conf.template
@@ -1,6 +1,5 @@
 server {
     listen 80;
-    listen [::]:80;
     server_name $APPSMITH_DOMAIN;
 
     client_max_body_size 150m;

--- a/app/client/docker/templates/nginx-app-https.conf.template
+++ b/app/client/docker/templates/nginx-app-https.conf.template
@@ -1,6 +1,5 @@
 server {
     listen 80;
-    listen [::]:80;
     server_name $APPSMITH_DOMAIN;
 
     return 301 https://$host$request_uri;
@@ -8,7 +7,6 @@ server {
 
 server {
     listen 443 ssl http2;
-    listen [::]:443 ssl http2;
     server_name _;
 
     ssl_certificate ${APPSMITH_SSL_CERT_PATH};

--- a/app/client/docker/templates/nginx-app.conf.template
+++ b/app/client/docker/templates/nginx-app.conf.template
@@ -1,6 +1,5 @@
 server {
     listen 80;
-    listen [::]:80;
     server_name dev.appsmith.com;
 
     return 301 https://$host$request_uri;
@@ -8,7 +7,6 @@ server {
 
 server {
     listen 443 ssl http2;
-    listen [::]:443 ssl http2;
     server_name dev.appsmith.com;
     client_max_body_size 150m;
 

--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -233,7 +233,6 @@ http {
 $(if [[ $use_https == 1 ]]; then echo "
     server {
         listen $http_listen_port default_server;
-        listen [::]:$http_listen_port default_server;
         server_name $domain;
         return 301 https://\$host$(if [[ $https_listen_port != 443 ]]; then echo ":$https_listen_port"; fi)\$request_uri;
     }
@@ -242,13 +241,11 @@ $(if [[ $use_https == 1 ]]; then echo "
     server {
 $(if [[ $use_https == 1 ]]; then echo "
         listen $https_listen_port ssl http2 default_server;
-        listen [::]:$https_listen_port ssl http2 default_server;
         server_name $domain;
         ssl_certificate '$cert_file';
         ssl_certificate_key '$key_file';
 "; else echo "
         listen $http_listen_port default_server;
-        listen [::]:$http_listen_port default_server;
         server_name _;
 "; fi)
 

--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -24,7 +24,6 @@ access_log /dev/stdout;
 
 server {
   listen ${PORT:-80} default_server;
-  listen [::]:${PORT:-80} default_server;
   server_name $CUSTOM_DOMAIN;
 
   client_max_body_size 150m;

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -30,7 +30,6 @@ access_log /dev/stdout;
 
 server {
   listen 80;
-  listen [::]:80;
   server_name $CUSTOM_DOMAIN;
 
   return 301 https://\$host\$request_uri;
@@ -38,7 +37,6 @@ server {
 
 server {
   listen 443 ssl http2;
-  listen [::]:443 ssl http2;
   server_name _;
 
   ssl_certificate $SSL_CERT_PATH;


### PR DESCRIPTION

This reverts commit b3dbd85dbe1312faf630405f54f2003134534f1f.

This causes NGINX to fail to start if IPv6 is not available on the system.
