### PR TITLE
chore: Specify `user` explicitly in dev NGINX conf

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -202,6 +202,7 @@ worker_connections=1024
 
 echo "
 worker_processes  1;
+user $(id -u -n) $(id -g -n);
 
 error_log $nginx_error_log info;
 


### PR DESCRIPTION
We're seeing a strange permission error when the NGINX worker process is running as `nobody` on macOS, _sometimes_. So we're now specifying the `user` explicitly to avoid any such permission problems.
