### PR TITLE
updated error message on logo

### DIFF
--- a/app/client/src/api/ApiUtils.ts
+++ b/app/client/src/api/ApiUtils.ts
@@ -130,10 +130,10 @@ export const apiFailureResponseInterceptor = (error: any) => {
       ...error,
       clientDefinedError: true,
       statusCode: "AE-APP-4013",
-      message: createMessage(ERROR_413, 100),
+      message: createMessage(ERROR_413, 1),
       pluginErrorDetails: {
         appsmithErrorCode: "AE-APP-4013",
-        appsmithErrorMessage: createMessage(ERROR_413, 100),
+        appsmithErrorMessage: createMessage(ERROR_413, 1),
         errorType: "INTERNAL_ERROR", // this value is from the server, hence cannot construct enum type.
         title: createMessage(GENERIC_API_EXECUTION_ERROR),
       },


### PR DESCRIPTION
## Description
> Error message on uploading Logo shows 100MB instead of 1MB
>
> Error message included 100 MB as input number, changed it to 1 MB.
>
#### PR fixes following issue(s)
Fixes # (23301)
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
