### PR TITLE
fix: Show more button should become show less when clicked

### DIFF
--- a/app/client/src/components/utils/CollapseComponent.tsx
+++ b/app/client/src/components/utils/CollapseComponent.tsx
@@ -35,6 +35,7 @@ const CollapseWrapper = styled.div`
 
 function CollapseComponent(props: {
   children?: React.ReactNode;
+  openTitle?: string;
   title?: string;
   isOpen?: boolean;
   titleStyle?: React.CSSProperties;
@@ -54,7 +55,7 @@ function CollapseComponent(props: {
         onClick={handleIsOpen}
         style={props.titleStyle}
       >
-        {props.title}
+        {open && props.openTitle ? props.openTitle : props.title}
         <Icon
           className={`icon ${open ? "collapse" : ""}`}
           color="#4B4848"

--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -416,7 +416,11 @@ function DatasourceCard(props: DatasourceCardProps) {
             e.stopPropagation();
           }}
         >
-          <CollapseComponent title="Show More" titleStyle={{ maxWidth: 120 }}>
+          <CollapseComponent
+            openTitle="Show Less"
+            title="Show More"
+            titleStyle={{ maxWidth: 120 }}
+          >
             <DatasourceInfo>
               <RenderDatasourceInformation
                 config={currentFormConfig[0]}


### PR DESCRIPTION
Fix: Active datasource listing: Show more button should become show less when clicked

## Description
In the active datasource listing page, when the user clicks on "show more", the button name should be changed to "Show less".
In general, show more is changed to show less as a good usability practice.

> Add a TL;DR when description is extra long (helps content team)

Fixes #21368


Media
[Screencast from 2023-04-01 23-01-04.webm](https://user-images.githubusercontent.com/85070570/229305889-e7e75150-2ce5-4139-90c5-d3f199ce446e.webm)



## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)



## How Has This Been Tested?
- Jest

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
