### PR TITLE
fix: Oauth authorize will now redirect to the correct git branch (#21188)

### DIFF
--- a/app/client/src/sagas/DatasourcesSagas.ts
+++ b/app/client/src/sagas/DatasourcesSagas.ts
@@ -135,6 +135,7 @@ import { fetchPluginFormConfig } from "actions/pluginActions";
 import { addClassToDocumentBody } from "pages/utils";
 import { AuthorizationStatus } from "pages/common/datasourceAuth";
 import { getFormDiffPaths, getFormName } from "utils/editorContextUtils";
+import { getCurrentGitBranch } from "selectors/gitSyncSelectors";
 
 function* fetchDatasourcesSaga(
   action: ReduxAction<{ workspaceId?: string } | undefined>,
@@ -469,9 +470,13 @@ function* redirectAuthorizationCodeSaga(
 ) {
   const { datasourceId, pageId, pluginType } = actionPayload.payload;
   const isImport: string = yield select(getWorkspaceIdForImport);
+  const branchName: string | undefined = yield select(getCurrentGitBranch);
 
   if (pluginType === PluginType.API) {
-    window.location.href = `/api/v1/datasources/${datasourceId}/pages/${pageId}/code`;
+    window.location.href =
+      `/api/v1/datasources/${datasourceId}/pages/${pageId}/code` + !!branchName
+        ? `?branch=` + branchName
+        : ``;
   } else {
     try {
       // Get an "appsmith token" from the server

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/DatasourceControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/DatasourceControllerCE.java
@@ -83,9 +83,12 @@ public class DatasourceControllerCE extends BaseController<DatasourceService, Da
 
     @JsonView(Views.Public.class)
     @GetMapping("/{datasourceId}/pages/{pageId}/code")
-    public Mono<Void> getTokenRequestUrl(@PathVariable String datasourceId, @PathVariable String pageId, ServerWebExchange serverWebExchange) {
+    public Mono<Void> getTokenRequestUrl(@PathVariable String datasourceId,
+                                         @PathVariable String pageId,
+                                         @RequestParam(name = FieldName.BRANCH_NAME, required = false) String branchName,
+                                         ServerWebExchange serverWebExchange) {
         log.debug("Going to retrieve token request URL for datasource with id: {} and page id: {}", datasourceId, pageId);
-        return authenticationService.getAuthorizationCodeURLForGenericOauth2(datasourceId, pageId, serverWebExchange.getRequest())
+        return authenticationService.getAuthorizationCodeURLForGenericOauth2(datasourceId, pageId, branchName, serverWebExchange.getRequest())
                 .flatMap(url -> {
                     serverWebExchange.getResponse().setStatusCode(HttpStatus.FOUND);
                     serverWebExchange.getResponse().getHeaders().setLocation(URI.create(url));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/AuthenticationServiceCE.java
@@ -15,10 +15,11 @@ public interface AuthenticationServiceCE {
      *
      * @param datasourceId required to validate the details in the request and populate redirect url
      * @param pageId       Required to populate redirect url
+     * @param branchName
      * @param httpRequest  Used to find the redirect domain
      * @return a url String to continue the authorization flow
      */
-    Mono<String> getAuthorizationCodeURLForGenericOauth2(String datasourceId, String pageId, ServerHttpRequest httpRequest);
+    Mono<String> getAuthorizationCodeURLForGenericOauth2(String datasourceId, String pageId, String branchName, ServerHttpRequest httpRequest);
 
     /**
      * This is the method that handles callback for generic OAuth2. We will be retrieving and storing token information here


### PR DESCRIPTION
## Description
- The redirect url fetched from the `/datasources/authorize` endpoint didn't consider the branch query parameter.
- Save and authorize will pass the branch name as query parameter to the token request
- The token request will pass the branch name in oauth state which will be used by the redirect url to redirect to the correct page and branch.
- If there is no git branch connected, the earlier implementation will work as it is without the branch name in request param or oauth state.

#### PR fixes following issue(s)
Fixes #21188

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
