### PR TITLE
fix: send analytics event diff thread super user creation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -284,6 +284,14 @@ public class UserSignupCEImpl implements UserSignupCE {
                                 return pair.getT2();
                             });
 
+                    /*
+                     * Here, we have decided to move these 2 analytics events to a separate thread.
+                     * - create superuser event
+                     * - installation setup event
+                     * These 2 events have been put in a separate thread, because both of them don't have any impact
+                     * on the user flow, but one of them (installation setup event) is causing performance impact
+                     * when creating superuser (performance impact is because of an external network call in NetworkUtils.getExternalAddress()).
+                     */
                     Mono<User> sendCreateSuperUserEvent = sendCreateSuperUserEventOnSeparateThreadMono(user);
 
                     Mono<Boolean> installationSetupAnalyticsMono = sendInstallationSetupAnalyticsOnSeparateThreadMono(userFromRequest, user, userData);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/UserSignupCEImpl.java
@@ -37,6 +37,7 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
 import org.springframework.web.server.WebSession;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -283,74 +284,9 @@ public class UserSignupCEImpl implements UserSignupCE {
                                 return pair.getT2();
                             });
 
-                    Mono<User> sendCreateSuperUserEvent = analyticsService.sendObjectEvent(AnalyticsEvents.CREATE_SUPERUSER, user, null)
-                            .elapsed()
-                            .map(pair -> {
-                                log.debug("UserSignupCEImpl::Time taken to send create super user event: {} ms", pair.getT1());
-                                return pair.getT2();
-                            });
+                    Mono<User> sendCreateSuperUserEvent = sendCreateSuperUserEventOnSeparateThreadMono(user);
 
-                    Mono<String> getInstanceIdMono = configService.getInstanceId()
-                            .elapsed()
-                            .map(pair -> {
-                                log.debug("UserSignupCEImpl::Time taken to get instance ID: {} ms", pair.getT1());
-                                return pair.getT2();
-                            });;
-
-                    Mono<String> getExternalAddressMono = NetworkUtils.getExternalAddress().defaultIfEmpty("unknown")
-                            .elapsed()
-                            .map(pair -> {
-                                log.debug("UserSignupCEImpl::Time taken to get external address: {} ms", pair.getT1());
-                                return pair.getT2();
-                            });
-
-                    Mono<Long> installationSetupAnalyticsMono = Mono.zip(getInstanceIdMono, getExternalAddressMono)
-                            .flatMap(tuple -> {
-                                final String instanceId = tuple.getT1();
-                                final String ip = tuple.getT2();
-                                log.debug("Installation setup complete.");
-                                String newsletterSignedUpUserEmail = userFromRequest.isSignupForNewsletter() ? user.getEmail() : "";
-                                String newsletterSignedUpUserName = userFromRequest.isSignupForNewsletter() ? user.getName() : "";
-                                Map<String, Object> analyticsProps = new HashMap<>();
-                                analyticsProps.put(DISABLE_TELEMETRY, !userFromRequest.isAllowCollectingAnonymousData());
-                                analyticsProps.put(SUBSCRIBE_MARKETING, userFromRequest.isSignupForNewsletter());
-                                analyticsProps.put(EMAIL, newsletterSignedUpUserEmail);
-                                analyticsProps.put(ROLE, ObjectUtils.defaultIfNull(userData.getRole(), ""));
-                                analyticsProps.put(GOAL, ObjectUtils.defaultIfNull(userData.getUseCase(), ""));
-                                // ip is a reserved keyword for tracking events in Mixpanel though this is allowed in
-                                // Segment. Instead of showing the ip as is Mixpanel provides derived property.
-                                // As we want derived props alongwith the ip address we are sharing the ip
-                                // address in separate keys
-                                // Ref: https://help.mixpanel.com/hc/en-us/articles/360001355266-Event-Properties
-                                analyticsProps.put(IP, ip);
-                                analyticsProps.put(IP_ADDRESS, ip);
-                                analyticsProps.put(NAME, ObjectUtils.defaultIfNull(newsletterSignedUpUserName, ""));
-
-                                analyticsService.identifyInstance(
-                                        instanceId,
-                                        userData.getRole(),
-                                        userData.getUseCase(),
-                                        newsletterSignedUpUserEmail,
-                                        newsletterSignedUpUserName,
-                                        ip);
-
-                                return analyticsService.sendEvent(
-                                                AnalyticsEvents.INSTALLATION_SETUP_COMPLETE.getEventName(),
-                                                instanceId,
-                                                analyticsProps,
-                                                false
-                                        ).thenReturn(1L)
-                                        .elapsed()
-                                        .map(pair -> {
-                                            log.debug("UserSignupCEImpl::Time taken to send installation setup complete analytics event: {} ms", pair.getT1());
-                                            return pair.getT2();
-                                        });
-                            })
-                            .elapsed()
-                            .map(pair -> {
-                                log.debug("UserSignupCEImpl::Time taken to send installation setup analytics event: {} ms", pair.getT1());
-                                return pair.getT2();
-                            });;
+                    Mono<Boolean> installationSetupAnalyticsMono = sendInstallationSetupAnalyticsOnSeparateThreadMono(userFromRequest, user, userData);
 
                     Mono<Long> allSecondaryFunctions = Mono.when(userDataMono, installationSetupAnalyticsMono, applyEnvManagerChangesMono, sendCreateSuperUserEvent)
                             .thenReturn(1L)
