### PR TITLE
fix: disable diagonal resize for widgets in auto layout

### DIFF
--- a/app/client/src/components/editorComponents/ResizableUtils.ts
+++ b/app/client/src/components/editorComponents/ResizableUtils.ts
@@ -112,7 +112,9 @@ export function isResizingDisabled(
 
   if (
     (direction === ReflowDirection.TOP ||
-      direction === ReflowDirection.BOTTOM) &&
+      direction === ReflowDirection.BOTTOM ||
+      direction === ReflowDirection.BOTTOMLEFT ||
+      direction === ReflowDirection.BOTTOMRIGHT) &&
     vertical
   )
     return true;

--- a/app/client/src/resizable/autolayoutresize/index.tsx
+++ b/app/client/src/resizable/autolayoutresize/index.tsx
@@ -482,6 +482,7 @@ export function ReflowResizable(props: ResizableProps) {
               x: 0,
             };
           }
+
           setNewDimensions(
             ReflowDirection.BOTTOMRIGHT,
             updatedPositions,
@@ -490,6 +491,7 @@ export function ReflowResizable(props: ResizableProps) {
         }
       },
       component: props.handles.bottomRight,
+      handleDirection: ReflowDirection.BOTTOMRIGHT,
       affectsWidth: true,
     });
   }
@@ -547,9 +549,11 @@ export function ReflowResizable(props: ResizableProps) {
         }
       },
       component: props.handles.bottomLeft,
+      handleDirection: ReflowDirection.BOTTOMLEFT,
       affectsWidth: true,
     });
   }
+
   const onResizeStop = () => {
     togglePointerEvents(true);
     if (isAutoLayout) {
@@ -598,7 +602,8 @@ export function ReflowResizable(props: ResizableProps) {
           !(
             props.responsiveBehavior === ResponsiveBehavior.Fill &&
             handle?.affectsWidth
-          )
+          ) &&
+          !disableResizing
         }
         checkForCollision={checkForCollision}
         direction={handle.handleDirection}


### PR DESCRIPTION
## Description
- We can still resize `Button & Rating` widgets diagonally, we should disable the diagonal resize handlers for those widgets that cannot be resized vertically.

Fixes #21412 

Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)



## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual


### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
