### PR TITLE
moved gitSyncId from BranchAwareDomain to BaseDomain

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BaseDomain.java
@@ -1,6 +1,7 @@
 package com.appsmith.external.models;
 
 import com.appsmith.external.views.Views;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
 import lombok.Setter;
@@ -77,6 +78,13 @@ public abstract class BaseDomain implements Persistable<String>, AppsmithDomain,
     @Transient
     @JsonView(Views.Public.class)
     public Set<String> userPermissions = new HashSet<>();
+
+    // This field will only be used for git related functionality to sync the action object across different instances.
+    // This field will be deprecated once we move to the new git sync implementation.
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonView(Views.Internal.class)
+    @Deprecated
+    String gitSyncId;
 
     @Deprecated
     public void sanitiseToExportDBObject() {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BranchAwareDomain.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/BranchAwareDomain.java
@@ -1,9 +1,7 @@
 package com.appsmith.external.models;
 
 import com.appsmith.external.views.Views;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,13 +12,6 @@ public abstract class BranchAwareDomain extends BaseDomain {
     // connected applications and will be used to connect resources across the branches
     @JsonView(Views.Internal.class)
     DefaultResources defaultResources;
-
-    // This field will only be used for git related functionality to sync the action object across different instances.
-    // This field will be deprecated once we move to the new git sync implementation.
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    @JsonView(Views.Internal.class)
-    @Deprecated
-    String gitSyncId;
 
     @Override
     @Deprecated

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/DatabaseChangelog2.java
@@ -820,7 +820,7 @@ public class DatabaseChangelog2 {
         ensureIndexes(mongoTemplate, ActionCollection.class,
                 makeIndex(
                         defaultResources + "." + FieldName.APPLICATION_ID,
-                        fieldName(QBranchAwareDomain.branchAwareDomain.gitSyncId),
+                        fieldName(QBaseDomain.baseDomain.gitSyncId),
                         fieldName(QBaseDomain.baseDomain.deleted)
                 )
                         .named("defaultApplicationId_gitSyncId_deleted_compound_index")
@@ -829,7 +829,7 @@ public class DatabaseChangelog2 {
         ensureIndexes(mongoTemplate, NewAction.class,
                 makeIndex(
                         defaultResources + "." + FieldName.APPLICATION_ID,
-                        fieldName(QBranchAwareDomain.branchAwareDomain.gitSyncId),
+                        fieldName(QBaseDomain.baseDomain.gitSyncId),
                         fieldName(QBaseDomain.baseDomain.deleted)
                 )
                         .named("defaultApplicationId_gitSyncId_deleted_compound_index")
@@ -838,7 +838,7 @@ public class DatabaseChangelog2 {
         ensureIndexes(mongoTemplate, NewPage.class,
                 makeIndex(
                         defaultResources + "." + FieldName.APPLICATION_ID,
-                        fieldName(QBranchAwareDomain.branchAwareDomain.gitSyncId),
+                        fieldName(QBaseDomain.baseDomain.gitSyncId),
                         fieldName(QBaseDomain.baseDomain.deleted)
                 )
                         .named("defaultApplicationId_gitSyncId_deleted_compound_index")


### PR DESCRIPTION
## Description
Moved `gitSyncId` from `BranchAwareDomain` to `BaseDomain` because it's changing property order in the git files.

Fixes #22282

Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
