### PR TITLE
fix: cursor position not between parenthesis for function autocomplete

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
@@ -3,7 +3,6 @@ import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 const {
   AggregateHelper: agHelper,
   CommonLocators: locator,
-  DataSources: dataSources,
   EntityExplorer: ee,
   LibraryInstaller: installer,
   PropertyPane: propPane,

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
@@ -3,6 +3,7 @@ import { ObjectsRegistry } from "../../../../support/Objects/Registry";
 const {
   AggregateHelper: agHelper,
   CommonLocators: locator,
+  DataSources: dataSources,
   EntityExplorer: ee,
   LibraryInstaller: installer,
   PropertyPane: propPane,
@@ -108,5 +109,17 @@ describe("Autocomplete bug fixes", function () {
     installer.uninstallLibrary("uuidjs");
     propPane.TypeTextIntoField("Text", "{{UUID.");
     agHelper.AssertElementAbsence(locator._hints);
+  });
+
+  it("9. Bug #20449 Cursor should be between parenthesis when function is autocompleted", function () {
+    ee.SelectEntityByName("Text1");
+    propPane.TypeTextIntoField("Text", "{{console.l");
+
+    agHelper.GetNClickByContains(locator._hints, "log");
+
+    propPane.TypeTextIntoField("Text", '"hello"', false);
+
+    // If the cursor was not between parenthesis, the following command will fail
+    propPane.ValidatePropertyFieldValue("Text", '{{console.log("hello")}}');
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
@@ -4,6 +4,7 @@ const {
   AggregateHelper: agHelper,
   CommonLocators: locator,
   EntityExplorer: ee,
+  JSEditor: jsEditor,
   LibraryInstaller: installer,
   PropertyPane: propPane,
 } = ObjectsRegistry;
@@ -110,7 +111,7 @@ describe("Autocomplete bug fixes", function () {
     agHelper.AssertElementAbsence(locator._hints);
   });
 
-  it("9. Bug #20449 Cursor should be between parenthesis when function is autocompleted", function () {
+  it("9. Bug #20449 Cursor should be between parenthesis when function is autocompleted (Property Pane)", function () {
     ee.SelectEntityByName("Text1");
     propPane.TypeTextIntoField("Text", "{{console.l");
 
@@ -120,5 +121,36 @@ describe("Autocomplete bug fixes", function () {
 
     // If the cursor was not between parenthesis, the following command will fail
     propPane.ValidatePropertyFieldValue("Text", '{{console.log("hello")}}');
+  });
+
+  it("10. Bug #20449 Cursor should be between parenthesis when function is autocompleted (JS Object)", function () {
+    jsEditor.CreateJSObject(
+      `export default {
+    myFun1: () => {
+
+    },
+  }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: true,
+        prettify: false,
+      },
+    );
+
+    agHelper.GetNClick(jsEditor._lineinJsEditor(3));
+
+    cy.get(jsEditor._lineinJsEditor(3)).type("console.l");
+
+    agHelper.GetNClickByContains(locator._hints, "log");
+
+    cy.get("body").type("'hello'");
+
+    // If the cursor was not between parenthesis, the following command will fail
+    agHelper.GetNAssertContains(
+      jsEditor._lineinJsEditor(3),
+      "console.log('hello')",
+    );
   });
 });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Autocomplete/Autocomplete_Spec.ts
@@ -141,11 +141,11 @@ describe("Autocomplete bug fixes", function () {
 
     agHelper.GetNClick(jsEditor._lineinJsEditor(3));
 
-    cy.get(jsEditor._lineinJsEditor(3)).type("console.l");
+    agHelper.TypeText(locator._codeMirrorTextArea, "console.l");
 
     agHelper.GetNClickByContains(locator._hints, "log");
 
-    cy.get("body").type("'hello'");
+    agHelper.TypeText(locator._codeMirrorTextArea, "'hello'");
 
     // If the cursor was not between parenthesis, the following command will fail
     agHelper.GetNAssertContains(

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -316,8 +316,10 @@ export class PropertyPane {
     toVerifySave && this.agHelper.AssertAutoSave();
   }
 
-  public TypeTextIntoField(endp: string, value: string) {
-    this.RemoveText(endp);
+  public TypeTextIntoField(endp: string, value: string, removeText = true) {
+    if (removeText) {
+      this.RemoveText(endp);
+    }
     cy.get(
       this.locator._propertyControl +
         endp.replace(/ +/g, "").toLowerCase() +

--- a/app/client/src/utils/autocomplete/CodemirrorTernService.ts
+++ b/app/client/src/utils/autocomplete/CodemirrorTernService.ts
@@ -365,8 +365,8 @@ class CodeMirrorTernService {
     return obj;
   }
 
-  getHint(cm: CodeMirror.Editor) {
-    return new Promise((resolve) => {
+  async getHint(cm: CodeMirror.Editor) {
+    const hints = await new Promise((resolve) => {
       this.request(
         cm,
         {
@@ -382,6 +382,18 @@ class CodeMirrorTernService {
         (error, data) => this.requestCallback(error, data, cm, resolve),
       );
     });
+
+    // When a function is picked, move the cursor between the parenthesis
+    CodeMirror.on(hints, "pick", (selected: CommandsCompletion) => {
+      if (selected.type === AutocompleteDataType.FUNCTION) {
+        cm.setCursor({
+          line: cm.getCursor().line,
+          ch: cm.getCursor().ch - 1,
+        });
+      }
+    });
+
+    return hints;
   }
 
   showContextInfo(cm: CodeMirror.Editor, queryName: string, callbackFn?: any) {


### PR DESCRIPTION
## Description
When using autocomplete suggestion, earlier on selecting a function the cursor was placed at the end of the parenthesis forcing the user to press one more key (left arrow) before filling the arguments. Now the cursor is placed right between the parenthesis.

Fixes #20449 

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
