### PR TITLE
fix: Radio Group options are aligned with the label

### DIFF
--- a/app/client/src/widgets/RadioGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/component/index.tsx
@@ -64,6 +64,8 @@ const StyledRadioGroup = styled(RadioGroup)<StyledRadioGroupProps>`
         );
       }
     }
+
+    margin-bottom: 0;
   }
 
   .${Classes.SWITCH} {

--- a/app/client/src/widgets/RadioGroupWidget/component/index.tsx
+++ b/app/client/src/widgets/RadioGroupWidget/component/index.tsx
@@ -26,6 +26,11 @@ export const RadioGroupContainer = styled.div<RadioGroupContainerProps>`
     ${({ labelPosition }) =>
       labelPosition === LabelPosition.Left && "min-height: 30px"};
   }
+
+  ${({ compactMode, labelPosition }) =>
+    !compactMode &&
+    labelPosition === LabelPosition.Left &&
+    "align-items: center"};
 `;
 
 export interface StyledRadioGroupProps {


### PR DESCRIPTION
## Description
When the label is on the left of the radio widget, the options are aligned to the top of the container.

In this PR this issue is fixed.
#### PR fixes following issue(s)
Fixes #23847

#### Media

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
