### PR TITLE
fix: Add default value for hasChanges meta property in Form Widget

### DIFF
--- a/app/client/cypress/fixtures/formWithtabdsl.json
+++ b/app/client/cypress/fixtures/formWithtabdsl.json
@@ -1,0 +1,488 @@
+{
+    "dsl": {
+        "widgetName": "MainContainer",
+        "backgroundColor": "none",
+        "rightColumn": 4896,
+        "snapColumns": 64,
+        "detachFromLayout": true,
+        "widgetId": "0",
+        "topRow": 0,
+        "bottomRow": 640,
+        "containerStyle": "none",
+        "snapRows": 124,
+        "parentRowSpace": 1,
+        "type": "CANVAS_WIDGET",
+        "canExtend": true,
+        "version": 77,
+        "minHeight": 1292,
+        "dynamicTriggerPathList": [],
+        "parentColumnSpace": 1,
+        "dynamicBindingPathList": [],
+        "leftColumn": 0,
+        "children": [
+            {
+                "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+                "widgetName": "Tabs1",
+                "borderColor": "#E0DEDE",
+                "isCanvas": true,
+                "displayName": "Tabs",
+                "iconSVG": "/static/media/icon.74a6d653c8201e66f1cd367a3fba2657.svg",
+                "topRow": 17,
+                "bottomRow": 64,
+                "parentRowSpace": 10,
+                "type": "TABS_WIDGET",
+                "hideCard": false,
+                "shouldScrollContents": true,
+                "animateLoading": true,
+                "parentColumnSpace": 17.0625,
+                "leftColumn": 17,
+                "dynamicBindingPathList": [
+                    {
+                        "key": "accentColor"
+                    },
+                    {
+                        "key": "borderRadius"
+                    },
+                    {
+                        "key": "boxShadow"
+                    }
+                ],
+                "children": [
+                    {
+                        "tabId": "tab1",
+                        "widgetName": "Canvas1",
+                        "displayName": "Canvas",
+                        "bottomRow": 430,
+                        "topRow": 0,
+                        "parentRowSpace": 1,
+                        "type": "CANVAS_WIDGET",
+                        "canExtend": true,
+                        "hideCard": true,
+                        "shouldScrollContents": false,
+                        "minHeight": 150,
+                        "parentColumnSpace": 1,
+                        "leftColumn": 0,
+                        "dynamicBindingPathList": [],
+                        "children": [],
+                        "isDisabled": false,
+                        "key": "j764fvhdc8",
+                        "isDeprecated": false,
+                        "tabName": "Tab 1",
+                        "rightColumn": 409.5,
+                        "detachFromLayout": true,
+                        "widgetId": "dvv9rszk98",
+                        "minWidth": 450,
+                        "isVisible": true,
+                        "version": 1,
+                        "parentId": "3cxgot9zxu",
+                        "renderMode": "CANVAS",
+                        "isLoading": false,
+                        "responsiveBehavior": "fill",
+                        "flexLayers": []
+                    },
+                    {
+                        "tabId": "tab2",
+                        "widgetName": "Canvas2",
+                        "displayName": "Canvas",
+                        "bottomRow": 430,
+                        "topRow": 0,
+                        "parentRowSpace": 1,
+                        "type": "CANVAS_WIDGET",
+                        "canExtend": true,
+                        "hideCard": true,
+                        "shouldScrollContents": false,
+                        "minHeight": 150,
+                        "parentColumnSpace": 1,
+                        "leftColumn": 0,
+                        "dynamicBindingPathList": [],
+                        "children": [
+                            {
+                                "boxShadow": "{{appsmith.theme.boxShadow.appBoxShadow}}",
+                                "borderColor": "#E0DEDE",
+                                "widgetName": "Form1",
+                                "isCanvas": true,
+                                "displayName": "Form",
+                                "iconSVG": "/static/media/icon.ea3e08d130e59c56867ae40114c10eed.svg",
+                                "searchTags": [
+                                    "group"
+                                ],
+                                "topRow": 2,
+                                "bottomRow": 41,
+                                "parentRowSpace": 10,
+                                "type": "FORM_WIDGET",
+                                "hideCard": false,
+                                "shouldScrollContents": true,
+                                "animateLoading": true,
+                                "parentColumnSpace": 6.0859375,
+                                "leftColumn": 18,
+                                "dynamicBindingPathList": [
+                                    {
+                                        "key": "borderRadius"
+                                    },
+                                    {
+                                        "key": "boxShadow"
+                                    }
+                                ],
+                                "children": [
+                                    {
+                                        "widgetName": "Canvas3",
+                                        "displayName": "Canvas",
+                                        "topRow": 0,
+                                        "bottomRow": 390,
+                                        "parentRowSpace": 1,
+                                        "type": "CANVAS_WIDGET",
+                                        "canExtend": false,
+                                        "hideCard": true,
+                                        "minHeight": 400,
+                                        "parentColumnSpace": 1,
+                                        "leftColumn": 0,
+                                        "dynamicBindingPathList": [],
+                                        "children": [
+                                            {
+                                                "widgetName": "Text1",
+                                                "displayName": "Text",
+                                                "iconSVG": "/static/media/icon.97c59b523e6f70ba6f40a10fc2c7c5b5.svg",
+                                                "searchTags": [
+                                                    "typography",
+                                                    "paragraph",
+                                                    "label"
+                                                ],
+                                                "topRow": 1,
+                                                "bottomRow": 5,
+                                                "type": "TEXT_WIDGET",
+                                                "hideCard": false,
+                                                "animateLoading": true,
+                                                "overflow": "NONE",
+                                                "fontFamily": "{{appsmith.theme.fontFamily.appFont}}",
+                                                "dynamicTriggerPathList": [],
+                                                "leftColumn": 1.5,
+                                                "dynamicBindingPathList": [
+                                                    {
+                                                        "key": "truncateButtonColor"
+                                                    },
+                                                    {
+                                                        "key": "fontFamily"
+                                                    },
+                                                    {
+                                                        "key": "borderRadius"
+                                                    }
+                                                ],
+                                                "shouldTruncate": false,
+                                                "truncateButtonColor": "{{appsmith.theme.colors.primaryColor}}",
+                                                "text": "Forms",
+                                                "key": "r9dc4pq7r9",
+                                                "isDeprecated": false,
+                                                "rightColumn": 25.5,
+                                                "textAlign": "LEFT",
+                                                "dynamicHeight": "AUTO_HEIGHT",
+                                                "widgetId": "qksruse64t",
+                                                "minWidth": 450,
+                                                "isVisible": true,
+                                                "fontStyle": "BOLD",
+                                                "textColor": "#231F20",
+                                                "version": 1,
+                                                "parentId": "619ak6ypjc",
+                                                "renderMode": "CANVAS",
+                                                "isLoading": false,
+                                                "responsiveBehavior": "fill",
+                                                "originalTopRow": 1,
+                                                "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                                "maxDynamicHeight": 9000,
+                                                "originalBottomRow": 7,
+                                                "fontSize": "1.25rem",
+                                                "minDynamicHeight": 4
+                                            },
+                                            {
+                                                "resetFormOnClick": true,
+                                                "boxShadow": "none",
+                                                "widgetName": "Button1",
+                                                "buttonColor": "{{appsmith.theme.colors.primaryColor}}",
+                                                "displayName": "Button",
+                                                "iconSVG": "/static/media/icon.cca026338f1c8eb6df8ba03d084c2fca.svg",
+                                                "searchTags": [
+                                                    "click",
+                                                    "submit"
+                                                ],
+                                                "topRow": 33,
+                                                "bottomRow": 37,
+                                                "type": "BUTTON_WIDGET",
+                                                "hideCard": false,
+                                                "animateLoading": true,
+                                                "leftColumn": 46,
+                                                "dynamicBindingPathList": [
+                                                    {
+                                                        "key": "buttonColor"
+                                                    },
+                                                    {
+                                                        "key": "borderRadius"
+                                                    }
+                                                ],
+                                                "text": "Submit",
+                                                "isDisabled": false,
+                                                "key": "idwi315w14",
+                                                "isDeprecated": false,
+                                                "rightColumn": 62,
+                                                "isDefaultClickDisabled": true,
+                                                "widgetId": "nl78h0n0c6",
+                                                "minWidth": 120,
+                                                "isVisible": true,
+                                                "recaptchaType": "V3",
+                                                "version": 1,
+                                                "parentId": "619ak6ypjc",
+                                                "renderMode": "CANVAS",
+                                                "isLoading": false,
+                                                "responsiveBehavior": "hug",
+                                                "disabledWhenInvalid": true,
+                                                "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                                "buttonVariant": "PRIMARY",
+                                                "placement": "CENTER"
+                                            },
+                                            {
+                                                "resetFormOnClick": true,
+                                                "boxShadow": "none",
+                                                "widgetName": "Button2",
+                                                "buttonColor": "{{appsmith.theme.colors.primaryColor}}",
+                                                "displayName": "Button",
+                                                "iconSVG": "/static/media/icon.cca026338f1c8eb6df8ba03d084c2fca.svg",
+                                                "searchTags": [
+                                                    "click",
+                                                    "submit"
+                                                ],
+                                                "topRow": 33,
+                                                "bottomRow": 37,
+                                                "type": "BUTTON_WIDGET",
+                                                "hideCard": false,
+                                                "animateLoading": true,
+                                                "leftColumn": 30,
+                                                "dynamicBindingPathList": [
+                                                    {
+                                                        "key": "buttonColor"
+                                                    },
+                                                    {
+                                                        "key": "borderRadius"
+                                                    }
+                                                ],
+                                                "text": "Reset",
+                                                "isDisabled": false,
+                                                "key": "idwi315w14",
+                                                "isDeprecated": false,
+                                                "rightColumn": 46,
+                                                "isDefaultClickDisabled": true,
+                                                "widgetId": "pp0sgksr2t",
+                                                "minWidth": 120,
+                                                "isVisible": true,
+                                                "recaptchaType": "V3",
+                                                "version": 1,
+                                                "parentId": "619ak6ypjc",
+                                                "renderMode": "CANVAS",
+                                                "isLoading": false,
+                                                "responsiveBehavior": "hug",
+                                                "disabledWhenInvalid": false,
+                                                "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                                "buttonVariant": "SECONDARY",
+                                                "placement": "CENTER"
+                                            },
+                                            {
+                                                "resetFormOnClick": false,
+                                                "boxShadow": "none",
+                                                "widgetName": "Button3",
+                                                "buttonColor": "{{appsmith.theme.colors.primaryColor}}",
+                                                "displayName": "Button",
+                                                "iconSVG": "/static/media/icon.cca026338f1c8eb6df8ba03d084c2fca.svg",
+                                                "searchTags": [
+                                                    "click",
+                                                    "submit"
+                                                ],
+                                                "topRow": 11,
+                                                "bottomRow": 15,
+                                                "parentRowSpace": 10,
+                                                "type": "BUTTON_WIDGET",
+                                                "hideCard": false,
+                                                "animateLoading": true,
+                                                "parentColumnSpace": 3.2059326171875,
+                                                "dynamicTriggerPathList": [],
+                                                "leftColumn": 19,
+                                                "dynamicBindingPathList": [
+                                                    {
+                                                        "key": "buttonColor"
+                                                    },
+                                                    {
+                                                        "key": "borderRadius"
+                                                    }
+                                                ],
+                                                "text": "Submits",
+                                                "isDisabled": false,
+                                                "key": "5d84fxt6f1",
+                                                "isDeprecated": false,
+                                                "rightColumn": 35,
+                                                "isDefaultClickDisabled": true,
+                                                "widgetId": "6a4yfgt8ed",
+                                                "minWidth": 120,
+                                                "isVisible": true,
+                                                "recaptchaType": "V3",
+                                                "version": 1,
+                                                "parentId": "619ak6ypjc",
+                                                "renderMode": "CANVAS",
+                                                "isLoading": false,
+                                                "responsiveBehavior": "hug",
+                                                "disabledWhenInvalid": false,
+                                                "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                                "buttonVariant": "PRIMARY",
+                                                "placement": "CENTER"
+                                            }
+                                        ],
+                                        "key": "j764fvhdc8",
+                                        "isDeprecated": false,
+                                        "rightColumn": 146.0625,
+                                        "detachFromLayout": true,
+                                        "widgetId": "619ak6ypjc",
+                                        "containerStyle": "none",
+                                        "minWidth": 450,
+                                        "isVisible": true,
+                                        "version": 1,
+                                        "parentId": "b4uvnqer5n",
+                                        "renderMode": "CANVAS",
+                                        "isLoading": false,
+                                        "responsiveBehavior": "fill",
+                                        "flexLayers": []
+                                    }
+                                ],
+                                "borderWidth": "1",
+                                "positioning": "fixed",
+                                "key": "xzrlaqv3ih",
+                                "backgroundColor": "#FFFFFF",
+                                "isDeprecated": false,
+                                "rightColumn": 55,
+                                "dynamicHeight": "AUTO_HEIGHT",
+                                "widgetId": "b4uvnqer5n",
+                                "minWidth": 450,
+                                "isVisible": true,
+                                "parentId": "54lb6er5mu",
+                                "renderMode": "CANVAS",
+                                "isLoading": false,
+                                "responsiveBehavior": "fill",
+                                "originalTopRow": 2,
+                                "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                                "maxDynamicHeight": 9000,
+                                "originalBottomRow": 41,
+                                "minDynamicHeight": 10
+                            }
+                        ],
+                        "isDisabled": false,
+                        "key": "j764fvhdc8",
+                        "isDeprecated": false,
+                        "tabName": "Tab 2",
+                        "rightColumn": 409.5,
+                        "detachFromLayout": true,
+                        "widgetId": "54lb6er5mu",
+                        "minWidth": 450,
+                        "isVisible": true,
+                        "version": 1,
+                        "parentId": "3cxgot9zxu",
+                        "renderMode": "CANVAS",
+                        "isLoading": false,
+                        "responsiveBehavior": "fill",
+                        "flexLayers": []
+                    }
+                ],
+                "borderWidth": 1,
+                "key": "mxh84g60py",
+                "backgroundColor": "#FFFFFF",
+                "isDeprecated": false,
+                "rightColumn": 41,
+                "dynamicHeight": "AUTO_HEIGHT",
+                "widgetId": "3cxgot9zxu",
+                "accentColor": "{{appsmith.theme.colors.primaryColor}}",
+                "defaultTab": "Tab 1",
+                "shouldShowTabs": true,
+                "minWidth": 450,
+                "tabsObj": {
+                    "tab1": {
+                        "label": "Tab 1",
+                        "id": "tab1",
+                        "widgetId": "dvv9rszk98",
+                        "isVisible": true,
+                        "index": 0,
+                        "positioning": "vertical"
+                    },
+                    "tab2": {
+                        "label": "Tab 2",
+                        "id": "tab2",
+                        "widgetId": "54lb6er5mu",
+                        "isVisible": true,
+                        "index": 1,
+                        "positioning": "vertical"
+                    }
+                },
+                "isVisible": true,
+                "version": 3,
+                "parentId": "0",
+                "renderMode": "CANVAS",
+                "isLoading": false,
+                "responsiveBehavior": "fill",
+                "originalTopRow": 17,
+                "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                "maxDynamicHeight": 9000,
+                "originalBottomRow": 64,
+                "minDynamicHeight": 15
+            },
+            {
+                "widgetName": "Text2",
+                "displayName": "Text",
+                "iconSVG": "/static/media/icon.97c59b523e6f70ba6f40a10fc2c7c5b5.svg",
+                "searchTags": [
+                    "typography",
+                    "paragraph",
+                    "label"
+                ],
+                "topRow": 26,
+                "bottomRow": 30,
+                "parentRowSpace": 10,
+                "type": "TEXT_WIDGET",
+                "hideCard": false,
+                "animateLoading": true,
+                "overflow": "NONE",
+                "fontFamily": "{{appsmith.theme.fontFamily.appFont}}",
+                "parentColumnSpace": 17.0625,
+                "dynamicTriggerPathList": [],
+                "leftColumn": 0,
+                "dynamicBindingPathList": [
+                    {
+                        "key": "truncateButtonColor"
+                    },
+                    {
+                        "key": "fontFamily"
+                    },
+                    {
+                        "key": "borderRadius"
+                    },
+                    {
+                        "key": "text"
+                    }
+                ],
+                "shouldTruncate": false,
+                "truncateButtonColor": "{{appsmith.theme.colors.primaryColor}}",
+                "text": "{{Form1.hasChanges}}",
+                "key": "r9dc4pq7r9",
+                "isDeprecated": false,
+                "rightColumn": 16,
+                "textAlign": "LEFT",
+                "dynamicHeight": "AUTO_HEIGHT",
+                "widgetId": "y70cnp2n58",
+                "minWidth": 450,
+                "isVisible": true,
+                "fontStyle": "BOLD",
+                "textColor": "#231F20",
+                "version": 1,
+                "parentId": "0",
+                "renderMode": "CANVAS",
+                "isLoading": false,
+                "responsiveBehavior": "fill",
+                "borderRadius": "{{appsmith.theme.borderRadius.appBorderRadius}}",
+                "maxDynamicHeight": 9000,
+                "fontSize": "1rem",
+                "minDynamicHeight": 4
+            }
+        ]
+    }
+}

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/BugTests/Bug18369_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/BugTests/Bug18369_Spec.ts
@@ -1,0 +1,20 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+const ee = ObjectsRegistry.EntityExplorer,
+  locator = ObjectsRegistry.CommonLocators,
+  agHelper = ObjectsRegistry.AggregateHelper;
+
+describe("JS Function Execution", function() {
+  before(() => {
+    cy.fixture("formWithtabdsl.json").then((val: any) => {
+      agHelper.AddDsl(val);
+    });
+    ee.NavigateToSwitcher("explorer");
+  });
+
+  it("Doesn't show lint errors for 'form.hasChanges' for form in inactive tab", () => {
+    ee.SelectEntityByName("Text2", "Widgets");
+    agHelper.Sleep(4000);
+    agHelper.AssertElementAbsence(locator._lintErrorElement);
+  });
+});

--- a/app/client/src/widgets/FormWidget/widget/index.tsx
+++ b/app/client/src/widgets/FormWidget/widget/index.tsx
@@ -124,6 +124,12 @@ class FormWidget extends ContainerWidget {
     };
   }
 
+  static getMetaPropertiesMap(): Record<string, any> {
+    return {
+      hasChanges: false,
+    };
+  }
+
   static getDerivedPropertiesMap(): DerivedPropertiesMap {
     return { positioning: Positioning.Fixed };
   }


### PR DESCRIPTION
## Description

This PR adds a default value of `false` for the hasChanges meta property of the Form Widget

Fixes #18369 




## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
