### PR TITLE
fix: gsheets edit mode switch

### DIFF
--- a/app/client/src/ee/api/ApiUtils.ts
+++ b/app/client/src/ee/api/ApiUtils.ts
@@ -1,6 +1,6 @@
 export * from "ce/api/ApiUtils";
 
-const DEFAULT_ENV_ID = "unused_env";
+export const DEFAULT_ENV_ID = "unused_env";
 
 export const getEnvironmentIdForHeader = (): string => {
   return DEFAULT_ENV_ID;

--- a/app/client/src/pages/Editor/DataSourceEditor/DSFormHeader.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DSFormHeader.tsx
@@ -35,12 +35,12 @@ export const FormTitleContainer = styled.div`
 export const Header = styled.div`
   display: flex;
   flex-direction: row;
-  flex: "1 1 10%";
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid var(--ads-v2-color-border);
   padding: var(--ads-v2-spaces-7) 0 var(--ads-v2-spaces-7);
   margin: 0 var(--ads-v2-spaces-7);
+  height: 120px;
 `;
 
 export const PluginImageWrapper = styled.div`

--- a/app/client/src/pages/Editor/DataSourceEditor/index.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/index.tsx
@@ -193,7 +193,7 @@ class DatasourceEditorRouter extends React.Component<Props, State> {
         id: "",
         name: "",
         userPermissions: [],
-        showFilterPane: true,
+        showFilterPane: false,
       },
       unblock: () => {
         return undefined;
@@ -664,6 +664,7 @@ class DatasourceEditorRouter extends React.Component<Props, State> {
                     pluginName={pluginName}
                     pluginPackageName={pluginPackageName}
                     pluginType={pluginType as PluginType}
+                    setDatasourceViewMode={setDatasourceViewMode}
                     showFilterComponent={showFilterComponent}
                     triggerSave={triggerSave}
                     viewMode={viewMode}

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -486,6 +486,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
                 pluginPackageName={pluginPackageName}
                 pluginType={plugin?.type as PluginType}
                 scopeValue={scopeValue}
+                setDatasourceViewMode={setDatasourceViewMode}
                 shouldDisplayAuthMessage={!isGoogleSheetPlugin}
                 showFilterComponent={false}
                 triggerSave={this.props.isDatasourceBeingSavedFromPopup}
@@ -621,8 +622,16 @@ const mapDispatchToProps = (dispatch: any): DatasourceFormFunctions => ({
   toggleSaveActionFlag: (flag) => dispatch(toggleSaveActionFlag(flag)),
   toggleSaveActionFromPopupFlag: (flag) =>
     dispatch(toggleSaveActionFromPopupFlag(flag)),
-  setDatasourceViewMode: (viewMode: boolean) =>
-    dispatch(setDatasourceViewMode(viewMode)),
+  setDatasourceViewMode: (viewMode: boolean) => {
+    // Construct URLSearchParams object instance from current URL querystring.
+    const queryParams = new URLSearchParams(window.location.search);
+
+    queryParams.set("viewMode", viewMode.toString());
+    // Replace current querystring with the new one.
+    history.replaceState({}, "", "?" + queryParams.toString());
+
+    dispatch(setDatasourceViewMode(viewMode));
+  },
   createTempDatasource: (data: any) =>
     dispatch(createTempDatasourceFromForm(data)),
   loadFilePickerAction: () => dispatch(loadFilePickerAction()),

--- a/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
+++ b/app/client/src/pages/Editor/SaaSEditor/DatasourceForm.tsx
@@ -93,6 +93,7 @@ interface StateProps extends JSONtoFormProps {
   isDatasourceBeingSaved: boolean;
   isDatasourceBeingSavedFromPopup: boolean;
   isFormDirty: boolean;
+  isPluginAuthorized: boolean;
   gsheetToken?: string;
   gsheetProjectID?: string;
   showDebugger: boolean;
@@ -350,6 +351,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
       hiddenHeader,
       isDeleting,
       isInsideReconnectModal,
+      isPluginAuthorized,
       isSaving,
       isTesting,
       pageId,
@@ -368,9 +370,6 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
     */
     const isGoogleSheetPlugin =
       pluginPackageName === PluginPackageName.GOOGLE_SHEETS;
-
-    const isPluginAuthorized =
-      plugin && isDatasourceAuthorizedForQueryCreation(formData, plugin);
 
     const createFlow = datasourceId === TEMP_DATASOURCE_ID;
 
@@ -401,7 +400,7 @@ class DatasourceSaaSEditor extends JSONtoForm<Props, State> {
             datasourceId={datasourceId}
             isDeleting={isDeleting}
             isNewDatasource={createFlow}
-            isPluginAuthorized={isPluginAuthorized || false}
+            isPluginAuthorized={isPluginAuthorized}
             pluginImage={pluginImage}
             pluginName={plugin?.name || ""}
             pluginType={plugin?.type || ""}
@@ -579,6 +578,11 @@ const mapStateToProps = (state: AppState, props: any) => {
     viewMode = viewModeFromURLParams === "true";
   }
 
+  const isPluginAuthorized =
+    !!plugin && !!formData
+      ? isDatasourceAuthorizedForQueryCreation(formData, plugin)
+      : true;
+
   return {
     datasource,
     datasourceButtonConfiguration,
@@ -597,6 +601,7 @@ const mapStateToProps = (state: AppState, props: any) => {
     pluginPackageName:
       props.pluginPackageName || props.match?.params?.pluginPackageName,
     initialValues,
+    isPluginAuthorized,
     pluginId: pluginId,
     actions: state.entities.actions,
     formName: DATASOURCE_SAAS_FORM,

--- a/app/client/src/pages/common/datasourceAuth/index.tsx
+++ b/app/client/src/pages/common/datasourceAuth/index.tsx
@@ -6,7 +6,6 @@ import {
   updateDatasource,
   redirectAuthorizationCode,
   getOAuthAccessToken,
-  setDatasourceViewMode,
   createDatasourceFromForm,
   toggleSaveActionFlag,
 } from "actions/datasourceActions";
@@ -49,6 +48,7 @@ interface Props {
   pluginType: PluginType;
   pluginName: string;
   pluginPackageName: string;
+  setDatasourceViewMode: (viewMode: boolean) => void;
   isSaving: boolean;
   isTesting: boolean;
   shouldDisplayAuthMessage?: boolean;
@@ -134,6 +134,7 @@ function DatasourceAuth({
   isTesting,
   viewMode,
   shouldDisplayAuthMessage = true,
+  setDatasourceViewMode,
   triggerSave,
   isFormDirty,
   scopeValue,
@@ -321,7 +322,7 @@ function DatasourceAuth({
                 params: getQueryParams(),
               });
               history.push(URL);
-            } else dispatch(setDatasourceViewMode(true));
+            } else setDatasourceViewMode(true);
           }}
           size="md"
         >

--- a/app/client/src/reducers/entityReducers/datasourceReducer.ts
+++ b/app/client/src/reducers/entityReducers/datasourceReducer.ts
@@ -12,6 +12,7 @@ import type {
 import { TEMP_DATASOURCE_ID } from "constants/Datasource";
 import type { DropdownOption } from "design-system-old";
 import produce from "immer";
+import { assign } from "lodash";
 
 export interface DatasourceDataState {
   list: Datasource[];
@@ -337,6 +338,15 @@ const datasourceReducer = createReducer(initialState, {
     state: DatasourceDataState,
     action: ReduxAction<Datasource>,
   ): DatasourceDataState => {
+    return produce(state, (draftState) => {
+      draftState.loading = false;
+      draftState.list.forEach((datasource) => {
+        if (datasource.id === action.payload.id) {
+          assign(datasource, action.payload);
+        }
+      });
+    });
+
     return {
       ...state,
       loading: false,


### PR DESCRIPTION
## Description
Fixes bug of gsheets not going into edit mode

#### PR fixes following issue(s)
Fixes #23775

#### Media

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
