### PR TITLE
fix: Fix annoying issue with Entity form control in google sheets

### DIFF
--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -211,7 +211,7 @@ function renderDropdown(
       }
 
       const isOptionDynamic = options.some((opt) => "disabled" in opt);
-      if (isOptionDynamic) {
+      if (isOptionDynamic && !!props?.isRequired) {
         const isCurrentOptionDisabled = options.some(
           (opt) => opt?.value === selectedValue && opt.disabled,
         );

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -209,6 +209,18 @@ function renderDropdown(
         selectedValue = tempValues;
         props.input?.onChange(tempValues);
       }
+
+      const isOptionDynamic = options.some((opt) => "disabled" in opt);
+      const isCurrentOptionDisabled = options.some(
+        (opt) => opt?.value === selectedValue && opt.disabled,
+      );
+      if (isOptionDynamic && (!tempSelectedValues || isCurrentOptionDisabled)) {
+        const firstEnabledOption = props?.options.find((opt) => !opt?.disabled);
+        if (firstEnabledOption) {
+          selectedValue = firstEnabledOption?.value as string;
+          props.input?.onChange(firstEnabledOption?.value);
+        }
+      }
     }
   }
 

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -211,14 +211,18 @@ function renderDropdown(
       }
 
       const isOptionDynamic = options.some((opt) => "disabled" in opt);
-      const isCurrentOptionDisabled = options.some(
-        (opt) => opt?.value === selectedValue && opt.disabled,
-      );
-      if (isOptionDynamic && (!tempSelectedValues || isCurrentOptionDisabled)) {
-        const firstEnabledOption = props?.options.find((opt) => !opt?.disabled);
-        if (firstEnabledOption) {
-          selectedValue = firstEnabledOption?.value as string;
-          props.input?.onChange(firstEnabledOption?.value);
+      if (isOptionDynamic) {
+        const isCurrentOptionDisabled = options.some(
+          (opt) => opt?.value === selectedValue && opt.disabled,
+        );
+        if (!tempSelectedValues || isCurrentOptionDisabled) {
+          const firstEnabledOption = props?.options.find(
+            (opt) => !opt?.disabled,
+          );
+          if (firstEnabledOption) {
+            selectedValue = firstEnabledOption?.value as string;
+            props.input?.onChange(firstEnabledOption?.value);
+          }
         }
       }
     }


### PR DESCRIPTION
In google sheet query creation, when I select operation as insert many, update one, and update many, in the entity dropdown only sheet rows option is enabled by default, other options of spreadsheet and sheet are disabled, Since a single option is enabled for these operations we can default the dropdown to this option for above three operations. This PR fixes that.

Fixes #21700 
> if no issue exists, please create an issue and ask the maintainers about this first

- Bug fix (non-breaking change which fixes an issue)

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
