### PR TITLE
fix: add fix for anonymous data and newsletter to not show up in cypress airgapped tests

### DIFF
--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1307,6 +1307,17 @@ Cypress.Commands.add("createSuperUser", () => {
       );
       expect(interception.request.body).contains("signupForNewsletter=true");
     });
+  } else {
+    cy.wait("@createSuperUser").then((interception) => {
+      expect(interception.request.body).should(
+        "not.contain",
+        "allowCollectingAnonymousData=true",
+      );
+      expect(interception.request.body).should(
+        "not.contain",
+        "signupForNewsletter=true",
+      );
+    });
   }
 
   cy.LogOut();

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1299,12 +1299,21 @@ Cypress.Commands.add("createSuperUser", () => {
   cy.get(welcomePage.useCaseDropdownOption).eq(1).click();
   cy.get(welcomePage.submitButton).should("not.be.disabled");
   cy.get(welcomePage.submitButton).click();
-  cy.wait("@createSuperUser").then((interception) => {
-    expect(interception.request.body).contains(
-      "allowCollectingAnonymousData=true",
-    );
-    expect(interception.request.body).contains("signupForNewsletter=true");
-  });
+  if (Cypress.env("AIRGAPPED")) {
+    cy.wait("@createSuperUser").then((interception) => {
+      expect(interception.request.body).contains(
+        "allowCollectingAnonymousData=false",
+      );
+      expect(interception.request.body).contains("signupForNewsletter=false");
+    });
+  } else {
+    cy.wait("@createSuperUser").then((interception) => {
+      expect(interception.request.body).contains(
+        "allowCollectingAnonymousData=true",
+      );
+      expect(interception.request.body).contains("signupForNewsletter=true");
+    });
+  }
 
   cy.LogOut();
   cy.wait(2000);

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1299,14 +1299,8 @@ Cypress.Commands.add("createSuperUser", () => {
   cy.get(welcomePage.useCaseDropdownOption).eq(1).click();
   cy.get(welcomePage.submitButton).should("not.be.disabled");
   cy.get(welcomePage.submitButton).click();
-  if (Cypress.env("AIRGAPPED")) {
-    cy.wait("@createSuperUser").then((interception) => {
-      expect(interception.request.body).contains(
-        "allowCollectingAnonymousData=false",
-      );
-      expect(interception.request.body).contains("signupForNewsletter=false");
-    });
-  } else {
+  //in case of airgapped both anonymous data and newsletter are disabled
+  if (!Cypress.env("AIRGAPPED")) {
     cy.wait("@createSuperUser").then((interception) => {
       expect(interception.request.body).contains(
         "allowCollectingAnonymousData=true",


### PR DESCRIPTION

## Description
Fix Airgapped cypress tests failing due to superuser expecting anonymousdata and newsletter to be true.


#### Type of change
> Please delete options that are not relevant.

- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
