### PR TITLE
fix: branding favicon url airgapped

### DIFF
--- a/app/client/src/utils/hooks/useBrandingTheme.ts
+++ b/app/client/src/utils/hooks/useBrandingTheme.ts
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 
 import { getTenantConfig } from "@appsmith/selectors/tenantSelectors";
 import { useEffect } from "react";
+import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
 
 const useBrandingTheme = () => {
   const config = useSelector(getTenantConfig);
@@ -38,7 +39,7 @@ const useBrandingTheme = () => {
       document.getElementsByTagName("head")[0].appendChild(favicon);
     }
 
-    favicon.href = config.brandFaviconUrl;
+    favicon.href = getAssetUrl(config.brandFaviconUr);
   }, [
     config.brandColors.primary,
     config.brandColors.background,


### PR DESCRIPTION
## Description

- Wrap favicon url with getAssetUrl function.


Fixes #22903


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
