### PR TITLE
fix: Don't log all env variables when starting up

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-set -o xtrace
 
 if [[ -n ${APPSMITH_SEGMENT_CE_KEY-} ]]; then
   ip="$(curl -sS https://api64.ipify.org || echo unknown)"


### PR DESCRIPTION
Because tracing is turned on in the `entrypoint.sh`, everything we source also log all names and values, including the `docker.env` file. This means all env values are printed to the logs.

This PR disables the tracing to fix this. It was enabled originally for improved logging information for some of the issues we were facing at the time, but if we still need such logging information, we need to log those explicitly with `echo`, instead of using `xtrace`.
