### PR TITLE
chore: Updating empty state for members in the invite modal

### DIFF
--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -165,7 +165,7 @@ export const USERS_HAVE_ACCESS_TO_ALL_APPS = () =>
   "Users will have access to all applications in this workspace";
 export const USERS_HAVE_ACCESS_TO_ONLY_THIS_APP = () =>
   "Users will only have access to this application";
-export const NO_USERS_INVITED = () => "No users invited yet";
+export const NO_USERS_INVITED = () => "You haven't invited any users yet";
 
 export const CREATE_PASSWORD_RESET_SUCCESS = () => `Your password has been set`;
 export const CREATE_PASSWORD_RESET_SUCCESS_LOGIN_LINK = () => `Login`;

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -165,6 +165,7 @@ export const USERS_HAVE_ACCESS_TO_ALL_APPS = () =>
   "Users will have access to all applications in this workspace";
 export const USERS_HAVE_ACCESS_TO_ONLY_THIS_APP = () =>
   "Users will only have access to this application";
+export const NO_USERS_INVITED = () => "No users invited yet";
 
 export const CREATE_PASSWORD_RESET_SUCCESS = () => `Your password has been set`;
 export const CREATE_PASSWORD_RESET_SUCCESS_LOGIN_LINK = () => `Login`;

--- a/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
+++ b/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
@@ -33,6 +33,7 @@ import {
   INVITE_USERS_VALIDATION_EMAIL_LIST,
   INVITE_USERS_VALIDATION_ROLE_EMPTY,
   USERS_HAVE_ACCESS_TO_ALL_APPS,
+  NO_USERS_INVITED,
 } from "@appsmith/constants/messages";
 import { isEmail } from "utils/formhelpers";
 import {
@@ -69,7 +70,7 @@ import { isEllipsisActive } from "utils/helpers";
 import { USER_PHOTO_ASSET_URL } from "constants/userConstants";
 import type { WorkspaceUserRoles } from "@appsmith/constants/workspaceConstants";
 
-const { cloudHosting, mailEnabled } = getAppsmithConfigs();
+const { cloudHosting } = getAppsmithConfigs();
 
 export const CommonTitleTextStyle = css`
   color: ${Colors.CHARCOAL};
@@ -202,15 +203,9 @@ export const MailConfigContainer = styled.div`
   padding: 24px 4px;
   padding-bottom: 0;
   align-items: center;
-  && > span {
-    color: ${(props) => props.theme.colors.modal.email.message};
-    font-weight: 500;
-    font-size: 14px;
-  }
-  && > a {
-    color: ${(props) => props.theme.colors.modal.email.desc};
-    font-size: 12px;
-    text-decoration: underline;
+
+  > div {
+    margin: 8px 0;
   }
 `;
 
@@ -334,7 +329,6 @@ function WorkspaceInviteUsersForm(props: any) {
   const {
     allUsers,
     anyTouched,
-    disableEmailSetup = false,
     disableManageUsers = false,
     disableUserList = false,
     error,
@@ -520,17 +514,10 @@ function WorkspaceInviteUsersForm(props: any) {
           <Loading size={30} />
         ) : (
           <>
-            {!mailEnabled && !disableEmailSetup && (
+            {allUsers.length === 0 && (
               <MailConfigContainer>
-                {allUsers.length === 0 && <NoEmailConfigImage />}
-                <span>You haven’t setup any email service yet</span>
-                <a
-                  href="https://docs.appsmith.com/v/v1.2.1/setup/docker/email"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Please configure your email service to invite people
-                </a>
+                <NoEmailConfigImage />
+                <div>{createMessage(NO_USERS_INVITED)}</div>
               </MailConfigContainer>
             )}
             {!disableUserList && (

--- a/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
+++ b/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
@@ -203,9 +203,10 @@ export const MailConfigContainer = styled.div`
   padding: 24px 4px;
   padding-bottom: 0;
   align-items: center;
-
-  > div {
-    margin: 8px 0;
+  && > span {
+    color: ${(props) => props.theme.colors.modal.email.message};
+    font-weight: 500;
+    font-size: 14px;
   }
 `;
 
@@ -517,7 +518,7 @@ function WorkspaceInviteUsersForm(props: any) {
             {allUsers.length === 0 && (
               <MailConfigContainer>
                 <NoEmailConfigImage />
-                <div>{createMessage(NO_USERS_INVITED)}</div>
+                <span>{createMessage(NO_USERS_INVITED)}</span>
               </MailConfigContainer>
             )}
             {!disableUserList && (


### PR DESCRIPTION
## Description

Updating empty state for members in the invite modal. Earlier, we used to show a message that email setup needs to be completed to invite users, but this doesn't hold true today. So we are removing this and adding the message "You haven't invited any users yet" in case there are no members to show in the invite modal.

Fixes [#22017](https://github.com/appsmithorg/appsmith/issues/22017)

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?
> This has been tested manually and works as expected.

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
