### PR TITLE
fix: Bounding box of widgets inside ListWidget

### DIFF
--- a/app/client/src/sagas/AutoLayoutUpdateSagas.tsx
+++ b/app/client/src/sagas/AutoLayoutUpdateSagas.tsx
@@ -204,6 +204,8 @@ function* updateWidgetDimensionsSaga(
   const mainCanvasWidth: number = yield select(getMainCanvasWidth);
 
   const widget = allWidgets[widgetId];
+  if (!widget) return;
+
   const widgetMinMaxDimensions = getWidgetMinMaxDimensionsInPixel(
     widget,
     mainCanvasWidth,

--- a/app/client/src/utils/autoLayout/AutoLayoutUtils.ts
+++ b/app/client/src/utils/autoLayout/AutoLayoutUtils.ts
@@ -513,9 +513,9 @@ function getPadding(canvas: FlattenedWidgetProps): number {
   }
 
   if (canvas.noPad) {
-    // Widgets like ListWidget choose to have no container padding so will only have widget padding
-    padding = WIDGET_PADDING * 2;
+    padding -= WIDGET_PADDING;
   }
+
   return padding;
 }
 

--- a/app/client/src/widgets/ListWidgetV2/index.ts
+++ b/app/client/src/widgets/ListWidgetV2/index.ts
@@ -368,6 +368,7 @@ export const CONFIG = {
                 bottomRow: 6,
                 leftColumn: GridDefaults.DEFAULT_GRID_COLUMNS - 16,
                 rightColumn: GridDefaults.DEFAULT_GRID_COLUMNS,
+                widthInPercentage: 16 / GridDefaults.DEFAULT_GRID_COLUMNS,
               },
             });
           },

--- a/app/client/src/widgets/MetaWidgetContextProvider.tsx
+++ b/app/client/src/widgets/MetaWidgetContextProvider.tsx
@@ -48,6 +48,10 @@ function MetaWidgetContextProvider({
     metaEditorContextProps.modifyMetaWidgets ??
     editorContextProps.modifyMetaWidgets;
 
+  const updateWidgetDimension =
+    metaEditorContextProps.updateWidgetDimension ??
+    editorContextProps.updateWidgetDimension;
+
   const setWidgetCache =
     metaEditorContextProps.setWidgetCache ?? editorContextProps.setWidgetCache;
 
@@ -77,6 +81,7 @@ function MetaWidgetContextProvider({
       getWidgetCache,
       deleteMetaWidgets,
       updateMetaWidgetProperty,
+      updateWidgetDimension,
     }),
     [
       executeAction,
@@ -93,6 +98,7 @@ function MetaWidgetContextProvider({
       getWidgetCache,
       deleteMetaWidgets,
       updateMetaWidgetProperty,
+      updateWidgetDimension,
     ],
   );
 


### PR DESCRIPTION
- `updateWidgetDimension` was being `undefined` for ListWidgetV2 since it is not getting added into MetaWidgetContextProvider. This is why the Auto dimension updates was not getting triggered causes issues with widget bounding box.
- `widthInPercentage` was not defined in the ListWidgetV2's default image causes issue with Image widget's width while resizing.
- padding calculations got adjusted for List widget so that widget bounding box sticks properly to the widget content.

fixes #21859