### PR TITLE
fix: null check before accessing accessing properties in table and phone input widget

### DIFF
--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -274,7 +274,7 @@ class PhoneInputWidget extends BaseInputWidget<
     let formattedValue;
 
     // Don't format, as value is typed, when user is deleting
-    if (value && value.length > this.props.text.length) {
+    if (value && value.length > this.props.text?.length) {
       formattedValue = this.getFormattedPhoneNumber(value);
     } else {
       formattedValue = value;

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -1,5 +1,6 @@
 import { Alignment } from "@blueprintjs/core";
 import type { ColumnProperties } from "../component/Constants";
+import { StickyType } from "../component/Constants";
 import { CellAlignmentTypes } from "../component/Constants";
 import type { TableWidgetProps } from "../constants";
 import { ColumnTypes, InlineEditingSaveOptions } from "../constants";
@@ -193,7 +194,8 @@ export const updateColumnOrderHook = (
 
     const rightColumnIndex = findIndex(
       newColumnOrder,
-      (colName: string) => props.primaryColumns[colName].sticky === "right",
+      (colName: string) =>
+        props.primaryColumns[colName]?.sticky === StickyType.RIGHT,
     );
 
     if (rightColumnIndex !== -1) {


### PR DESCRIPTION
## Description

Fixes #22207
Fixes #22209 

The [sentry](https://github.com/appsmithorg/appsmith/issues/22207) issue occurred because the code was trying to access the `sticky` property of a column that did not exist in the table widget. Hence to mitigate this I have added an optional chaining check.

This PR also fixes #22209 by adding optional chaining while accessing the `text` prop in the phone input widget

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual
    - Check that the console error is not thrown similar to the above sentry issue.

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
