### PR TITLE
fix: Remove console log on MetaWidgetUpdate

### DIFF
--- a/app/client/src/widgets/MetaHOC.tsx
+++ b/app/client/src/widgets/MetaHOC.tsx
@@ -136,19 +136,6 @@ function withMeta(WrappedWidget: typeof BaseWidget) {
       propertyValue: unknown,
       actionExecution?: DebouncedExecuteActionPayload,
     ): void => {
-      AppsmithConsole.info({
-        logType: LOG_TYPE.WIDGET_UPDATE,
-        text: "Widget property was updated",
-        source: {
-          type: ENTITY_TYPE.WIDGET,
-          id: this.props.widgetId,
-          name: this.props.widgetName,
-          propertyPath: propertyName,
-        },
-        state: {
-          [propertyName]: propertyValue,
-        },
-      });
       this.handleUpdateWidgetMetaProperty(
         propertyName,
         propertyValue,


### PR DESCRIPTION
Fixes #22527 

Based on debugging the performance logs, it seems like for now that the console log on every character type is causing a lag in the performance.

This becomes more accentuated for a list widget. Commenting out the logging for now since the issue is marked critical

In the meanwhile, @SatishGandham will help to triage the further cause of this issue.