### PR TITLE
fix: remove unnecessary packages dependency settings

### DIFF
--- a/app/client/packages/design-system/headless/package.json
+++ b/app/client/packages/design-system/headless/package.json
@@ -19,8 +19,7 @@
     "@react-stately/toggle": "^3.5.1",
     "@react-types/button": "^3.7.1",
     "@react-types/checkbox": "^3.4.3",
-    "@react-types/shared": "^3.17.0",
-    "classnames": "*"
+    "@react-types/shared": "^3.17.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"

--- a/app/client/packages/design-system/theming/package.json
+++ b/app/client/packages/design-system/theming/package.json
@@ -9,14 +9,6 @@
     "prettier:ci": "prettier --check .",
     "build:tokens": "npx ts-node ./src/utils/buildTokens.ts"
   },
-  "dependencies": {
-    "react": "*",
-    "react-dom": "*"
-  },
-  "devDependencies": {
-    "@types/react": "*",
-    "@types/react-dom": "*"
-  },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
   }

--- a/app/client/packages/design-system/widgets/package.json
+++ b/app/client/packages/design-system/widgets/package.json
@@ -14,14 +14,10 @@
     "@design-system/headless": "*",
     "@design-system/theming": "*",
     "@react-aria/utils": "^3.16.0",
-    "colorjs.io": "^0.4.3",
-    "eslint-plugin-storybook": "^0.6.10",
-    "react": "*",
-    "react-dom": "*"
+    "colorjs.io": "^0.4.3"
   },
   "devDependencies": {
-    "@types/react": "*",
-    "@types/react-dom": "*"
+    "eslint-plugin-storybook": "^0.6.10"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"

--- a/app/client/packages/storybook/package.json
+++ b/app/client/packages/storybook/package.json
@@ -38,8 +38,6 @@
     "@capsizecss/core": "^3.1.0",
     "@capsizecss/metrics": "^1.0.1",
     "colorjs.io": "^0.4.3",
-    "react": "^17.0.2",
-    "react-docgen-typescript": "^2.2.2",
-    "react-dom": "^17.0.2"
+    "react-docgen-typescript": "^2.2.2"
   }
 }

--- a/app/client/yarn.lock
+++ b/app/client/yarn.lock
@@ -8684,11 +8684,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@*:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
-
 classnames@2.x, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
@@ -18031,14 +18026,6 @@ react-documents@^1.0.4:
   resolved "https://registry.npmjs.org/react-documents/-/react-documents-1.0.4.tgz"
   integrity sha512-EpoY+MZEu3hPffIWA4FadUYu8daubNkr+LK2zuoPkCAVtyNY+z+/RuzzTriuhjcDydKXzgzp42kQTfAD2j3Mxw==
 
-react-dom@*:
-  version "18.2.0"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
-  dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.23.0"
-
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -18536,13 +18523,6 @@ react-window@^1.8.6:
 react-zoom-pan-pinch@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-1.6.1.tgz"
-
-react@*:
-  version "18.2.0"
-  resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
 
 react@^17.0.2:
   version "17.0.2"
@@ -19362,13 +19342,6 @@ scheduler@^0.20.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
-  dependencies:
-    loose-envify "^1.1.0"
 
 schema-utils@2.7.0:
   version "2.7.0"


### PR DESCRIPTION
## Description
We are for using the same version in packages as the main app. [This code](https://github.com/appsmithorg/appsmith/blob/release/app/client/packages/design-system/theming/package.json#L12-L19) should says yarn take the version from the main package.json. But for some reason, yarn resolves it in his own way, so we decided to delete these lines and leave only information about React only in `peerDependencies`.

> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?
- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag