### PR TITLE
fix: Autocomplete trigger changes

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
@@ -422,7 +422,7 @@ describe("Autocomplete tests", () => {
     });
   });
 
-  it.only("10. Bug #10115 Autocomplete needs to show async await keywords instead of showing 'no suggestions'", () => {
+  it("10. Bug #10115 Autocomplete needs to show async await keywords instead of showing 'no suggestions'", () => {
     // create js object
     _.jsEditor.CreateJSObject(
       `export default 

--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
@@ -422,7 +422,7 @@ describe("Autocomplete tests", () => {
     });
   });
 
-  it("10. Bug #10115 Autocomplete needs to show async await keywords instead of showing 'no suggestions'", () => {
+  it("10. Bug #15429 Random keystrokes trigger autocomplete to show up", () => {
     // create js object
     _.jsEditor.CreateJSObject(
       `export default 

--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
@@ -440,25 +440,52 @@ describe("Autocomplete tests", () => {
       },
     );
 
-    _.agHelper.GetNClick(_.jsEditor._lineinJsEditor(4));
+    //Paste the code and assert that the hints are not present
+    _.jsEditor.CreateJSObject(`const x = "Hello world;"`, {
+      paste: true,
+      completeReplace: true,
+      toRun: false,
+      shouldCreateNewJSObj: false,
+      prettify: false,
+    });
 
-    _.agHelper.Paste(_.jsEditor._lineinJsEditor(4), "showA");
+    _.agHelper.AssertElementAbsence(_.locators._hints);
 
-    _.agHelper.GetNAssertElementText(
-      _.locators._hints,
-      "await",
-      "have.text",
-      0,
+    //Paste the code and assert that the hints are not present
+    _.jsEditor.CreateJSObject(
+      `export default 
+      myFunc1() {
+        showAlert("Hello world");
+
+      }
+    }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: false,
+        prettify: false,
+      },
     );
 
-    _.agHelper.TypeText(_.locators._codeMirrorTextArea, "{ctrl}{backspace}");
+    _.agHelper.AssertElementAbsence(_.locators._hints);
 
-    _.agHelper.GetNAssertElementText(
-      _.locators._hints,
-      "await",
-      "have.text",
-      0,
-    );
+    _.agHelper.GetElement(_.jsEditor._lineinJsEditor(4)).click();
+
+    //Assert that hints are not present inside the string
+    _.agHelper.TypeText(_.locators._codeMirrorTextArea, `const x = "`);
+
+    _.agHelper.AssertElementAbsence(_.locators._hints);
+
+    _.agHelper.SelectNRemoveLineText(_.jsEditor._lineinJsEditor(4));
+
+    //Assert that hints are not present when line is cleared with backspace
+    _.agHelper.AssertElementAbsence(_.locators._hints);
+
+    //Assert that hints are not present when token is a comment
+    _.agHelper.TypeText(_.locators._codeMirrorTextArea, "// showA'");
+
+    _.agHelper.AssertElementAbsence(_.locators._hints);
 
     cy.get("@jsObjName").then((jsObjName) => {
       jsName = jsObjName;

--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/Autocomplete_JS_spec.ts
@@ -421,4 +421,54 @@ describe("Autocomplete tests", () => {
       );
     });
   });
+
+  it.only("10. Bug #10115 Autocomplete needs to show async await keywords instead of showing 'no suggestions'", () => {
+    // create js object
+    _.jsEditor.CreateJSObject(
+      `export default 
+      myFunc1() {
+        showAlert("Hello world");
+
+      }
+    }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: true,
+        prettify: false,
+      },
+    );
+
+    _.agHelper.GetNClick(_.jsEditor._lineinJsEditor(4));
+
+    _.agHelper.Paste(_.jsEditor._lineinJsEditor(4), "showA");
+
+    _.agHelper.GetNAssertElementText(
+      _.locators._hints,
+      "await",
+      "have.text",
+      0,
+    );
+
+    _.agHelper.TypeText(_.locators._codeMirrorTextArea, "{ctrl}{backspace}");
+
+    _.agHelper.GetNAssertElementText(
+      _.locators._hints,
+      "await",
+      "have.text",
+      0,
+    );
+
+    cy.get("@jsObjName").then((jsObjName) => {
+      jsName = jsObjName;
+      _.entityExplorer.SelectEntityByName(jsName as string, "Queries/JS");
+      _.entityExplorer.ActionContextMenuByEntityName(
+        jsName as string,
+        "Delete",
+        "Are you sure?",
+        true,
+      );
+    });
+  });
 });

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -1283,6 +1283,14 @@ class CodeEditor extends Component<Props, State> {
     // Check if the user is trying to comment out the line, in that case we should not show autocomplete
     const isCtrlOrCmdPressed = event.metaKey || event.ctrlKey;
 
+    const isAltKeyPressed = event.altKey;
+
+    // If alt key is pressed, do not show autocomplete
+    // Windows and Linux use Alt + Enter to add a new line
+    // Alt key is used to enter non-english characters which are invalid entity names
+    // So we can safely disable autocomplete when alt key is pressed
+    if (isAltKeyPressed) return;
+
     if (isModifierKey(key)) return;
     const code = `${event.ctrlKey ? "Ctrl+" : ""}${event.code}`;
     if (isCloseKey(code) || isCloseKey(key)) {

--- a/app/client/src/components/editorComponents/CodeEditor/index.tsx
+++ b/app/client/src/components/editorComponents/CodeEditor/index.tsx
@@ -1292,13 +1292,19 @@ class CodeEditor extends Component<Props, State> {
     }
     const cursor = cm.getCursor();
     const line = cm.getLine(cursor.line);
+    const token = cm.getTokenAt(cursor);
     let showAutocomplete = false;
     const prevChar = line[cursor.ch - 1];
 
-    /* Check if the character before cursor is completable to show autocomplete which backspacing */
-    if (key === "/" && !isCtrlOrCmdPressed) {
+    // If the token is a comment or string, do not show autocomplete
+    if (token?.type && ["comment", "string"].includes(token.type)) return;
+    if (isCtrlOrCmdPressed) {
+      // If cmd or ctrl is pressed only show autocomplete for space key
+      showAutocomplete = key === " ";
+    } else if (key === "/") {
       showAutocomplete = true;
     } else if (event.code === "Backspace") {
+      /* Check if the character before cursor is completable to show autocomplete which backspacing */
       showAutocomplete = !!prevChar && /[a-zA-Z_0-9.]/.test(prevChar);
     } else if (key === "{") {
       /* Autocomplete for { should show up only when a user attempts to write {{}} and not a code block. */


### PR DESCRIPTION
## Description
PR to fix autocomplete trigger
- Disables autocomplete trigger when ctrl/meta/alt is pressed except for (ctrl/meta)+space.
- Disable autocomplete inside strings and comments

#### PR fixes following issue(s)
Fixes #15429

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [x] Cypress
>
#### Test Plan
- Keyboard shortcut check for autocomplete
- Copy paste action-based check
- autocomplete suggestions inside strings and comments

#### Issues raised during DP testing
https://github.com/appsmithorg/appsmith/pull/24025#issuecomment-1577062645
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [x] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [x] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [x] Cypress test cases have been added and approved by SDET/manual QA
- [x] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
