### PR TITLE
chore : disable hot reloading of cypress tests to reduce memory overload

### DIFF
--- a/app/client/cypress.config.ts
+++ b/app/client/cypress.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "cypress";
 
 export default defineConfig({
-  // watchForFileChanges: false,
+  watchForFileChanges: false,
   defaultCommandTimeout: 30000,
   requestTimeout: 21000,
   responseTimeout: 30000,


### PR DESCRIPTION
Disabling hot reloading eases up the memory pressure on local development system