### PR TITLE
ci: Fix for combined-failed-spec-ci cache not found issue

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -89,11 +89,13 @@ jobs:
       # In case this is second attempt try restoring failed tests
       - name: Restore the previous failed combine result
         if: steps.run_result.outputs.run_result == 'failedtest'
-        uses: actions/cache@v3
+        uses: martijnhols/actions-cache/restore@v3
         with:
           path: |
             ~/combined_failed_spec_ci
           key: ${{ github.run_id }}-"ci-test-result"
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
             
       # failed_spec_env will contain list of all failed specs
       # We are using environment variable instead of regular to support multiline

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -133,11 +133,13 @@ jobs:
       # Force save the CI failed spec list into a cache
       - name: Store the combined run result for CI
         if: needs.ci-test.result != 'success'
-        uses: actions/cache@v3
+        uses: martijnhols/actions-cache/save@v3
         with:
           path: |
             ~/combined_failed_spec_ci
           key: ${{ github.run_id }}-"ci-test-result"
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
             
       # Upload combined failed CI spec list to a file
       # This is done for debugging.

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -114,11 +114,13 @@ jobs:
       # Force save the CI failed spec list into a cache
       - name: Store the combined run result for CI
         if: needs.ci-test.result != 'success'
-        uses: actions/cache@v3
+        uses: martijnhols/actions-cache/save@v3
         with:
           path: |
             ~/combined_failed_spec_ci
           key: ${{ github.run_id }}-"ci-test-result"
+          restore-keys: |
+            ${{ github.run_id }}-${{ github.job }}
 
       # Upload combined failed CI spec list to a file
       # This is done for debugging.


### PR DESCRIPTION
## Description
- Fix for combined-failed-spec-ci cache not found issue

## Type of change
- YML file changes

## How Has This Been Tested?
- Manual

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
