### PR TITLE
fix: split button into 2 button components to fix issue in firefox.

### DIFF
--- a/app/client/cypress/locators/welcomePage.json
+++ b/app/client/cypress/locators/welcomePage.json
@@ -9,6 +9,7 @@
   "roleInput": ".t--welcome-form-role-input input",
   "useCaseDropdown": ".t--welcome-form-role-usecase",
   "useCaseDropdownOption": ".rc-select-item-option-content",
+  "continueButton": ".t--welcome-form-continue-button",
   "submitButton": ".t--welcome-form-submit-button",
   "dataCollection": ".t--welcome-form-datacollection",
   "newsLetter": ".t--welcome-form-newsletter",

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -1292,17 +1292,17 @@ Cypress.Commands.add("createSuperUser", () => {
   cy.get(welcomePage.email).should("be.visible");
   cy.get(welcomePage.password).should("be.visible");
   cy.get(welcomePage.verifyPassword).should("be.visible");
-  cy.get(welcomePage.submitButton).should("be.disabled");
+  cy.get(welcomePage.continueButton).should("be.disabled");
 
   cy.get(welcomePage.firstName).type(Cypress.env("USERNAME"));
-  cy.get(welcomePage.submitButton).should("be.disabled");
+  cy.get(welcomePage.continueButton).should("be.disabled");
   cy.get(welcomePage.email).type(Cypress.env("USERNAME"));
-  cy.get(welcomePage.submitButton).should("be.disabled");
+  cy.get(welcomePage.continueButton).should("be.disabled");
   cy.get(welcomePage.password).type(Cypress.env("PASSWORD"));
-  cy.get(welcomePage.submitButton).should("be.disabled");
+  cy.get(welcomePage.continueButton).should("be.disabled");
   cy.get(welcomePage.verifyPassword).type(Cypress.env("PASSWORD"));
-  cy.get(welcomePage.submitButton).should("not.be.disabled");
-  cy.get(welcomePage.submitButton).click();
+  cy.get(welcomePage.continueButton).should("not.be.disabled");
+  cy.get(welcomePage.continueButton).click();
 
   cy.get(welcomePage.roleDropdown).click();
   cy.get(welcomePage.roleDropdownOption).eq(1).click();
@@ -1312,14 +1312,7 @@ Cypress.Commands.add("createSuperUser", () => {
   cy.get(welcomePage.submitButton).should("not.be.disabled");
   cy.get(welcomePage.submitButton).click();
   //in case of airgapped both anonymous data and newsletter are disabled
-  if (!Cypress.env("AIRGAPPED")) {
-    cy.wait("@createSuperUser").then((interception) => {
-      expect(interception.request.body).contains(
-        "allowCollectingAnonymousData=true",
-      );
-      expect(interception.request.body).contains("signupForNewsletter=true");
-    });
-  } else {
+  if (Cypress.env("AIRGAPPED")) {
     cy.wait("@createSuperUser").then((interception) => {
       expect(interception.request.body).to.not.contain(
         "allowCollectingAnonymousData=true",
@@ -1327,6 +1320,13 @@ Cypress.Commands.add("createSuperUser", () => {
       expect(interception.request.body).to.not.contain(
         "signupForNewsletter=true",
       );
+    });
+  } else {
+    cy.wait("@createSuperUser").then((interception) => {
+      expect(interception.request.body).contains(
+        "allowCollectingAnonymousData=true",
+      );
+      expect(interception.request.body).contains("signupForNewsletter=true");
     });
   }
 

--- a/app/client/src/pages/setup/DetailsForm.tsx
+++ b/app/client/src/pages/setup/DetailsForm.tsx
@@ -182,22 +182,35 @@ export default function DetailsForm(
             )}
           </div>
         )}
-        <ButtonWrapper>
-          <Button
-            className="t--welcome-form-submit-button w-100"
-            isDisabled={props.invalid}
-            kind="primary"
-            onClick={() => {
-              if (isFirstPage) setFormState(1);
-            }}
-            size="md"
-            type={isFirstPage ? "button" : "submit"}
-          >
-            {isFirstPage
-              ? createMessage(CONTINUE)
-              : createMessage(ONBOARDING_STATUS_GET_STARTED)}
-          </Button>
-        </ButtonWrapper>
+        {isFirstPage && (
+          <ButtonWrapper>
+            <Button
+              className="t--welcome-form-continue-button w-100"
+              isDisabled={props.invalid}
+              kind="primary"
+              onClick={() => {
+                setFormState(1);
+              }}
+              size="md"
+              type="button"
+            >
+              {createMessage(CONTINUE)}
+            </Button>
+          </ButtonWrapper>
+        )}
+        {!isFirstPage && (
+          <ButtonWrapper>
+            <Button
+              className="t--welcome-form-submit-button w-100"
+              isDisabled={props.invalid}
+              kind="primary"
+              size="md"
+              type="submit"
+            >
+              {createMessage(ONBOARDING_STATUS_GET_STARTED)}
+            </Button>
+          </ButtonWrapper>
+        )}
       </StyledFormBodyWrapper>
     </DetailsFormWrapper>
   );


### PR DESCRIPTION
## Description

Split button into 2 button components to fix issue in firefox.
Slack Thread: https://theappsmith.slack.com/archives/CGBPVEJ5C/p1685460441276709

#### PR fixes following issue(s)
Fixes #23902
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
