### PR TITLE
fix: connect datasource size issue in the generate page form

### DIFF
--- a/app/client/src/pages/Editor/GeneratePage/components/DataSourceOption.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/DataSourceOption.tsx
@@ -8,7 +8,7 @@ import type {
 } from "design-system-old";
 import { Classes, Text, TextType } from "design-system-old";
 import _ from "lodash";
-import { Tooltip, Button } from "design-system";
+import { Tooltip, Icon } from "design-system";
 import { getAssetUrl } from "@appsmith/utils/airgapHelpers";
 
 // ---------- Helpers and constants ----------
@@ -61,6 +61,12 @@ const ImageWrapper = styled.div`
 export const DatasourceImage = styled.img`
   height: 16px;
   width: 16px;
+`;
+
+const CreateIconWrapper = styled.div`
+  margin: 0px 8px 0px 0px;
+  cursor: pointer;
+  height: 16px;
 `;
 
 interface DataSourceOptionType extends RenderDropdownOptionType {
@@ -116,7 +122,9 @@ function DataSourceOption({
         width={optionWidth}
       >
         {isConnectNewDataSourceBtn ? (
-          <Button isIconButton kind="tertiary" size="md" startIcon="plus" />
+          <CreateIconWrapper>
+            <Icon name="plus" size="md" />
+          </CreateIconWrapper>
         ) : pluginImages[(dropdownOption as DropdownOption)?.data?.pluginId] ? (
           <ImageWrapper>
             <DatasourceImage


### PR DESCRIPTION
#### Description
Fixes the connect new data source button height issue in the generate page form.

Fixes https://github.com/appsmithorg/appsmith/issues/24167

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
- [ ] Manual
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
