### PR TITLE
test: Cypress - Flaky fix 

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Linting/BasicLint_spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Linting/BasicLint_spec.ts
@@ -35,8 +35,8 @@ const clickButtonAndAssertLintError = (
 
   //Reload and Check for presence/ absence of lint error
   agHelper.RefreshPage();
-  agHelper.AssertElementVisible(locator._visibleTextDiv("Explorer"));
-  agHelper.Sleep(2500);
+  // agHelper.AssertElementVisible(locator._visibleTextDiv("Explorer"));
+  // agHelper.Sleep(2500);
   ee.SelectEntityByName("Button1", "Widgets");
   shouldExist
     ? agHelper.AssertElementExist(locator._lintErrorElement)

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ThemingTests/Basic_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/ThemingTests/Basic_spec.js
@@ -858,7 +858,7 @@ describe("App Theming funtionality", function () {
 
     //Resetting back to theme
     ee.NavigateToSwitcher("explorer");
-    agHelper.Sleep(2500);
+    //agHelper.Sleep(2500);
     ee.ExpandCollapseEntity("Widgets"); //to expand widgets
     ee.SelectEntityByName("Button2");
     cy.moveToStyleTab();

--- a/app/client/cypress/integration/Regression_TestSuite/ServerSideTests/Params/PassingParams_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ServerSideTests/Params/PassingParams_Spec.ts
@@ -230,7 +230,7 @@ describe("[Bug] - 10784 - Passing params from JS to SQL query should not break",
 
   it("12. Delete all entities - Query, JSObjects, Datasource + Bug 12532", () => {
     _.deployMode.NavigateBacktoEditor();
-    _.agHelper.Sleep(2500);
+    //_.agHelper.Sleep(2500);
     _.entityExplorer.ExpandCollapseEntity("Queries/JS");
     _.entityExplorer.ActionContextMenuByEntityName(
       "ParamsTest",

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -1054,8 +1054,12 @@ export class AggregateHelper {
     return this.GetElement(selector).should("not.be.focused");
   }
 
-  public AssertElementVisible(selector: ElementType, index = 0) {
-    return this.GetElement(selector)
+  public AssertElementVisible(
+    selector: ElementType,
+    index = 0,
+    timeout = 20000,
+  ) {
+    return this.GetElement(selector, timeout)
       .eq(index)
       .scrollIntoView()
       .should("be.visible");

--- a/app/client/cypress/support/Pages/EntityExplorer.ts
+++ b/app/client/cypress/support/Pages/EntityExplorer.ts
@@ -134,8 +134,9 @@ export class EntityExplorer {
         if (expand && arrow == "arrow-right") {
           cy.xpath(this._expandCollapseArrow(entityName))
             .eq(index)
+            .wait(500)
             .trigger("click", { force: true })
-            .wait(1000);
+            .wait(500);
           // this.agHelper
           //   .GetElement(this._expandCollapseSection(entityName))
           //   .then(($div: any) => {
@@ -151,8 +152,9 @@ export class EntityExplorer {
         } else if (!expand && arrow == "arrow-down") {
           cy.xpath(this._expandCollapseArrow(entityName))
             .eq(index)
+            .wait(500)
             .trigger("click", { force: true })
-            .wait(1000);
+            .wait(500);
           // this.agHelper
           //   .GetElement(this._expandCollapseSection(entityName))
           //   .then(($div: any) => {

--- a/app/client/cypress/support/Pages/EntityExplorer.ts
+++ b/app/client/cypress/support/Pages/EntityExplorer.ts
@@ -122,7 +122,11 @@ export class EntityExplorer {
   }
 
   public ExpandCollapseEntity(entityName: string, expand = true, index = 0) {
-    this.agHelper.AssertElementVisible(this._expandCollapseArrow(entityName));
+    this.agHelper.AssertElementVisible(
+      this._expandCollapseArrow(entityName),
+      0,
+      30000,
+    );
     cy.xpath(this._expandCollapseArrow(entityName))
       .eq(index)
       .invoke("attr", "name")

--- a/app/client/cypress/support/Pages/EntityExplorer.ts
+++ b/app/client/cypress/support/Pages/EntityExplorer.ts
@@ -124,7 +124,7 @@ export class EntityExplorer {
   public ExpandCollapseEntity(entityName: string, expand = true, index = 0) {
     this.agHelper.AssertElementVisible(
       this._expandCollapseArrow(entityName),
-      0,
+      index,
       30000,
     );
     cy.xpath(this._expandCollapseArrow(entityName))
@@ -134,7 +134,7 @@ export class EntityExplorer {
         if (expand && arrow == "arrow-right") {
           cy.xpath(this._expandCollapseArrow(entityName))
             .eq(index)
-            .trigger("click", { multiple: true })
+            .trigger("click", { force: true })
             .wait(1000);
           // this.agHelper
           //   .GetElement(this._expandCollapseSection(entityName))
@@ -151,7 +151,7 @@ export class EntityExplorer {
         } else if (!expand && arrow == "arrow-down") {
           cy.xpath(this._expandCollapseArrow(entityName))
             .eq(index)
-            .trigger("click", { multiple: true })
+            .trigger("click", { force: true })
             .wait(1000);
           // this.agHelper
           //   .GetElement(this._expandCollapseSection(entityName))


### PR DESCRIPTION
## Description

- This PR adds timeout for the EntityExpand() - to solve all the recent issue seen with Expanding of Entity Explorer items - either after refresh/page load/from view to edit mode navigations

## Type of change

- Script update (non-breaking change which fixes CI timeout issues with EntityExplorer click)


## How Has This Been Tested?
- Cypress CI run

## Checklist:
### QA activity:
- [x] Added Test Plan Approved label after reviewing all Cypress test
