### PR TITLE
fix: consider port while constructing blob url in camera widget and plugin action execution

### DIFF
--- a/app/client/src/utils/AppsmithUtils.tsx
+++ b/app/client/src/utils/AppsmithUtils.tsx
@@ -339,10 +339,7 @@ export const isBlobUrl = (url: string) => {
  */
 export const createBlobUrl = (data: Blob | MediaSource, type: string) => {
   let url = URL.createObjectURL(data);
-  url = url.replace(
-    `${window.location.protocol}//${window.location.hostname}/`,
-    "",
-  );
+  url = url.replace(`${window.location.origin}/`, "");
 
   return `${url}?type=${type}`;
 };
@@ -353,9 +350,7 @@ export const createBlobUrl = (data: Blob | MediaSource, type: string) => {
  * @returns [string,string] [blobUrl, type]
  */
 export const parseBlobUrl = (blobId: string) => {
-  const url = `blob:${window.location.protocol}//${
-    window.location.hostname
-  }/${blobId.substring(5)}`;
+  const url = `blob:${window.location.origin}/${blobId.substring(5)}`;
   return url.split("?type=");
 };
 


### PR DESCRIPTION
## Description

While creating a blob URL we should consider the port number where the Appsmith is running. This PR adds the port number to the blob URL.

Fixes https://github.com/appsmithorg/appsmith/issues/22387

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
