### PR TITLE
fix: Adding a check to not update the settings if the variable doesn't exist in docker.env

### DIFF
--- a/app/client/src/pages/Settings/SettingsForm.tsx
+++ b/app/client/src/pages/Settings/SettingsForm.tsx
@@ -273,8 +273,12 @@ export default withRouter(
     };
     _.forEach(AdminConfig.settingsMap, (setting, name) => {
       const fieldValue = selector(state, name);
+      const doNotUpdate =
+        setting.controlType === SettingTypes.CHECKBOX &&
+        !settingsConfig[name] &&
+        !fieldValue;
 
-      if (fieldValue !== settingsConfig[name]) {
+      if (fieldValue !== settingsConfig[name] && !doNotUpdate) {
         newProps.settings[name] = fieldValue;
       }
     });


### PR DESCRIPTION
## Description

Adding a check to not update the settings if the variable doesn't exist in docker.env and the value for this variable is changed to false via the Admin settings page.

#### PR fixes following issue(s)
Fixes #23473 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
