### PR TITLE
chore: [One-click binding] mongodb testcases cypress

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/OneClickBinding/TableWidget/mongoDB_spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/OneClickBinding/TableWidget/mongoDB_spec.ts
@@ -1,0 +1,99 @@
+import * as _ from "../../../../../support/Objects/ObjectsCore";
+import { ChooseAndAssertForm } from "../Utility";
+
+describe("one click binding mongodb datasource", function () {
+  before(() => {
+    _.entityExplorer.DragDropWidgetNVerify("tablewidgetv2", 400);
+  });
+
+  it("test connect datasource", () => {
+    //#region bind to mongoDB datasource
+    _.entityExplorer.NavigateToSwitcher("Explorer");
+
+    _.dataSources.CreateDataSource("Mongo");
+
+    cy.get("@dsName").then((dsName) => {
+      _.entityExplorer.NavigateToSwitcher("Widgets");
+
+      ChooseAndAssertForm(`New from ${dsName}`, dsName, "netflix", "creator");
+    });
+
+    _.agHelper.GetNClick(".t--one-click-binding-connect-data");
+    cy.wait("@postExecute");
+    cy.wait(2000);
+    //#endregion
+
+    //#region validate search through table is working
+    const rowWithAValidText = "Mike Flanagan";
+    //enter a search text
+    _.agHelper.TypeText(
+      ".t--widget-tablewidgetv2 .t--search-input input",
+      rowWithAValidText,
+    );
+    (cy as any).wait(1000);
+    // check if the table rows are present for the given search entry
+    _.agHelper.GetNAssertContains(
+      '.t--widget-tablewidgetv2 [role="rowgroup"] [role="button"]',
+      rowWithAValidText,
+    );
+    //#endregion
+
+    //#region table update operation is working
+    const someColumnIndex = 1;
+    (cy as any).editTableCell(someColumnIndex, 0);
+    //update the first value of the row
+    const someUUID = Cypress._.random(0, 1e6);
+    const enteredSomeValue = "123" + someUUID;
+
+    (cy as any).enterTableCellValue(someColumnIndex, 0, enteredSomeValue);
+    (cy as any).wait(1000);
+
+    (cy as any).saveTableCellValue(someColumnIndex, 0);
+    //commit that update
+    (cy as any).saveTableRow(12, 0);
+
+    (cy as any).wait(1000);
+
+    // check if the updated value is present
+    (cy as any).readTableV2data(0, someColumnIndex).then((cellData: any) => {
+      expect(cellData).to.equal(enteredSomeValue);
+    });
+    //#endregion
+
+    //#region check if the table insert operation works
+    //clear input
+    _.table.resetSearch();
+    // cy.get(".t--widget-tablewidgetv2 .t--search-input input").clear();
+
+    //lets create a new row and check to see the insert operation is working
+    _.agHelper.GetNClick(".t--add-new-row");
+    _.agHelper.AssertElementExist(".new-row");
+
+    const someText = "new row " + Cypress._.random(0, 1e6);
+    const searchColumnIndex = 3;
+    (cy as any).enterTableCellValue(searchColumnIndex, 0, someText);
+
+    (cy as any).saveTableCellValue(searchColumnIndex, 0);
+    // save a row with some random text
+    _.agHelper.GetNClickByContains(
+      ".t--widget-tablewidgetv2 button",
+      "Save row",
+    );
+
+    (cy as any).wait(5000);
+
+    //search the table for a row having the text used to create a new row
+    _.agHelper.TypeText(
+      ".t--widget-tablewidgetv2 .t--search-input input",
+      someText,
+    );
+    (cy as any).wait(1000);
+
+    //check if that row is present
+    _.agHelper.GetNAssertContains(
+      '.t--widget-tablewidgetv2 [role="rowgroup"] [role="button"]',
+      someText,
+    );
+    //#endregion
+  });
+});


### PR DESCRIPTION
## Description
Added test cases to test one click binding for a MongoDB datasource.

#### PR fixes following issue(s)
Fixes #22993

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
- [x] Cypress

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
