### PR TITLE
fix: regression fix

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_regression_fix_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/ListV2/Listv2_regression_fix_spec.js
@@ -1,0 +1,29 @@
+const widgetsPage = require("../../../../../locators/Widgets.json");
+const publishPage = require("../../../../../locators/publishWidgetspage.json");
+
+const widgetSelector = (name) => `[data-widgetname-cy="${name}"]`;
+
+describe("List widget v2 Regression", () => {
+  it("1. List widget V2 with invisible widgets", () => {
+    cy.dragAndDropToCanvas("listwidgetv2", {
+      x: 300,
+      y: 300,
+    });
+    cy.openPropertyPaneByWidgetName("Text1", "textwidget");
+
+    cy.get(widgetsPage.toggleVisible).click({ force: true });
+    cy.testJsontext("visible", "false");
+    cy.PublishtheApp();
+    cy.get(`${widgetSelector("Text1")}`).should("not.exist");
+
+    cy.get(`${widgetSelector("List1")} div[type="CONTAINER_WIDGET"]`).each(
+      ($el) => {
+        cy.wrap($el).click({ force: true });
+        cy.wrap($el)
+          .parent()
+          .should("have.css", "outline", "rgb(59, 130, 246) solid 0.8px");
+      },
+    );
+    cy.get(publishPage.backToEditor).click({ force: true });
+  });
+});

--- a/app/client/src/widgets/withWidgetProps.tsx
+++ b/app/client/src/widgets/withWidgetProps.tsx
@@ -219,7 +219,10 @@ function withWidgetProps(WrappedWidget: typeof BaseWidget) {
 
     // We don't render invisible widgets in view mode
     if (shouldCollapseWidgetInViewOrPreviewMode) {
-      if (widgetProps.bottomRow !== widgetProps.topRow) {
+      if (
+        widgetProps.bottomRow !== widgetProps.topRow &&
+        !widgetProps.isMetaWidget
+      ) {
         dispatch({
           type: ReduxActionTypes.UPDATE_WIDGET_AUTO_HEIGHT,
           payload: {


### PR DESCRIPTION
## Description

The invisible widget seems to regress the List widget. This PR fixes this by disabling Auto height Saga updates on the List widget Child WIdgets.


Fixes #21519

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
