### PR TITLE
chore: Load OAuth2 configurations dynamically

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/OAuth2ClientRegistrationRepository.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/OAuth2ClientRegistrationRepository.java
@@ -1,0 +1,103 @@
+package com.appsmith.server.configurations;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class OAuth2ClientRegistrationRepository implements ReactiveClientRegistrationRepository {
+
+    public static final String GOOGLE_REGISTRATION_ID = "google";
+
+    public static final String GITHUB_REGISTRATION_ID = "github";
+
+    @Value("${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:}")
+    private String googleClientId;
+
+    @Value("${APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET:}")
+    private String googleClientSecret;
+
+    @Value("${APPSMITH_OAUTH2_GITHUB_CLIENT_ID:}")
+    private String githubClientId;
+
+    @Value("${APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET:}")
+    private String githubClientSecret;
+
+    private Map<String, ClientRegistration> registrations = new HashMap<>();
+
+    @PostConstruct
+    void init() {
+        recreateGoogleClientRegistration();
+        recreateGithubClientRegistration();
+    }
+
+    @Override
+    public Mono<ClientRegistration> findByRegistrationId(String registrationId) {
+        return Mono.justOrEmpty(registrations.get(registrationId));
+    }
+
+    private void recreateGoogleClientRegistration() {
+        if (StringUtils.isEmpty(googleClientId)) {
+            registrations.remove(GOOGLE_REGISTRATION_ID);
+        } else {
+            registrations.put(
+                GOOGLE_REGISTRATION_ID,
+                CommonOAuth2Provider.GOOGLE.getBuilder(GOOGLE_REGISTRATION_ID)
+                    .clientId(googleClientId)
+                    .clientSecret(googleClientSecret)
+                    .userNameAttributeName("email")
+                    .build()
+            );
+        }
+    }
+
+    private void recreateGithubClientRegistration() {
+        if (StringUtils.isEmpty(githubClientId)) {
+            registrations.remove(GITHUB_REGISTRATION_ID);
+        } else {
+            registrations.put(
+                GITHUB_REGISTRATION_ID,
+                CommonOAuth2Provider.GITHUB.getBuilder(GITHUB_REGISTRATION_ID)
+                    .clientId(githubClientId)
+                    .clientSecret(githubClientSecret)
+                    .userNameAttributeName("login")
+                    .build()
+            );
+        }
+    }
+
+    public void setGoogleClientId(String googleClientId) {
+        this.googleClientId = googleClientId;
+        recreateGoogleClientRegistration();
+    }
+
+    public void setGoogleClientSecret(String googleClientSecret) {
+        this.googleClientSecret = googleClientSecret;
+        recreateGoogleClientRegistration();
+    }
+
+    public void setGithubClientId(String githubClientId) {
+        this.githubClientId = githubClientId;
+        recreateGithubClientRegistration();
+    }
+
+    public void setGithubClientSecret(String githubClientSecret) {
+        this.githubClientSecret = githubClientSecret;
+        recreateGithubClientRegistration();
+    }
+
+    public Set<String> getAvailableClientIds() {
+        // Note, this is a live-set. If the underlying map gets a key added or removed, it'll be reflected in this Set.
+        return registrations.keySet();
+    }
+
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/TenantServiceImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/TenantServiceImpl.java
@@ -1,13 +1,13 @@
 package com.appsmith.server.services;
 
+import com.appsmith.server.configurations.OAuth2ClientRegistrationRepository;
 import com.appsmith.server.repositories.TenantRepository;
 import com.appsmith.server.services.ce.TenantServiceCEImpl;
+import jakarta.validation.Validator;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Service;
 import reactor.core.scheduler.Scheduler;
-
-import jakarta.validation.Validator;
 
 @Service
 public class TenantServiceImpl extends TenantServiceCEImpl implements TenantService {
@@ -18,7 +18,17 @@ public class TenantServiceImpl extends TenantServiceCEImpl implements TenantServ
                              ReactiveMongoTemplate reactiveMongoTemplate,
                              TenantRepository repository,
                              AnalyticsService analyticsService,
-                             ConfigService configService) {
-        super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService, configService);
+                             ConfigService configService,
+                             OAuth2ClientRegistrationRepository oAuth2ClientRegistrationRepository) {
+        super(
+            scheduler,
+            validator,
+            mongoConverter,
+            reactiveMongoTemplate,
+            repository,
+            analyticsService,
+            configService,
+            oAuth2ClientRegistrationRepository
+        );
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services.ce;
 
 import com.appsmith.external.helpers.AppsmithBeanUtils;
 import com.appsmith.server.acl.AclPermission;
+import com.appsmith.server.configurations.OAuth2ClientRegistrationRepository;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Tenant;
 import com.appsmith.server.domains.TenantConfiguration;
@@ -27,15 +28,19 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
 
     private final ConfigService configService;
 
+    private final OAuth2ClientRegistrationRepository oAuth2ClientRegistrationRepository;
+
     public TenantServiceCEImpl(Scheduler scheduler,
                                Validator validator,
                                MongoConverter mongoConverter,
                                ReactiveMongoTemplate reactiveMongoTemplate,
                                TenantRepository repository,
                                AnalyticsService analyticsService,
-                               ConfigService configService) {
+                               ConfigService configService,
+                               OAuth2ClientRegistrationRepository oAuth2ClientRegistrationRepository) {
         super(scheduler, validator, mongoConverter, reactiveMongoTemplate, repository, analyticsService);
         this.configService = configService;
+        this.oAuth2ClientRegistrationRepository = oAuth2ClientRegistrationRepository;
     }
 
     @Override
@@ -91,12 +96,8 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
 
                     config.setGoogleMapsKey(System.getenv("APPSMITH_GOOGLE_MAPS_API_KEY"));
 
-                    if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GOOGLE_CLIENT_ID"))) {
-                        config.addThirdPartyAuth("google");
-                    }
-
-                    if (StringUtils.hasText(System.getenv("APPSMITH_OAUTH2_GITHUB_CLIENT_ID"))) {
-                        config.addThirdPartyAuth("github");
+                    for (final String clientId : oAuth2ClientRegistrationRepository.getAvailableClientIds()) {
+                        config.addThirdPartyAuth(clientId);
                     }
 
                     return tenant;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManagerImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/EnvManagerImpl.java
@@ -3,11 +3,11 @@ package com.appsmith.server.solutions;
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.configurations.GoogleRecaptchaConfig;
+import com.appsmith.server.configurations.OAuth2ClientRegistrationRepository;
 import com.appsmith.server.helpers.FileUtils;
 import com.appsmith.server.helpers.PolicyUtils;
 import com.appsmith.server.helpers.UserUtils;
 import com.appsmith.server.notifications.EmailSender;
-import com.appsmith.server.repositories.TenantRepository;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.services.AnalyticsService;
 import com.appsmith.server.services.ConfigService;
@@ -40,10 +40,11 @@ public class EnvManagerImpl extends EnvManagerCEImpl implements EnvManager {
                           ConfigService configService,
                           UserUtils userUtils,
                           TenantService tenantService,
-                          ObjectMapper objectMapper) {
+                          ObjectMapper objectMapper,
+                          OAuth2ClientRegistrationRepository oAuth2ClientRegistrationRepository) {
 
         super(sessionUserService, userService, analyticsService, userRepository, policyUtils, emailSender, commonConfig,
                 emailConfig, javaMailSender, googleRecaptchaConfig, fileUtils, permissionGroupService, configService,
-                userUtils, tenantService, objectMapper);
+                userUtils, tenantService, objectMapper, oAuth2ClientRegistrationRepository);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/EnvManagerCEImpl.java
@@ -4,6 +4,7 @@ import com.appsmith.external.constants.AnalyticsEvents;
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.configurations.GoogleRecaptchaConfig;
+import com.appsmith.server.configurations.OAuth2ClientRegistrationRepository;
 import com.appsmith.server.constants.EnvVariables;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Tenant;
@@ -84,7 +85,9 @@ import static com.appsmith.server.constants.EnvVariables.APPSMITH_MAIL_PORT;
 import static com.appsmith.server.constants.EnvVariables.APPSMITH_MAIL_SMTP_AUTH;
 import static com.appsmith.server.constants.EnvVariables.APPSMITH_MAIL_USERNAME;
 import static com.appsmith.server.constants.EnvVariables.APPSMITH_OAUTH2_GITHUB_CLIENT_ID;
+import static com.appsmith.server.constants.EnvVariables.APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET;
 import static com.appsmith.server.constants.EnvVariables.APPSMITH_OAUTH2_GOOGLE_CLIENT_ID;
+import static com.appsmith.server.constants.EnvVariables.APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET;
 import static com.appsmith.server.constants.EnvVariables.APPSMITH_RECAPTCHA_SECRET_KEY;
 import static com.appsmith.server.constants.EnvVariables.APPSMITH_RECAPTCHA_SITE_KEY;
 import static com.appsmith.server.constants.EnvVariables.APPSMITH_REPLY_TO;
@@ -119,6 +122,8 @@ public class EnvManagerCEImpl implements EnvManagerCE {
 
     private final ObjectMapper objectMapper;
 
+    private final OAuth2ClientRegistrationRepository oAuth2ClientRegistrationRepository;
+
     /**
      * This regex pattern matches environment variable declarations like `VAR_NAME=value` or `VAR_NAME="value"` or just
      * `VAR_NAME=`. It also defines two named capture groups, `name` and `value`, for the variable's name and value
@@ -147,7 +152,8 @@ public class EnvManagerCEImpl implements EnvManagerCE {
                             ConfigService configService,
                             UserUtils userUtils,
                             TenantService tenantService,
-                            ObjectMapper objectMapper) {
+                            ObjectMapper objectMapper,
+                            OAuth2ClientRegistrationRepository oAuth2ClientRegistrationRepository) {
 
         this.sessionUserService = sessionUserService;
         this.userService = userService;
@@ -165,6 +171,7 @@ public class EnvManagerCEImpl implements EnvManagerCE {
         this.userUtils = userUtils;
         this.tenantService = tenantService;
         this.objectMapper = objectMapper;
+        this.oAuth2ClientRegistrationRepository = oAuth2ClientRegistrationRepository;
     }
 
     /**
@@ -401,6 +408,22 @@ public class EnvManagerCEImpl implements EnvManagerCE {
 
                     if (changesCopy.containsKey(APPSMITH_SIGNUP_ALLOWED_DOMAINS.name())) {
                         commonConfig.setAllowedDomainsString(changesCopy.remove(APPSMITH_SIGNUP_ALLOWED_DOMAINS.name()));
+                    }
+
+                    if (changesCopy.containsKey(APPSMITH_OAUTH2_GOOGLE_CLIENT_ID.name())) {
+                        oAuth2ClientRegistrationRepository.setGoogleClientId(changesCopy.remove(APPSMITH_OAUTH2_GOOGLE_CLIENT_ID.name()));
+                    }
+
+                    if (changesCopy.containsKey(APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET.name())) {
+                        oAuth2ClientRegistrationRepository.setGoogleClientSecret(changesCopy.remove(APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET.name()));
+                    }
+
+                    if (changesCopy.containsKey(APPSMITH_OAUTH2_GITHUB_CLIENT_ID.name())) {
+                        oAuth2ClientRegistrationRepository.setGithubClientId(changesCopy.remove(APPSMITH_OAUTH2_GITHUB_CLIENT_ID.name()));
+                    }
+
+                    if (changesCopy.containsKey(APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET.name())) {
+                        oAuth2ClientRegistrationRepository.setGithubClientSecret(changesCopy.remove(APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET.name()));
                     }
 
                     if (changesCopy.containsKey(APPSMITH_ADMIN_EMAILS.name())) {

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -28,14 +28,6 @@ logging.level.com.appsmith=debug
 logging.level.com.external.plugins=debug
 logging.pattern.console=[%d{ISO8601, UTC}] %X - %m%n
 
-#Spring security
-spring.security.oauth2.client.registration.google.client-id=${APPSMITH_OAUTH2_GOOGLE_CLIENT_ID:missing_value_sentinel}
-spring.security.oauth2.client.registration.google.client-secret=${APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET:}
-spring.security.oauth2.client.provider.google.userNameAttribute=email
-spring.security.oauth2.client.registration.github.client-id=${APPSMITH_OAUTH2_GITHUB_CLIENT_ID:missing_value_sentinel}
-spring.security.oauth2.client.registration.github.client-secret=${APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET:}
-spring.security.oauth2.client.provider.github.userNameAttribute=login
-
 # Accounts from specific domains are allowed to login
 # DEPRECATED, in favor of signup.allowed-domains
 oauth2.allowed-domains=${APPSMITH_OAUTH2_ALLOWED_DOMAINS:}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/EnvManagerTest.java
@@ -3,6 +3,7 @@ package com.appsmith.server.solutions;
 import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.EmailConfig;
 import com.appsmith.server.configurations.GoogleRecaptchaConfig;
+import com.appsmith.server.configurations.OAuth2ClientRegistrationRepository;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.exceptions.AppsmithError;
 import com.appsmith.server.exceptions.AppsmithException;
@@ -80,6 +81,9 @@ public class EnvManagerTest {
     @MockBean
     private ObjectMapper objectMapper;
 
+    @MockBean
+    private OAuth2ClientRegistrationRepository oAuth2ClientRegistrationRepository;
+
     EnvManager envManager;
 
     @BeforeEach
@@ -99,7 +103,8 @@ public class EnvManagerTest {
                 configService,
                 userUtils,
                 tenantService,
-                objectMapper);
+                objectMapper,
+                oAuth2ClientRegistrationRepository);
     }
 
     @Test


### PR DESCRIPTION
This PR will load OAuth2 configurations for Google and GitHub dynamically, instead of having Spring pick them up statically at startup.

Why do we need this?

1. This will enable us change OAuth2 configuration without needing a restart from Admin Settings.
2. This will lead us towards being able to load the client-id and client-secret from the database, instead-of/in-addition-to the environment variables.

Note that this only contains backend changes, and the client still requests a restart, although it's not required. I'll change client's behaviour there in a separate PR. This one, doesn't break any API contract.