### PR TITLE
Added loginTimeout datasource param for jdbc connection to reduce tim…

### DIFF
--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/java/com/external/plugins/SnowflakePlugin.java
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/java/com/external/plugins/SnowflakePlugin.java
@@ -31,6 +31,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -51,6 +52,10 @@ public class SnowflakePlugin extends BasePlugin {
     private static final int MINIMUM_POOL_SIZE = 1;
 
     private static final int MAXIMUM_POOL_SIZE = 5;
+
+    private static final String SNOWFLAKE_DB_LOGIN_TIMEOUT_PROPERTY_KEY = "loginTimeout";
+
+    private static final int SNOWFLAKE_DB_LOGIN_TIMEOUT_VALUE_SEC = 15;
 
     public SnowflakePlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -151,6 +156,7 @@ public class SnowflakePlugin extends BasePlugin {
             properties.setProperty("role", String.valueOf(datasourceConfiguration.getProperties().get(3).getValue()));
             /* Ref: https://github.com/appsmithorg/appsmith/issues/19784 */
             properties.setProperty("jdbc_query_result_format", "json");
+            properties.setProperty(SNOWFLAKE_DB_LOGIN_TIMEOUT_PROPERTY_KEY, String.valueOf(SNOWFLAKE_DB_LOGIN_TIMEOUT_VALUE_SEC));
 
             return Mono
                     .fromCallable(() -> {


### PR DESCRIPTION
## Description

> In this pr, loginTimout param is added to datasourceProperties map of HikariConfig object so that the ssl peer is verified within the UI timeout limit
> This fixes the issue: https://github.com/appsmithorg/appsmith/issues/22035

Fixes #22035

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
> Add a Snowflake DB with wrong account name as provided in the related issue. Test the datasource, and wait for the error to come up. Error should show up on UI in ~15 seconds with message that ssl peer identity validation has failed.

- Manual
- Jest
- Cypress

### Test Plan
> Add a Snowflake DB with wrong account name as provided in the related issue. Test the datasource, and wait for the error to come up. Error should show up on UI in ~15 seconds with message that ssl peer identity validation has failed. A correct account id should be instantly validated. This is because with the account id provided in the issue, the error took 60 seconds to occur which now has been reduced to 15 seconds.


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
