### PR TITLE
fix: Security Vulnerability in GitHub Workflows

### DIFF
--- a/.github/workflows/CypressAddKnownfailedtests.yml
+++ b/.github/workflows/CypressAddKnownfailedtests.yml
@@ -19,9 +19,11 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           XATATOKEN: ${{ secrets.XATA_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          echo "Issue title: ${{ github.event.issue.title }}"
-          echo "Issue body: ${{ github.event.issue.body }}"
+          echo "Issue title: $ISSUE_TITLE"
+          echo "Issue body: $ISSUE_BODY"
           #echo "$GITHUB_CONTEXT"
           chmod a+x app/client/cypress/xataadd.sh
           echo "${{ github.event.issue.title }}"|awk '{print $2}'
@@ -41,9 +43,11 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           XATATOKEN: ${{ secrets.XATA_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          echo "Issue title: ${{ github.event.issue.title }}"
-          echo "Issue body: ${{ github.event.issue.body }}"
+          echo "Issue title: $ISSUE_TITLE"
+          echo "Issue body: $ISSUE_BODY"
           #echo "$GITHUB_CONTEXT"
           chmod a+x app/client/cypress/xatadel.sh
           echo "${{ github.event.issue.title }}"|awk '{print $2}'|xargs app/client/cypress/xatadel.sh


### PR DESCRIPTION
"github.event.issue.title" is potentially untrusted. avoid using it directly in inline scripts. instead, pass it through an environment variable. see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions for more details.

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
