### PR TITLE
feat: [#22155] Optional SSL support for Redshift plugin

### DIFF
--- a/app/server/appsmith-plugins/redshiftPlugin/src/main/java/com/external/plugins/exceptions/RedshiftErrorMessages.java
+++ b/app/server/appsmith-plugins/redshiftPlugin/src/main/java/com/external/plugins/exceptions/RedshiftErrorMessages.java
@@ -21,4 +21,8 @@ public class RedshiftErrorMessages {
     public static final String JDBC_DRIVER_LOADING_ERROR_MSG = "Error loading Redshift JDBC Driver class.";
 
     public static final String CONNECTION_POOL_CREATION_FAILED_ERROR_MSG = "Exception occurred while creating connection pool. One or more arguments in the datasource configuration may be invalid. Please check your datasource configuration.";
+
+    public static final String SSL_CONFIGURATION_ERROR_MSG = "The Appsmith server has failed to fetch SSL configuration from datasource configuration form. ";
+
+    public static final String INVALID_SSL_OPTION_ERROR_MSG = "The Appsmith server has found an unexpected SSL option: %s.";
 }

--- a/app/server/appsmith-plugins/redshiftPlugin/src/main/java/com/external/plugins/exceptions/RedshiftPluginError.java
+++ b/app/server/appsmith-plugins/redshiftPlugin/src/main/java/com/external/plugins/exceptions/RedshiftPluginError.java
@@ -17,6 +17,16 @@ public enum RedshiftPluginError implements BasePluginError {
             ErrorType.INTERNAL_ERROR,
             "{1}",
             "{2}"
+    ),
+    REDSHIFT_PLUGIN_ERROR(
+            500,
+            "PE-RED-5001",
+            "{0}",
+            AppsmithErrorAction.LOG_EXTERNALLY,
+            "Query execution error",
+            ErrorType.INTERNAL_ERROR,
+            "{1}",
+            "{2}"
     )
     ;
 

--- a/app/server/appsmith-plugins/redshiftPlugin/src/main/resources/form.json
+++ b/app/server/appsmith-plugins/redshiftPlugin/src/main/resources/form.json
@@ -82,7 +82,12 @@
           "label": "SSL Mode",
           "configProperty": "datasourceConfiguration.connection.ssl.authType",
           "controlType": "DROP_DOWN",
+          "initialValue": "DEFAULT",
           "options": [
+            {
+              "label": "Default",
+              "value": "DEFAULT"
+            },
             {
               "label": "No SSL",
               "value": "NO_SSL"


### PR DESCRIPTION
## Description

> 1. Optional SSL support for Redshift plugin, 2. The default value would be 'DEFAULT' -> default config

Closes #22155 

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist:
### Dev activity
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
