### PR TITLE
perf: work around the V8 service worker regression

### DIFF
--- a/app/client/craco.build.config.js
+++ b/app/client/craco.build.config.js
@@ -16,6 +16,7 @@ plugins.push(
     mode: "development",
     swDest: "./pageService.js",
     maximumFileSizeToCacheInBytes: 11 * 1024 * 1024,
+    exclude: [/\.map$/, /^manifest.*\.js$/, /index\.html/],
   }),
 );
 

--- a/app/client/craco.build.config.js
+++ b/app/client/craco.build.config.js
@@ -17,8 +17,12 @@ plugins.push(
     swDest: "./pageService.js",
     maximumFileSizeToCacheInBytes: 11 * 1024 * 1024,
     exclude: [
+      // Don’t cache source maps and PWA manifests.
+      // (These are the default values of the `exclude` option: https://developer.chrome.com/docs/workbox/reference/workbox-build/#type-WebpackPartial,
+      // so we need to specify them explicitly if we’re extending this array.)
       /\.map$/,
       /^manifest.*\.js$/,
+      // Don’t cache the root html file
       /index\.html/,
       // Don’t cache LICENSE.txt files emitted by CRA
       // when a chunk includes some license comments

--- a/app/client/craco.build.config.js
+++ b/app/client/craco.build.config.js
@@ -16,7 +16,16 @@ plugins.push(
     mode: "development",
     swDest: "./pageService.js",
     maximumFileSizeToCacheInBytes: 11 * 1024 * 1024,
-    exclude: [/\.map$/, /^manifest.*\.js$/, /index\.html/],
+    exclude: [
+      /\.map$/,
+      /^manifest.*\.js$/,
+      /index\.html/,
+      // Don’t cache LICENSE.txt files emitted by CRA
+      // when a chunk includes some license comments
+      /LICENSE\.txt/,
+    ],
+    // Don’t cache-bust JS and CSS chunks
+    dontCacheBustURLsMatching: /\.[0-9a-zA-Z]{8}\.chunk\.(js|css)$/,
   }),
 );
 

