### PR TITLE
fix: assign 100% width to fill widgets on mobile viewport

### DIFF
--- a/app/client/src/utils/autoLayout/positionUtils.test.ts
+++ b/app/client/src/utils/autoLayout/positionUtils.test.ts
@@ -168,6 +168,75 @@ describe("test PositionUtils methods", () => {
           .fillWidgetLength,
       ).toEqual(24);
     });
+    it("should assign 64 columns to each fill widget on mobile viewport", () => {
+      const widgets = {
+        "1": {
+          widgetId: "1",
+          leftColumn: 0,
+          rightColumn: 16,
+          alignment: FlexLayerAlignment.Start,
+          topRow: 0,
+          bottomRow: 4,
+          type: "",
+          widgetName: "",
+          renderMode: RenderModes.CANVAS,
+          version: 1,
+          parentColumnSpace: 10,
+          parentRowSpace: 10,
+          isLoading: false,
+          responsiveBehavior: ResponsiveBehavior.Fill,
+        },
+        "2": {
+          widgetId: "2",
+          leftColumn: 16,
+          rightColumn: 64,
+          alignment: FlexLayerAlignment.Start,
+          topRow: 0,
+          bottomRow: 7,
+          type: "",
+          widgetName: "",
+          renderMode: RenderModes.CANVAS,
+          version: 1,
+          parentColumnSpace: 10,
+          parentRowSpace: 10,
+          isLoading: false,
+          responsiveBehavior: ResponsiveBehavior.Fill,
+        },
+        "3": {
+          widgetId: "3",
+          leftColumn: 48,
+          rightColumn: 64,
+          alignment: FlexLayerAlignment.End,
+          topRow: 0,
+          bottomRow: 7,
+          type: "",
+          widgetName: "",
+          renderMode: RenderModes.CANVAS,
+          version: 1,
+          parentColumnSpace: 10,
+          parentRowSpace: 10,
+          isLoading: false,
+          responsiveBehavior: ResponsiveBehavior.Fill,
+        },
+      };
+      const layer: FlexLayer = {
+        children: [
+          { id: "1", align: FlexLayerAlignment.Start },
+          { id: "2", align: FlexLayerAlignment.Start },
+          { id: "3", align: FlexLayerAlignment.End },
+        ],
+      };
+      const { fillWidgetLength, info } = extractAlignmentInfo(
+        widgets,
+        layer,
+        true,
+        64,
+        1,
+        true,
+      );
+      expect(fillWidgetLength).toEqual(64);
+      expect(info[0].columns).toEqual(128);
+    });
     it("should allocate columns for fill widgets that match min widths if enough space is unavailable", () => {
       const widgets = {
         "1": {

--- a/app/client/src/utils/autoLayout/positionUtils.ts
+++ b/app/client/src/utils/autoLayout/positionUtils.ts
@@ -416,11 +416,16 @@ export function extractAlignmentInfo(
     .sort((a, b) => b.columns - a.columns)
     .forEach((each, index) => {
       const { child, columns } = each;
-      // If minWidth > availableColumns / # of fill widgets => assign columns based on minWidth and update fillLength for remaining fill widgets.
-      const width = columns > fillWidgetLength ? columns : fillWidgetLength;
-      availableColumns = Math.max(availableColumns - width, 0);
-      if (fillChildren.length - index - 1 > 0)
-        fillWidgetLength = availableColumns / (fillChildren.length - index - 1);
+      // For mobile viewport, use only fillWidgetLength == 64.
+      let width = fillWidgetLength;
+      if (!isMobile) {
+        // If minWidth > availableColumns / # of fill widgets => assign columns based on minWidth and update fillLength for remaining fill widgets.
+        width = columns > fillWidgetLength ? columns : fillWidgetLength;
+        availableColumns = Math.max(availableColumns - width, 0);
+        if (fillChildren.length - index - 1 > 0)
+          fillWidgetLength =
+            availableColumns / (fillChildren.length - index - 1);
+      }
       if (child.align === FlexLayerAlignment.Start) {
         startColumns += width;
         const index = startChildren.findIndex(


### PR DESCRIPTION
## Description

Issue: Fill widgets are not assigned 64 columns on mobile viewport if placed in the same flex layer.

Fix: Add a check for mobile viewport to override the minWidth logic.

Fixes # ([issue](https://github.com/appsmithorg/appsmith/issues/22917))

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Manual
- Jest

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag

