### PR TITLE
ci: Added steps to use the pre built docker image instead of building a new one

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -77,7 +77,7 @@ jobs:
       pr: ${{ github.event.client_payload.pull_request.number }}
 
   perf-test:
-    needs: [ client-build, server-build, rts-build ]
+    needs: [ build-docker-image ]
     # Only run if the build step is successful
     if: success()
     name: perf-test

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -107,53 +107,21 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         run: yarn install --frozen-lockfile
 
-      # Setup Java
-      - name: Set up JDK 17
-        if: steps.run_result.outputs.run_result != 'success'
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Download the react build artifact
-        if: steps.run_result.outputs.run_result != 'success'
-        uses: actions/download-artifact@v3
-        with:
-          name: client-build
-          path: app/client/build
-
-      - name: Download the server build artifact
-        if: steps.run_result.outputs.run_result != 'success'
-        uses: actions/download-artifact@v3
-        with:
-          name: server-build
-          path: app/server/dist
-
-      - name: Download the rts build artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: rts-dist
-          path: app/rts/dist
-
-      - name: Un-tar the rts folder
-        working-directory: "."
-        run: |
-          tar -xvf app/rts/dist/rts-dist.tar -C app/rts/
-          echo "Cleaning up the tar files"
-          rm app/rts/dist/rts-dist.tar
-
       - name: Installing Yarn serve
         if: steps.run_result.outputs.run_result != 'success'
         run: |
           yarn global add serve
           echo "$(yarn global bin)" >> $GITHUB_PATH
-      # We don't use Depot Docker builds because it's faster for local Docker images to be built locally.
-      # It's slower and more expensive to build these Docker images on Depot and download it back to the CI node.
-      - name: Build  docker image
-        if: steps.run_result.outputs.run_result != 'success'
-        working-directory: "."
+     
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: cicontainer
+
+      - name: Load Docker image from tar file
         run: |
-          docker build -t cicontainer .
+          gunzip cicontainer.tar.gz
+          docker load -i cicontainer.tar
 
       - name: Create folder
         if: steps.run_result.outputs.run_result != 'success'
@@ -163,8 +131,7 @@ jobs:
         run: |
           mkdir -p cicontainerlocal/stacks/configuration/
 
-
-      - name: Load docker image
+      - name: Run docker image
         if: steps.run_result.outputs.run_result != 'success'
         env:
           APPSMITH_LICENSE_KEY: ${{ secrets.APPSMITH_LICENSE_KEY }}

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -36,22 +36,22 @@ jobs:
     with:
       pr: 0
 
-  perf-test:
-    needs: [client-build, server-build, rts-build]
-    # Only run if the build step is successful
-    if: success()
-    name: perf-test
-    uses: ./.github/workflows/perf-test.yml
-    secrets: inherit
-    with:
-      pr: 0
-
   build-docker-image:
     needs: [ client-build, server-build, rts-build ]
     # Only run if the build step is successful
     if: success()
     name: build-docker-image
     uses: ./.github/workflows/build-docker-image.yml
+    secrets: inherit
+    with:
+      pr: 0
+
+  perf-test:
+    needs: [ build-docker-image ]
+    # Only run if the build step is successful
+    if: success()
+    name: perf-test
+    uses: ./.github/workflows/perf-test.yml
     secrets: inherit
     with:
       pr: 0


### PR DESCRIPTION
## Description
- Added steps to use the pre built docker image instead of building a new one in perf-test.yml

## Type of change
- perf-test.yml

## How Has This Been Tested?
- Manual

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
