### PR TITLE
fix: geo location prop is visible on airgap

### DIFF
--- a/app/client/src/components/editorComponents/ActionCreator/FieldGroup/FieldGroupConfig.ts
+++ b/app/client/src/components/editorComponents/ActionCreator/FieldGroup/FieldGroupConfig.ts
@@ -22,6 +22,9 @@ import {
   WATCH_GEO_LOCATION,
 } from "@appsmith/constants/messages";
 import type { FieldGroupConfig } from "../types";
+import { isAirgapped } from "@appsmith/utils/airgapHelpers";
+
+const isAirgappedInstance = isAirgapped();
 
 export const FIELD_GROUP_CONFIG: FieldGroupConfig = {
   [AppsmithFunction.none]: {
@@ -137,26 +140,32 @@ export const FIELD_GROUP_CONFIG: FieldGroupConfig = {
     defaultParams: `""`,
     icon: "clear-interval",
   },
-  [AppsmithFunction.getGeolocation]: {
-    label: createMessage(GET_GEO_LOCATION),
-    fields: [FieldType.CALLBACK_FUNCTION_FIELD_GEOLOCATION],
-    defaultParams: `(location) => {
+  ...(!isAirgappedInstance && {
+    [AppsmithFunction.getGeolocation]: {
+      label: createMessage(GET_GEO_LOCATION),
+      fields: [FieldType.CALLBACK_FUNCTION_FIELD_GEOLOCATION],
+      defaultParams: `(location) => {
       // add code here
     }`,
-    icon: "get-geolocation",
-  },
-  [AppsmithFunction.watchGeolocation]: {
-    label: createMessage(WATCH_GEO_LOCATION),
-    fields: [],
-    defaultParams: "",
-    icon: "watch-geolocation",
-  },
-  [AppsmithFunction.stopWatchGeolocation]: {
-    label: createMessage(STOP_WATCH_GEO_LOCATION),
-    fields: [],
-    defaultParams: "",
-    icon: "stop-watch-geolocation",
-  },
+      icon: "get-geolocation",
+    },
+  }),
+  ...(!isAirgappedInstance && {
+    [AppsmithFunction.watchGeolocation]: {
+      label: createMessage(WATCH_GEO_LOCATION),
+      fields: [],
+      defaultParams: "",
+      icon: "watch-geolocation",
+    },
+  }),
+  ...(!isAirgappedInstance && {
+    [AppsmithFunction.stopWatchGeolocation]: {
+      label: createMessage(STOP_WATCH_GEO_LOCATION),
+      fields: [],
+      defaultParams: "",
+      icon: "stop-watch-geolocation",
+    },
+  }),
   [AppsmithFunction.postWindowMessage]: {
     label: createMessage(POST_MESSAGE),
     fields: [


### PR DESCRIPTION
## Description

- This hides the geo location prop on button on click for airgapped instances.


Fixes #23009 


Media

https://user-images.githubusercontent.com/74818788/236300435-276de1cf-5595-4f6a-ae68-6b16869c6c9e.mov

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)



## How Has This Been Tested?

- Manual


### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
