### PR TITLE
fix: adding a back button in git revert modal

### DIFF
--- a/app/client/src/pages/Editor/gitSync/DisconnectGitModal.tsx
+++ b/app/client/src/pages/Editor/gitSync/DisconnectGitModal.tsx
@@ -5,7 +5,12 @@ import {
   getIsDisconnectGitModalOpen,
 } from "selectors/gitSyncSelectors";
 import { useDispatch, useSelector } from "react-redux";
-import { revokeGit, setIsDisconnectGitModalOpen } from "actions/gitSyncActions";
+import {
+  revokeGit,
+  setDisconnectingGitApplication,
+  setIsDisconnectGitModalOpen,
+  setIsGitSyncModalOpen,
+} from "actions/gitSyncActions";
 import {
   Button,
   Callout,
@@ -22,6 +27,7 @@ import {
   createMessage,
   GIT_REVOKE_ACCESS,
   GIT_TYPE_REPO_NAME_FOR_REVOKING_ACCESS,
+  GO_BACK,
   NONE_REVERSIBLE_MESSAGE,
   REVOKE,
 } from "@appsmith/constants/messages";
@@ -35,6 +41,13 @@ function DisconnectGitModal() {
   const gitDisconnectDocumentUrl = useSelector(getDisconnectDocUrl);
   const [appName, setAppName] = useState("");
   const [isRevoking, setIsRevoking] = useState(false);
+
+  const handleClickOnBack = useCallback(() => {
+    dispatch(setIsDisconnectGitModalOpen(false));
+    dispatch(setIsGitSyncModalOpen({ isOpen: true }));
+    dispatch(setDisconnectingGitApplication({ id: "", name: "" }));
+  }, [dispatch]);
+
   const handleClose = useCallback(() => {
     dispatch(setIsDisconnectGitModalOpen(false));
   }, [dispatch, setIsDisconnectGitModalOpen]);
@@ -103,9 +116,17 @@ function DisconnectGitModal() {
         </ModalBody>
         <ModalFooter>
           <Button
+            className="t--git-revoke-back-button"
+            kind="secondary"
+            onClick={handleClickOnBack}
+            size="md"
+          >
+            {createMessage(GO_BACK)}
+          </Button>
+          <Button
             className="t--git-revoke-button"
             isDisabled={shouldDisableRevokeButton}
-            kind="error"
+            kind="primary"
             onClick={onDisconnectGit}
             size="md"
           >


### PR DESCRIPTION
## Description
Adds a back button to git revoke access modal. Clicking on the back button takes user back to the previous modal. This PR is in accordance with ADS v2

#### PR fixes following issue(s)
Fixes #23032 

#### Media
Before
![image](https://github.com/appsmithorg/appsmith/assets/8724051/6b2014b2-e86c-42ee-a529-21c3feaf34fe)

After
![image](https://github.com/appsmithorg/appsmith/assets/8724051/4ade9f78-314e-4f2d-9d45-fbcc07ddc7d4)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
Manually tested

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
