### PR TITLE
fix: Build failure because of access token signature difference in EE repo

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
@@ -66,10 +66,6 @@ public class UserData extends BaseDomain {
     @JsonView(Views.Internal.class)
     Map<String, GitProfile> gitProfiles;
 
-    // JWT tokens
-    @JsonView(Views.Internal.class)
-    String accessToken;
-
     @JsonView(Views.Public.class)
     Map<String, Object> userClaims;
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/configurations/CommonConfigTest.java
@@ -23,7 +23,7 @@ public class CommonConfigTest {
     public void objectMapper_BeanCreated_WithPublicJsonViewAsDefault() throws JsonProcessingException {
         UserData userData = new UserData();
         userData.setRole("abcd"); // this is public field
-        userData.setAccessToken("token"); // this is internal field
+        userData.setUserId("userId"); // this is internal field
         userData.setUserPermissions(null);
 
         String value = objectMapper.writeValueAsString(userData);


### PR DESCRIPTION
## Description

This PR fixes the build failure which got introduced because of the recent PR merged as a part of enabling default JsonView https://github.com/appsmithorg/appsmith/pull/21766