### PR TITLE
perf: preload route chunks for view and edit modes

### DIFF
--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -3,6 +3,7 @@ const CracoAlias = require("craco-alias");
 const CracoBabelLoader = require("craco-babel-loader");
 const path = require("path");
 const webpack = require("webpack");
+const IconChunkNamingPlugin = require("./webpack/IconChunkNamingPlugin");
 
 module.exports = {
   devServer: {
@@ -60,6 +61,8 @@ module.exports = {
             "./src/components/designSystems/blueprintjs/icon/index.js",
           ),
         ),
+        // Give icon chunks names like `icon.dfd465bd.chunk.js` instead of `35140.dfd465bd.chunk.js`
+        new IconChunkNamingPlugin(),
       ],
     },
   },

--- a/app/client/craco.common.config.js
+++ b/app/client/craco.common.config.js
@@ -1,3 +1,4 @@
+const assert = require("assert");
 const CracoAlias = require("craco-alias");
 const CracoBabelLoader = require("craco-babel-loader");
 const path = require("path");
@@ -90,15 +91,65 @@ module.exports = {
       },
     },
     {
+      // Prioritize the local src directory over node_modules.
+      // This matters for cases where `src/<dirname>` and `node_modules/<dirname>` both exist –
+      // e.g., when `<dirname>` is `entities`: https://github.com/appsmithorg/appsmith/pull/20964#discussion_r1124782356
       plugin: {
-        // Prioritize the local src directory over node_modules.
-        // This matters for cases where `src/<dirname>` and `node_modules/<dirname>` both exist –
-        // e.g., when `<dirname>` is `entities`: https://github.com/appsmithorg/appsmith/pull/20964#discussion_r1124782356
         overrideWebpackConfig: ({ webpackConfig }) => {
           webpackConfig.resolve.modules = [
             path.resolve(__dirname, "src"),
             ...webpackConfig.resolve.modules,
           ];
+          return webpackConfig;
+        },
+      },
+    },
+    // Emit dedicated HTML files for edit and view modes. This is done as an optimization (to preload
+    // route-specific chunks on the most critical routes) and doesn’t affect the actual app behavior.
+    {
+      plugin: {
+        overrideWebpackConfig: ({ webpackConfig }) => {
+          const htmlWebpackPlugin = webpackConfig.plugins.find(
+            (plugin) => plugin.constructor.name === "HtmlWebpackPlugin",
+          );
+
+          // CRA must include HtmlWebpackPlugin: https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-scripts/config/webpack.config.js#L608-L632
+          // If it doesn’t, perhaps the version of CRA has changed, or plugin names got mangled?
+          assert(
+            htmlWebpackPlugin,
+            "Cannot find HtmlWebpackPlugin in webpack config",
+          );
+
+          // HtmlWebpackPlugin must have the userOptions field: https://github.com/jantimon/html-webpack-plugin/blob/d5ce5a8f2d12a2450a65ec51c285dd54e36cd921/index.js#L34.
+          // If it doesn’t, perhaps the version of HtmlWebpackPlugin has changed?
+          assert(
+            htmlWebpackPlugin.userOptions,
+            "htmlWebpackPlugin.userOptions must be defined",
+          );
+
+          // Instead of requiring HtmlWebpackPlugin directly, use the same version that CRA uses
+          const HtmlWebpackPlugin = htmlWebpackPlugin.constructor;
+
+          const htmlWebpackPluginForEditMode = new HtmlWebpackPlugin({
+            ...htmlWebpackPlugin.userOptions,
+            filename: "edit.html",
+            // This option isn’t used by HtmlWebpackPlugin itself – instead, it’s passed to
+            // our custom template
+            appsmithHtmlTarget: "edit-mode",
+          });
+          const htmlWebpackPluginForViewMode = new HtmlWebpackPlugin({
+            ...htmlWebpackPlugin.userOptions,
+            filename: "view.html",
+            // This option isn’t used by HtmlWebpackPlugin itself – instead, it’s passed to
+            // our custom template
+            appsmithHtmlTarget: "view-mode",
+          });
+
+          webpackConfig.plugins.push(
+            htmlWebpackPluginForEditMode,
+            htmlWebpackPluginForViewMode,
+          );
+
           return webpackConfig;
         },
       },

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Performance/LinkRelPreload_Spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Performance/LinkRelPreload_Spec.js
@@ -1,0 +1,92 @@
+import emptyDSL from "../../../../fixtures/emptyDSL.json";
+
+// Hi, developer!
+//
+// To make Appsmith load faster, we code-split away some routes. (For example, if a user visits
+// the view mode, it doesn’t need to load code for the edit mode, right?)
+//
+// This works very well to reduce the bundle size. However, it also makes some routes load slower.
+// E.g., when you open an edit mode link (like https://dev.appsmith.com/app/142f9a81/page1-6424e6eafeaa7e0199eb1938/edit),
+// edit mode chunks don’t start loading until the main bundle loads. This creates a network waterfall:
+//   [main bundle]
+//                [edit mode chunk 1]
+//                [edit mode chunk 2]
+//                [edit mode chunk 3]
+//                                   [app is rendered]
+//
+// To avoid the waterfall, we emit <link rel="preload"> tags for all code-split chunks that
+// an empty editor or an empty published app loads. This turns the above waterfall into this:
+//   [main bundle]
+//   [edit mode chunk 1]
+//   [edit mode chunk 2]
+//   [edit mode chunk 3]
+//                      [app is rendered]
+//
+// This test exists to ensure that all code-split chunks are <link rel="preload">ed. If this test
+// started failing for you, it’s likely you import()ed some new chunks that the edit or the view mode uses.
+// To fix the test, see preloading instructions in public/index.html.
+
+describe("html should include <link rel='preload'>s for all code-split javascript", function () {
+  before(() => {
+    cy.addDsl(emptyDSL);
+  });
+
+  it("in edit mode", function () {
+    testLinkRelPreloads();
+  });
+
+  it("in view mode", function () {
+    cy.PublishtheApp();
+
+    testLinkRelPreloads();
+  });
+});
+
+function testLinkRelPreloads() {
+  const jsRequests = [];
+
+  // Intercept all JS network requests and collect them
+  cy.intercept("/static/js/*.js", (req) => {
+    // Ignore
+    // - requests to worker files
+    // - requests to icons
+    // - request to the main bundle
+    // as those aren’t <link rel="preload">ed by design
+    if (
+      req.url.includes("Worker.") ||
+      req.url.includes("/icon.") ||
+      req.url.includes("/main.")
+    ) {
+      return;
+    }
+    jsRequests.push(req.url);
+  }).as("jsRequests");
+
+  // Make all web workers empty. This prevents web workers from loading additional chunks,
+  // as we need to collect only chunks from the main thread
+  cy.intercept("/static/js/*Worker.*.js", { body: "" }).as("workerRequests");
+
+  cy.reload();
+
+  cy.waitForNetworkIdle("/static/js/*.js", 5000, { timeout: 60 * 1000 });
+
+  cy.document().then((document) => {
+    const links = [
+      ...document.querySelectorAll("link[rel=preload][as=script]"),
+    ].map((link) => link.href);
+
+    const uniqueRequests = [...new Set(jsRequests)];
+    const requestsString = `[${uniqueRequests.length} items] ${uniqueRequests
+      .sort()
+      .join(", ")}`;
+
+    const uniqueLinks = [...new Set(links)];
+    const linksString = `[${uniqueLinks.length} items] ${uniqueLinks
+      .sort()
+      .join(", ")}`;
+
+    // Comparing strings instead of deep-qualling arrays because this is the only way
+    // to see which chunks are actually missing: https://github.com/cypress-io/cypress/issues/4084
+    cy.wrap(requestsString).should("equal", linksString);
+  });
+}

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -16,6 +16,7 @@
 
 import "cypress-real-events/support";
 import "cypress-wait-until";
+import "cypress-network-idle";
 import "cypress-xpath";
 import * as MESSAGES from "../../../client/src/ce/constants/messages.ts";
 import "./ApiCommands";

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -263,6 +263,7 @@
     "cypress-file-upload": "^4.1.1",
     "cypress-image-snapshot": "^4.0.1",
     "cypress-multi-reporters": "^1.2.4",
+    "cypress-network-idle": "^1.14.2",
     "cypress-real-events": "^1.7.1",
     "cypress-wait-until": "^1.7.2",
     "cypress-xpath": "^1.4.0",

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -17,7 +17,12 @@
   </style>
   <%=
     (function () {
-      // Emit additional `link rel="preload"` tags for the edit mode and the view mode
+      // This code emits additional `link rel="preload"` tags for edit.html and view.html.
+      // This helps to load edit and view modes faster.
+      //
+      // If you code-split some code and need to preload it as well, here’s how to do that:
+      //  1) Give your import a name (use the `webpackChunkName` comment: `import(/* webpackChunkName: "my-name" */ "./my-file")`)
+      //  2) Add the name into the `chunksToPreload` array below
       let chunksToPreload = [];
       if (htmlWebpackPlugin.options.appsmithHtmlTarget === 'edit-mode') {
         chunksToPreload = [

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -145,7 +145,14 @@
     });
 
     const registerPageServiceWorker = () => {
-      if ("serviceWorker" in navigator) {
+      if (
+        "serviceWorker" in navigator
+        // Disable the service worker in Cypress tests. We primarily do this to make
+        // the Performance/LinkRelPreload_Spec.js test work (as it collects URLs all network requests,
+        // and service worker requests fail it.) But, anecdotally, disabling the service worker
+        // also seems to make the tests a bit faster, as the network load is lower.
+        && !window.Cypress
+      ) {
         window.addEventListener("load", function () {
           navigator.serviceWorker.register("/pageService.js").catch(error => {
             console.error("Service Worker Registration failed: " + error);

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -15,6 +15,34 @@
       transition: all ease-in 0.3s;
     }
   </style>
+  <%=
+    (function () {
+      // Emit additional `link rel="preload"` tags for the edit mode and the view mode
+      let chunksToPreload = [];
+      if (htmlWebpackPlugin.options.appsmithHtmlTarget === 'edit-mode') {
+        chunksToPreload = [
+          ...compilation.namedChunkGroups.get("editor").chunks,
+          ...compilation.namedChunkGroups.get("global-search").chunks,
+        ]
+      } else if (htmlWebpackPlugin.options.appsmithHtmlTarget === 'view-mode') {
+        chunksToPreload = [...compilation.namedChunkGroups.get("AppViewer").chunks]
+      }
+
+      return chunksToPreload.flatMap(i => [...i.files])
+        .map(url => `<link rel="preload" as="${getPreloadValueForFile(url)}" href="${webpackConfig.output.publicPath + url}" />`)
+        .join('\n')
+
+      function getPreloadValueForFile(fileName) {
+        if (fileName.endsWith('.js')) {
+          return 'script';
+        } else if (fileName.endsWith('.css')) {
+          return 'style';
+        }
+
+        throw new Error(`Unknown preload type for file: ${fileName}`);
+      }
+    })()
+  %>
   <script>
     // '' (empty strings), 'false' are falsy
     // could return either boolean or string based on value

--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -250,7 +250,12 @@ type EditorHeaderProps = {
 };
 
 const GlobalSearch = lazy(() => {
-  return retryPromise(() => import("components/editorComponents/GlobalSearch"));
+  return retryPromise(
+    () =>
+      import(
+        /* webpackChunkName: "global-search" */ "components/editorComponents/GlobalSearch"
+      ),
+  );
 });
 
 export function ShareButtonComponent() {

--- a/app/client/src/widgets/ChartWidget/widget/index.tsx
+++ b/app/client/src/widgets/ChartWidget/widget/index.tsx
@@ -19,12 +19,7 @@ import { Colors } from "constants/Colors";
 import type { Stylesheet } from "entities/AppTheming";
 
 const ChartComponent = lazy(() =>
-  retryPromise(
-    () =>
-      import(
-        /* webpackPrefetch: true, webpackChunkName: "charts" */ "../component"
-      ),
-  ),
+  retryPromise(() => import(/* webpackChunkName: "charts" */ "../component")),
 );
 
 class ChartWidget extends BaseWidget<ChartWidgetProps, WidgetState> {

--- a/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
+++ b/app/client/src/widgets/RichTextEditorWidget/widget/index.tsx
@@ -21,10 +21,7 @@ export enum RTEFormats {
   HTML = "html",
 }
 const RichTextEditorComponent = lazy(() =>
-  retryPromise(
-    () =>
-      import(/* webpackChunkName: "rte",webpackPrefetch: 2 */ "../component"),
-  ),
+  retryPromise(() => import(/* webpackChunkName: "rte" */ "../component")),
 );
 
 const converter = new showdown.Converter();

--- a/app/client/webpack/IconChunkNamingPlugin.js
+++ b/app/client/webpack/IconChunkNamingPlugin.js
@@ -1,0 +1,51 @@
+/**
+ * We use `importSvg()` and `importRemixIcon()` utilities to code-split icons away.
+ * This plugin renames the chunks that contain these icons from
+ *   35140.dfd465bd.chunk.js
+ * to
+ *   icon.dfd465bd.chunk.js
+ * to make it easier to filter them out in the network tab.
+ *
+ * Why do it here and not in `chunkFilename`, as canonically intended? Because
+ * we have lots of icons, and, as of Mar 2023, V8 (the JS engine in Chrome)
+ * can’t handle that: https://bugs.chromium.org/p/v8/issues/detail?id=13887
+ */
+class IconChunkNamingPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap(
+      "IconChunkNamingPlugin",
+      (compilation) => {
+        compilation.hooks.afterOptimizeChunks.tap(
+          "IconChunkNamingPlugin",
+          (chunks) => {
+            const { chunkGraph } = compilation;
+
+            // Walk over all chunks webpack emits
+            for (const chunk of chunks) {
+              // Get all modules in the current chunk
+              const chunkModules = chunkGraph.getChunkModules(chunk);
+
+              // Only if the chunk has exactly one module...
+              const hasOnlyOneModule = chunkModules.length === 1;
+              if (!hasOnlyOneModule) continue;
+
+              // ...and that module is either a SVG icon or a Remix icon...
+              const modulePath = chunkModules[0].resource;
+              const isSvgIcon =
+                modulePath.endsWith(".svg.js") || modulePath.endsWith(".svg");
+              const isRemixIcon = modulePath.match(
+                /node_modules[\\\/]remixicon-react[\\\/]/,
+              );
+              if (!isSvgIcon && !isRemixIcon) continue;
+
+              // ...then rename the chunk to "icon"
+              chunk.name = "icon";
+            }
+          },
+        );
+      },
+    );
+  }
+}
+
+module.exports = IconChunkNamingPlugin;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -8448,6 +8448,7 @@ __metadata:
     cypress-image-snapshot: ^4.0.1
     cypress-log-to-output: ^1.1.2
     cypress-multi-reporters: ^1.2.4
+    cypress-network-idle: ^1.14.2
     cypress-real-events: ^1.7.1
     cypress-wait-until: ^1.7.2
     cypress-xpath: ^1.4.0
@@ -11693,6 +11694,13 @@ __metadata:
   peerDependencies:
     mocha: ">=3.1.2"
   checksum: 9bcc63f1bafa991d9eecca54bfc7bae8b564b73a7b28b48a5c3d75c297b3d661254ae2e803f4d8b7f9a0428a5258d416437fdf68729730b1acceb8533f582c4d
+  languageName: node
+  linkType: hard
+
+"cypress-network-idle@npm:^1.14.2":
+  version: 1.14.2
+  resolution: "cypress-network-idle@npm:1.14.2"
+  checksum: 3f4780a38713ac3b6a07d5a6f0bb524c336a88b82020e323c09ab745a22031c345556bfea34043e30e2a89a147ca14ebe2f950ffa43362150a385a9314eb1829
   languageName: node
   linkType: hard
 
@@ -29147,8 +29155,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^7.4.6":
-  version: 7.5.8
-  resolution: "ws@npm:7.5.8"
+  version: 7.5.9
+  resolution: "ws@npm:7.5.9"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -29157,7 +29165,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 49479ccf3ddab6500c5906fbcc316e9c8cd44b0ffb3903a6c1caf9b38cb9e06691685722a4c642cfa7d4c6eb390424fc3142cd4f8b940cfc7a9ce9761b1cd65b
+  checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR implements route preloading for edit and view modes. In my tests on an emulated 4G connection, this makes edit and view modes load 1-1.5s sooner¹:

<img width="1032" alt="Screenshot 2023-03-30 at 01 20 44" src="https://user-images.githubusercontent.com/2953267/228952203-2d401172-ae7c-4780-b38d-31b40a63b487.png">

_↑ Edit mode. (Each line is a separate test run. `es5` is the `bundle-optimization` build, `es5-preload` is this branch’s build. `spinnerRender` is time until the spinner became visible; `fmp` is time until widgets became visible._

<img width="1032" alt="Screenshot 2023-03-30 at 01 25 45" src="https://user-images.githubusercontent.com/2953267/228952208-30c3b703-bd6b-44e7-971c-e2fa1cbf528a.png">

_↑ View mode_

_¹ — Unfortunately, a large chunk of the delay is slow waterfalling API responses which I can’t control (but Appsmith is working on separately). Hence, while the absolute improvement is big, the relative one is small._

### How this works

- During the build time, we now emit two new files (`build/edit.html` and `build/view.html`). These files are identical to `build/index.html`, with the only difference – they include additional `<link rel="preload">` tags:

   ```html
   <link rel="preload" as="script" href="/static/js/20204.4e1d68a3.chunk.js" />
  <link rel="preload" as="script" href="/static/js/85342.2ee5493d.chunk.js" />
  <link rel="preload" as="script" href="/static/js/69141.80219ba3.chunk.js" />
  <link rel="preload" as="style" href="/static/css/92067.2c8c92d5.chunk.css" />
  <link rel="preload" as="script" href="/static/js/92067.02797c81.chunk.js" />
  <link rel="preload" as="script" href="/static/js/79624.63f1a5a9.chunk.js" />
  <link rel="preload" as="script" href="/static/js/54102.1274415f.chunk.js" />
  <link rel="preload" as="script" href="/static/js/29549.e40bd2ec.chunk.js" />
  <link rel="preload" as="script" href="/static/js/47128.6dea5b2b.chunk.js" />
  <link rel="preload" as="script" href="/static/js/7207.8709ca68.chunk.js" />
  <link rel="preload" as="script" href="/static/js/39427.3928a9cf.chunk.js" />
  <link rel="preload" as="script" href="/static/js/99662.8131f01c.chunk.js" />
  <link rel="preload" as="script" href="/static/js/editor.3b1b5510.chunk.js" />
  <link rel="preload" as="script" href="/static/js/69141.80219ba3.chunk.js" />
  <link rel="preload" as="script" href="/static/js/75280.41f43bef.chunk.js" />
  <link rel="preload" as="script" href="/static/js/47128.6dea5b2b.chunk.js" />
  <link rel="preload" as="script" href="/static/js/global-search.701a10f6.chunk.js" />
  ```

- The URLs for these tags are taken from webpack compilation stats. There’s no magic – I just checked which `import()`s each page relies on, gave every import a name, and then picked chunks generated by these imports:

  https://github.com/appsmithorg/appsmith/blob/d880f6a1b3cceff109d3ae6b5a99c845f6306789/app/client/public/index.html#L26-L34

- In the future, the edit and view modes might start relying on more `import()`s. To make sure we don’t forget to update the template, I set up a Cypress test that loads the page, tracks all loaded JS files, and ensures they are all present in `<link rel="preload">`s:

  https://github.com/appsmithorg/appsmith/blob/d880f6a1b3cceff109d3ae6b5a99c845f6306789/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Performance/LinkRelPreload_Spec.js#L46-L91

### Why this is needed

To make Appsmith load faster, we code-split away some routes. (For example, if a user visits the view mode, it doesn’t need to load code for the edit mode, right?)

This works very well to reduce the bundle size. However, it also makes some routes load slower. E.g., when you open an edit mode link (like https://dev.appsmith.com/app/142f9a81/page1-6424e6eafeaa7e0199eb1938/edit), edit mode chunks don’t start loading until the main bundle loads. This creates a network waterfall:

```
[main bundle]
             [edit mode chunk 1]
             [edit mode chunk 2]
             [edit mode chunk 3]
                                [app is rendered]
```

To avoid the waterfall, we emit `<link rel="preload">` tags for all code-split chunks that an empty editor or an empty published app loads. This turns the above waterfall into this:

```
[main bundle]
[edit mode chunk 1]
[edit mode chunk 2]
[edit mode chunk 3]
                   [app is rendered]
```
 

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)



## How Has This Been Tested?

- Manual
- Cypress (note that Cypress tests won’t work without “Remaining changes” above)

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
