### PR TITLE
fix: Fix command interpolation error in replicaSet check

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -189,7 +189,7 @@ init_replica_set() {
     else
       echo -e "\033[0;31m***************************************************************************************\033[0m"
       echo -e "\033[0;31m*      MongoDB Replica Set is not enabled                                             *\033[0m"
-      echo -e "\033[0;31m*      Please ensure the credentials provided for MongoDB, has `readWrite` role.      *\033[0m"
+      echo -e "\033[0;31m*      Please ensure the credentials provided for MongoDB, has 'readWrite' role.      *\033[0m"
       echo -e "\033[0;31m***************************************************************************************\033[0m"
       exit 1
     fi


### PR DESCRIPTION
If the replicaSet check fails, we see the following error:

```
readWrite command not found
```

This is because of using the command interpolation backticks in the double-quoted string.
