### PR TITLE
fix: Changed SMTP placeholder for SMTP plugin (#21458)

### DIFF
--- a/app/server/appsmith-plugins/smtpPlugin/src/main/resources/editor/send.json
+++ b/app/server/appsmith-plugins/smtpPlugin/src/main/resources/editor/send.json
@@ -73,7 +73,7 @@
           "configProperty": "actionConfiguration.formData.send.attachments",
           "controlType": "QUERY_DYNAMIC_TEXT",
           "evaluationSubstitutionType": "TEMPLATE",
-          "placeholderText": "{{Filepicker.files[0]}}"
+          "placeholderText": "{{Filepicker.files}}"
         }
       ]
     }


### PR DESCRIPTION
## Description
Fixed the attachment placeholder for a query created on SMTP datasource

Fixes #21458 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

For sending email with attachments, tested `{{FilePicker.files}}` and `{{[FilePicker.files[0]]}}`, both works successfully but `{{FilePicker.files[0]}}`

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
