### PR TITLE
fix: action reducers were using old implementation of updating state

### DIFF
--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -1,4 +1,4 @@
-import { createReducer } from "utils/ReducerUtils";
+import { createImmerReducer } from "utils/ReducerUtils";
 import type { ReduxAction } from "@appsmith/constants/ReduxActionConstants";
 import {
   ReduxActionTypes,
@@ -9,7 +9,6 @@ import type { ExecuteErrorPayload } from "constants/AppsmithActionConstants/Acti
 import _ from "lodash";
 import type { Action } from "entities/Action";
 import type { UpdateActionPropertyActionPayload } from "actions/pluginActionActions";
-import produce from "immer";
 
 export interface ActionData {
   isLoading: boolean;
@@ -34,13 +33,13 @@ export interface PartialActionData {
 
 const initialState: ActionDataState = [];
 
-const actionsReducer = createReducer(initialState, {
+const actionsReducer = createImmerReducer(initialState, {
   [ReduxActionTypes.FETCH_ACTIONS_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action[]>,
-  ): ActionDataState => {
+  ) => {
     return action.payload.map((action) => {
-      const foundAction = state.find((currentAction) => {
+      const foundAction = draftMetaState.find((currentAction) => {
         return currentAction.config.id === action.id;
       });
       return {
@@ -51,19 +50,20 @@ const actionsReducer = createReducer(initialState, {
     });
   },
   [ReduxActionTypes.FETCH_ACTIONS_VIEW_MODE_SUCCESS]: (
-    state: ActionDataState,
+    _: ActionDataState,
     action: ReduxAction<Action[]>,
-  ): ActionDataState =>
-    action.payload.map((a) => ({
+  ) => {
+    return action.payload.map((a) => ({
       isLoading: false,
       config: a,
-    })),
+    }));
+  },
   [ReduxActionTypes.FETCH_ACTIONS_FOR_PAGE_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action[]>,
-  ): ActionDataState => {
+  ) => {
     if (action.payload.length > 0) {
-      const stateActionMap = _.keyBy(state, "config.id");
+      const stateActionMap = _.keyBy(draftMetaState, "config.id");
       const result: ActionDataState = [];
 
       action.payload.forEach((actionPayload: Action) => {
@@ -90,99 +90,100 @@ const actionsReducer = createReducer(initialState, {
 
       return result;
     }
-    return state;
   },
   [ReduxActionTypes.SUBMIT_CURL_FORM_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action>,
-  ) => state.concat([{ config: action.payload, isLoading: false }]),
+  ) => {
+    return draftMetaState.concat([
+      { config: action.payload, isLoading: false },
+    ]);
+  },
   [ReduxActionErrorTypes.FETCH_ACTIONS_ERROR]: () => initialState,
   [ReduxActionErrorTypes.FETCH_ACTIONS_VIEW_MODE_ERROR]: () => initialState,
   [ReduxActionTypes.CREATE_ACTION_INIT]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action>,
-  ): ActionDataState =>
-    state.concat([
+  ) => {
+    return draftMetaState.concat([
       {
         config: { ...action.payload, id: action.payload.name },
         isLoading: false,
       },
-    ]),
+    ]);
+  },
   [ReduxActionTypes.CREATE_ACTION_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (
         a.config.pageId === action.payload.pageId &&
         a.config.id === action.payload.name
       ) {
-        return { ...a, config: action.payload };
+        a.config = action.payload;
       }
-      return a;
-    }),
+    });
+  },
   [ReduxActionErrorTypes.CREATE_ACTION_ERROR]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action>,
-  ): ActionDataState =>
-    state.filter(
+  ) => {
+    return draftMetaState.filter(
       (a) =>
         a.config.name !== action.payload.name &&
         a.config.id !== action.payload.name,
-    ),
+    );
+  },
   [ReduxActionTypes.UPDATE_ACTION_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{ data: Action }>,
-  ): ActionDataState =>
-    state.map((a) => {
-      if (a.config.id === action.payload.data.id)
-        return { ...a, config: action.payload.data };
-      return a;
-    }),
+  ) => {
+    draftMetaState.forEach((a) => {
+      if (a.config.id === action.payload.data.id) {
+        a.config = action.payload.data;
+      }
+    });
+  },
   [ReduxActionTypes.UPDATE_ACTION_PROPERTY]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<UpdateActionPropertyActionPayload>,
-  ) =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
         return _.set(a, `config.${action.payload.field}`, action.payload.value);
       }
-      return a;
-    }),
+    });
+  },
   [ReduxActionTypes.DELETE_ACTION_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{ id: string }>,
-  ): ActionDataState => state.filter((a) => a.config.id !== action.payload.id),
+  ) => {
+    return draftMetaState.filter((a) => a.config.id !== action.payload.id);
+  },
   [ReduxActionTypes.EXECUTE_PLUGIN_ACTION_REQUEST]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{ id: string }>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
-        return {
-          ...a,
-          isLoading: true,
-        };
+        a.isLoading = true;
       }
