### PR TITLE
fix: Removed hard coded 4 seconds timeout for action execution in MySQL

### DIFF
--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/java/com/external/plugins/MySqlPlugin.java
@@ -346,7 +346,6 @@ public class MySqlPlugin extends BasePlugin {
                     },
                     Connection::close
             )
-            .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
             .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
             .onErrorMap(PoolShutdownException.class, error -> new StaleConnectionException())
             .onErrorMap(R2dbcNonTransientResourceException.class, error -> new StaleConnectionException())
@@ -628,7 +627,6 @@ public class MySqlPlugin extends BasePlugin {
                     },
                     Connection::close
                     )
-                    .timeout(Duration.ofSeconds(VALIDATION_CHECK_TIMEOUT))
                     .onErrorMap(TimeoutException.class, error -> new StaleConnectionException())
                     .onErrorMap(PoolShutdownException.class, error -> new StaleConnectionException())
                     .subscribeOn(scheduler);

--- a/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/test/java/com/external/plugins/MySqlPluginTest.java
@@ -422,6 +422,25 @@ public class MySqlPluginTest {
                         .verifyComplete();
         }
 
+    @Test
+    public void testExecuteWithLongRunningQuery() {
+        Mono<ConnectionPool> dsConnectionMono = pluginExecutor.datasourceCreate(dsConfig);
+
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setBody("SELECT SLEEP(20);");
+
+        Mono<Object> executeMono = dsConnectionMono.flatMap(conn -> pluginExecutor.executeParameterized(conn,
+                new ExecuteActionDTO(), dsConfig, actionConfiguration));
+        StepVerifier.create(executeMono)
+                .assertNext(obj -> {
+                    ActionExecutionResult result = (ActionExecutionResult) obj;
+                    assertNotNull(result);
+                    assertTrue(result.getIsExecutionSuccess());
+                    assertNotNull(result.getBody());
+                })
+                .verifyComplete();
+    }
+
         @Test
         public void testStaleConnectionCheck() {
                 ActionConfiguration actionConfiguration = new ActionConfiguration();


### PR DESCRIPTION
## Description

We seem to have introduced a hard coded 4 seconds execution timeout in the MySQL plugin that was. causing the more complicated queries to throw a stale connection exception. This PR reverts that change to allow queries to run completely.

Fixes #17324 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- JUnit
- 
### Test Plan
Please use [this](https://www.notion.so/appsmith/Secondary-Stale-Connection-Issue-498b349be64b494abf8d5a34a23a45b8) document to verify all scenarios where we were seeing a stale connection exception.

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
