### PR TITLE
[Blocked] fix: Checking for stale connection when Oauth token expires (#21769)

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/connections/OAuth2AuthorizationCode.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/connections/OAuth2AuthorizationCode.java
@@ -63,13 +63,9 @@ public class OAuth2AuthorizationCode extends APIConnection implements UpdatableC
     }
 
     private static boolean isAuthenticationResponseValid(OAuth2 oAuth2) {
-        if (oAuth2.getAuthenticationResponse() == null
-                || isBlank(oAuth2.getAuthenticationResponse().getToken())
-                || isExpired(oAuth2)) {
-            return false;
-        }
-
-        return true;
+        return oAuth2.getAuthenticationResponse() != null
+                && !isBlank(oAuth2.getAuthenticationResponse().getToken())
+                && !oAuth2.isExpired();
     }
 
     public static Mono<OAuth2AuthorizationCode> create(DatasourceConfiguration datasourceConfiguration) {
@@ -90,18 +86,6 @@ public class OAuth2AuthorizationCode extends APIConnection implements UpdatableC
 
         updateConnection(connection, oAuth2);
         return Mono.just(connection);
-    }
-
-    private static boolean isExpired(OAuth2 oAuth2) {
-        if (oAuth2.getAuthenticationResponse().getExpiresAt() == null) {
-            return false;
-        }
-
-        OAuth2AuthorizationCode connection = new OAuth2AuthorizationCode();
-        Instant now = connection.clock.instant();
-        Instant expiresAt = oAuth2.getAuthenticationResponse().getExpiresAt();
-
-        return now.isAfter(expiresAt.minus(Duration.ofMinutes(1)));
     }
 
     private Mono<OAuth2> generateOAuth2Token(DatasourceConfiguration datasourceConfiguration) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/connections/OAuth2ClientCredentials.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/connections/OAuth2ClientCredentials.java
@@ -35,6 +35,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import java.util.function.Predicate;
 
 @Setter
 @Getter
@@ -64,12 +65,7 @@ public class OAuth2ClientCredentials extends APIConnection implements UpdatableC
                         && x.getAuthenticationResponse().getToken() != null
                         && !x.getAuthenticationResponse().getToken().isBlank())
                 .filter(x -> x.getAuthenticationResponse().getExpiresAt() != null)
