### PR TITLE
POC: preload chunks from other routes while idle

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -219,15 +219,6 @@
       pricingUrl: parseConfig("__APPSMITH_PRICING_URL__") || "https://www.appsmith.com/pricing",
     };
   </script>
-  <script>
-    window.__appsmith__allMainThreadNonIconChunkIds = <%= JSON.stringify(compilation.chunks
-      // Filter out the icons
-      .filter(i => i.name !== 'icon')
-      // Filter out worker-owned chunks (this logic might be fragile)
-      .filter(i => [...i.groupsIterable].some(group => !group.name?.toLowerCase().includes('worker')))
-      .map(i => i.id)
-    ) %>;
-  </script>
 </body>
 
 </html>

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -219,6 +219,16 @@
       pricingUrl: parseConfig("__APPSMITH_PRICING_URL__") || "https://www.appsmith.com/pricing",
     };
   </script>
+  <% debugger; %>
+  <script>
+    window.__appsmith__allMainThreadNonIconChunkIds = <%= JSON.stringify(compilation.chunks
+      // Filter out the icons
+      .filter(i => i.name !== 'icon')
+      // Filter out worker-owned chunks (this logic might be fragile)
+      .filter(i => [...i.groupsIterable].some(group => !group.name?.toLowerCase().includes('worker')))
+      .map(i => i.id)
+    ) %>;
+  </script>
 </body>
 
 </html>

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -219,7 +219,6 @@
       pricingUrl: parseConfig("__APPSMITH_PRICING_URL__") || "https://www.appsmith.com/pricing",
     };
   </script>
