### PR TITLE
chore: Check for AVX instruction earlier than the first mongod run

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -163,6 +163,15 @@ init_replica_set() {
     fi
   done
 
+  if [[ $isUriLocal -gt 0 && -f /proc/cpuinfo ]] && ! grep --quiet avx /proc/cpuinfo; then
+    echo "====================================================================================================" >&2
+    echo "==" >&2
+    echo "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
+    echo "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
+    echo "==" >&2
+    echo "====================================================================================================" >&2
+  fi
+
   if [[ $shouldPerformInitdb -gt 0 && $isUriLocal -eq 0 ]]; then
     echo "Initializing Replica Set for local database"
     # Start installed MongoDB service - Dependencies Layer
@@ -189,15 +198,6 @@ init_replica_set() {
   fi
 
   if [[ $isUriLocal -gt 0 ]]; then
-    if [[ -f /proc/cpuinfo ]] && ! grep --quiet avx /proc/cpuinfo; then
-      echo "====================================================================================================" >&2
-      echo "==" >&2
-      echo "== AVX instruction not found in your CPU. Appsmith's embedded MongoDB may not start. Please use an external MongoDB instance instead." >&2
-      echo "== See https://docs.appsmith.com/getting-started/setup/instance-configuration/custom-mongodb-redis#custom-mongodb for instructions." >&2
-      echo "==" >&2
-      echo "====================================================================================================" >&2
-    fi
-
     echo "Checking Replica Set of external MongoDB"
 
     if appsmithctl check-replica-set; then


### PR DESCRIPTION
We're already checking for the AVX instruction, and producing a helpful message about it. But, we're doing that check _after_ we invoke the `mongod` process, which fails on such processes, and the error message is never shown.

This PR changes this, by doing the check before that `mongod` command is run.
