### PR TITLE
ci: Resetting the failed_spec_ci in case of success in ci-test.yml

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -393,6 +393,12 @@ jobs:
           cd ${{ github.workspace }}/app/client/cypress/
           find screenshots -type f \( -iname "*\(attempt 2\).png" -o -iname "*before all hook*" -o -iname "*after all hook*" \) | sed 's/screenshots/cypress\/integration/g'| sed 's:/[^/]*$::' | sort -u > ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
 
+      # reset the failed_spec_ci file in case of success
+      - name: In case of test success reset the failed_spec_ci file
+        if: success()
+        run: |
+          rm -f ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
+
       # Upload failed test list using common path for all matrix job
       - name: Upload failed test list artifact
         if: failure()


### PR DESCRIPTION
## Description
- Resetting the failed_spec_ci in case of success in ci-test.yml

## Type of change
- yml file changes

## How Has This Been Tested?
- Workflow run

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
