### PR TITLE
ci: Upload an empty failed-spec-ci file if all the specs are  passed

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -398,10 +398,11 @@ jobs:
         if: success()
         run: |
           rm -f ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
+          echo  "empty" >> ~/failed_spec_ci/failed_spec_ci-${{ matrix.job }}
 
       # Upload failed test list using common path for all matrix job
       - name: Upload failed test list artifact
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: failed-spec-ci

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -114,14 +114,6 @@ jobs:
         with:
           name: failed-spec-ci
           path: ~/failed_spec_ci
-
-      # delete-artifact
-      - name: delete existing failed-spec-ci artifact
-        if: needs.ci-test.result != 'success'
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: failed-spec-ci
-          failOnError: false
           
       # In case for any ci job failure, create combined failed spec
       - name: "combine all specs for CI"

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -96,14 +96,6 @@ jobs:
           name: failed-spec-ci
           path: ~/failed_spec_ci
 
-      # delete-artifact
-      - name: delete existing failed-spec-ci artifact
-        if: needs.ci-test.result != 'success'
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: failed-spec-ci
-          failOnError: false
-
       # In case for any ci job failure, create combined failed spec
       - name: "combine all specs for CI"
         if: needs.ci-test.result != 'success'


### PR DESCRIPTION
## Description
-  Upload an empty failed-spec-ci file if all the specs are  passed

## Type of change
- YML file changes

## How Has This Been Tested?
- github actions

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
