### PR TITLE
fix: Updating height for Select and Menu components on home page & members page

### DIFF
--- a/app/client/src/ce/pages/workspace/Members.tsx
+++ b/app/client/src/ce/pages/workspace/Members.tsx
@@ -383,10 +383,13 @@ export default function MemberSettings(props: PageProps) {
         return (
           <Select
             className="t--user-status"
+            dropdownMatchSelectWidth={false}
+            dropdownStyle={{ width: "400px" }}
             isLoading={
               roleChangingUserInfo &&
               roleChangingUserInfo.username === data.username
             }
+            listHeight={300}
             onSelect={(_value: string, option: any) => {
               dispatch(
                 changeWorkspaceUserRole(workspaceId, option.key, data.username),
@@ -404,7 +407,9 @@ export default function MemberSettings(props: PageProps) {
                   >
                     {role.value}
                   </Text>
-                  <Text kind="body-s">{role.description}</Text>
+                  {role.description && (
+                    <Text kind="body-s">{role.description}</Text>
+                  )}
                 </div>
               </Option>
             ))}

--- a/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
+++ b/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
@@ -430,7 +430,9 @@ function WorkspaceInviteUsersForm(props: any) {
                     >
                       {role.value}
                     </Text>
-                    <Text kind="body-s">{role.description}</Text>
+                    {role.description && (
+                      <Text kind="body-s">{role.description}</Text>
+                    )}
                   </div>
                 </Option>
               ))}

--- a/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
+++ b/app/client/src/ce/pages/workspace/WorkspaceInviteUsersForm.tsx
@@ -414,6 +414,7 @@ function WorkspaceInviteUsersForm(props: any) {
               data-testid="t--invite-role-input"
               isDisabled={disableDropdown}
               isMultiSelect={isMultiSelectDropdown}
+              listHeight={400}
               onDeselect={onRemoveOptions}
               onSelect={onSelect}
               optionLabelProp="label"

--- a/app/client/src/pages/Applications/ApplicationCard.tsx
+++ b/app/client/src/pages/Applications/ApplicationCard.tsx
@@ -64,7 +64,6 @@ import urlBuilder from "entities/URLRedirect/URLAssembly";
 import { toast } from "design-system";
 import { getAppsmithConfigs } from "@appsmith/configs";
 import { addItemsInContextMenu } from "@appsmith/utils";
-import "./ApplicationMenu.css";
 
 const { cloudHosting } = getAppsmithConfigs();
 
@@ -580,7 +579,7 @@ export function ApplicationCard(props: ApplicationCardProps) {
             startIcon="context-menu"
           />
         </MenuTrigger>
-        <MenuContent>
+        <MenuContent side="right" style={{ maxHeight: "unset" }}>
           {hasEditPermission && (
             <div
               onKeyDown={(e) => {

--- a/app/client/src/pages/Applications/ApplicationMenu.css
+++ b/app/client/src/pages/Applications/ApplicationMenu.css
@@ -1,8 +1,0 @@
-.ads-v2-menu {
-  overflow: unset;
-}
-
-.ads-v2-menu .menu-items-wrapper {
-  height: 132px;
-  overflow: auto;
-}

--- a/app/client/src/pages/workspace/settings.tsx
+++ b/app/client/src/pages/workspace/settings.tsx
@@ -90,7 +90,7 @@ export const TabsWrapper = styled.div`
 
     .tab-panel {
       overflow: auto;
-      height: calc(100% - 76px);
+      height: calc(100% - 46px);
     }
   }
 `;


### PR DESCRIPTION
## Description

Updating height for Select and Menu components on home page & members page

#### PR fixes following issue(s)
Fixes https://www.notion.so/appsmith/Unnecessary-scroll-in-drop-downs-menus-9ab1171baab54e6dbae70d617e96449b?pvs=4

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
