### PR TITLE
chore: [One-click binding] Mongo db widget query generator

### DIFF
--- a/app/client/src/queryGenerators/BaseQueryGenerator.ts
+++ b/app/client/src/queryGenerators/BaseQueryGenerator.ts
@@ -1,0 +1,3 @@
+export class BaseQueryGenerator {
+  build() {}
+}

--- a/app/client/src/queryGenerators/BaseQueryGenerator.ts
+++ b/app/client/src/queryGenerators/BaseQueryGenerator.ts
@@ -1,3 +1,10 @@
+export enum COMMAND_TYPES {
+  "FIND" = "FIND",
+  "INSERT" = "INSERT",
+  "UPDATE" = "UPDATE",
+}
 export class BaseQueryGenerator {
-  build() {}
+  build(command: COMMAND_TYPES, tableName: string) {
+    return { command: { data: command }, collection: { data: tableName } };
+  }
 }

--- a/app/client/src/queryGenerators/MongoDB.test.ts
+++ b/app/client/src/queryGenerators/MongoDB.test.ts
@@ -1,0 +1,42 @@
+import MongoDB from "./mongoDb";
+
+describe("WidgetProps tests", () => {
+  const mongoDb = new MongoDB();
+  const expr = mongoDb.buildSelectQuery({
+    select: {
+      limit: "{{data_table.pageSize}}",
+      where: '{{data_table.searchText||""}}/i',
+      offset: "{{(data_table.pageNo - 1) * data_table.pageSize}}",
+      orderBy: "{{data_table.sortOrder.column || 'genres'}}",
+      sortOrder: '{{data_table.sortOrder.order == "desc" ? -1 : 1}}',
+    },
+    config: {
+      tableName: "someTable",
+      datasourceId: "someId",
+      // ignore it columns
+      columns: [{ name: "someColumn1", alias: "someColumn1" }],
+      widgetId: "someWidgetId",
+      searchableColumn: "title",
+    },
+    version: 0,
+    create: {
+      value: "",
+    },
+    insert: {
+      value: "",
+      where: "",
+    },
+    recordsCount: false,
+  });
+  expect(expr).toEqual([
+    { limit: "{{data_table.pageSize}}" },
+    { filter: { title: '{{data_table.searchText||""}}/i' } },
+    { skip: "{{(data_table.pageNo - 1) * data_table.pageSize}}" },
+    {
+      sort: {
+        "{{data_table.sortOrder.column || 'genres'}}":
+          '{{data_table.sortOrder.order == "desc" ? -1 : 1}}',
+      },
+    },
+  ]);
+});

