### PR TITLE
fix: Correct data-widgetid

### DIFF
--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -130,7 +130,7 @@ function ContainerComponentWrapper(
           ? "auto-layout"
           : ""
       }`}
-      data-widgetId={props.widgetId}
+      data-widgetid={props.widgetId}
       dropDisabled={props.dropDisabled}
       onClick={props.onClick}
       onClickCapture={props.onClickCapture}


### PR DESCRIPTION
replace data-widgetId with data-widgetid to resolve console warning: act_devtools_backend.js:2655 Warning: React does not recognize the `data-widgetId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `data-widgetid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

## Description

Resolves #22301 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual

### Test Plan
Start new page
Add container widget
Open browser console
Reload page
Inspect error messages

### Issues raised during DP testing

## Checklist:
### Dev activity
- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag

### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
