### PR TITLE
test: Cypress - Disabling back welcome screen triggers

### DIFF
--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1237,17 +1237,18 @@ Cypress.Commands.add("createSuperUser", () => {
   cy.get(welcomePage.nextButton).should("not.be.disabled");
   cy.get(welcomePage.nextButton).click();
   cy.get(welcomePage.newsLetter).should("be.visible");
-  //cy.get(welcomePage.newsLetter).trigger("mouseover").click();
+  cy.get(welcomePage.newsLetter).trigger("mouseover").click();
   //cy.get(welcomePage.newsLetter).find("input").uncheck();//not working
   cy.get(welcomePage.dataCollection).should("be.visible");
-  //cy.get(welcomePage.dataCollection).trigger("mouseover").click();
+  cy.get(welcomePage.dataCollection).trigger("mouseover").click();
+  cy.wait(1000); //for toggles to settle
   cy.get(welcomePage.createButton).should("be.visible");
   cy.get(welcomePage.createButton).click({ force: true });
   cy.wait("@createSuperUser").then((interception) => {
-    expect(interception.request.body).contains(
+    expect(interception.request.body).not.contains(
       "allowCollectingAnonymousData=true",
     );
-    expect(interception.request.body).contains("signupForNewsletter=true");
+    expect(interception.request.body).not.contains("signupForNewsletter=true");
   });
   cy.LogOut();
   cy.wait(2000);


### PR DESCRIPTION
## Description

- This PR adds back the toggling off for telemetry & stay in touch toggles. Adds wait for toggles to settle before clicking on the button.

## Type of change

- Script fix


## How Has This Been Tested?

- Cypress runs local

## Checklist:

### QA activity:
- [X] Added Test Plan Approved label after reviewing all Cypress test
