### PR TITLE
fix: Updating the logic to fix datasource reconnect modal issue

### DIFF
--- a/app/client/src/actions/datasourceActions.ts
+++ b/app/client/src/actions/datasourceActions.ts
@@ -40,10 +40,15 @@ export const updateDatasource = (
   payload: Datasource,
   onSuccess?: ReduxAction<unknown>,
   onError?: ReduxAction<unknown>,
-): ReduxActionWithCallbacks<Datasource, unknown, unknown> => {
+  isInsideReconnectModal?: boolean,
+): ReduxActionWithCallbacks<
+  Datasource & { isInsideReconnectModal: boolean },
+  unknown,
+  unknown
+> => {
   return {
     type: ReduxActionTypes.UPDATE_DATASOURCE_INIT,
-    payload,
+    payload: { ...payload, isInsideReconnectModal: !!isInsideReconnectModal },
     onSuccess,
     onError,
   };

--- a/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DBForm.tsx
@@ -55,6 +55,8 @@ interface DatasourceDBEditorProps extends JSONtoFormProps {
   isDatasourceBeingSavedFromPopup: boolean;
   isFormDirty: boolean;
   datasourceDeleteTrigger: () => void;
+  // isInsideReconnectModal: indicates that the datasource form is rendering inside reconnect modal
+  isInsideReconnectModal?: boolean;
 }
 
 type Props = DatasourceDBEditorProps &
@@ -211,6 +213,7 @@ class DatasourceDBEditor extends JSONtoForm<Props> {
                 formData={formData}
                 getSanitizedFormData={_.memoize(this.getSanitizedData)}
                 isFormDirty={this.props.isFormDirty}
+                isInsideReconnectModal={this.props.isInsideReconnectModal}
                 isInvalid={this.validate()}
                 shouldRender={!viewMode}
                 triggerSave={this.props.isDatasourceBeingSavedFromPopup}

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -70,6 +70,8 @@ interface ReduxStateProps {
   applicationSlug: string;
   pageSlug: string;
   fromImporting?: boolean;
+  // isInsideReconnectModal: indicates that the datasource form is rendering inside reconnect modal
+  isInsideReconnectModal?: boolean;
   isDatasourceBeingSaved: boolean;
   triggerSave: boolean;
   isFormDirty: boolean;
@@ -176,6 +178,7 @@ class DataSourceEditor extends React.Component<Props> {
       fromImporting,
       isDeleting,
       isFormDirty,
+      isInsideReconnectModal,
       isNewDatasource,
       isSaving,
       isTesting,
@@ -198,6 +201,7 @@ class DataSourceEditor extends React.Component<Props> {
         hiddenHeader={fromImporting}
         isDeleting={isDeleting}
         isFormDirty={isFormDirty}
+        isInsideReconnectModal={isInsideReconnectModal}
         isNewDatasource={isNewDatasource}
         isSaving={isSaving}
         isTesting={isTesting}

--- a/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/ReconnectDatasourceModal.tsx
@@ -525,6 +525,8 @@ function ReconnectDatasourceModal() {
                     applicationId={appId}
                     datasourceId={selectedDatasourceId}
                     fromImporting
+                    // isInsideReconnectModal: indicates that the datasource form is rendering inside reconnect modal
+                    isInsideReconnectModal
                     pageId={pageId}
                   />
                 </DBFormWrapper>

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -52,6 +52,7 @@ interface Props {
   isInvalid: boolean;
   pageId?: string;
   shouldRender?: boolean;
+  isInsideReconnectModal?: boolean;
   datasourceButtonConfiguration: string[] | undefined;
   shouldDisplayAuthMessage?: boolean;
   triggerSave?: boolean;
@@ -113,6 +114,7 @@ function DatasourceAuth({
   triggerSave,
   isFormDirty,
   scopeValue,
+  isInsideReconnectModal,
 }: Props) {
   const authType =
     formData && "authType" in formData
@@ -256,9 +258,16 @@ function DatasourceAuth({
     if (datasource.id === TEMP_DATASOURCE_ID) {
       dispatch(createDatasourceFromForm(getSanitizedFormData()));
     } else {
-      dispatch(setDatasourceViewMode(true));
-      // we dont need to redirect it to active ds list instead ds would be shown in view only mode
-      dispatch(updateDatasource(getSanitizedFormData()));
+      // If the datasource is being saved from the reconnect modal, we don't want to redirect to the active datasource list
+      if (!isInsideReconnectModal) dispatch(setDatasourceViewMode(true));
+      dispatch(
+        updateDatasource(
+          getSanitizedFormData(),
+          undefined,
+          undefined,
+          isInsideReconnectModal,
+        ),
+      );
     }
   };
 

--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -346,7 +346,11 @@ export function* deleteDatasourceSaga(
 }
 
 function* updateDatasourceSaga(
-  actionPayload: ReduxActionWithCallbacks<Datasource, unknown, unknown>,
+  actionPayload: ReduxActionWithCallbacks<
+    Datasource & { isInsideReconnectModal: boolean },
+    unknown,
+    unknown
+  >,
 ) {
   try {
     const queryParams = getQueryParams();
@@ -409,7 +413,6 @@ function* updateDatasourceSaga(
       if (expandDatasourceId === response.data.id) {
         yield put(fetchDatasourceStructure(response.data.id, true));
       }
-      yield put(setDatasourceViewMode(true));
 
       AppsmithConsole.info({
         text: "Datasource configuration saved",
@@ -423,9 +426,14 @@ function* updateDatasourceSaga(
         },
       });
 
-      // updating form initial values to latest data, so that next time when form is opened
-      // isDirty will use updated initial values data to compare actual values with
-      yield put(initialize(DATASOURCE_DB_FORM, response.data));
+      // If the datasource is being updated from the reconnect modal, we don't want to change the view mode
+      // or update initial values as the next form open will be from the reconnect modal itself
+      if (!datasourcePayload.isInsideReconnectModal) {
+        yield put(setDatasourceViewMode(true));
+        // updating form initial values to latest data, so that next time when form is opened
+        // isDirty will use updated initial values data to compare actual values with
+        yield put(initialize(DATASOURCE_DB_FORM, response.data));
+      }
     }
   } catch (error) {
     yield put({


### PR DESCRIPTION
## Description

Updating the logic to fix datasource reconnect modal issue where the form content was getting retained even when the datasource has been changed.

#### PR fixes following issue(s)
Fixes # (issue number)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
