### PR TITLE
ci: Fix to fetch the sha id from client_payload instead of event.pull_request

### DIFF
--- a/.github/workflows/ci-merge-check.yml
+++ b/.github/workflows/ci-merge-check.yml
@@ -39,14 +39,14 @@ jobs:
       - name: get status-checks from pr
         id: pr_status_check
         run: |
-          status_link="https://api.github.com/repos/appsmithorg/appsmith/statuses/${{github.event.pull_request.head.sha}}"
+          status_link="https://api.github.com/repos/appsmithorg/appsmith/statuses/${{github.event.client_payload.pull_request.head.sha}}"
           curl --silent "$status_link"|jq -r '.[]'|jq -r 'select(.state | contains("success") | not) | .context' >> ~/check1
           echo "status=`grep -c -v 'cypress\|Vercel\|DeepSource' ~/check1`" >> $GITHUB_OUTPUT
 
       - name: get status-checks from check suite
         id: suite_status_check
         run: |
-          check_runs_link="https://api.github.com/repos/appsmithorg/appsmith/commits/${{steps.pr.outputs.sha}}/check-runs"
+          check_runs_link="https://api.github.com/repos/appsmithorg/appsmith/commits/${{github.event.client_payload.pull_request.head.sha}}/check-runs"
           curl --silent "$check_runs_link"|jq -r '.check_runs[] | select(.conclusion | contains("success") | not ) | .name' >> ~/check2
           echo "status1=`grep -c 'Check for Test Plan Approved label' ~/check2`" >> $GITHUB_OUTPUT
           curl --silent "$check_runs_link"|jq -r '.check_runs[] | .name' >> ~/check3


### PR DESCRIPTION
## Description
- Fix to fetch the sha id from client_payload instead of event.pull_request in ci-merge-check

## Type of change
- ci-merge-check.yml

## How Has This Been Tested?
- Github actions

## Checklist:
### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
