### PR TITLE
chore: update init-container images and update probes

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 2.0.2
+version: 2.0.3
 dependencies:
 - condition: redis.enabled
   name: redis

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -26,5 +26,5 @@ Please update your DNS records with your domain by the address. You can use foll
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 
-To expose your Appsmith service to be accessible from the Internet, please refer to our docs here https://docs.appsmith.com/setup/kubernetes#expose-appsmith.
+To expose your Appsmith service to be accessible from the Internet, please refer to our docs here https://docs.appsmith.com/getting-started/setup/installation-guides/kubernetes/publish-appsmith-online.
 {{- end }}

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -49,16 +49,16 @@ spec:
       {{- if ((.Values.initContainer.redis).image) }}
         image: {{ .Values.initContainer.redis.image }}
       {{- else }}
-        image: "alpine"
+        image: "docker.io/library/redis:6.2-alpine"
       {{- end }}
-        command: ['sh', '-c', "apk add redis; until redis-cli -h {{ include "appsmith.fullname" . }}-redis-master.{{.Release.Namespace}}.svc.cluster.local ping; do echo waiting for redis; sleep 2; done"]
+        command: ['sh', '-c', "until redis-cli -h {{ include "appsmith.fullname" . }}-redis-master.{{.Release.Namespace}}.svc.cluster.local ping ; do echo waiting for redis; sleep 2; done"]
       {{- end }}
       {{- if .Values.mongodb.enabled }}
       - name: mongo-init-container
       {{- if ((.Values.initContainer.mongodb).image) }}
         image: {{ .Values.initContainer.mongodb.image }}
       {{- else }}
-        image:  "docker.io/bitnami/mongodb:4.4.11-debian-10-r12"
+        image:  "docker.io/bitnami/mongodb:5.0.17-debian-11-r5"
       {{- end }}
         command: ['sh', '-c', "until mongo --host appsmith-mongodb.{{.Release.Namespace}}.svc.cluster.local --eval 'db.runCommand({ping:1})' ; do echo waiting for mongo; sleep 2; done"]
       {{- end }}
@@ -78,19 +78,26 @@ spec:
             - name: supervisord
               containerPort: 9001
               protocol: TCP
+          {{- $probes := .Values.probes | default dict }}
           startupProbe:
             # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.
             httpGet:
-              path: /
               port: http
+              path: {{ dig "startupProbe" "api" "/api/v1/health" $probes }}
+            failureThreshold: {{ dig "startupProbe" "failureThreshold" 3 $probes }}
+            periodSeconds: {{ dig "startupProbe" "periodSeconds" 60 $probes }}
           livenessProbe:
             httpGet:
-              path: /
               port: http
+              path: {{ dig "livenessProbe" "api" "/api/v1/health" $probes }}
+            failureThreshold: {{ dig "livenessProbe" "failureThreshold" 3 $probes }}
+            periodSeconds: {{ dig "livenessProbe" "periodSeconds" 60 $probes }}
           readinessProbe:
             httpGet:
-              path: /api/v1/users/me
               port: http
+              path: {{ dig "readinessProbe" "api" "/api/v1/health" $probes }}
+            failureThreshold: {{ dig "readinessProbe" "failureThreshold" 3 $probes }}
+            periodSeconds: {{ dig "readinessProbe" "periodSeconds" 60 $probes }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Fixes: [21271](https://github.com/appsmithorg/appsmith/issues/21272)
Fixes: [221](https://github.com/appsmithorg/cloud-deployment/issues/221)
Fixes: [24020](https://github.com/appsmithorg/appsmith/issues/24020)
This will help update the init-container image and also updates the probes so that user doesnt find the necessity to restart manually. Rather, kubelet restarts it by self.

**Case-1:**

```
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ cat values.yaml | grep probes
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ helm install appsmith . -n goutham --create-namespace --dry-run  > temp.yaml
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ tail -n 60 temp.yaml
            {}
          image: "index.docker.io/appsmith/appsmith-ce:latest"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 80
              protocol: TCP
            - name: https
              containerPort: 443
              protocol: TCP
            - name: supervisord
              containerPort: 9001
              protocol: TCP
          startupProbe:
            # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 3
            periodSeconds: 60
          livenessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 3
            periodSeconds: 10
          readinessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 3
            periodSeconds: 10
```

**Case-2**
```
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ cat values.yaml | grep probes
probes: {}
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ helm install appsmith . -n goutham --create-namespace --dry-run  > temp.yaml
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ tail -n 60 temp.yaml
            {}
          image: "index.docker.io/appsmith/appsmith-ce:latest"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 80
              protocol: TCP
            - name: https
              containerPort: 443
              protocol: TCP
            - name: supervisord
              containerPort: 9001
              protocol: TCP
          startupProbe:
            # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 3
            periodSeconds: 60
          livenessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 3
            periodSeconds: 10
          readinessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 3
            periodSeconds: 10
```

**Case-3:**
```
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ head -n 15 values.yaml
probes:
  livenessProbe:
    api: "/api/v1/health"
    failureThreshold: 8
    periodSeconds: 40
  readinessProbe:
    api: "/api/v1/health"
    failureThreshold: 9
    periodSeconds: 50
  startupProbe:
    api: "/api/v1/health"
    failureThreshold: 10
    periodSeconds: 60
## Redis parameters
redis:
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ helm install appsmith . -n goutham --create-namespace --dry-run  > temp.yaml
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ tail -n 60 temp.yaml
            {}
          image: "index.docker.io/appsmith/appsmith-ce:latest"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 80
              protocol: TCP
            - name: https
              containerPort: 443
              protocol: TCP
            - name: supervisord
              containerPort: 9001
              protocol: TCP
          startupProbe:
            # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 10
            periodSeconds: 60
          livenessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 8
            periodSeconds: 40
          readinessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 9
            periodSeconds: 50
          resources:
            limits: {}
            requests: {}
          volumeMounts:
```
**Case-4**
```
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ head -n 15 values.yaml
probes:
  livenessProbe:
    api: "/api/v1/health"
    # failureThreshold: 8
    periodSeconds: 40
  readinessProbe:
    # api: "/api/v1/health"
    failureThreshold: 9
    periodSeconds: 50
  startupProbe:
    api: "/api/v1/health"
    failureThreshold: 10
    # periodSeconds: 60
## Redis parameters
redis:
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ helm install appsmith . -n goutham --create-namespace --dry-run  > temp.yaml
(base) ➜  helm git:(update/cosmetic/changes/ce) ✗ tail -n 60 temp.yaml
            {}
          image: "index.docker.io/appsmith/appsmith-ce:latest"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 80
              protocol: TCP
            - name: https
              containerPort: 443
              protocol: TCP
            - name: supervisord
              containerPort: 9001
              protocol: TCP
          startupProbe:
            # The `livenessProbe` and `readinessProbe` will be disabled until the `startupProbe` is successful.
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 10
            periodSeconds: 60
          livenessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 3
            periodSeconds: 40
          readinessProbe:
            httpGet:
              port: http
              path: "/api/v1/health"
            failureThreshold: 9
            periodSeconds: 50
          resources:
            limits: {}
            requests: {}
```