### PR TITLE
fix: available columns calculation in assigning width to fill widgets

### DIFF
--- a/app/client/src/utils/autoLayout/positionUtils.ts
+++ b/app/client/src/utils/autoLayout/positionUtils.ts
@@ -401,7 +401,7 @@ export function extractAlignmentInfo(
     }
   }
 
-  const availableColumns: number =
+  let availableColumns: number =
     GridDefaults.DEFAULT_GRID_COLUMNS -
     startColumns -
     centerColumns -
@@ -417,11 +417,12 @@ export function extractAlignmentInfo(
     .forEach((each, index) => {
       const { child, columns } = each;
       let width = fillWidgetLength;
-      // If the fill widget's minWidth is greater than the available space, then assign the widget's minWidth as its width.
-      if (columns > fillWidgetLength) {
+      if (columns > availableColumns) width = columns;
+      else if (columns > fillWidgetLength) {
+        // If the fill widget's minWidth is greater than the available space, then assign the widget's minWidth as its width.
         width = columns;
-        fillWidgetLength =
-          (availableColumns - width) / (fillChildren.length - index - 1);
+        availableColumns = Math.min(availableColumns - width, 0);
+        fillWidgetLength = availableColumns / (fillChildren.length - index - 1);
       }
       if (child.align === FlexLayerAlignment.Start) {
         startColumns += width;


### PR DESCRIPTION
## Description

On smaller viewports, space can not be equally divided between fill widgets because it is less than the min width of some. Width allocation is done in descending order of min width requirement of fill widgets. Allocation width is now being deducted from available columns to fix the logic.

Fixes # https://github.com/appsmithorg/appsmith/issues/22555



## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Jest
- 
## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag

