### PR TITLE
chore: Bringing the callout banner on top under form login config page

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/config/authentication/index.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication/index.tsx
@@ -28,13 +28,23 @@ import { getThirdPartyAuths } from "@appsmith/selectors/tenantSelectors";
 
 const { disableLoginForm } = getAppsmithConfigs();
 
-const FormAuth: AdminConfigType = {
+export const FormAuth: AdminConfigType = {
   type: SettingCategories.FORM_AUTH,
   controlType: SettingTypes.GROUP,
   title: "Form Login",
   subText: "Enable your workspace to sign in with Appsmith Form.",
   canSave: true,
   settings: [
+    {
+      id: "APPSMITH_FORM_CALLOUT_BANNER",
+      category: SettingCategories.FORM_AUTH,
+      subCategory: SettingSubCategories.FORMLOGIN,
+      controlType: SettingTypes.LINK,
+      label:
+        "The form login method does not verify the emails of users that create accounts.",
+      url: SIGNUP_RESTRICTION_DOC,
+      calloutType: "Warning",
+    },
     {
       id: "APPSMITH_FORM_LOGIN_DISABLED",
       category: SettingCategories.FORM_AUTH,
@@ -53,16 +63,6 @@ const FormAuth: AdminConfigType = {
         value
           ? "Allow only invited users to signup"
           : "Allow all users to signup",
-    },
-    {
-      id: "APPSMITH_FORM_CALLOUT_BANNER",
-      category: SettingCategories.FORM_AUTH,
-      subCategory: SettingSubCategories.FORMLOGIN,
-      controlType: SettingTypes.LINK,
-      label:
-        "The form login method does not verify the emails of users that create accounts.",
-      url: SIGNUP_RESTRICTION_DOC,
-      calloutType: "Warning",
     },
   ],
 };


### PR DESCRIPTION
## Description
Bringing the callout banner on top under form login config page

Fixes [#23134](https://github.com/appsmithorg/appsmith/issues/23134)

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
