### PR TITLE
fix: peeking on undefined properties

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/PeekOverlay/PeekOverlay_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/PeekOverlay/PeekOverlay_Spec.ts
@@ -103,6 +103,25 @@ describe("Peek overlay", () => {
       _.peekOverlay.VerifyDataType("array");
       _.peekOverlay.CheckObjectArrayInOverlay([{}, {}, {}]);
       _.peekOverlay.ResetHover();
+
+      // basic nested property
+      _.peekOverlay.HoverCode(20, 7, "id");
+      _.peekOverlay.IsOverlayOpen();
+      _.peekOverlay.VerifyDataType("number");
+      _.peekOverlay.CheckPrimitiveValue("1");
+      _.peekOverlay.ResetHover();
+
+      // undefined object
+      _.peekOverlay.HoverCode(21, 1, "aljshdlja");
+      _.peekOverlay.IsOverlayOpen(false);
+      _.peekOverlay.ResetHover();
+
+      // this keyword
+      _.peekOverlay.HoverCode(22, 3, "numArray");
+      _.peekOverlay.IsOverlayOpen();
+      _.peekOverlay.VerifyDataType("array");
+      _.peekOverlay.CheckPrimitveArrayInOverlay([1, 2, 3]);
+      _.peekOverlay.ResetHover();
     });
   });
 });
