### PR TITLE
fix: Add email validation for 4 letter email domain extension names

### DIFF
--- a/app/client/src/widgets/InputWidgetV2/widget/derived.js
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.js
@@ -67,8 +67,12 @@ export default {
     }
     switch (props.inputType) {
       case "EMAIL":
+        /**
+         * Explanation of Regex:
+         *  https://stackoverflow.com/questions/15017052/understanding-email-validation-using-javascript
+         * */
         const emailRegex = new RegExp(
-          /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/,
+          /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})+$/,
         );
         if (!emailRegex.test(value)) {
           /* email should conform to generic email regex */

--- a/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
+++ b/app/client/src/widgets/InputWidgetV2/widget/derived.test.ts
@@ -450,6 +450,18 @@ describe("Derived property - ", () => {
       );
 
       expect(isValid).toBeFalsy();
+
+      isValid = derivedProperty.isValid(
+        {
+          inputType: InputTypes.EMAIL,
+          inputText: "test@appsmith.INFO",
+          isRequired: true,
+        },
+        null,
+        _,
+      );
+
+      expect(isValid).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Fixes #23576

Steps to repro:

QA Steps:
1. Use an email with four letter extension : .info, .tech
2. Check case insensitive extension validations. Both .info and .INFO should be valid email addresses
