### PR TITLE
fix: Prevent evalTree and configTree from being undefined

### DIFF
--- a/app/client/src/utils/configTree.ts
+++ b/app/client/src/utils/configTree.ts
@@ -4,7 +4,7 @@ export default class ConfigTreeActions {
   static tree: ConfigTree = {};
 
   static setConfigTree = (configTree: ConfigTree) => {
-    this.tree = configTree;
+    this.tree = configTree || {};
   };
 
   static getConfigTree = () => {

--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
@@ -27,6 +27,8 @@ export function evalTreeWithChanges(updatedValuePaths: string[][]) {
   let evalMetaUpdates: EvalMetaUpdates = [];
   let staleMetaIds: string[] = [];
   const pathsToClearErrorsFor: any[] = [];
+  let unevalTree: UnEvalTree = {};
+  let configTree: ConfigTree = {};
 
   if (dataTreeEvaluator) {
     const setupUpdateTreeResponse =
@@ -51,6 +53,8 @@ export function evalTreeWithChanges(updatedValuePaths: string[][]) {
       JSON.stringify(updateResponse.evalMetaUpdates),
     );
     staleMetaIds = updateResponse.staleMetaIds;
+    unevalTree = dataTreeEvaluator.getOldUnevalTree();
+    configTree = dataTreeEvaluator.oldConfigTree;
   }
 
   const evalTreeResponse: EvalTreeResponseData = {
@@ -63,7 +67,7 @@ export function evalTreeWithChanges(updatedValuePaths: string[][]) {
     logs,
     unEvalUpdates,
     isCreateFirstTree,
-    configTree: dataTreeEvaluator?.oldConfigTree as ConfigTree,
+    configTree,
     staleMetaIds,
     pathsToClearErrorsFor,
     isNewWidgetAdded: false,
@@ -72,7 +76,7 @@ export function evalTreeWithChanges(updatedValuePaths: string[][]) {
 
   const data: UpdateDataTreeMessageData = {
     workerResponse: evalTreeResponse,
-    unevalTree: dataTreeEvaluator?.getOldUnevalTree() as UnEvalTree,
+    unevalTree,
   };
 
   sendMessage.call(self, {

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -27,6 +27,7 @@ import type {
   ConfigTree,
   WidgetEntityConfig,
   DataTreeEntityConfig,
+  UnEvalTree,
 } from "entities/DataTree/dataTreeFactory";
 import type {
   ActionEntity,
@@ -143,7 +144,7 @@ export default class DataTreeEvaluator {
   unParsedEvalTree: DataTree = {};
   allKeys: Record<string, true> = {};
   privateWidgets: PrivateWidgets = {};
-  oldUnEvalTree: DataTree = {};
+  oldUnEvalTree: UnEvalTree = {};
   oldConfigTree: ConfigTree = {};
   errors: EvalError[] = [];
   logs: unknown[] = [];
@@ -600,7 +601,7 @@ export default class DataTreeEvaluator {
   }
 
   setupTree(
-    localUnEvalTree: DataTree,
+    localUnEvalTree: UnEvalTree,
     updatedValuePaths: string[][],
     extraParams: {
       totalUpdateTreeSetupStartTime?: any;


### PR DESCRIPTION
## Description
This PR prevents evalTree and configTree from being undefined values.
#### PR fixes following issue(s)
Fixes #23283 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
Nil
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR

#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
