### PR TITLE
feat: add logic to create files based on plugin type

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
@@ -286,10 +286,11 @@ public class FileUtilsImpl implements FileInterface {
                             if(Boolean.TRUE.equals(isResourceUpdated)) {
                                 saveActions(
                                         resource.getValue(),
-                                        applicationGitReference.getActionBody().containsKey(resource.getKey()) ? applicationGitReference.getActionBody().get(resource.getKey()) : null,
+                                        applicationGitReference.getActionBody().getOrDefault(resource.getKey(), null),
                                         queryName,
                                         actionSpecificDirectory.resolve(queryName),
-                                        gson
+                                        gson,
+                                        applicationGitReference.getActionsFileMapping().getOrDefault(resource.getKey(), CommonConstants.JSON_EXTENSION)
                                 );
                                 // Delete the resource from the old file structure v2
                                 deleteFile(pageSpecificDirectory.resolve(ACTION_DIRECTORY).resolve(queryName + CommonConstants.JSON_EXTENSION));
@@ -409,13 +410,13 @@ public class FileUtilsImpl implements FileInterface {
      * @param gson
      * @return if the file operation is successful
      */
-    private boolean saveActions(Object sourceEntity, String body, String resourceName, Path path, Gson gson) {
+    private boolean saveActions(Object sourceEntity, String body, String resourceName, Path path, Gson gson, String fileType) {
         try {
             Files.createDirectories(path);
             // Write the user written query to .txt file to make conflict handling easier
             // Body will be null if the action is of type JS
             if (body != null) {
-                Path bodyPath = path.resolve(resourceName + CommonConstants.TEXT_FILE_EXTENSION);
+                Path bodyPath = path.resolve(resourceName + fileType);
                 writeStringToFile(body, bodyPath);
             }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/GitPluginTypeFileMapping.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/constants/GitPluginTypeFileMapping.java
@@ -1,0 +1,19 @@
+package com.appsmith.external.constants;
+
+public enum GitPluginTypeFileMapping {
+    DB(".sql"),
+    JS(".js"),
+    SAAS(".json"),
+    API(".json"),
+    REMOTE(".json");
+
+    final String value;
+
+    GitPluginTypeFileMapping(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApplicationGitReference.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApplicationGitReference.java
@@ -19,6 +19,7 @@ public class ApplicationGitReference {
     Object theme;
     Map<String, Object> actions;
     Map<String, String> actionBody;
+    Map<String, String> actionsFileMapping;
     Map<String, Object> actionCollections;
     Map<String, String> actionCollectionBody;
     Map<String, Object> pages;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -1,6 +1,7 @@
 package com.appsmith.server.helpers;
 
 import com.appsmith.external.constants.AnalyticsEvents;
+import com.appsmith.external.constants.GitPluginTypeFileMapping;
 import com.appsmith.external.git.FileInterface;
 import com.appsmith.external.helpers.Stopwatch;
 import com.appsmith.external.models.ActionDTO;
@@ -154,6 +155,7 @@ public class GitFileUtils {
         // Insert only active pages which will then be committed to repo as individual file
         Map<String, Object> resourceMap = new HashMap<>();
         Map<String, String> resourceMapBody = new HashMap<>();
+        Map<String, String> fileExtensionMapping = new HashMap<>();
         applicationJson
                 .getPageList()
                 .stream()
@@ -205,10 +207,15 @@ public class GitFileUtils {
                         // For the regular actions we save the body field to git repo
                         resourceMapBody.put(prefix, body);
                     }
+
+                    // prefix will be used for naming the json file while saving the action to git repo
+                    fileExtensionMapping.put(prefix, GitPluginTypeFileMapping.valueOf(newAction.getPluginType().toString()).getValue());
+
                     resourceMap.put(prefix, newAction);
                 });
         applicationReference.setActions(new HashMap<>(resourceMap));
         applicationReference.setActionBody(new HashMap<>(resourceMapBody));
+        applicationReference.setActionsFileMapping(new HashMap<>(fileExtensionMapping));
         resourceMap.clear();
         resourceMapBody.clear();
 


### PR DESCRIPTION
## Description

> After splitting the content of queries into two different files, we are storing everything as text files. But we can identify the PlugIn and use the appropriate file extension while writing to the file system.
Ex - DB type plugins have .sql files


Fixes #21371 


## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
