### PR TITLE
fix: Table Widget property to specify if prev or next buttons were pressed

### DIFF
--- a/app/client/cypress/fixtures/tableV2NewDslWithPagination.json
+++ b/app/client/cypress/fixtures/tableV2NewDslWithPagination.json
@@ -88,7 +88,7 @@
                         "key": "primaryColumns.orderAmount.computedValue"
                     }
                 ],
-                "leftColumn": 16,
+                "leftColumn": 1,
                 "delimiter": ",",
                 "defaultSelectedRowIndex": 0,
                 "accentColor": "{{appsmith.theme.colors.primaryColor}}",
@@ -136,7 +136,7 @@
                 ],
                 "dynamicPropertyPathList": [],
                 "displayName": "Table",
-                "bottomRow": 111,
+                "bottomRow": 132,
                 "columnWidthMap": {
                     "task": 245,
                     "step": 62,
@@ -273,7 +273,7 @@
                 "rightColumn": 50,
                 "textSize": "0.875rem",
                 "widgetId": "8o3mdylmxa",
-                "tableData": "{{[\n  {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 2736212,\n    \"email\": \"lindsay.ferguson@reqres.in\",\n    \"userName\": \"Lindsay Ferguson\",\n    \"productName\": \"Tuna Salad\",\n    \"orderAmount\": 9.99\n  },\n  {\n    \"id\": 6788734,\n    \"email\": \"tobias.funke@reqres.in\",\n    \"userName\": \"Tobias Funke\",\n    \"productName\": \"Beef steak\",\n    \"orderAmount\": 19.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  }\n]}}",
+                "tableData": "{{[\n  {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  }, {\n    \"id\": 2381224,\n    \"email\": \"michael.lawson@reqres.in\",\n    \"userName\": \"Michael Lawson\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 2736212,\n    \"email\": \"lindsay.ferguson@reqres.in\",\n    \"userName\": \"Lindsay Ferguson\",\n    \"productName\": \"Tuna Salad\",\n    \"orderAmount\": 9.99\n  },\n  {\n    \"id\": 6788734,\n    \"email\": \"tobias.funke@reqres.in\",\n    \"userName\": \"Tobias Funke\",\n    \"productName\": \"Beef steak\",\n    \"orderAmount\": 19.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  },\n\t  {\n    \"id\": 7434532,\n    \"email\": \"byron.fields@reqres.in\",\n    \"userName\": \"Byron Fields\",\n    \"productName\": \"Chicken Sandwich\",\n    \"orderAmount\": 4.99\n  },\n  {\n    \"id\": 7434532,\n    \"email\": \"ryan.holmes@reqres.in\",\n    \"userName\": \"Ryan Holmes\",\n    \"productName\": \"Avocado Panini\",\n    \"orderAmount\": 7.99\n  }\n]}}",
                 "label": "Data",
                 "searchKey": "",
                 "parentId": "0",
@@ -282,6 +282,35 @@
                 "isVisibleSearch": true,
                 "isVisiblePagination": true,
                 "verticalAlignment": "CENTER"
+            },
+            {
+                "widgetName": "Text1",
+                "rightColumn": 60,
+                "textAlign": "LEFT",
+                "displayName": "Text",
+                "widgetId": "16zkg2v0na",
+                "topRow": 83,
+                "bottomRow": 87,
+                "parentRowSpace": 10,
+                "isVisible": true,
+                "type": "TEXT_WIDGET",
+                "fontStyle": "BOLD",
+                "textColor": "#231F20",
+                "version": 1,
+                "hideCard": false,
+                "parentId": "0",
+                "isLoading": false,
+                "parentColumnSpace": 17.28125,
+                "dynamicTriggerPathList": [],
+                "leftColumn": 51,
+                "dynamicBindingPathList": [
+                    {
+                        "key": "text"
+                    }
+                ],
+                "fontSize": "PARAGRAPH",
+                "text": "{{Table1.previousPageVisited}} {{Table1.nextPageVisited}}",
+                "key": "r76o6tqjaz"
             }
         ]
     }

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_PropertyPane_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_PropertyPane_spec.js
@@ -215,7 +215,7 @@ describe("Table Widget V2 property pane feature validation", function () {
       cy.wait(500);
       cy.readTableV2dataPublish("1", "0").then((tabData2) => {
         expect(tabData2)
-          .to.equal("lindsay.ferguson@reqres.in")
+          .to.equal("michael.lawson@reqres.in")
           .to.eq(actualEmail);
         cy.log("computed value of URL is " + tabData2);
       });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_Widget_Copy_Paste_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_Widget_Copy_Paste_spec.js
@@ -39,7 +39,7 @@ describe("Test Suite to validate copy/paste table Widget V2", function () {
     cy.selectAction("Show Bindings");
     cy.wait(200);
     cy.get(apiwidget.propertyList).then(function ($lis) {
-      expect($lis).to.have.length(20);
+      expect($lis).to.have.length(22);
       expect($lis.eq(0)).to.contain("{{Table1Copy.selectedRow}}");
       expect($lis.eq(1)).to.contain("{{Table1Copy.selectedRows}}");
     });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_pagination_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_pagination_spec.js
@@ -1,5 +1,8 @@
 const commonlocators = require("../../../../../locators/commonlocators.json");
 const dsl = require("../../../../../fixtures/tableV2NewDslWithPagination.json");
+const { ObjectsRegistry } = require("../../../../../support/Objects/Registry");
+
+const table = ObjectsRegistry.Table;
 
 describe("Table Widget property pane feature validation", function () {
   before(() => {
@@ -13,10 +16,63 @@ describe("Table Widget property pane feature validation", function () {
       .click()
       .type("26");
     cy.wait(1000);
-    cy.get(`.t--draggable-tablewidgetv2 span[data-pagecount="20"]`).should(
+    cy.get(`.t--draggable-tablewidgetv2 span[data-pagecount="11"]`).should(
       "exist",
     );
 
+    // Cleanup
+    cy.UncheckWidgetProperties(commonlocators.serverSidePaginationCheckbox);
     cy.closePropertyPane();
+  });
+
+  it("2. updates previous and next pagination propeties properly in non server side pagination mode", function () {
+    cy.openPropertyPane("tablewidgetv2");
+
+    // The text field has two bindings in its text value, as below
+    // "{{Table1.previousPageVisited}} {{Table1.nextPageVisited}}"
+
+    // Click on next page
+    cy.get(".t--table-widget-next-page").click();
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false true");
+
+    // Click on previous page
+    cy.get(".t--table-widget-prev-page").click();
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "true false");
+
+    // Type and go to next page
+    cy.get(".t--table-widget-page-input .bp3-input").clear().type("2{enter}");
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false true");
+
+    // Type and go to previous page
+    cy.get(".t--table-widget-page-input .bp3-input").clear().type("1{enter}");
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "true false");
+
+    // pagination flags should get reset whenever a user searches for any text
+
+    table.SearchTable("Michael Lawson");
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false false");
+    table.resetSearch();
+
+    // Pagination properties should get reset when user filters for any criteria.
+    cy.get(".t--table-widget-next-page").click();
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false true");
+    table.OpenNFilterTable("userName", "contains", "Michael Lawson");
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false false");
+    table.RemoveFilter();
+
+    cy.get(".t--table-widget-next-page").click();
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false true");
+
+    // pagination properties should work in server side mode
+    cy.CheckWidgetProperties(commonlocators.serverSidePaginationCheckbox);
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false false");
+
+    // Click on next page
+    cy.get(".t--table-widget-next-page").click();
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "false true");
+
+    // Click on previous page
+    cy.get(".t--table-widget-prev-page").click();
+    cy.get(commonlocators.bodyTextStyle).should("have.text", "true false");
   });
 });

--- a/app/client/cypress/support/Pages/Table.ts
+++ b/app/client/cypress/support/Pages/Table.ts
@@ -350,11 +350,15 @@ export class Table {
     cy.get(this._searchText).eq(index).type(searchTxt);
   }
 
+  public resetSearch() {
+    this.agHelper.GetNClick(this._searchBoxCross);
+  }
+
   public RemoveSearchTextNVerify(
     cellDataAfterSearchRemoved: string,
     tableVersion: "v1" | "v2" = "v1",
   ) {
-    this.agHelper.GetNClick(this._searchBoxCross);
+    this.resetSearch();
     this.ReadTableRowColumnData(0, 0, tableVersion).then(
       (aftSearchRemoved: any) => {
         expect(aftSearchRemoved).to.eq(cellDataAfterSearchRemoved);
@@ -394,6 +398,12 @@ export class Table {
     //this.agHelper.ClickButton("APPLY")
   }
 
+  public RemoveFilter(toClose = true, removeOne = false, index = 0) {
+    if (removeOne) this.agHelper.GetNClick(this._removeFilter, index);
+    else this.agHelper.GetNClick(this._clearAllFilter);
+    if (toClose) this.CloseFilter();
+  }
+
   public RemoveFilterNVerify(
     cellDataAfterFilterRemoved: string,
     toClose = true,
@@ -401,9 +411,7 @@ export class Table {
     index = 0,
     tableVersion: "v1" | "v2" = "v1",
   ) {
-    if (removeOne) this.agHelper.GetNClick(this._removeFilter, index);
-    else this.agHelper.GetNClick(this._clearAllFilter);
-    if (toClose) this.CloseFilter();
+    this.RemoveFilter(toClose, removeOne, index);
     this.ReadTableRowColumnData(0, 0, tableVersion).then(
       (aftFilterRemoved: any) => {
         expect(aftFilterRemoved).to.eq(cellDataAfterFilterRemoved);

--- a/app/client/src/ce/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/ce/utils/autocomplete/EntityDefinitions.ts
@@ -154,6 +154,8 @@ export const entityDefinitions = {
     tableHeaders: generateTypeDef(widget.tableHeaders),
     newRow: generateTypeDef(widget.newRow),
     isAddRowInProgress: "bool",
+    previousPageVisited: generateTypeDef(widget.previousPageVisited),
+    nextPageVisited: generateTypeDef(widget.nextPageButtonClicked),
   }),
   VIDEO_WIDGET: {
     "!doc":

--- a/app/client/src/widgets/TableWidgetV2/constants.ts
+++ b/app/client/src/widgets/TableWidgetV2/constants.ts
@@ -22,6 +22,12 @@ export type EditableCell = {
   inputValue: string;
 };
 
+export enum PaginationDirection {
+  INITIAL = "INITIAL",
+  PREVIOUS_PAGE = "PREVIOUS_PAGE",
+  NEXT_PAGE = "NEXT_PAGE",
+}
+
 export enum EditableCellActions {
   SAVE = "SAVE",
   DISCARD = "DISCARD",


### PR DESCRIPTION
… (#10522)

Fixes #10522

We have added two new boolean meta properties, previousPageVisited and nextPageVisited, that are set whenever respective pagination button is clicked. This property is updated for server side pagination mode as well as non server side pagination mode.

By default, both properties are set to false.

When the user clicks on previous page button or tries to enter a page number which is less than current page number, `previousPageVisited` is set to `true` and `nextPageVisited` is set to `false`.

The users can use these property as follows in their code : 

```
myFun1: () => {
		if (Table1.nextPageVisited == true){
			NextQuery.run()
		}
		else if (Table1.prevPageVisited == true){
			PrevQuery.run()
		}
		else {
			BaseQuery.run()
		}
	}
```

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [x] Test plan has been approved by relevant developers
- [x] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test


### Test Plan
> https://github.com/appsmithorg/TestSmith/issues/2371