### PR TITLE
ci: Stop restarting MsSQL container

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -169,7 +169,7 @@ jobs:
         run : |
           docker run --name=mssqldb -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Root@123" -p 1433:1433 -d mcr.microsoft.com/azure-sql-edge
           docker exec -i mssqldb /bin/bash -c "echo -e '[mysqld]\ntcpport=1433\ntcpnodelay=1' >> /var/opt/mssql/mssql.conf"
-          docker restart mssqldb
+       # docker restart mssqldb
        # sudo ufw allow 1433/tcp
        # docker cp init-mssql-dump-for-test.sql mssqldb:var/init-mssql-dump-for-test.sql
        # docker exec -i mssqldb /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Root@123 -i /var/init-mssql-dump-for-test.sql

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -168,7 +168,7 @@ jobs:
         working-directory : app/client/cypress
         run : |
           docker run --name=mssqldb -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Root@123" -p 1433:1433 -d mcr.microsoft.com/azure-sql-edge
-          docker exec -i mssqldb /bin/bash -c "echo -e '[mysqld]\ntcpport=1433\ntcpnodelay=1' >> /var/opt/mssql/mssql.conf"
+       # docker exec -i mssqldb /bin/bash -c "echo -e '[mysqld]\ntcpport=1433\ntcpnodelay=1' >> /var/opt/mssql/mssql.conf"
        # docker restart mssqldb
        # sudo ufw allow 1433/tcp
        # docker cp init-mssql-dump-for-test.sql mssqldb:var/init-mssql-dump-for-test.sql


### PR DESCRIPTION
## Description

- This PR removes the restarting of the MsSQL container which is throwing error sometimes in CI runs - WARNING: Failed to load /var/opt/mssql/mssql.conf ini file with error open /var/opt/mssql/mssql.conf: no such file or directory

## Type of change

- yml file update

## Checklist:
###  QA activity:
- [X] Added Test Plan Approved label after reviewing all changes
