### PR TITLE
test: updated the container spec

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Multiple_Container_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Multiple_Container_spec.js
@@ -34,7 +34,6 @@ describe("Dynamic Height Width validation for multiple container", function () {
                   .then((checkboxheight) => {
                     cy.get(commonlocators.addOption).click({ force: true });
                     cy.get(commonlocators.addOption).click({ force: true });
-
                     cy.wait("@updateLayout").should(
                       "have.nested.property",
                       "response.body.responseMeta.status",

--- a/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Multiple_Container_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Multiple_Container_spec.js
@@ -39,7 +39,6 @@ describe("Dynamic Height Width validation for multiple container", function () {
                       "response.body.responseMeta.status",
                       200,
                     );
-                    cy.wait(5000); //allow for container to adjust height for new option added
                     cy.get(".t--widget-checkboxgroupwidget")
                       .invoke("css", "height")
                       .then((newcheckboxheight) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Multiple_Container_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/DynamicHeight/Multiple_Container_spec.js
@@ -33,6 +33,8 @@ describe("Dynamic Height Width validation for multiple container", function () {
                   .invoke("css", "height")
                   .then((checkboxheight) => {
                     cy.get(commonlocators.addOption).click({ force: true });
+                    cy.get(commonlocators.addOption).click({ force: true });
+
                     cy.wait("@updateLayout").should(
                       "have.nested.property",
                       "response.body.responseMeta.status",


### PR DESCRIPTION
Fixed Multiple-Container spec under Dynamic Heights.

- After Adding a new option to Checkbox widget the new option was getting added in the same line so the height remained same
- Now we are adding another option to validate auto height feature across widgets used in testing within the spec