### PR TITLE
chore: Refined `fgAccent` (light mode), fixed missing return in `fg` (light mode)

### DIFF
--- a/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/utils/TokensAccessor/LightModeTheme.ts
@@ -224,11 +224,11 @@ export class LightModeTheme implements ColorModeTheme {
     if (this.seedIsAchromatic) {
       color.oklch.l = 0.12;
       color.oklch.c = 0;
+      return color;
     }
 
     color.oklch.l = 0.12;
     color.oklch.c = 0.032;
-
     return color;
   }
 
@@ -237,13 +237,13 @@ export class LightModeTheme implements ColorModeTheme {
 
     if (this.bg.contrastAPCA(this.seedColor) <= 60) {
       if (this.seedIsAchromatic) {
-        color.oklch.l = 0.25;
+        color.oklch.l = 0.45;
         color.oklch.c = 0;
         return color;
       }
 
-      color.oklch.l = 0.25;
-      color.oklch.c = 0.064;
+      color.oklch.l = 0.45;
+      color.oklch.c = 0.164;
       return color;
     }
 


### PR DESCRIPTION
## Description

tl;dr Preserving more color in fgAccent when the seed doesn't pass the contrast check, more saturated and pure color for better harmony. Also fixed `fg` that missed a return for achromatic seeds rule.

Fixes #22699 

## Media
New on the left, current on the right

https://github.com/appsmithorg/appsmith/assets/80973/e4731b10-fa4c-45bb-a0e1-9591a9bbce2a



## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual

### Test Plan
Initial POC refinement, no testing necessary

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