@@ -414,4 +350,86 @@ public class UserSignupCEImpl implements UserSignupCE {
                 });
     }
 
+    private Mono<Boolean> sendInstallationSetupAnalyticsOnSeparateThreadMono(UserSignupRequestDTO userFromRequest,
+                                                                             User user,
+                                                                             UserData userData) {
+
+        Mono<String> getInstanceIdMono = configService.getInstanceId()
+                .elapsed()
+                .map(pair -> {
+                    log.debug("UserSignupCEImpl::Time taken to get instance ID: {} ms", pair.getT1());
+                    return pair.getT2();
+                });;
+
+        Mono<String> getExternalAddressMono = NetworkUtils.getExternalAddress().defaultIfEmpty("unknown")
+                .elapsed()
+                .map(pair -> {
+                    log.debug("UserSignupCEImpl::Time taken to get external address: {} ms", pair.getT1());
+                    return pair.getT2();
+                });
+
+        Mono.zip(getInstanceIdMono, getExternalAddressMono)
+                .flatMap(tuple -> {
+                    final String instanceId = tuple.getT1();
+                    final String ip = tuple.getT2();
+                    log.debug("Installation setup complete.");
+                    String newsletterSignedUpUserEmail = userFromRequest.isSignupForNewsletter() ? user.getEmail() : "";
+                    String newsletterSignedUpUserName = userFromRequest.isSignupForNewsletter() ? user.getName() : "";
+                    Map<String, Object> analyticsProps = new HashMap<>();
+                    analyticsProps.put(DISABLE_TELEMETRY, !userFromRequest.isAllowCollectingAnonymousData());
+                    analyticsProps.put(SUBSCRIBE_MARKETING, userFromRequest.isSignupForNewsletter());
+                    analyticsProps.put(EMAIL, newsletterSignedUpUserEmail);
+                    analyticsProps.put(ROLE, ObjectUtils.defaultIfNull(userData.getRole(), ""));
+                    analyticsProps.put(GOAL, ObjectUtils.defaultIfNull(userData.getUseCase(), ""));
+                    // ip is a reserved keyword for tracking events in Mixpanel though this is allowed in
+                    // Segment. Instead of showing the ip as is Mixpanel provides derived property.
+                    // As we want derived props alongwith the ip address we are sharing the ip
+                    // address in separate keys
+                    // Ref: https://help.mixpanel.com/hc/en-us/articles/360001355266-Event-Properties
+                    analyticsProps.put(IP, ip);
+                    analyticsProps.put(IP_ADDRESS, ip);
+                    analyticsProps.put(NAME, ObjectUtils.defaultIfNull(newsletterSignedUpUserName, ""));
+
+                    analyticsService.identifyInstance(
+                            instanceId,
+                            userData.getRole(),
+                            userData.getUseCase(),
+                            newsletterSignedUpUserEmail,
+                            newsletterSignedUpUserName,
+                            ip);
+
+                    return analyticsService.sendEvent(
+                                    AnalyticsEvents.INSTALLATION_SETUP_COMPLETE.getEventName(),
+                                    instanceId,
+                                    analyticsProps,
+                                    false
+                            ).thenReturn(1L)
+                            .elapsed()
+                            .map(pair -> {
+                                log.debug("UserSignupCEImpl::Time taken to send installation setup complete analytics event: {} ms", pair.getT1());
+                                return pair.getT2();
+                            });
+                })
+                .elapsed()
+                .map(pair -> {
+                    log.debug("UserSignupCEImpl::Time taken to send installation setup analytics event: {} ms", pair.getT1());
+                    return pair.getT2();
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+        return Mono.just(Boolean.TRUE);
+    }
+
+    private Mono<User> sendCreateSuperUserEventOnSeparateThreadMono(User user) {
+        analyticsService.sendObjectEvent(AnalyticsEvents.CREATE_SUPERUSER, user, null)
+                .elapsed()
+                .map(pair -> {
+                    log.debug("UserSignupCEImpl::Time taken to send create super user event: {} ms", pair.getT1());
+                    return pair.getT2();
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe();
+
+        return Mono.just(user);
+    }
 }


### PR DESCRIPTION
## Description
> The code changes here move the analytics event to a separate thread which are sent while creating a super user. This was causing a performance, because of an external call which happens from Appsmith. Moving these 2 events to a separate thread will not have any impact on the Super user creation flow.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/22147

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> This will be tested as part of Cypress test cases, where we have seen reproductions of the timeout.

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>

#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
