### PR TITLE
chore: Move zippy setup after the script injection.

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -33,18 +33,6 @@
     };
     const CLOUD_HOSTING = parseConfig("__APPSMITH_CLOUD_HOSTING__");
     const ZIPY_KEY = parseConfig("__APPSMITH_ZIPY_SDK_KEY__");
-    if (CLOUD_HOSTING && ZIPY_KEY) {
-      const script = document.createElement('script');
-      script.crossOrigin = "anonymous";
-      script.defer = true;
-      script.src = "https://cdn.zipy.ai/sdk/v1.0/zipy.min.umd.js";
-      script.onload = () => {
-        window.zipy && window.zipy.init(ZIPY_KEY);
-      }
-      const head = document.getElementsByTagName('head')[0];
-      head && head.appendChild(script);
-    }
-
   </script>
   <%=
     (function () {
@@ -80,6 +68,17 @@
     })()
   %>
   <script>
+    if (CLOUD_HOSTING && ZIPY_KEY) {
+      const script = document.createElement('script');
+      script.crossOrigin = "anonymous";
+      script.defer = true;
+      script.src = "https://cdn.zipy.ai/sdk/v1.0/zipy.min.umd.js";
+      script.onload = () => {
+        window.zipy && window.zipy.init(ZIPY_KEY);
+      }
+      const head = document.getElementsByTagName('head')[0];
+      head && head.appendChild(script);
+    }
     // This function is triggered on load of google apis javascript library
     // Even though the script is loaded asynchronously, in case of firefox run on windows
     // The gapi script is getting loaded even before the last script of index.html


### PR DESCRIPTION
In earlier PR #23882, along with moving the env variables before the script injection, we also moved zippy setup.
Moving it back below the script injection now.

