### PR TITLE
Disable hot reloading of cypress tests

### DIFF
--- a/app/client/cypress.json
+++ b/app/client/cypress.json
@@ -1,5 +1,6 @@
 {
 	"baseUrl": "https://dev.appsmith.com/",
+	"watchForFileChanges" : false,
 	"defaultCommandTimeout": 20000,
 	"requestTimeout": 21000,
 	"responseTimeout": 20000,


### PR DESCRIPTION
Disabling hot reloading would disable running of cypress tests on its own whenever anything is changed in the current test case.

I think this might be helpful for scenarios when a developer is writing/completing their test case and don't intend to re-run the test until they have completed their code. This would prevent unnecessary test runs and keep the memory footprint low.

A lower foot print would help in reduced flakiness when an actual test run is required.

If a developer wants to re-run the test, they have to switch cypress app nonetheless, and can press the refresh button at that time.

Please suggest if this would appropriate as a team wide change.