### PR TITLE
fix: Use createImmerReducer to avoid spreading objects 

### DIFF
--- a/app/client/src/ce/reducers/settingsReducer.ts
+++ b/app/client/src/ce/reducers/settingsReducer.ts
@@ -3,7 +3,7 @@ import {
   ReduxActionErrorTypes,
   ReduxActionTypes,
 } from "@appsmith/constants/ReduxActionConstants";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 
 export const initialState: SettingsReduxState = {
   isLoading: false,
@@ -89,4 +89,4 @@ export const handlers = {
   }),
 };
 
-export default createReducer(initialState, handlers);
+export default createImmerReducer(initialState, handlers);

--- a/app/client/src/ce/reducers/tenantReducer.ts
+++ b/app/client/src/ce/reducers/tenantReducer.ts
@@ -9,7 +9,7 @@ import {
   APPSMITH_BRAND_PRIMARY_COLOR,
   createBrandColorsFromPrimaryColor,
 } from "utils/BrandingUtils";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 
 export interface TenantReduxState<T> {
   userPermissions: string[];
@@ -66,4 +66,4 @@ export const handlers = {
   }),
 };
 
-export default createReducer(initialState, handlers);
+export default createImmerReducer(initialState, handlers);

--- a/app/client/src/ce/reducers/uiReducers/applicationsReducer.tsx
+++ b/app/client/src/ce/reducers/uiReducers/applicationsReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type {
   ReduxAction,
   ApplicationPayload,
@@ -527,7 +527,7 @@ export const handlers = {
   },
 };
 
