### PR TITLE
fix: show callback button in action selector cards for chainable actions by default

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Onboarding/GuidedTour_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Onboarding/GuidedTour_spec.js
@@ -98,7 +98,7 @@ describe("excludeForAirgap", "Guided Tour", function () {
       "Execute a query",
       "updateCustomerInfo.run",
     ),
-      cy.get(_.propPane._actionCallbacks).click();
+      cy.get(_.propPane._actionCallbacks).first().click();
     cy.get(_.propPane._actionAddCallback("success")).click().wait(500);
     cy.get(_.locators._dropDownValue("Execute a query"))
       .click()

--- a/app/client/cypress/support/commands.js
+++ b/app/client/cypress/support/commands.js
@@ -853,10 +853,10 @@ Cypress.Commands.add("closePropertyPane", () => {
 
 Cypress.Commands.add(
   "onClickActions",
-  (forSuccess, forFailure, actionType, actionValue) => {
+  (forSuccess, forFailure, actionType, actionValue, idx = 0) => {
     propPane.SelectActionByTitleAndValue(actionType, actionValue);
 
-    cy.get(propPane._actionCallbacks).click();
+    cy.get(propPane._actionCallbacks).last().click();
 
     // add a success callback
     cy.get(propPane._actionAddCallback("success")).click().wait(500);

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.test.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Provider } from "react-redux";
-import store from "store";
+import { testStore } from "store";
 import { ThemeProvider } from "styled-components";
 import { lightTheme } from "selectors/themeSelectors";
 import { render } from "@testing-library/react";
@@ -9,6 +9,7 @@ import type { TActionBlock } from "../../types";
 import { APPSMITH_GLOBAL_FUNCTIONS } from "../../constants";
 
 describe("tests for Action Tree in Action Selector", () => {
+  const store = testStore({});
   it("callback button is rendered for chainable actions", function () {
     const actionBlock: TActionBlock = {
       code: "showAlert('Hello')",

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.test.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Provider } from "react-redux";
+import store from "store";
+import { ThemeProvider } from "styled-components";
+import { lightTheme } from "selectors/themeSelectors";
+import { render } from "@testing-library/react";
+import ActionTree from "./ActionTree";
+import type { TActionBlock } from "../../types";
+import { APPSMITH_GLOBAL_FUNCTIONS } from "../../constants";
+
+describe("tests for Action Tree in Action Selector", () => {
+  it("callback button is rendered for chainable actions", function () {
+    const actionBlock: TActionBlock = {
+      code: "showAlert('Hello')",
+      actionType: APPSMITH_GLOBAL_FUNCTIONS.showAlert,
+      success: {
+        blocks: [],
+      },
+      error: {
+        blocks: [],
+      },
+    };
+    const component = render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <ActionTree
+            actionBlock={actionBlock}
+            id="xyz"
+            level={0}
+            onChange={() => {
+              return;
+            }}
+          />
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    const callbackBtn = component.queryByTestId("t--callback-btn-xyz");
+    expect(callbackBtn).not.toBeNull();
+  });
+
+  it("callback button should not be rendered for actions that are not chainable", function () {
+    const actionBlock: TActionBlock = {
+      code: "setInterval(() => showAlert('Hello'), 1000, 'test')",
+      actionType: APPSMITH_GLOBAL_FUNCTIONS.setInterval,
+      success: {
+        blocks: [],
+      },
+      error: {
+        blocks: [],
+      },
+    };
+    const component = render(
+      <Provider store={store}>
+        <ThemeProvider theme={lightTheme}>
+          <ActionTree
+            actionBlock={actionBlock}
+            id="xyz"
+            level={0}
+            onChange={() => {
+              return;
+            }}
+          />
+        </ThemeProvider>
+      </Provider>,
+    );
+
+    const callbackBtn = component.queryByTestId("t--callback-btn-xyz");
+    expect(callbackBtn).toBeNull();
+  });
+});

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.tsx
@@ -171,6 +171,7 @@ export default function ActionTree(props: {
       {areCallbacksApplicable ? (
         <CallbackButton
           className="callback-collapse flex w-full justify-between px-2 py-1 border-t-transparent t--action-callbacks"
+          data-testid={`t--callback-btn-${id}`}
           onClick={() => {
             setCallbacksExpanded((prev) => !prev);
           }}

--- a/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.tsx
+++ b/app/client/src/components/editorComponents/ActionCreator/viewComponents/Action/ActionTree.tsx
@@ -64,14 +64,11 @@ export default function ActionTree(props: {
     setActionBlock(props.actionBlock);
   }, [props.actionBlock]);
 
-  const [touched, setTouched] = React.useState(false);
-
   const [callbacksExpanded, setCallbacksExpanded] = React.useState(false);
 
   const handleCardSelection = useCallback(() => {
     if (selectedBlockId === id) return;
     selectBlock(id);
-    setTouched(true);
   }, [id, selectedBlockId]);
 
   useEffect(() => {
@@ -132,8 +129,6 @@ export default function ActionTree(props: {
     areCallbacksApplicable = callbacksCount > 0;
   }
 
-  const showCallbacks = selectedBlockId === id || touched;
-
   const callbackBlocks = [
     {
       label: "On success",
@@ -169,16 +164,15 @@ export default function ActionTree(props: {
           level={props.level}
           onSelect={handleCardSelection}
           selected={isOpen}
-          showCallbacks={showCallbacks && areCallbacksApplicable}
+          showCallbacks={areCallbacksApplicable}
           variant={props.variant}
         />
       </ActionSelector>
-      {showCallbacks && areCallbacksApplicable ? (
+      {areCallbacksApplicable ? (
         <CallbackButton
           className="callback-collapse flex w-full justify-between px-2 py-1 border-t-transparent t--action-callbacks"
           onClick={() => {
             setCallbacksExpanded((prev) => !prev);
-            setTouched(true);
           }}
         >
           <Text kind="action-s">Callbacks</Text>


### PR DESCRIPTION
## Description
show callback button in action selector cards for chain-able actions by default
- Removed touched state from ActionCard that tracks interaction on card.
- Added unit test to assert callback button render

#### Fixes #23857

#### Media
<img width="272" alt="Screenshot 2023-06-06 at 13 13 27" src="https://github.com/appsmithorg/appsmith/assets/32433245/17a98382-988f-4a62-b15f-a026aebf45b0">

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [x] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
