### PR TITLE
fix: settings pane close icon hover

### DIFF
--- a/app/client/src/pages/Editor/AppSettingsPane/PaneHeader.tsx
+++ b/app/client/src/pages/Editor/AppSettingsPane/PaneHeader.tsx
@@ -12,7 +12,7 @@ import styled from "styled-components";
 
 const StyledHeader = styled.div`
   height: 48px;
-  padding: 10px 0px 12px;
+  padding: 10px 0px 10px;
   border-bottom: 1px solid ${Colors.GRAY_300};
   margin-bottom: 0;
 `;
@@ -22,7 +22,7 @@ const StyledText = styled.div`
 `;
 
 const StyledIcon = styled(Icon)`
-  height: 49px;
+  height: 48px;
   width: 48px;
   justify-content: center;
   &:hover {

--- a/app/client/src/pages/Editor/AppSettingsPane/PaneHeader.tsx
+++ b/app/client/src/pages/Editor/AppSettingsPane/PaneHeader.tsx
@@ -12,12 +12,22 @@ import styled from "styled-components";
 
 const StyledHeader = styled.div`
   height: 48px;
-  padding: 10px 16px 12px;
+  padding: 10px 0px 12px;
   border-bottom: 1px solid ${Colors.GRAY_300};
+  margin-bottom: 0;
 `;
 
 const StyledText = styled.div`
   font-size: 16px;
+`;
+
+const StyledIcon = styled(Icon)`
+  height: 49px;
+  width: 48px;
+  justify-content: center;
+  &:hover {
+    background-color: var(--appsmith-color-black-200);
+  }
 `;
 
 function PaneHeader() {
@@ -28,8 +38,7 @@ function PaneHeader() {
         content={APP_SETTINGS_CLOSE_TOOLTIP()}
         position={PopoverPosition.BOTTOM}
       >
-        <Icon
-          className="pr-2"
+        <StyledIcon
           fillColor={Colors.GREY_10}
           id="t--close-app-settings-pane"
           name="double-arrow-right"


### PR DESCRIPTION
## Description

Add a hover state to the close icon.
![image](https://user-images.githubusercontent.com/66776129/228449579-4cae2602-3e2a-4036-8ce8-55121882a72d.png)


Fixes #19198


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
