### PR TITLE
chore: Add default view for JsonView

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/SerializationUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/util/SerializationUtils.java
@@ -3,6 +3,7 @@ package com.appsmith.util;
 import com.appsmith.external.converters.HttpMethodConverter;
 import com.appsmith.external.converters.ISOStringToInstantConverter;
 import com.appsmith.external.models.DatasourceStructure;
+import com.appsmith.external.views.Views;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,13 @@ public class SerializationUtils {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        /*
+         Setting Views.Public as default view class for the serializer.
+         Views.Public.class will be used if a controller has no JsonView annotation present.
+         It'll be overridden by the JsonView annotation in the controller.
+        */
+        objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Views.Public.class));
 
         return objectMapper;
     }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
@@ -1,0 +1,32 @@
+package com.appsmith.server.configurations;
+
+import com.appsmith.server.domains.UserData;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+public class CommonConfigTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * This method tests that objectMapper bean is created and it has Views.Public set as the default for the JsonView.
+     */
+    @Test
+    public void objectMapper_BeanCreated_WithPublicJsonViewAsDefault() throws JsonProcessingException {
+        UserData userData = new UserData();
+        userData.setRole("abcd"); // this is public field
+        userData.setAccessToken("token"); // this is internal field
+        userData.setUserPermissions(null);
+
+        String value = objectMapper.writeValueAsString(userData);
+        JSONAssert.assertEquals("{\"role\":\"abcd\",\"new\":true}", value, true);
+    }
+}


### PR DESCRIPTION
## Description

This PR sets the `Public` as default view class for JsonView. It'll be overridden if the controller has it's another view set. This will prevent any accidental case when JsonView annotation is missing.

Fixes #21948


## Type of change

- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- JUnit tests

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
