### PR TITLE
ci: Use vars for DOCKER_HUB_ORGANIZATION

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -237,7 +237,7 @@ jobs:
           context: app/client
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{needs.prelude.outputs.tag}}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{needs.prelude.outputs.tag}}
 
       # Only build & tag with latest if the tag doesn't contain beta
       - name: Build and push client image latest
@@ -247,7 +247,7 @@ jobs:
           context: app/client
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:latest
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:latest
 
       - name: Build and push fat image
         uses: depot/build-push-action@v1
@@ -258,7 +258,7 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{needs.prelude.outputs.tag}}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{needs.prelude.outputs.tag}}
 
       # Only build & tag with latest if the tag doesn't contain beta
       - name: Build and push fat image latest
@@ -271,7 +271,7 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:latest
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:latest
 
       - name: Build and push server image
         uses: depot/build-push-action@v1
@@ -281,7 +281,7 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{needs.prelude.outputs.tag}}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{needs.prelude.outputs.tag}}
 
       # Only build & tag with latest if the tag doesn't contain beta
       - name: Build and push server image latest
@@ -293,4 +293,4 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:latest
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-server:latest

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-dp
+          repository: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp
           tags: ce-${{ github.event.client_payload.pull_request.number }}
     outputs:
       imageHash: ce-${{ github.event.client_payload.pull_request.number }}
@@ -181,7 +181,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.APPSMITH_CI_AWS_SECRET_ACCESS_KEY }}
           IMAGE_HASH: ${{ needs.push-image.outputs.imageHash }}
           AWS_RELEASE_CERT: ${{ secrets.APPSMITH_AWS_RELEASE_CERT_RELEASE }}
-          DOCKER_HUB_ORGANIZATION: ${{ secrets.DOCKER_HUB_ORGANIZATION }}
+          DOCKER_HUB_ORGANIZATION: ${{ vars.DOCKER_HUB_ORGANIZATION }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request.number }}

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -218,7 +218,7 @@ jobs:
           context: app/client
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{steps.vars.outputs.tag}}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{steps.vars.outputs.tag}}
 
       # Build master Docker image and push to Docker Hub
       - name: Push client master image to Docker Hub with commit tag
@@ -228,8 +228,8 @@ jobs:
           context: app/client
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{ github.sha }}
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:nightly
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:${{ github.sha }}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-editor:nightly
 
       - name: Build and push release image to Docker Hub
         if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
@@ -241,7 +241,7 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{steps.vars.outputs.tag}}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{steps.vars.outputs.tag}}
 
       - name: Build and push master image to Docker Hub with commit tag
         if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
@@ -253,8 +253,8 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{ github.sha }}
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:nightly
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{ github.sha }}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:nightly
 
       # - name: Check and push CI image to Docker Hub with commit tag
       #   if: success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
@@ -266,16 +266,16 @@ jobs:
       #       tag="${{ steps.vars.outputs.tag }}"
       #     fi
       #     docker run --detach --publish 80:80 --name appsmith \
-      #       "${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:$tag"
+      #       "${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:$tag"
       #     sleep 180
       #     cd deploy/docker
       #     if bash run-test.sh; then
       #       echo "Fat container test passed. Pushing image."
-      #       docker push --all-tags ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce
+      #       docker push --all-tags ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce
       #     else
       #       echo "Fat container test FAILED. Not pushing image."
       #       # Temporarily pushing even if test fails.
-      #       docker push --all-tags ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-ce
+      #       docker push --all-tags ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce
       #     fi
 
       # Build release Docker image and push to Docker Hub
@@ -288,7 +288,7 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{steps.vars.outputs.tag}}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{steps.vars.outputs.tag}}
 
       # Build master Docker image and push to Docker Hub
       - name: Push server master image to Docker Hub with commit tag
@@ -300,5 +300,5 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY }}
           tags: |
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{ github.sha }}
-            ${{ secrets.DOCKER_HUB_ORGANIZATION }}/appsmith-server:nightly
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-server:${{ github.sha }}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-server:nightly


### PR DESCRIPTION
GitHub's Variables, unlike Secrets, don't get masked in the output, and are ideal for non-secret... _variables_. I'm switching on such secret here, and depending on our experience with this, we'll look to moving more.

Of course, goes without saying, do NOT use these variables for secrets. When in doubt, use Secrets.

[Learn more about Variables](https://docs.github.com/en/actions/learn-github-actions/variables).

- I'd like approvals from all three of you before I merge this please.
- Please approve only, don't merge. I'll merge this _after_ we tag the upcoming version.
