### PR TITLE
fix: moustache brackets not showing up in bold

### DIFF
--- a/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/BugTests/Bug7113_Spec.ts
+++ b/app/client/cypress/integration/Regression_TestSuite/ClientSideTests/BugTests/Bug7113_Spec.ts
@@ -1,0 +1,26 @@
+import * as _ from "../../../../support/Objects/ObjectsCore";
+
+const { agHelper, entityExplorer, propPane } = _;
+
+describe("Bug 7113 - Moustache brackets in bold", () => {
+  it("should show {{ }} in bold", () => {
+    cy.fixture("buttondsl").then((val: any) => {
+      agHelper.AddDsl(val);
+    });
+
+    entityExplorer.SelectEntityByName("Button1", "Widgets");
+
+    propPane.EnterJSContext(
+      "onClick",
+      `{{Api1.run({
+      "key": Button1.text
+    }).then(() => {
+      storeValue('my-secret-key', Button3.text);
+      Query1.run();
+    }).catch(() => {});const a = { a: "key"} }}`,
+    );
+
+    cy.get("span").contains("{{").should("have.class", "binding-brackets");
+    cy.get("span").contains("}}").should("have.class", "binding-brackets");
+  });
+});

--- a/app/client/src/constants/BindingsConstants.ts
+++ b/app/client/src/constants/BindingsConstants.ts
@@ -1,4 +1,4 @@
 export const DATA_BIND_REGEX = /{{([\s\S]*?)}}/;
 export const DATA_BIND_REGEX_GLOBAL = /{{([\s\S]*?)}}/g;
-export const AUTOCOMPLETE_MATCH_REGEX = /{{\s*.*?\s*}}/g;
+export const AUTOCOMPLETE_MATCH_REGEX = /{{\s*.*?\s*}}|^{{|}}$/g;
 export const QUOTED_BINDING_REGEX = /["']({{[\s\S]*?}})["']/g;


### PR DESCRIPTION

## Description
This fixes an issue where the moustache brackets `{{` or `}}` were not being shown in bold.

#### PR fixes following issue(s)
Fixes #7113

#### Media
Before|After
---|---
<img width="276" alt="Screenshot 2023-05-12 at 1 09 14 AM" src="https://github.com/appsmithorg/appsmith/assets/13567359/2149bb5a-089e-4fa6-aa5e-a4f89b84d188">|<img width="272" alt="Screenshot 2023-05-12 at 1 08 34 AM" src="https://github.com/appsmithorg/appsmith/assets/13567359/bdc2d099-5750-4bdb-96b3-8836b7f2d043">

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
