### PR TITLE
chore: Exclude published mode resources for navigation settings and custom JS libraries

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -257,7 +257,8 @@ public class Application extends BaseDomain {
         this.setServerSchemaVersion(null);
         this.setIsManualUpdate(false);
         this.setDefaultPermissionGroup(null);
-        this.setPublishedCustomJSLibs(new HashSet<>());
+        this.setPublishedCustomJSLibs(null);
+        this.setPublishedApplicationDetail(null);
         this.setExportWithConfiguration(null);
         this.setForkWithConfiguration(null);
         this.setForkingEnabled(null);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/domains/Application.java
@@ -257,8 +257,7 @@ public class Application extends BaseDomain {
         this.setServerSchemaVersion(null);
         this.setIsManualUpdate(false);
         this.setDefaultPermissionGroup(null);
-        this.setPublishedCustomJSLibs(null);
-        this.setPublishedApplicationDetail(null);
+        this.setPublishedCustomJSLibs(new HashSet<>());
         this.setExportWithConfiguration(null);
         this.setForkWithConfiguration(null);
         this.setForkingEnabled(null);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/GitFileUtils.java
@@ -357,6 +357,8 @@ public class GitFileUtils {
         // Don't commit application name as while importing we are using the repoName as application name
         application.setName(null);
         application.setPublishedPages(null);
+        application.setPublishedApplicationDetail(null);
+        application.setPublishedCustomJSLibs(null);
         application.setIsPublic(null);
         application.setSlug(null);
     }


### PR DESCRIPTION
The Git Repo only includes the Edit Mode resources for the Application.json as right after committing we deploy the application. This change set removes Publish Mode App Settings and Custom JS Libs from the Git commit.

Fixes #22785 