### PR TITLE
fix: Firestore Invalid DS Test Success

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -904,7 +904,7 @@ public class FirestorePlugin extends BasePlugin {
                         try {
                             return FirebaseApp.getInstance(projectId);
                         } catch (IllegalStateException e) {
-                            return FirebaseApp.initializeApp(options,projectId);
+                            return FirebaseApp.initializeApp(options, projectId);
                         }
                     })
                     .map(FirestoreClient::getFirestore)
@@ -919,9 +919,17 @@ public class FirestorePlugin extends BasePlugin {
                         try {
                             connection.listCollections();
                         } catch (FirestoreException e){
-                            log.debug("Invalid datasource configuration : {}",e.getMessage());
+                            log.debug("Invalid datasource configuration : {}", e.getMessage());
+                            if(e.getMessage().contains("Metadata operations require admin authentication")){
+                                String metaDataAccessMissingMessage = "Unable to validate ProjectID, provided service " +
+                                        "account doesn't has access to metadata";
+                                DatasourceTestResult datasourceTestResult = new DatasourceTestResult();
+                                datasourceTestResult.setMessages(new HashSet<>(Collections.singletonList(
+                                        metaDataAccessMissingMessage)));
+                                return Mono.just(datasourceTestResult);
+                            }
                             return Mono.just(new DatasourceTestResult(FirestoreErrorMessages.
-                                    DS_VALIDATION_FAILED_FOR_PROJECT_ID));
+                                    DS_CONNECTION_FAILED_FOR_PROJECT_ID));
                         }
                         return Mono.just(new DatasourceTestResult());
                     });

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/FirestorePlugin.java
@@ -921,11 +921,9 @@ public class FirestorePlugin extends BasePlugin {
                         } catch (FirestoreException e){
                             log.debug("Invalid datasource configuration : {}", e.getMessage());
                             if(e.getMessage().contains("Metadata operations require admin authentication")){
-                                String metaDataAccessMissingMessage = "Unable to validate ProjectID, provided service " +
-                                        "account doesn't has access to metadata";
                                 DatasourceTestResult datasourceTestResult = new DatasourceTestResult();
                                 datasourceTestResult.setMessages(new HashSet<>(Collections.singletonList(
-                                        metaDataAccessMissingMessage)));
+                                        FirestoreErrorMessages.META_DATA_ACCESS_MISSING_MESSAGE)));
                                 return Mono.just(datasourceTestResult);
                             }
                             return Mono.just(new DatasourceTestResult(FirestoreErrorMessages.

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
@@ -58,6 +58,9 @@ public class FirestoreErrorMessages {
 
     public static final String WHERE_CONDITION_UNPARSABLE_AS_JSON_LIST_ERROR_MSG = "Unable to parse condition value as a JSON list.";
 
+    public static final String DS_CONNECTION_FAILED_FOR_PROJECT_ID = "Unable to connect to the database, No database found for the given ProjectID.";
+
+
     /*
      ************************************************************************************************************************************************
                                         Error messages related to validation of datasource.
@@ -66,8 +69,6 @@ public class FirestoreErrorMessages {
 
     public static final String DS_VALIDATION_FAILED_FOR_SERVICE_ACC_CREDENTIALS_ERROR_MSG = "Validation failed for field 'Service Account Credentials'. Please check the " +
             "value provided in the 'Service Account Credentials' field.";
-
-    public static final String DS_VALIDATION_FAILED_FOR_PROJECT_ID = "Invalid project id, no database found for given project id";
     public static final String DS_MISSING_PROJECT_ID_AND_CLIENTJSON_ERROR_MSG = "Missing ProjectID and ClientJSON in datasource.";
 
     public static final String DS_MISSING_PROJECT_ID_ERROR_MSG = "Missing ProjectID in datasource.";

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
@@ -58,7 +58,7 @@ public class FirestoreErrorMessages {
 
     public static final String WHERE_CONDITION_UNPARSABLE_AS_JSON_LIST_ERROR_MSG = "Unable to parse condition value as a JSON list.";
 
-    public static final String DS_CONNECTION_FAILED_FOR_PROJECT_ID = "Unable to connect to the database, No database found for the given ProjectID.";
+    public static final String DS_CONNECTION_FAILED_FOR_PROJECT_ID = "Unable to connect to the Firestore project. No project found for the given ProjectID.";
 
     /*
      ************************************************************************************************************************************************

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
@@ -67,6 +67,7 @@ public class FirestoreErrorMessages {
     public static final String DS_VALIDATION_FAILED_FOR_SERVICE_ACC_CREDENTIALS_ERROR_MSG = "Validation failed for field 'Service Account Credentials'. Please check the " +
             "value provided in the 'Service Account Credentials' field.";
 
+    public static final String DS_VALIDATION_FAILED_FOR_PROJECT_ID = "Invalid project id, no database found for given project id";
     public static final String DS_MISSING_PROJECT_ID_AND_CLIENTJSON_ERROR_MSG = "Missing ProjectID and ClientJSON in datasource.";
 
     public static final String DS_MISSING_PROJECT_ID_ERROR_MSG = "Missing ProjectID in datasource.";

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/java/com/external/plugins/exceptions/FirestoreErrorMessages.java
@@ -60,7 +60,6 @@ public class FirestoreErrorMessages {
 
     public static final String DS_CONNECTION_FAILED_FOR_PROJECT_ID = "Unable to connect to the database, No database found for the given ProjectID.";
 
-
     /*
      ************************************************************************************************************************************************
                                         Error messages related to validation of datasource.
@@ -76,4 +75,13 @@ public class FirestoreErrorMessages {
     public static final String DS_MISSING_CLIENTJSON_ERROR_MSG = "Missing ClientJSON in datasource.";
 
     public static final String DS_MISSING_FIRESTORE_URL_ERROR_MSG = "Missing Firestore URL.";
+
+    /*
+     ************************************************************************************************************************************************
+                                        Warning messages related to datasource.
+     ************************************************************************************************************************************************
+     */
+    public static final String META_DATA_ACCESS_MISSING_MESSAGE = "Hi, it seems that the credentials provided here " +
+            "don't have the permission to gather metadata information. Please reach out to your database admin " +
+            "to understand more. ";
 }

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -28,6 +28,10 @@ import com.google.cloud.firestore.FieldValue;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.GeoPoint;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.cloud.FirestoreClient;
+import com.google.firebase.internal.EmulatorCredentials;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -629,7 +633,7 @@ public class FirestorePluginTest {
     }
 
     @Test
-    public void testTestDatasource_withCorrectCredentials_returnsWithoutInvalids() {
+    public void testDatasource_withCorrectCredentials_returnsWithoutInvalids() {
 
         FirestorePlugin.FirestorePluginExecutor spyExecutor = Mockito.spy(pluginExecutor);
 
@@ -646,17 +650,39 @@ public class FirestorePluginTest {
     }
 
     @Test
-    public void testTestDatasource_withInvalidProjectId() {
+    public void testDatasource_withValidProjectId_WithoutMetaDataAccess() {
 
+        //This test validates the Firestore connection, not the ProjectId given by the user
         FirestorePlugin.FirestorePluginExecutor spyExecutor = Mockito.spy(pluginExecutor);
-        Firestore firestoreConnection1 = FirestoreOptions.newBuilder()
-                .setHost(emulator.getEmulatorEndpoint())
-                .setCredentials(NoCredentials.getInstance())
-                .setRetrySettings(ServiceOptions.getNoRetrySettings())
+        Mockito.when(spyExecutor.datasourceCreate(dsConfig)).thenReturn(Mono.just(firestoreConnection));
+        final Mono<DatasourceTestResult> testDatasourceMono = spyExecutor.testDatasource(dsConfig);
+
+        StepVerifier.create(testDatasourceMono)
+                .assertNext(datasourceTestResult -> {
+                    assertNotNull(datasourceTestResult);
+                    assertTrue(datasourceTestResult.isSuccess());
+                    assertTrue(datasourceTestResult.getInvalids().isEmpty());
+                    assertFalse(datasourceTestResult.getMessages().isEmpty());
+                    assertTrue(datasourceTestResult.getMessages().stream().anyMatch(s -> s.equals("Unable to validate " +
+                            "ProjectID, provided service account doesn't has access to metadata")));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void testDatasource_withInvalidProjectId_WithMetaDataAccess() {
+
+        //This validates firestore connection and the ProjectId given by the user
+        FirestorePlugin.FirestorePluginExecutor spyExecutor = Mockito.spy(pluginExecutor);
+
+        FirebaseOptions firebaseOptions = FirebaseOptions.builder()
                 .setProjectId("test-project-invalid")
-                .build()
-                .getService();
-        Mockito.when(spyExecutor.datasourceCreate(dsConfig)).thenReturn(Mono.just(firestoreConnection1));
+                .setDatabaseUrl(emulator.getEmulatorEndpoint())
+                .setCredentials(new EmulatorCredentials())
+                .build();
+        FirebaseApp.initializeApp(firebaseOptions);
+        Firestore firestore = FirestoreClient.getFirestore();
+        Mockito.when(spyExecutor.datasourceCreate(dsConfig)).thenReturn(Mono.just(firestore));
         final Mono<DatasourceTestResult> testDatasourceMono = spyExecutor.testDatasource(dsConfig);
 
         StepVerifier.create(testDatasourceMono)
@@ -664,6 +690,8 @@ public class FirestorePluginTest {
                     assertNotNull(datasourceTestResult);
                     assertFalse(datasourceTestResult.isSuccess());
                     assertFalse(datasourceTestResult.getInvalids().isEmpty());
+                    assertTrue(datasourceTestResult.getInvalids().stream().anyMatch(s -> s.equals(
+                            FirestoreErrorMessages.DS_CONNECTION_FAILED_FOR_PROJECT_ID)));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -663,8 +663,8 @@ public class FirestorePluginTest {
                     assertTrue(datasourceTestResult.isSuccess());
                     assertTrue(datasourceTestResult.getInvalids().isEmpty());
                     assertFalse(datasourceTestResult.getMessages().isEmpty());
-                    assertTrue(datasourceTestResult.getMessages().stream().anyMatch(s -> s.equals("Unable to validate " +
-                            "ProjectID, provided service account doesn't has access to metadata")));
+                    assertTrue(datasourceTestResult.getMessages().stream().anyMatch(s -> s.equals(FirestoreErrorMessages
+                            .META_DATA_ACCESS_MISSING_MESSAGE)));
                 })
                 .verifyComplete();
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -646,6 +646,29 @@ public class FirestorePluginTest {
     }
 
     @Test
+    public void testTestDatasource_withInvalidProjectId() {
+
+        FirestorePlugin.FirestorePluginExecutor spyExecutor = Mockito.spy(pluginExecutor);
+        Firestore firestoreConnection1 = FirestoreOptions.newBuilder()
+                .setHost(emulator.getEmulatorEndpoint())
+                .setCredentials(NoCredentials.getInstance())
+                .setRetrySettings(ServiceOptions.getNoRetrySettings())
+                .setProjectId("test-project-invalid")
+                .build()
+                .getService();
+        Mockito.when(spyExecutor.datasourceCreate(dsConfig)).thenReturn(Mono.just(firestoreConnection1));
+        final Mono<DatasourceTestResult> testDatasourceMono = spyExecutor.testDatasource(dsConfig);
+
+        StepVerifier.create(testDatasourceMono)
+                .assertNext(datasourceTestResult -> {
+                    assertNotNull(datasourceTestResult);
+                    assertFalse(datasourceTestResult.isSuccess());
+                    assertFalse(datasourceTestResult.getInvalids().isEmpty());
+                })
+                .verifyComplete();
+    }
+
+    @Test
     public void testGetDocumentsInCollectionOrdering() {
         ActionConfiguration actionConfiguration = new ActionConfiguration();
 

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -674,7 +674,8 @@ public class FirestorePluginTest {
 
         //This validates firestore connection and the ProjectId given by the user
         FirestorePlugin.FirestorePluginExecutor spyExecutor = Mockito.spy(pluginExecutor);
-
+        //We cannot use the datasource create flow here as the client authentication json in unknown. Hence, using the
+        //default emulator credentials
         FirebaseOptions firebaseOptions = FirebaseOptions.builder()
                 .setProjectId("test-project-invalid")
                 .setDatabaseUrl(emulator.getEmulatorEndpoint())

--- a/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
+++ b/app/server/appsmith-plugins/firestorePlugin/src/test/java/com/external/plugins/FirestorePluginTest.java
@@ -674,7 +674,7 @@ public class FirestorePluginTest {
 
         //This validates firestore connection and the ProjectId given by the user
         FirestorePlugin.FirestorePluginExecutor spyExecutor = Mockito.spy(pluginExecutor);
-        //We cannot use the datasource create flow here as the client authentication json in unknown. Hence, using the
+        //We cannot use the datasource create flow here as the client authentication json is unknown. Hence, using the
         //default emulator credentials
         FirebaseOptions firebaseOptions = FirebaseOptions.builder()
                 .setProjectId("test-project-invalid")


### PR DESCRIPTION
## Description

- The following PR fixes the issue where the firestore test data source was returning success even after providing an invalid project id.
- The PR address the invalid project id only not the db URL as it is fetched from the auth json If the URL is invalid in user provided entry. Also, the value is mutable at runtime from the firestore side.
-  For more detailed description of the following can be found in the notion doc here: https://www.notion.so/Firestore-c3f5c816a68a45b18395da74be97d666

Fixes #21373 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual
- JUnit

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
