### PR TITLE
fix: Added "children" to autocomplete list for multiTree and singleTree widgets

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
@@ -162,7 +162,7 @@ describe("Autocomplete bug fixes", function () {
     );
   });
 
-  it("2. Bug #13983 Verifies if 'children' shows up in autocomplete list", function () {
+  it("2. Bug #23641 Verifies if 'children' shows up in autocomplete list", function () {
     _.entityExplorer.DragDropWidgetNVerify(
       _.draggableWidgets.MULTITREESELECT,
       200,

--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
@@ -162,18 +162,18 @@ describe("Autocomplete bug fixes", function () {
     );
   });
 
-  it("2. Bug #23641 Verifies if 'children' shows up in autocomplete list", function () {
+  it("11. Bug #23641 Verifies if 'children' shows up in autocomplete list", function () {
     _.entityExplorer.DragDropWidgetNVerify(
       _.draggableWidgets.MULTITREESELECT,
-      200,
-      200,
+      400,
+      400,
     );
     _.entityExplorer.DragDropWidgetNVerify(
       _.draggableWidgets.TREESELECT,
-      400,
-      400,
+      600,
+      600,
     );
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TEXT, 600, 600);
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TEXT, 400, 600);
     _.entityExplorer.SelectEntityByName("Text1");
     _.propPane.TypeTextIntoField("Text", "{{TreeSelect1.options[0].c");
     _.agHelper.AssertElementExist(_.locators._hints);

--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
@@ -163,17 +163,20 @@ describe("Autocomplete bug fixes", function () {
   });
 
   it("11. Bug #23641 Verifies if 'children' shows up in autocomplete list", function () {
+    _.entityExplorer.NavigateToSwitcher("Widgets");
+    _.agHelper.SelectAllWidgets();
+    _.agHelper.PressDelete();
     _.entityExplorer.DragDropWidgetNVerify(
       _.draggableWidgets.MULTITREESELECT,
-      400,
-      400,
+      200,
+      200,
     );
     _.entityExplorer.DragDropWidgetNVerify(
       _.draggableWidgets.TREESELECT,
-      600,
-      600,
+      200,
+      400,
     );
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TEXT, 400, 600);
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TEXT, 200, 600);
     _.entityExplorer.SelectEntityByName("Text1");
     _.propPane.TypeTextIntoField("Text", "{{TreeSelect1.options[0].c");
     _.agHelper.AssertElementExist(_.locators._hints);

--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_Spec.ts
@@ -161,4 +161,34 @@ describe("Autocomplete bug fixes", function () {
       "console.log('hello')",
     );
   });
+
+  it("2. Bug #13983 Verifies if 'children' shows up in autocomplete list", function () {
+    _.entityExplorer.DragDropWidgetNVerify(
+      _.draggableWidgets.MULTITREESELECT,
+      200,
+      200,
+    );
+    _.entityExplorer.DragDropWidgetNVerify(
+      _.draggableWidgets.TREESELECT,
+      400,
+      400,
+    );
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TEXT, 600, 600);
+    _.entityExplorer.SelectEntityByName("Text1");
+    _.propPane.TypeTextIntoField("Text", "{{TreeSelect1.options[0].c");
+    _.agHelper.AssertElementExist(_.locators._hints);
+    _.agHelper.GetNAssertElementText(
+      _.locators._hints,
+      "children",
+      "contain.text",
+    );
+
+    _.propPane.TypeTextIntoField("Text", "{{MultiTreeSelect1.options[0].c");
+    _.agHelper.AssertElementExist(_.locators._hints);
+    _.agHelper.GetNAssertElementText(
+      _.locators._hints,
+      "children",
+      "contain.text",
+    );
+  });
 });

--- a/app/client/src/ce/utils/autocomplete/EntityDefinitions.ts
+++ b/app/client/src/ce/utils/autocomplete/EntityDefinitions.ts
@@ -72,6 +72,11 @@ export const GLOBAL_DEFS = {
     label: "string",
     value: "string",
   },
+  $__dropdrowOptionWithChildren__$: {
+    label: "string",
+    value: "string",
+    children: "[$__dropdrowOptionWithChildren__$]",
+  },
   $__chartDataPoint__$: {
     x: "string",
     y: "string",

--- a/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/MultiSelectTreeWidget/widget/index.tsx
@@ -71,7 +71,7 @@ class MultiSelectTreeWidget extends BaseWidget<
       },
       isDisabled: "bool",
       isValid: "bool",
-      options: "[$__dropdownOption__$]",
+      options: "[$__dropdrowOptionWithChildren__$]",
     };
   }
 

--- a/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
+++ b/app/client/src/widgets/SingleSelectTreeWidget/widget/index.tsx
@@ -490,7 +490,7 @@ class SingleSelectTreeWidget extends BaseWidget<
       },
       isDisabled: "bool",
       isValid: "bool",
-      options: "[$__dropdownOption__$]",
+      options: "[$__dropdrowOptionWithChildren__$]",
     };
   }
 


### PR DESCRIPTION
## Description
Added "children" to autocomplete list for multiTree and singleTree widgets

#### PR fixes following issue(s)
Fixes #23641
>
>
#### Media
<img width="288" alt="Screenshot 2023-06-05 at 12 24 10" src="https://github.com/appsmithorg/appsmith/assets/32433245/317a2d81-c7e5-4c12-bf03-c898f18a45f5">

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
