### PR TITLE
Improve the CI build time

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -51,7 +51,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: client-build
-          path: app/client/build
+          path: app/client/build.tar
+
+      - name: Unpack the client build artifact
+        if: steps.run_result.outputs.run_result != 'success'
+        run: |
+          mkdir -p app/client/build
+          tar -xvf app/client/build.tar -C app/client/build
 
       - name: Download the server build artifact
         if: steps.run_result.outputs.run_result != 'success'

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -92,8 +92,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16.14.0"
-          cache: "yarn"
-          cache-dependency-path: "app/yarn.lock"
+
+      # actions/setup-node@v3 doesn’t work properly with Yarn 3
+      # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
+      # Restoring the cache manually instead
+      - name: Restore Yarn cache
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/cache@v3
+        with:
+          path: app/.yarn/cache
+          key: v1-yarn3-${{ hashFiles('app/yarn.lock') }}
+          restore-keys: |
+            v1-yarn3-
 
       # Install all the dependencies
       - name: Install dependencies

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -171,12 +171,16 @@ jobs:
             app/client/build/
           key: ${{ github.run_id }}-${{ github.job }}-client
 
+      - name: Pack the client build directory
+        run: |
+          tar -cvf ./build.tar -C build .
+
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload react build bundle
         uses: actions/upload-artifact@v3
         with:
           name: client-build
-          path: app/client/build/
+          path: app/client/build.tar
 
       # Set status = success
       - name: Save the status of the run

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -91,12 +91,16 @@ jobs:
             yarn build
           ls -l build
 
+      - name: Pack the client build directory
+        run: |
+          tar -cvf ./build.tar -C build .
+
       # Upload the build artifact so that it can be used by the test & deploy job in the workflow
       - name: Upload react build bundle
         uses: actions/upload-artifact@v3
         with:
           name: client-build
-          path: app/client/build/
+          path: app/client/build.tar
 
   server-build:
     needs:

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -119,7 +119,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: client-build
-          path: app/client/build
+          path: app/client/build.tar
+
+      - name: Unpack the client build artifact
+        if: steps.run_result.outputs.run_result != 'success'
+        run: |
+          mkdir -p app/client/build
+          tar -xvf app/client/build.tar -C app/client/build
 
       - name: Download the server build artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/rts-build.yml
+++ b/.github/workflows/rts-build.yml
@@ -82,8 +82,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16.14.0"
-          cache: "yarn"
-          cache-dependency-path: "app/yarn.lock"
+
+      # actions/setup-node@v3 doesn’t work properly with Yarn 3
+      # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
+      # Restoring the cache manually instead
+      - name: Restore Yarn cache
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/cache@v3
+        with:
+          path: app/.yarn/cache
+          key: v1-yarn3-${{ hashFiles('app/yarn.lock') }}
+          restore-keys: |
+            v1-yarn3-
 
       # Here, the GITHUB_REF is of type /refs/head/<branch_name>. We extract branch_name from this by removing the
       # first 11 characters. This can be used to build images for several branches

--- a/.github/workflows/shared-modules.yml
+++ b/.github/workflows/shared-modules.yml
@@ -81,8 +81,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16.14.0"
-          cache: "yarn"
-          cache-dependency-path: "app/yarn.lock"
+
+      # actions/setup-node@v3 doesn’t work properly with Yarn 3
+      # when the project lives in a subdirectory: https://github.com/actions/setup-node/issues/488
+      # Restoring the cache manually instead
+      - name: Restore Yarn cache
+        if: steps.run_result.outputs.run_result != 'success'
+        uses: actions/cache@v3
+        with:
+          path: app/.yarn/cache
+          key: v1-yarn3-${{ hashFiles('app/yarn.lock') }}
+          restore-keys: |
+            v1-yarn3-
 
       # Install all the dependencies
       - name: Install dependencies

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -175,7 +175,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: client-build
-          path: app/client/build
+          path: app/client/build.tar
+
+      - name: Unpack the client build artifact
+        if: steps.run_result.outputs.run_result != 'success'
+        run: |
+          mkdir -p app/client/build
+          tar -xvf app/client/build.tar -C app/client/build
 
       - name: Download the server build artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/upgrade-appsmith-tests.yml
+++ b/.github/workflows/upgrade-appsmith-tests.yml
@@ -161,7 +161,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: client-build
-          path: app/client/build
+          path: app/client/build.tar
+
+      - name: Unpack the client build artifact
+        if: steps.run_result.outputs.run_result != 'success'
+        run: |
+          mkdir -p app/client/build
+          tar -xvf app/client/build.tar -C app/client/build
 
       - name: Download the server build artifact
         uses: actions/download-artifact@v3

--- a/app/client/.gitignore
+++ b/app/client/.gitignore
@@ -12,6 +12,8 @@
 
 # production
 /build
+# used to pack build artifacts in CI
+build.tar
 
 # misc
 .DS_Store

--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -6,8 +6,11 @@ GIT_SHA=$(eval git rev-parse HEAD)
 echo $GIT_SHA
 echo "Sentry Auth Token: $SENTRY_AUTH_TOKEN"
 
-# build cra app
-REACT_APP_SENTRY_RELEASE=$GIT_SHA REACT_APP_CLIENT_LOG_LEVEL=ERROR EXTEND_ESLINT=true craco --max-old-space-size=4096 build --config craco.build.config.js
+export REACT_APP_SENTRY_RELEASE=$GIT_SHA
+export REACT_APP_CLIENT_LOG_LEVEL=ERROR
+# Disable ESLint – we have a separate CI step to run it
+export DISABLE_ESLINT_PLUGIN=true
+craco --max-old-space-size=4096 build --config craco.build.config.js
 
 if [ "$GITHUB_REPOSITORY" == "appsmithorg/appsmith-ee" ]; then
     echo "Deleting sourcemaps for EE"


### PR DESCRIPTION
## Description

This PR improves the duration of the `client-build` CI pipeline:
- Enables proper package caching for Yarn 3. This lowers the `yarn install` time from 5m to ~50s (starting with the second run). ea8114f59e9fa7018809084d0b17dde800a776d5
- Packs build artifacts into an archive before uploading. GitHub actions require a separate API call for every file they need to upload, so the more files there are, the longer it takes. This lowers the artifact uploading time from ~5.5m to 30 seconds. 53b8eb2836b0aca74b2e1759fee9473bf1a0f228
- Disables ESLint plugin during the production build. The ESLint plugin is unnecessary since we have a separate ESLint checking step. This saves ~1 minute per build. 21c8ea8c17540c594679cb3d5c4678500af9e262


## Type of change

- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual: tested the `client-build` job in my fork.
  - Note: I **have not** tested the `Unpack the client build artifact` step in jobs like `on-demand-build-docker-image-deploy-preview.yml` – let’s launch them from this branch to make sure they work.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
