### PR TITLE
fix: [#21180] Firestore plugin -> "Timestamp Path" fix

### DIFF
--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/addToCollection.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/addToCollection.json
@@ -25,7 +25,6 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/addToCollection.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/addToCollection.json
@@ -25,7 +25,7 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": true,
+      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/createDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/createDocument.json
@@ -25,7 +25,6 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/createDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/createDocument.json
@@ -25,7 +25,7 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": true,
+      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/setDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/setDocument.json
@@ -25,7 +25,6 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/setDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/setDocument.json
@@ -25,7 +25,7 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": true,
+      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/updateDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/updateDocument.json
@@ -34,7 +34,6 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }

--- a/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/updateDocument.json
+++ b/app/server/appsmith-plugins/firestorePlugin/src/main/resources/editor/updateDocument.json
@@ -34,7 +34,7 @@
       "configProperty": "actionConfiguration.formData.timestampValuePath.data",
       "controlType": "QUERY_DYNAMIC_INPUT_TEXT",
       "evaluationSubstitutionType": "TEMPLATE",
-      "isRequired": true,
+      "isRequired": false,
       "initialValue": "",
       "placeholderText": "[ \"checkinLog.timestampKey\" ]"
     }


### PR DESCRIPTION
## Description

> Firestore plugin -> "Timestamp Path" field must not be required field (isRequired: false)

Closes #21180 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:
### Dev activity
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
