### PR TITLE
fix: disable uppy informer and hide welcome tour cta for airgap

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -80,7 +80,7 @@
     "cypress-log-to-output": "^1.1.2",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",
-    "design-system-old": "npm:@appsmithorg/design-system-old@0.0.0-alpha-20230421065909",
+    "design-system-old": "npm:@appsmithorg/design-system-old@1.1.5",
     "downloadjs": "^1.4.7",
     "exceljs": "^4.3.0",
     "fast-deep-equal": "^3.1.3",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -80,7 +80,7 @@
     "cypress-log-to-output": "^1.1.2",
     "dayjs": "^1.10.6",
     "deep-diff": "^1.0.2",
-    "design-system-old": "npm:@appsmithorg/design-system-old@1.1.4",
+    "design-system-old": "npm:@appsmithorg/design-system-old@0.0.0-alpha-20230421065909",
     "downloadjs": "^1.4.7",
     "exceljs": "^4.3.0",
     "fast-deep-equal": "^3.1.3",

--- a/app/client/src/pages/Editor/FirstTimeUserOnboarding/Checklist.tsx
+++ b/app/client/src/pages/Editor/FirstTimeUserOnboarding/Checklist.tsx
@@ -51,7 +51,7 @@ import type { CanvasWidgetsReduxState } from "reducers/entityReducers/canvasWidg
 import { triggerWelcomeTour } from "./Utils";
 import { builderURL, integrationEditorURL } from "RouteBuilder";
 import { ASSETS_CDN_URL } from "constants/ThirdPartyConstants";
-import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
+import { getAssetUrl, isAirgapped } from "@appsmith/utils/airgapHelpers";
 
 const Wrapper = styled.div`
   padding: ${(props) => props.theme.spaces[7]}px 55px;
@@ -217,6 +217,7 @@ function getSuggestedNextActionAndCompletedTasks(
 }
 
 export default function OnboardingChecklist() {
+  const isAirgappedInstance = isAirgapped();
   const dispatch = useDispatch();
   const datasources = useSelector(getDatasources);
   const pageId = useSelector(getCurrentPageId);
@@ -557,23 +558,25 @@ export default function OnboardingChecklist() {
           )}
         </StyledListItem>
       </StyledList>
-      <StyledFooter
-        className="flex"
-        onClick={() => triggerWelcomeTour(dispatch)}
-      >
-        <StyledImg
-          alt="rocket"
-          src={getAssetUrl(`${ASSETS_CDN_URL}/Rocket.png`)}
-        />
-        <Text style={{ lineHeight: "14px" }} type={TextType.P1}>
-          {createMessage(ONBOARDING_CHECKLIST_FOOTER)}
-        </Text>
-        <Icon
-          color={theme.colors.applications.iconColor}
-          icon="chevron-right"
-          iconSize={16}
-        />
-      </StyledFooter>
+      {!isAirgappedInstance && (
+        <StyledFooter
+          className="flex"
+          onClick={() => triggerWelcomeTour(dispatch)}
+        >
+          <StyledImg
+            alt="rocket"
+            src={getAssetUrl(`${ASSETS_CDN_URL}/Rocket.png`)}
+          />
+          <Text style={{ lineHeight: "14px" }} type={TextType.P1}>
+            {createMessage(ONBOARDING_CHECKLIST_FOOTER)}
+          </Text>
+          <Icon
+            color={theme.colors.applications.iconColor}
+            icon="chevron-right"
+            iconSize={16}
+          />
+        </StyledFooter>
+      )}
     </Wrapper>
   );
 }

--- a/app/client/src/pages/UserProfile/UserProfileImagePicker.tsx
+++ b/app/client/src/pages/UserProfile/UserProfileImagePicker.tsx
@@ -7,8 +7,10 @@ import { USER_PHOTO_ASSET_URL } from "constants/userConstants";
 import { DisplayImageUpload } from "design-system-old";
 
 import type Uppy from "@uppy/core";
+import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 
 function FormDisplayImage() {
+  const isAirgappedInstance = isAirgapped();
   const [file, setFile] = useState<any>();
   const dispatch = useDispatch();
   const user = useSelector(getCurrentUser);
@@ -53,6 +55,7 @@ function FormDisplayImage() {
 
   return (
     <DisplayImageUpload
+      disableUppyInformer={isAirgappedInstance}
       onChange={onSelectFile}
       onRemove={removeProfileImage}
       submit={upload}

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -9969,10 +9969,10 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
 
-"design-system-old@npm:@appsmithorg/design-system-old@0.0.0-alpha-20230421065909":
-  version "0.0.0-alpha-20230421065909"
-  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system-old/-/design-system-old-0.0.0-alpha-20230421065909.tgz#55cebbab809ae80596663e42c988d513d0b1c803"
-  integrity sha512-7jsZkm3iLicuW6pMozONpEGHpIEQ1rQhDwka24O2fyPBNlyNFj80030XkFXab2yaXNXMlx92BRyWmJZ4w6aHVg==
+"design-system-old@npm:@appsmithorg/design-system-old@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system-old/-/design-system-old-1.1.5.tgz#4911f997cedebf8c8bc20ddef9bb7e2e657d8be5"
+  integrity sha512-h2XOWYryvmkl5ZjRgQ56HDNaSH+uzR0s7V2ZRt4iZBspXyf0wdf4fCcgIByZesRwLHFLmBPR2hQjOUcEnILVSQ==
   dependencies:
     emoji-mart "3.0.1"
 

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -9969,10 +9969,10 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
 
-"design-system-old@npm:@appsmithorg/design-system-old@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system-old/-/design-system-old-1.1.4.tgz#f779945d28297d5c16a4af30929d9988ab033182"
-  integrity sha512-W4ZsbjbvfjBi4U4wNeTPr1JasnxGwwF3/vbzoANd+A2+0vbg1+FkQcr7hwvy1AS/iVgPah+TGIXwk3vTs7WowQ==
+"design-system-old@npm:@appsmithorg/design-system-old@0.0.0-alpha-20230421065909":
+  version "0.0.0-alpha-20230421065909"
+  resolved "https://registry.yarnpkg.com/@appsmithorg/design-system-old/-/design-system-old-0.0.0-alpha-20230421065909.tgz#55cebbab809ae80596663e42c988d513d0b1c803"
+  integrity sha512-7jsZkm3iLicuW6pMozONpEGHpIEQ1rQhDwka24O2fyPBNlyNFj80030XkFXab2yaXNXMlx92BRyWmJZ4w6aHVg==
   dependencies:
     emoji-mart "3.0.1"
 


### PR DESCRIPTION
## Description
- In an airgapped instance, the `No internet connection` message from uppy should be disabled.


Fixes #22366 
> if no issue exists, please create an issue and ask the maintainers about this first


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)



## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
