### PR TITLE
feat: Unfurl all Entity Explorer sections in new app

### DIFF
--- a/app/client/src/ce/sagas/ApplicationSagas.tsx
+++ b/app/client/src/ce/sagas/ApplicationSagas.tsx
@@ -113,6 +113,7 @@ import { getCurrentUser } from "selectors/usersSelectors";
 import { ERROR_CODES } from "@appsmith/constants/ApiConstants";
 import { safeCrashAppRequest } from "actions/errorActions";
 import { isAirgapped } from "@appsmith/utils/airgapHelpers";
+import { setAllEntityCollapsibleStates } from "../../actions/editorContextActions";
 
 export const getDefaultPageId = (
   pages?: ApplicationPagePayload[],
@@ -602,6 +603,16 @@ export function* createApplicationSaga(
         const FirstTimeUserOnboardingApplicationId: string = yield select(
           getFirstTimeUserOnboardingApplicationId,
         );
+        // All new apps will have the Entity Explorer unfurled so that users
+        // can find the entities they have created
+        yield put(
+          setAllEntityCollapsibleStates({
+            Widgets: true,
+            ["Queries/JS"]: true,
+            Datasources: true,
+          }),
+        );
+
         if (
           isFirstTimeUserOnboardingEnabled &&
           FirstTimeUserOnboardingApplicationId === ""


### PR DESCRIPTION
## Description

Making sure that whenever a user creates a new app, we will have the entity explorer will uncollapsed Widgets, Query Datasource sections so that the user can find the entities they create easily

Fixes #21893


Media

https://user-images.githubusercontent.com/12022471/233955568-52b0e645-86b8-4058-adb3-48c9f4a7b501.mov




## Type of change
- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