-const applicationsReducer = createReducer(initialState, handlers);
+const applicationsReducer = createImmerReducer(initialState, handlers);
 
 export type creatingApplicationMap = Record<string, boolean>;
 

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -34,7 +34,7 @@ export interface PartialActionData {
 
 const initialState: ActionDataState = [];
 
-const actionsReducer = createReducer(initialState, {
+const actionsReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_ACTIONS_SUCCESS]: (
     state: ActionDataState,
     action: ReduxAction<Action[]>,

--- a/app/client/src/reducers/entityReducers/appReducer.ts
+++ b/app/client/src/reducers/entityReducers/appReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type { User } from "constants/userConstants";
@@ -57,7 +57,7 @@ const initialState: AppDataState = {
   },
 };
 
-const appReducer = createReducer(initialState, {
+const appReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SET_APP_MODE]: (
     state: AppDataState,
     action: ReduxAction<APP_MODE>,

--- a/app/client/src/reducers/entityReducers/datasourceReducer.ts
+++ b/app/client/src/reducers/entityReducers/datasourceReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -47,7 +47,7 @@ const initialState: DatasourceDataState = {
   gsheetToken: "",
 };
 
-const datasourceReducer = createReducer(initialState, {
+const datasourceReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_MOCK_DATASOURCES_INIT]: (
     state: DatasourceDataState,
   ) => {

--- a/app/client/src/reducers/entityReducers/jsActionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/jsActionsReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { JSAction, JSCollection } from "entities/JSCollection";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
@@ -42,7 +42,7 @@ export interface JSExecutionError {
 export type BatchedJSExecutionData = Record<string, JSExecutionData[]>;
 export type BatchedJSExecutionErrors = Record<string, JSExecutionError[]>;
 
-const jsActionsReducer = createReducer(initialState, {
+const jsActionsReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_JS_ACTIONS_SUCCESS]: (
     state: JSCollectionDataState,
     action: ReduxAction<JSCollection[]>,

--- a/app/client/src/reducers/entityReducers/metaReducer/index.ts
+++ b/app/client/src/reducers/entityReducers/metaReducer/index.ts
@@ -1,5 +1,5 @@
 import { set } from "lodash";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type {
   UpdateWidgetMetaPropertyPayload,
   ResetWidgetMetaPayload,
@@ -19,7 +19,7 @@ export type MetaState = Record<string, WidgetMetaState>;
 
 export const initialState: MetaState = {};
 
-export const metaReducer = createReducer(initialState, {
+export const metaReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.UPDATE_META_STATE]: (
     state: MetaState,
     action: ReduxAction<{

--- a/app/client/src/reducers/entityReducers/pageListReducer.tsx
+++ b/app/client/src/reducers/entityReducers/pageListReducer.tsx
@@ -14,7 +14,7 @@ import type {
 import type { UpdatePageRequest, UpdatePageResponse } from "api/PageApi";
 import { sortBy } from "lodash";
 import type { DSL } from "reducers/uiReducers/pageCanvasStructureReducer";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 
 const initialState: PageListReduxState = {
   pages: [],
@@ -25,7 +25,7 @@ const initialState: PageListReduxState = {
   loading: {},
 };
 
-export const pageListReducer = createReducer(initialState, {
+export const pageListReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.DELETE_PAGE_INIT]: (
     state: PageListReduxState,
     action: ReduxAction<{ id: string }>,

--- a/app/client/src/reducers/entityReducers/pluginsReducer.ts
+++ b/app/client/src/reducers/entityReducers/pluginsReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -43,7 +43,7 @@ const initialState: PluginDataState = {
   fetchingDefaultPlugins: false,
 };
 
-const pluginsReducer = createReducer(initialState, {
+const pluginsReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_PLUGINS_REQUEST]: (state: PluginDataState) => {
     return { ...state, loading: true };
   },

--- a/app/client/src/reducers/evaluationReducers/formEvaluationReducer.ts
+++ b/app/client/src/reducers/evaluationReducers/formEvaluationReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type { FetchPageRequest } from "api/PageApi";
@@ -55,7 +55,7 @@ export const isValidFormConfig = (
 
 const initialState: FormEvaluationState = {};
 
-const formEvaluation = createReducer(initialState, {
+const formEvaluation = createImmerReducer(initialState, {
   [ReduxActionTypes.SET_FORM_EVALUATION]: (
     state: FormEvaluationState,
     action: ReduxAction<FormEvaluationState>,

--- a/app/client/src/reducers/evaluationReducers/triggerReducer.ts
+++ b/app/client/src/reducers/evaluationReducers/triggerReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type {
@@ -23,7 +23,7 @@ export type TriggerActionLoadingPayload = {
 
 const initialState: TriggerValuesEvaluationState = {};
 
-const triggers = createReducer(initialState, {
+const triggers = createImmerReducer(initialState, {
   [ReduxActionTypes.INIT_TRIGGER_VALUES]: (
     state: FormEvaluationState,
     action: ReduxAction<FormEvaluationState>,

--- a/app/client/src/reducers/uiReducers/analyticsReducer.ts
+++ b/app/client/src/reducers/uiReducers/analyticsReducer.ts
@@ -1,5 +1,5 @@
 import { ReduxActionTypes } from "ce/constants/ReduxActionConstants";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 
 export type SegmentState = "INIT_SUCCESS" | "INIT_UNCERTAIN";
 
@@ -34,4 +34,4 @@ export const handlers = {
   }),
 };
 
-export default createReducer(initialState, handlers);
+export default createImmerReducer(initialState, handlers);

--- a/app/client/src/reducers/uiReducers/apiNameReducer.ts
+++ b/app/client/src/reducers/uiReducers/apiNameReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -10,7 +10,7 @@ const initialState: ApiNameReduxState = {
   errors: {},
 };
 
-const apiNameReducer = createReducer(initialState, {
+const apiNameReducer = createImmerReducer(initialState, {
   [ReduxActionErrorTypes.SAVE_ACTION_NAME_ERROR]: (
     state: ApiNameReduxState,
     action: ReduxAction<{ actionId: string }>,

--- a/app/client/src/reducers/uiReducers/apiPaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/apiPaneReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -37,7 +37,7 @@ export interface ApiPaneReduxState {
   selectedRightPaneTab?: number;
 }
 
-const apiPaneReducer = createReducer(initialState, {
+const apiPaneReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_ACTIONS_INIT]: (state: ApiPaneReduxState) => ({
     ...state,
     isFetching: true,

--- a/app/client/src/reducers/uiReducers/appCollabReducer.ts
+++ b/app/client/src/reducers/uiReducers/appCollabReducer.ts
@@ -1,6 +1,6 @@
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { User } from "entities/AppCollab/CollabInterfaces";
 import { cloneDeep } from "lodash";
 
@@ -10,7 +10,7 @@ const initialState: AppCollabReducerState = {
   pageEditors: [],
 };
 
-const appCollabReducer = createReducer(initialState, {
+const appCollabReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.APP_COLLAB_LIST_EDITORS]: (
     state: AppCollabReducerState,
     action: ReduxAction<any>,

--- a/app/client/src/reducers/uiReducers/appSettingsPaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/appSettingsPaneReducer.ts
@@ -1,13 +1,13 @@
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type { AppSettingsTabs } from "pages/Editor/AppSettingsPane/AppSettings";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 
 const initialState: AppSettingsPaneReduxState = {
   isOpen: false,
 };
 
-const appSettingsPaneReducer = createReducer(initialState, {
+const appSettingsPaneReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.OPEN_APP_SETTINGS_PANE]: (
     state: AppSettingsPaneReduxState,
     action: ReduxAction<AppSettingsPaneContext>,

--- a/app/client/src/reducers/uiReducers/appViewReducer.tsx
+++ b/app/client/src/reducers/uiReducers/appViewReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -11,7 +11,7 @@ const initialState: AppViewReduxState = {
   headerHeight: 0,
 };
 
-const appViewReducer = createReducer(initialState, {
+const appViewReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.RESET_EDITOR_SUCCESS]: (state: AppViewReduxState) => {
     return { ...state, initialized: false };
   },

--- a/app/client/src/reducers/uiReducers/authReducer.ts
+++ b/app/client/src/reducers/uiReducers/authReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import {
   ReduxActionTypes,
   ReduxActionErrorTypes,
@@ -9,7 +9,7 @@ const initialState: AuthState = {
   isTokenValid: false,
 };
 
-const authReducer = createReducer(initialState, {
+const authReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.RESET_PASSWORD_VERIFY_TOKEN_INIT]: () => ({
     isTokenValid: false,
     isValidatingToken: true,

--- a/app/client/src/reducers/uiReducers/datasourceNameReducer.ts
+++ b/app/client/src/reducers/uiReducers/datasourceNameReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -10,7 +10,7 @@ const initialState: DatasourceNameReduxState = {
   errors: {},
 };
 
-const datasourceNameReducer = createReducer(initialState, {
+const datasourceNameReducer = createImmerReducer(initialState, {
   [ReduxActionErrorTypes.UPDATE_DATASOURCE_NAME_ERROR]: (
     state: DatasourceNameReduxState,
     action: ReduxAction<{ id: string }>,

--- a/app/client/src/reducers/uiReducers/datasourcePaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/datasourcePaneReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type { Datasource } from "entities/Datasource";
@@ -29,7 +29,7 @@ export interface DatasourcePaneReduxState {
   defaultKeyValueArrayConfig: Array<string>;
 }
 
-const datasourcePaneReducer = createReducer(initialState, {
+const datasourcePaneReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.UPDATE_DATASOURCE_DRAFT]: (
     state: DatasourcePaneReduxState,
     action: ReduxAction<{ id: string; draft: Partial<Datasource> }>,

--- a/app/client/src/reducers/uiReducers/editorReducer.tsx
+++ b/app/client/src/reducers/uiReducers/editorReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type {
   ReduxAction,
   UpdateCanvasPayload,
@@ -39,7 +39,7 @@ const initialState: EditorReduxState = {
   zoomLevel: 1,
 };
 
-const editorReducer = createReducer(initialState, {
+const editorReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.RESET_EDITOR_SUCCESS]: (state: EditorReduxState) => {
     return { ...state, initialized: false };
   },

--- a/app/client/src/reducers/uiReducers/errorReducer.tsx
+++ b/app/client/src/reducers/uiReducers/errorReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type {
   ReduxAction,
   ReduxActionErrorPayload,
@@ -13,7 +13,7 @@ const initialState: ErrorReduxState = {
   currentError: { sourceAction: "", message: "" },
 };
 
-const errorReducer = createReducer(initialState, {
+const errorReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SAFE_CRASH_APPSMITH]: (
     state: ErrorReduxState,
     action: ReduxAction<ReduxActionErrorPayload>,

--- a/app/client/src/reducers/uiReducers/explorerReducer.ts
+++ b/app/client/src/reducers/uiReducers/explorerReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -96,7 +96,7 @@ const setUpdatingDatasourceEntity = (
   return state;
 };
 
-const explorerReducer = createReducer(initialState, {
+const explorerReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_PAGE_INIT]: setUpdatingEntity,
   [ReduxActionErrorTypes.FETCH_PAGE_ERROR]: setEntityUpdateError,
   [ReduxActionTypes.FETCH_PAGE_SUCCESS]: setEntityUpdateSuccess,

--- a/app/client/src/reducers/uiReducers/gitSyncReducer.ts
+++ b/app/client/src/reducers/uiReducers/gitSyncReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionErrorTypes,
@@ -36,7 +36,7 @@ const initialState: GitSyncReducerState = {
   },
 };
 
-const gitSyncReducer = createReducer(initialState, {
+const gitSyncReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SET_IS_GIT_SYNC_MODAL_OPEN]: (
     state: GitSyncReducerState,
     action: ReduxAction<{

--- a/app/client/src/reducers/uiReducers/globalSearchReducer.ts
+++ b/app/client/src/reducers/uiReducers/globalSearchReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type {
@@ -32,7 +32,7 @@ const initialState: GlobalSearchReduxState = {
   },
 };
 
-const globalSearchReducer = createReducer(initialState, {
+const globalSearchReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SET_GLOBAL_SEARCH_QUERY]: (
     state: GlobalSearchReduxState,
     action: ReduxAction<string>,

--- a/app/client/src/reducers/uiReducers/guidedTourReducer.ts
+++ b/app/client/src/reducers/uiReducers/guidedTourReducer.ts
@@ -1,6 +1,6 @@
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 
 const initialState: GuidedTourState = {
   guidedTour: false,
@@ -32,7 +32,7 @@ export interface GuidedTourState {
   forceShowContent: number;
 }
 
-const guidedTourReducer = createReducer(initialState, {
+const guidedTourReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.ENABLE_GUIDED_TOUR]: (
     state: GuidedTourState,
     action: ReduxAction<boolean>,

--- a/app/client/src/reducers/uiReducers/helpReducer.ts
+++ b/app/client/src/reducers/uiReducers/helpReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 
@@ -8,7 +8,7 @@ const initialState: HelpReduxState = {
   defaultRefinement: "",
 };
 
-const helpReducer = createReducer(initialState, {
+const helpReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SET_DEFAULT_REFINEMENT]: (
     state: HelpReduxState,
     action: ReduxAction<string>,

--- a/app/client/src/reducers/uiReducers/importReducer.ts
+++ b/app/client/src/reducers/uiReducers/importReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -10,7 +10,7 @@ const initialState: ImportReduxState = {
   errorPayload: {},
 };
 
-const importReducer = createReducer(initialState, {
+const importReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SUBMIT_CURL_FORM_INIT]: (state: ImportReduxState) => {
     return {
       ...state,

--- a/app/client/src/reducers/uiReducers/importedCollectionsReducer.ts
+++ b/app/client/src/reducers/uiReducers/importedCollectionsReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -15,7 +15,7 @@ const initialState: ImportedCollectionsReduxState = {
   importedCollections: [],
 };
 
-const importedCollectionsReducer = createReducer(initialState, {
+const importedCollectionsReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_IMPORTED_COLLECTIONS_INIT]: (
     state: ImportedCollectionsReduxState,
   ) => ({ ...state, isFetchingImportedCollections: true }),

--- a/app/client/src/reducers/uiReducers/jsObjectNameReducer.tsx
+++ b/app/client/src/reducers/uiReducers/jsObjectNameReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -10,7 +10,7 @@ const initialState: JSObjectNameReduxState = {
   errors: {},
 };
 
-const jsObjectNameReducer = createReducer(initialState, {
+const jsObjectNameReducer = createImmerReducer(initialState, {
   [ReduxActionErrorTypes.SAVE_JS_COLLECTION_NAME_ERROR]: (
     state: JSObjectNameReduxState,
     action: ReduxAction<{ actionId: string }>,

--- a/app/client/src/reducers/uiReducers/jsPaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/jsPaneReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -29,7 +29,7 @@ const initialState: JsPaneReduxState = {
   selectedResponseTab: "",
 };
 
-const jsPaneReducer = createReducer(initialState, {
+const jsPaneReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_JS_ACTIONS_INIT]: (state: JsPaneReduxState) => ({
     ...state,
     isFetching: true,

--- a/app/client/src/reducers/uiReducers/onBoardingReducer.ts
+++ b/app/client/src/reducers/uiReducers/onBoardingReducer.ts
@@ -1,6 +1,6 @@
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 
 const initialState: OnboardingState = {
   // Signposting
@@ -21,7 +21,7 @@ export interface OnboardingState {
   showFirstTimeUserOnboardingModal: boolean;
 }
 
-const onboardingReducer = createReducer(initialState, {
+const onboardingReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.TOGGLE_ONBOARDING_WIDGET_SELECTION]: (
     state: OnboardingState,
     action: ReduxAction<boolean>,

--- a/app/client/src/reducers/uiReducers/providerReducer.ts
+++ b/app/client/src/reducers/uiReducers/providerReducer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -36,7 +36,7 @@ const initialState: ProvidersReduxState = {
   fetchProvidersError: false,
 };
 
-const providersReducer = createReducer(initialState, {
+const providersReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_PROVIDERS_INIT]: (state: ProvidersReduxState) => ({
     ...state,
     isFetchingProviders: true,

--- a/app/client/src/reducers/uiReducers/queryPaneReducer.ts
+++ b/app/client/src/reducers/uiReducers/queryPaneReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -35,7 +35,7 @@ export interface QueryPaneReduxState {
   responseTabHeight: number;
 }
 
-const queryPaneReducer = createReducer(initialState, {
+const queryPaneReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.CREATE_ACTION_INIT]: (state: QueryPaneReduxState) => {
     return {
       ...state,

--- a/app/client/src/reducers/uiReducers/reflowReducer.ts
+++ b/app/client/src/reducers/uiReducers/reflowReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReflowReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type { ReflowedSpaceMap } from "reflow/reflowTypes";
@@ -8,7 +8,7 @@ const initialState: widgetReflow = {
   reflowingWidgets: {},
 };
 
-export const widgetReflowReducer = createReducer(initialState, {
+export const widgetReflowReducer = createImmerReducer(initialState, {
   [ReflowReduxActionTypes.STOP_REFLOW]: () => {
     return {
       isReflowing: false,

--- a/app/client/src/reducers/uiReducers/releasesReducer.ts
+++ b/app/client/src/reducers/uiReducers/releasesReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 
@@ -7,7 +7,7 @@ const initialState: ReleasesState = {
   releaseItems: [],
 };
 
-const importReducer = createReducer(initialState, {
+const importReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_RELEASES_SUCCESS]: (
     _state: ReleasesState,
     action: ReduxAction<{ payload: Record<string, unknown> }>,

--- a/app/client/src/reducers/uiReducers/tableFilterPaneReducer.tsx
+++ b/app/client/src/reducers/uiReducers/tableFilterPaneReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type {
   ReduxAction,
   ShowPropertyPanePayload,
@@ -11,7 +11,7 @@ const initialState: TableFilterPaneReduxState = {
   lastWidgetId: undefined,
 };
 
-const tableFilterPaneReducer = createReducer(initialState, {
+const tableFilterPaneReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SHOW_TABLE_FILTER_PANE]: (
     state: TableFilterPaneReduxState,
     action: ReduxAction<ShowPropertyPanePayload>,

--- a/app/client/src/reducers/uiReducers/templateReducer.ts
+++ b/app/client/src/reducers/uiReducers/templateReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionErrorTypes,
@@ -24,7 +24,7 @@ const initialState: TemplatesReduxState = {
   showTemplatesModal: false,
 };
 
-const templateReducer = createReducer(initialState, {
+const templateReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.GET_ALL_TEMPLATES_INIT]: (state: TemplatesReduxState) => {
     return {
       ...state,

--- a/app/client/src/reducers/uiReducers/tourReducer.ts
+++ b/app/client/src/reducers/uiReducers/tourReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import type { TourType } from "entities/Tour";
@@ -9,7 +9,7 @@ const initialState: TourReducerState = {
   activeTourType: undefined,
 };
 
-const tourReducer = createReducer(initialState, {
+const tourReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SET_ACTIVE_TOUR]: (
     state: TourReducerState,
     action: ReduxAction<TourType>,

--- a/app/client/src/reducers/uiReducers/usersReducer.ts
+++ b/app/client/src/reducers/uiReducers/usersReducer.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -26,7 +26,7 @@ const initialState: UsersReduxState = {
   },
 };
 
-const usersReducer = createReducer(initialState, {
+const usersReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_USER_INIT]: (state: UsersReduxState) => ({
     ...state,
     loadingStates: {

--- a/app/client/src/reducers/uiReducers/websocketReducer.ts
+++ b/app/client/src/reducers/uiReducers/websocketReducer.ts
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 
@@ -7,7 +7,7 @@ const initialState: WebsocketReducerState = {
   pageLevelSocketConnected: false,
 };
 
-const websocketReducer = createReducer(initialState, {
+const websocketReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.SET_IS_APP_LEVEL_WEBSOCKET_CONNECTED]: (
     state: WebsocketReducerState,
     action: ReduxAction<boolean>,


### PR DESCRIPTION
## Description
Refactored incorrect use of `createReducer` to use `createImmerReducer` wherever required. 
>`createImmerReducer` should have been used whenever the handler object was generic. This is now fixed.


Fixes #20035 

## Type of change



- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)



## How Has This Been Tested?
- Manual
- Cypress

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reviewing all Cypress test
