### PR TITLE
ci: Picking up the unique records from the specs from the failed specs in ci-test.yml

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -380,7 +380,7 @@ jobs:
         if: failure()
         run: |
           cd ${{ github.workspace }}/app/client/cypress/
-          find screenshots -type f -iname "*\(attempt 2\).png" | sed 's/screenshots/cypress\/integration/g'| sed 's:/[^/]*$::' > ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
+          find screenshots -type f -iname "*\(attempt 2\).png" | sed 's/screenshots/cypress\/integration/g'| sed 's:/[^/]*$::' | sort -u > ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
 
       # Upload failed test list using common path for all matrix job
       - name: Upload failed test list artifact


### PR DESCRIPTION
## Description
- Picking up the unique records from the specs from the failed specs in ci-test.yml

## Type of change
- ci-test.yml

## How Has This Been Tested?
- Manual

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
