### PR TITLE
fix: Design System - Modal - right attribute bound to incorrect prop

### DIFF
--- a/app/client/src/components/designSystems/appsmith/ModalComponent.tsx
+++ b/app/client/src/components/designSystems/appsmith/ModalComponent.tsx
@@ -111,7 +111,7 @@ export function ModalComponent(props: ModalComponentProps) {
         bottom={props.bottom}
         height={props.height}
         left={props.left}
-        right={props.bottom}
+        right={props.right}
         top={props.top}
         width={props.width}
         zIndex={props.zIndex !== undefined ? props.zIndex : Layers.modalWidget}

--- a/app/client/src/widgets/ModalWidget/component/index.tsx
+++ b/app/client/src/widgets/ModalWidget/component/index.tsx
@@ -292,7 +292,7 @@ export default function ModalComponent(props: ModalComponentProps) {
           left={props.left}
           maxWidth={props.maxWidth}
           minSize={props.minSize}
-          right={props.bottom}
+          right={props.right}
           smallHeaderHeight={theme.smallHeaderHeight}
           top={props.top}
           width={props.width}


### PR DESCRIPTION
## Description
The ModalComponent of the design system doesn't set the right attribute correctly. The component already supports the right attribute as a prop, but it's not bound to it (bound to bottom instead).

#### PR fixes following issue(s)
Fixes #23035

#### Media

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [x] Jest
- [ ] Cypress
>
>

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
