### PR TITLE
 fix: showing undefined binding on / command dropdown instead of name for js objects

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/PropertyPaneSuggestion_spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/PropertyPaneSuggestion_spec.ts
@@ -1,7 +1,12 @@
 import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 
-const { AggregateHelper, CommonLocators, EntityExplorer, PropertyPane } =
-  ObjectsRegistry;
+const {
+  AggregateHelper,
+  CommonLocators,
+  EntityExplorer,
+  JSEditor,
+  PropertyPane,
+} = ObjectsRegistry;
 
 describe("Property Pane Suggestions", () => {
   before(() => {
@@ -30,5 +35,18 @@ describe("Property Pane Suggestions", () => {
     AggregateHelper.GetNClickByContains(CommonLocators._hints, "appsmith");
 
     PropertyPane.ValidatePropertyFieldValue("Label", "{{appsmith}}");
+  });
+
+  it("2. [Bug]-[2040]: undefined binding on / command dropdown", () => {
+    // Create js object
+    JSEditor.CreateJSObject("");
+    EntityExplorer.SelectEntityByName("Button1", "Widgets");
+    PropertyPane.TypeTextIntoField("Label", "/");
+    AggregateHelper.GetNAssertElementText(
+      CommonLocators._hints,
+      "JSObject1",
+      "have.text",
+      1,
+    );
   });
 });

--- a/app/client/src/entities/DataTree/dataTreeJSAction.ts
+++ b/app/client/src/entities/DataTree/dataTreeJSAction.ts
@@ -54,6 +54,7 @@ export const generateDataTreeJSAction = (js: JSCollectionData): any => {
       body: removeThisReference,
       ENTITY_TYPE: ENTITY_TYPE.JSACTION,
       actionId: js.config.id,
+      name: js.config.name,
     },
     configEntity: {
       actionId: js.config.id,


### PR DESCRIPTION
## Description
fix: showing undefined binding on / command dropdown instead of name for js objects

Fixes #22337 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
