### PR TITLE
fix: send empty license key to intercom for CE

### DIFF
--- a/app/client/src/ce/utils/licenseHelpers.ts
+++ b/app/client/src/ce/utils/licenseHelpers.ts
@@ -1,1 +1,1 @@
-export const getLicenseId = () => "";
+export const getLicenseKey = () => "";

--- a/app/client/src/ce/utils/licenseHelpers.ts
+++ b/app/client/src/ce/utils/licenseHelpers.ts
@@ -1,0 +1,1 @@
+export const getLicenseId = () => "";

--- a/app/client/src/ee/utils/licenseHelpers.ts
+++ b/app/client/src/ee/utils/licenseHelpers.ts
@@ -1,0 +1,1 @@
+export * from "ce/utils/licenseHelpers";

--- a/app/client/src/utils/bootIntercom.ts
+++ b/app/client/src/utils/bootIntercom.ts
@@ -1,6 +1,7 @@
 import type { User } from "constants/userConstants";
 import { getAppsmithConfigs } from "@appsmith/configs";
 import { sha256 } from "js-sha256";
+import { getLicenseId } from "@appsmith/utils/licenseHelpers";
 
 const { appVersion, cloudHosting, intercomAppID } = getAppsmithConfigs();
 
@@ -35,7 +36,7 @@ export const updateIntercomProperties = (instanceId: string, user?: User) => {
         !cloudHosting ? appVersion.edition : ""
       } ${appVersion.id}`,
       instanceId,
-      "License ID": "3rd license",
+      "License ID": getLicenseId(),
     });
   }
 };

--- a/app/client/src/utils/bootIntercom.ts
+++ b/app/client/src/utils/bootIntercom.ts
@@ -1,7 +1,7 @@
 import type { User } from "constants/userConstants";
 import { getAppsmithConfigs } from "@appsmith/configs";
 import { sha256 } from "js-sha256";
-import { getLicenseId } from "@appsmith/utils/licenseHelpers";
+import { getLicenseKey } from "@appsmith/utils/licenseHelpers";
 
 const { appVersion, cloudHosting, intercomAppID } = getAppsmithConfigs();
 
@@ -36,7 +36,7 @@ export const updateIntercomProperties = (instanceId: string, user?: User) => {
         !cloudHosting ? appVersion.edition : ""
       } ${appVersion.id}`,
       instanceId,
-      "License ID": getLicenseId(),
+      "License ID": getLicenseKey(),
     });
   }
 };


### PR DESCRIPTION

Sending licence key to intercom after consent is given. For CE users, sending license key as empty string

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
- [ ] Manual
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
