### PR TITLE
chore: WDS colors `bdNeutral` and `bdNeutralHover`

### DIFF
--- a/app/client/packages/design-system/theming/src/utils/TokensAccessor/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/utils/TokensAccessor/DarkModeTheme.ts
@@ -179,7 +179,7 @@ export class DarkModeTheme implements ColorModeTheme {
   private get bdAccent() {
     const color = this.seedColor.clone();
 
-    if (this.seedColor.contrastAPCA(this.bg) <= 15) {
+    if (this.bg.contrastAPCA(this.seedColor) > -15) {
       if (this.seedIsAchromatic) {
         color.oklch.l = 0.985;
         color.oklch.c = 0;
@@ -195,26 +195,37 @@ export class DarkModeTheme implements ColorModeTheme {
   }
 
   private get bdNeutral() {
-    const color = this.seedColor.clone();
+    const color = this.bdAccent.clone();
 
-    if (this.seedColor.contrastAPCA(this.bg) >= -25 && !this.seedIsAchromatic) {
-      color.oklch.c = 0.008;
-      return color;
-    }
+    color.oklch.c = 0.035;
 
     if (this.seedIsAchromatic) {
-      color.oklch.l = 0.15;
       color.oklch.c = 0;
-      return color;
     }
 
-    color.oklch.l = 0.15;
-    color.oklch.c = 0.064;
+    if (this.bg.contrastAPCA(color) > -25) {
+      color.oklch.l = color.oklch.l + 0.15;
+    }
+
     return color;
   }
 
   private get bdNeutralHover() {
-    return this.bdNeutral.clone().lighten(0.06);
+    const color = this.bdNeutral.clone();
+
+    if (this.bdNeutral.oklch.l < 0.8) {
+      color.oklch.l = color.oklch.l + 0.15;
+    }
+
+    if (this.bdNeutral.oklch.l >= 0.8 && this.bdNeutral.oklch.l < 0.9) {
+      color.oklch.l = color.oklch.l + 0.1;
+    }
+
+    if (this.bdNeutral.oklch.l >= 0.9) {
+      color.oklch.l = color.oklch.l - 0.25;
+    }
+
+    return color;
   }
 
   private get bdFocus() {

--- a/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
@@ -293,26 +293,41 @@ export class LightModeTheme implements ColorModeTheme {
   }
 
   private get bdNeutral() {
-    const color = this.seedColor.clone();
+    const color = this.bdAccent.clone();
 
-    if (this.seedColor.contrastAPCA(this.bg) <= -25 && !this.seedIsAchromatic) {
-      color.oklch.c = 0.016;
-      return color;
-    }
+    color.oklch.c = 0.035;
 
     if (this.seedIsAchromatic) {
-      color.oklch.l = 0.15;
       color.oklch.c = 0;
-      return color;
     }
 
-    color.oklch.l = 0.15;
-    color.oklch.c = 0.064;
+    if (this.bg.contrastAPCA(color) < 25) {
+      color.oklch.l = color.oklch.l - 0.2;
+    }
+
     return color;
   }
 
   private get bdNeutralHover() {
-    return this.bdNeutral.clone().lighten(0.06);
+    const color = this.bdNeutral.clone();
+
+    if (this.bdNeutral.oklch.l < 0.06) {
+      color.oklch.l = color.oklch.l + 0.6;
+    }
+
+    if (this.bdNeutral.oklch.l >= 0.06 && this.bdNeutral.oklch.l < 0.25) {
+      color.oklch.l = color.oklch.l + 0.4;
+    }
+
+    if (this.bdNeutral.oklch.l >= 0.25 && this.bdNeutral.oklch.l < 0.5) {
+      color.oklch.l = color.oklch.l + 0.25;
+    }
+
+    if (this.bdNeutral.oklch.l >= 0.5) {
+      color.oklch.l = color.oklch.l + 0.1;
+    }
+
+    return color;
   }
 
   private get bdFocus() {

--- a/app/client/packages/design-system/widgets/src/components/Spinner/index.styled.tsx
+++ b/app/client/packages/design-system/widgets/src/components/Spinner/index.styled.tsx
@@ -1,9 +1,5 @@
 import styled from "styled-components";
-import { importRemixIcon } from "design-system-old";
-
-const LoaderIcon = importRemixIcon(
-  () => import("remixicon-react/Loader2FillIcon"),
-);
+import LoaderIcon from "remixicon-react/Loader2FillIcon";
 
 export const StyledSpinner = styled(LoaderIcon)`
   animation: spin 1s linear infinite;


### PR DESCRIPTION
## Description

tl;dr Fixed APCA contrast checks and logic for `bdNeutral`, fixed `bdAccent` check too (see also #23218 for more stuff to fix). Adjusted gradations of hover for the color to make it visible in both modes.

Fixes #22823   

## Media
New on the left, current on the right (using the latest DP instead of release deploy, since it's failing at the moment of creation of this PR)
https://github.com/appsmithorg/appsmith/assets/80973/cfcb7aa7-17cd-454d-a452-779efba20158

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual

### Test Plan
Initial POC refinement, no testing necessary

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
