### PR TITLE
fix: no input validation error in totalRecordsCount

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.test.ts
@@ -16,7 +16,9 @@ import { StickyType } from "../component/Constants";
 
 describe("PropertyUtils - ", () => {
   it("totalRecordsCountValidation - should test with all possible values", () => {
-    const ERROR_MESSAGE = "This value must be a number";
+    const ERROR_MESSAGE = [
+      { name: "ValidationError", message: "This value must be a number" },
+    ];
 
     const values = [
       [
@@ -24,7 +26,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: true,
           parsed: 0,
-          message: [""],
+          messages: [],
         },
       ],
       [
@@ -32,7 +34,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: true,
           parsed: 0,
-          message: [""],
+          messages: [],
         },
       ],
       [
@@ -40,7 +42,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: true,
           parsed: 0,
-          message: [""],
+          messages: [],
         },
       ],
       [
@@ -48,7 +50,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: false,
           parsed: 0,
-          message: [ERROR_MESSAGE],
+          messages: ERROR_MESSAGE,
         },
       ],
       [
@@ -56,7 +58,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: false,
           parsed: 0,
-          message: [ERROR_MESSAGE],
+          messages: ERROR_MESSAGE,
         },
       ],
       [
@@ -64,7 +66,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: false,
           parsed: 0,
-          message: [ERROR_MESSAGE],
+          messages: ERROR_MESSAGE,
         },
       ],
       [
@@ -72,7 +74,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: true,
           parsed: 1,
-          message: [""],
+          messages: [],
         },
       ],
       [
@@ -80,7 +82,7 @@ describe("PropertyUtils - ", () => {
         {
           isValid: true,
           parsed: 1,
-          message: [""],
+          messages: [],
         },
       ],
     ];

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -32,7 +32,7 @@ export function totalRecordsCountValidation(
     return {
       isValid: true,
       parsed: defaultValue,
-      message: [""],
+      messages: [],
     };
   } else if (
     (!_.isFinite(value) && !_.isString(value)) ||
@@ -44,7 +44,7 @@ export function totalRecordsCountValidation(
     return {
       isValid: false,
       parsed: defaultValue,
-      message: [ERROR_MESSAGE],
+      messages: [{ name: "ValidationError", message: ERROR_MESSAGE }],
     };
   } else {
     /*
@@ -53,7 +53,7 @@ export function totalRecordsCountValidation(
     return {
       isValid: true,
       parsed: Number(value),
-      message: [""],
+      messages: [],
     };
   }
 }


### PR DESCRIPTION
## Description

Input validation object signature was incorrect for totalrecordscount, so that has caused the error not to show up. Have corrected in this PR

Fixes #22550 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual
- Jest

### Test Plan
> https://github.com/appsmithorg/TestSmith/issues/2371

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [x] Test plan has been approved by relevant developers
- [x] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
