### PR TITLE
fix: set Api.data on promise resolution

### DIFF
--- a/app/client/src/workers/Evaluation/fns/actionFns.ts
+++ b/app/client/src/workers/Evaluation/fns/actionFns.ts
@@ -1,8 +1,9 @@
 import { isTrueObject } from "@appsmith/workers/Evaluation/evaluationUtils";
 import { promisify } from "./utils/Promisify";
+import type { ActionEntity } from "entities/DataTree/types";
 
 function runFnDescriptor(
-  this: any,
+  this: ActionEntity,
   onSuccessOrParams?: (data: any) => unknown | Record<string, unknown>,
   onError?: (e: string) => unknown,
   params = {},
@@ -30,7 +31,7 @@ export type TRunDescription = ReturnType<typeof runFnDescriptor>;
 export type TRunActionType = TRunDescription["type"];
 
 export default async function run(
-  this: any,
+  this: ActionEntity,
   onSuccessOrParams?: (data: any) => unknown | Record<string, unknown>,
   onError?: (e: string) => unknown,
   params = {},
@@ -38,6 +39,13 @@ export default async function run(
   const executor = promisify(runFnDescriptor.bind(this));
   try {
     const response = await executor(onSuccessOrParams, onError, params);
+
+    // @ts-expect-error: globalThis type is not defined
+    const action = globalThis[this.name];
+    if (action) {
+      action.data = response[0];
+    }
+
     if (typeof onSuccessOrParams === "function") {
       onSuccessOrParams.apply(this, response);
       return;
@@ -57,7 +65,7 @@ export default async function run(
   }
 }
 
-function clearFnDescriptor(this: any) {
+function clearFnDescriptor(this: ActionEntity) {
   return {
     type: "CLEAR_PLUGIN_ACTION" as const,
     payload: {
@@ -70,6 +78,6 @@ export type TClearArgs = Parameters<typeof clearFnDescriptor>;
 export type TClearDescription = ReturnType<typeof clearFnDescriptor>;
 export type TClearActionType = TClearDescription["type"];
 
-export async function clear(this: any) {
+export async function clear(this: ActionEntity) {
   return promisify(clearFnDescriptor.bind(this))();
 }

--- a/app/client/src/workers/Evaluation/fns/index.ts
+++ b/app/client/src/workers/Evaluation/fns/index.ts
@@ -133,15 +133,12 @@ export const entityFns = [
   {
     name: "clear",
     qualifier: (entity: DataTreeEntity) => isAction(entity),
-    fn: (entity: DataTreeEntity, entityName: string) => {
-      // @ts-expect-error: name is not defined on ActionEntity
-      entity.name = entityName;
-      return getFnWithGuards(
+    fn: (entity: DataTreeEntity, entityName: string) =>
+      getFnWithGuards(
         clear.bind(entity as ActionEntity),
         `${entityName}.clear`,
         [isAsyncGuard],
-      );
-    },
+      ),
   },
   {
     name: "getGeoLocation",

--- a/app/client/src/workers/Evaluation/fns/index.ts
+++ b/app/client/src/workers/Evaluation/fns/index.ts
@@ -61,6 +61,7 @@ import {
   watchGeoLocation,
 } from "./geolocationFns";
 import { getFnWithGuards, isAsyncGuard } from "./utils/fnGuard";
+import type { ActionEntity } from "entities/DataTree/types";
 
 // cloudHosting -> to use in EE
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -119,16 +120,28 @@ export const entityFns = [
   {
     name: "run",
     qualifier: (entity: DataTreeEntity) => isAction(entity),
-    fn: (entity: DataTreeEntity, entityName: string) =>
-      getFnWithGuards(run.bind(entity), `${entityName}.run`, [isAsyncGuard]),
+    fn: (entity: DataTreeEntity, entityName: string) => {
+      // @ts-expect-error: name is not defined on ActionEntity
+      entity.name = entityName;
+      return getFnWithGuards(
+        run.bind(entity as ActionEntity),
+        `${entityName}.run`,
+        [isAsyncGuard],
+      );
+    },
   },
   {
     name: "clear",
     qualifier: (entity: DataTreeEntity) => isAction(entity),
-    fn: (entity: DataTreeEntity, entityName: string) =>
-      getFnWithGuards(clear.bind(entity), `${entityName}.clear`, [
-        isAsyncGuard,
-      ]),
+    fn: (entity: DataTreeEntity, entityName: string) => {
+      // @ts-expect-error: name is not defined on ActionEntity
+      entity.name = entityName;
+      return getFnWithGuards(
+        clear.bind(entity as ActionEntity),
+        `${entityName}.clear`,
+        [isAsyncGuard],
+      );
+    },
   },
   {
     name: "getGeoLocation",

--- a/app/client/src/workers/Evaluation/getEntityForContext.ts
+++ b/app/client/src/workers/Evaluation/getEntityForContext.ts
@@ -4,7 +4,6 @@ import JSObjectCollection from "./JSObject/Collection";
 import JSFactory from "./JSObject/JSVariableFactory";
 import { jsObjectFunctionFactory } from "./fns/utils/jsObjectFnFactory";
 import type { JSActionEntity } from "entities/DataTree/types";
-import { klona } from "klona/full";
 
 function getJSFunctionsForEntity({
   jsObject,
@@ -55,9 +54,6 @@ export function getEntityForEvalContext(
 
         jsObjectForEval = JSFactory.create(entityName, jsObjectForEval);
         return Object.assign(jsObjectForEval, fns);
-      }
-      case ENTITY_TYPE.ACTION: {
-        return klona(entity);
       }
     }
   }

--- a/app/client/src/workers/Evaluation/getEntityForContext.ts
+++ b/app/client/src/workers/Evaluation/getEntityForContext.ts
@@ -4,6 +4,7 @@ import JSObjectCollection from "./JSObject/Collection";
 import JSFactory from "./JSObject/JSVariableFactory";
 import { jsObjectFunctionFactory } from "./fns/utils/jsObjectFnFactory";
 import type { JSActionEntity } from "entities/DataTree/types";
+import { klona } from "klona/full";
 
 function getJSFunctionsForEntity({
   jsObject,
@@ -54,6 +55,9 @@ export function getEntityForEvalContext(
 
         jsObjectForEval = JSFactory.create(entityName, jsObjectForEval);
         return Object.assign(jsObjectForEval, fns);
+      }
+      case ENTITY_TYPE.ACTION: {
+        return klona(entity);
       }
     }
   }


### PR DESCRIPTION
## Description

Set the `api.data` as soon as promise is resolved to avoid race condition.

NOTE: We have added a logic to set the global context similar to storeValue as a temporary fix. 

#### PR fixes following issue(s)
Fixes #23052


#### Type of change

- Bug fix (non-breaking change which fixes an issue)


## Testing

#### How Has This Been Tested?

#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
