### PR TITLE
test: skip forkTemplateToGitConnectedApp_Spec 

### DIFF
--- a/app/client/cypress/e2e/Regression_TestSuite/ClientSideTests/Templates/ForkTemplateToGitConnectedApp.js
+++ b/app/client/cypress/e2e/Regression_TestSuite/ClientSideTests/Templates/ForkTemplateToGitConnectedApp.js
@@ -60,8 +60,8 @@ describe("excludeForAirgap", "Fork a template to the current app", () => {
     // );
     cy.commitAndPush();
   });
-
-  it("2. Bug #17262 On forking template to a child branch of git connected app is throwing Page not found error ", function () {
+  // skipping this test as saving page is taking lot of time
+  it.skip("2. Bug #17262 On forking template to a child branch of git connected app is throwing Page not found error ", function () {
     _.gitSync.CreateGitBranch(branchName, true);
     cy.get("@gitbranchName").then((branName) => {
       branchName = branName;

--- a/app/client/cypress/e2e/Regression_TestSuite/ClientSideTests/Templates/ForkTemplateToGitConnectedApp.js
+++ b/app/client/cypress/e2e/Regression_TestSuite/ClientSideTests/Templates/ForkTemplateToGitConnectedApp.js
@@ -88,8 +88,7 @@ describe("excludeForAirgap", "Fork a template to the current app", () => {
       cy.wait(2000);
       cy.get(homePage.applicationCard).first().trigger("mouseover");
       cy.get(homePage.appEditIcon).first().click({ force: true });
-      cy.wait(15000); // add wait for page to save
-      _.agHelper.AssertAutoSave();
+      cy.wait(20000); // add wait for page to save
       cy.switchGitBranch(branchName);
       cy.get(homePage.publishButton).click({ force: true });
       _.agHelper.AssertElementExist(_.gitSync._bottomBarPull);


### PR DESCRIPTION
## Description

Skipping this test case, until we have unique test id for loader while switching branch from @albinAppsmith , currently it fails because it tries to assert loader not to be present in git sync modal after creating branch, but since saving page loader exists it becomes flaky as both have same class name.
