### PR TITLE
fix: Combine app navigation tests where possible to reduce Cypress cloud costs

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/AppNavigation_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/AppNavigation_spec.js
@@ -7,49 +7,48 @@ const agHelper = ObjectsRegistry.AggregateHelper;
 const homePage = ObjectsRegistry.HomePage;
 
 describe("General checks for app navigation", function () {
-  it("1. App header should appear when there is a single page in the application", () => {
+  it("1. App header should appear when there is a single page in the application, and navigation should appear alongside app header when there are two pages", () => {
+    // App header should appear when there is a single page in the application
     deployMode.DeployApp();
     cy.get(appNavigationLocators.header).should("exist");
     deployMode.NavigateBacktoEditor();
-  });
 
-  it("2. App header and navigation should appear when two pages are in the application", () => {
+    // Navigation should appear alongside app header when there are two pages
     cy.Createpage("Page 2");
     deployMode.DeployApp();
     cy.get(appNavigationLocators.topStacked).should("exist");
   });
 
-  it("3. Application name, share button, edit button, and user dropdown should be available in the app header", () => {
+  it("2. Application name, share button, edit button, and user dropdown should be available in the app header", () => {
     cy.get(appNavigationLocators.applicationName).should("exist");
     cy.get(appNavigationLocators.shareButton).should("exist");
     cy.get(appNavigationLocators.editButton).should("exist");
     cy.get(appNavigationLocators.userProfileDropdownButton).should("exist");
   });
 
-  it("4. Share button should open the share modal", () => {
+  it("3. Share button should open the share modal, edit button should take us back to the editor, and clicking on user profile button should open up the dropdown menu", () => {
+    // Share
     cy.get(
       `${appNavigationLocators.header} ${appNavigationLocators.shareButton}`,
     ).click();
     cy.wait(1000);
     cy.get(appNavigationLocators.modal).should("exist");
     cy.get(appNavigationLocators.modalClose).first().click({ force: true });
-  });
 
-  it("5. Edit button should take us back to the editor", () => {
+    // Edit
     cy.get(
       `${appNavigationLocators.header} ${appNavigationLocators.editButton}`,
     ).click();
     cy.get(commonLocators.canvas).should("exist");
-  });
 
-  it("6. Clicking on user profile button should open up the dropdown menu", () => {
+    // User profile dropdown
     deployMode.DeployApp();
     cy.get(appNavigationLocators.userProfileDropdownButton).click();
     cy.get(appNavigationLocators.userProfileDropdownMenu).should("exist");
     deployMode.NavigateBacktoEditor();
   });
 
-  it("7. Import an application, deploy and verify if the Top+Stacked navigation style shows up with all the pages and a page change happens", () => {
+  it("4. Import an application, deploy and verify if the Top+Stacked navigation style shows up with all the pages and a page change happens", () => {
     // Import an application
     homePage.NavigateToHome();
     homePage.ImportApp("appNavigationTestingApp.json");

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/NavigationSettings_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/NavigationSettings_spec.js
@@ -5,12 +5,10 @@ const deployMode = ObjectsRegistry.DeployMode;
 const agHelper = ObjectsRegistry.AggregateHelper;
 
 describe("Test app's navigation settings", function () {
-  it("1. Open app settings and navigation tab should be there", () => {
+  it("1. Open app settings and navigation tab should be there and when the navigation tab is selected, navigation preview should be visible", () => {
     cy.get(appNavigationLocators.appSettingsButton).click();
     cy.get(appNavigationLocators.navigationSettingsTab).should("exist");
-  });
 
-  it("2. When navigation tab is selected, should show navigation preview", () => {
     // Should not exist when the tab is not selected
     cy.get(appNavigationLocators.navigationPreview).should("not.exist");
     cy.get(appNavigationLocators.navigationSettingsTab).click();
@@ -19,7 +17,7 @@ describe("Test app's navigation settings", function () {
     cy.get(appNavigationLocators.navigationPreview).should("exist");
   });
 
-  it("3. Toggle 'Show navbar' to off, the app header and navigation should not appear when deployed", () => {
+  it("2. Toggle 'Show navbar' to off, the app header and navigation should not appear when deployed", () => {
     // Toggle show navbar to off
     cy.get(appNavigationLocators.navigationSettings.showNavbar).click({
       force: true,
@@ -38,7 +36,7 @@ describe("Test app's navigation settings", function () {
     });
   });
 
-  it("4. Change 'Orientation' to 'Side', deploy, and the sidebar should appear", () => {
+  it("3. Change 'Orientation' to 'Side', deploy, and the sidebar should appear", () => {
     cy.get(
       appNavigationLocators.navigationSettings.orientationOptions.side,
     ).click({
@@ -51,7 +49,7 @@ describe("Test app's navigation settings", function () {
     deployMode.NavigateBacktoEditor();
   });
 
-  it("5. Change 'Orientation' back to 'Top', and 'Nav style' to 'Inline', page navigation items should appear inline", () => {
+  it("4. Change 'Orientation' back to 'Top', and 'Nav style' to 'Inline', page navigation items should appear inline", () => {
     cy.Createpage("Page 2");
     cy.get(appNavigationLocators.appSettingsButton).click();
     cy.get(appNavigationLocators.navigationSettingsTab).click();

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/SidebarCollapse_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/SidebarCollapse_spec.js
@@ -17,12 +17,12 @@ describe("Test Sidebar Collapse", function () {
     cy.get(appNavigationLocators.sidebarCollapseButton).should("exist");
   });
 
-  it("2. Sidebar should collapse on click of collapse button", () => {
+  it("3. Sidebar should collapse and open on click of collapse button again", () => {
+    // Collapse
     cy.get(appNavigationLocators.sidebarCollapseButton).click({ force: true });
     cy.get(appNavigationLocators.sidebar).should("not.have.class", "is-open");
-  });
 
-  it("3. Sidebar should open on click of collapse button again", () => {
+    // Open
     cy.get(appNavigationLocators.sidebarCollapseButton).click({ force: true });
     cy.get(appNavigationLocators.sidebar).should("have.class", "is-open");
     // Back to editor

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/Sidebar_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/Sidebar_spec.js
@@ -55,15 +55,15 @@ describe("Test Sidebar navigation style", function () {
       .should("have.class", "is-active");
   });
 
-  it("3. The background of sidebar should be white since light color style is default", () => {
+  it("3. Sidebar background should be default to white, and should change when background color is set to theme", () => {
+    // The background of sidebar should be white since light color style is default
     cy.get(appNavigationLocators.sidebar).should(
       "have.css",
       "background-color",
       "rgb(255, 255, 255)",
     );
-  });
 
-  it("4. Changing color style to theme should change navigation's background color", () => {
+    // Changing color style to theme should change navigation's background color
     deployMode.NavigateBacktoEditor();
     cy.get(appNavigationLocators.appSettingsButton).click();
     cy.get(appNavigationLocators.navigationSettingsTab).click();
@@ -80,33 +80,33 @@ describe("Test Sidebar navigation style", function () {
     );
   });
 
-  it("5. Application name, share button, edit button, and user dropdown should be available in the app sidebar", () => {
+  it("4. Application name, share button, edit button, and user dropdown should be available in the app sidebar", () => {
     cy.get(appNavigationLocators.applicationName).should("exist");
     cy.get(appNavigationLocators.shareButton).should("exist");
     cy.get(appNavigationLocators.editButton).should("exist");
     cy.get(appNavigationLocators.userProfileDropdownButton).should("exist");
   });
 
-  it("6. Share button should open the share modal", () => {
+  it("5. Share button should open the share modal, edit button should take us back to the editor, and clicking on user profile button should open up the dropdown menu", () => {
+    // Share
     cy.get(
       `${appNavigationLocators.sidebar} ${appNavigationLocators.shareButton}`,
     ).click();
     cy.wait(1000);
     cy.get(appNavigationLocators.modal).should("exist");
     cy.get(appNavigationLocators.modalClose).first().click({ force: true });
-  });
 
-  it("7. Edit button should take us back to the editor", () => {
+    // Edit
     cy.get(
       `${appNavigationLocators.sidebar} ${appNavigationLocators.editButton}`,
     ).click();
     cy.get(commonLocators.canvas).should("exist");
-  });
 
-  it("8. Clicking on user profile button should open up the dropdown menu", () => {
+    // User profile dropdown
     deployMode.DeployApp();
     cy.get(appNavigationLocators.userProfileDropdownButton).click();
     cy.get(appNavigationLocators.userProfileDropdownMenu).should("exist");
+
     // Back to editor
     cy.get(
       `${appNavigationLocators.sidebar} ${appNavigationLocators.editButton}`,

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/TopInline_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/TopInline_spec.js
@@ -44,11 +44,11 @@ describe("Test Top + Inline navigation style", function () {
     cy.get(appNavigationLocators.topInline).should("exist");
   });
 
-  it("2. 'More' button should exist", () => {
+  it("2. More button should exist and when clicked on it, it should open the dropdown with rest of the pages", () => {
+    // 'More' button should exist
     cy.get(appNavigationLocators.topInlineMoreButton).should("exist");
-  });
 
-  it("3. When clicked on 'More' button, it should open the dropdown with rest of the pages", () => {
+    // Should open the dropdown
     cy.get(appNavigationLocators.topInlineMoreButton).click({ force: true });
     cy.get(appNavigationLocators.topInlineMoreDropdown).should("exist");
     cy.get(appNavigationLocators.topInlineMoreDropdown).should(
@@ -62,7 +62,7 @@ describe("Test Top + Inline navigation style", function () {
     );
   });
 
-  it("4. Page change from inside this dropdown should work", () => {
+  it("3. Page change from inside this dropdown should work", () => {
     const pageName = "Page5 - with long long name";
 
     cy.get(appNavigationLocators.topInlineMoreDropdownItem)
@@ -89,7 +89,7 @@ describe("Test Top + Inline navigation style", function () {
       .should("have.class", "is-active");
   });
 
-  it("5. Page change should work", () => {
+  it("4. Page change should work", () => {
     const pageName = "Page1 - with long long name";
 
     cy.get(appNavigationLocators.navigationMenuItem)
@@ -105,15 +105,15 @@ describe("Test Top + Inline navigation style", function () {
       .should("have.class", "is-active");
   });
 
-  it("6. The background of nav should be white since light color style is default", () => {
+  it("5. Navigation's background should be default to white, and should change when background color is set to theme", () => {
+    // The background should be white since light color style is default
     cy.get(appNavigationLocators.header).should(
       "have.css",
       "background-color",
       "rgb(255, 255, 255)",
     );
-  });
 
-  it("7. Changing color style to theme should change navigation's background color", () => {
+    // Changing color style to theme should change navigation's background color
     deployMode.NavigateBacktoEditor();
     cy.get(appNavigationLocators.appSettingsButton).click();
     cy.get(appNavigationLocators.navigationSettingsTab).click();
@@ -130,33 +130,34 @@ describe("Test Top + Inline navigation style", function () {
     );
   });
 
-  it("8. Application name, share button, edit button, and user dropdown should be available in the app header", () => {
+  it("6. Application name, share button, edit button, and user dropdown should be available in the app header", () => {
     cy.get(appNavigationLocators.applicationName).should("exist");
     cy.get(appNavigationLocators.shareButton).should("exist");
     cy.get(appNavigationLocators.editButton).should("exist");
     cy.get(appNavigationLocators.userProfileDropdownButton).should("exist");
   });
 
-  it("9. Share button should open the share modal", () => {
+  it("7. Share button should open the share modal, edit button should take us back to the editor, and clicking on user profile button should open up the dropdown menu", () => {
+    // Share
     cy.get(
       `${appNavigationLocators.header} ${appNavigationLocators.shareButton}`,
     ).click();
     cy.wait(1000);
     cy.get(appNavigationLocators.modal).should("exist");
     cy.get(appNavigationLocators.modalClose).first().click({ force: true });
-  });
 
-  it("10. Edit button should take us back to the editor", () => {
+    // Edit
     cy.get(
       `${appNavigationLocators.header} ${appNavigationLocators.editButton}`,
     ).click();
     cy.get(commonLocators.canvas).should("exist");
-  });
 
-  it("11. Clicking on user profile button should open up the dropdown menu", () => {
+    // User profile dropdown
     deployMode.DeployApp();
     cy.get(appNavigationLocators.userProfileDropdownButton).click();
     cy.get(appNavigationLocators.userProfileDropdownMenu).should("exist");
+
+    // Back to editor
     deployMode.NavigateBacktoEditor();
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/TopStacked_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/AppNavigation/TopStacked_spec.js
@@ -93,45 +93,16 @@ describe("Test Top + Stacked navigation style", function () {
       .should("be.visible");
   });
 
-  it("4. The background of nav should be white since light color style is default", () => {
+  it("4. Navigation's background should be default to white, and should change when background color is set to theme", () => {
+    // The background should be white since light color style is default
     cy.get(appNavigationLocators.topStacked).should(
       "have.css",
       "background-color",
       "rgb(255, 255, 255)",
     );
-  });
 
-  it("5. Application name, share button, edit button, and user dropdown should be available in the app header", () => {
-    cy.get(appNavigationLocators.applicationName).should("exist");
-    cy.get(appNavigationLocators.shareButton).should("exist");
-    cy.get(appNavigationLocators.editButton).should("exist");
-    cy.get(appNavigationLocators.userProfileDropdownButton).should("exist");
-  });
-
-  it("6. Share button should open the share modal", () => {
-    cy.get(
-      `${appNavigationLocators.header} ${appNavigationLocators.shareButton}`,
-    ).click();
-    cy.wait(1000);
-    cy.get(appNavigationLocators.modal).should("exist");
-    cy.get(appNavigationLocators.modalClose).first().click({ force: true });
-  });
-
-  it("7. Edit button should take us back to the editor", () => {
-    cy.get(
-      `${appNavigationLocators.header} ${appNavigationLocators.editButton}`,
-    ).click();
-    cy.get(commonLocators.canvas).should("exist");
-  });
-
-  it("8. Clicking on user profile button should open up the dropdown menu", () => {
-    deployMode.DeployApp();
-    cy.get(appNavigationLocators.userProfileDropdownButton).click();
-    cy.get(appNavigationLocators.userProfileDropdownMenu).should("exist");
+    // Changing color style to theme should change navigation's background color
     deployMode.NavigateBacktoEditor();
-  });
-
-  it("9. Changing color style to theme should change navigation's background color", () => {
     cy.get(appNavigationLocators.appSettingsButton).click();
     cy.get(appNavigationLocators.navigationSettingsTab).click();
     cy.get(
@@ -145,6 +116,36 @@ describe("Test Top + Stacked navigation style", function () {
       "background-color",
       "rgb(85, 61, 233)",
     );
+  });
+
+  it("5. Application name, share button, edit button, and user dropdown should be available in the app header", () => {
+    cy.get(appNavigationLocators.applicationName).should("exist");
+    cy.get(appNavigationLocators.shareButton).should("exist");
+    cy.get(appNavigationLocators.editButton).should("exist");
+    cy.get(appNavigationLocators.userProfileDropdownButton).should("exist");
+  });
+
+  it("6. Share button should open the share modal, edit button should take us back to the editor, and clicking on user profile button should open up the dropdown menu", () => {
+    // Share
+    cy.get(
+      `${appNavigationLocators.header} ${appNavigationLocators.shareButton}`,
+    ).click();
+    cy.wait(1000);
+    cy.get(appNavigationLocators.modal).should("exist");
+    cy.get(appNavigationLocators.modalClose).first().click({ force: true });
+
+    // Edit
+    cy.get(
+      `${appNavigationLocators.header} ${appNavigationLocators.editButton}`,
+    ).click();
+    cy.get(commonLocators.canvas).should("exist");
+
+    // User profile dropdown
+    deployMode.DeployApp();
+    cy.get(appNavigationLocators.userProfileDropdownButton).click();
+    cy.get(appNavigationLocators.userProfileDropdownMenu).should("exist");
+
+    // Back to editor
     deployMode.NavigateBacktoEditor();
   });
 });


### PR DESCRIPTION
## Description
Reducing the number of `it` blocks in Cypress test cases helps us save costs on Cypress cloud. This PR does a refactor on Cypress tests written for App Navigation.

Fixes #21847 

## Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?
- Manual
- Cypress

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
