### PR TITLE
fix: add borderWidth to column space calculation

### DIFF
--- a/app/client/src/sagas/WidgetOperationUtils.ts
+++ b/app/client/src/sagas/WidgetOperationUtils.ts
@@ -60,6 +60,7 @@ import { isWidget } from "@appsmith/workers/Evaluation/evaluationUtils";
 import { CANVAS_DEFAULT_MIN_HEIGHT_PX } from "constants/AppConstants";
 import type { MetaState } from "reducers/entityReducers/metaReducer";
 import { Positioning } from "utils/autoLayout/constants";
+import { AppPositioningTypes } from "reducers/entityReducers/pageListReducer";
 
 export interface CopiedWidgetGroup {
   widgetId: string;
@@ -759,7 +760,14 @@ export function getSnappedGrid(LayoutWidget: WidgetProps, canvasWidth: number) {
     // Widgets like ListWidget choose to have no container padding so will only have widget padding
     padding = WIDGET_PADDING * 2;
   }
-  const width = canvasWidth - padding;
+  const borderWidth =
+    LayoutWidget.appPositioningType === AppPositioningTypes.AUTO
+      ? parseInt(
+          LayoutWidget?.borderWidth || LayoutWidget?.parentBorderWidth || "0",
+          10,
+        ) || 0
+      : 0;
+  const width = canvasWidth - padding - borderWidth * 2;
   return {
     snapGrid: {
       snapRowSpace: GridDefaults.DEFAULT_GRID_ROW_HEIGHT,

--- a/app/client/src/utils/autoLayout/AutoLayoutUtils.ts
+++ b/app/client/src/utils/autoLayout/AutoLayoutUtils.ts
@@ -519,8 +519,9 @@ function getPadding(canvas: FlattenedWidgetProps): number {
   if (canvas.noPad) {
     padding -= WIDGET_PADDING;
   }
-
-  return padding;
+  const borderWidth: number =
+    parseInt(canvas?.borderWidth || canvas?.parentBorderWidth || "0", 10) || 0;
+  return padding + borderWidth * 2;
 }
 
 /**

--- a/app/client/src/widgets/withWidgetProps.tsx
+++ b/app/client/src/widgets/withWidgetProps.tsx
@@ -44,6 +44,7 @@ import { CANVAS_DEFAULT_MIN_HEIGHT_PX } from "constants/AppConstants";
 import { getGoogleMapsApiKey } from "ce/selectors/tenantSelectors";
 import ConfigTreeActions from "utils/configTree";
 import { getSelectedWidgetAncestry } from "../selectors/widgetSelectors";
+import { getParentWidget } from "../selectors/widgetSelectors";
 
 const WIDGETS_WITH_CHILD_WIDGETS = ["LIST_WIDGET", "FORM_WIDGET"];
 const WIDGETS_REQUIRING_SELECTED_ANCESTRY = ["MODAL_WIDGET", "TABS_WIDGET"];
@@ -64,6 +65,10 @@ function withWidgetProps(WrappedWidget: typeof BaseWidget) {
     const canvasWidget = useSelector((state: AppState) =>
       getWidget(state, widgetId),
     );
+    const parentWidget = useSelector((state: AppState) =>
+      getParentWidget(state, widgetId),
+    );
+
     const metaWidget = useSelector(getMetaWidget(widgetId));
 
     const mainCanvasProps = useSelector((state: AppState) =>
@@ -189,6 +194,10 @@ function withWidgetProps(WrappedWidget: typeof BaseWidget) {
         widgetProps.shouldScrollContents = props.shouldScrollContents;
         widgetProps.canExtend = props.canExtend;
         widgetProps.parentId = props.parentId;
+
+        widgetProps.parentBorderWidth = parentWidget
+          ? parentWidget?.borderWidth || "0"
+          : "0";
       } else if (widgetId !== MAIN_CONTAINER_WIDGET_ID) {
         widgetProps.parentColumnSpace = props.parentColumnSpace;
         widgetProps.parentRowSpace = props.parentRowSpace;


### PR DESCRIPTION
## Description

Issue: increasing border width of containers cuts off widgets and highlights along the edges.
Cause: Column space calculation doesn't account for border widths.

Fix: To account for parent's border width in canvas' column space calculation, the value is passed as a new prop ```parentBorderWidth```. Discount the value from the canvas width to rectify the calclulation

> Add a TL;DR when description is extra long (helps content team)

Fixes # (issue)

1. https://github.com/appsmithorg/appsmith/issues/22680


Media

https://user-images.githubusercontent.com/5424788/234401024-2a73865e-bb1c-4160-ab6b-53f74d17b6f9.mov



## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag

