### PR TITLE
fix: Google Sheets Scope Label Change

### DIFF
--- a/app/client/cypress/integration/SanitySuite/Datasources/GoogleSheetsStub_spec.ts
+++ b/app/client/cypress/integration/SanitySuite/Datasources/GoogleSheetsStub_spec.ts
@@ -12,8 +12,9 @@ describe("Google Sheets datasource test cases", function () {
     dataSources.NavigateToDSCreateNew();
     dataSources.CreatePlugIn("Google Sheets");
     VerifyFunctionDropdown([
-      "Read/Write | Selected Google Sheets",
-      "Read/Write | All Google Sheets",
+      "Read / Write / Delete | Selected Google Sheets",
+      "Read / Write / Delete | All Google Sheets",
+      "Read / Write | All Google Sheets",
       "Read | All Google Sheets",
     ]);
     dataSources.SaveDSFromDialog(false);

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
@@ -90,7 +90,7 @@
               "value": "https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive.readonly"
             },
             {
-              "label": "Read Only | All Google Sheets",
+              "label": "Read | All Google Sheets",
               "value": "https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/drive.readonly"
             }
           ],

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
@@ -94,7 +94,10 @@
               "value": "https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/drive.readonly"
             }
           ],
-          "initialValue": "https://www.googleapis.com/auth/drive.file"
+          "initialValue": "https://www.googleapis.com/auth/drive.file",
+          "customStyles": {
+            "width": "340px"
+          }
         }
       ]
     }

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/form.json
@@ -78,15 +78,19 @@
           "controlType": "DROP_DOWN",
           "options": [
             {
-              "label": "Read/Write | Selected Google Sheets",
+              "label": "Read / Write / Delete | Selected Google Sheets",
               "value": "https://www.googleapis.com/auth/drive.file"
             },
             {
-              "label": "Read/Write | All Google Sheets",
+              "label": "Read / Write / Delete | All Google Sheets",
               "value": "https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive"
             },
             {
-              "label": "Read | All Google Sheets",
+              "label": "Read / Write | All Google Sheets",
+              "value": "https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive.readonly"
+            },
+            {
+              "label": "Read Only | All Google Sheets",
               "value": "https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/drive.readonly"
             }
           ],


### PR DESCRIPTION
## Description

- The following PR changes the label values seen by the user in the scope selection drop-down menu while creating a Google Sheet data source.
- The changes accommodate for one specific scope that was present in the previous implementation and is not present now i.e read/write without delete permission for which a new scope has been added.
- Also with these changes the migration for old data sources is not required since we have added all the previously used scopes here.
- Figma Link: https://www.figma.com/file/TcFhqEbAc8ymHTRF5wR1qv/Limited-GSheet-Access?node-id=506-32761
- Notion link for migration: https://www.notion.so/appsmith/Google-Sheet-Migration-ab7bbfbdae1f40189a957b6ae5374145

Fixes #22327 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
