### PR TITLE
ci: storybook build and deploy for appsmith wds

### DIFF
--- a/.github/workflows/build-wds-preview.yml
+++ b/.github/workflows/build-wds-preview.yml
@@ -1,0 +1,22 @@
+# If someone with write access comments "/build-wds-preview" on a pull request, emit a repository_dispatch event
+name: Build WDS Preview
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  build-deploy-preview:
+    runs-on: ubuntu-latest
+    # Only run for PRs, not issue comments
+    if: |
+      github.event.issue.pull_request
+    steps:
+
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          issue-type: pull-request
+          token: ${{ secrets.APPSMITH_DEPLOY_PREVIEW_PAT }}
+          commands: |
+            build-wds-preview

--- a/.github/workflows/wds-vercel-preview.yml
+++ b/.github/workflows/wds-vercel-preview.yml
@@ -1,15 +1,14 @@
 name: Build WDS Vercel Preview
 on:
-  issue_comment:
   workflow_dispatch:
+  repository_dispatch:
+    types: [ build-wds-preview-command ]
 jobs:
-  vercel-build:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/build-wds-preview') }}
+  vercel-deploy-preview:
+    if: github.event_name == 'repository_dispatch'
     name: vercel-wds-build
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: /app/client/packages/storybook
+
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WDS_PROJECT_ID }}
@@ -28,13 +27,97 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16.14.0"
-   
+        
+      - name: Pull Vercel Environment Information
+        working-directory: ./app/client/packages/storybook
+        run: vercel pull --yes --token=${{ secrets.VERCEL_WDS_TOKEN }}
+      
+      - name: Build Project Artifacts
+        working-directory: ./app/client/packages/storybook
+        run: vercel build --yes --token=${{ secrets.VERCEL_TOKEN }}
+        
+        
+      - name: Deploy Project Artifacts to Vercel
+        working-directory: ./app/client/packages/storybook
+        id: set-dpurl
+        run: |
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_WDS_TOKEN }} >> ~/run_result.txt
+          echo "::set-output name=dpurl::$(cat ~/run_result.txt)"
+          
+      - name: vercel-notify
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+           issue-number: ${{ github.event.client_payload.pull_request.number }}
+           body: |
+             Deploy-Preview-URL: ${{ steps.set-dpurl.outputs.dpurl }}
+             
+  vercel-deploy-release:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/release'
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WDS_PROJECT_ID }}
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          ref: release
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Use Node.js 16.14.0
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.14.0"
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: ./app/client/packages/storybook
+        run: vercel pull --yes --token=${{ secrets.VERCEL_WDS_TOKEN }}
 
       - name: Build Project Artifacts
-        run: vercel build --yes --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: ./app/client/packages/storybook
+        run: vercel build --prod --yes --token=${{ secrets.VERCEL_WDS_TOKEN }}
+
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: ./app/client/packages/storybook
+        id: set-dpurl
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_WDS_TOKEN }} 
+      
+  vercel-deploy-prod:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WDS_PROD_PROJECT_ID }}
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Use Node.js 16.14.0
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.14.0"
+
+      - name: Pull Vercel Environment Information
+        working-directory: ./app/client/packages/storybook
+        run: vercel pull --yes --token=${{ secrets.VERCEL_WDS_TOKEN }}
+
+      - name: Build Project Artifacts
+        working-directory: ./app/client/packages/storybook
+        run: vercel build --prod --yes --token=${{ secrets.VERCEL_WDS_TOKEN }}
+
+
+      - name: Deploy Project Artifacts to Vercel
+        working-directory: ./app/client/packages/storybook
+        id: set-dpurl
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_WDS_TOKEN }} 
+      

--- a/.github/workflows/wds-vercel-preview.yml
+++ b/.github/workflows/wds-vercel-preview.yml
@@ -1,0 +1,40 @@
+name: Build WDS Vercel Preview
+on:
+  issue_comment:
+
+jobs:
+  vercel-build:
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/build-wds-preview') }}
+    name: vercel-wds-build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: /app/client/packages/storybook
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WDS_PROJECT_ID }}
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Use Node.js 16.14.0
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.14.0"
+   
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --yes --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/wds-vercel-preview.yml
+++ b/.github/workflows/wds-vercel-preview.yml
@@ -1,7 +1,7 @@
 name: Build WDS Vercel Preview
 on:
   issue_comment:
-
+  workflow_dispatch:
 jobs:
   vercel-build:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/build-wds-preview') }}

--- a/app/client/build-wds-storybook.sh
+++ b/app/client/build-wds-storybook.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Build WDS storybook and move to the static folder
+yarn --cwd packages/storybook build
+mv -f ./packages/storybook/storybook-static ./build/storybook
+

--- a/app/client/build-wds-storybook.sh
+++ b/app/client/build-wds-storybook.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Build WDS storybook and move to the static folder
-yarn --cwd packages/storybook build
-mv -f ./packages/storybook/storybook-static ./build/storybook
-

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -16,8 +16,3 @@ if [ "$GITHUB_REPOSITORY" == "appsmithorg/appsmith-ee" ]; then
 fi
 
 echo "build finished"
-
-# build storybook and move to the static folder
-yarn --cwd packages/storybook build
-mv -f ./packages/storybook/storybook-static ./build/storybook
-


### PR DESCRIPTION
## Description

- Removed WDS storybook from the client build.sh.
- Added workflow to deploy Vercel previews for release and prod.
- Added workflow to trigger event on commenting `/build-wds-preview` to a PR.