### PR TITLE
fix: firefox file picker not showing up issue fixed

### DIFF
--- a/app/client/src/constants/Datasource.ts
+++ b/app/client/src/constants/Datasource.ts
@@ -2,3 +2,4 @@ export const TEMP_DATASOURCE_ID = "temp-id-0";
 export const DATASOURCE_NAME_DEFAULT_PREFIX = "Untitled Datasource ";
 export const GOOGLE_SHEET_SPECIFIC_SHEETS_SCOPE =
   "https://www.googleapis.com/auth/drive.file";
+export const GOOGLE_SHEET_FILE_PICKER_OVERLAY_CLASS = "overlay";

--- a/app/client/src/pages/Editor/SaaSEditor/GoogleSheetFilePicker.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/GoogleSheetFilePicker.tsx
@@ -80,6 +80,18 @@ function GoogleSheetFilePicker({
     }
   }, [gsheetToken, scriptLoadedFlag, pickerInitiated, gsheetProjectID]);
 
+  // This is added in useEffect instead of file picker callback,
+  // because in case when browser has blocked third party cookies
+  // The file picker needs to be displayed with allow cookies option
+  // hence as soon as file picker is visible we should remove the overlay
+  // Ref: https://github.com/appsmithorg/appsmith/issues/22753
+  useEffect(() => {
+    if (!!pickerVisible) {
+      const className = "overlay";
+      removeClassFromDocumentBody(className);
+    }
+  }, [pickerVisible]);
+
   // This triggers google's picker object from google apis script to create file picker and display it
   // It takes google sheet token and project id as inputs
   const createPicker = async (accessToken: string, projectID: string) => {
@@ -98,12 +110,7 @@ function GoogleSheetFilePicker({
   };
 
   const pickerCallback = async (data: any) => {
-    if (data.action === FilePickerActionStatus.LOADED) {
-      // Remove document body overlay as soon as file picker is loaded
-      // As we are adding overlay for file picker background div
-      const className = "overlay";
-      removeClassFromDocumentBody(className);
-    } else if (
+    if (
       data.action === FilePickerActionStatus.CANCEL ||
       data.action === FilePickerActionStatus.PICKED
     ) {

--- a/app/client/src/pages/Editor/SaaSEditor/GoogleSheetFilePicker.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/GoogleSheetFilePicker.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { FilePickerActionStatus } from "entities/Datasource";
 import { useDispatch } from "react-redux";
 import { filePickerCallbackAction } from "actions/datasourceActions";
+import { GOOGLE_SHEET_FILE_PICKER_OVERLAY_CLASS } from "constants/Datasource";
 
 interface Props {
   datasourceId: string;
@@ -87,8 +88,7 @@ function GoogleSheetFilePicker({
   // Ref: https://github.com/appsmithorg/appsmith/issues/22753
   useEffect(() => {
     if (!!pickerVisible) {
-      const className = "overlay";
-      removeClassFromDocumentBody(className);
+      removeClassFromDocumentBody(GOOGLE_SHEET_FILE_PICKER_OVERLAY_CLASS);
     }
   }, [pickerVisible]);
 

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -120,6 +120,7 @@ import {
 } from "RouteBuilder";
 import {
   DATASOURCE_NAME_DEFAULT_PREFIX,
+  GOOGLE_SHEET_FILE_PICKER_OVERLAY_CLASS,
   TEMP_DATASOURCE_ID,
 } from "constants/Datasource";
 import { getUntitledDatasourceSequence } from "utils/DatasourceSagaUtils";
@@ -1424,7 +1425,6 @@ function* loadFilePickerSaga() {
   // This adds overlay on document body
   // This is done for google sheets file picker, as file picker needs to be shown on blank page
   // when overlay needs to be shown, we get showPicker search param in redirect url
-  const className = "overlay";
   const appsmithToken = localStorage.getItem(APPSMITH_TOKEN_STORAGE_KEY);
   const search = new URLSearchParams(window.location.search);
   const isShowFilePicker = search.get(SHOW_FILE_PICKER_KEY);
@@ -1437,7 +1437,7 @@ function* loadFilePickerSaga() {
     !!appsmithToken &&
     !!gapiScriptLoaded
   ) {
-    addClassToDocumentBody(className);
+    addClassToDocumentBody(GOOGLE_SHEET_FILE_PICKER_OVERLAY_CLASS);
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes a bug:
- Google sheet file picker is not visible in firefox browser.

> Add a TL;DR when description is extra long (helps content team)

Fixes #22753 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
