### PR TITLE
fix(jsonwidget): Phone Number Default Config

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
+++ b/app/client/src/widgets/JSONFormWidget/widget/propertyConfig/properties/input.ts
@@ -232,7 +232,34 @@ const PROPERTIES = {
           },
         },
         hidden: (...args: HiddenFnParams) =>
-          getSchemaItem(...args).fieldTypeNotIncludes(INPUT_TYPES),
+          getSchemaItem(...args).fieldTypeNotIncludes(INPUT_TYPES) ||
+          getSchemaItem(...args).fieldTypeMatches(FieldType.PHONE_NUMBER_INPUT),
+        dependencies: ["schema"],
+      },
+      {
+        helpText:
+          "Sets the default text of the widget. The text is updated if the default text changes",
+        propertyName: "defaultValue",
+        label: "Default value",
+        controlType: "JSON_FORM_COMPUTE_VALUE",
+        placeholderText: "(000) 000-0000",
+        isBindProperty: true,
+        isTriggerProperty: false,
+        validation: {
+          type: ValidationTypes.FUNCTION,
+          params: {
+            fn: defaultValueValidation,
+            expected: {
+              type: "string",
+              example: `(000) 000-0000`,
+              autocompleteDataType: AutocompleteDataType.STRING,
+            },
+          },
+        },
+        hidden: (...args: HiddenFnParams) =>
+          getSchemaItem(...args).fieldTypeNotMatches(
+            FieldType.PHONE_NUMBER_INPUT,
+          ),
         dependencies: ["schema"],
       },
       {


### PR DESCRIPTION
## Description

Writes a specialised config for Phone Number Inputs to show a different placeholder text. `(000) 000-0000` instead of `John Doe` 

Fixed just the placeholder text. Comparing to the regular PhoneNumberInput the placeholder and formatting were off. This PR fixes only the placeholder as per scope of issue.


#### PR fixes following issue(s)
Fixes #14061 

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>

<img width="294" alt="image" src="https://github.com/appsmithorg/appsmith/assets/31009437/aa6fcc43-b0bd-46d1-8b3e-f4397b74519d">

#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?

- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
