### PR TITLE
fix: Preventing modal close action on clicking outside of the modal

### DIFF
--- a/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
+++ b/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
@@ -122,7 +122,10 @@ export default function IntroductionModal({ close }: IntroductionModalProps) {
 
   return (
     <Modal onOpenChange={closeModal} open={modalAlwaysOpen}>
-      <ModalContent style={{ width: "920px" }}>
+      <ModalContent
+        onPointerDownOutside={(e) => e.preventDefault()}
+        style={{ width: "920px" }}
+      >
         <ModalHeader className="t--how-appsmith-works-modal-header">
           {createMessage(WELCOME_TO_APPSMITH)}
         </ModalHeader>

--- a/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
+++ b/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
@@ -123,6 +123,7 @@ export default function IntroductionModal({ close }: IntroductionModalProps) {
   return (
     <Modal onOpenChange={closeModal} open={modalAlwaysOpen}>
       <ModalContent
+        onEscapeKeyDown={(e) => e.preventDefault()}
         onInteractOutside={(e) => e.preventDefault()}
         style={{ width: "920px" }}
       >

--- a/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
+++ b/app/client/src/pages/Editor/FirstTimeUserOnboarding/IntroductionModal.tsx
@@ -123,7 +123,7 @@ export default function IntroductionModal({ close }: IntroductionModalProps) {
   return (
     <Modal onOpenChange={closeModal} open={modalAlwaysOpen}>
       <ModalContent
-        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
         style={{ width: "920px" }}
       >
         <ModalHeader className="t--how-appsmith-works-modal-header">


### PR DESCRIPTION
## Description

Preventing modal close action on clicking outside of the modal

#### PR fixes following issue(s)
Fixes https://www.notion.so/appsmith/Welcome-modal-should-not-be-dismissed-on-losing-focus-3620f488f27743bba9bbb54dc4c0bb85?pvs=4

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
