### PR TITLE
chore: Fix path for running cypress binary from node modules

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -18,7 +18,7 @@
     "test:ci": "CYPRESS_BASE_URL=https://dev.appsmith.com cypress/test.sh --env=ci",
     "eject": "react-scripts eject",
     "start-prod": "REACT_APP_ENVIRONMENT=PRODUCTION craco start",
-    "cytest": "REACT_APP_TESTING=TESTING REACT_APP_ENVIRONMENT=DEVELOPMENT craco start & ./node_modules/.bin/cypress open",
+    "cytest": "REACT_APP_TESTING=TESTING REACT_APP_ENVIRONMENT=DEVELOPMENT craco start & ../node_modules/.bin/cypress open",
     "test:unit": "jest -b --colors --no-cache --silent --coverage --collectCoverage=true --coverageDirectory='../../' --coverageReporters='json-summary'",
     "test:jest": "jest --watch",
     "generate:widget": "plop --plopfile generators/index.js",


### PR DESCRIPTION
Fixes #23428

This doesn't require a test plan or a test run, since these changes are for running the cypress test suite locally.
