### PR TITLE
test: Cypress - Redis spec fix for CI runs

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ServerSideTests/Datasources/Redis_Basic_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ServerSideTests/Datasources/Redis_Basic_Spec.ts
@@ -59,11 +59,12 @@ describe("Validate Redis DS", () => {
     //Get All keys from HSET
     _.dataSources.EnterQuery(getAll);
     _.dataSources.RunQueryNVerifyResponseViews(8); //4 keys, 4 values
-    _.dataSources.ReadQueryTableResponse(0).then(($cellData: any) => {
-      expect($cellData).to.eq("ingredients");
-    });
+    //order not always matching - hence commented
+    // _.dataSources.ReadQueryTableResponse(0).then(($cellData: any) => {
+    //   expect($cellData).to.eq("ingredients");
+    // });
     // _.dataSources.ReadQueryTableResponse(6).then(($cellData: any) => {
-    //   expect($cellData).to.eq("instructions"); //order not always matching - hence commented
+    //   expect($cellData).to.eq("instructions");
     // });
 
     //Ading one more key/value to HSET


### PR DESCRIPTION
## Description

- This PR fixes the redis spec failures in CI. When HGet run on a Hash set in Redis DB - the results can be in any order & hence spec is failing in CI on multiple runs. Hence commenting the index check.

## Type of change

- Script update

## How Has This Been Tested?
- Cypress CI runs

## Checklist:
### QA activity:
- [x] Added Test Plan Approved label after reviewing all changes
