### PR TITLE
fix: Entity Explorer test case

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
@@ -102,6 +102,8 @@ describe("Entity explorer tests related to query and datasource", function () {
     ee.ActionContextMenuByEntityName("Query1", "Edit Name");
     cy.EditApiNameFromExplorer("MyQuery");
     ee.ActionContextMenuByEntityName("MyQuery", "Move to page", pageid);
+    cy.wait(2000);
+    ee.ExpandCollapseEntity("Queries/JS");
     ee.SelectEntityByName("MyQuery");
     cy.wait(2000);
     cy.runQuery();

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
@@ -102,6 +102,7 @@ describe("Entity explorer tests related to query and datasource", function () {
     ee.ActionContextMenuByEntityName("Query1", "Edit Name");
     cy.EditApiNameFromExplorer("MyQuery");
     ee.ActionContextMenuByEntityName("MyQuery", "Move to page", pageid);
+    cy.CheckAndUnfoldEntityItem("Queries/JS");
     ee.SelectEntityByName("MyQuery");
     cy.wait(2000);
     cy.runQuery();

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ExplorerTests/Entity_Explorer_Query_Datasource_spec.js
@@ -102,7 +102,6 @@ describe("Entity explorer tests related to query and datasource", function () {
     ee.ActionContextMenuByEntityName("Query1", "Edit Name");
     cy.EditApiNameFromExplorer("MyQuery");
     ee.ActionContextMenuByEntityName("MyQuery", "Move to page", pageid);
-    cy.CheckAndUnfoldEntityItem("Queries/JS");
     ee.SelectEntityByName("MyQuery");
     cy.wait(2000);
     cy.runQuery();

--- a/app/client/cypress/integration/Regression_TestSuite/ServerSideTests/ApiTests/API_ContextMenu_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ServerSideTests/ApiTests/API_ContextMenu_spec.js
@@ -22,6 +22,7 @@ describe("API Panel Test Functionality ", function () {
     cy.get("body").click(0, 0);
     ee.ActionContextMenuByEntityName("FirstAPICopy", "Move to page", "Page1");
     cy.wait(2000);
+    ee.ExpandCollapseEntity("Queries/JS");
     cy.get(".t--entity-name").contains("FirstAPICopy").click({ force: true });
     cy.get(apiwidget.resourceUrl).should("contain.text", "{{ '/random' }}");
   });

--- a/app/client/src/reducers/uiReducers/editorContextReducer.ts
+++ b/app/client/src/reducers/uiReducers/editorContextReducer.ts
@@ -192,9 +192,6 @@ export const editorContextReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.CREATE_ACTION_SUCCESS]: (state: EditorContextState) => {
     state.entityCollapsibleFields[entitySections["Queries/JS"]] = true;
   },
-  [ReduxActionTypes.MOVE_ACTION_SUCCESS]: (state: EditorContextState) => {
-    state.entityCollapsibleFields[entitySections["Queries/JS"]] = true;
-  },
   [ReduxActionTypes.CREATE_JS_ACTION_SUCCESS]: (state: EditorContextState) => {
     state.entityCollapsibleFields[entitySections["Queries/JS"]] = true;
   },

--- a/app/client/src/reducers/uiReducers/editorContextReducer.ts
+++ b/app/client/src/reducers/uiReducers/editorContextReducer.ts
@@ -192,6 +192,9 @@ export const editorContextReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.CREATE_ACTION_SUCCESS]: (state: EditorContextState) => {
     state.entityCollapsibleFields[entitySections["Queries/JS"]] = true;
   },
+  [ReduxActionTypes.MOVE_ACTION_SUCCESS]: (state: EditorContextState) => {
+    state.entityCollapsibleFields[entitySections["Queries/JS"]] = true;
+  },
   [ReduxActionTypes.CREATE_JS_ACTION_SUCCESS]: (state: EditorContextState) => {
     state.entityCollapsibleFields[entitySections["Queries/JS"]] = true;
   },


### PR DESCRIPTION
## Description

Fix test case failing because of changes in https://github.com/appsmithorg/appsmith/pull/21789
It caused failures in tests that had a move of action involved.
This change will update the test cases to open the entity collapsible section after a move of action

> Fix failing test case


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
