### PR TITLE
test: Cypress | Handling confirmation dialogs

### DIFF
--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -1,4 +1,4 @@
-name: Build client server without running Unit tests
+name: Run Cypress without running Unit tests
 
 on:
   # This workflow can be triggered manually from the GitHub Actions page

--- a/.github/workflows/build-client-server.yml
+++ b/.github/workflows/build-client-server.yml
@@ -1,4 +1,4 @@
-name: Run Cypress without running Unit tests
+name: Build Client, Server & Run only Cypress
 
 on:
   # This workflow can be triggered manually from the GitHub Actions page

--- a/.github/workflows/ci-test-limited.yml
+++ b/.github/workflows/ci-test-limited.yml
@@ -165,15 +165,15 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         uses: actions/cache@v3
         with:
-          path: app/.yarn/cache
-          key: v1-yarn3-${{ hashFiles('app/yarn.lock') }}
+          path: app/client/.yarn/cache
+          key: v1-yarn3-${{ hashFiles('app/client/yarn.lock') }}
           restore-keys: |
             v1-yarn3-
 
       # Install all the dependencies
       - name: Install dependencies
+        working-directory : app/client
         run: |
-          cd app/client
           yarn install --immutable
 
       - name: Setting up the cypress tests

--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
@@ -204,12 +204,12 @@ describe("Git import flow ", function () {
     // validate data binding in edit and deploy mode
     cy.latestDeployPreview();
     cy.get(".tbody").should("have.length", 2);
-    cy.get(".tbody").first().should("contain.text", "Test user 7");
+    _.table.AssertTableLoaded(0, 1, "v1");
     cy.xpath("//input[@value='this is a test']");
     cy.xpath("//input[@value='Success']");
     // navigate to Page1 and verify data
     cy.get(".t--page-switch-tab").contains("Page1 Copy").click({ force: true });
-    cy.get(".tbody").first().should("contain.text", "Test user 7");
+    _.table.AssertTableLoaded(0, 1, "v1");
     cy.xpath("//input[@value='this is a test']");
     cy.xpath("//input[@value='Success']");
     cy.get(commonlocators.backToEditor).click();

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
@@ -373,8 +373,8 @@ describe("JS Function Execution", function () {
     // click "Yes" button for all onPageload && ConfirmExecute functions
     for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
       //_.agHelper.AssertElementPresence(_.jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
-      _.agHelper.ClickButton("Yes");
-      _.agHelper.Sleep();
+      _.jsEditor.ConfirmationClick("Yes");
+      _.agHelper.Sleep(2000);
     }
     // Switch to settings tab and assert order
     _.agHelper.GetNClick(_.jsEditor._settingsTab);
@@ -418,8 +418,8 @@ describe("JS Function Execution", function () {
     // click "Yes" button for all onPageload && ConfirmExecute functions
     for (let i = 0; i <= onPageLoadAndConfirmExecuteFunctionsLength - 1; i++) {
       //_.agHelper.AssertElementPresence(_.jsEditor._dialog("Confirmation Dialog")); // Not working in edit mode
-      _.agHelper.GetNClick(".ads-v2-button__content-children", 1, true);
-      _.agHelper.Sleep(); //for current pop up to close & next to appear!
+      _.jsEditor.ConfirmationClick("Yes");
+      _.agHelper.Sleep(2000); //for current pop up to close & next to appear!
     }
     _.entityExplorer.ExpandCollapseEntity("Queries/JS");
     _.entityExplorer.SelectEntityByName(jsObj, "Queries/JS");

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad1_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad1_Spec.ts
@@ -52,7 +52,7 @@ describe("JSObjects OnLoad Actions tests", function () {
       _.agHelper.AssertElementVisible(
         _.jsEditor._dialogBody((jsName as string) + ".getEmployee"),
       );
-      _.agHelper.ClickButton("Yes");
+      _.jsEditor.ConfirmationClick("Yes");
       _.agHelper.Sleep(1000);
     });
     _.agHelper.ValidateNetworkExecutionSuccess("@postExecute");
@@ -67,7 +67,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     _.agHelper.AssertElementVisible(
       _.jsEditor._dialogBody((jsName as string) + ".getEmployee"),
     );
-    _.agHelper.ClickButton("Yes");
+    _.jsEditor.ConfirmationClick("Yes");
     //_.agHelper.Sleep(1000);
     _.agHelper.ValidateToastMessage("getEmployee ran successfully"); //Verify this toast comes in EDIT page only
     _.entityExplorer.SelectEntityByName(jsName as string, "Queries/JS");
@@ -81,7 +81,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     _.agHelper.AssertElementVisible(
       _.jsEditor._dialogBody((jsName as string) + ".getEmployee"),
     );
-    _.agHelper.ClickButton("No");
+    _.jsEditor.ConfirmationClick("No");
     _.agHelper.AssertContains(`${jsName + ".getEmployee"} was cancelled`);
     _.table.WaitForTableEmpty();
     _.agHelper.WaitUntilAllToastsDisappear();
@@ -91,8 +91,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     _.agHelper.AssertElementVisible(
       _.jsEditor._dialogBody((jsName as string) + ".getEmployee"),
     );
-    _.agHelper.ClickButton("Yes");
-    _.agHelper.AssertElementAbsence(_.locators._toastMsg);
+    _.jsEditor.ConfirmationClick("Yes");
     // _.agHelper.ValidateNetworkExecutionSuccess("@postExecute");
     _.table.ReadTableRowColumnData(0, 0).then((cellData) => {
       expect(cellData).to.be.equal("2");
@@ -102,7 +101,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     _.agHelper.AssertElementVisible(
       _.jsEditor._dialogBody((jsName as string) + ".getEmployee"),
     );
-    _.agHelper.ClickButton("Yes");
+    _.jsEditor.ConfirmationClick("Yes");
     _.agHelper.ValidateToastMessage("getEmployee ran successfully"); //Verify this toast comes in EDIT page only
   });
 
@@ -139,7 +138,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     // ee.SelectEntityByName(jsName as string);
     // _.jsEditor.EnableDisableAsyncFuncSettings("getEmployee", true, true);
     // _.agHelper.GetNClick(_.jsEditor._runButton);
-    // _.agHelper.ClickButton("Yes");
+    // _.jsEditor.ConfirmationClick("Yes");
   });
 
   it("6. Tc 55 - Verify OnPage Load - Enabling & Before Function calling Enabling for JSOBject & deleting testdata", function () {
@@ -149,7 +148,8 @@ describe("JSObjects OnLoad Actions tests", function () {
     // _.agHelper.AssertElementVisible(
     //   _.jsEditor._dialogBody((jsName as string) + ".getEmployee"),
     // );
-    // _.agHelper.ClickButton("Yes");
+    // _.jsEditor.ConfirmationClick("Yes");
+
     // _.agHelper.AssertElementAbsence(_.locators._toastMsg);
     // _.table.ReadTableRowColumnData(0, 0, 2000).then((cellData) => {
     //   expect(cellData).to.be.equal("2");
@@ -160,7 +160,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     // _.agHelper.AssertElementVisible(
     //   _.jsEditor._dialogBody((jsName as string) + ".getEmployee"),
     // );
-    // _.agHelper.ClickButton("Yes");
+    // _.jsEditor.ConfirmationClick("Yes");
     // _.agHelper.ValidateToastMessage("getEmployee ran successfully"); //Verify this toast comes in EDIT page only
 
     _.entityExplorer.SelectEntityByName(jsName as string, "Queries/JS");

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
@@ -143,12 +143,12 @@ describe("JSObjects OnLoad Actions tests", function () {
     _.jsEditor.EnableDisableAsyncFuncSettings("film", true, true);
 
     _.deployMode.DeployApp();
-    for (let dialog = 1; dialog <= 3; dialog++) {
+    for (let dialog = 1; dialog <= 5; dialog++) {
       _.jsEditor.ConfirmationClick("Yes");
       _.agHelper.Sleep(500);
     }
     _.deployMode.NavigateBacktoEditor();
-    for (let dialog = 1; dialog <= 3; dialog++) {
+    for (let dialog = 1; dialog <= 5; dialog++) {
       _.jsEditor.ConfirmationClick("Yes");
       _.agHelper.Sleep(500);
     }

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
@@ -144,12 +144,12 @@ describe("JSObjects OnLoad Actions tests", function () {
 
     _.deployMode.DeployApp();
     for (let dialog = 1; dialog <= 3; dialog++) {
-      _.agHelper.ClickButton("Yes");
+      _.jsEditor.ConfirmationClick("Yes");
       _.agHelper.Sleep(500);
     }
     _.deployMode.NavigateBacktoEditor();
     for (let dialog = 1; dialog <= 3; dialog++) {
-      _.agHelper.ClickButton("Yes");
+      _.jsEditor.ConfirmationClick("Yes");
       _.agHelper.Sleep(500);
     }
   });
@@ -223,7 +223,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     _.agHelper.AssertElementVisible(
       _.jsEditor._dialogBody("JSObject1." + jsMethod),
     );
-    _.agHelper.ClickButton("No");
+    _.jsEditor.ConfirmationClick("No");
     _.agHelper.Sleep(1000);
 
     shouldCheckImport && _.homePage.AssertNCloseImport();
@@ -232,11 +232,11 @@ describe("JSObjects OnLoad Actions tests", function () {
     _.agHelper.AssertElementVisible(
       _.jsEditor._dialogBody("JSObject1." + jsMethod),
     );
-    _.agHelper.ClickButton("Yes");
+    _.jsEditor.ConfirmationClick("Yes");
     if (faliureMsg) _.agHelper.ValidateToastMessage(faliureMsg);
     else _.agHelper.Sleep(3000);
     _.deployMode.NavigateBacktoEditor();
-    _.agHelper.ClickButton("No");
+    _.jsEditor.ConfirmationClick("No");
     _.agHelper.Sleep(2000);
   }
 

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
@@ -106,7 +106,7 @@ describe("JSObjects OnLoad Actions tests", function () {
       // _.agHelper.AssertElementVisible(
       //   _.jsEditor._dialogBody((jsName as string) + ".callTrump"),
       // );
-      // _.agHelper.ClickButton("No");
+      // _.jsEditor.ConfirmationClick("No");
       // _.agHelper.WaitUntilToastDisappear(
       //   `${jsName + ".callTrump"} was cancelled`,
       // ); //When Confirmation is NO validate error toast!
@@ -115,7 +115,7 @@ describe("JSObjects OnLoad Actions tests", function () {
       _.agHelper.AssertContains("cancelled"); //Quotes
       //One Quotes confirmation - for API true
       // _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("Quotes"));
-      // _.agHelper.ClickButton("No");
+      // _.jsEditor.ConfirmationClick("No");
       _.agHelper.WaitUntilAllToastsDisappear();
 
       _.jsEditor.ConfirmationClick("No");
@@ -123,7 +123,7 @@ describe("JSObjects OnLoad Actions tests", function () {
 
       // //Another for API called via JS callQuotes()
       // _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("Quotes"));
-      //_.agHelper.ClickButton("No");
+      // _.jsEditor.ConfirmationClick("No");
       //_.agHelper.WaitUntilToastDisappear('The action "Quotes" has failed');No toast appears!
 
       _.agHelper.AssertElementAbsence(
@@ -183,7 +183,7 @@ describe("JSObjects OnLoad Actions tests", function () {
 
     _.jsEditor.ConfirmationClick("No");
     // _.agHelper.AssertElementExist(_.jsEditor._dialogInDeployView);
-    // _.agHelper.ClickButton("No");
+    // _.jsEditor.ConfirmationClick("No");
     _.agHelper.AssertContains("cancelled");
     _.entityExplorer.ExpandCollapseEntity("Queries/JS");
     cy.fixture("datasources").then((datasourceFormData) => {
@@ -357,7 +357,7 @@ describe("JSObjects OnLoad Actions tests", function () {
     // Uncomment below aft Bug 13826 is fixed & add for Yes also!
     // _.agHelper.SelectDropDown("Akron");
     // _.agHelper.AssertElementPresence(_.jsEditor._dialogBody("getCountry"));
-    // _.agHelper.ClickButton("No");
+    // _.jsEditor.ConfirmationClick("No");
 
     _.agHelper.WaitUntilToastDisappear("getBooks was cancelled");
     _.agHelper.GetNClick(_.locators._widgetInDeployed("imagewidget"));

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
@@ -1,7 +1,7 @@
 import * as _ from "../../../../support/Objects/ObjectsCore";
 let dsName: any, jsName: any;
 
-describe.skip("JSObjects OnLoad Actions tests", function () {
+describe("JSObjects OnLoad Actions tests", function () {
   beforeEach(() => {
     _.agHelper.RestoreLocalStorageCache();
   });
@@ -78,17 +78,25 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
         .and("contain", jsName as string)
         .and("contain", "will be executed automatically on page load");
 
-      _.agHelper.WaitUntilToastDisappear("Quotes");
+      //_.agHelper.WaitUntilToastDisappear("Quotes");
 
       _.entityExplorer.SelectEntityByName("Input2");
       _.propPane.UpdatePropertyFieldValue(
         "Default value",
         "{{" + jsObjName + ".callTrump.data.message}}",
       );
-      _.agHelper.WaitUntilToastDisappear(
+
+      _.agHelper.AssertContains(
         (("[" + jsName) as string) +
           ".callTrump] will be executed automatically on page load",
+        "be.visible",
+        _.locators._toastMsg,
       );
+
+      // _.agHelper.WaitUntilToastDisappear(
+      //   (("[" + jsName) as string) +
+      //     ".callTrump] will be executed automatically on page load",
+      // );
 
       _.deployMode.DeployApp();
 
@@ -103,15 +111,15 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
       //   `${jsName + ".callTrump"} was cancelled`,
       // ); //When Confirmation is NO validate error toast!
 
-      _.agHelper.GetNClick(_.jsEditor._confirmationModalBtns("No"));
-      _.agHelper.AssertContains("was cancelled"); //Quotes
+      _.jsEditor.ConfirmationClick("No");
+      _.agHelper.AssertContains("cancelled"); //Quotes
       //One Quotes confirmation - for API true
       // _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("Quotes"));
       // _.agHelper.ClickButton("No");
-      // _.agHelper.WaitUntilToastDisappear("Quotes was cancelled");
+      _.agHelper.WaitUntilAllToastsDisappear();
 
-      _.agHelper.GetNClick(_.jsEditor._confirmationModalBtns("No"));
-      _.agHelper.AssertContains("User cancelled"); //callTrump
+      _.jsEditor.ConfirmationClick("No");
+      _.agHelper.AssertContains("cancelled"); //callTrump
 
       // //Another for API called via JS callQuotes()
       // _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("Quotes"));
@@ -127,19 +135,19 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
       //   _.jsEditor._dialogBody((jsName as string) + ".callTrump"),
       // );
       _.agHelper.AssertElementExist(_.jsEditor._dialogInDeployView);
-      _.agHelper.GetNClick(_.jsEditor._confirmationModalBtns("Yes")); //call trumpy - jsobj
+      _.jsEditor.ConfirmationClick("Yes"); //call trumpy - jsobj
 
       //_.agHelper.GetNClick(".ads-v2-button__content-children", 1, true);
       _.agHelper.Sleep(2000);
 
       //_.agHelper.AssertElementVisible(_.jsEditor._dialogBody("WhatTrumpThinks")); //Since JS call is Yes, dependent confirmation should appear aswell!
       _.agHelper.AssertElementExist(_.jsEditor._dialogInDeployView);
-      _.agHelper.GetNClick(_.jsEditor._confirmationModalBtns("Yes")); //trumpy - api
+      _.jsEditor.ConfirmationClick("Yes"); //trumpy - api
       _.agHelper.Sleep(3000);
 
       //_.agHelper.AssertElementVisible(_.jsEditor._dialogBody("Quotes"));
       _.agHelper.AssertElementExist(_.jsEditor._dialogInDeployView);
-      _.agHelper.GetNClick(_.jsEditor._confirmationModalBtns("Yes")); //quotes - api
+      _.jsEditor.ConfirmationClick("Yes"); //quotes - api
 
       //_.agHelper.Sleep(2000);
       //_.agHelper.AssertElementVisible(_.jsEditor._dialogBody("Quotes"));
@@ -164,17 +172,19 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
   it("2. Tc #1912 - API with OnPageLoad & Confirmation both enabled & called directly & setting previous Api's confirmation to false", () => {
     _.deployMode.NavigateBacktoEditor();
     _.agHelper.AssertElementExist(_.jsEditor._dialogInDeployView);
-    _.agHelper.ClickButton("No");
-    _.agHelper.AssertContains("was cancelled"); //_.agHelper.AssertContains("Quotes was cancelled");
+    _.jsEditor.ConfirmationClick("No");
+    _.agHelper.AssertContains("cancelled"); //_.agHelper.AssertContains("Quotes was cancelled");
 
     _.agHelper.WaitUntilAllToastsDisappear();
     _.agHelper.AssertElementExist(_.jsEditor._dialogInDeployView);
-    _.agHelper.ClickButton("No"); //Ask Favour abt below
+    _.jsEditor.ConfirmationClick("No"); //Ask Favour abt below
     //_.agHelper.ValidateToastMessage("callQuotes ran successfully"); //Verify this toast comes in EDIT page only
+    _.agHelper.AssertContains("cancelled");
 
+    _.jsEditor.ConfirmationClick("No");
     // _.agHelper.AssertElementExist(_.jsEditor._dialogInDeployView);
     // _.agHelper.ClickButton("No");
-    _.agHelper.AssertContains("User cancelled");
+    _.agHelper.AssertContains("cancelled");
     _.entityExplorer.ExpandCollapseEntity("Queries/JS");
     cy.fixture("datasources").then((datasourceFormData) => {
       _.apiPage.CreateAndFillApi(
@@ -202,16 +212,16 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
 
     _.deployMode.DeployApp();
     _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("CatFacts"));
-    _.agHelper.ClickButton("No");
+    _.jsEditor.ConfirmationClick("No");
     _.agHelper.ValidateToastMessage("CatFacts was cancelled");
 
     _.agHelper.WaitUntilToastDisappear("CatFacts was cancelled");
     _.agHelper.GetNClick(_.locators._widgetInDeployed("imagewidget"));
     _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("CatFacts"));
-    _.agHelper.ClickButton("Yes");
+    _.jsEditor.ConfirmationClick("Yes");
     cy.get(_.locators._toastMsg).contains(/Your cat fact|Oh No/g);
     _.deployMode.NavigateBacktoEditor();
-    _.agHelper.ClickButton("No");
+    _.jsEditor.ConfirmationClick("No");
   });
 
   it("3. Tc #1646, 60 - Honouring the order of execution & Bug 13826 + Bug 13646", () => {
@@ -335,7 +345,7 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
   it("4. Tc #1646 - Honouring the order of execution & Bug 13826 + Bug 13646 - Delpoy page", () => {
     _.deployMode.DeployApp();
     _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("getBooks"));
-    _.agHelper.ClickButton("No");
+    _.jsEditor.ConfirmationClick("No");
     _.agHelper.ValidateToastMessage("getBooks was cancelled");
     _.agHelper
       .GetText(_.locators._jsonFormInputField("name"), "val")
@@ -352,7 +362,7 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
     _.agHelper.WaitUntilToastDisappear("getBooks was cancelled");
     _.agHelper.GetNClick(_.locators._widgetInDeployed("imagewidget"));
     _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("getBooks"));
-    _.agHelper.ClickButton("Yes");
+    _.jsEditor.ConfirmationClick("Yes");
     //callBooks, getId confirmations also expected aft bug 13646 is fixed & covering tc 1646
 
     _.agHelper
@@ -365,7 +375,7 @@ describe.skip("JSObjects OnLoad Actions tests", function () {
 
     _.deployMode.NavigateBacktoEditor();
     _.agHelper.AssertElementVisible(_.jsEditor._dialogBody("getBooks"));
-    _.agHelper.ClickButton("No");
+    _.jsEditor.ConfirmationClick("No");
     _.agHelper.ValidateToastMessage("getBooks was cancelled");
 
     _.entityExplorer.SelectEntityByName(jsName as string, "Queries/JS");

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,1 +1,4 @@
-cypress/e2e/**/**/*
+cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad2_Spec.ts
+cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
+cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
+

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,3 +1,4 @@
+cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad1_Spec.ts
 cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad2_Spec.ts
 cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
 cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,5 +1,1 @@
-cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad1_Spec.ts
-cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad2_Spec.ts
-cypress/e2e/Regression/ServerSide/OnLoadTests/JsOnLoad3_Spec.ts
-cypress/e2e/Regression/ServerSide/JsFunctionExecution/JSFunctionExecution_spec.ts
-
+cypress/e2e/**/**/*

--- a/app/client/cypress/support/Pages/JSEditor.ts
+++ b/app/client/cypress/support/Pages/JSEditor.ts
@@ -100,7 +100,7 @@ export class JSEditor {
   _confirmationModalBtns = (text: string) =>
     "//div[@data-testid='t--query-run-confirmation-modal']//span[text()='" +
     text +
-    "']/ancestor::button[@type='button']";
+    "']";
   //#endregion
 
   //#region constants
@@ -372,6 +372,24 @@ export class JSEditor {
 
   public AssertSelectedFunction(funName: string) {
     cy.get(this._funcDropdownValue).contains(funName).should("exist");
+  }
+
+  public ConfirmationClick(type: "Yes" | "No") {
+    //this.agHelper.GetNClick(this._confirmationModalBtns(type), 0, true);
+    this.agHelper
+      .GetElement(this._confirmationModalBtns(type))
+      .eq(0)
+      .scrollIntoView()
+      .then(($element: any) => {
+        cy.get($element).trigger("click", {
+          force: true,
+        });
+      });
+
+    if (type == "Yes")
+      this.agHelper.AssertElementAbsence(
+        this.locator._specificToast("canceled"),
+      ); //Asserting NO is not clicked
   }
 
   //#endregion


### PR DESCRIPTION
## Description
- This PR handles the proper click of No & Yes in the confirmation modals during a query/js object run
- Also updated the ci-test-limited.yml for Installing dependencies from right path
- GitImport - 5th case - flakyfix

#### PR fixes following issue(s)
- Unskips the JsOnload3 spec
- JSFunctionExecution_spec.ts - flaky fix

#### Type of change
- Script update

## Testing
>
#### How Has This Been Tested?
- [X] Cypress run

## Checklist:

#### QA activity:
- [X] Added `Test Plan Approved` label aftee test changes were reviewed
