### PR TITLE
chore: [Usage pulse] view mode check should factor in the widget path in URL

### DIFF
--- a/app/client/src/usagePulse/index.ts
+++ b/app/client/src/usagePulse/index.ts
@@ -1,8 +1,12 @@
+import { isEditorPath } from "ce/pages/Editor/Explorer/helpers";
 import {
   BUILDER_VIEWER_PATH_PREFIX,
   VIEWER_PATH_DEPRECATED_REGEX,
 } from "constants/routes";
-import { noop } from "lodash";
+import { APP_MODE } from "entities/App";
+import { isNil, noop } from "lodash";
+import { getAppMode } from "selectors/applicationSelectors";
+import store from "store";
 import history from "utils/history";
 
 const PULSE_API_ENDPOINT = "/api/v1/usage-pulse";
@@ -25,8 +29,16 @@ class UsagePulse {
   }
 
   static sendPulse() {
+    let mode = getAppMode(store.getState());
+
+    if (isNil(mode)) {
+      mode = isEditorPath(window.location.pathname)
+        ? APP_MODE.EDIT
+        : APP_MODE.PUBLISHED;
+    }
+
     const data: Record<string, unknown> = {
-      viewMode: !window.location.href.endsWith("/edit"),
+      viewMode: mode === APP_MODE.PUBLISHED,
     };
 
     if (UsagePulse.userAnonymousId) {


### PR DESCRIPTION
Fixes https://github.com/appsmithorg/cloud-services/issues/589


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