-      return a;
-    }),
+    });
+  },
   [ReduxActionTypes.EXECUTE_PLUGIN_ACTION_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: Array<ActionData | PartialActionData>,
     action: ReduxAction<{ id: string; response: ActionResponse }>,
-  ): PartialActionData[] => {
-    const foundAction = state.find((stateAction) => {
+  ) => {
+    const foundAction = draftMetaState.find((stateAction) => {
       return stateAction.config.id === action.payload.id;
     });
     if (foundAction) {
-      return state.map((stateAction) => {
+      draftMetaState.forEach((stateAction) => {
         if (stateAction.config.id === action.payload.id) {
-          return {
-            ...stateAction,
-            isLoading: false,
-            data: action.payload.response,
-          };
+          stateAction.isLoading = false;
+          stateAction.data = action.payload.response;
         }
-        return stateAction;
       });
     } else {
       const partialAction: PartialActionData = {
@@ -190,151 +191,128 @@ const actionsReducer = createReducer(initialState, {
         config: { id: action.payload.id },
         data: action.payload.response,
       };
-      return [...state, partialAction];
+      draftMetaState.push(partialAction);
     }
   },
   [ReduxActionTypes.SET_ACTION_RESPONSE_DISPLAY_FORMAT]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<UpdateActionPropertyActionPayload>,
-  ) =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
         return _.set(a, `data.${action.payload.field}`, action.payload.value);
       }
-      return a;
-    }),
+    });
+  },
   [ReduxActionTypes.CLEAR_ACTION_RESPONSE]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{ actionId: string }>,
-  ): ActionDataState => {
-    return state.map((stateAction) => {
+  ) => {
+    draftMetaState.forEach((stateAction) => {
       if (stateAction.config.id === action.payload.actionId) {
-        return {
-          ...stateAction,
-          data: undefined,
-        };
+        stateAction.data = undefined;
       }
-      return stateAction;
     });
   },
   [ReduxActionErrorTypes.EXECUTE_PLUGIN_ACTION_ERROR]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<ExecuteErrorPayload>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.actionId) {
-        return { ...a, isLoading: false, data: action.payload.data };
+        a.isLoading = false;
+        a.data = action.payload.data;
       }
-      return a;
-    }),
-  [ReduxActionTypes.RUN_ACTION_REQUEST]: (
-    state: ActionDataState,
-    action: ReduxAction<{ id: string }>,
-  ): ActionDataState =>
-    state.map((a) => {
-      if (action.payload.id === a.config.id) {
-        return {
-          ...a,
-          isLoading: true,
-        };
-      }
+    });
+  },
 
-      return a;
-    }),
-  [ReduxActionTypes.RUN_ACTION_SUCCESS]: (
-    state: ActionDataState,
-    action: ReduxAction<{ [id: string]: ActionResponse }>,
-  ): ActionDataState => {
-    const actionId = Object.keys(action.payload)[0];
-    return state.map((a) => {
-      if (a.config.id === actionId) {
-        return { ...a, isLoading: false, data: action.payload[actionId] };
+  [ReduxActionTypes.RUN_ACTION_REQUEST]: (
+    draftMetaState: ActionDataState,
+    action: ReduxAction<{ id: string }>,
+  ) => {
+    draftMetaState.forEach((a) => {
+      if (action.payload.id === a.config.id) {
+        a.isLoading = true;
       }
-      return a;
+    });
+  },
+  [ReduxActionTypes.RUN_ACTION_SUCCESS]: (
+    draftMetaState: ActionDataState,
+    action: ReduxAction<{ [id: string]: ActionResponse }>,
+  ) => {
+    const actionId = Object.keys(action.payload)[0];
+    draftMetaState.forEach((a) => {
+      if (a.config.id === actionId) {
+        a.isLoading = false;
+        _.assign(a.data, action.payload[actionId]);
+      }
     });
   },
   [ReduxActionErrorTypes.RUN_ACTION_ERROR]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{ id: string }>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
-        return { ...a, isLoading: false };
+        a.isLoading = false;
       }
-
-      return a;
-    }),
+    });
+  },
   [ReduxActionTypes.RUN_ACTION_CANCELLED]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{ id: string }>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
-        return { ...a, isLoading: false };
+        a.isLoading = false;
       }
-
-      return a;
-    }),
+    });
+  },
   [ReduxActionTypes.MOVE_ACTION_INIT]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{
       id: string;
       destinationPageId: string;
       name: string;
     }>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
-        return {
-          ...a,
-          config: {
-            ...a.config,
-            name: action.payload.name,
-            pageId: action.payload.destinationPageId,
-          },
-        };
+        a.config.name = action.payload.name;
+        a.config.pageId = action.payload.destinationPageId;
       }
-
-      return a;
-    }),
+    });
+  },
   [ReduxActionTypes.MOVE_ACTION_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
-        return { ...a, config: action.payload };
+        a.config = action.payload;
       }
-
-      return a;
-    }),
+    });
+  },
   [ReduxActionErrorTypes.MOVE_ACTION_ERROR]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{ id: string; originalPageId: string }>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (a.config.id === action.payload.id) {
-        return {
-          ...a,
-          config: {
-            ...a.config,
-            pageId: action.payload.originalPageId,
-          },
-        };
+        a.config.pageId = action.payload.originalPageId;
       }
