### PR TITLE
docs: Enable replica set with with docker-compose

### DIFF
--- a/app/server/docker-compose.yml
+++ b/app/server/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "8080:8080"
     depends_on:
       mongo:
-        condition: service_started
+        condition: service_healthy
       redis:
         condition: service_healthy
     networks:

--- a/app/server/docker-compose.yml
+++ b/app/server/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ./container-volumes/git-storage:/data/git-storage
 
   mongo:
-    image: mongo:6
+    image: mongo:5
     environment:
       - MONGO_INITDB_DATABASE=appsmith
     volumes:
@@ -29,17 +29,17 @@ services:
       - appsmith
     command: "--replSet rs0"
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh mongo:27017/test --quiet
+      test: echo 'db.runCommand("ping").ok' | mongo mongo:27017/test --quiet
 
   mongo-initiate:
-    image: mongo:6
+    image: mongo:5
     restart: "on-failure"
     depends_on:
       mongo:
         condition: service_started
     networks:
       - appsmith
-    entrypoint: [ "bash", "-c", "mongosh --host mongo:27017 --eval 'rs.initiate()'" ]
+    entrypoint: [ "bash", "-c", "mongo --host mongo:27017 --eval 'rs.initiate()'" ]
 
   redis:
     image: redis

--- a/app/server/docker-compose.yml
+++ b/app/server/docker-compose.yml
@@ -10,26 +10,43 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - mongo
-      - redis
+      mongo:
+        condition: service_started
+      redis:
+        condition: service_healthy
     networks:
       - appsmith
     volumes:
       - ./container-volumes/git-storage:/data/git-storage
 
   mongo:
-    image: mongo:4.4.6
+    image: mongo:6
     environment:
       - MONGO_INITDB_DATABASE=appsmith
     volumes:
       - ./container-volumes/mongo:/data/db
     networks:
       - appsmith
+    command: "--replSet rs0"
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh mongo:27017/test --quiet
+
+  mongo-initiate:
+    image: mongo:6
+    restart: "on-failure"
+    depends_on:
+      mongo:
+        condition: service_started
+    networks:
+      - appsmith
+    entrypoint: [ "bash", "-c", "mongosh --host mongo:27017 --eval 'rs.initiate()'" ]
 
   redis:
     image: redis
     networks:
       - appsmith
+    healthcheck:
+      test: ["CMD", "redis-cli","ping"]
 
 networks:
   appsmith:


### PR DESCRIPTION
## Description

I tried to run the project as described [here](https://github.com/appsmithorg/appsmith/blob/release/contributions/ServerSetup.md#steps-for-setup), however when trying to export and import a project I get a MongoDB error.

After asking for help on Discord [this PR](https://github.com/appsmithorg/appsmith/pull/20757) was merged.
It solves the problem, however it is a manual process.

So I create this PR to solve this problem.


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

I deleted all project data and ran docker-compose.


### Test Plan


### Issues raised during DP testing


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test