### PR TITLE
fix: Remove JSON.parse for accessing Airtable query result (#22711)

### DIFF
--- a/app/client/cypress/integration/SanitySuite/Datasources/Airtable_Basic_Spec.ts
+++ b/app/client/cypress/integration/SanitySuite/Datasources/Airtable_Basic_Spec.ts
@@ -34,7 +34,7 @@ describe("Validate Airtable Ds", () => {
 
     _.dataSources.RunQuery();
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       jsonSpecies.records.forEach((record: { fields: any }) => {
         specieslist.push(record.fields.Species_ID);
       });
@@ -53,7 +53,7 @@ describe("Validate Airtable Ds", () => {
 
     _.dataSources.RunQuery();
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       const hasOnlyAllowedKeys = jsonSpecies.records.every((record: any) => {
         const fieldKeys = Object.keys(record.fields);
         return (
@@ -79,7 +79,7 @@ describe("Validate Airtable Ds", () => {
     });
     _.dataSources.RunQuery();
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       expect(jsonSpecies.records.length).to.eq(11); //making sure only 11 record fields are returned
     });
 
@@ -91,7 +91,7 @@ describe("Validate Airtable Ds", () => {
     });
     _.dataSources.RunQuery();
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       expect(jsonSpecies.records.length).to.eq(6); //making sure only 6 record fields are returned, honouring the PageSize
 
       //Validating offset
@@ -104,7 +104,7 @@ describe("Validate Airtable Ds", () => {
       _.dataSources.RunQuery();
 
       cy.get("@postExecute").then((resObj: any) => {
-        jsonSpecies = JSON.parse(resObj.response.body.data.body);
+        jsonSpecies = resObj.response.body.data.body;
         expect(jsonSpecies.records.length).to.eq(5); //making sure only remaining records are returned
       });
     });
@@ -124,7 +124,7 @@ describe("Validate Airtable Ds", () => {
     _.dataSources.RunQuery();
 
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       const allRecordsWithRodentTaxa = jsonSpecies.records.filter(
         (record: { fields: { Taxa: string } }) =>
           record.fields.Taxa === "Rodent",
@@ -158,7 +158,7 @@ describe("Validate Airtable Ds", () => {
     _.dataSources.RunQuery();
 
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       const sorted = jsonSpecies.records.every(
         (record: { fields: { Species_ID: string } }, i: number) => {
           if (i === 0) {
@@ -193,7 +193,7 @@ describe("Validate Airtable Ds", () => {
     _.dataSources.RunQuery();
 
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       const sorted = jsonSpecies.records.every(
         (record: { fields: { Species_ID: string } }, i: number) => {
           if (i === 0) {
@@ -232,7 +232,7 @@ describe("Validate Airtable Ds", () => {
     _.dataSources.RunQuery();
 
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       const isJSONValid = jsonSpecies.records.every(
         (record: { fields: { Species_ID: any } }) => {
           const speciesID = record.fields.Species_ID;
@@ -269,7 +269,7 @@ describe("Validate Airtable Ds", () => {
     _.dataSources.RunQuery();
 
     cy.get("@postExecute").then((resObj: any) => {
-      jsonSpecies = JSON.parse(resObj.response.body.data.body);
+      jsonSpecies = resObj.response.body.data.body;
       //cy.log("jsonSpecies is"+ jsonSpecies)
       expect(jsonSpecies.records.length).to.eq(1); //making sure only inserted record is returned
 
@@ -289,7 +289,7 @@ describe("Validate Airtable Ds", () => {
       _.dataSources.RunQuery();
 
       cy.get("@postExecute").then((resObj: any) => {
-        jsonSpecies = JSON.parse(resObj.response.body.data.body);
+        jsonSpecies = resObj.response.body.data.body;
         const hasOnlyInsertedRecord = () => {
           return (
             jsonSpecies.fields.Species_ID === "SF" &&
@@ -325,7 +325,7 @@ describe("Validate Airtable Ds", () => {
       _.dataSources.RunQuery();
 
       cy.get("@postExecute").then((resObj: any) => {
-        jsonSpecies = JSON.parse(resObj.response.body.data.body);
+        jsonSpecies = resObj.response.body.data.body;
         const hasOnlyUpdatedRecord = () => {
           return (
             jsonSpecies.records[0].fields.Species_ID === "SG" &&
@@ -348,7 +348,7 @@ describe("Validate Airtable Ds", () => {
       _.dataSources.RunQuery();
 
       cy.get("@postExecute").then((resObj: any) => {
-        jsonSpecies = JSON.parse(resObj.response.body.data.body);
+        jsonSpecies = resObj.response.body.data.body;
         expect(jsonSpecies.deleted).to.be.true;
       });
     });


### PR DESCRIPTION
## Description


Fixes #22711 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change


- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
