### PR TITLE
fix: added userPermissions in newPage Api

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageNameIdDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/PageNameIdDTO.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Set;
+
 @Getter
 @Setter
 public class PageNameIdDTO {
@@ -29,6 +31,9 @@ public class PageNameIdDTO {
 
     @JsonView(Views.Public.class)
     Boolean isHidden;
+
+    @JsonView(Views.Public.class)
+    Set<String> userPermissions;
 
     // This field will represent the default pageId for current page in git system where we are connecting resources
     // among the branches

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -119,16 +119,17 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
         ArrayList<String> includedFields = new ArrayList<>(List.of(
                 FieldName.APPLICATION_ID,
                 FieldName.DEFAULT_RESOURCES,
-                "unpublishedPage.name",
-                "unpublishedPage.icon",
-                "unpublishedPage.isHidden",
-                "unpublishedPage.slug",
-                "unpublishedPage.customSlug",
-                "publishedPage.name",
-                "publishedPage.icon",
-                "publishedPage.isHidden",
-                "publishedPage.slug",
-                "publishedPage.customSlug"
+                fieldName(QNewPage.newPage.policies),
+                (fieldName(QNewPage.newPage.unpublishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.name)),
+                (fieldName(QNewPage.newPage.unpublishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.icon)),
+                (fieldName(QNewPage.newPage.unpublishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.isHidden)),
+                (fieldName(QNewPage.newPage.unpublishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.slug)),
+                (fieldName(QNewPage.newPage.unpublishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.customSlug)),
+                (fieldName(QNewPage.newPage.publishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.name)),
+                (fieldName(QNewPage.newPage.publishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.icon)),
+                (fieldName(QNewPage.newPage.publishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.isHidden)),
+                (fieldName(QNewPage.newPage.publishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.slug)),
+                (fieldName(QNewPage.newPage.publishedPage) + "." + fieldName(QNewPage.newPage.unpublishedPage.customSlug))
         ));
 
         Criteria idsCriterion = where("id").in(ids);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
@@ -342,6 +342,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
                         pageNameIdDTO.setSlug(pageDTO.getSlug());
                         pageNameIdDTO.setIcon(pageDTO.getIcon());
                         pageNameIdDTO.setCustomSlug(pageDTO.getCustomSlug());
+                        pageNameIdDTO.setUserPermissions(pageFromDb.getUserPermissions());
 
                         if (pageNameIdDTO.getId().equals(defaultPageId)) {
                             pageNameIdDTO.setIsDefault(true);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/NewPageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/NewPageServiceTest.java
@@ -103,6 +103,7 @@ public class NewPageServiceTest {
                     assertThat(applicationPagesDTO.getApplication().getViewMode()).isFalse();
                     assertThat(applicationPagesDTO.getApplication().getName()).isEqualTo("app_" + randomId);
                     assertThat(applicationPagesDTO.getPages()).isNotEmpty();
+                    applicationPagesDTO.getPages().forEach(pageNameIdDTO -> assertThat(pageNameIdDTO.getUserPermissions()).isNotEmpty());
                 })
                 .verifyComplete();
     }
@@ -137,6 +138,7 @@ public class NewPageServiceTest {
                     assertThat(applicationPagesDTO.getApplication().getViewMode()).isTrue();
                     assertThat(applicationPagesDTO.getApplication().getName()).isEqualTo("app_" + randomId);
                     assertThat(applicationPagesDTO.getPages()).isNotEmpty();
+                    applicationPagesDTO.getPages().forEach(pageNameIdDTO -> assertThat(pageNameIdDTO.getUserPermissions()).isNotEmpty());
                 })
                 .verifyComplete();
     }
@@ -167,6 +169,7 @@ public class NewPageServiceTest {
                     assertThat(applicationPagesDTO.getApplication()).isNotNull();
                     assertThat(applicationPagesDTO.getApplication().getName()).isEqualTo("app_" + randomId);
                     assertThat(applicationPagesDTO.getPages()).isNotEmpty();
+                    applicationPagesDTO.getPages().forEach(pageNameIdDTO -> assertThat(pageNameIdDTO.getUserPermissions()).isNotEmpty());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

### Issue:
Need to add userPermissions in response to newPages Api inside pages array: These are the APIs
/v1/pages?applicationId={applicationId}&mode={mode} - Get method
/v1/pages/application/:applicationId - Get method

### Solution:
Added userPermissions in the response of the above APIs.

### Changes:
These are the changes done in the following file to add userPermission in the newPage Api response
1. New FieldName added which is used in query
2. userPermission attribute added in PageNameIdDTO
3. userPermission coming from db set to response in NewPageServiceCEImpl
4. Test cases updated

Fix #21887

## How Has This Been Tested?
1. Manual testing through postman and UI
2. Junit
### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
