### PR TITLE
fix: MongoDB Invalid DB Name Error Msg

### DIFF
--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -827,10 +827,13 @@ public class MongoPlugin extends BasePlugin {
                         final String defaultDatabaseName;
                         if (datasourceConfiguration.getConnection() != null) {
                             defaultDatabaseName = datasourceConfiguration.getConnection().getDefaultDatabaseName();
-                        } else defaultDatabaseName = null;
+                        } else {
+                            defaultDatabaseName = null;
+                        }
 
                         final String authDatabaseName;
-                        if (datasourceConfiguration.getAuthentication() != null) {
+                        if (datasourceConfiguration.getAuthentication() != null &&
+                                !((DBAuth)datasourceConfiguration.getAuthentication()).getDatabaseName().isBlank()) {
                             authDatabaseName = ((DBAuth) datasourceConfiguration.getAuthentication()).getDatabaseName();
                         } else {
                             return Mono.just(new DatasourceTestResult(

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -134,6 +134,7 @@ import static com.external.plugins.utils.MongoPluginUtils.isRawCommand;
 import static java.lang.Boolean.TRUE;
 import static java.util.Arrays.asList;
 import static org.apache.logging.log4j.util.Strings.isBlank;
+import static org.apache.logging.log4j.util.Strings.isEmpty;
 
 public class MongoPlugin extends BasePlugin {
 
@@ -833,7 +834,7 @@ public class MongoPlugin extends BasePlugin {
 
                         final String authDatabaseName;
                         if (datasourceConfiguration.getAuthentication() != null &&
-                                isBlank(((DBAuth)datasourceConfiguration.getAuthentication()).getDatabaseName())) {
+                                isEmpty(((DBAuth)datasourceConfiguration.getAuthentication()).getDatabaseName())) {
                             authDatabaseName = ((DBAuth) datasourceConfiguration.getAuthentication()).getDatabaseName();
                         } else {
                             return Mono.just(new DatasourceTestResult(

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -822,7 +822,7 @@ public class MongoPlugin extends BasePlugin {
             } else defaultDatabaseName = null;
 
             final String databaseName;
-            if (datasourceConfiguration.getConnection() != null) {
+            if (datasourceConfiguration.getConnection() != null && datasourceConfiguration.getAuthentication() != null) {
                 databaseName = ((DBAuth) datasourceConfiguration.getAuthentication()).getDatabaseName();
             } else databaseName = null;
 

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -834,7 +834,7 @@ public class MongoPlugin extends BasePlugin {
 
                         final String authDatabaseName;
                         if (datasourceConfiguration.getAuthentication() != null &&
-                                isEmpty(((DBAuth)datasourceConfiguration.getAuthentication()).getDatabaseName())) {
+                                !isBlank(((DBAuth)datasourceConfiguration.getAuthentication()).getDatabaseName())) {
                             authDatabaseName = ((DBAuth) datasourceConfiguration.getAuthentication()).getDatabaseName();
                         } else {
                             return Mono.just(new DatasourceTestResult(

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/MongoPlugin.java
@@ -833,7 +833,7 @@ public class MongoPlugin extends BasePlugin {
 
                         final String authDatabaseName;
                         if (datasourceConfiguration.getAuthentication() != null &&
-                                !((DBAuth)datasourceConfiguration.getAuthentication()).getDatabaseName().isBlank()) {
+                                isBlank(((DBAuth)datasourceConfiguration.getAuthentication()).getDatabaseName())) {
                             authDatabaseName = ((DBAuth) datasourceConfiguration.getAuthentication()).getDatabaseName();
                         } else {
                             return Mono.just(new DatasourceTestResult(

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
@@ -56,7 +56,7 @@ public class MongoPluginErrorMessages {
             "check the URI once.";
 
     public static final String DS_MISSING_DEFAULT_DATABASE_NAME_ERROR_MSG = "Missing default database name.";
-    public static final String DS_INVALID_USER_DATABASE_NAME = "Database Name is invalid, no database found with this name.";
+    public static final String DS_INVALID_AUTH_DATABASE_NAME = "Authentication Database Name is invalid, no database found with this name.";
     public static final String DS_MISSING_ENDPOINTS_ERROR_MSG = "Missing endpoint(s).";
     public static final String DS_NO_PORT_EXPECTED_IN_REPLICA_SET_CONNECTION_ERROR_MSG = "REPLICA_SET connections should not be given a port." +
             " If you are trying to specify all the shards, please add more than one.";

--- a/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/main/java/com/external/plugins/exceptions/MongoPluginErrorMessages.java
@@ -56,6 +56,7 @@ public class MongoPluginErrorMessages {
             "check the URI once.";
 
     public static final String DS_MISSING_DEFAULT_DATABASE_NAME_ERROR_MSG = "Missing default database name.";
+    public static final String DS_INVALID_USER_DATABASE_NAME = "Database Name is invalid, no database found with this name.";
     public static final String DS_MISSING_ENDPOINTS_ERROR_MSG = "Missing endpoint(s).";
     public static final String DS_NO_PORT_EXPECTED_IN_REPLICA_SET_CONNECTION_ERROR_MSG = "REPLICA_SET connections should not be given a port." +
             " If you are trying to specify all the shards, please add more than one.";

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginDatasourceTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginDatasourceTest.java
@@ -188,6 +188,36 @@ public class MongoPluginDatasourceTest {
                 .verifyComplete();
     }
 
+    @Test
+    public void testDatasourceFailWithEmptyDefaultDatabaseNameAndInvalidUserDBName() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        dsConfig.getConnection().setDefaultDatabaseName("");
+        DBAuth dbAuth = new DBAuth();
+        dbAuth.setDatabaseName("abcd");
+        dsConfig.setAuthentication(dbAuth);
+        StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
+                .assertNext(datasourceTestResult -> {
+                    assertNotNull(datasourceTestResult);
+                    assertFalse(datasourceTestResult.isSuccess());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testDatasourceFailWithEmptyDefaultDatabaseNameAndValidUserDBName() {
+        DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        dsConfig.getConnection().setDefaultDatabaseName("");
+        DBAuth dbAuth = new DBAuth();
+        dbAuth.setDatabaseName("test");
+        dsConfig.setAuthentication(dbAuth);
+        StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
+                .assertNext(datasourceTestResult -> {
+                    assertNotNull(datasourceTestResult);
+                    assertTrue(datasourceTestResult.isSuccess());
+                })
+                .verifyComplete();
+    }
+
     /*
      * 1. Test that when a query is attempted to run on mongodb but refused because of lack of authorization.
      */

--- a/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginDatasourceTest.java
+++ b/app/server/appsmith-plugins/mongoPlugin/src/test/java/com/external/plugins/MongoPluginDatasourceTest.java
@@ -189,7 +189,7 @@ public class MongoPluginDatasourceTest {
     }
 
     @Test
-    public void testDatasourceFailWithEmptyDefaultDatabaseNameAndInvalidUserDBName() {
+    public void testDatasourceFailWithEmptyDefaultDatabaseNameAndInvalidAuthDBName() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         dsConfig.getConnection().setDefaultDatabaseName("");
         DBAuth dbAuth = new DBAuth();
@@ -198,13 +198,16 @@ public class MongoPluginDatasourceTest {
         StepVerifier.create(pluginExecutor.testDatasource(dsConfig))
                 .assertNext(datasourceTestResult -> {
                     assertNotNull(datasourceTestResult);
+                    assertTrue(datasourceTestResult.getInvalids().stream().anyMatch(error ->
+                            error.contains("Authentication Database Name is invalid, " +
+                                    "no database found with this name.")));
                     assertFalse(datasourceTestResult.isSuccess());
                 })
                 .verifyComplete();
     }
 
     @Test
-    public void testDatasourceFailWithEmptyDefaultDatabaseNameAndValidUserDBName() {
+    public void testDatasourceSuccessWithEmptyDefaultDatabaseNameAndValidAuthDBName() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
         dsConfig.getConnection().setDefaultDatabaseName("");
         DBAuth dbAuth = new DBAuth();
@@ -260,6 +263,9 @@ public class MongoPluginDatasourceTest {
     @Test
     public void testTestDatasource_withCorrectCredentials_returnsWithoutInvalids() {
         DatasourceConfiguration dsConfig = createDatasourceConfiguration();
+        DBAuth dbAuth = new DBAuth();
+        dbAuth.setDatabaseName("test");
+        dsConfig.setAuthentication(dbAuth);
 
         final Mono<DatasourceTestResult> testDatasourceMono = pluginExecutor.testDatasource(dsConfig);
 


### PR DESCRIPTION
## Description

- This PR adds a check to throw a proper error if the default database name is empty and an invalid database name is provided in the authentication section for mongo db.
- Added JUnit test cases for the same. one for an invalid db name and one for a valid db name (Both with empty default db name)
- There is one more issue observed here which is not taken part in this ticket. When you try to save the mongo data source with the default database name and empty database name under auth section. Once you try to save the data source it will throw an internal server error. Created a ticket for the same: https://app.zenhub.com/workspaces/data-integration-pod-6322a759b3296d249ce5c4ed/issues/gh/appsmithorg/appsmith/21598

Fixes #12260 

## Type of change
- Bug Fix(non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual
- JUnit TC added 

### **Checklist**:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [ ]  My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [ ]  PR is being merged under a feature flag

### **QA activity:**

- [ ]  Test plan has been approved by relevant developers
- [ ]  Test plan has been peer reviewed by QA
- [ ]  Cypress test cases have been added and approved by either SDET or manual QA
- [ ]  Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ]  Added Test Plan Approved label after reveiwing all Cypress test
