### PR TITLE
fix: Sorting by renamed custom column

### DIFF
--- a/app/client/cypress/fixtures/testdata.json
+++ b/app/client/cypress/fixtures/testdata.json
@@ -103,6 +103,7 @@
   "tabBinding": "{{Tabs1.selectedTab",
   "pageloadBinding": "{{PageLoadApi.data[1].id}}{{Input1.text}}",
   "currentRowEmail": "{{currentRow.email}}",
+  "currentIndex": "{{currentIndex}}",
   "currentRowOrderAmt": "{{currentRow.orderAmount}}",
   "momentDate": "{{moment()}}",
   "defaultRowIndexBinding": "{{Table1.selectedRowIndex",

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_Sorting_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/TableV2_Sorting_spec.js
@@ -1,0 +1,65 @@
+const dsl = require("../../../../../fixtures/tableV2NewDslWithPagination.json");
+const commonlocators = require("../../../../../locators/commonlocators.json");
+const testdata = require("../../../../../fixtures/testdata.json");
+
+describe("Table Widget V2 Sorting", function () {
+  before(() => {
+    cy.addDsl(dsl);
+  });
+
+  it("verifies that table sorting works for a custom column with computed value even when it is renamed", function () {
+    cy.openPropertyPane("tablewidgetv2");
+    cy.addColumnV2("customColumn1");
+    cy.editColumn("customColumn1");
+    cy.updateComputedValueV2(testdata.currentIndex);
+    cy.backFromPropertyPanel();
+
+    // Ensure simple sorting for a custom column in working
+    // customColumn1 is at index 5 in the table
+    cy.sortColumn("customColumn1", "ascending");
+    cy.readTableV2data(0, 5).then((data) => {
+      expect(data).to.eq("0");
+    });
+    cy.readTableV2data(1, 5).then((data) => {
+      expect(data).to.eq("1");
+    });
+
+    cy.sortColumn("customColumn1", "descending");
+    cy.readTableV2data(0, 5).then((data) => {
+      expect(data).to.eq("9");
+    });
+    cy.readTableV2data(1, 5).then((data) => {
+      expect(data).to.eq("8");
+    });
+
+    // Rename customColumn1 to customColumn2
+    cy.openPropertyPane("tablewidgetv2");
+    cy.editColumn("customColumn1");
+    cy.get(".t--property-pane-title").click({ force: true });
+    cy.get(".t--property-pane-title")
+      .type("customColumn2", { delay: 300 })
+      .type("{enter}");
+
+    // Ensure that renaming preserves existing data in the table
+    cy.readTableV2data(0, 5).then((data) => {
+      expect(data).to.eq("9");
+    });
+
+    // Ensure ascending/descending sorting works in the table with the renamed column
+    cy.sortColumn("customColumn2", "ascending");
+    cy.readTableV2data(0, 5).then((data) => {
+      expect(data).to.eq("0");
+    });
+    cy.readTableV2data(1, 5).then((data) => {
+      expect(data).to.eq("1");
+    });
+
+    cy.sortColumn("customColumn2", "descending");
+    cy.readTableV2data(0, 5).then((data) => {
+      expect(data).to.eq("9");
+    });
+    cy.readTableV2data(1, 5).then((data) => {
+      expect(data).to.eq("8");
+    });
+  });
+});

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1582,6 +1582,17 @@ Cypress.Commands.add("freezeColumnFromDropdown", (columnName, direction) => {
   cy.wait(500);
 });
 
+Cypress.Commands.add("sortColumn", (columnName, direction) => {
+  cy.get(`[data-header=${columnName}] .header-menu .bp3-popover2-target`).click(
+    { force: true },
+  );
+  cy.get(".bp3-menu")
+    .contains(`Sort column ${direction}`)
+    .click({ force: true });
+
+  cy.wait(500);
+});
+
 Cypress.Commands.add("checkIfColumnIsFrozenViaCSS", (rowNum, coumnNum) => {
   cy.getTableV2DataSelector(rowNum, coumnNum).then((selector) => {
     cy.get(selector).should("have.css", "position", "sticky");

--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -319,7 +319,7 @@ export default {
       const sortBycolumn = columns.find(
         (column) => column.id === sortByColumnId,
       );
-      const sortByColumnOriginalId = sortBycolumn.originalId;
+      const sortByColumnOriginalId = sortBycolumn.alias;
 
       const columnType =
         sortBycolumn && sortBycolumn.columnType


### PR DESCRIPTION
Fixes #19928 

Steps to repro:

1. Add a custom column named `customColumn1` to a table.
2. Modify the computed value for it to `{{currentIndex}}`.
3. Ensure that sorting is working for the table using `customColumn1`.
4. Go to property pane settings for this column and rename it to `customColumn2` from its title in the property pane.
5. Ensure that sorting is working using `customColumn2`.

Actual Behavior:
Sorting isn't working using `customColumn2`.

Expected Behavior:
Sorting should work using `customColumn2`.

