### PR TITLE
feat: autocomplete feature for email and password

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Input/Inputv2_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Input/Inputv2_spec.js
@@ -257,7 +257,7 @@ describe("Input widget V2 - ", () => {
       },
     ].forEach(({ expected, input }) => enterAndTest(input, expected));
 
-    validateAutocomplteAttribute();
+    validateAutocompleteAttribute();
   });
 
   it("6. Validate DataType - EMAIL can be entered into Input widget", () => {
@@ -328,7 +328,7 @@ describe("Input widget V2 - ", () => {
       },
     ].forEach(({ expected, input }) => enterAndTest(input, expected));
 
-    validateAutocomplteAttribute();
+    validateAutocompleteAttribute();
   });
 
   it("7. Validating other properties - Input validity with #valid", () => {
@@ -446,7 +446,7 @@ describe("Input widget V2 - ", () => {
     cy.get(".t--widget-textwidget").should("contain", expected);
   }
 
-  function validateAutocomplteAttribute() {
+  function validateAutocompleteAttribute() {
     //validate autocomplete behaviour for email and password
 
     cy.openPropertyPane("textwidget");

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Input/Inputv2_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/Input/Inputv2_spec.js
@@ -256,6 +256,8 @@ describe("Input widget V2 - ", () => {
         expected: "test@appsmith.com:test@appsmith.com:true",
       },
     ].forEach(({ expected, input }) => enterAndTest(input, expected));
+
+    validateAutocomplteAttribute();
   });
 
   it("6. Validate DataType - EMAIL can be entered into Input widget", () => {
@@ -325,6 +327,8 @@ describe("Input widget V2 - ", () => {
         expected: "test@appsmith.com:test@appsmith.com:true",
       },
     ].forEach(({ expected, input }) => enterAndTest(input, expected));
+
+    validateAutocomplteAttribute();
   });
 
   it("7. Validating other properties - Input validity with #valid", () => {
@@ -430,6 +434,42 @@ describe("Input widget V2 - ", () => {
     // Check if isDirty is reset to false
     cy.get(".t--widget-textwidget").should("contain", "false");
   });
+
+  function enterAndTest(text, expected) {
+    cy.get(`.t--widget-${widgetName} input`).clear();
+    cy.wait(300);
+    if (text) {
+      cy.get(`.t--widget-${widgetName} input`)
+        .click({ force: true })
+        .type(text);
+    }
+    cy.get(".t--widget-textwidget").should("contain", expected);
+  }
+
+  function validateAutocomplteAttribute() {
+    //validate autocomplete behaviour for email and password
+
+    cy.openPropertyPane("textwidget");
+    cy.openPropertyPane(widgetName);
+    //check if autofill toggle option is present and is checked by default
+    cy.get(".t--property-control-allowautofill input").should("be.checked");
+    //check if autocomplete attribute is not present in the text widget when autofill is enabled
+    cy.get(widgetInput).should("not.have.attr", "autocomplete");
+
+    //toggle off autofill
+    cy.get(".t--property-control-allowautofill input").click({ force: true });
+    cy.get(".t--property-control-allowautofill input").should("not.be.checked");
+
+    //autocomplete should now be present in the text widget
+    cy.get(widgetInput).should("have.attr", "autocomplete", "off");
+
+    //select a non email or password option
+    cy.selectDropdownValue(".t--property-control-datatype", "text");
+    //autofill toggle should not be present as this restores autofill to be enabled
+    cy.get(".t--property-control-allowautofill input").should("not.exist");
+    //autocomplete attribute should not be present in the text widget
+    cy.get(widgetInput).should("not.have.attr", "autocomplete");
+  }
 
   function enterAndTest(text, expected) {
     cy.get(`.t--widget-${widgetName} input`).clear();

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/JSONForm/JSONForm_FieldProperties_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/JSONForm/JSONForm_FieldProperties_spec.js
@@ -87,13 +87,14 @@ describe("Text Field Property Control", () => {
     cy.get(`${fieldPrefix}-name`).should("exist");
   });
 
-  it("8. disables field when disabled switched on", () => {
+  it("8. disables field when disabled switched on and when autofill is disabled we should see the autofill attribute in the input field", () => {
     cy.togglebar(`.t--property-control-disabled input`);
     cy.get(`${fieldPrefix}-name input`).each(($el) => {
       cy.wrap($el).should("have.attr", "disabled");
     });
 
     cy.togglebarDisable(`.t--property-control-disabled input`);
+    validateAutocompleteAttributeInJSONForm();
   });
 
   it("9. throws error when REGEX does not match the input value", () => {
@@ -326,3 +327,31 @@ describe("Text Field Property Control", () => {
     cy.get(`${fieldPrefix}-radio`).should("exist");
   });
 });
+
+function validateAutocompleteAttributeInJSONForm() {
+  //select password input fiel
+  cy.selectDropdownValue(commonlocators.jsonFormFieldType, "Password Input");
+
+  //check if autofill toggle option is present and is checked by default
+  cy.get(".t--property-control-allowautofill input").should("be.checked");
+  //check if autocomplete attribute is not present in the text widget when autofill is enabled
+  cy.get(`${fieldPrefix}-name input`).should("not.have.attr", "autocomplete");
+
+  //toggle off autofill
+  cy.get(".t--property-control-allowautofill input").click({ force: true });
+  cy.get(".t--property-control-allowautofill input").should("not.be.checked");
+
+  //autocomplete should now be present in the text widget
+  cy.get(`${fieldPrefix}-name input`).should(
+    "have.attr",
+    "autocomplete",
+    "off",
+  );
+
+  //select a non email or password option
+  cy.selectDropdownValue(commonlocators.jsonFormFieldType, /^Text Input/);
+  //autofill toggle should not be present as this restores autofill to be enabled
+  cy.get(".t--property-control-allowautofill input").should("not.exist");
+  //autocomplete attribute should not be present in the text widget
+  cy.get(`${fieldPrefix}-name input`).should("not.have.attr", "autocomplete");
+}

--- a/app/client/src/widgets/BaseInputWidget/component/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/component/index.tsx
@@ -583,6 +583,7 @@ class BaseInputComponent extends React.Component<
       this.textAreaInputComponent()
     ) : (
       <InputGroup
+        autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
         className={this.props.isLoading ? "bp3-skeleton" : ""}
         disabled={this.props.disabled}
@@ -757,6 +758,7 @@ export interface BaseInputComponentProps extends ComponentProps {
   compactMode: boolean;
   isInvalid: boolean;
   autoFocus?: boolean;
+  autoComplete?: string;
   iconName?: IconName;
   iconAlign?: Omit<Alignment, "center">;
   showError: boolean;

--- a/app/client/src/widgets/BaseInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/BaseInputWidget/widget/index.tsx
@@ -10,6 +10,8 @@ import { isAutoLayout } from "utils/autoLayout/flexWidgetUtils";
 import type { DerivedPropertiesMap } from "utils/WidgetFactory";
 import type { WidgetProps, WidgetState } from "widgets/BaseWidget";
 import BaseWidget from "widgets/BaseWidget";
+import type { InputWidgetProps } from "widgets/InputWidgetV2/widget";
+import { isInputTypeEmailOrPassword } from "widgets/InputWidgetV2/widget/Utilities";
 import BaseInputComponent from "../component";
 import { InputTypes } from "../constants";
 import { checkInputTypeTextByProps } from "../utils";
@@ -240,6 +242,24 @@ class BaseInputWidget<
             isBindProperty: true,
             isTriggerProperty: false,
             validation: { type: ValidationTypes.BOOLEAN },
+          },
+          {
+            propertyName: "shouldAllowAutofill",
+            label: "Allow autofill",
+            helpText: "Allow users to autofill values from browser",
+            controlType: "SWITCH",
+            isJSConvertible: true,
+            isBindProperty: true,
+            isTriggerProperty: false,
+            validation: { type: ValidationTypes.BOOLEAN },
+            hidden: (props: InputWidgetProps) => {
+              //should be shown for only inputWidgetV2 and for email or password input types
+              return !(
+                isInputTypeEmailOrPassword(props?.inputType) &&
+                props.type === "INPUT_WIDGET_V2"
+              );
+            },
+            dependencies: ["inputType"],
           },
           {
             propertyName: "allowFormatting",

--- a/app/client/src/widgets/InputWidgetV2/component/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/component/index.tsx
@@ -41,6 +41,7 @@ class InputComponent extends React.Component<InputComponentProps> {
       <BaseInputComponent
         accentColor={this.props.accentColor}
         allowNumericCharactersOnly={this.props.allowNumericCharactersOnly}
+        autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
         borderRadius={this.props.borderRadius}
         boxShadow={this.props.boxShadow}
@@ -94,6 +95,7 @@ export interface InputComponentProps extends BaseInputComponentProps {
   borderRadius?: string;
   boxShadow?: string;
   accentColor?: string;
+  autoComplete?: string;
 }
 
 export default InputComponent;

--- a/app/client/src/widgets/InputWidgetV2/widget/Utilities.ts
+++ b/app/client/src/widgets/InputWidgetV2/widget/Utilities.ts
@@ -28,3 +28,7 @@ export function getParsedText(value: string, inputType: InputTypes) {
 
   return text;
 }
+
+export function isInputTypeEmailOrPassword(inputType?: string) {
+  return inputType === InputTypes.EMAIL || inputType === InputTypes.PASSWORD;
+}

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -320,20 +320,6 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
               dependencies: ["dynamicHeight"],
             },
             {
-              propertyName: "shouldAllowAutofill",
-              label: "Allow autofill",
-              helpText: "Allow users to autofill values from browser",
-              controlType: "SWITCH",
-              isJSConvertible: true,
-              isBindProperty: true,
-              isTriggerProperty: false,
-              validation: { type: ValidationTypes.BOOLEAN },
-              hidden: (props: InputWidgetProps) => {
-                return !isInputTypeEmailOrPassword(props?.inputType);
-              },
-              dependencies: ["inputType"],
-            },
-            {
               helpText:
                 "Sets the default text of the widget. The text is updated if the default text changes",
               propertyName: "defaultText",

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -26,7 +26,7 @@ import {
   InputTypes,
   NumberInputStepButtonPosition,
 } from "widgets/BaseInputWidget/constants";
-import { getParsedText } from "./Utilities";
+import { getParsedText, isInputTypeEmailOrPassword } from "./Utilities";
 import type { Stylesheet } from "entities/AppTheming";
 import {
   isAutoHeightEnabledForWidget,
@@ -233,7 +233,7 @@ export function maxValueValidation(max: any, props: InputWidgetProps, _?: any) {
 function InputTypeUpdateHook(
   props: WidgetProps,
   propertyName: string,
-  propertyValue: unknown,
+  propertyValue: any,
 ) {
   const updates = [
     {
@@ -250,6 +250,12 @@ function InputTypeUpdateHook(
       });
     }
   }
+  //if input type is email or password default the autofill state to be true
+  // the user needs to explicity set autofill to fault disable autofill
+  updates.push({
+    propertyPath: "shouldAllowAutofill",
+    propertyValue: isInputTypeEmailOrPassword(propertyValue),
+  });
 
   return updates;
 }
@@ -312,6 +318,20 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
               isTriggerProperty: false,
               updateHook: InputTypeUpdateHook,
               dependencies: ["dynamicHeight"],
+            },
+            {
+              propertyName: "shouldAllowAutofill",
+              label: "Allow autofill",
+              helpText: "Allow users to autofill values from browser",
+              controlType: "SWITCH",
+              isJSConvertible: true,
+              isBindProperty: true,
+              isTriggerProperty: false,
+              validation: { type: ValidationTypes.BOOLEAN },
+              hidden: (props: InputWidgetProps) => {
+                return !isInputTypeEmailOrPassword(props?.inputType);
+              },
+              dependencies: ["inputType"],
             },
             {
               helpText:
@@ -672,10 +692,15 @@ class InputWidget extends BaseInputWidget<InputWidgetProps, WidgetState> {
     } else {
       conditionalProps.buttonPosition = NumberInputStepButtonPosition.NONE;
     }
-
+    const autoFillProps =
+      !this.props.shouldAllowAutofill &&
+      isInputTypeEmailOrPassword(this.props.inputType)
+        ? { autoComplete: "off" }
+        : {};
     return (
       <InputComponent
         accentColor={this.props.accentColor}
+        {...autoFillProps}
         // show label and Input side by side if true
         autoFocus={this.props.autoFocus}
         borderRadius={this.props.borderRadius}

--- a/app/client/src/widgets/JSONFormWidget/constants.ts
+++ b/app/client/src/widgets/JSONFormWidget/constants.ts
@@ -65,6 +65,7 @@ export type JSON = Obj | Obj[];
 export type FieldComponentBaseProps = {
   defaultValue?: string | number;
   isDisabled: boolean;
+  shouldAllowAutofill?: boolean;
   isRequired?: boolean;
   isVisible: boolean;
   label: string;

--- a/app/client/src/widgets/JSONFormWidget/fields/BaseInputField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/BaseInputField.tsx
@@ -349,9 +349,17 @@ function BaseInputField<TSchemaItem extends SchemaItem>({
   }, [schemaItem, isDirty, isValueValid, inputText]);
 
   const fieldComponent = useMemo(() => {
+    const autoFillProps =
+      !schemaItem.shouldAllowAutofill &&
+      [FieldType.EMAIL_INPUT, FieldType.PASSWORD_INPUT].includes(
+        schemaItem.fieldType,
+      )
+        ? { autoComplete: "off" }
+        : {};
     return (
       <BaseInputComponent
         {...conditionalProps}
+        {...autoFillProps}
         accentColor={schemaItem.accentColor}
         borderRadius={schemaItem.borderRadius}
         boxShadow={schemaItem.boxShadow}

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
@@ -37,7 +37,15 @@ export const fieldTypeUpdateHook = (
     widgetName,
     fieldThemeStylesheets: childStylesheet,
   });
+  const isInputOrEmailSelected = [
+    FieldType.EMAIL_INPUT,
+    FieldType.PASSWORD_INPUT,
+  ].includes(fieldType);
 
+  const schemaItemWithAutoFillState = {
+    ...newSchemaItem,
+    ["shouldAllowAutofill"]: isInputOrEmailSelected,
+  };
   /**
    * TODO(Ashit): Not suppose to update the whole schema but just
    * the path within the schema. This is just a hack to make sure
@@ -45,7 +53,7 @@ export const fieldTypeUpdateHook = (
    * the updateProperty function is fixed.
    */
   const updatedSchema = { schema: klona(schema) };
-  set(updatedSchema, schemaItemPath, newSchemaItem);
+  set(updatedSchema, schemaItemPath, schemaItemWithAutoFillState);
 
   return [{ propertyPath: "schema", propertyValue: updatedSchema.schema }];
 };

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/helper.ts
@@ -42,10 +42,12 @@ export const fieldTypeUpdateHook = (
     FieldType.PASSWORD_INPUT,
   ].includes(fieldType);
 
-  const schemaItemWithAutoFillState = {
-    ...newSchemaItem,
-    ["shouldAllowAutofill"]: isInputOrEmailSelected,
-  };
+  const schemaItemWithAutoFillState = isInputOrEmailSelected
+    ? {
+        ...newSchemaItem,
+        shouldAllowAutofill: true,
+      }
+    : newSchemaItem;
   /**
    * TODO(Ashit): Not suppose to update the whole schema but just
    * the path within the schema. This is just a hack to make sure

--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/common.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/common.ts
@@ -279,6 +279,24 @@ const COMMON_PROPERTIES = {
         dependencies: ["schema", "sourceData"],
         updateHook: updateChildrenDisabledStateHook,
       },
+      {
+        propertyName: "shouldAllowAutofill",
+        label: "Allow autofill",
+        helpText: "Allow users to autofill values from browser",
+        controlType: "SWITCH",
+        isJSConvertible: true,
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: { type: ValidationTypes.BOOLEAN },
+        hidden: (...args: HiddenFnParams) => {
+          //should be shown for only inputWidgetV2 and for email or password input types
+          return getSchemaItem(...args).fieldTypeNotIncludes([
+            FieldType.EMAIL_INPUT,
+            FieldType.PASSWORD_INPUT,
+          ]);
+        },
+        dependencies: ["schema", "sourceData"],
+      },
     ],
     events: [
       {


### PR DESCRIPTION
## Description
This PR brings in the autofill toggle when the user selects either email or password. It is always defaulted to the enabled state, the user need to toggle it off to get the text widget to have autocomplete attribute set to "off".

Fixes #22566 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


## How Has This Been Tested?

- Manual
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
