### PR TITLE
chore: Linter check for dangling it.only tests

### DIFF
--- a/app/client/.eslintrc.js
+++ b/app/client/.eslintrc.js
@@ -83,9 +83,9 @@ eslintConfig.overrides = [
         "error",
         {
           selector:
-            'CallExpression[callee.object.name="it"][callee.property.name="only"]',
+            'CallExpression[callee.object.name="it"][callee.property.name="only"], CallExpression[callee.object.name="describe"][callee.property.name="only"]',
           message:
-            "Reason: Dangling it.only test skips other tests in the file and reduces test coverage.",
+            "Reason: Dangling *.only tests skip other tests in the file and reduce test coverage.",
         },
       ],
     },

--- a/app/client/.eslintrc.js
+++ b/app/client/.eslintrc.js
@@ -76,6 +76,20 @@ eslintConfig.overrides = [
         getRestrictedSyntaxOverrideForCodeEditor(eslintConfig),
     },
   },
+  {
+    files: ["**/*.test.js", "*.test.ts", "*.test.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            'CallExpression[callee.object.name="it"][callee.property.name="only"]',
+          message:
+            "Reason: Dangling it.only test skips other tests in the file and reduces test coverage.",
+        },
+      ],
+    },
+  },
 ];
 
 function getRestrictedImportsOverrideForCodeEditor(eslintConfig) {

--- a/app/client/cypress/.eslintrc.json
+++ b/app/client/cypress/.eslintrc.json
@@ -13,5 +13,21 @@
     "@typescript-eslint/no-non-null-assertion": "error",
     "cypress/unsafe-to-chain-command": "off",
     "@typescript-eslint/adjacent-overload-signatures": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*[sS]pec.js", "**/*[sS]pec.ts"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector":
+            "CallExpression[callee.object.name=\"it\"][callee.property.name=\"only\"]",
+            "message":
+            "Reason: Dangling it.only test skips other tests in the file and reduces test coverage."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/app/client/cypress/.eslintrc.json
+++ b/app/client/cypress/.eslintrc.json
@@ -21,10 +21,8 @@
         "no-restricted-syntax": [
           "error",
           {
-            "selector":
-            "CallExpression[callee.object.name=\"it\"][callee.property.name=\"only\"]",
-            "message":
-            "Reason: Dangling it.only test skips other tests in the file and reduces test coverage."
+            "selector": "CallExpression[callee.object.name=\"it\"][callee.property.name=\"only\"], CallExpression[callee.object.name=\"describe\"][callee.property.name=\"only\"]",
+            "message": "Reason: Dangling *.only tests skip other tests in the file and reduce test coverage."
           }
         ]
       }


### PR DESCRIPTION
## Description
Dangling it.only tests skips other tests in the file and reduces our test coverage.

Added rule in .eslintrc to detect it.only calls in test files.
Cypress tests are named as `*_spec.js`, `*_Spec.js`, `*_spec.ts` and `*_Spec.ts`, whereas other tests follow the `*.test.js|ts|jsx` convention. So, I added this rule differently for Cypress and Default ESLint configuration.

#### PR fixes following issue(s)
Fixes #23708

#### Media

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
- [X] Manual

Test Cases:
- Cypress: Button_Text_WithRecaptcha_spec.js contains it.only test, which starts getting detected by ESLint after this change.
- Default: Randomly picked files (which has *.test.js, *.test.ts, or *.test.tsx extensions) and  changed some it tests to it.only tests. All these cases where detected by ESLint after this change.

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
