### PR TITLE
fix: Fix action menu for queries and js objects

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Actions/MoreActionsMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/Actions/MoreActionsMenu.tsx
@@ -14,7 +14,7 @@ import { noop } from "lodash";
 import TreeDropdown from "pages/Editor/Explorer/TreeDropdown";
 import { useNewActionName } from "./helpers";
 import styled from "styled-components";
-import { Classes, Icon, IconSize } from "design-system-old";
+import { Icon, IconSize } from "design-system-old";
 import { Intent, Position } from "@blueprintjs/core";
 import { inGuidedTour } from "selectors/onboardingSelectors";
 import { toggleShowDeviationDialog } from "actions/onboardingActions";
@@ -25,7 +25,6 @@ import {
   CONTEXT_MOVE,
   createMessage,
 } from "@appsmith/constants/messages";
-import type { IconName } from "@blueprintjs/icons";
 
 type EntityContextMenuProps = {
   id: string;
@@ -49,27 +48,15 @@ export const MoreActionablesContainer = styled.div<{ isOpen?: boolean }>`
     width: auto;
   }
 
-  .${Classes.ICON} {
-    fill: ${(props) => props.theme.colors.treeDropdown.targetIcon.normal};
-  }
-
   ${(props) =>
     props.isOpen
       ? `
 		background-color: ${props.theme.colors.treeDropdown.targetBg};
-
-    &&&& .${Classes.ICON} {
-      fill: ${props.theme.colors.treeDropdown.targetIcon.hover};
-    }
 	`
       : null}
 
   &:hover {
     background-color: ${(props) => props.theme.colors.treeDropdown.targetBg};
-
-    &&&& .${Classes.ICON} {
-      fill: ${(props) => props.theme.colors.treeDropdown.targetIcon.hover};
-    }
   }
 `;
 
@@ -128,7 +115,6 @@ export function MoreActionsMenu(props: EntityContextMenuProps) {
     ...(isChangePermitted
       ? [
           {
-            icon: "duplicate" as IconName,
             value: "copy",
             onSelect: noop,
             label: createMessage(CONTEXT_COPY),
@@ -144,7 +130,6 @@ export function MoreActionsMenu(props: EntityContextMenuProps) {
     ...(isChangePermitted
       ? [
           {
-            icon: "swap-horizontal" as IconName,
             value: "move",
             onSelect: noop,
             label: createMessage(CONTEXT_MOVE),
@@ -173,7 +158,6 @@ export function MoreActionsMenu(props: EntityContextMenuProps) {
       ? [
           {
             confirmDelete: confirmDelete,
-            icon: "trash" as IconName,
             value: "delete",
             onSelect: () => {
               confirmDelete

--- a/app/client/src/pages/Editor/Explorer/JSActions/MoreJSActionsMenu.tsx
+++ b/app/client/src/pages/Editor/Explorer/JSActions/MoreJSActionsMenu.tsx
@@ -26,7 +26,6 @@ import {
 } from "components/editorComponents/CodeEditor/utils/autoIndentUtils";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import { updateJSCollectionBody } from "../../../../actions/jsPaneActions";
-import type { IconName } from "@blueprintjs/icons";
 
 type EntityContextMenuProps = {
   id: string;
@@ -58,19 +57,11 @@ export const MoreActionablesContainer = styled.div<{ isOpen?: boolean }>`
     props.isOpen
       ? `
 		background-color: ${props.theme.colors.treeDropdown.targetBg};
-
-    &&&& svg > path {
-      fill: ${props.theme.colors.treeDropdown.targetIcon.hover};
-    }
 	`
       : null}
 
   &:hover {
     background-color: ${(props) => props.theme.colors.treeDropdown.targetBg};
-
-    &&&& svg > path {
-      fill: ${(props) => props.theme.colors.treeDropdown.targetIcon.hover};
-    }
   }
 `;
 
@@ -121,7 +112,6 @@ export function MoreJSCollectionsMenu(props: EntityContextMenuProps) {
     ...(isChangePermitted
       ? [
           {
-            icon: "duplicate" as IconName,
             value: "copy",
             onSelect: noop,
             label: createMessage(CONTEXT_COPY),
@@ -138,7 +128,6 @@ export function MoreJSCollectionsMenu(props: EntityContextMenuProps) {
     ...(isChangePermitted
       ? [
           {
-            icon: "swap-horizontal" as IconName,
             value: "move",
             onSelect: noop,
             label: createMessage(CONTEXT_MOVE),
@@ -161,7 +150,6 @@ export function MoreJSCollectionsMenu(props: EntityContextMenuProps) {
       ? [
           {
             value: "prettify",
-            icon: "code" as IconName,
             subText: prettifyCodeKeyboardShortCut,
             onSelect: () => {
               /*
@@ -184,7 +172,6 @@ export function MoreJSCollectionsMenu(props: EntityContextMenuProps) {
       ? [
           {
             confirmDelete: confirmDelete,
-            icon: "trash" as IconName,
             value: "delete",
             onSelect: () => {
               confirmDelete


### PR DESCRIPTION
The Action menu found in the Query and JsObject editors looked very different from the menu found in the entity explorer. This PR fixes that and makes them more uniform across the app using the Entity Explorer menu as the de factor menu used in appsmith.

Fixes # 

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
