### PR TITLE
fix: Omnibar not showing recent entities

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/OtherUIFeatures/Omnibar_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/OtherUIFeatures/Omnibar_spec.js
@@ -139,27 +139,31 @@ describe("Omnibar functionality test cases", () => {
     cy.get(omnibar.globalSearch).click({ force: true });
     cy.get(omnibar.categoryTitle).eq(0).click();
     // verify recently opened items with their subtext i.e page name
-    cy.xpath(omnibar.recentlyopenItem).eq(0).should("have.text", "Page1");
     cy.xpath(omnibar.recentlyopenItem)
-      .eq(1)
-      .should("have.text", "Audio1")
-      .next()
-      .should("have.text", "Page1");
-    cy.xpath(omnibar.recentlyopenItem)
-      .eq(2)
+      .eq(0)
       .should("have.text", "Button1")
       .next()
       .should("have.text", "Page1");
+
     cy.xpath(omnibar.recentlyopenItem)
-      .eq(3)
+      .eq(1)
       .should("have.text", "Omnibar2")
       .next()
       .should("have.text", "Page1");
+
     cy.xpath(omnibar.recentlyopenItem)
-      .eq(4)
+      .eq(2)
       .should("have.text", "Omnibar1")
       .next()
       .should("have.text", "Page1");
+
+    cy.xpath(omnibar.recentlyopenItem)
+      .eq(3)
+      .should("have.text", "Audio1")
+      .next()
+      .should("have.text", "Page1");
+
+    cy.xpath(omnibar.recentlyopenItem).eq(4).should("have.text", "Page1");
   });
 
   it("7. Verify documentation should open in new tab, on clicking open documentation", function () {

--- a/app/client/src/components/editorComponents/GlobalSearch/index.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/index.tsx
@@ -267,15 +267,12 @@ function GlobalSearch() {
   const recentEntityIds = recentEntities
     .map((r) => getEntityId(r))
     .filter(Boolean);
-  const recentEntityIndex = useCallback(
-    (entity) => {
-      if (entity.kind === SEARCH_ITEM_TYPES.document) return -1;
-      const id =
-        entity.id || entity.widgetId || entity.config?.id || entity.pageId;
-      return recentEntityIds.indexOf(id);
-    },
-    [recentEntities],
-  );
+  const recentEntityIndex = (entity: any) => {
+    if (entity.kind === SEARCH_ITEM_TYPES.document) return -1;
+    const id =
+      entity.id || entity.widgetId || entity.config?.id || entity.pageId;
+    return recentEntityIds.indexOf(id);
+  };
 
   const resetSearchQuery = useSelector(searchQuerySelector);
   const lastSelectedWidgetId = useSelector(getLastSelectedWidget);

--- a/app/client/src/components/editorComponents/GlobalSearch/useRecentEntities.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/useRecentEntities.tsx
@@ -14,7 +14,10 @@ import { FocusEntity } from "navigation/FocusEntity";
 const recentEntitiesSelector = (state: AppState) =>
   state.ui.globalSearch.recentEntities || [];
 
-const useResentEntities = () => {
+const useResentEntities = (): Array<{
+  entityType: FocusEntity;
+  [key: string]: any;
+}> => {
   const widgetsMap = useSelector(getAllWidgetsMap);
   const recentEntities = useSelector(recentEntitiesSelector);
   const actions = useSelector(getActions);

--- a/app/client/src/components/editorComponents/GlobalSearch/useRecentEntities.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/useRecentEntities.tsx
@@ -10,7 +10,7 @@ import { SEARCH_ITEM_TYPES } from "./utils";
 import { get } from "lodash";
 import type { JSCollectionData } from "reducers/entityReducers/jsActionsReducer";
 import { FocusEntity } from "navigation/FocusEntity";
-import type { DataTreeEntityObject } from "../../../entities/DataTree/dataTreeFactory";
+import type { DataTreeEntityObject } from "entities/DataTree/dataTreeFactory";
 
 const recentEntitiesSelector = (state: AppState) =>
   state.ui.globalSearch.recentEntities || [];

--- a/app/client/src/components/editorComponents/GlobalSearch/useRecentEntities.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/useRecentEntities.tsx
@@ -10,14 +10,16 @@ import { SEARCH_ITEM_TYPES } from "./utils";
 import { get } from "lodash";
 import type { JSCollectionData } from "reducers/entityReducers/jsActionsReducer";
 import { FocusEntity } from "navigation/FocusEntity";
+import type { DataTreeEntityObject } from "../../../entities/DataTree/dataTreeFactory";
 
 const recentEntitiesSelector = (state: AppState) =>
   state.ui.globalSearch.recentEntities || [];
 
-const useResentEntities = (): Array<{
-  entityType: FocusEntity;
-  [key: string]: any;
-}> => {
+const useResentEntities = (): Array<
+  DataTreeEntityObject & {
+    entityType: FocusEntity;
+  }
+> => {
   const widgetsMap = useSelector(getAllWidgetsMap);
   const recentEntities = useSelector(recentEntitiesSelector);
   const actions = useSelector(getActions);

--- a/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
+++ b/app/client/src/components/editorComponents/GlobalSearch/utils.tsx
@@ -1,14 +1,13 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
-  createMessage,
   ACTION_OPERATION_DESCRIPTION,
+  createMessage,
   DOC_DESCRIPTION,
   NAV_DESCRIPTION,
   SNIPPET_DESCRIPTION,
 } from "@appsmith/constants/messages";
 import type { ValidationTypes } from "constants/WidgetValidation";
 import type { Datasource } from "entities/Datasource";
-import { useEffect, useState } from "react";
 import { fetchRawGithubContentList } from "./githubHelper";
 import { PluginPackageName, PluginType } from "entities/Action";
 import type { WidgetType } from "constants/WidgetConstants";
@@ -18,8 +17,8 @@ import type { AppState } from "@appsmith/reducers";
 import WidgetFactory from "utils/WidgetFactory";
 import {
   CurlIconV2,
-  JsFileIconV2,
   GraphQLIconV2,
+  JsFileIconV2,
 } from "pages/Editor/Explorer/ExplorerIcons";
 import { createNewApiAction } from "actions/apiPaneActions";
 import { createNewJSCollection } from "actions/jsPaneActions";
@@ -28,7 +27,7 @@ import { getQueryParams } from "utils/URLUtils";
 import history from "utils/history";
 import { curlImportPageURL } from "RouteBuilder";
 import { isMacOrIOS, modText, shiftText } from "utils/helpers";
-import type { FocusEntity } from "navigation/FocusEntity";
+import { FocusEntity } from "navigation/FocusEntity";
 
 export type SelectEvent =
   | React.MouseEvent
@@ -317,18 +316,25 @@ export const attachKind = (source: any[], kind: string) => {
   }));
 };
 
-export const getEntityId = (entity: any) => {
+export const getEntityId = (entity: {
+  entityType: FocusEntity;
+  [key: string]: any;
+}) => {
   const { entityType } = entity;
   switch (entityType) {
-    case "page":
-      return entity.pageId;
-    case "datasource":
+    case FocusEntity.DATASOURCE:
       return entity.id;
-    case "widget":
-      return entity.widgetId;
-    case "action":
-    case "jsAction":
+    case FocusEntity.API:
+    case FocusEntity.QUERY:
+    case FocusEntity.JS_OBJECT:
       return entity.config?.id;
+    case FocusEntity.PROPERTY_PANE:
+      return entity.widgetId;
+    case FocusEntity.CANVAS:
+    case FocusEntity.PAGE:
+      return entity.pageId;
+    case FocusEntity.NONE:
+      break;
   }
 };
 


### PR DESCRIPTION
## Description

The Omnibar is supposed to update its order to ensure recent items are listed first. This stopped working at some time and this PR fixes it

> Omnibar will list recently accessed items first

Fixes #18963

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
