### PR TITLE
chore: Intercom consent is defaulted to true on cloud hosting

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserServiceCEImpl.java
@@ -819,7 +819,8 @@ public class UserServiceCEImpl extends BaseService<UserRepository, User, String>
                     profile.setUseCase(userData.getUseCase());
                     profile.setPhotoId(userData.getProfilePhotoAssetId());
                     profile.setEnableTelemetry(!commonConfig.isTelemetryDisabled());
-                    profile.setIntercomConsentGiven(userData.isIntercomConsentGiven());
+                    // Intercom consent is defaulted to true on cloud hosting
+                    profile.setIntercomConsentGiven(commonConfig.isCloudHosting() ? true : userData.isIntercomConsentGiven());
                     profile.setSuperUser(isSuperUser);
                     profile.setConfigurable(!StringUtils.isEmpty(commonConfig.getEnvFilePath()));
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.appsmith.server.services;
 
 import com.appsmith.external.models.Policy;
 import com.appsmith.external.services.EncryptionService;
+import com.appsmith.server.configurations.CommonConfig;
 import com.appsmith.server.configurations.WithMockAppsmithUser;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.LoginSource;
@@ -12,6 +13,7 @@ import com.appsmith.server.domains.UserData;
 import com.appsmith.server.domains.Workspace;
 import com.appsmith.server.dtos.InviteUsersDTO;
 import com.appsmith.server.dtos.ResetUserPasswordDTO;
+import com.appsmith.server.dtos.UserProfileDTO;
 import com.appsmith.server.dtos.UserSignupDTO;
 import com.appsmith.server.dtos.UserUpdateDTO;
 import com.appsmith.server.exceptions.AppsmithError;
@@ -32,6 +34,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.DirtiesContext;
@@ -70,6 +73,9 @@ public class UserServiceTest {
     UserService userService;
 
     @Autowired
+    SessionUserService sessionUserService;
+
+    @Autowired
     UserAndAccessManagementService userAndAccessManagementService;
 
     @Autowired
@@ -100,6 +106,9 @@ public class UserServiceTest {
 
     @Autowired
     PermissionGroupRepository permissionGroupRepository;
+
+    @SpyBean
+    CommonConfig commonConfig;
 
     @BeforeEach
     public void setup() {
@@ -496,6 +505,22 @@ public class UserServiceTest {
                 .assertNext(userData -> {
                     assertNotNull(userData);
                     assertThat(userData.isIntercomConsentGiven()).isTrue();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void getIntercomConsentOfUserOnCloudHosting_AlwaysTrue() {
+        Mockito.when(commonConfig.isCloudHosting()).thenReturn(true);
+
+        Mono<UserProfileDTO> userProfileDTOMono = sessionUserService.getCurrentUser()
+                .flatMap(userService::buildUserProfileDTO);
+
+        StepVerifier.create(userProfileDTOMono)
+                .assertNext(userProfileDTO -> {
+                    assertNotNull(userProfileDTO);
+                    assertThat(userProfileDTO.isIntercomConsentGiven()).isTrue();
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description

This PR makes the Intercom consent flag true always for the cloud-hosted version.

#### PR fixes following issue(s)
Fixes #23214


#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [x] JUnit
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
