### PR TITLE
feat: To store user's Intercom email share consent on backend

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
@@ -74,7 +74,7 @@ public class UserData extends BaseDomain {
     private List<String> recentlyUsedTemplateIds;
 
     // Status of user's consent on sharing email for Intercom communications
-    @JsonView(Views.Public.class)
+    @JsonView(Views.Internal.class)
     private boolean isIntercomConsentGiven;
 
     @JsonView(Views.Public.class)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/UserData.java
@@ -73,6 +73,10 @@ public class UserData extends BaseDomain {
     @JsonView(Views.Public.class)
     private List<String> recentlyUsedTemplateIds;
 
+    // Status of user's consent on sharing email for Intercom communications
+    @JsonView(Views.Public.class)
+    private boolean isIntercomConsentGiven;
+
     @JsonView(Views.Public.class)
     public GitProfile getGitProfileByKey(String key) {
         // Always use DEFAULT_GIT_PROFILE as fallback

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserProfileDTO.java
@@ -37,6 +37,9 @@ public class UserProfileDTO {
     @JsonProperty("adminSettingsVisible")
     boolean adminSettingsVisible = false;
 
+    @JsonProperty("isIntercomConsentGiven")
+    boolean isIntercomConsentGiven = false;
+
     String photoId;
 
     String role;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserUpdateDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserUpdateDTO.java
@@ -14,12 +14,14 @@ public class UserUpdateDTO {
 
     private String useCase;
 
+    private boolean isIntercomConsentGiven;
+
     public boolean hasUserUpdates() {
         return name != null;
     }
 
     public boolean hasUserDataUpdates() {
-        return role != null || useCase != null;
+        return role != null || useCase != null || isIntercomConsentGiven;
     }
 
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -686,8 +686,15 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
 
         if (allUpdates.hasUserDataUpdates()) {
             final UserData updates = new UserData();
-            updates.setRole(allUpdates.getRole());
-            updates.setUseCase(allUpdates.getUseCase());
+            if (StringUtils.hasLength(allUpdates.getRole())) {
+                updates.setRole(allUpdates.getRole());
+            }
+            if (StringUtils.hasLength(allUpdates.getUseCase())) {
+                updates.setUseCase(allUpdates.getUseCase());
+            }
+            if (allUpdates.isIntercomConsentGiven()) {
+                updates.setIntercomConsentGiven(true);
+            }
             updatedUserDataMono = userDataService.updateForCurrentUser(updates).cache();
             monos.add(updatedUserDataMono.then());
         } else {
@@ -765,7 +772,7 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                     profile.setUseCase(userData.getUseCase());
                     profile.setPhotoId(userData.getProfilePhotoAssetId());
                     profile.setEnableTelemetry(!commonConfig.isTelemetryDisabled());
-
+                    profile.setIntercomConsentGiven(userData.isIntercomConsentGiven());
                     profile.setSuperUser(isSuperUser);
                     profile.setConfigurable(!StringUtils.isEmpty(commonConfig.getEnvFilePath()));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -442,6 +442,39 @@ public class UserServiceTest {
 
     @Test
     @WithUserDetails(value = "api_user")
+    public void updateIntercomConsentOfUser() {
+        final Mono<UserData> userDataMono = userDataService.getForUserEmail("api_user");
+        StepVerifier.create(userDataMono)
+                .assertNext(userData -> {
+                    assertNotNull(userData);
+                    assertThat(userData.isIntercomConsentGiven()).isFalse();
+                })
+                .verifyComplete();
+
+        UserUpdateDTO updateUser = new UserUpdateDTO();
+        updateUser.setIntercomConsentGiven(true);
+        final Mono<UserData> updateToTrueMono = userService.updateCurrentUser(updateUser, null)
+                .then(userDataMono);
+        StepVerifier.create(updateToTrueMono)
+                .assertNext(userData -> {
+                    assertNotNull(userData);
+                    assertThat(userData.isIntercomConsentGiven()).isTrue();
+                })
+                .verifyComplete();
+
+        updateUser.setIntercomConsentGiven(false);
+        final Mono<UserData> updateToFalseAfterTrueMono = userService.updateCurrentUser(updateUser, null)
+                .then(userDataMono);
+        StepVerifier.create(updateToFalseAfterTrueMono)
+                .assertNext(userData -> {
+                    assertNotNull(userData);
+                    assertThat(userData.isIntercomConsentGiven()).isTrue();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
     public void updateNameRoleAndUseCaseOfUser() {
         UserUpdateDTO updateUser = new UserUpdateDTO();
         updateUser.setName("New name of user here");


### PR DESCRIPTION
## Description

Currently, there is no way for us to know any details about a user when they reach out to support via Intercom. Thus, we are not able to offer the right level of support to them basis their current plan.

The idea is to ask for consent to share user details with Appsmith before Intercom is enabled for a user, the basis which support can determine the right level of support.

This PR helps to store and retrieve the flag variable for a particular user which says whether the consent was given or not.

Fixes #22611

## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- Manual
- JUnit

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
