### PR TITLE
fix: enable change in background color on hover for Icon Button cell in Table widget V2

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/IconButtonCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/IconButtonCell.tsx
@@ -58,6 +58,7 @@ function IconButton(props: {
         buttonVariant={props.buttonVariant}
         compactMode={props.compactMode}
         disabled={props.disabled}
+        hasOnClickAction
         icon={props.iconName}
         loading={loading}
         onClick={handleClick}

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/IconButtonCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/IconButtonCell.tsx
@@ -58,6 +58,11 @@ function IconButton(props: {
         buttonVariant={props.buttonVariant}
         compactMode={props.compactMode}
         disabled={props.disabled}
+        /**
+         * We pass hasOnClickAction as true because Icon buttons in tables are always used as button
+         * and not Icons (which do not have hover state).
+         * Hene we pass hasOnClickAction true to enable BG color change on hover.
+         **/
         hasOnClickAction
         icon={props.iconName}
         loading={loading}


### PR DESCRIPTION
## Description
This PR passes a prop named: `hasOnClickAction` as `true` to the `StyledButton` of the `IconButtonCell` component of the table widget v2. 

**Root cause:** This happens so because inside the IconButtonWidget’s component we conditionally showcase the background color. If `hasOnClickAction` exists then we show change in BG color on hover. 

**************Reason:************** People use icon button widget as icon widget as well. If there's no onclick then people just want to use the icon as a way to display something

**********Proposed solution:********** Always pass the `hasOnClickAction` as true to the IconButtonWidget’s component via table cell

#### PR fixes following issue(s)
Fixes #17775 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
