### PR TITLE
fix: Sort/Freeze control existing after they are disabled

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/component/TableStyledWrappers.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/TableStyledWrappers.tsx
@@ -298,6 +298,10 @@ export const TableWrapper = styled.div<{
       display: block;
     }
 
+    &.hide-menu {
+      display: none;
+    }
+
     &.hide {
       &:hover {
         .bp3-popover2-target {

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
@@ -266,7 +266,11 @@ const HeaderCellComponent = (props: HeaderProps) => {
           </Title>
         </ColumnNameContainer>
       </div>
-      <div className={`header-menu${!isMenuOpen ? " hide" : ""}`}>
+      <div
+        className={`header-menu ${
+          !isSortable && !props.canFreezeColumn && "hide-menu"
+        } ${!isMenuOpen && "hide"}`}
+      >
         <Popover2
           content={
             <Menu className={MENU_CONTENT_CLASS}>

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
@@ -268,7 +268,7 @@ const HeaderCellComponent = (props: HeaderProps) => {
       </div>
       <div
         className={`header-menu ${
-          disableSort && !props.canFreezeColumn && "hide-menu"
+          !isSortable && !props.canFreezeColumn && "hide-menu"
         } ${!isMenuOpen && "hide"}`}
       >
         <Popover2

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
@@ -268,7 +268,7 @@ const HeaderCellComponent = (props: HeaderProps) => {
       </div>
       <div
         className={`header-menu ${
-          !disableSort && !props.canFreezeColumn && "hide-menu"
+          disableSort && !props.canFreezeColumn && "hide-menu"
         } ${!isMenuOpen && "hide"}`}
       >
         <Popover2

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/HeaderCell.tsx
@@ -268,7 +268,7 @@ const HeaderCellComponent = (props: HeaderProps) => {
       </div>
       <div
         className={`header-menu ${
-          !isSortable && !props.canFreezeColumn && "hide-menu"
+          !disableSort && !props.canFreezeColumn && "hide-menu"
         } ${!isMenuOpen && "hide"}`}
       >
         <Popover2


### PR DESCRIPTION
## Description
Sort and Freeze controls where visible even after disabling them. This caused unwanted premature truncation of the header text.
Now, when both the controls are disabled, we don't see the freeze/sort drop-down.
#### PR fixes following issue(s)
Fixes #23200 
#### Media
[Screencast from 02-06-23 11:59:25 AM IST.webm](https://github.com/appsmithorg/appsmith/assets/48979376/b0381f6a-f596-4931-bf45-e7b397097091)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [X] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [x] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
