### PR TITLE
feat: disable spreadsheet entity in case of insert/delete one

### DIFF
--- a/app/client/src/actions/evaluationActions.ts
+++ b/app/client/src/actions/evaluationActions.ts
@@ -8,6 +8,7 @@ import type { DataTree } from "entities/DataTree/dataTreeFactory";
 import type { DependencyMap } from "utils/DynamicBindingUtils";
 import type { Diff } from "deep-diff";
 import type { QueryActionConfig } from "entities/Action";
+import type { DatasourceConfiguration } from "entities/Datasource";
 
 export const FIRST_EVAL_REDUX_ACTIONS = [
   // Pages
@@ -183,6 +184,7 @@ export const startFormEvaluations = (
   pluginId: string,
   actionDiffPath?: string,
   hasRouteChanged?: boolean,
+  datasourceConfiguration?: DatasourceConfiguration,
 ) => {
   return {
     type: ReduxActionTypes.RUN_FORM_EVALUATION,
@@ -193,6 +195,7 @@ export const startFormEvaluations = (
       pluginId,
       actionDiffPath,
       hasRouteChanged,
+      datasourceConfiguration,
     },
   };
 };

--- a/app/client/src/sagas/FormEvaluationSaga.ts
+++ b/app/client/src/sagas/FormEvaluationSaga.ts
@@ -28,6 +28,7 @@ import {
   extractQueueOfValuesToBeFetched,
 } from "./helper";
 import type { Action as ReduxActionType } from "redux";
+import type { DatasourceConfiguration } from "entities/Datasource";
 
 export type FormEvalActionPayload = {
   formId: string;
@@ -38,6 +39,7 @@ export type FormEvalActionPayload = {
   settingConfig?: FormConfigType[];
   actionDiffPath?: string;
   hasRouteChanged?: boolean;
+  datasourceConfiguration?: DatasourceConfiguration;
 };
 
 // This value holds an array of values that needs to be dynamically fetched

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -261,7 +261,6 @@ function* formValueChangeSaga(
       getDatasource,
       values.datasource.id,
     );
-    console.log(datasource);
 
     // Editing form fields triggers evaluations.
     // We pass the action to run form evaluations when the dataTree evaluation is complete

--- a/app/client/src/sagas/QueryPaneSagas.ts
+++ b/app/client/src/sagas/QueryPaneSagas.ts
@@ -253,6 +253,16 @@ function* formValueChangeSaga(
       return;
     }
 
+    // get datasource configuration based on datasource id
+    // pass it to run form evaluations method
+    // This is required for google sheets, as we need to modify query
+    // state based on datasource config
+    const datasource: Datasource | undefined = yield select(
+      getDatasource,
+      values.datasource.id,
+    );
+    console.log(datasource);
+
     // Editing form fields triggers evaluations.
     // We pass the action to run form evaluations when the dataTree evaluation is complete
     const postEvalActions =
@@ -265,6 +275,7 @@ function* formValueChangeSaga(
               values.pluginId,
               field,
               hasRouteChanged,
+              datasource?.datasourceConfiguration,
             ),
           ]
         : [];

--- a/app/client/src/workers/Evaluation/formEval.ts
+++ b/app/client/src/workers/Evaluation/formEval.ts
@@ -14,6 +14,7 @@ import { isArray, isEmpty, isString, merge, uniq } from "lodash";
 import { extractEvalConfigFromFormConfig } from "components/formControls/utils";
 import { isDynamicValue } from "utils/DynamicBindingUtils";
 import { isTrueObject } from "@appsmith/workers/Evaluation/evaluationUtils";
+import type { DatasourceConfiguration } from "entities/Datasource";
 
 export enum ConditionType {
   HIDE = "hide", // When set, the component will be shown until condition is true
@@ -290,6 +291,8 @@ function evaluateDynamicValuesConfig(
 function evaluateFormConfigElements(
   actionConfiguration: ActionConfig,
   config: FormConfigEvalObject,
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  datasourceConfiguration?: DatasourceConfiguration,
 ) {
   const paths = Object.keys(config);
   if (paths.length > 0) {
@@ -310,6 +313,7 @@ function evaluate(
   currentEvalState: FormEvalOutput,
   actionDiffPath?: string,
   hasRouteChanged?: boolean,
+  datasourceConfiguration?: DatasourceConfiguration,
 ) {
   Object.keys(currentEvalState).forEach((key: string) => {
     try {
@@ -403,6 +407,7 @@ function evaluate(
                     currentEvalState[key]
                       .evaluateFormConfig as EvaluatedFormConfig
                   ).evaluateFormConfigObject,
+                  datasourceConfiguration,
                 );
             }
           });
@@ -420,6 +425,7 @@ function getFormEvaluation(
   currentEvalState: FormEvaluationState,
   actionDiffPath?: string,
   hasRouteChanged?: boolean,
+  datasourceConfiguration?: DatasourceConfiguration,
 ): FormEvaluationState {
   // Only change the form evaluation state if the form ID is same or the evaluation state is present
   if (!!currentEvalState && currentEvalState.hasOwnProperty(formId)) {
@@ -472,6 +478,7 @@ function getFormEvaluation(
         currentEvalState[formId],
         actionDiffPath,
         hasRouteChanged,
+        datasourceConfiguration,
       );
     } else {
       conditionToBeEvaluated = {
@@ -483,6 +490,7 @@ function getFormEvaluation(
         conditionToBeEvaluated,
         actionDiffPath,
         hasRouteChanged,
+        datasourceConfiguration,
       );
     }
 
@@ -534,8 +542,13 @@ export function setFormEvaluationSaga(
     // This is the initial evaluation state, evaluations can now be run on top of this
     return { [payload.formId]: finalEvalObj };
   } else {
-    const { actionConfiguration, actionDiffPath, formId, hasRouteChanged } =
-      payload;
+    const {
+      actionConfiguration,
+      actionDiffPath,
+      datasourceConfiguration,
+      formId,
+      hasRouteChanged,
+    } = payload;
     // In case the formData is not ready or the form is not of type UQI, return empty state
     if (!actionConfiguration || !actionConfiguration.formData) {
       return currentEvalState;
@@ -546,6 +559,7 @@ export function setFormEvaluationSaga(
         currentEvalState,
         actionDiffPath,
         hasRouteChanged,
+        datasourceConfiguration,
       );
     }
   }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/root.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/root.json
@@ -60,7 +60,7 @@
               "value": "ROWS"
             },
             {
-              "disabled": "{{ ['FETCH_MANY', 'FETCH_DETAILS', 'INSERT_ONE', 'DELETE_ONE'].includes(actionConfiguration.formData.command.data) === false }}",
+              "disabled": "{{ ['FETCH_MANY', 'FETCH_DETAILS', 'INSERT_ONE', 'DELETE_ONE'].includes(actionConfiguration.formData.command.data) === false || (['INSERT_ONE', 'DELETE_ONE'].includes(actionConfiguration.formData.command.data) === true &&  ['https://www.googleapis.com/auth/drive.file'].includes(datasourceConfiguration.authentication.scopeString) === true)}}",
               "label": "Spreadsheet",
               "value": "SPREADSHEET"
             },


### PR DESCRIPTION
## Description

This PR fixes:
- When google sheet datasource is created with selected sheets scope, in this case we need to disable spreadsheet option in the entity dropdown of the query, so that user cannot delete/insert from selected sheets

> Add a TL;DR when description is extra long (helps content team)

Fixes #22152 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
