### PR TITLE
fix: Re-gzip html files after env variables substitution

### DIFF
--- a/deploy/docker/scripts/run-nginx.sh
+++ b/deploy/docker/scripts/run-nginx.sh
@@ -84,6 +84,9 @@ apply-env-vars() {
   )
   fs.writeFileSync("'"$served"'", content)
   '
+  pushd "$(dirname "$served")"
+  gzip --keep --force "$(basename "$served")"
+  popd
 }
 
 apply-env-vars /opt/appsmith/index.html.original /opt/appsmith/editor/index.html


### PR DESCRIPTION
We replace env variables in `index.html`, `view.html` and `edit.html`, just before start NGINX. But the `.gz` versions of these files don't have these changes applied to them. This PR gzips those HTML files again, after the substitutions are applied.

From https://github.com/appsmithorg/appsmith/pull/23539#issuecomment-1554509537.
