### PR TITLE
fix: tooltip in gsheets query pagination field

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/fetch_many.json
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/resources/editor/fetch_many.json
@@ -158,7 +158,7 @@
           },
           "tooltipText": {
             "limit": "Bind to the pageSize property of your widget {{Table1.pageSize}}",
-            "offset": "Bind to the index of the first row to display {{(Table1.pageNo-1)*pageSize}}"
+            "offset": "Bind to the index of the first row to display {{(Table1.pageNo-1)*Table1.pageSize}}"
           }
         }
       ]


### PR DESCRIPTION
## Description

In the google sheets query for operation `Fetch Many`-->`Sheet Rows`, the tooltip is as follows:
![Screenshot 2023-04-21 at 15 30 15](https://user-images.githubusercontent.com/94514895/233608160-613a931b-0f5f-403e-9a29-49018dc415e7.png)

this example is incorrect, it should be `...Table1.pageSize`, and not just `pageSize`

Fixes #21384



## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)



## How Has This Been Tested?
- Manual

### Test Plan


### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