-
-      return a;
-    }),
+    });
+  },
   [ReduxActionTypes.COPY_ACTION_INIT]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{
       id: string;
       destinationPageId: string;
       name: string;
     }>,
-  ): ActionDataState =>
-    state.concat(
-      state
+  ) => {
+    return draftMetaState.concat(
+      draftMetaState
         .filter((a) => a.config.id === action.payload.id)
         .map((a) => ({
           ...a,
@@ -346,33 +324,30 @@ const actionsReducer = createReducer(initialState, {
             pageId: action.payload.destinationPageId,
           },
         })),
-    ),
+    );
+  },
   [ReduxActionTypes.COPY_ACTION_SUCCESS]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<Action>,
-  ): ActionDataState =>
-    state.map((a) => {
+  ) => {
+    draftMetaState.forEach((a) => {
       if (
         a.config.pageId === action.payload.pageId &&
         a.config.name === action.payload.name
       ) {
-        return {
-          ...a,
-          config: action.payload,
-        };
+        a.config = action.payload;
       }
-
-      return a;
-    }),
+    });
+  },
   [ReduxActionErrorTypes.COPY_ACTION_ERROR]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<{
       id: string;
       destinationPageId: string;
       name: string;
     }>,
-  ): ActionDataState =>
-    state.filter((a) => {
+  ) => {
+    return draftMetaState.filter((a) => {
       if (a.config.pageId === action.payload.destinationPageId) {
         if (
           a.config.id === action.payload.id ||
@@ -384,9 +359,10 @@ const actionsReducer = createReducer(initialState, {
       }
 
       return true;
-    }),
+    });
+  },
   [ReduxActionTypes.SET_ACTION_TO_EXECUTE_ON_PAGELOAD]: (
-    state: ActionDataState,
+    draftMetaState: ActionDataState,
     action: ReduxAction<
       Array<{
         executeOnLoad: boolean;
@@ -395,24 +371,22 @@ const actionsReducer = createReducer(initialState, {
       }>
     >,
   ) => {
-    return produce(state, (draft) => {
-      const actionUpdateSearch = _.keyBy(action.payload, "id");
-      draft.forEach((action, index) => {
-        if (action.config.id in actionUpdateSearch) {
-          draft[index].config.executeOnLoad =
-            actionUpdateSearch[action.config.id].executeOnLoad;
-        }
-      });
+    const actionUpdateSearch = _.keyBy(action.payload, "id");
+    draftMetaState.forEach((action) => {
+      if (action.config.id in actionUpdateSearch) {
+        action.config.executeOnLoad =
+          actionUpdateSearch[action.config.id].executeOnLoad;
+      }
     });
   },
 
   [ReduxActionTypes.SWITCH_CURRENT_PAGE_ID]: (
-    state: ActionDataState,
-  ): ActionDataState =>
-    state.map((action) => ({
-      ...action,
-      data: undefined,
-    })),
+    draftMetaState: ActionDataState,
+  ) => {
+    draftMetaState.forEach((a) => {
+      a.data = undefined;
+    });
+  },
 });
 
 export default actionsReducer;

--- a/app/client/src/reducers/entityReducers/actionsReducer.tsx
+++ b/app/client/src/reducers/entityReducers/actionsReducer.tsx
@@ -179,12 +179,9 @@ const actionsReducer = createImmerReducer(initialState, {
       return stateAction.config.id === action.payload.id;
     });
     if (foundAction) {
-      draftMetaState.forEach((stateAction) => {
-        if (stateAction.config.id === action.payload.id) {
-          stateAction.isLoading = false;
-          stateAction.data = action.payload.response;
-        }
-      });
+      foundAction.isLoading = false;
+      if (foundAction.data) _.assign(foundAction.data, action.payload.response);
+      else foundAction.data = action.payload.response;
     } else {
       const partialAction: PartialActionData = {
         isLoading: false,
@@ -244,7 +241,8 @@ const actionsReducer = createImmerReducer(initialState, {
     draftMetaState.forEach((a) => {
       if (a.config.id === actionId) {
         a.isLoading = false;
-        _.assign(a.data, action.payload[actionId]);
+        if (a.data) _.assign(a.data, action.payload[actionId]);
+        else a.data = action.payload[actionId];
       }
     });
   },


### PR DESCRIPTION
## Description

In this PR `ActionReducer` code was refactored to use `createImmerReducer` instead of `createReducer`, which helped in solving the gsheet error of spreadsheet name mismatch and api url field update failing autosave by updating the redux
store values properly.

### TL;DR
When a query that was used to create a spreadsheet is changed, the query's meta values are not updated, and the server encounters the spreadsheet name mismatch error. This was taking place because the server was keeping outdated values due to the redux store's failure to update with the latest values. It was happening as a result of an outdated reducer implementation in ActionReducer that didn't use createImmerReducer (using package immer). 
This also fixes the issue with the api url field failing autosaving with updated values.


Fixes #21193 
Fixes #20608
> if no issue exists, please create an issue and ask the maintainers about this first


Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update


## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
