### PR TITLE
chore : disable react overlay for warnings/error in dev mode

### DIFF
--- a/app/client/craco.dev.config.js
+++ b/app/client/craco.dev.config.js
@@ -3,6 +3,14 @@ const { merge } = require("webpack-merge");
 const common = require("./craco.common.config.js");
 
 module.exports = merge(common, {
+  devServer: {
+    client: {
+      overlay: {
+        warnings: false,
+        errors: false
+      }
+    }
+  },
   optimization: {
     minimize: false,
   },


### PR DESCRIPTION
Fixes #23631

This PR disables the react overlay seen during development.

This improves developer efficiency while writing code and running tests as the developer will not have to manually close the overlay.

The prettier warnings will show up nonetheless because of pre-commit lint hook, so I believe that this change shouldn't affect the processes around code quality