### PR TITLE
fix: Hint text in create query (sql based datasources)

### DIFF
--- a/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/templates/CREATE.aql
+++ b/app/server/appsmith-plugins/arangoDBPlugin/src/main/resources/templates/CREATE.aql
@@ -1,7 +1,7 @@
 INSERT {
     name: "{{ nameInput.text }}",
     gender: "{{ genderDropdown.selectedOptionValue }}",
-    email: "{{ nameInput.text }}"
+    email: "{{ emailInput.text }}"
 } INTO users
 
 // nameInput and genderDropdown are example widgets, replace them with your widget names. To understand more please

--- a/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/templates/CREATE.sql
+++ b/app/server/appsmith-plugins/mssqlPlugin/src/main/resources/templates/CREATE.sql
@@ -4,5 +4,5 @@ VALUES
   (
     {{ nameInput.text }},
     {{ genderDropdown.selectedOptionValue }},
-    {{ nameInput.text }}
+    {{ emailInput.text }}
   );

--- a/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/templates/CREATE.sql
+++ b/app/server/appsmith-plugins/mysqlPlugin/src/main/resources/templates/CREATE.sql
@@ -4,5 +4,5 @@ VALUES
   (
     {{ nameInput.text }},
     {{ genderDropdown.selectedOptionValue }},
-    {{ nameInput.text }}
+    {{ emailInput.text }}
   );

--- a/app/server/appsmith-plugins/oraclePlugin/src/main/resources/templates/CREATE.sql
+++ b/app/server/appsmith-plugins/oraclePlugin/src/main/resources/templates/CREATE.sql
@@ -4,5 +4,5 @@ VALUES
   (
     {{ nameInput.text }},
     {{ genderDropdown.selectedOptionValue }},
-    {{ nameInput.text }}
+    {{ emailInput.text }}
   );

--- a/app/server/appsmith-plugins/postgresPlugin/src/main/resources/templates/CREATE.sql
+++ b/app/server/appsmith-plugins/postgresPlugin/src/main/resources/templates/CREATE.sql
@@ -4,5 +4,5 @@ VALUES
   (
     {{ nameInput.text }},
     {{ genderDropdown.selectedOptionValue }},
-    {{ nameInput.text }}
+    {{ emailInput.text }}
   );

--- a/app/server/appsmith-plugins/redshiftPlugin/src/main/resources/templates/CREATE.sql
+++ b/app/server/appsmith-plugins/redshiftPlugin/src/main/resources/templates/CREATE.sql
@@ -4,5 +4,5 @@ VALUES
   (
     {{ nameInput.text }},
     {{ genderDropdown.selectedOptionValue }},
-    {{ nameInput.text }}
+    {{ emailInput.text }}
   );

--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/templates/CREATE.sql
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/templates/CREATE.sql
@@ -4,5 +4,5 @@ VALUES
   (
     {{ nameInput.text }},
     {{ genderDropdown.selectedOptionValue }},
-    {{ nameInput.text }}
+    {{ emailInput.text }}
   );


### PR DESCRIPTION
## Description
Hint text in create query in SQL-based data sources showing double `nameInput.text` field.
This PR replaced second `nameInput.text` field with `emailInput.text` in all sql datasources where this issue was occurring.

Fixes #22011
Fixes #22117


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Jest
- Cypress


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
