### PR TITLE
ci: Reverting the use of combined-failed-spec-ci artifact instead of cache

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -89,16 +89,20 @@ jobs:
       # In case this is second attempt try restoring failed tests
       - name: Restore the previous failed combine result
         if: steps.run_result.outputs.run_result == 'failedtest'
-        uses: actions/download-artifact@v3
+        uses: martijnhols/actions-cache/restore@v3
         with:
-          name: combined_failed_spec_ci
-
+          path: |
+            ~/combined_failed_spec_ci
+          key: ${{ github.run_id }}-"ci-test-result"
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
+            
       # failed_spec_env will contain list of all failed specs
       # We are using environment variable instead of regular to support multiline
       - name: Get failed_spec
         if: steps.run_result.outputs.run_result == 'failedtest'
         run: |
-          failed_spec_env=$(cat combined_failed_spec_ci)
+          failed_spec_env=$(cat ~/combined_failed_spec_ci)
           echo "failed_spec_env<<EOF" >> $GITHUB_ENV
           echo "$failed_spec_env" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -140,6 +140,15 @@ jobs:
           key: ${{ github.run_id }}-"ci-test-result"
           restore-keys: |
             ${{ github.run_id }}-${{ github.job }}
+            
+      # Upload combined failed CI spec list to a file
+      # This is done for debugging.
+      - name: upload combined failed spec
+        if: needs.ci-test.result != 'success'
+        uses: actions/upload-artifact@v3
+        with:
+          name: combined_failed_spec_ci
+          path: ~/combined_failed_spec_ci
 
       - name: Get Latest flaky Tests
         shell: bash

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -114,14 +114,6 @@ jobs:
         with:
           name: failed-spec-ci
           path: ~/failed_spec_ci
-      
-      # delete-artifact
-      - name: delete existing combined_failed_spec_ci artifact
-        if: needs.ci-test.result != 'success'
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: combined_failed_spec_ci
-          failOnError: false
 
       # delete-artifact
       - name: delete existing failed-spec-ci artifact
@@ -138,13 +130,16 @@ jobs:
           rm -f ~/combined_failed_spec_ci
           cat ~/failed_spec_ci/failed_spec_ci* >> ~/combined_failed_spec_ci
 
-      # Upload combined failed CI spec list to a file
-      - name: upload combined failed spec
+      # Force save the CI failed spec list into a cache
+      - name: Store the combined run result for CI
         if: needs.ci-test.result != 'success'
-        uses: actions/upload-artifact@v3
+        uses: martijnhols/actions-cache/save@v3
         with:
-          name: combined_failed_spec_ci
-          path: ~/combined_failed_spec_ci
+          path: |
+            ~/combined_failed_spec_ci
+          key: ${{ github.run_id }}-"ci-test-result"
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
 
       - name: Get Latest flaky Tests
         shell: bash

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -97,14 +97,6 @@ jobs:
           path: ~/failed_spec_ci
 
       # delete-artifact
-      - name: delete existing combined_failed_spec_ci artifact
-        if: needs.ci-test.result != 'success'
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: combined_failed_spec_ci
-          failOnError: false
-
-      # delete-artifact
       - name: delete existing failed-spec-ci artifact
         if: needs.ci-test.result != 'success'
         uses: geekyeggo/delete-artifact@v2
@@ -118,6 +110,17 @@ jobs:
         run: |
           rm -f ~/combined_failed_spec_ci
           cat ~/failed_spec_ci/failed_spec_ci* >> ~/combined_failed_spec_ci
+
+      # Force save the CI failed spec list into a cache
+      - name: Store the combined run result for CI
+        if: needs.ci-test.result != 'success'
+        uses: martijnhols/actions-cache/save@v3
+        with:
+          path: |
+            ~/combined_failed_spec_ci
+          key: ${{ github.run_id }}-"ci-test-result"
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
 
       # Upload combined failed CI spec list to a file
       # This is done for debugging.


### PR DESCRIPTION
## Description
- Reverting the use of combined-failed-spec-ci artifact instead of cache

## Type of change
- yml file changes

## How Has This Been Tested?
- Manual

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