-  <% debugger; %>
   <script>
     window.__appsmith__allMainThreadNonIconChunkIds = <%= JSON.stringify(compilation.chunks
       // Filter out the icons

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -19,6 +19,7 @@ import GlobalStyles from "globalStyles";
 // enable autofreeze only in development
 import { setAutoFreeze } from "immer";
 import AppErrorBoundary from "./AppErrorBoundry";
+import { executePreexecuteQueue } from "preexecute";
 const shouldAutoFreeze = process.env.NODE_ENV === "development";
 setAutoFreeze(shouldAutoFreeze);
 
@@ -66,26 +67,6 @@ if ((window as any).Cypress) {
   (window as any).store = store;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-if (window.__appsmith__allMainThreadNonIconChunkIds) {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const chunks = [...window.__appsmith__allMainThreadNonIconChunkIds];
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  console.log("Loading chunks", chunks, __webpack_chunk_load__);
-  const loadChunk = async () => {
-    const chunkId = chunks.shift();
-    console.log("Loading chunk", chunkId);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    await __webpack_chunk_load__(chunkId);
-
-    if (chunks.length) {
-      requestIdleCallback(loadChunk);
-    }
-  };
-
-  requestIdleCallback(loadChunk);
-}
+setTimeout(() => {
+  executePreexecuteQueue();
+}, 5000);

--- a/app/client/src/index.tsx
+++ b/app/client/src/index.tsx
@@ -65,3 +65,27 @@ ReactDOM.render(<App />, document.getElementById("root"));
 if ((window as any).Cypress) {
   (window as any).store = store;
 }
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+if (window.__appsmith__allMainThreadNonIconChunkIds) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const chunks = [...window.__appsmith__allMainThreadNonIconChunkIds];
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  console.log("Loading chunks", chunks, __webpack_chunk_load__);
+  const loadChunk = async () => {
+    const chunkId = chunks.shift();
+    console.log("Loading chunk", chunkId);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    await __webpack_chunk_load__(chunkId);
+
+    if (chunks.length) {
+      requestIdleCallback(loadChunk);
+    }
+  };
+
+  requestIdleCallback(loadChunk);
+}

--- a/app/client/src/pages/AppViewer/loader.tsx
+++ b/app/client/src/pages/AppViewer/loader.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import PageLoadingBar from "pages/common/PageLoadingBar";
 import { retryPromise } from "utils/AppsmithUtils";
+import { preexecuteChunk } from "preexecute";
+
+const appViewerImport = () =>
+  import(/* webpackChunkName: "AppViewer" */ "./index");
+preexecuteChunk(appViewerImport);
 
 class AppViewerLoader extends React.PureComponent<any, { Page: any }> {
   constructor(props: any) {
@@ -12,9 +17,7 @@ class AppViewerLoader extends React.PureComponent<any, { Page: any }> {
   }
 
   componentDidMount() {
-    retryPromise(
-      () => import(/* webpackChunkName: "AppViewer" */ "./index"),
-    ).then((module) => {
+    retryPromise(appViewerImport).then((module) => {
       this.setState({ Page: module.default });
     });
   }

--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -92,6 +92,7 @@ import EmbedSnippetForm from "@appsmith/pages/Applications/EmbedSnippetTab";
 import { getAppsmithConfigs } from "@appsmith/configs";
 import { isMultiPaneActive } from "selectors/multiPaneSelectors";
 import { getIsAppSettingsPaneWithNavigationTabOpen } from "selectors/appSettingsPaneSelectors";
+import { preexecuteChunk } from "preexecute";
 
 const { cloudHosting } = getAppsmithConfigs();
 
@@ -212,13 +213,13 @@ type EditorHeaderProps = {
   currentUser?: User;
 };
 
-const GlobalSearch = lazy(() => {
-  return retryPromise(
-    () =>
-      import(
-        /* webpackChunkName: "global-search" */ "components/editorComponents/GlobalSearch"
-      ),
+const globalSearchImport = () =>
+  import(
+    /* webpackChunkName: "global-search" */ "components/editorComponents/GlobalSearch"
   );
+preexecuteChunk(globalSearchImport);
+const GlobalSearch = lazy(() => {
+  return retryPromise(globalSearchImport);
 });
 
 const theme = getTheme(ThemeMode.LIGHT);

--- a/app/client/src/pages/Editor/loader.tsx
+++ b/app/client/src/pages/Editor/loader.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import PageLoadingBar from "pages/common/PageLoadingBar";
 import { retryPromise } from "utils/AppsmithUtils";
+import { preexecuteChunk } from "preexecute";
+
+const editorImport = () => import(/* webpackChunkName: "editor" */ "./index");
+preexecuteChunk(editorImport);
 
 class EditorLoader extends React.PureComponent<any, { Page: any }> {
   constructor(props: any) {
@@ -12,11 +16,9 @@ class EditorLoader extends React.PureComponent<any, { Page: any }> {
   }
 
   componentDidMount() {
-    retryPromise(() => import(/* webpackChunkName: "editor" */ "./index")).then(
-      (module) => {
-        this.setState({ Page: module.default });
-      },
-    );
+    retryPromise(editorImport).then((module) => {
+      this.setState({ Page: module.default });
+    });
   }
   render() {
     const { Page } = this.state;

--- a/app/client/src/preexecute.ts
+++ b/app/client/src/preexecute.ts
@@ -1,0 +1,21 @@
+const queue: Array<() => Promise<any>> = [];
+
+export function preexecuteChunk(importFn: () => Promise<any>) {
+  queue.push(importFn);
+}
+
+export async function executePreexecuteQueue() {
+  const loadChunk = async () => {
+    const importFn = queue.shift();
+    if (!importFn) {
+      return;
+    }
+
+    console.log("Pre-executing import", importFn);
+    await importFn();
+
+    requestIdleCallback(loadChunk);
+  };
+
+  requestIdleCallback(loadChunk);
+}


### PR DESCRIPTION
This POC implements the idea of “what if we not only preloaded chunks ahead of time, but also pre-executed them?”

Note the concerns:

> 1) **This increases complexity / maintenance costs.** If there’s some chunk that expects to be executed only in specific environment, it will throw upon loading. Today, it’s worker chunks (in my implementation, I have to explicitly filter them out). Tomorrow, it might be a chunk with the code that assumes it’s running at the view URL (and throws when it’s executed somewhere else).
> 
> 2) **This doesn’t save any network costs.** We have all chunks preloaded by the service worker anyway.
> 
> 3) **The biggest issue: in practice, this might actually make the UX worse.** The key challenge with this feature is that we don’t eliminate the compilation/execution cost – we just trigger it earlier. This might actually make the UX worse.
> 
>    Let’s say we have a chunk that takes 1000 ms to execute. Right now, that chunk will execute when you navigate from eg Dashboard to Editor. This won’t be great, but this won’t be terrible either – you’ll see a spinner, so you’ll expect the slowness.
> 
>    Now, let’s say we’ve shipped this feature and made this chunk pre-execute during idleness. We waited until the idle moment (using `requestIdleCallback()`), started executing this chunk... and 50 ms later, the user tries to interact with the app. Suddenly, the app UI is blocked for 950 ms, with zero indication of what’s happening.
> 
>    I believe random unpredictable delays like this one ↑ are way worse than visible, predictable delays when you’re navigating between routes. What’s even worse is they are super random, so it’s possible we’ll see a win in lab settings (“editor loads faster!”) whereas the actual UX will degrade (“this app lags every time I open the dashboard, gah”).