### PR TITLE
chore: remove unused control in select widget

### DIFF
--- a/app/client/src/widgets/SelectWidget/widget/index.tsx
+++ b/app/client/src/widgets/SelectWidget/widget/index.tsx
@@ -498,21 +498,6 @@ class SelectWidget extends BaseWidget<SelectWidgetProps, WidgetState> {
         ],
       },
       {
-        sectionName: "Colors",
-        children: [
-          {
-            propertyName: "accentColor",
-            label: "Accent Color",
-            controlType: "COLOR_PICKER",
-            isJSConvertible: true,
-            isBindProperty: true,
-            isTriggerProperty: false,
-            validation: { type: ValidationTypes.TEXT },
-            invisible: true,
-          },
-        ],
-      },
-      {
         sectionName: "Border and Shadow",
         children: [
           {


### PR DESCRIPTION
This PR removes a useless property called Colors is visible in the property pane which does not have any sub-property inside it.

Fixes #19241

## Type of change

> Please delete options that are not relevant.

- Bug fix

## How Has This Been Tested?
- Manual

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
