### PR TITLE
Fix: Remove excess padding on right side and fix widget drop in nested containers

### DIFF
--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -98,6 +98,13 @@ export const DefaultDimensionMap = {
 export const CONTAINER_GRID_PADDING =
   GridDefaults.DEFAULT_GRID_ROW_HEIGHT * 0.6;
 
+/**
+ * Padding introduced by container-like widgets in AutoLayout mode.
+ * FlexComponent - margin: 2px (2 * 2 = 4px) [Deploy mode = 4px ( 4 * 2 = 8px)]
+ * ResizeWrapper - padding: 1px, border: 1px (2 * 2 = 4px) [Deploy mode = 0px]
+ * ContainerComponent - border: 1px (1 * 2 = 2px) [Deploy mode = 2px]
+ * Total - 5px (5 * 2 = 10px)
+ */
 export const AUTO_LAYOUT_CONTAINER_PADDING = 5;
 
 export const WIDGET_PADDING = GridDefaults.DEFAULT_GRID_ROW_HEIGHT * 0.4;

--- a/app/client/src/constants/WidgetConstants.tsx
+++ b/app/client/src/constants/WidgetConstants.tsx
@@ -98,6 +98,8 @@ export const DefaultDimensionMap = {
 export const CONTAINER_GRID_PADDING =
   GridDefaults.DEFAULT_GRID_ROW_HEIGHT * 0.6;
 
+export const AUTO_LAYOUT_CONTAINER_PADDING = 5;
+
 export const WIDGET_PADDING = GridDefaults.DEFAULT_GRID_ROW_HEIGHT * 0.4;
 
 export const WIDGET_CLASSNAME_PREFIX = "WIDGET_";

--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -6,6 +6,7 @@ import {
 } from "./selectors";
 import _, { find, isString, reduce, remove } from "lodash";
 import type { WidgetType } from "constants/WidgetConstants";
+import { AUTO_LAYOUT_CONTAINER_PADDING } from "constants/WidgetConstants";
 import {
   CONTAINER_GRID_PADDING,
   FLEXBOX_PADDING,
@@ -60,6 +61,7 @@ import { isWidget } from "@appsmith/workers/Evaluation/evaluationUtils";
 import { CANVAS_DEFAULT_MIN_HEIGHT_PX } from "constants/AppConstants";
 import type { MetaState } from "reducers/entityReducers/metaReducer";
 import { Positioning } from "utils/autoLayout/constants";
+import { AppPositioningTypes } from "reducers/entityReducers/pageListReducer";
 
 export interface CopiedWidgetGroup {
   widgetId: string;
@@ -744,7 +746,12 @@ export function getMousePositions(
  */
 export function getSnappedGrid(LayoutWidget: WidgetProps, canvasWidth: number) {
   // For all widgets inside a container, we remove both container padding as well as widget padding from component width
-  let padding = (CONTAINER_GRID_PADDING + WIDGET_PADDING) * 2;
+  let padding =
+    ((LayoutWidget?.appPositioningType === AppPositioningTypes.AUTO
+      ? AUTO_LAYOUT_CONTAINER_PADDING
+      : CONTAINER_GRID_PADDING) +
+      WIDGET_PADDING) *
+    2;
   if (
     LayoutWidget.widgetId === MAIN_CONTAINER_WIDGET_ID ||
     LayoutWidget.type === "CONTAINER_WIDGET"

--- a/app/client/src/utils/autoLayout/AutoLayoutUtils.ts
+++ b/app/client/src/utils/autoLayout/AutoLayoutUtils.ts
@@ -5,8 +5,8 @@ import {
   GridDefaults,
   MAIN_CONTAINER_WIDGET_ID,
   WIDGET_PADDING,
-  CONTAINER_GRID_PADDING,
   DefaultDimensionMap,
+  AUTO_LAYOUT_CONTAINER_PADDING,
 } from "constants/WidgetConstants";
 import type {
   CanvasWidgetsReduxState,
@@ -507,9 +507,9 @@ function getPadding(canvas: FlattenedWidgetProps): number {
   if (canvas.widgetId === MAIN_CONTAINER_WIDGET_ID) {
     padding = FLEXBOX_PADDING * 2;
   } else if (canvas.type === "CONTAINER_WIDGET") {
-    padding = (CONTAINER_GRID_PADDING + FLEXBOX_PADDING) * 2;
+    padding = (AUTO_LAYOUT_CONTAINER_PADDING + FLEXBOX_PADDING) * 2;
   } else if (canvas.isCanvas) {
-    padding = CONTAINER_GRID_PADDING * 2;
+    padding = AUTO_LAYOUT_CONTAINER_PADDING * 2;
   }
 
   if (canvas.noPad) {

--- a/app/client/src/utils/autoLayout/highlightUtils.ts
+++ b/app/client/src/utils/autoLayout/highlightUtils.ts
@@ -384,12 +384,8 @@ function getPositionForInitialHighlight(
   columnSpace: number,
   startPosition: number | undefined,
 ): number {
-  const containerWidth = 64 * columnSpace;
-  const endPosition =
-    containerWidth +
-    (canvasId !== MAIN_CONTAINER_WIDGET_ID
-      ? FLEXBOX_PADDING
-      : FLEXBOX_PADDING / 2);
+  const containerWidth = GridDefaults.DEFAULT_GRID_COLUMNS * columnSpace;
+  const endPosition = containerWidth + FLEXBOX_PADDING / 2;
   if (alignment === FlexLayerAlignment.End) {
     return endPosition;
   } else if (alignment === FlexLayerAlignment.Center) {
@@ -480,12 +476,18 @@ function updateVerticalHighlightDropZone(
   for (const [index, highlight] of highlights.entries()) {
     const nextHighlight: HighlightInfo | undefined = highlights[index + 1];
     const previousHighlight: HighlightInfo | undefined = highlights[index - 1];
-    const leftZone = previousHighlight
-      ? (highlight.posX - previousHighlight.posX) * zoneSize
-      : highlight.posX + DEFAULT_HIGHLIGHT_SIZE;
-    const rightZone = nextHighlight
-      ? (nextHighlight.posX - highlight.posX) * zoneSize
-      : canvasWidth - highlight.posX;
+    const leftZone = Math.max(
+      previousHighlight
+        ? (highlight.posX - previousHighlight.posX) * zoneSize
+        : highlight.posX + DEFAULT_HIGHLIGHT_SIZE,
+      4,
+    );
+    const rightZone = Math.max(
+      nextHighlight
+        ? (nextHighlight.posX - highlight.posX) * zoneSize
+        : canvasWidth - highlight.posX,
+      4,
+    );
     highlights[index] = {
       ...highlight,
       dropZone: {

--- a/app/client/src/utils/hooks/useDynamicAppLayout.tsx
+++ b/app/client/src/utils/hooks/useDynamicAppLayout.tsx
@@ -47,7 +47,6 @@ import { useWindowSizeHooks } from "./dragResizeHooks";
 import type { AppState } from "ce/reducers";
 import { ReduxActionTypes } from "ce/constants/ReduxActionConstants";
 
-const BORDERS_WIDTH = 2;
 const GUTTER_WIDTH = 72;
 export const AUTOLAYOUT_RESIZER_WIDTH_BUFFER = 40;
 
@@ -194,7 +193,7 @@ export const useDynamicAppLayout = () => {
       case maxWidth < 0:
       case appLayout?.type === "FLUID":
       case calculatedWidth < maxWidth && calculatedWidth > minWidth:
-        const totalWidthToSubtract = BORDERS_WIDTH + gutterWidth;
+        const totalWidthToSubtract = gutterWidth;
         // NOTE: gutter + border width will be only substracted when theme mode and preview mode are off
         return (
           calculatedWidth -
@@ -225,11 +224,7 @@ export const useDynamicAppLayout = () => {
     let scale = 1;
     if (isMultiPane && appLayout?.type !== "FLUID") {
       let canvasSpace =
-        screenWidth -
-        tabsPaneWidth -
-        SIDE_NAV_WIDTH -
-        GUTTER_WIDTH -
-        BORDERS_WIDTH;
+        screenWidth - tabsPaneWidth - SIDE_NAV_WIDTH - GUTTER_WIDTH;
       if (paneCount === 3) canvasSpace -= propertyPaneWidth;
       // Scale will always be between 0.5 to 1
       scale = Math.max(

--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -187,7 +187,7 @@ function ContainerComponent(props: ContainerComponentProps) {
         resizeDisabled={props.resizeDisabled}
         shouldScrollContents={
           props.shouldScrollContents &&
-          props.appPositioningType !== AppPositioningTypes.AUTO
+          props.appPositioningType !== AppPositioningTypes.AUTO // Disable scrollbar on autolayout canvas as it meddles with canvas drag and highlight position.
         }
         type={props.type}
         widgetId={props.widgetId}

--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -155,7 +155,10 @@ function ContainerComponent(props: ContainerComponentProps) {
         onClick={props.onClick}
         onClickCapture={props.onClickCapture}
         resizeDisabled={props.resizeDisabled}
-        shouldScrollContents={props.shouldScrollContents}
+        shouldScrollContents={
+          props.shouldScrollContents &&
+          props.appPositioningType !== AppPositioningTypes.AUTO
+        }
         type={props.type}
         widgetId={props.widgetId}
       >
@@ -182,7 +185,10 @@ function ContainerComponent(props: ContainerComponentProps) {
         onClick={props.onClick}
         onClickCapture={props.onClickCapture}
         resizeDisabled={props.resizeDisabled}
-        shouldScrollContents={props.shouldScrollContents}
+        shouldScrollContents={
+          props.shouldScrollContents &&
+          props.appPositioningType !== AppPositioningTypes.AUTO
+        }
         type={props.type}
         widgetId={props.widgetId}
       >
@@ -212,6 +218,7 @@ export interface ContainerComponentProps extends WidgetStyleContainerProps {
   justifyContent?: string;
   alignItems?: string;
   dropDisabled?: boolean;
+  appPositioningType?: AppPositioningTypes;
 }
 
 export default ContainerComponent;


### PR DESCRIPTION
## Description

Issues:
1. Excess padding on right side on MainContainer and other container-like widgets.
2. End highlight not visible in deeply nested containers.

Causes:
1.a. Border around the MainContainer has been removed. However, the border width was still being deducted from the total width.
1.b. For parentColumnSpace calculation, CONTAINER_GRID_PADDING (= 6px) was used. However, on AutoLayout canvases, containers only account for 5px in padding, resulting in excess space of 2px on the right side.
2.a. End position highlight has negative drop zones causing it to be excluded from selection calculations. 
2.b. container scrollbars are causing the drag on the canvas to not get triggered.

Fixes # (issue)

1. https://github.com/appsmithorg/appsmith/issues/20705
2. https://github.com/appsmithorg/appsmith/issues/21311


Media


https://user-images.githubusercontent.com/5424788/232890004-2f66b697-e84c-4625-966d-894cc63f70b7.mov




## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag

