### PR TITLE
ci: Remove license in ci-test.yml

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -128,8 +128,6 @@ jobs:
 
       - name: Create folder
         if: steps.run_result.outputs.run_result != 'success'
-        env:
-          APPSMITH_LICENSE_KEY: ${{ secrets.APPSMITH_LICENSE_KEY }}
         working-directory: "."
         run: |
           mkdir -p cicontainerlocal/stacks/configuration/
@@ -146,8 +144,6 @@ jobs:
 
       - name: Run Appsmith & TED docker image
         if: steps.run_result.outputs.run_result != 'success'
-        env:
-          APPSMITH_LICENSE_KEY: ${{ secrets.APPSMITH_LICENSE_KEY }}
         working-directory: "."
         run: |
           sudo /etc/init.d/ssh stop ;
@@ -158,7 +154,7 @@ jobs:
           -v ~/git-server/repos:/git-server/repos  appsmith/test-event-driver:latest
           cd cicontainerlocal
           docker run -d --name appsmith -p 80:80 -p 9001:9001 \
-            -v "$PWD/stacks:/appsmith-stacks" -e APPSMITH_LICENSE_KEY=$APPSMITH_LICENSE_KEY \
+            -v "$PWD/stacks:/appsmith-stacks" \
             -e APPSMITH_DISABLE_TELEMETRY=true \
             -e APPSMITH_CLOUD_SERVICES_BASE_URL=http://host.docker.internal:5001 \
             --add-host=host.docker.internal:host-gateway --add-host=api.segment.io:host-gateway --add-host=t.appsmith.com:host-gateway \


### PR DESCRIPTION
The License key is unused in this repo. Setting it here is misleading, and can cause confusions at best, or missed accidental License failures at worst.

This PR removes the License key occurrences from `ci-test.yml`.

Note: Please review/approve only. Don't merge. This will likely cause a conflict, so I'd like to be available when this is merged so I can resolve the conflict. Thanks!