### PR TITLE
fix: Fix default selected row on a page change when primary key is selected in a table and is unavailable in new data

### DIFF
--- a/app/client/cypress/support/RapidMode.ts
+++ b/app/client/cypress/support/RapidMode.ts
@@ -1,5 +1,5 @@
 /**
- * Sample configuration to be appended to cypress.env.json file
+ * Sample configuration to be appended to app/client/cypress.env.json file
  * Documentation on using it is here : https://github.com/appsmithorg/appsmith/blob/release/contributions/docs/TestAutomation.md
  * 
  * "RAPID_MODE": {

--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.test.ts
@@ -86,7 +86,7 @@ describe("getOriginalRowIndex", () => {
       selectedRowIndex,
       "step",
     );
-    const expected = -1;
+    const expected = 1;
     expect(result).toStrictEqual(expected);
   });
 

--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
@@ -51,7 +51,7 @@ export const getOriginalRowIndex = (
   primaryColumnId: string,
 ) => {
   let primaryKey = "";
-  let index = -1;
+  let index = selectedRowIndex ?? -1;
 
   if (
     !_.isNil(selectedRowIndex) &&

--- a/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/utilities.ts
@@ -49,9 +49,13 @@ export const getOriginalRowIndex = (
   tableData: TableData,
   selectedRowIndex: number | undefined,
   primaryColumnId: string,
-) => {
+): number => {
   let primaryKey = "";
-  let index = selectedRowIndex ?? -1;
+  let index = -1;
+
+  if (prevTableData && prevTableData.length == 0) {
+    return selectedRowIndex ?? index;
+  }
 
   if (
     !_.isNil(selectedRowIndex) &&


### PR DESCRIPTION
Fixes #24344


Steps to repro are in the connected issue.