### PR TITLE
fix: Maintain focus on editor when Escape is pressed with autocomplete menu open

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/IDE/MaintainContext&Focus_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/IDE/MaintainContext&Focus_spec.js
@@ -9,6 +9,7 @@ const agHelper = ObjectsRegistry.AggregateHelper;
 const dataSources = ObjectsRegistry.DataSources;
 const ee = ObjectsRegistry.EntityExplorer;
 const apiPage = ObjectsRegistry.ApiPage;
+const locators = ObjectsRegistry.CommonLocators;
 
 describe("MaintainContext&Focus", function () {
   it("1. Import the test application", () => {
@@ -164,6 +165,7 @@ describe("MaintainContext&Focus", function () {
       "Rest_Api_1",
     );
   });
+
   it("9. Datasource edit mode has to be maintained", () => {
     ee.SelectEntityByName("Appsmith", "Datasources");
     dataSources.EditDatasource();
@@ -190,5 +192,14 @@ describe("MaintainContext&Focus", function () {
     agHelper.Sleep();
     agHelper.GetNClick(dataSources._queryResponse("SETTINGS"));
     cy.xpath(queryLocators.queryTimeout).should("be.focused");
+  });
+
+  it("11. Maintain focus of code editor when Escape is pressed with autcomplete open", () => {
+    cy.SearchEntityandOpen("JSObject1");
+    cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 4 });
+    cy.get(locators._codeMirrorTextArea).type("showA");
+    agHelper.GetNAssertElementText(_.locators._hints, "showAlert()");
+    agHelper.PressEscape();
+    cy.assertCursorOnCodeInput(".js-editor", { ch: 7, line: 4 });
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/IDE/MaintainContext&Focus_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/IDE/MaintainContext&Focus_spec.js
@@ -194,7 +194,7 @@ describe("MaintainContext&Focus", function () {
     cy.xpath(queryLocators.queryTimeout).should("be.focused");
   });
 
-  it("11. Maintain focus of code editor when Escape is pressed with autcomplete open", () => {
+  it("11. Bug 21999 Maintain focus of code editor when Escape is pressed with autcomplete open", () => {
     cy.SearchEntityandOpen("JSObject1");
     cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 4 });
     cy.get(locators._codeMirrorTextArea).type("showA");

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/IDE/MaintainContext&Focus_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/IDE/MaintainContext&Focus_spec.js
@@ -198,7 +198,7 @@ describe("MaintainContext&Focus", function () {
     cy.SearchEntityandOpen("JSObject1");
     cy.assertCursorOnCodeInput(".js-editor", { ch: 2, line: 4 });
     cy.get(locators._codeMirrorTextArea).type("showA");
-    agHelper.GetNAssertElementText(_.locators._hints, "showAlert()");
+    agHelper.GetNAssertElementText(locators._hints, "showAlert()");
     agHelper.PressEscape();
     cy.assertCursorOnCodeInput(".js-editor", { ch: 7, line: 4 });
   });

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -248,6 +248,7 @@ class CodeEditor extends Component<Props, State> {
   };
   // this is the higlighted element for any highlighted text in the codemirror
   highlightedUrlElement: HTMLElement | undefined;
+  // this is the outer element encompassing the editor
   codeEditorTarget = React.createRef<HTMLDivElement>();
   editor!: CodeMirror.Editor;
   hinters: Hinter[] = [];
@@ -689,7 +690,7 @@ class CodeEditor extends Component<Props, State> {
         }
         break;
       case "Escape":
-        if (this.state.isFocused) {
+        if (this.state.isFocused && !this.state.hinterOpen) {
           this.codeEditorTarget.current?.focus();
           this.codeEditorTarget.current?.dispatchEvent(
             interactionAnalyticsEvent({ key: e.key }),


### PR DESCRIPTION
## Description

When typing content in the editor, the autocomplete menu pops up to suggest possible matches. If we press escape, the autocomplete menu closes but the editor loses focus, and users have to click again to regain focus and type.

This PR fixes this issue and removes this defect.

Fixes #21999 

Screen recording - https://www.loom.com/share/697f689f85b7426d88032f6487a9f7d9

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Cypress

## Test Plan

### Issues raised during DP testing


## Checklist:

### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer-reviewed by QA
- [x] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [x] Added Test Plan Approved label after reviewing all Cypress test