--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -33,7 +33,7 @@ const regexMap = {
 
 //////////////////////////////////////////////////////////
 // Note: if you need to filter out some files from precaching,
-// do that in InjectManifest plugin options
+// do that in InjectManifest’s `exclude` plugin options
 const toPrecache = self.__WB_MANIFEST;
 
 const isChromium =

--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -1,4 +1,8 @@
-import { PrecacheController, PrecacheRoute } from "workbox-precaching";
+import {
+  PrecacheController,
+  PrecacheRoute,
+  precacheAndRoute,
+} from "workbox-precaching";
 import { clientsClaim, setCacheNameDetails, skipWaiting } from "workbox-core";
 import { registerRoute, Route } from "workbox-routing";
 import {
@@ -28,79 +32,95 @@ const regexMap = {
 };
 
 //////////////////////////////////////////////////////////
-// Use a custom PrecacheController strategy that starts caching pages
-// on `activate` instead of `install`. This code is based on
-// https://developer.chrome.com/docs/workbox/modules/workbox-precaching/#using-precachecontroller-directly
-// but uses the `activate` event instead of the `install` one.
-// The `activate` event is fired after the `install` one, and
-// (based on experiments) it’s also fired only once per installation.
-//
-// This works around a problematic V8 heuristic. V8 generates a "full" code cache
-// for scripts cached from the `install` event (see https://v8.dev/blog/code-caching-for-devs#use-service-worker-caches).
-// The "full" code cache makes the execution of the app a bit faster
-// (V8 doesn’t need to compile functions on demand) but is much, much slower
-// to deserialize, adding up to a several-second app startup delay
-// (see https://bugs.chromium.org/p/chromium/issues/detail?id=1428605).
-const precacheController = new PrecacheController();
-precacheController.addToCacheList(
-  // If you need to filter out some files, do that in InjectManifest plugin options
-  self.__WB_MANIFEST,
-);
+// Note: if you need to filter out some files from precaching,
+// do that in InjectManifest plugin options
+const toPrecache = self.__WB_MANIFEST;
 
-let installEvent;
-self.addEventListener("install", (event) => {
-  installEvent = event;
-});
+const isChromium =
+  navigator.userAgentData &&
+  navigator.userAgentData.brands.some((data) => data.brand == "Chromium");
+if (isChromium) {
+  // In Chromium, we use a custom PrecacheController strategy that starts caching pages
+  // on `activate` instead of `install`. This code is based on
+  // https://developer.chrome.com/docs/workbox/modules/workbox-precaching/#using-precachecontroller-directly
+  // but uses the `activate` event instead of the `install` one.
+  // The `activate` event is fired after the `install` one, and
+  // (based on experiments) it’s also fired only once per installation.
+  //
+  // This works around a problematic V8 heuristic. V8 generates a "full" code cache
+  // for scripts cached from the `install` event (see https://v8.dev/blog/code-caching-for-devs#use-service-worker-caches).
+  // The "full" code cache makes the execution of the app a bit faster
+  // (V8 doesn’t need to compile functions on demand) but is much, much slower
+  // to deserialize, adding up to a several-second app startup delay
+  // (see https://bugs.chromium.org/p/chromium/issues/detail?id=1428605).
+  //
+  // We haven’t tested whether other browsers are affected by the same issue.
+  //
+  // Hopefully, this branch of code could be deleted when https://bugs.chromium.org/p/chromium/issues/detail?id=1428605
+  // is resolved.
+  const precacheController = new PrecacheController();
+  precacheController.addToCacheList(toPrecache);
 
-let isActivating = false;
-self.addEventListener("activate", (activateEvent) => {
-  isActivating = true;
+  let installEvent;
+  self.addEventListener("install", (event) => {
+    installEvent = event;
+  });
 
-  activateEvent.waitUntil(
-    (async function () {
-      // Make the `waitUntil` function a noop – otherwise, it throws
-      // when called outside of the `install` event handler.
-      installEvent.waitUntil = () => {
-        /* Do nothing */
-      };
+  let isActivating = false;
+  self.addEventListener("activate", (activateEvent) => {
+    isActivating = true;
 
-      // precacheController.install() *has* to receive the `install` event,
-      // or it won’t save the preloaded assets to the cache. This is true
-      // as of `workbox-precaching@npm:6.5.3`. The relevant check lives here:
-      // https://github.com/GoogleChrome/workbox/blob/95f97a207fd51efb3f8a653f6e3e58224183a778/packages/workbox-precaching/src/PrecacheStrategy.ts#L101
-      await precacheController.install(installEvent);
-      await precacheController.activate(activateEvent);
+    activateEvent.waitUntil(
+      (async function () {
+        // Make the `waitUntil` function a noop – otherwise, it throws
+        // when called outside of the `install` event handler.
+        installEvent.waitUntil = () => {
+          /* Do nothing */
+        };
 
-      isActivating = false;
-    })(),
-  );
-});
+        // precacheController.install() *has* to receive the `install` event,
+        // or it won’t save the preloaded assets to the cache. This is true
+        // as of `workbox-precaching@npm:6.5.3`. The relevant check lives here:
+        // https://github.com/GoogleChrome/workbox/blob/95f97a207fd51efb3f8a653f6e3e58224183a778/packages/workbox-precaching/src/PrecacheStrategy.ts#L101
+        await precacheController.install(installEvent);
+        await precacheController.activate(activateEvent);
 
-// Note: the solution we have here is pretty fragile because it relies on us knowing PrecacheController
-// internals (eg we know that `precacheController.install()` has to receive an `install` event, and
-// it doesn’t work with `activate`). This sanity check exists to make sure we don’t silently break
-// service worker precaching when we upgrade the workbox version.
-self.addEventListener("fetch", async (event) => {
-  const url = new URL(event.request.url);
-  if (
-    url.origin.includes(".appsmith.com") &&
-    url.pathname.startsWith("/static/js/")
-  ) {
-    const response = await caches.match(event.request);
+        isActivating = false;
+      })(),
+    );
+  });
 
-    if (!response && !isActivating) {
-      log.error(
-        "[service worker] Sanity check failed: no cached response found for " +
-          event.request.url +
-          ". If you see this regularly, it’s likely the service worker preloading got broken.",
-      );
+  // Note: the solution we have here is pretty fragile because it relies on us knowing PrecacheController
+  // internals (eg we know that `precacheController.install()` has to receive an `install` event, and
+  // it doesn’t work with `activate`). This sanity check exists to make sure we don’t silently break
+  // service worker precaching when we upgrade the workbox version.
+  self.addEventListener("fetch", async (event) => {
+    const url = new URL(event.request.url);
+    if (
+      url.origin.includes(".appsmith.com") &&
+      url.pathname.startsWith("/static/js/")
+    ) {
+      const response = await caches.match(event.request);
+
+      if (!response && !isActivating) {
+        log.error(
+          "[service worker] Sanity check failed: no cached response found for " +
+            event.request.url +
+            ". If you see this regularly, it’s likely the service worker preloading got broken.",
+        );
+      }
     }
-  }
-});
+  });
 
-const precacheRoute = new PrecacheRoute(precacheController);
-registerRoute(precacheRoute);
-// End of custom PrecacheController strategy
+  const precacheRoute = new PrecacheRoute(precacheController);
+  registerRoute(precacheRoute);
+} else {
+  // In non-Chromium browsers, we use the default strategy. E.g., as of Mar 2023,
+  // in Firefox, the Chromium strategy causes chunk requests to hang while the `activate`
+  // event handler is busy caching everything.
+  precacheAndRoute(toPrecache);
+}
+
 //////////////////////////////////////////////////////////
 
 self.__WB_DISABLE_DEV_DEBUG_LOGS = false;

--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -1,4 +1,4 @@
-import { precacheAndRoute } from "workbox-precaching";
+import { PrecacheController, PrecacheRoute } from "workbox-precaching";
 import { clientsClaim, setCacheNameDetails, skipWaiting } from "workbox-core";
 import { registerRoute, Route } from "workbox-routing";
 import {
@@ -7,6 +7,7 @@ import {
   StaleWhileRevalidate,
 } from "workbox-strategies";
 import { ExpirationPlugin } from "workbox-expiration";
+import log from "loglevel";
 
 setCacheNameDetails({
   prefix: "appsmith",
@@ -26,13 +27,84 @@ const regexMap = {
   providers: new RegExp(/v1\/marketplace\/(providers|templates)/),
 };
 
-/* eslint-disable no-restricted-globals */
-const toPrecache = self.__WB_MANIFEST.filter(
-  (file) => !file.url.includes("index.html"),
+//////////////////////////////////////////////////////////
+// Use a custom PrecacheController strategy that starts caching pages
+// on `activate` instead of `install`. This code is based on
+// https://developer.chrome.com/docs/workbox/modules/workbox-precaching/#using-precachecontroller-directly
+// but uses the `activate` event instead of the `install` one.
+// The `activate` event is fired after the `install` one, and
+// (based on experiments) it’s also fired only once per installation.
+//
+// This works around a problematic V8 heuristic. V8 generates a "full" code cache
+// for scripts cached from the `install` event (see https://v8.dev/blog/code-caching-for-devs#use-service-worker-caches).
+// The "full" code cache makes the execution of the app a bit faster
+// (V8 doesn’t need to compile functions on demand) but is much, much slower
+// to deserialize, adding up to a several-second app startup delay
+// (see https://bugs.chromium.org/p/chromium/issues/detail?id=1428605).
+const precacheController = new PrecacheController();
+precacheController.addToCacheList(
+  // If you need to filter out some files, do that in InjectManifest plugin options
+  self.__WB_MANIFEST,
 );
-precacheAndRoute(toPrecache);
+
+let installEvent;
+self.addEventListener("install", (event) => {
+  installEvent = event;
+});
+
+let isActivating = false;
+self.addEventListener("activate", (activateEvent) => {
+  isActivating = true;
+
+  activateEvent.waitUntil(
+    (async function () {
+      // Make the `waitUntil` function a noop – otherwise, it throws
+      // when called outside of the `install` event handler.
+      installEvent.waitUntil = () => {
+        /* Do nothing */
+      };
+
+      // precacheController.install() *has* to receive the `install` event,
+      // or it won’t save the preloaded assets to the cache. This is true
+      // as of `workbox-precaching@npm:6.5.3`. The relevant check lives here:
+      // https://github.com/GoogleChrome/workbox/blob/95f97a207fd51efb3f8a653f6e3e58224183a778/packages/workbox-precaching/src/PrecacheStrategy.ts#L101
+      await precacheController.install(installEvent);
+      await precacheController.activate(activateEvent);
+
+      isActivating = false;
+    })(),
+  );
+});
+
+// Note: the solution we have here is pretty fragile because it relies on us knowing PrecacheController
+// internals (eg we know that `precacheController.install()` has to receive an `install` event, and
+// it doesn’t work with `activate`). This sanity check exists to make sure we don’t silently break
+// service worker precaching when we upgrade the workbox version.
+self.addEventListener("fetch", async (event) => {
+  const url = new URL(event.request.url);
+  if (
+    url.origin.includes(".appsmith.com") &&
+    url.pathname.startsWith("/static/js/")
+  ) {
+    const response = await caches.match(event.request);
+
+    if (!response && !isActivating) {
+      log.error(
+        "[service worker] Sanity check failed: no cached response found for " +
+          event.request.url +
+          ". If you see this regularly, it’s likely the service worker preloading got broken.",
+      );
+    }
+  }
+});
+
+const precacheRoute = new PrecacheRoute(precacheController);
+registerRoute(precacheRoute);
+// End of custom PrecacheController strategy
+//////////////////////////////////////////////////////////
 
 self.__WB_DISABLE_DEV_DEBUG_LOGS = false;
+
 skipWaiting();
 clientsClaim();
 


### PR DESCRIPTION
## Description

This pull request works around [a problematic V8 heuristic](https://bugs.chromium.org/p/chromium/issues/detail?id=1428605) that makes bundle init much slower. This heuristic affects both `release` and `bundle-optimization` branches, but seem to be triggering more frequently in `bundle-optimization`.

The PR works around the heuristic by moving the pre-caching step from the `install` event to the `activate` one (which, per [this V8 blog post](https://v8.dev/blog/code-caching-for-devs#use-service-worker-caches), disables the heuristic).

On repeat visits, this seems to make main bundle init **8× faster (!)** compared to the `release` branch. (See the last screenshot below for more details.)

### More info

We use the [`workbox`](https://github.com/GoogleChrome/workbox) library in our service worker. `workbox` fetches and caches all build chunks whenever the service worker is installed for the first time.

Coincidentally, V8 (Chromium’s JS engine) [generates a “full code cache”](https://v8.dev/blog/code-caching-for-devs#use-service-worker-caches) for scripts cached while a service worker is installing. "Full code cache” is a result of compiling a whole script into bytecode. It makes execution of the app faster – now, you don’t need to compile scripts every time the app loads; you can just restore the compiled bytecode from the cache.

“It makes execution faster” – except it doesn’t! For whatever reason, in Appsmith, we observed a huge regression when the service worker-generated code cache would kick in. The cache will be extremely slow to deserialize, making total bundle execution 2-3 times longer:

| First load (no sw cache) | Subsequent load (with sw cache) |
| --- | --- |
| The bundle takes 880 ms to execute (compiling the necessary functions on the fly) <br> <img width="1115" alt="Screenshot 2023-04-02 at 22 09 47" src="https://user-images.githubusercontent.com/2953267/229376618-3fb27e83-54d3-4d69-8839-2335e449628c.png"> | The bundle now takes just 500 ms to execute, but we spend 1870 ms in “Compile Code” (which actually just deserializes service worker’s code cache) <br> <img width="1115" alt="Screenshot 2023-04-02 at 22 09 40" src="https://user-images.githubusercontent.com/2953267/229376719-0b7088e5-a2a1-422a-a69b-2e5688fc7d0b.png"> |

This sounds like a V8 issue, so we filed a bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1428605

### Results

To work around this, in Chromium, we now cache all assets from the `activate` event listener. This is non-canonical but seems to work well. 

Here’s how this affects performance:

![Screenshot 2023-04-02 at 21 18 26 2](https://user-images.githubusercontent.com/2953267/229377460-58ec5e86-4826-437d-b96b-6ee0194dd39f.png)

The code caches from the service worker are still used in all branches. However, while `release` and `bundle-optimization` branches get slower (because they use the “full” code cache), this branch gets _faster_ (because it uses a “normal” code cache). As a result, we get an 8× improvement between the branches!

See this V8 article for more details about different code caches: https://v8.dev/blog/code-caching-for-devs#use-service-worker-caches

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual: checking that the service worker works in Chromium, Firefox, and Safari

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
