### PR TITLE
fix: curl import empty headers issue fixed

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/CurlImportFlow_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/CurlImportFlow_spec.js
@@ -66,17 +66,9 @@ describe("Test curl import flow", function () {
 
   it("3. Bug:19214 Test curl import flow for request without any headers", function () {
     cy.fixture("datasources").then((datasourceFormData) => {
-      cy.NavigateToApiEditor();
-      _.dataSources.NavigateToDSCreateNew();
-      cy.get(ApiEditor.curlImage).click({ force: true });
-      cy.get("textarea").type(
-        "curl -X POST " + datasourceFormData["echoApiUrl"],
-        {
-          force: true,
-          parseSpecialCharSequences: false,
-        },
+      _.dataSources.FillCurlNImport(
+        "curl -X GET " + datasourceFormData["echoApiUrl"],
       );
-      cy.importCurl();
       _.apiPage.AssertEmptyHeaderKeyValuePairsPresent(0);
       _.apiPage.AssertEmptyHeaderKeyValuePairsPresent(1);
     });

--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/CurlImportFlow_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/CurlImportFlow_spec.js
@@ -63,4 +63,22 @@ describe("Test curl import flow", function () {
       });
     });
   });
+
+  it("3. Bug:19214 Test curl import flow for request without any headers", function () {
+    cy.fixture("datasources").then((datasourceFormData) => {
+      cy.NavigateToApiEditor();
+      _.dataSources.NavigateToDSCreateNew();
+      cy.get(ApiEditor.curlImage).click({ force: true });
+      cy.get("textarea").type(
+        "curl -X POST " + datasourceFormData["echoApiUrl"],
+        {
+          force: true,
+          parseSpecialCharSequences: false,
+        },
+      );
+      cy.importCurl();
+      _.apiPage.AssertEmptyHeaderKeyValuePairsPresent(0);
+      _.apiPage.AssertEmptyHeaderKeyValuePairsPresent(1);
+    });
+  });
 });

--- a/app/client/cypress/support/Pages/ApiPage.ts
+++ b/app/client/cypress/support/Pages/ApiPage.ts
@@ -409,4 +409,9 @@ export class ApiPage {
     if (apiName) this.agHelper.RenameWithInPane(apiName);
     cy.get(this._resourceUrl).should("be.visible");
   }
+
+  AssertEmptyHeaderKeyValuePairsPresent(index: number) {
+    this.agHelper.AssertElementVisible(this._headerKey(index));
+    this.agHelper.AssertElementVisible(this._headerValue(index));
+  }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CurlImporterServiceCEImpl.java
@@ -427,9 +427,7 @@ public class CurlImporterServiceCEImpl extends BaseApiImporter implements CurlIm
             }
         }
 
-        if (!headers.isEmpty()) {
-            actionConfiguration.setHeaders(headers);
-        }
+        actionConfiguration.setHeaders(headers);
 
         if (!dataParts.isEmpty()) {
             if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(contentType)) {


### PR DESCRIPTION
## Description
This PR fixes:
- When we import api request using curl and if api request does not have any header values, the imported request looks like below, empty key value headers are missing.
<img width="764" alt="Screenshot 2023-06-02 at 1 30 34 PM" src="https://github.com/appsmithorg/appsmith/assets/30018882/21b70393-ea05-4281-ba3e-b1819c907dd5">

#### PR fixes following issue(s)
Fixes #19214 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
