### PR TITLE
Fix: Autocomplete's best match suggestion overlaps with text on the property pane.

### DIFF
--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -167,6 +167,7 @@ class CodeMirrorTernService {
     cm.showHint({
       hint: this.getHint.bind(this),
       completeSingle: false,
+      alignWithWord: false,
       extraKeys: {
         Up: (cm: CodeMirror.Editor, handle: any) => {
           handle.moveFocus(-1);


### PR DESCRIPTION
## Description
Fix: Autocomplete's best match suggestion overlaps with text on the property pane.

Fixes #15906 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
