### PR TITLE
fix: Updating the page permissions only if the data is being sent to the reducer

### DIFF
--- a/app/client/src/reducers/entityReducers/pageListReducer.tsx
+++ b/app/client/src/reducers/entityReducers/pageListReducer.tsx
@@ -129,7 +129,7 @@ export const pageListReducer = createReducer(initialState, {
     action: ReduxAction<{ id: string; slug?: string; permissions?: string[] }>,
   ) => {
     const pageList = state.pages.map((page) => {
-      if (page.pageId === action.payload.id)
+      if (page.pageId === action.payload.id && action.payload.permissions)
         page.userPermissions = action.payload.permissions;
       return page;
     });


### PR DESCRIPTION
## Description

> Updating the page permissions only if the data is being sent to the reducer to avoid making page permissions blank and leading to GAC-based error for auto-saving of pages.

Fixes [#20677](https://github.com/appsmithorg/appsmith/issues/20677)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
> Followed the steps mentioned in the issue before and after this fix. Before the fix, the issue was reproducible. After the fix, the issue is resolved and we don't see the error anymore.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
