### PR TITLE
ci: Removing the old combined failed spec file

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -89,13 +89,9 @@ jobs:
       # In case this is second attempt try restoring failed tests
       - name: Restore the previous failed combine result
         if: steps.run_result.outputs.run_result == 'failedtest'
-        uses: martijnhols/actions-cache/restore@v3
+        uses: actions/download-artifact@v3
         with:
-          path: |
-            ~/combined_failed_spec_ci
-          key: ${{ github.run_id }}-"ci-test-result"
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}
+          name: combined_failed_spec_ci
 
       # failed_spec_env will contain list of all failed specs
       # We are using environment variable instead of regular to support multiline

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -108,24 +108,21 @@ jobs:
           name: failed-spec-ci
           path: ~/failed_spec_ci
 
+      # delete-artifact
+      - name: delete existing combined_failed_spec_ci artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: combined_failed_spec_ci
+          failOnError: false
+
       # In case for any ci job failure, create combined failed spec
       - name: "combine all specs for CI"
         if: needs.ci-test.result != 'success'
-        run: cat ~/failed_spec_ci/failed_spec_ci* >> ~/combined_failed_spec_ci
-
-      # Force save the CI failed spec list into a cache
-      - name: Store the combined run result for CI
-        if: needs.ci-test.result != 'success'
-        uses: martijnhols/actions-cache/save@v3
-        with:
-          path: |
-            ~/combined_failed_spec_ci
-          key: ${{ github.run_id }}-"ci-test-result"
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}
+        run: |
+          rm -f ~/combined_failed_spec_ci
+          cat ~/failed_spec_ci/failed_spec_ci* >> ~/combined_failed_spec_ci
 
       # Upload combined failed CI spec list to a file
-      # This is done for debugging.
       - name: upload combined failed spec
         if: needs.ci-test.result != 'success'
         uses: actions/upload-artifact@v3
@@ -134,7 +131,7 @@ jobs:
           path: ~/combined_failed_spec_ci
       
       # delete-artifact
-      - name: delete failed-spec-ci artifact
+      - name: delete existing failed-spec-ci artifact
         uses: geekyeggo/delete-artifact@v2
         with:
           name: failed-spec-ci

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -89,28 +89,19 @@ jobs:
           name: failed-spec-ci
           path: ~/failed_spec_ci
 
+      # delete-artifact
+      - name: delete existing combined_failed_spec_ci artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: combined_failed_spec_ci
+          failOnError: false
+
       # In case for any ci job failure, create combined failed spec
       - name: "combine all specs for CI"
         if: needs.ci-test.result != 'success'
-        run: cat ~/failed_spec_ci/failed_spec_ci* >> ~/combined_failed_spec_ci
-
-      # Force save the CI failed spec list into a cache
-      - name: Store the combined run result for CI
-        if: needs.ci-test.result != 'success'
-        uses: martijnhols/actions-cache/save@v3
-        with:
-          path: |
-            ~/combined_failed_spec_ci
-          key: ${{ github.run_id }}-"ci-test-result"
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.job }}
-      
-      # delete-artifact
-      - name: delete failed-spec-ci artifact
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: failed-spec-ci
-          failOnError: false
+        run: |
+          rm -f ~/combined_failed_spec_ci
+          cat ~/failed_spec_ci/failed_spec_ci* >> ~/combined_failed_spec_ci
 
       # Upload combined failed CI spec list to a file
       # This is done for debugging.
@@ -120,6 +111,13 @@ jobs:
         with:
           name: combined_failed_spec_ci
           path: ~/combined_failed_spec_ci
+
+      # delete-artifact
+      - name: delete existing failed-spec-ci artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: failed-spec-ci
+          failOnError: false
 
       - name: Return status for ui-matrix
         run: |


### PR DESCRIPTION
## Description
- Removing the old combined failed spec file

## Type of change
- workflow files

## How Has This Been Tested?
- Manual

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
