### PR TITLE
ci: Starting Arango DB container for running Arango test scripts in CI runs

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -164,10 +164,11 @@ jobs:
             --add-host=host.docker.internal:host-gateway --add-host=api.segment.io:host-gateway --add-host=t.appsmith.com:host-gateway \
             cicontainer
             
-      - name: Setup MSSQL docker container
+      - name: Setup MSSQL & Arango docker containers
         working-directory : app/client/cypress
         run : |
           docker run --name=mssqldb -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Root@123" -p 1433:1433 -d mcr.microsoft.com/azure-sql-edge
+          docker run --name arangodb -e ARANGO_USERNAME=root -e ARANGO_ROOT_PASSWORD=Arango -p 8529:8529 -d arangodb
        # docker exec -i mssqldb /bin/bash -c "echo -e '[mysqld]\ntcpport=1433\ntcpnodelay=1' >> /var/opt/mssql/mssql.conf"
        # docker restart mssqldb
        # sudo ufw allow 1433/tcp


### PR DESCRIPTION
## Description

- This PR includes Arango as separate docker container inside CI that can be used for running Arango datasource test cases in CI

## Type of change

- Yml file update


## Checklist:
- [X] Added Test Plan Approved label after reviewing all changes
