### PR TITLE
fix: Fix crash on passing invalid mark option to category slider widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategroySlider_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Sliders/CategroySlider_spec.ts
@@ -72,4 +72,12 @@ describe("Category Slider spec", () => {
       expect($label).to.eq("sm");
     });
   });
+
+  it("does not crash if an invalid mark option is passed", function () {
+    cy.get(".t--property-control-options .t--js-toggle").first().click();
+    cy.updateCodeInput(".t--property-control-options", "[[]]");
+    cy.get(".t--widget-categorysliderwidget")
+      .contains("Oops, Something went wrong.")
+      .should("not.exist");
+  });
 });

--- a/app/client/cypress/fixtures/categorySliderWidgetDsl.json
+++ b/app/client/cypress/fixtures/categorySliderWidgetDsl.json
@@ -82,7 +82,7 @@
         "labelAlignment": "left",
         "renderMode": "CANVAS",
         "isLoading": false,
-        "showMarksLabel": false
+        "showMarksLabel": true
       },
       {
         "widgetName": "Text1",

--- a/app/client/src/widgets/CategorySliderWidget/validations.ts
+++ b/app/client/src/widgets/CategorySliderWidget/validations.ts
@@ -12,7 +12,7 @@ export function optionsCustomValidation(
     if (options.length < 2) {
       return {
         isValid: false,
-        parsed: options,
+        parsed: [],
         messages: [
           {
             name: "ValidationError",


### PR DESCRIPTION
Fixes #23228

Steps to Repro:

1. Dnd Category Slider Widget
2. Toggle JS Mode in options field
3. Enter `[[]]`
4. Observe the crash

Expected behavior : The widget shouldn't crash
