### PR TITLE
ci: Deleting the combined-failed-spec-ci in ci-test-result

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -390,7 +390,7 @@ jobs:
 
       # Upload failed test list using common path for all matrix job
       - name: Upload failed test list artifact
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: failed-spec-ci

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -100,6 +100,13 @@ jobs:
           PAYLOAD_CONTEXT: ${{ toJson(github.event.client_payload) }}
         run: echo "$PAYLOAD_CONTEXT"
 
+      # Deleting the existing dir's if any
+      - name: Delete existing directories
+        if: needs.ci-test.result != 'success'
+        run: |
+          rm -f ~/failed_spec_ci
+          rm -f ~/combined_failed_spec_ci
+
       # Download failed_spec list for all jobs
       - uses: actions/download-artifact@v3
         if: needs.ci-test.result
@@ -107,6 +114,14 @@ jobs:
         with:
           name: failed-spec-ci
           path: ~/failed_spec_ci
+      
+      # delete-artifact
+      - name: delete existing combined_failed_spec_ci artifact
+        if: needs.ci-test.result != 'success'
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: combined_failed_spec_ci
+          failOnError: false
 
       # delete-artifact
       - name: delete existing failed-spec-ci artifact
@@ -115,7 +130,7 @@ jobs:
         with:
           name: failed-spec-ci
           failOnError: false
-
+          
       # In case for any ci job failure, create combined failed spec
       - name: "combine all specs for CI"
         if: needs.ci-test.result != 'success'

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -81,6 +81,13 @@ jobs:
     steps:
       - run: echo "All ci-test matrices completed"
 
+      # Deleting the existing dir's if any
+      - name: Delete existing directories
+        if: needs.ci-test.result != 'success'
+        run: |
+          rm -f ~/failed_spec_ci
+          rm -f ~/combined_failed_spec_ci
+
       # Download failed_spec_ci list for all CI container jobs
       - uses: actions/download-artifact@v3
         if: needs.ci-test.result
@@ -88,6 +95,14 @@ jobs:
         with:
           name: failed-spec-ci
           path: ~/failed_spec_ci
+
+      # delete-artifact
+      - name: delete existing combined_failed_spec_ci artifact
+        if: needs.ci-test.result != 'success'
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: combined_failed_spec_ci
+          failOnError: false
 
       # delete-artifact
       - name: delete existing failed-spec-ci artifact


### PR DESCRIPTION
## Description
- Deleting the combined-failed-spec-ci in ci-test-result

## Type of change
- Yml file changes

## How Has This Been Tested?
- Manual

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
