### PR TITLE
fix: don’t cache icons by the service worker

### DIFF
--- a/app/client/craco.build.config.js
+++ b/app/client/craco.build.config.js
@@ -19,6 +19,23 @@ plugins.push(
     mode: "development",
     swDest: "./pageService.js",
     maximumFileSizeToCacheInBytes: 11 * 1024 * 1024,
+    exclude: [
+      // Don’t cache source maps and PWA manifests.
+      // (These are the default values of the `exclude` option: https://developer.chrome.com/docs/workbox/reference/workbox-build/#type-WebpackPartial,
+      // so we need to specify them explicitly if we’re extending this array.)
+      /\.map$/,
+      /^manifest.*\.js$/,
+      // Don’t cache the root html file
+      /index\.html/,
+      // Don’t cache LICENSE.txt files emitted by CRA
+      // when a chunk includes some license comments
+      /LICENSE\.txt/,
+      // Don’t cache icons as there are hundreds of them, and caching them all
+      // one by one keeps the network busy for a long time (which is bad for battery life)
+      /\/icon.*\.(js|png|svg)$/,
+    ],
+    // Don’t cache-bust JS and CSS chunks
+    dontCacheBustURLsMatching: /\.[0-9a-zA-Z]{8}\.chunk\.(js|css)$/,
   }),
 );
 

--- a/app/client/src/serviceWorker.js
+++ b/app/client/src/serviceWorker.js
@@ -27,9 +27,9 @@ const regexMap = {
 };
 
 /* eslint-disable no-restricted-globals */
-const toPrecache = self.__WB_MANIFEST.filter(
-  (file) => !file.url.includes("index.html"),
-);
+// Note: if you need to filter out some files from precaching,
+// do that in craco.build.config.js → workbox webpack plugin options
+const toPrecache = self.__WB_MANIFEST;
 precacheAndRoute(toPrecache);
 
 self.__WB_DISABLE_DEV_DEBUG_LOGS = false;


### PR DESCRIPTION
## Description

This PR prevents the service worker from caching the icons.

For the background on why we moved from `.filter()` to `exclude: []`, see https://github.com/appsmithorg/appsmith/pull/21996#discussion_r1156075049 (that PR was reverted later).

#### Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?

- [ ] Manual: built the app, cleared service worker caches, reloaded, ensured the service worker doesn’t preload icons anymore

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
