### PR TITLE
fix: Disable redis and mongo by default

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 2.0.2
+version: 2.0.3
 dependencies:
 - condition: redis.enabled
   name: redis

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,6 @@
 ## Redis parameters
 redis:
-  enabled: true
+  enabled: false
   auth:
     enabled: false
   master:
@@ -10,7 +10,7 @@ redis:
     nodeSelector: {}
 
 mongodb:
-  enabled: true
+  enabled: false
   service:
     nameOverride: appsmith-mongodb
   auth:


### PR DESCRIPTION
The reason we are running all off them inside fat-container is that, we have observed a couple of people who are trying to deploy appsmith fail because of not having enough resources to schedule mongo and redis. Thereby, we thought its best kept them disabled to install appsmith .

To deploy appsmith on minikube also it is best to keep them inside fat-container-pod