### PR TITLE
ci: Fix for failed spec comment issue

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -132,6 +132,13 @@ jobs:
         with:
           name: combined_failed_spec_ci
           path: ~/combined_failed_spec_ci
+      
+      # delete-artifact
+      - name: delete failed-spec-ci artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: failed-spec-ci
+          failOnError: false
 
       - name: Get Latest flaky Tests
         shell: bash

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -104,6 +104,13 @@ jobs:
           key: ${{ github.run_id }}-"ci-test-result"
           restore-keys: |
             ${{ github.run_id }}-${{ github.job }}
+      
+      # delete-artifact
+      - name: delete failed-spec-ci artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: failed-spec-ci
+          failOnError: false
 
       # Upload combined failed CI spec list to a file
       # This is done for debugging.


### PR DESCRIPTION
## Description
- Added step to delete the failed-spec-ci after combining all results to address the issue

## Type of change
- ci

## How Has This Been Tested?
- Manual

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
