### PR TITLE
chore: update multiple-environments feature flag criteria 

### DIFF
--- a/app/server/appsmith-server/src/main/resources/features/init-flags.yml
+++ b/app/server/appsmith-server/src/main/resources/features/init-flags.yml
@@ -68,8 +68,8 @@ ff4j:
       flipstrategy:
         class: com.appsmith.server.featureflags.strategies.EmailBasedRolloutStrategy
         param:
-          - name: emailDomains
-            value: appsmith.com,moolya.com
+          - name: emails
+            value: me-eng1@appsmith.com, me-eng2@appsmith.com, me-qa1@appsmith.com, me-qa2@appsmith.com, me-demo@appsmith.com
 
     - uid: MULTIPLE_PANES
       enable: true


### PR DESCRIPTION
## Description

As part of ongoing efforts to improve our feature flagging process, this Pull Request updates the "multiple-environments" feature flag criteria to limit access to a specific list of email addresses, rather than the entire Appsmith domain. This will help to reduce the impact of the latest merges and ensure that only authorised users have access to the feature.

Specifically, this Pull Request modifies the existing criteria for the "multiple-environments" feature flag and changes the access control from email domains to individual email addresses. This ensures that only users with approved email addresses can access the feature, and reduces the risk of unauthorised access or unintended consequences resulting from recent code merges.

description generated by chatGPT

The email addresses are as follows:
1. [me-eng1@appsmith.com](mailto:me-eng1@appsmith.com)
2. [me-eng2@appsmith.com](mailto:me-eng2@appsmith.com)
3. [me-qa1@appsmith.com](mailto:me-qa1@appsmith.com)
4. [me-qa2@appsmith.com](mailto:me-qa2@appsmith.com)
5. [me-demo@appsmith.com](mailto:me-demo@appsmith.com)

> changed the feature flag strategy from emailDomain to email and assigned five emails

Fixes #22626

## How Has This Been Tested?
- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
