### PR TITLE
WDS Color: refine `bgAccentHover` (light mode)

### DIFF
--- a/app/client/packages/design-system/theming/src/utils/ColorsAccessor/ColorsAccessor.ts
+++ b/app/client/packages/design-system/theming/src/utils/ColorsAccessor/ColorsAccessor.ts
@@ -38,11 +38,11 @@ export class ColorsAccessor {
   }
 
   get isGreen() {
-    return this.color.oklch.h >= 105 && this.color.oklch.h <= 165;
+    return this.color.oklch.h >= 116 && this.color.oklch.h <= 165;
   }
 
   get isYellow() {
-    return this.color.oklch.h >= 60 && this.color.oklch.h <= 75;
+    return this.color.oklch.h >= 60 && this.color.oklch.h <= 115;
   }
 
   get isRed() {

--- a/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
@@ -12,6 +12,7 @@ export class LightModeTheme implements ColorModeTheme {
   private readonly seedIsAchromatic: boolean;
   private readonly seedIsCold: boolean;
   private readonly seedIsVeryLight: boolean;
+  private readonly seedIsYellow: boolean;
 
   constructor(private color: ColorTypes) {
     const {
@@ -21,6 +22,7 @@ export class LightModeTheme implements ColorModeTheme {
       isAchromatic,
       isCold,
       isVeryLight,
+      isYellow,
       lightness,
     } = new ColorsAccessor(color);
     this.seedColor = seedColor;
@@ -30,6 +32,7 @@ export class LightModeTheme implements ColorModeTheme {
     this.seedIsAchromatic = isAchromatic;
     this.seedIsCold = isCold;
     this.seedIsVeryLight = isVeryLight;
+    this.seedIsYellow = isYellow;
   }
 
   public getColors = () => {
@@ -97,12 +100,32 @@ export class LightModeTheme implements ColorModeTheme {
   private get bgAccentHover() {
     const color = this.bgAccent.clone();
 
-    if (this.seedLightness < 0.18) {
-      color.oklch.l = this.seedLightness + 0.3;
+    if (this.seedLightness < 0.06) {
+      color.oklch.l = this.seedLightness + 0.28;
     }
 
-    if (this.seedLightness >= 0.18 && this.seedLightness < 0.4) {
-      color.oklch.l = this.seedLightness + 0.15;
+    if (this.seedLightness > 0.06 && this.seedLightness < 0.14) {
+      color.oklch.l = this.seedLightness + 0.2;
+    }
+
+    if (
+      this.seedLightness >= 0.14 &&
+      this.seedLightness < 0.25 &&
+      this.seedIsCold
+    ) {
+      color.oklch.l = this.seedLightness + 0.1;
+    }
+
+    if (
+      this.seedLightness >= 0.14 &&
+      this.seedLightness < 0.21 &&
+      !this.seedIsCold
+    ) {
+      color.oklch.l = this.seedLightness + 0.13;
+    }
+
+    if (this.seedLightness >= 0.21 && this.seedLightness < 0.4) {
+      color.oklch.l = this.seedLightness + 0.09;
     }
 
     if (this.seedLightness >= 0.4 && this.seedLightness < 0.7) {
@@ -113,7 +136,13 @@ export class LightModeTheme implements ColorModeTheme {
       color.oklch.l = this.seedLightness + 0.03;
     }
 
-    if (this.seedIsVeryLight) {
+    if (this.seedIsVeryLight && this.seedIsYellow) {
+      color.oklch.l = 0.945;
+      color.oklch.c = this.seedChroma * 0.93;
+      color.oklch.h = this.seedHue;
+    }
+
+    if (this.seedIsVeryLight && !this.seedIsYellow) {
       color.oklch.l = 0.95;
       color.oklch.c = this.seedChroma * 1.15;
       color.oklch.h = this.seedHue;


### PR DESCRIPTION
## Description

tl;dr Slightly darker hover for dark seeds, overall refinements in the medium, special exceptions for very light yellows. Minor fixes in utility functions.

Fixes #22823  

## Media
New on the left, current on the right
https://user-images.githubusercontent.com/80973/236816955-2be0773f-2c51-4e53-9e61-844a61ad7f2c.mov

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual

### Test Plan
Initial POC refinement, no testing necessary

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
