### PR TITLE
feat: Added setter configs to JsonForm, Input and Table widgets

### DIFF
--- a/app/client/src/entities/AppTheming/index.ts
+++ b/app/client/src/entities/AppTheming/index.ts
@@ -75,3 +75,11 @@ export type AppTheme = {
     };
   };
 };
+
+export type SetterConfig = {
+  __setters: {
+    [key: string]: {
+      path: string;
+    };
+  };
+};

--- a/app/client/src/widgets/InputWidget/index.ts
+++ b/app/client/src/widgets/InputWidget/index.ts
@@ -38,6 +38,7 @@ export const CONFIG = {
     config: Widget.getPropertyPaneConfig(),
     stylesheetConfig: Widget.getStylesheetConfig(),
     autocompleteDefinitions: Widget.getAutocompleteDefinitions(),
+    setterConfig: Widget.getSetterConfig(),
   },
 };
 

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -774,7 +774,7 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
           path: "isRequired",
         },
         setValue: {
-          path: "inputText",
+          path: "meta.inputText",
         },
       },
     };

--- a/app/client/src/widgets/InputWidget/widget/index.tsx
+++ b/app/client/src/widgets/InputWidget/widget/index.tsx
@@ -29,7 +29,7 @@ import {
   getLocale,
 } from "../component/utilities";
 import { LabelPosition } from "components/constants";
-import type { Stylesheet } from "entities/AppTheming";
+import type { SetterConfig, Stylesheet } from "entities/AppTheming";
 import { checkInputTypeTextByProps } from "widgets/BaseInputWidget/utils";
 import { DefaultAutocompleteDefinitions } from "widgets/WidgetUtils";
 import type { AutocompletionDefinitions } from "widgets/constants";
@@ -758,6 +758,25 @@ class InputWidget extends BaseWidget<InputWidgetProps, WidgetState> {
       accentColor: "{{appsmith.theme.colors.primaryColor}}",
       borderRadius: "{{appsmith.theme.borderRadius.appBorderRadius}}",
       boxShadow: "none",
+    };
+  }
+
+  static getSetterConfig(): SetterConfig {
+    return {
+      __setters: {
+        setVisibility: {
+          path: "isVisible",
+        },
+        setDisabled: {
+          path: "isDisabled",
+        },
+        setRequired: {
+          path: "isRequired",
+        },
+        setValue: {
+          path: "inputText",
+        },
+      },
     };
   }
 

--- a/app/client/src/widgets/JSONFormWidget/index.ts
+++ b/app/client/src/widgets/JSONFormWidget/index.ts
@@ -97,6 +97,7 @@ export const CONFIG = {
     styleConfig: Widget.getPropertyPaneStyleConfig(),
     stylesheetConfig: Widget.getStylesheetConfig(),
     autocompleteDefinitions: Widget.getAutocompleteDefinitions(),
+    setterConfig: Widget.getSetterConfig(),
   },
   autoLayout: {
     widgetSize: [

--- a/app/client/src/widgets/JSONFormWidget/widget/index.tsx
+++ b/app/client/src/widgets/JSONFormWidget/widget/index.tsx
@@ -24,6 +24,7 @@ import { convertSchemaItemToFormData } from "../helper";
 import type {
   ButtonStyles,
   ChildStylesheet,
+  SetterConfig,
   Stylesheet,
 } from "entities/AppTheming";
 import type { BatchPropertyUpdatePayload } from "actions/controlActions";
@@ -233,6 +234,22 @@ class JSONFormWidget extends BaseWidget<
       fieldState: generateTypeDef(widget.fieldState),
       isValid: "bool",
     });
+  }
+
+  static getSetterConfig(): SetterConfig {
+    return {
+      __setters: {
+        setVisibility: {
+          path: "isVisible",
+        },
+        setDisabled: {
+          path: "isDisabled",
+        },
+        setData: {
+          path: "formData",
+        },
+      },
+    };
   }
 
   static defaultProps = {};

--- a/app/client/src/widgets/TableWidgetV2/index.ts
+++ b/app/client/src/widgets/TableWidgetV2/index.ts
@@ -253,6 +253,7 @@ export const CONFIG = {
     stylesheetConfig: Widget.getStylesheetConfig(),
     loadingProperties: Widget.getLoadingProperties(),
     autocompleteDefinitions: Widget.getAutocompleteDefinitions(),
+    setterConfig: Widget.getSetterConfig(),
   },
   autoLayout: {
     widgetSize: [

--- a/app/client/src/widgets/TableWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/index.tsx
@@ -95,7 +95,7 @@ import { SelectCell } from "../component/cellComponents/SelectCell";
 import { CellWrapper } from "../component/TableStyledWrappers";
 import localStorage from "utils/localStorage";
 import { generateNewColumnOrderFromStickyValue } from "./utilities";
-import type { Stylesheet } from "entities/AppTheming";
+import type { SetterConfig, Stylesheet } from "entities/AppTheming";
 import { DateCell } from "../component/cellComponents/DateCell";
 import type { MenuItem } from "widgets/MenuButtonWidget/constants";
 import { MenuItemsSource } from "widgets/MenuButtonWidget/constants";
@@ -273,6 +273,22 @@ class TableWidgetV2 extends BaseWidget<TableWidgetProps, WidgetState> {
           discardButtonColor: "{{appsmith.theme.colors.primaryColor}}",
           discardBorderRadius:
             "{{appsmith.theme.borderRadius.appBorderRadius}}",
+        },
+      },
+    };
+  }
+
+  static getSetterConfig(): SetterConfig {
+    return {
+      __setters: {
+        setVisibility: {
+          path: "isVisible",
+        },
+        setSelectedRowIndex: {
+          path: "selectedRowIndex",
+        },
+        setData: {
+          path: "tableData",
         },
       },
     };


### PR DESCRIPTION
## Description
Added setter configs to JsonForm, Input and Table widgets to be used to build the setters in evaluations

Fixes #22701  

## Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
