### PR TITLE
fix: ipv6 nginx startup error

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -383,6 +383,9 @@ init_postgres || runEmbeddedPostgres=0
 }
 
 init_loading_pages(){
+  # The default NGINX configuration includes an IPv6 listen directive. But not all
+  # servers support it, and we don't need it. So we remove it here before starting
+  # NGINX.
   sed -i '/\[::\]:80 default_server;/d' /etc/nginx/sites-enabled/default
   local starting_page="/opt/appsmith/templates/appsmith_starting.html"
   local initializing_page="/opt/appsmith/templates/appsmith_initializing.html"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -383,6 +383,7 @@ init_postgres || runEmbeddedPostgres=0
 }
 
 init_loading_pages(){
+  sed -i '/\[::\]:80 default_server;/d' /etc/nginx/sites-enabled/default
   local starting_page="/opt/appsmith/templates/appsmith_starting.html"
   local initializing_page="/opt/appsmith/templates/appsmith_initializing.html"
   local editor_load_page="/opt/appsmith/editor/loading.html" 


### PR DESCRIPTION
Fixes: [24013](https://github.com/appsmithorg/appsmith/issues/24013)
The issue started with the introduction of adding of startup-events. Because of the ipv6 header
```

server {
	listen 80 default_server;
        listen [::]:80 default_server;
}

```
 present in the 
`/etc/nginx/sites-enabled/default` and calling nginx [here](https://github.com/appsmithorg/appsmith/blob/release/deploy/docker/entrypoint.sh#L392). 

With this change we are removing ```listen [::]:80 default_server;``` from the file before starting nginx. 