-                .filter(x -> {
-                    Instant now = connection.clock.instant();
-                    Instant expiresAt = x.getAuthenticationResponse().getExpiresAt();
-
-                    return now.isBefore(expiresAt.minus(Duration.ofMinutes(1)));
-                })
+                .filter(Predicate.not(OAuth2::isExpired))
                 // If invalid, regenerate token
                 .switchIfEmpty(connection.generateOAuth2Token(datasourceConfiguration))
                 // Store valid token

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -2,6 +2,7 @@ package com.appsmith.external.models;
 
 import com.appsmith.external.constants.Authentication;
 import com.appsmith.external.views.Views;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -58,6 +59,11 @@ public class AuthenticationDTO implements AppsmithDomain {
     @JsonView(Views.Public.class)
     public Mono<Boolean> hasExpired() {
         return Mono.just(Boolean.FALSE);
+    }
+
+    @JsonIgnore
+    public boolean isExpired() {
+        return false;
     }
 
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/AuthenticationDTO.java
@@ -61,6 +61,12 @@ public class AuthenticationDTO implements AppsmithDomain {
         return Mono.just(Boolean.FALSE);
     }
 
+    /**
+     * This function has been added to check if Auth token is expired.
+     * By default, it is assume that the token is not expired.
+     * Override to provide custom check for token expiry.
+     * @return true if auth token is expired, else false
+     */
     @JsonIgnore
     public boolean isExpired() {
         return false;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -109,4 +109,11 @@ public class OAuth2 extends AuthenticationDTO {
 
         return Mono.just(authenticationResponse.expiresAt.isBefore(Instant.now().plusSeconds(60)));
     }
+
+    @Override
+    public boolean isExpired() {
+        return this.authenticationResponse == null
+                || this.authenticationResponse.expiresAt == null
+                || this.authenticationResponse.expiresAt.isBefore(Instant.now().plusSeconds(60));
+    }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/OAuth2.java
@@ -112,8 +112,8 @@ public class OAuth2 extends AuthenticationDTO {
 
     @Override
     public boolean isExpired() {
-        return this.authenticationResponse == null
-                || this.authenticationResponse.expiresAt == null
-                || this.authenticationResponse.expiresAt.isBefore(Instant.now().plusSeconds(60));
+        return this.authenticationResponse != null
+                && this.authenticationResponse.expiresAt != null
+                && this.authenticationResponse.expiresAt.isBefore(Instant.now().plusSeconds(60));
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
@@ -79,6 +79,11 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
     }
 
     @Override
+    public boolean isConnectionStale(DatasourceConfiguration datasourceConfiguration) {
+        return datasourceConfiguration.getAuthentication().isExpired();
+    }
+
+    @Override
     public Mono<DatasourceTestResult> testDatasource(DatasourceConfiguration datasourceConfiguration) {
         // At this point, the URL can be invalid because of mustache template keys inside it. Hence, connecting to
         // and verifying the URL isn't feasible. Since validation happens just before testing, and since validation

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
@@ -79,7 +79,7 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
     }
 
     @Override
-    public boolean isConnectionStale(DatasourceConfiguration datasourceConfiguration) {
+    public boolean isConnectionStale(APIConnection connection, DatasourceConfiguration datasourceConfiguration) {
         return datasourceConfiguration.getAuthentication().isExpired();
     }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
@@ -79,7 +79,7 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
     }
 
     @Override
-    public boolean isConnectionStale(APIConnection connection, DatasourceConfiguration datasourceConfiguration) {
+    public boolean isConnectionValid(APIConnection connection, DatasourceConfiguration datasourceConfiguration) {
         return datasourceConfiguration.getAuthentication().isExpired();
     }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -75,6 +75,17 @@ public interface PluginExecutor<C> extends ExtensionPoint, CrudTemplateService {
     }
 
     /**
+     * By default, the connection is not considered stale if all the other checks are passed.
+     * This function can be implemented if additional steps are required to check
+     * if the connection for a plugin is stale or not.
+     * @param datasourceConfiguration
+     * @return boolean
+     */
+    default boolean isConnectionStale(DatasourceConfiguration datasourceConfiguration) {
+        return false;
+    }
+
+    /**
      * This function checks if the datasource is valid. It should only check if all the mandatory fields are filled and
      * if the values are of the right format. It does NOT check the validity of those fields.
      * Please use {@link #testDatasource(DatasourceConfiguration)} to establish the correctness of those fields.

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -75,13 +75,13 @@ public interface PluginExecutor<C> extends ExtensionPoint, CrudTemplateService {
     }
 
     /**
-     * By default, the connection is not considered stale if all the other checks are passed.
+     * By default, the connection is not considered valid if all the other checks are passed.
      * This function can be overridden if additional steps are required to check if the connection
-     * for a plugin is stale or not.
+     * for a plugin is valid or not.
      * @param datasourceConfiguration
      * @return boolean
      */
-    default boolean isConnectionStale(C connection, DatasourceConfiguration datasourceConfiguration) {
+    default boolean isConnectionValid(C connection, DatasourceConfiguration datasourceConfiguration) {
         return false;
     }
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -76,12 +76,12 @@ public interface PluginExecutor<C> extends ExtensionPoint, CrudTemplateService {
 
     /**
      * By default, the connection is not considered stale if all the other checks are passed.
-     * This function can be implemented if additional steps are required to check
-     * if the connection for a plugin is stale or not.
+     * This function can be overridden if additional steps are required to check if the connection
+     * for a plugin is stale or not.
      * @param datasourceConfiguration
      * @return boolean
      */
-    default boolean isConnectionStale(DatasourceConfiguration datasourceConfiguration) {
+    default boolean isConnectionStale(C connection, DatasourceConfiguration datasourceConfiguration) {
         return false;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCE.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services.ce;
 
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.BaseDomain;
+import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.server.domains.DatasourceContext;
 import com.appsmith.server.domains.DatasourceContextIdentifier;
 import com.appsmith.server.domains.Plugin;
@@ -25,12 +26,13 @@ public interface DatasourceContextServiceCE {
      * @return DatasourceContext
      */
     Mono<DatasourceContext<?>> getDatasourceContext(Datasource datasource, DatasourceContextIdentifier datasourceContextIdentifier,
-                                                    Map<String, BaseDomain> environmentMap);
+                                                    Map<String, BaseDomain> environmentMap, PluginExecutor pluginExecutor);
 
     Mono<DatasourceContext<?>> getRemoteDatasourceContext(Plugin plugin, Datasource datasource);
 
     <T> Mono<T> retryOnce(Datasource datasource, DatasourceContextIdentifier datasourceContextIdentifier,
-                          Map<String, BaseDomain> environmentMap, Function<DatasourceContext<?>, Mono<T>> task);
+                          Map<String, BaseDomain> environmentMap, Function<DatasourceContext<?>, Mono<T>> task,
+                          PluginExecutor pluginExecutor);
 
     Mono<DatasourceContext<?>> deleteDatasourceContext(DatasourceContextIdentifier datasourceContextIdentifier);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -78,7 +78,7 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                                                                                DatasourceContextIdentifier datasourceContextIdentifier) {
         synchronized (monitor) {
             /* Destroy any stale connection to free up resource */
-            final boolean isStale = getIsStale(datasource, datasourceContextIdentifier);
+            final boolean isStale = getIsStale(datasource, datasourceContextIdentifier, pluginExecutor);
             if (isStale) {
                 final Object connection = datasourceContextMap.get(datasourceContextIdentifier).getConnection();
                 if (connection != null) {
@@ -210,6 +210,15 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                 && datasourceContextMap.get(datasourceContextIdentifier) != null
                 && datasource.getUpdatedAt() != null
                 && datasource.getUpdatedAt().isAfter(datasourceContextMap.get(datasourceContextIdentifier).getCreationTime());
+    }
+
+    public boolean getIsStale(
+            Datasource datasource, DatasourceContextIdentifier datasourceContextIdentifier, PluginExecutor<Object> pluginExecutor) {
+        DatasourceContext<?> datasourceContext = datasourceContextMap.get(datasourceContextIdentifier);
+        return getIsStale(datasource, datasourceContextIdentifier)
+                || (datasource.getId() != null
+                    && datasourceContext != null
+                    && pluginExecutor.isConnectionStale(datasource.getDatasourceConfiguration()));
     }
 
     protected boolean isValidDatasourceContextAvailable(Datasource datasource,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -211,7 +211,7 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
         DatasourceContext<?> datasourceContext = datasourceContextMap.get(datasourceContextIdentifier);
         return datasource.getId() != null && datasourceContext != null
                 && ((datasource.getUpdatedAt() != null && datasource.getUpdatedAt().isAfter(datasourceContext.getCreationTime()))
-                    || pluginExecutor.isConnectionStale(datasourceContext.getConnection(), datasource.getDatasourceConfiguration()));
+                    || pluginExecutor.isConnectionValid(datasourceContext.getConnection(), datasource.getDatasourceConfiguration()));
     }
 
     protected boolean isValidDatasourceContextAvailable(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -112,9 +112,9 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                 datasourceContextMap.put(datasourceContextIdentifier, datasourceContext);
             }
 
-            Mono<Object> connectionMono = pluginExecutor.datasourceCreate(datasource.getDatasourceConfiguration()).cache();
+            Mono<Object> connectionMonoCache = pluginExecutor.datasourceCreate(datasource.getDatasourceConfiguration()).cache();
 
-            Mono<DatasourceContext<Object>> datasourceContextMonoCache = connectionMono
+            Mono<DatasourceContext<Object>> datasourceContextMonoCache = connectionMonoCache
                     .flatMap(connection -> updateDatasourceAndSetAuthentication(connection, datasource,
                                                                                 datasourceContextIdentifier))
                     .map(connection -> {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -802,7 +802,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
                                     .zipWhen(validatedDatasource -> getDsContextForActionExecution(validatedDatasource,
                                             plugin,
                                             datasourceContextIdentifier,
-                                            environmentMap))
+                                            environmentMap, pluginExecutor))
                                     .flatMap(tuple2 -> {
                                         Datasource validatedDatasource = tuple2.getT1();
                                         DatasourceContext<?> resourceContext = tuple2.getT2();
@@ -884,16 +884,19 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
      * @param environmentMap
      * @return datasourceContextMono
      */
-    protected Mono<DatasourceContext<?>> getDsContextForActionExecution(Datasource validatedDatasource, Plugin plugin,
-                                                                        DatasourceContextIdentifier datasourceContextIdentifier,
-                                                                        Map<String, BaseDomain> environmentMap) {
+    protected Mono<DatasourceContext<?>> getDsContextForActionExecution(
+            Datasource validatedDatasource,
+            Plugin plugin,
+            DatasourceContextIdentifier datasourceContextIdentifier,
+            Map<String, BaseDomain> environmentMap,
+            PluginExecutor<?> pluginExecutor) {
         if (plugin.isRemotePlugin()) {
             return datasourceContextService.getRemoteDatasourceContext(plugin, validatedDatasource)
                     .tag("plugin", plugin.getPackageName())
                     .name(ACTION_EXECUTION_DATASOURCE_CONTEXT_REMOTE)
                     .tap(Micrometer.observation(observationRegistry));
         }
-        return datasourceContextService.getDatasourceContext(validatedDatasource, datasourceContextIdentifier, environmentMap)
+        return datasourceContextService.getDatasourceContext(validatedDatasource, datasourceContextIdentifier, environmentMap, pluginExecutor)
                 .tag("plugin", plugin.getPackageName())
                 .name(ACTION_EXECUTION_DATASOURCE_CONTEXT)
                 .tap(Micrometer.observation(observationRegistry));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
@@ -97,7 +97,8 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
                                     .retryOnce(datasource2, datasourceContextIdentifier, environmentMap,
                                                resourceContext -> ((PluginExecutor<Object>) pluginExecutor)
                                                        .getStructure(resourceContext.getConnection(),
-                                                                     datasource2.getDatasourceConfiguration())); // this datasourceConfiguration is unevaluated for DBAuth type.
+                                                                     datasource2.getDatasourceConfiguration()),
+                                               pluginExecutor); // this datasourceConfiguration is unevaluated for DBAuth type.
                         }))
                 .timeout(Duration.ofSeconds(GET_STRUCTURE_TIMEOUT_SECONDS))
                 .onErrorMap(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
@@ -106,7 +106,7 @@ public class DatasourceTriggerSolutionCEImpl implements DatasourceTriggerSolutio
                                     return datasourceContextService.getRemoteDatasourceContext(plugin, datasource1);
                                 } else {
                                     return datasourceContextService.getDatasourceContext(datasource, datasourceContextIdentifier,
-                                                                                                     environmentMap);
+                                                                                                     environmentMap, pluginExecutor);
                                 }
                             })
                             // Now that we have the context (connection details), execute the action.

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -83,7 +83,7 @@ public class DatasourceContextServiceTest {
     @WithUserDetails(value = "api_user")
     public void testDatasourceCache_afterDatasourceDeleted_doesNotReturnOldConnection() {
         // Never require the datasource connectin to be stale
-        doReturn(false).doReturn(false).when(datasourceContextService).getIsStale(any(), any());
+        doReturn(false).doReturn(false).when(datasourceContextService).getIsStale(any(), any(), any());
 
         MockPluginExecutor mockPluginExecutor = new MockPluginExecutor();
         MockPluginExecutor spyMockPluginExecutor = spy(mockPluginExecutor);
@@ -228,7 +228,7 @@ public class DatasourceContextServiceTest {
     @Test
     @WithUserDetails(value = "api_user")
     public void testCachedDatasourceCreate() {
-        doReturn(false).doReturn(false).when(datasourceContextService).getIsStale(any(), any());
+        doReturn(false).doReturn(false).when(datasourceContextService).getIsStale(any(), any(), any());
 
         MockPluginExecutor mockPluginExecutor = new MockPluginExecutor();
         MockPluginExecutor spyMockPluginExecutor = spy(mockPluginExecutor);


### PR DESCRIPTION

## Description
For checking if the connection is stale or not for authenticated api, only the datasource `updatedAt` field was checked.
If `updatedAt` time is greater than connection `creationTime`, the connection is considered stale.
Added an additional check for Oauth token expiry. If token is expired, the connection will be considered stale and a new connection will be created using the `refresh_token` 

Fixes #21769

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
