### PR TITLE
fix: Cannot read properties of undefined (reading 'matches') 

### DIFF
--- a/app/client/src/utils/hooks/useWidgetFocus/useWidgetFocus.tsx
+++ b/app/client/src/utils/hooks/useWidgetFocus/useWidgetFocus.tsx
@@ -1,10 +1,13 @@
+import { useSelector } from "react-redux";
 import { useCallback, useEffect, useRef } from "react";
 
 import { handleTab } from "./handleTab";
 import { CANVAS_WIDGET } from "./tabbable";
+import { getIsAutoLayout } from "selectors/canvasSelectors";
 
 function useWidgetFocus(): (instance: HTMLElement | null) => void {
   const ref = useRef<HTMLElement | null>();
+  const isAutoLayout = useSelector(getIsAutoLayout);
 
   // This is a callback that will be called when the ref is set
   const setRef = useCallback((node: HTMLElement | null) => {
@@ -18,6 +21,7 @@ function useWidgetFocus(): (instance: HTMLElement | null) => void {
   }, []);
 
   useEffect(() => {
+    if (isAutoLayout) return;
     if (!ref.current) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
The useWidgetFocus is failing in autoLayoutMode. The hook was meant for absolute positioning mode, not for autolayout where everything is positioned relatively.

#### PR fixes following issue(s)
Fixes #23880

>
#### Type of change
- Bug fix 
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress

#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
