### PR TITLE
fix: casing for url,Url to URL in restapi pagination tab

### DIFF
--- a/app/client/cypress/locators/apiWidgetslocator.json
+++ b/app/client/cypress/locators/apiWidgetslocator.json
@@ -34,7 +34,7 @@
   "apiInputTab": "li:contains('API Input')",
   "paginationOption": ".t--apiFormPaginationType div>input",
   "paginationWithTable": "//label[contains(text(),'Paginate with Table Page No')] ",
-  "paginationWithUrl": "//label[contains(text(),'Paginate with Response Url')]",
+  "paginationWithUrl": "//label[contains(text(),'Paginate with Response URL')]",
   "panigationNextUrl": ".t--apiFormPaginationNext div>textarea",
   "panigationPrevUrl": ".t--apiFormPaginationPrev div>textarea",
   "TestNextUrl": ".t--apiFormPaginationNextTest",

--- a/app/client/src/pages/Editor/APIEditor/Pagination.tsx
+++ b/app/client/src/pages/Editor/APIEditor/Pagination.tsx
@@ -117,7 +117,7 @@ export default function Pagination(props: PaginationProps) {
               value: PaginationType.PAGE_NO,
             },
             {
-              label: "Paginate with Response Url",
+              label: "Paginate with Response URL",
               value: PaginationType.URL,
             },
           ]}
@@ -183,14 +183,14 @@ export default function Pagination(props: PaginationProps) {
                   </Text>
                 </StepTitle>
                 <Step type={TextType.P1}>Configure Next and Previous URL </Step>
-                <Step type={TextType.P1}>Previous url</Step>
+                <Step type={TextType.P1}>Previous URL</Step>
                 <PaginationFieldWrapper
                   data-replay-id={btoa("actionConfiguration.prev")}
                 >
                   <DynamicTextField
                     border={CodeEditorBorder.ALL_SIDE}
                     className="t--apiFormPaginationPrev"
-                    evaluatedPopUpLabel="Previous Url"
+                    evaluatedPopUpLabel="Previous URL"
                     fill={!!true}
                     focusElementName={`${props.actionName}.actionConfiguration.prev`}
                     height="100%"
@@ -210,14 +210,14 @@ export default function Pagination(props: PaginationProps) {
                     type="button"
                   />
                 </PaginationFieldWrapper>
-                <Step type={TextType.P1}>Next url</Step>
+                <Step type={TextType.P1}>Next URL</Step>
                 <PaginationFieldWrapper
                   data-replay-id={btoa("actionConfiguration.next")}
                 >
                   <DynamicTextField
                     border={CodeEditorBorder.ALL_SIDE}
                     className="t--apiFormPaginationNext"
-                    evaluatedPopUpLabel="Next Url"
+                    evaluatedPopUpLabel="Next URL"
                     fill={!!true}
                     focusElementName={`${props.actionName}.actionConfiguration.next`}
                     height="100%"


### PR DESCRIPTION
## Description

REST API pagination tab has inconsistent casing for `URL` - it is `url` and `Url` in some places:



Fixes # (issue)
#19550 


Media
![Screenshot 2023-04-25 at 18 58 58](https://user-images.githubusercontent.com/94514895/234292925-0e3e7064-aa73-447d-b22b-897bd472acb6.png)



## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
