### PR TITLE
ci: Deleting the failed-spec-ci once it is downloaded in ci-test-result to avoid getting specs from older runs

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -386,7 +386,7 @@ jobs:
         if: failure()
         run: |
           cd ${{ github.workspace }}/app/client/cypress/
-          find screenshots -type f -iname "*\(attempt 2\).png" | sed 's/screenshots/cypress\/integration/g'| sed 's:/[^/]*$::' | sort -u > ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
+          find screenshots -type f \( -iname "*\(attempt 2\).png" -o -iname "*before all hook \(failed\).png" \) | sed 's/screenshots/cypress\/integration/g'| sed 's:/[^/]*$::' | sort -u > ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
 
       # Upload failed test list using common path for all matrix job
       - name: Upload failed test list artifact

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -108,6 +108,14 @@ jobs:
           name: failed-spec-ci
           path: ~/failed_spec_ci
 
+      # delete-artifact
+      - name: delete existing failed-spec-ci artifact
+        if: needs.ci-test.result != 'success'
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: failed-spec-ci
+          failOnError: false
+
       # In case for any ci job failure, create combined failed spec
       - name: "combine all specs for CI"
         if: needs.ci-test.result != 'success'

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -89,6 +89,14 @@ jobs:
           name: failed-spec-ci
           path: ~/failed_spec_ci
 
+      # delete-artifact
+      - name: delete existing failed-spec-ci artifact
+        if: needs.ci-test.result != 'success'
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: failed-spec-ci
+          failOnError: false
+
       # In case for any ci job failure, create combined failed spec
       - name: "combine all specs for CI"
         if: needs.ci-test.result != 'success'


### PR DESCRIPTION
## Description
- Deleting the failed-spec-ci once it is downloaded in ci-test-result to avoid getting specs from older runs

## Type of change
- yml file changes


## How Has This Been Tested?
- Manual


## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
