### PR TITLE
fix: update request template url

### DIFF
--- a/app/client/src/pages/Templates/Template/RequestTemplate.tsx
+++ b/app/client/src/pages/Templates/Template/RequestTemplate.tsx
@@ -47,7 +47,7 @@ const StyledImage = styled.img`
 `;
 
 const REQUEST_TEMPLATE_URL =
-  "https://app.appsmith.com/applications/6241b5a8c99df2369931a653/pages/6241b5a8c99df2369931a656";
+  "https://app.appsmith.com/app/request-templates/request-list-6241c12fc99df2369931a714";
 
 function RequestTemplate() {
   const onClick = () => {


### PR DESCRIPTION
Update Request Template URL

## Description
Update the REQUEST_TEMPLATE_URL to account for changes made to the Template Request App.

Fixes # (issue)
https://github.com/appsmithorg/appsmith/issues/21520

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- I have run the client and clicked on the "Request For A Template" button from the template tab. I confirmed that it redirected to the previous link, I made the change swapping the old URL string for the new one, saved and aran the test again. The new link directs to the correct page on the Request Template App.


## Checklist:
### Dev activity
- [✔️ ] My code follows the style guidelines of this project
- [ ✔️ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✔️ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organised project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reviewing all Cypress test
