### PR TITLE
fix: editor app name hover state

### DIFF
--- a/app/client/src/pages/Editor/EditorAppName/index.tsx
+++ b/app/client/src/pages/Editor/EditorAppName/index.tsx
@@ -35,7 +35,7 @@ const Container = styled.div`
   display: flex;
   cursor: pointer;
   &:hover {
-    background-color: var(--ads-v2-color-bg);
+    background-color: var(--ads-v2-color-bg-subtle);
   }
   & .${Classes.EDITABLE_TEXT} {
     height: ${(props) => props.theme.smallHeaderHeight} !important;

--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -8,7 +8,6 @@ import React, {
 } from "react";
 import styled, { ThemeProvider } from "styled-components";
 import classNames from "classnames";
-import { Classes as Popover2Classes } from "@blueprintjs/popover2";
 import type { ApplicationPayload } from "@appsmith/constants/ReduxActionConstants";
 import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { APPLICATIONS_URL } from "constants/routes";
@@ -139,10 +138,6 @@ const HeaderSection = styled.div`
   }
   :nth-child(3) {
     justify-content: flex-end;
-  }
-  > .${Popover2Classes.POPOVER2_TARGET} {
-    max-width: calc(100% - 50px);
-    min-width: 100px;
   }
 `;
 
@@ -426,32 +421,34 @@ export function EditorHeader(props: EditorHeaderProps) {
 
           <Tooltip
             content={createMessage(RENAME_APPLICATION_TOOLTIP)}
+            isDisabled={isPopoverOpen}
             placement="bottom"
-            visible={isPopoverOpen}
           >
-            <EditorAppName
-              applicationId={applicationId}
-              className="t--application-name editable-application-name max-w-48"
-              defaultSavingState={
-                isSavingName ? SavingState.STARTED : SavingState.NOT_STARTED
-              }
-              defaultValue={currentApplication?.name || ""}
-              editInteractionKind={EditInteractionKind.SINGLE}
-              fill
-              isError={isErroredSavingName}
-              isNewApp={
-                applicationList.filter((el) => el.id === applicationId).length >
-                0
-              }
-              isPopoverOpen={isPopoverOpen}
-              onBlur={(value: string) =>
-                updateApplicationDispatch(applicationId || "", {
-                  name: value,
-                  currentApp: true,
-                })
-              }
-              setIsPopoverOpen={setIsPopoverOpen}
-            />
+            <div>
+              <EditorAppName
+                applicationId={applicationId}
+                className="t--application-name editable-application-name max-w-48"
+                defaultSavingState={
+                  isSavingName ? SavingState.STARTED : SavingState.NOT_STARTED
+                }
+                defaultValue={currentApplication?.name || ""}
+                editInteractionKind={EditInteractionKind.SINGLE}
+                fill
+                isError={isErroredSavingName}
+                isNewApp={
+                  applicationList.filter((el) => el.id === applicationId)
+                    .length > 0
+                }
+                isPopoverOpen={isPopoverOpen}
+                onBlur={(value: string) =>
+                  updateApplicationDispatch(applicationId || "", {
+                    name: value,
+                    currentApp: true,
+                  })
+                }
+                setIsPopoverOpen={setIsPopoverOpen}
+              />
+            </div>
           </Tooltip>
           <EditorSaveIndicator />
         </HeaderSection>


### PR DESCRIPTION
## Description

Fixes tooltip showing up when the dropdown is open. Updates the hover color for the  app name.

Fixes https://www.notion.so/appsmith/Hover-state-and-tooltip-are-missing-over-renaming-the-app-677d4f298e67418dacd092bc4176fd33


Media


https://user-images.githubusercontent.com/67054171/236460058-12074c76-f6dc-42cf-8b40-b737ca2e8eed.mov




## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
