### PR TITLE
fix: curl import curly bracket fix

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -512,7 +512,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
             actionConfiguration.setQueryParameters(queryParameters);
         }
 
-        queryParameters.addAll(getParams(token));
+        queryParameters.addAll(getQueryParams(token));
 
         // Set the URL without the query params & the path.
         action.getDatasource().getDatasourceConfiguration().setUrl(base);
@@ -527,14 +527,14 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
         }
         return "";
     }
- 
-    private List<Property> getParams(String path) throws IndexOutOfBoundsException{
-        List<Property> paramsList = new ArrayList<>();
+
+    private List<Property> getQueryParams(String path) throws IndexOutOfBoundsException{
+        List<Property> queryParamList = new ArrayList<>();
         String[] paramsArray = path.split("\\?")[1].split("&");
-        for(String param : Arrays.asList(paramsArray)){
-            String[] paramMap = param.split("=");
-            paramsList.add(new Property(paramMap[0],paramMap[1]));
+        for(String queryParam : Arrays.asList(paramsArray)){
+            String[] paramMap = queryParam.split("=");
+            queryParamList.add(new Property(paramMap[0],paramMap[1]));
         }
-        return paramsList;
+        return queryParamList;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -489,7 +489,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
         return null;
     }
 
-    private void trySaveURL(ActionDTO action, String token) throws MalformedURLException, URISyntaxException,IndexOutOfBoundsException {
+    private void trySaveURL(ActionDTO action, String token) throws MalformedURLException, URISyntaxException, IndexOutOfBoundsException {
         // If the URL appears to not have a protocol set, prepend the `https` protocol.
         if (!token.matches("\\w+://.*")) {
             token = "http://" + token;


### PR DESCRIPTION
## Description

- While importing, a URI object was created to parse the query params from the URL string which doesn't allows curly brackets.
- Due to this a MalformedURLException was thrown. To avoid this removed the URI object creation.
- Added a method to split the URL string to fetch the query params

#### PR fixes following issue(s)
Fixes #19846 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
- [x] Manual
- [x] JUnit
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
