### PR TITLE
fix: null check before accessing editableCell property in table widget

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/Table.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/Table.tsx
@@ -359,7 +359,7 @@ export function Table(props: TableProps) {
                 columns={tableHeadercolumns}
                 currentPageIndex={currentPageIndex}
                 delimiter={props.delimiter}
-                disableAddNewRow={!!props.editableCell.column}
+                disableAddNewRow={!!props.editableCell?.column}
                 disabledAddNewRowSave={props.disabledAddNewRowSave}
                 filters={props.filters}
                 isAddRowInProgress={props.isAddRowInProgress}

--- a/app/client/src/widgets/TableWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/TableWidgetV2/widget/derived.js
@@ -698,7 +698,7 @@ export default {
   //
   getEditableCellValidity: (props, moment, _) => {
     if (
-      (!props.editableCell.column && !props.isAddRowInProgress) ||
+      (!props.editableCell?.column && !props.isAddRowInProgress) ||
       !props.primaryColumns
     ) {
       return {};
@@ -752,11 +752,11 @@ export default {
         });
     } else {
       const editedColumn = Object.values(props.primaryColumns).find(
-        (column) => column.alias === props.editableCell.column,
+        (column) => column.alias === props.editableCell?.column,
       );
 
       if (validatableColumns.includes(editedColumn.columnType)) {
-        editableColumns.push([editedColumn, props.editableCell.value]);
+        editableColumns.push([editedColumn, props.editableCell?.value]);
       }
     }
 


### PR DESCRIPTION
## Description

This PR adds optional chaining while accessing the properties of `editableCell` object in the table widget.

Fixes #20789


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please refer to the [comment.](https://github.com/appsmithorg/appsmith/issues/20789#issuecomment-1515845278)
### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
