### PR TITLE
chore: Removed server url from start-https command in ClientSetup

### DIFF
--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -64,6 +64,11 @@ sudo mv mkcert /usr/local/bin
    cd app/client
    ./start-https.sh
    ```
+   
+   Note:
+
+   - If you have the Server setup and running on your local, you do not need to pass a parameter when running `start-https.sh`.
+   - If you want to use release.app.appsmith asyour backend server, please checkout the section - [If you would like to hit a different Appsmith server](#if-you-would-like-to-hit-a-different-appsmith-server)
 
 ### Steps to build & run the code:
 

--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -62,7 +62,7 @@ sudo mv mkcert /usr/local/bin
 
    ```bash
    cd app/client
-   ./start-https.sh https://release.app.appsmith.com
+   ./start-https.sh
    ```
 
 ### Steps to build & run the code:

--- a/contributions/ClientSetup.md
+++ b/contributions/ClientSetup.md
@@ -67,8 +67,8 @@ sudo mv mkcert /usr/local/bin
    
    Note:
 
-   - If you have the Server setup and running on your local, you do not need to pass a parameter when running `start-https.sh`.
-   - If you want to use release.app.appsmith asyour backend server, please checkout the section - [If you would like to hit a different Appsmith server](#if-you-would-like-to-hit-a-different-appsmith-server)
+   - If you want to use the backend server running on your local, you do not need to pass a parameter when running `start-https.sh`. 
+   - If you want to use release.app.appsmith as your backend server, please check out the section - [If you would like to hit a different Appsmith server](#if-you-would-like-to-hit-a-different-appsmith-server)
 
 ### Steps to build & run the code:
 


### PR DESCRIPTION
## Description

In the Client Setup Document section for [Create local HTTPS certificates](https://github.com/appsmithorg/appsmith/blob/release/contributions/ClientSetup.md#if-you-would-like-to-hit-a-different-appsmith-server), removed the URL https://release.app.appsmith.com/ from the command ./start-https.sh as this step is already mentioned in the section [If you would like to hit a different Appsmith server](https://github.com/appsmithorg/appsmith/blob/release/contributions/ClientSetup.md#if-you-would-like-to-hit-a-different-appsmith-server)

Fixes #21955

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update


## How Has This Been Tested?
 
 - NA

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
