### PR TITLE
chore: Include user-agent in events from backend

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
@@ -21,7 +21,7 @@ public class ExchangeUtils {
      * @return a Mono that resolves to the value of the given header, if present. Else, an empty Mono.
      * @param headerName The header name to look for.
      */
-    public static Mono<String> getHeaderFromCurrentRequest(String headerName) {
+    private static Mono<String> getHeaderFromCurrentRequest(String headerName) {
         return Mono.deferContextual(Mono::just)
                 .flatMap(contextView -> Mono.justOrEmpty(
                         contextView.get(ServerWebExchange.class).getRequest().getHeaders().getFirst(headerName)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
@@ -8,6 +8,28 @@ import reactor.core.publisher.Mono;
 public class ExchangeUtils {
 
     public static final String HEADER_ANONYMOUS_USER_ID = "X-Anonymous-User-Id";
+    public static final String USER_AGENT = "User-Agent";
+
+    private ExchangeUtils() {
+        // This is a utility class. Instantiation is not allowed.
+    }
+
+    /**
+     * Returns the value of the given header, from the _current_ request. Since this gets the header from
+     * the current request, it has to be called from a request context. It won't work in new background contexts, like
+     * when calling `.subscribe()` on a Mono.
+     * @return a Mono that resolves to the value of the given header, if present. Else, `FieldName.ANONYMOUS_USER`.
+     * @param headerName The header name to look for.
+     */
+    public static Mono<String> getHeaderFromCurrentRequest(String headerName) {
+        return Mono.deferContextual(Mono::just)
+                .map(contextView -> ObjectUtils.defaultIfNull(
+                        contextView.get(ServerWebExchange.class).getRequest().getHeaders().getFirst(headerName),
+                        FieldName.ANONYMOUS_USER
+                ))
+                // An error is thrown when the context is not available. We don't want to fail the request in this case.
+                .onErrorResume(error -> Mono.empty());
+    }
 
     /**
      * Returns the value of `X-Anonymous-User-Id` header, from the _current_ request. Since this gets the header from
@@ -16,14 +38,13 @@ public class ExchangeUtils {
      * @return a Mono that resolves to the value of the `X-Anonymous-User-Id` header, if present. Else, `FieldName.ANONYMOUS_USER`.
      */
     public static Mono<String> getAnonymousUserIdFromCurrentRequest() {
-        return Mono.deferContextual(Mono::just)
-                .map(contextView -> ObjectUtils.defaultIfNull(
-                        contextView.get(ServerWebExchange.class).getRequest().getHeaders().getFirst(HEADER_ANONYMOUS_USER_ID),
-                        FieldName.ANONYMOUS_USER
-                ))
-                // An error is thrown when the context is not available. We don't want to fail the request in this case.
-                .onErrorResume(error -> Mono.empty())
-                .defaultIfEmpty(FieldName.ANONYMOUS_USER);
+        return getHeaderFromCurrentRequest(HEADER_ANONYMOUS_USER_ID)
+            .defaultIfEmpty(FieldName.ANONYMOUS_USER);
+    }
+
+    public static Mono<String> getUserAgentFromCurrentRequest() {
+        return getHeaderFromCurrentRequest(USER_AGENT)
+            .defaultIfEmpty("unavailable");
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/ExchangeUtils.java
@@ -18,14 +18,13 @@ public class ExchangeUtils {
      * Returns the value of the given header, from the _current_ request. Since this gets the header from
      * the current request, it has to be called from a request context. It won't work in new background contexts, like
      * when calling `.subscribe()` on a Mono.
-     * @return a Mono that resolves to the value of the given header, if present. Else, `FieldName.ANONYMOUS_USER`.
+     * @return a Mono that resolves to the value of the given header, if present. Else, an empty Mono.
      * @param headerName The header name to look for.
      */
     public static Mono<String> getHeaderFromCurrentRequest(String headerName) {
         return Mono.deferContextual(Mono::just)
-                .map(contextView -> ObjectUtils.defaultIfNull(
-                        contextView.get(ServerWebExchange.class).getRequest().getHeaders().getFirst(headerName),
-                        FieldName.ANONYMOUS_USER
+                .flatMap(contextView -> Mono.justOrEmpty(
+                        contextView.get(ServerWebExchange.class).getRequest().getHeaders().getFirst(headerName)
                 ))
                 // An error is thrown when the context is not available. We don't want to fail the request in this case.
                 .onErrorResume(error -> Mono.empty());

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/AnalyticsServiceCEImpl.java
@@ -196,16 +196,22 @@ public class AnalyticsServiceCEImpl implements AnalyticsServiceCE {
 
         return Mono.zip(
                         ExchangeUtils.getAnonymousUserIdFromCurrentRequest(),
+                        ExchangeUtils.getUserAgentFromCurrentRequest(),
                         configService.getInstanceId()
                                 .defaultIfEmpty("unknown-instance-id")
                 ).map(tuple -> {
                     final String userIdFromClient = tuple.getT1();
-                    final String instanceId = tuple.getT2();
+                    final String userAgent = tuple.getT2();
+                    final String instanceId = tuple.getT3();
                     String userIdToSend = finalUserId;
                     if (FieldName.ANONYMOUS_USER.equals(finalUserId)) {
                         userIdToSend = StringUtils.defaultIfEmpty(userIdFromClient, FieldName.ANONYMOUS_USER);
                     }
-                    TrackMessage.Builder messageBuilder = TrackMessage.builder(event).userId(userIdToSend);
+                    TrackMessage.Builder messageBuilder = TrackMessage.builder(event)
+                        .userId(userIdToSend)
+                        .context(Map.of(
+                            "userAgent", userAgent
+                        ));
                     analyticsProperties.put("originService", "appsmith-server");
                     analyticsProperties.put("instanceId", instanceId);
                     analyticsProperties.put("version", projectProperties.getVersion());


### PR DESCRIPTION
We get the `User-Agent` header for frontend events today, but not for backend events. This PR get the `User-Agent` header value, from the current request context, if any, and sends it along with any analytics events.

[Relevant Slack sonversation](https://theappsmith.slack.com/archives/C02MUD8DNUR/p1679579820266469?thread_ts=1679496974.642199&cid=C02MUD8DNUR).

Sample backend event with `userAgent`:

![Screenshot 2023-03-24 at 5 14 35 PM](https://user-images.githubusercontent.com/120119/227513810-b56acc15-4229-4dec-abc2-729ff22b4ecd.png)
