### PR TITLE
fix: reset page number server side pagination is just enabled in List widget

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_BasicClientSideData_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_BasicClientSideData_spec.js
@@ -1,8 +1,12 @@
 const simpleListDSL = require("../../../../../fixtures/Listv2/simpleList.json");
 const simpleListWithInputAndButtonDSL = require("../../../../../fixtures/Listv2/simpleListWithInputAndButton.json");
 const publishLocators = require("../../../../../locators/publishWidgetspage.json");
+const commonlocators = require("../../../../../locators/commonlocators.json");
 
 import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+
+const widgetSelector = (name) => `[data-widgetname-cy="${name}"]`;
+const containerWidgetSelector = `[type="CONTAINER_WIDGET"]`;
 
 let agHelper = ObjectsRegistry.AggregateHelper;
 
@@ -114,5 +118,35 @@ describe("List widget v2 - Basic client side data tests", () => {
         .find("input")
         .should("have.value", index + 1);
     });
+  });
+
+  it("4. Reset pageNo when serverside pagination is enabled", () => {
+    cy.get(`${widgetSelector("List1")} .rc-pagination-item-3`).click({
+      force: true,
+    });
+
+    cy.waitUntil(() =>
+      cy.get(commonlocators.listPaginateActivePage).should("have.text", "3"),
+    );
+
+    cy.waitUntil(() =>
+      cy
+        .get(
+          `${widgetSelector(
+            "List1",
+          )} ${containerWidgetSelector} .t--widget-imagewidget`,
+        )
+        .should("have.length", 2),
+    );
+
+    cy.openPropertyPane("listwidgetv2");
+    cy.togglebar(commonlocators.serverSidePaginationCheckbox);
+
+    // Page number resets
+    cy.waitUntil(() =>
+      cy.get(commonlocators.listPaginateActivePage).should("have.text", "1"),
+    );
+
+    cy.togglebarDisable(commonlocators.serverSidePaginationCheckbox);
   });
 });

--- a/app/client/src/widgets/ListWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/ListWidgetV2/widget/index.tsx
@@ -257,6 +257,11 @@ class ListWidget extends BaseWidget<
       this.pageSizeUpdated = true;
     }
 
+    if (this.serverPaginationJustEnabled(prevProps)) {
+      // reset pageNo when serverSide Pagination is just turned on
+      this.onPageChange(1);
+    }
+
     if (this.isCurrPageNoGreaterThanMaxPageNo()) {
       const totalRecords = this.getTotalDataCount();
 
@@ -812,6 +817,12 @@ class ListWidget extends BaseWidget<
       return totalRecordsCount;
 
     return defaultValue;
+  };
+
+  serverPaginationJustEnabled = (prevProps: ListWidgetProps) => {
+    return Boolean(
+      !prevProps.serverSidePagination && this.props.serverSidePagination,
+    );
   };
 
   shouldPaginate = () => {


### PR DESCRIPTION

## Description

Reset Page Number when server-side pagination is just turned on.

Fixes #20635

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress

### Test Plan
> https://github.com/appsmithorg/TestSmith/issues/2184

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [x] Test plan has been approved by relevant developers
- [x] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
