### PR TITLE
fix: Added single quotes on hint query containing mustache substitution fo…

### DIFF
--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/templates/CREATE.sql
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/templates/CREATE.sql
@@ -2,7 +2,7 @@ INSERT INTO users
   (name, gender, email)
 VALUES
   (
-    {{ nameInput.text }},
-    {{ genderDropdown.selectedOptionValue }},
-    {{ emailInput.text }}
+    '{{ nameInput.text }}',
+    '{{ genderDropdown.selectedOptionValue }}',
+    '{{ emailInput.text }}'
   );

--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/templates/UPDATE.sql
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/resources/templates/UPDATE.sql
@@ -1,3 +1,3 @@
 UPDATE users
   SET status = 'APPROVED'
-  WHERE id = {{ usersTable.selectedRow.id }};
+  WHERE id = '{{ usersTable.selectedRow.id }}';


### PR DESCRIPTION
## Description

> In this PR, single quotes have been added around substitution expression in hint query of Snowflake DB.
> This fixes the issue: https://github.com/appsmithorg/appsmith/issues/22132
> Single quotes is necessary in hint text because Snowflake DB don't have prepared statements mode yet and with single quotes, the substituted values appear in query without quotes leading to query execution error.

Fixes #22132 


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
> Running a query in Snowflake DB integration, having substitution expression not enclosed in quotes will give an error.
> Currently the hint query that has substitution expression has not enclosed then in single quotes. Hence adding single quotes around them to provide user with proper hint.

- Manual
### Test Plan
> Create a new "Create Query" for Snowflake DB. The hint query should contain the sample substitution expression in single quotes.
> Run a fetch query for Snowflake DB containing substitution expression without single quotes enclosing it and it should return an error.
> Run the query with quotes enclosing substitution expression and the query should run successfully.


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
