### PR TITLE
chore: Add rapid mode to skip new app creation in cypress test

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/Add_new_row_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Widgets/TableV2/Add_new_row_spec.js
@@ -193,6 +193,7 @@ describe("Table widget Add new row feature's", () => {
 
   describe("Validation flow", () => {
     before(() => {
+      cy.startServerAndRoutes();
       agHelper.RestoreLocalStorageCache();
       cy.addDsl(dsl);
     });
@@ -350,6 +351,7 @@ describe("Table widget Add new row feature's", () => {
 
   describe("Actions flow (save, discard)", () => {
     before(() => {
+      cy.startServerAndRoutes();
       agHelper.RestoreLocalStorageCache();
       cy.addDsl(dsl);
     });

--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Workspace/ShareAppTests_spec.js
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/Workspace/ShareAppTests_spec.js
@@ -56,11 +56,6 @@ describe("Create new workspace and share with a user", function () {
 
   it("3. Enable public access to Application", function () {
     cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
-    cy.wait("@applications").should(
-      "have.nested.property",
-      "response.body.responseMeta.status",
-      200,
-    );
     cy.SearchApp(appid);
     cy.wait("@getPagesForCreateApp").should(
       "have.nested.property",
@@ -117,11 +112,6 @@ describe("Create new workspace and share with a user", function () {
 
   it("6. login as Owner and disable public access", function () {
     cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
-    cy.wait("@applications").should(
-      "have.nested.property",
-      "response.body.responseMeta.status",
-      200,
-    );
     cy.SearchApp(appid);
     cy.wait("@getPagesForCreateApp").should(
       "have.nested.property",

--- a/app/client/cypress/support/index.js
+++ b/app/client/cypress/support/index.js
@@ -32,6 +32,17 @@ import "./themeCommands";
 import "./AdminSettingsCommands";
 /// <reference types="cypress-xpath" />
 
+let rapidMode = {
+  enabled: false, // Set to true to disable app creation
+  appName: "cf023e29", // Replace it with your app name
+  pageName: "page1", // Replace it with the page name
+  pageID: "644d0ec870cec01248edfc9a", // Replace it with pageID
+
+  url: function () {
+    return `app/${this.appName}/${this.pageName}-${this.pageID}/edit`;
+  },
+};
+
 Cypress.on("uncaught:exception", () => {
   // returning false here prevents Cypress from
   // failing the test
@@ -45,6 +56,24 @@ Cypress.on("fail", (error) => {
 Cypress.env("MESSAGES", MESSAGES);
 
 before(function () {
+  if (rapidMode.enabled) {
+    cy.startServerAndRoutes();
+    cy.getCookie("SESSION").then((cookie) => {
+      if (!cookie) {
+        cy.LoginFromAPI(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
+      }
+    });
+
+    Cypress.Cookies.preserveOnce("SESSION", "remember_token");
+    cy.visit(rapidMode.url());
+    cy.wait("@getWorkspace");
+  }
+});
+
+before(function () {
+  if (rapidMode.enabled) {
+    return;
+  }
   //console.warn = () => {}; //to remove all warnings in cypress console
   initLocalstorage();
   initLocalstorageRegistry();
@@ -85,12 +114,14 @@ before(function () {
 });
 
 before(function () {
+  if (rapidMode.enabled) {
+    return;
+  }
   //console.warn = () => {};
   Cypress.Cookies.preserveOnce("SESSION", "remember_token");
   const username = Cypress.env("USERNAME");
   const password = Cypress.env("PASSWORD");
   cy.LoginFromAPI(username, password);
-  cy.wait("@getMe");
   cy.wait(3000);
   cy.get(".t--applications-container .createnew")
     .should("be.visible")
@@ -121,6 +152,9 @@ beforeEach(function () {
 });
 
 after(function () {
+  if (rapidMode.enabled) {
+    return;
+  }
   //-- Deleting the application by Api---//
   cy.DeleteAppByApi();
   //-- LogOut Application---//


### PR DESCRIPTION
Fixes #22878

This pr adds a flag called 'rapidMode' in cypress index file.

```
cypress/support/index.js

let rapidMode = {
  enabled: false, // Set it to true to skip app creation during a test re-run
  appName: "4a9b62a0", // Replace it with your app name
  pageName: "page1", // Replace it with the page name
  pageID: "644f8d6e21506c33a366854b", // Replace it with pageID

  url: function () {
    return `app/${this.appName}/${this.pageName}-${this.pageID}/edit`;
  },
};
```
When rapid mode is enabled, the cypress test will

1. Skip relogin if the test user is already logged in.
2. Skip creation of a new app and use a previously created app, passed as param.

The flag needs to be disabled when the code needs to be merged to release, and is meant for debugging/testing while writing tests on local development setup only.

When enabled, a cypress test saves around 25 sec per rerun.

Future fixes would include skipping multiple workspace page visit if a developer is using dsl for setting up fixtures. It would save around another 10-15 seconds per test re-run.