### PR TITLE
[FIX] #23028 fixed TypeError: Cannot read properties of undefined (re…

### DIFF
--- a/app/client/src/workers/Evaluation/fns/utils/jsObjectFnFactory.ts
+++ b/app/client/src/workers/Evaluation/fns/utils/jsObjectFnFactory.ts
@@ -38,14 +38,15 @@ export function jsObjectFunctionFactory<P extends ReadonlyArray<unknown>>(
     try {
       const result = fn.call(this, ...args);
       if (isPromise(result)) {
-        result.then((res) => {
-          postProcessors.forEach((p) => p(name, res));
-          return res;
-        });
-        result.catch((e) => {
-          postProcessors.forEach((p) => p(name, undefined));
-          throw e;
-        });
+        return result
+          .then((res) => {
+            postProcessors.forEach((p) => p(name, res));
+            return res;
+          })
+          .catch((e) => {
+            postProcessors.forEach((p) => p(name, undefined));
+            throw e;
+          });
       } else {
         postProcessors.forEach((p) => p(name, result));
       }


### PR DESCRIPTION
…ading '0')
#23028 

Sentry Issue: [APPSMITH-6AF](https://appsmith.sentry.io/issues/4124582002/?referrer=github_integration)
TypeError: Cannot read properties of undefined (reading '0')
 - returning the result was missing.

## Description
>TypeError: Cannot read properties of undefined (reading '0')

> Sentry Issue: [APPSMITH-6AF](https://appsmith.sentry.io/issues/4124582002/?referrer=github_integration)
> TypeError: Cannot read properties of undefined (reading '0')
> at <anonymous> (workers/Evaluation/fns/utils/jsObjectFnFactory.ts:57:7)
>
#### PR fixes following issue(s)
Fixes # (issue number)
> #23028
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- #23028 - TypeError: Cannot read properties of undefined (reading '0')
>
>
>
## Testing
#### How Has This Been Tested?
- [x] Manual

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes