### PR TITLE
fix: Homepage menu and listItem bug fixes

### DIFF
--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -377,7 +377,7 @@ export function WorkspaceMenuItem({
       containerClassName={
         isFetchingApplications ? BlueprintClasses.SKELETON : ""
       }
-      ellipsize={20}
+      ellipsize={19}
       href={`${window.location.pathname}#${workspace.workspace.id}`}
       icon="workspace"
       key={workspace.workspace.id}
@@ -705,11 +705,15 @@ export function ApplicationsSection(props: any) {
           hasCreateNewApplicationPermission ||
           (canDeleteWorkspace && applications.length === 0);
 
+        const handleResetMenuState = () => {
+          setWorkspaceToOpenMenu(null);
+          setWarnLeavingWorkspace(false);
+          setWarnDeleteWorkspace(false);
+        };
+
         const handleWorkspaceMenuClose = (open: boolean) => {
           if (!open && !warnLeavingWorkspace && !warnDeleteWorkspace) {
-            setWorkspaceToOpenMenu(null);
-            setWarnLeavingWorkspace(false);
-            setWarnDeleteWorkspace(false);
+            handleResetMenuState();
           }
         };
 
@@ -797,7 +801,12 @@ export function ApplicationsSection(props: any) {
                             startIcon="context-menu"
                           />
                         </MenuTrigger>
-                        <MenuContent align="end" width="205px">
+                        <MenuContent
+                          align="end"
+                          onEscapeKeyDown={handleResetMenuState}
+                          onInteractOutside={handleResetMenuState}
+                          width="205px"
+                        >
                           {hasManageWorkspacePermissions && (
                             <>
                               <div className="px-3 py-2">
@@ -888,6 +897,7 @@ export function ApplicationsSection(props: any) {
                           )}
                           {applications.length === 0 && canDeleteWorkspace && (
                             <MenuItem
+                              className="error-menuitem"
                               onSelect={() => {
                                 warnDeleteWorkspace
                                   ? handleDeleteWorkspace(workspace.id)


### PR DESCRIPTION
## Description

This PR fixes below points
- Workspace menu not able to close when confirmation text is present
<img width="339" alt="Screenshot 2023-05-01 at 9 42 38 AM" src="https://user-images.githubusercontent.com/87797149/235405678-f9188706-9828-430d-813f-bddc5bc071f5.png">

- Left pane text ellipsis causing text break into two lines.
<img width="253" alt="Screenshot 2023-05-01 at 9 45 41 AM" src="https://user-images.githubusercontent.com/87797149/235405839-1c7e3db6-394a-422e-828a-446e04202003.png">

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
