### PR TITLE
fix: Changed import icon to have arrow face upwards

### DIFF
--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -848,7 +848,7 @@ export function ApplicationsSection(props: any) {
                           hasCreateNewApplicationPermission && (
                             <MenuItem
                               cypressSelector="t--workspace-import-app"
-                              icon="download"
+                              icon="upload-cloud"
                               onSelect={() =>
                                 setSelectedWorkspaceIdForImportApplication(
                                   workspace.id,


### PR DESCRIPTION
## Description

On Home Page,  Import icon in Workspace level settings  is same as the Export icon in Application settings. Import setting should have arrow pointing towards the cloud. Changing the icon to `upload-cloud`

Fixes #22294 

Media
![image](https://user-images.githubusercontent.com/34208835/231512494-89682efb-539b-4404-aa0d-8c0dd3b2a71e.png)


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
