### PR TITLE
fix: do not create files for empty body of queries in the git repo

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/FileUtilsImpl.java
@@ -414,7 +414,7 @@ public class FileUtilsImpl implements FileInterface {
             Files.createDirectories(path);
             // Write the user written query to .txt file to make conflict handling easier
             // Body will be null if the action is of type JS
-            if (body != null) {
+            if (StringUtils.hasLength(body)) {
                 Path bodyPath = path.resolve(resourceName + CommonConstants.TEXT_FILE_EXTENSION);
                 writeStringToFile(body, bodyPath);
             }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/service/GitExecutorImpl.java
@@ -494,8 +494,9 @@ public class GitExecutorImpl implements GitExecutor {
                 for (String x : modifiedAssets) {
                     if (x.contains(CommonConstants.CANVAS)) {
                         modifiedPages++;
-                    } else if (x.contains(GitDirectories.ACTION_DIRECTORY + "/") && !x.endsWith(".json")) {
-                        String queryName = x.substring(x.lastIndexOf("/") + 1);
+                    } else if (x.contains(GitDirectories.ACTION_DIRECTORY + "/")) {
+                        String queryName = x.split(GitDirectories.ACTION_DIRECTORY + "/")[1];
+                        queryName = queryName.substring(0, queryName.indexOf("/"));
                         String pageName = x.split("/")[1];
                         if (!queriesModified.contains(pageName + queryName)) {
                             queriesModified.add(pageName + queryName);


### PR DESCRIPTION
## Description

> We're currently creating an empty txt file even when there is no body for an API call. For eg, in GET API calls. We should check whether there is content in a file before creating the file.

Fixes #21683 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

### Test Plan

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