--- a/app/client/src/queryGenerators/MongoDB.test.ts
+++ b/app/client/src/queryGenerators/MongoDB.test.ts
@@ -1,42 +1,141 @@
-import MongoDB from "./mongoDb";
+import MongoDB from "./MongoDB";
 
 describe("WidgetProps tests", () => {
   const mongoDb = new MongoDB();
-  const expr = mongoDb.buildSelectQuery({
-    select: {
-      limit: "{{data_table.pageSize}}",
-      where: '{{data_table.searchText||""}}/i',
-      offset: "{{(data_table.pageNo - 1) * data_table.pageSize}}",
-      orderBy: "{{data_table.sortOrder.column || 'genres'}}",
-      sortOrder: '{{data_table.sortOrder.order == "desc" ? -1 : 1}}',
-    },
-    config: {
-      tableName: "someTable",
-      datasourceId: "someId",
-      // ignore it columns
-      columns: [{ name: "someColumn1", alias: "someColumn1" }],
-      widgetId: "someWidgetId",
-      searchableColumn: "title",
-    },
-    version: 0,
-    create: {
-      value: "",
-    },
-    insert: {
-      value: "",
-      where: "",
-    },
-    recordsCount: false,
-  });
-  expect(expr).toEqual([
-    { limit: "{{data_table.pageSize}}" },
-    { filter: { title: '{{data_table.searchText||""}}/i' } },
-    { skip: "{{(data_table.pageNo - 1) * data_table.pageSize}}" },
-    {
-      sort: {
-        "{{data_table.sortOrder.column || 'genres'}}":
-          '{{data_table.sortOrder.order == "desc" ? -1 : 1}}',
+  test("should build select form data correctly", () => {
+    const expr = mongoDb.buildSelect({
+      select: {
+        limit: "{{data_table.pageSize}}",
+        where: '{{data_table.searchText||""}}/i',
+        offset: "{{(data_table.pageNo - 1) * data_table.pageSize}}",
+        orderBy: "{{data_table.sortOrder.column || 'genres'}}",
+        sortOrder: '{{data_table.sortOrder.order == "desc" ? -1 : 1}}',
       },
-    },
-  ]);
+      config: {
+        tableName: "someTable",
+        datasourceId: "someId",
+        // ignore columns
+        columns: [{ name: "someColumn1", alias: "someColumn1" }],
+        widgetId: "someWidgetId",
+        searchableColumn: "title",
+      },
+      version: 0,
+      create: {
+        value: "",
+      },
+      insert: {
+        value: "",
+        where: "",
+      },
+      recordsCount: false,
+    });
+    expect(expr).toEqual({
+      collection: {
+        data: "someTable",
+      },
+      command: {
+        data: "FIND",
+      },
+      find: {
+        limit: {
+          data: "{{data_table.pageSize}}",
+        },
+        query: {
+          data: '{ title: {{data_table.searchText||""}}/i }',
+        },
+        skip: {
+          data: "{{(data_table.pageNo - 1) * data_table.pageSize}}",
+        },
+        sort: {
+          data: "{ {{data_table.sortOrder.column || 'genres'}}: {{data_table.sortOrder.order == \"desc\" ? -1 : 1}} }",
+        },
+      },
+    });
+  });
+
+  test("should build update form data correctly ", () => {
+    const expr = mongoDb.buildUpdate({
+      select: {
+        limit: "",
+        where: "",
+        offset: "",
+        orderBy: "",
+        sortOrder: "",
+      },
+      config: {
+        tableName: "someTable",
+        datasourceId: "someId",
+        // ignore columns
+        columns: [{ name: "someColumn1", alias: "someColumn1" }],
+        widgetId: "someWidgetId",
+        searchableColumn: "title",
+      },
+      version: 0,
+      create: {
+        value: "",
+      },
+      insert: {
+        value: "{rating : {$gte : 9}}",
+        where: "{ $inc: { score: 1 } }",
+      },
+      recordsCount: false,
+    });
+    expect(expr).toEqual({
+      collection: {
+        data: "someTable",
+      },
+      command: {
+        data: "UPDATE",
+      },
+      updateMany: {
+        query: {
+          data: "{ $inc: { score: 1 } }",
+        },
+        update: {
+          data: "{rating : {$gte : 9}}",
+        },
+      },
+    });
+  });
+  test("should build insert form data correctly ", () => {
+    const expr = mongoDb.buildInsert({
+      select: {
+        limit: "",
+        where: "",
+        offset: "",
+        orderBy: "",
+        sortOrder: "",
+      },
+      config: {
+        tableName: "someTable",
+        datasourceId: "someId",
+        // ignore columns
+        columns: [{ name: "someColumn1", alias: "someColumn1" }],
+        widgetId: "someWidgetId",
+        searchableColumn: "title",
+      },
+      version: 0,
+      create: {
+        value: "{{insert_form.formData}}",
+      },
+      insert: {
+        value: "",
+        where: "",
+      },
+      recordsCount: false,
+    });
+    expect(expr).toEqual({
+      collection: {
+        data: "someTable",
+      },
+      command: {
+        data: "INSERT",
+      },
+      insert: {
+        documents: {
+          data: "{{insert_form.formData}}",
+        },
+      },
+    });
+  });
 });

--- a/app/client/src/queryGenerators/MongoDB.ts
+++ b/app/client/src/queryGenerators/MongoDB.ts
@@ -1,0 +1,32 @@
+import type { CombinedConfig, GetQueryGenerationConfigResponse } from "./types";
+import { BaseQueryGenerator } from "./baseQueryGenerator";
+
+export default class MongoDB extends BaseQueryGenerator {
+  buildSelectQuery(combinedConfig: CombinedConfig) {
+    const { config, select } = combinedConfig;
+    //what should we do about columns
+    const buildCommand = Object.keys(select)
+      .map((key) => {
+        const value = select[key];
+        if (key === "offset") {
+          return { skip: value };
+        }
+        // TODO: the equaivalent key for where is filter but the app is generating query
+        if (key === "where") {
+          return { filter: { [config.searchableColumn]: value } };
+        }
+        if (key === "orderBy") {
+          return { sort: { [value]: select["sortOrder"] } };
+        }
+        if (key === "sortOrder") {
+          return;
+        }
+        //all other keys do not require translation like limit
+        return { [key]: value };
+      })
+      .filter((val) => !!val);
+    return buildCommand;
+  }
+
+  build() {}
+}

--- a/app/client/src/queryGenerators/types.ts
+++ b/app/client/src/queryGenerators/types.ts
@@ -2,6 +2,7 @@ export type FormConfig = {
   config: {
     tableName: string;
     datasourceId: string;
+    //TODO:check where to use this
     columns: {
       name: string;
       alias: string;
@@ -29,18 +30,8 @@ export type GetQueryGenerationConfigResponse = {
     value: string;
     where: string;
   };
+  //TODO:check where to use this
   recordsCount: boolean; //whether we need to query to find total record
   version: number; //version of the config object
 };
 export type CombinedConfig = FormConfig & GetQueryGenerationConfigResponse;
-/*
-{
-\n  "find": "rd_voting",
-    \n  "filter": { note: /{{data_table.searchText||""}}/i },
-    \n  "sort": {
-        \n{
-            {
-                data_table.sortOrder.column || \'members\'}}: {{data_table.sortOrder.order == "desc" ? -1 : 1}} \n},\n  "skip": {{(data_table.pageNo - 1) * data_table.pageSize}},
-                \n  "limit": { { data_table.pageSize } },
-    \n  "batchSize": {{data_table.pageSize}}\n}\n'
-*/

--- a/app/client/src/queryGenerators/types.ts
+++ b/app/client/src/queryGenerators/types.ts
@@ -1,0 +1,46 @@
+export type FormConfig = {
+  config: {
+    tableName: string;
+    datasourceId: string;
+    columns: {
+      name: string;
+      alias: string;
+    }[];
+    widgetId: string;
+    searchableColumn: string;
+  };
+  version: number;
+};
+
+export type GetQueryGenerationConfigResponse = {
+  select: {
+    limit: string;
+    offset: string;
+    where: string;
+    orderBy: string;
+    sortOrder: string;
+  };
+  create: {
+    // we just the property name, since different Db generates query differently
+    value: string;
+  };
+  insert: {
+    // we just the property name, since different Db generates query differently
+    value: string;
+    where: string;
+  };
+  recordsCount: boolean; //whether we need to query to find total record
+  version: number; //version of the config object
+};
+export type CombinedConfig = FormConfig & GetQueryGenerationConfigResponse;
+/*
+{
+\n  "find": "rd_voting",
+    \n  "filter": { note: /{{data_table.searchText||""}}/i },
+    \n  "sort": {
+        \n{
+            {
+                data_table.sortOrder.column || \'members\'}}: {{data_table.sortOrder.order == "desc" ? -1 : 1}} \n},\n  "skip": {{(data_table.pageNo - 1) * data_table.pageSize}},
+                \n  "limit": { { data_table.pageSize } },
+    \n  "batchSize": {{data_table.pageSize}}\n}\n'
+*/


### PR DESCRIPTION
## Description
This PR has the implementation to translate a config from one click binding calls to a mongoDB query config. Through this config we can build the correct action.

Fixes #21507

## Type of change
- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
- Jest


### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
