### PR TITLE
ci: Remove unused java setup step

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -21,7 +21,7 @@ jobs:
     defaults:
       run:
         shell: bash
-   
+
     steps:
       # Check out merge commit
       - name: Fork based /ok-to-test checkout
@@ -30,21 +30,13 @@ jobs:
         with:
           fetch-depth: 0
           ref: "refs/pull/${{ inputs.pr }}/merge"
-          
+
       # Checkout the code in the current branch in case the workflow is called because of a branch push event
       - name: Checkout the head commit of the branch
         if: inputs.pr == 0
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          
-      # Setup Java
-      - name: Set up JDK 17
-        if: steps.run_result.outputs.run_result != 'success'
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
 
       - name: Download the client build artifact
         if: steps.run_result.outputs.run_result != 'success'
@@ -80,13 +72,13 @@ jobs:
         working-directory: "."
         run: |
           docker build -t cicontainer .
-      
+
       # Saving the docker image to tar file
       - name: Save Docker image to tar file
         run: |
           docker save cicontainer -o cicontainer.tar
           gzip cicontainer.tar
-      
+
       # Uploading the artifact to use it in other subsequent runners
       - name: Upload Docker image to artifacts
         uses: actions/upload-artifact@v3
@@ -96,4 +88,3 @@ jobs:
 
       - name: Save the status of the run
         run: echo "run_result=success" >> $GITHUB_OUTPUT > ~/run_result
-        


### PR DESCRIPTION
We're setting up Java, but aren't using it in this workflow. This PR removes it.