### PR TITLE
chore: create a new index on permission groups for defaultDomainId & defaultDomainType

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration008CreateIndexDefaultDomainIdDefaultDomainTypeDropIndexDefaultWorkspaceId.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration008CreateIndexDefaultDomainIdDefaultDomainTypeDropIndexDefaultWorkspaceId.java
@@ -1,0 +1,48 @@
+package com.appsmith.server.migrations.db.ce;
+
+
+import com.appsmith.server.domains.PermissionGroup;
+import com.appsmith.server.domains.QPermissionGroup;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+
+import static com.appsmith.server.migrations.DatabaseChangelog1.dropIndexIfExists;
+import static com.appsmith.server.migrations.DatabaseChangelog1.ensureIndexes;
+import static com.appsmith.server.migrations.DatabaseChangelog1.makeIndex;
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.fieldName;
+
+@ChangeUnit(order = "008", id = "create-index-default-domain-id-default-domain-type", author = " ")
+public class Migration008CreateIndexDefaultDomainIdDefaultDomainTypeDropIndexDefaultWorkspaceId {
+
+    private final MongoTemplate mongoTemplate;
+
+    private final static String oldPermissionGroupIndexNameDefaultWorkspaceIdDeleted = "permission_group_workspace_deleted_compound_index";
+
+    private final static String newPermissionGroupIndexNameDefaultDomainIdDefaultDomainType = "permission_group_domainId_domainType_deleted_deleted_compound_index";
+
+    public Migration008CreateIndexDefaultDomainIdDefaultDomainTypeDropIndexDefaultWorkspaceId(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void rollBackExecution() {
+    }
+
+    @Execution
+    public void createNewIndexDefaultDomainIdDefaultDomainTypeAndDropOldIndexDefaultWorkspaceId() {
+        dropIndexIfExists(mongoTemplate, PermissionGroup.class, oldPermissionGroupIndexNameDefaultWorkspaceIdDeleted);
+        dropIndexIfExists(mongoTemplate, PermissionGroup.class, newPermissionGroupIndexNameDefaultDomainIdDefaultDomainType);
+
+        Index newIndexDefaultDomainIdDefaultDomainTypeDeletedDeletedAt = makeIndex(
+                fieldName(QPermissionGroup.permissionGroup.defaultDomainId),
+                fieldName(QPermissionGroup.permissionGroup.defaultDomainType),
+                fieldName(QPermissionGroup.permissionGroup.deleted),
+                fieldName(QPermissionGroup.permissionGroup.deletedAt)
+        ).named(newPermissionGroupIndexNameDefaultDomainIdDefaultDomainType);
+
+        ensureIndexes(mongoTemplate, PermissionGroup.class, newIndexDefaultDomainIdDefaultDomainTypeDeletedDeletedAt);
+    }
+}


### PR DESCRIPTION
## Description

> Create a new index on permission group with `defaultDomainId` + `defaultDomainType` + `deleted` +`deletedAt` in order to improve the performance of the queries which are used to find the permission groups using `defaultDomainId` and `defaultDomainType`. 

> Also, we are going to remove an already existing index: `permission_group_workspace_deleted_compound_index` which was used earlier, when we were still dependent on `defaultWorkspaceId`

Fixes #22674 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?
> Tested locally by running the server.
> Indices post the server start:
```
db.permissionGroup.getIndexes()
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  {
    v: 2,
    key: { assignedToUserIds: 1, deleted: 1 },
    name: 'permission_group_assignedUserIds_deleted_compound_index'
  },
  {
    v: 2,
    key: {
      defaultDomainId: 1,
      defaultDomainType: 1,
      deleted: 1,
      deletedAt: 1
    },
    name: 'permission_group_domainId_domainType_deleted_deleted_compound_index'
  }
]
```

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
