### PR TITLE
fix: gsheet trigger 500 issue fixed

### DIFF
--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/utils/SheetsUtil.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/main/java/com/external/utils/SheetsUtil.java
@@ -34,6 +34,7 @@ public class SheetsUtil {
     public static Set<String> getUserAuthorizedSheetIds(DatasourceConfiguration datasourceConfiguration) {
         OAuth2 oAuth2 = (OAuth2) datasourceConfiguration.getAuthentication();
         if (!isEmpty(datasourceConfiguration.getProperties())
+                && datasourceConfiguration.getProperties().size() > 1
                 && datasourceConfiguration.getProperties().get(USER_AUTHORIZED_SHEET_IDS_INDEX) != null
                 && datasourceConfiguration.getProperties().get(USER_AUTHORIZED_SHEET_IDS_INDEX).getValue() != null
                 && oAuth2.getScope() != null

--- a/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/SheetsUtilTest.java
+++ b/app/server/appsmith-plugins/googleSheetsPlugin/src/test/java/com/external/config/SheetsUtilTest.java
@@ -1,0 +1,54 @@
+package com.external.config;
+
+import com.appsmith.external.models.DatasourceConfiguration;
+import com.appsmith.external.models.OAuth2;
+import com.appsmith.external.models.Property;
+import com.external.utils.SheetsUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class SheetsUtilTest {
+
+    @Test
+    public void testGetUserAuthorizedSheetIds_allsheets_returnsNull() throws JsonProcessingException {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        List<Property> propList = new ArrayList<Property>();
+        Property prop = new Property();
+        prop.setKey("emailAddress");
+        prop.setValue("test_email");
+        propList.add(prop);
+        dsConfig.setProperties(propList);
+        Set<String> result = SheetsUtil.getUserAuthorizedSheetIds(dsConfig);
+        assertEquals(result, null);
+    }
+
+    @Test
+    public void testGetUserAuthorizedSheetIds_specificSheets_returnsSetOfFileIds() throws JsonProcessingException {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        List<Property> propList = new ArrayList<Property>();
+        OAuth2 oAuth2 = new OAuth2();
+
+        oAuth2.setScopeString("https://www.googleapis.com/auth/drive.file");
+        dsConfig.setAuthentication(oAuth2);
+
+        Property prop1 = new Property("emailAddress", "test_email");
+        propList.add(prop1);
+
+        List<String> ids = new ArrayList<String>();
+        ids.add("id1");
+
+        Property prop2 = new Property("userAuthorizedSheetIds", ids);
+        propList.add(prop2);
+
+        dsConfig.setProperties(propList);
+        Set<String> result = SheetsUtil.getUserAuthorizedSheetIds(dsConfig);
+        assertEquals(result.size(), 1);
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes:
- In gsheet datasource query, the spreadsheet list was not getting fetched. This Pr fixes the issue with trigger API, so that list of spreadsheets can be fetched successfully.

> Add a TL;DR when description is extra long (helps content team)

Fixes #22890 


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- JUnit

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
