### PR TITLE
fix: gsheets entity explorer issue with viewMode fixed

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources/DatasourceEntity.tsx
@@ -52,6 +52,7 @@ const ExplorerDatasourceEntity = React.memo(
           pageId,
           pluginPackageName: props.plugin.packageName,
           datasourceId: props.datasource.id,
+          params: { viewMode: true },
         });
       } else {
         url = datasourcesEditorIdURL({

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -341,7 +341,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
                 />
               </FormTitleContainer>
 
-              {viewMode && (
+              {!!viewMode && (
                 <ActionWrapper>
                   <EditDatasourceButton
                     category={Category.secondary}
@@ -418,7 +418,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
               {""}
             </>
           )}
-          {viewMode && (
+          {!!viewMode && (
             <ViewModeWrapper>
               <Connected
                 errorComponent={

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -433,7 +433,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
                 }
                 showDatasourceSavedText={!isGoogleSheetPlugin}
               />
-              <div style={{ marginTop: "30px" }}>
+              <div>
                 {!_.isNil(formConfig) &&
                 !_.isNil(datasource) &&
                 !hideDatasourceSection ? (


### PR DESCRIPTION
## Description

This PR fixes:
- When google sheets datasource is opened from entity explorer, it always opens in edit mode of the datasource, where as for other plugins, it opens in view mode. This PR fixes the issue with google sheets, so now when we open google sheets datasource from entity explorer, it opens up in view mode

> Add a TL;DR when description is extra long (helps content team)

Fixes #20343 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