@@ -127,7 +146,9 @@ const JsObjectContent = `export default {
     Table1;
     Table1.pageNo; 
     Table1.tableData;
-    Api1.data.users[0].id;
+    Api1.data[0].id;
+    aljshdlja;
+    this.numArray;
   },
   myFun2: async () => {
     storeValue("abc", 123)

--- a/app/client/cypress/e2e/Regression/ClientSide/PeekOverlay/PeekOverlay_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/PeekOverlay/PeekOverlay_Spec.ts
@@ -122,6 +122,11 @@ describe("Peek overlay", () => {
       _.peekOverlay.VerifyDataType("array");
       _.peekOverlay.CheckPrimitveArrayInOverlay([1, 2, 3]);
       _.peekOverlay.ResetHover();
+
+      // pageList is and internal property - peek overlay shouldn't work
+      _.peekOverlay.HoverCode(23, 1, "pageList");
+      _.peekOverlay.IsOverlayOpen(false);
+      _.peekOverlay.ResetHover();
     });
   });
 });
@@ -149,6 +154,7 @@ const JsObjectContent = `export default {
     Api1.data[0].id;
     aljshdlja;
     this.numArray;
+    pageList;
   },
   myFun2: async () => {
     storeValue("abc", 123)

--- a/app/client/cypress/e2e/Regression/ClientSide/PeekOverlay/PeekOverlay_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/PeekOverlay/PeekOverlay_Spec.ts
@@ -123,7 +123,7 @@ describe("Peek overlay", () => {
       _.peekOverlay.CheckPrimitveArrayInOverlay([1, 2, 3]);
       _.peekOverlay.ResetHover();
 
-      // pageList is and internal property - peek overlay shouldn't work
+      // pageList is an internal property - peek overlay shouldn't work
       _.peekOverlay.HoverCode(23, 1, "pageList");
       _.peekOverlay.IsOverlayOpen(false);
       _.peekOverlay.ResetHover();

--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -58,7 +58,7 @@
   "AirtableBase": "appubHrVbovcudwN6",
   "AirtableTable": "tblsFCQSskVFf7xNd",
 
-  "mockApiUrl": "http://localhost:5001/v1/mock-api?records=10",
+  "mockApiUrl": "http://host.docker.internal:5001/v1/mock-api?records=10",
   "echoApiUrl": "http://host.docker.internal:5001/v1/mock-api/echo",
   "randomCatfactUrl": "http://host.docker.internal:5001/v1/catfact/random",
 

--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -58,7 +58,7 @@
   "AirtableBase": "appubHrVbovcudwN6",
   "AirtableTable": "tblsFCQSskVFf7xNd",
 
-  "mockApiUrl": "http://host.docker.internal:5001/v1/mock-api?records=10",
+  "mockApiUrl": "http://localhost:5001/v1/mock-api?records=10",
   "echoApiUrl": "http://host.docker.internal:5001/v1/mock-api/echo",
   "randomCatfactUrl": "http://host.docker.internal:5001/v1/catfact/random",
 

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -754,7 +754,10 @@ class CodeEditor extends Component<Props, State> {
         .extractExpressionAtPosition(chIndex)
         .then((lineExpression: string) => {
           const paths = _.toPath(lineExpression);
-          if (!this.isPathLibrary(paths)) {
+          if (
+            !this.isPathLibrary(paths) &&
+            paths[0] in this.props.dynamicData
+          ) {
             this.showPeekOverlay(lineExpression, paths, tokenElement);
           } else {
             this.hidePeekOverlay();

--- a/app/client/src/constants/WidgetValidation.ts
+++ b/app/client/src/constants/WidgetValidation.ts
@@ -34,11 +34,15 @@ export type Validator = (
 
 export const ISO_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ss.sssZ";
 
-export const DATA_TREE_KEYWORDS = {
+export const DATATREE_INTERNAL_KEYWORDS = {
   actionPaths: "actionPaths",
-  appsmith: "appsmith",
   pageList: "pageList",
   [EXECUTION_PARAM_KEY]: EXECUTION_PARAM_KEY,
+};
+
+export const DATA_TREE_KEYWORDS = {
+  appsmith: "appsmith",
+  ...DATATREE_INTERNAL_KEYWORDS,
 };
 
 export const JAVASCRIPT_KEYWORDS = {

--- a/app/client/src/selectors/dataTreeSelectors.ts
+++ b/app/client/src/selectors/dataTreeSelectors.ts
@@ -22,6 +22,7 @@ import _, { get } from "lodash";
 import type { EvaluationError } from "utils/DynamicBindingUtils";
 import { getEvalErrorPath } from "utils/DynamicBindingUtils";
 import ConfigTreeActions from "utils/configTree";
+import { DATATREE_INTERNAL_KEYWORDS } from "constants/WidgetValidation";
 
 export const getUnevaluatedDataTree = createSelector(
   getActionsForCurrentPage,
@@ -96,7 +97,7 @@ export const getWidgetEvalValues = createSelector(
 export const getDataTreeForAutocomplete = createSelector(
   getDataTree,
   (tree: DataTree) => {
-    return _.omit(tree, ["pageList"]);
+    return _.omit(tree, Object.keys(DATATREE_INTERNAL_KEYWORDS));
   },
 );
 

--- a/app/client/src/selectors/dataTreeSelectors.ts
+++ b/app/client/src/selectors/dataTreeSelectors.ts
@@ -18,7 +18,7 @@ import { getPageList } from "./appViewSelectors";
 import type { AppState } from "@appsmith/reducers";
 import { getSelectedAppThemeProperties } from "./appThemingSelectors";
 import type { LoadingEntitiesState } from "reducers/evaluationReducers/loadingEntitiesReducer";
-import { get } from "lodash";
+import _, { get } from "lodash";
 import type { EvaluationError } from "utils/DynamicBindingUtils";
 import { getEvalErrorPath } from "utils/DynamicBindingUtils";
 import ConfigTreeActions from "utils/configTree";
@@ -96,7 +96,7 @@ export const getWidgetEvalValues = createSelector(
 export const getDataTreeForAutocomplete = createSelector(
   getDataTree,
   (tree: DataTree) => {
-    return tree;
+    return _.omit(tree, ["pagesList"]);
   },
 );
 

--- a/app/client/src/selectors/dataTreeSelectors.ts
+++ b/app/client/src/selectors/dataTreeSelectors.ts
@@ -96,7 +96,7 @@ export const getWidgetEvalValues = createSelector(
 export const getDataTreeForAutocomplete = createSelector(
   getDataTree,
   (tree: DataTree) => {
-    return _.omit(tree, ["pagesList"]);
+    return _.omit(tree, ["pageList"]);
   },
 );
 


### PR DESCRIPTION
## Description
Don't show peek overlay on undefined variables.
Also filter internal property `pageList`.

#### PR fixes following issue(s)
Fixes #23817

#### Media
https://www.loom.com/share/751ce60facdb446d9c1bb4208dc697c4

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
Tested random variables and strings for negative check
>
>
#### Issues raised during DP testing
none
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [x] Cypress test cases have been added and approved by SDET/manual QA
- [x] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
