### PR TITLE
fix: Updated server set up docs to lower confusion from logs

### DIFF
--- a/app/server/envs/dev.env.example
+++ b/app/server/envs/dev.env.example
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-APPSMITH_MONGODB_URI="mongodb://localhost:27017/appsmith?replicaSet=appsmith-replica-set"
+APPSMITH_MONGODB_URI="mongodb://localhost:27017/appsmith?replicaSet=rs0"
 
 APPSMITH_REDIS_URL="redis://127.0.0.1:6379"
 

--- a/contributions/ServerSetup.md
+++ b/contributions/ServerSetup.md
@@ -61,7 +61,7 @@ This document doesn't provide instructions to install Java and Maven because the
 The following command will start a MongoDB docker instance locally:
 
 ```console
-docker run -p 127.0.0.1:27017:27017 --name appsmith-mongodb --hostname=localhost -e MONGO_INITDB_DATABASE=appsmith -v /path/to/store/data:/data/db mongo --replSet rs0
+docker run -d -p 127.0.0.1:27017:27017 --name appsmith-mongodb --hostname=localhost -e MONGO_INITDB_DATABASE=appsmith -v /path/to/store/data:/data/db mongo --replSet rs0
 ```
 
 Please change the `/path/to/store/data` to a valid path on your system. This is where MongoDB will persist it's data across runs of this container.
@@ -95,7 +95,7 @@ rs.initiate({"_id": "rs0", "members" : [{"_id":0 , "host": "localhost:27017" }]}
 The following command will start a Redis docker instance locally:
 
 ```console
-docker run -p 127.0.0.1:6379:6379 --name appsmith-redis redis
+docker run -d -p 127.0.0.1:6379:6379 --name appsmith-redis redis
 ```
 
 Redis will now be running on `redis://localhost:6379`.
@@ -188,7 +188,7 @@ Note that as you have installed Docker Desktop with WSL based engine, you can ex
 The following command will start a MongoDB docker instance locally:
 
 ```console
-docker run -p 127.0.0.1:27017:27017 --name appsmith-mongodb --hostname=localhost -e MONGO_INITDB_DATABASE=appsmith -v /path/to/store/data:/data/db mongo mongod --replSet rs0
+docker run -d -p 127.0.0.1:27017:27017 --name appsmith-mongodb --hostname=localhost -e MONGO_INITDB_DATABASE=appsmith -v /path/to/store/data:/data/db mongo mongod --replSet rs0
 ```
 
 #### For Apple Silicon
@@ -196,7 +196,7 @@ docker run -p 127.0.0.1:27017:27017 --name appsmith-mongodb --hostname=localhost
 For M1 chip change the base image to [arm64v8 variant](https://hub.docker.com/r/arm64v8/mongo/)
 
 ```console
-docker run -p 127.0.0.1:27017:27017 --name appsmith-mongodb --hostname=localhost -e MONGO_INITDB_DATABASE=appsmith -v /path/to/store/data:/data/db arm64v8/mongo mongod --replSet rs0
+docker run -d -p 127.0.0.1:27017:27017 --name appsmith-mongodb --hostname=localhost -e MONGO_INITDB_DATABASE=appsmith -v /path/to/store/data:/data/db arm64v8/mongo mongod --replSet rs0
 ```
 
 
@@ -211,7 +211,7 @@ MongoDB will now be running on `mongodb://localhost:27017/appsmith`.
 The following command will start a Redis docker instance locally:
 
 ```console
-docker run -p 127.0.0.1:6379:6379 --name appsmith-redis redis
+docker run -d -p 127.0.0.1:6379:6379 --name appsmith-redis redis
 ```
 
 #### For Apple Silicon
@@ -219,7 +219,7 @@ docker run -p 127.0.0.1:6379:6379 --name appsmith-redis redis
 For M1 chip change the base image to [arm64v8 variant](https://hub.docker.com/r/arm64v8/redis/)
 
 ```console
-docker run -p 127.0.0.1:6379:6379 --name appsmith-redis arm64v8/redis
+docker run -d -p 127.0.0.1:6379:6379 --name appsmith-redis arm64v8/redis
 ```
 
 Redis will now be running on `redis://localhost:6379`.


### PR DESCRIPTION
Documentation update for server side set up, and a change to default value in env variables for Mongo to comply with the one we are using in the set up docs, to allow for a quick start and lower chance of failure.