### PR TITLE
fix: Snowflake error msg fix on test datasource timeout

### DIFF
--- a/app/server/appsmith-plugins/snowflakePlugin/src/main/java/com/external/plugins/SnowflakePlugin.java
+++ b/app/server/appsmith-plugins/snowflakePlugin/src/main/java/com/external/plugins/SnowflakePlugin.java
@@ -51,6 +51,7 @@ public class SnowflakePlugin extends BasePlugin {
     private static final int MINIMUM_POOL_SIZE = 1;
 
     private static final int MAXIMUM_POOL_SIZE = 5;
+    private static final int CONNECTION_TIMEOUT_MILLISECONDS = 25000;
 
     public SnowflakePlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -180,7 +181,7 @@ public class SnowflakePlugin extends BasePlugin {
              * @see https://www.javadoc.io/doc/com.zaxxer/HikariCP/latest/com/zaxxer/hikari/HikariConfig.html
              */
             config.setInitializationFailTimeout(-1);
-            config.setConnectionTimeout(25000);
+            config.setConnectionTimeout(CONNECTION_TIMEOUT_MILLISECONDS);
 
             // Set authentication properties
             DBAuth authentication = (DBAuth) datasourceConfiguration.getAuthentication();


### PR DESCRIPTION
## Description

- Set a flag called InitializationFailTimeout to -1 to create the connection pool asynchronously.
- Set the **connectionTimeout** value to timeout to handle any issue with the connection as the pool is getting created asynchronously now.
- Changed the error message returned to the user for an invalid Snowflake URL.

Fixes #16140 
Fixes #22035 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual
- Junit

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
