### PR TITLE
ci: move yarn prebuild command to build.sh

### DIFF
--- a/app/client/build.sh
+++ b/app/client/build.sh
@@ -8,6 +8,7 @@ echo "Sentry Auth Token: $SENTRY_AUTH_TOKEN"
 
 if [ "$REACT_APP_AIRGAP_ENABLED" == "true" ]; then
     echo "Building for airgapped Appsmith instances"
+    node download-assets.js;
     OUTPUT_PATH=build_airgap
 else
     echo "Building for non-airgapped Appsmith instances"

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "analyze": "yarn cra-bundle-analyzer",
     "start": "BROWSER=none EXTEND_ESLINT=true REACT_APP_ENVIRONMENT=DEVELOPMENT REACT_APP_CLIENT_LOG_LEVEL=debug HOST=dev.appsmith.com craco start",
-    "prebuild": "if [ \"$REACT_APP_AIRGAP_ENABLED\" = \"true\" ]; then node download-assets.js; fi",
     "build": "./build.sh",
     "build-airgap": "node download-assets.js && ./build.sh",
     "build-local": "craco --max-old-space-size=4096 build --config craco.build.config.js",


### PR DESCRIPTION
### Description
- Yarn prebuild is not working for some reason with yarn 3. So moved the prebuild command to build.sh.