### PR TITLE
chore: Refine bg and bgAccent (light mode)

### DIFF
--- a/app/client/packages/design-system/theming/src/utils/ColorsAccessor/ColorsAccessor.ts
+++ b/app/client/packages/design-system/theming/src/utils/ColorsAccessor/ColorsAccessor.ts
@@ -21,7 +21,7 @@ export class ColorsAccessor {
   }
 
   get isVeryLight() {
-    return this.color.oklch.l > 0.9;
+    return this.color.oklch.l > 0.93;
   }
 
   /* Chroma */

--- a/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
@@ -11,9 +11,10 @@ export class LightModeTheme implements ColorModeTheme {
   private readonly seedHue: number;
   private readonly seedIsAchromatic: boolean;
   private readonly seedIsCold: boolean;
+  private readonly seedIsVeryLight: boolean;
 
   constructor(private color: ColorTypes) {
-    const { chroma, hex, hue, isAchromatic, isCold, lightness } =
+    const { chroma, hex, hue, isAchromatic, isCold, isVeryLight, lightness } =
       new ColorsAccessor(color);
     this.seedColor = hex;
     this.seedLightness = lightness;
@@ -21,6 +22,7 @@ export class LightModeTheme implements ColorModeTheme {
     this.seedHue = hue;
     this.seedIsAchromatic = isAchromatic;
     this.seedIsCold = isCold;
+    this.seedIsVeryLight = isVeryLight;
   }
 
   public getColors = () => {
@@ -47,27 +49,51 @@ export class LightModeTheme implements ColorModeTheme {
    * Background colors
    */
   private get bg() {
-    if (this.seedIsAchromatic) {
-      return setLch(this.seedColor, {
+    let currentColor = this.seedColor;
+
+    if (this.seedIsVeryLight) {
+      currentColor = setLch(currentColor, {
+        l: 0.9,
+      });
+    }
+
+    if (!this.seedIsVeryLight) {
+      currentColor = setLch(currentColor, {
         l: 0.985,
+      });
+    }
+
+    if (this.seedIsCold) {
+      currentColor = setLch(currentColor, {
+        c: 0.009,
+      });
+    }
+
+    if (!this.seedIsCold) {
+      currentColor = setLch(currentColor, {
+        c: 0.007,
+      });
+    }
+
+    if (this.seedIsAchromatic) {
+      currentColor = setLch(currentColor, {
         c: 0,
       });
     }
 
-    return setLch(this.seedColor, {
-      l: 0.985,
-      c: this.seedIsCold ? 0.006 : 0.004,
-    });
+    return currentColor;
   }
 
   private get bgAccent() {
-    if (contrast(this.seedColor, this.bg) >= -15) {
-      return setLch(this.seedColor, {
-        l: 0.85,
+    let currentColor = this.seedColor;
+
+    if (this.seedIsVeryLight) {
+      currentColor = setLch(currentColor, {
+        l: 0.975,
       });
     }
 
-    return this.seedColor;
+    return currentColor;
   }
 
   private get bgAccentHover() {
@@ -75,7 +101,7 @@ export class LightModeTheme implements ColorModeTheme {
   }
 
   private get bgAccentActive() {
-    return lighten(this.bgAccentHover, 0.9);
+    return lighten(this.bgAccent, 0.9);
   }
 
   // used only for generating child colors, not used as a token
@@ -105,6 +131,7 @@ export class LightModeTheme implements ColorModeTheme {
         c: 0,
       });
     }
+
     return currentColor;
   }
 


### PR DESCRIPTION
## Description

tl;dr Slightly darker canvas background for very light seeds. It is still perceptually light mode, but now `bgAccent` doesn't need to be dark/dirty to stay visible against app background.

Fixes #22568 

## Media
New on the left, current on the right
<img width="2560" alt="Screenshot 2023-04-25 at 13 33 25" src="https://user-images.githubusercontent.com/80973/234264228-907d43a5-f816-4700-9b98-b34d86b38b4e.png">
<img width="2560" alt="Screenshot 2023-04-25 at 13 33 55" src="https://user-images.githubusercontent.com/80973/234264240-c688848c-e153-418b-9417-d770eb400ea0.png">

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual

### Test Plan
Initial POC refinement, no testing necessary

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
