### PR TITLE
ci: Reducing jobs count in ci-test-limited.yml

### DIFF
--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
+        job: [0, 1, 2, 3, 4]
 
     # Service containers to run with this job. Required for running tests
     services:


### PR DESCRIPTION
## Description
- This PR reduces the jobs used count to minimal in ci-limited-tests.yml for safer side
- Folks using it can add/remove jobs further as needed in their PR along with updating limites-tests.txt present in cypress folder for running limited Cypress tests


#### QA activity:
- [x] Added `Test Plan Approved` label after reviewing all changes
