### PR TITLE
fix: hide telemetry form for airgap instance

### DIFF
--- a/app/client/src/pages/setup/DetailsForm.tsx
+++ b/app/client/src/pages/setup/DetailsForm.tsx
@@ -33,6 +33,7 @@ import {
   Size,
 } from "design-system-old";
 import { roleOptions, useCaseOptions } from "./constants";
+import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 
 const DetailsFormWrapper = styled.div`
   width: 100%;
@@ -49,6 +50,8 @@ export default function DetailsForm(
   props: SetupFormProps & { onNext?: () => void },
 ) {
   const ref = React.createRef<HTMLDivElement>();
+
+  const isAirgappedInstance = isAirgapped();
 
   return (
     <DetailsFormWrapper ref={ref}>
@@ -144,11 +147,11 @@ export default function DetailsForm(
             category={Category.secondary}
             className="t--welcome-form-next-button"
             disabled={props.invalid}
-            onClick={props.onNext}
+            onClick={!isAirgappedInstance ? props.onNext : undefined}
             size={Size.medium}
             tag="button"
             text="Next"
-            type="button"
+            type={!isAirgappedInstance ? "button" : "submit"}
           />
         </ButtonWrapper>
       </StyledFormBodyWrapper>

--- a/app/client/src/pages/setup/SetupForm.tsx
+++ b/app/client/src/pages/setup/SetupForm.tsx
@@ -120,6 +120,7 @@ export type SetupFormProps = DetailsFormValues & {
   >;
 
 function SetupForm(props: SetupFormProps) {
+  const isAirgappedInstance = isAirgapped();
   const signupURL = `/api/v1/${SUPER_USER_SUBMIT_PATH}`;
   const [showDetailsForm, setShowDetailsForm] = useState(true);
   const formRef = useRef<HTMLFormElement>(null);
@@ -159,8 +160,6 @@ function SetupForm(props: SetupFormProps) {
     form.appendChild(useCaseInput);
     return true;
   };
-
-  const isAirgappedInstance = !isAirgapped();
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLFormElement>) => {
     if (event.key === "Enter") {

--- a/app/client/src/pages/setup/SetupForm.tsx
+++ b/app/client/src/pages/setup/SetupForm.tsx
@@ -22,6 +22,8 @@ import { isEmail, isStrongPassword } from "utils/formhelpers";
 import type { AppState } from "@appsmith/reducers";
 import { SUPER_USER_SUBMIT_PATH } from "@appsmith/constants/ApiConstants";
 import { useState } from "react";
+import { isAirgapped } from "@appsmith/utils/airgapHelpers";
+import { noop } from "utils/AppsmithUtils";
 
 const PageWrapper = styled.div`
   width: 100%;
@@ -158,6 +160,8 @@ function SetupForm(props: SetupFormProps) {
     return true;
   };
 
+  const isAirgappedInstance = !isAirgapped();
+
   const onKeyDown = (event: React.KeyboardEvent<HTMLFormElement>) => {
     if (event.key === "Enter") {
       if (props.valid) {
@@ -201,12 +205,17 @@ function SetupForm(props: SetupFormProps) {
           ref={formRef}
         >
           <SetupStep active={showDetailsForm}>
-            <DetailsForm {...props} onNext={onNext} />
+            <DetailsForm
+              {...props}
+              onNext={!isAirgappedInstance ? onNext : () => noop}
+            />
           </SetupStep>
-          <SetupStep active={!showDetailsForm}>
-            <DataCollectionForm />
-            <NewsletterForm />
-          </SetupStep>
+          {!isAirgappedInstance && (
+            <SetupStep active={!showDetailsForm}>
+              <DataCollectionForm />
+              <NewsletterForm />
+            </SetupStep>
+          )}
         </form>
         <SpaceFiller />
       </SetupFormContainer>


### PR DESCRIPTION
## Description

- Since telemetry and newsletters are by default disabled in airgap we don't need it for airgapped instances.


Fixes #22369 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)



## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
