### PR TITLE
chore: Log JS Function execution

### DIFF
--- a/app/client/src/ce/sagas/ActionExecution/ActionExecutionSagas.ts
+++ b/app/client/src/ce/sagas/ActionExecution/ActionExecutionSagas.ts
@@ -128,7 +128,7 @@ export function* executeAppAction(payload: ExecuteTriggerPayload): any {
     {
       source,
       triggerPropertyName,
-      triggerKind: TriggerKind.APP_ACTION_EXECUTION,
+      triggerKind: TriggerKind.EVENT_EXECUTION,
     },
     callbackData,
     globalContext,

--- a/app/client/src/ce/sagas/ActionExecution/ActionExecutionSagas.ts
+++ b/app/client/src/ce/sagas/ActionExecution/ActionExecutionSagas.ts
@@ -5,6 +5,7 @@ import type {
   ExecuteTriggerPayload,
   TriggerSource,
 } from "constants/AppsmithActionConstants/ActionConstants";
+import { TriggerKind } from "constants/AppsmithActionConstants/ActionConstants";
 import * as log from "loglevel";
 import { all, call, put, takeEvery, takeLatest } from "redux-saga/effects";
 import {
@@ -37,6 +38,7 @@ import type { ActionDescription } from "@appsmith/workers/Evaluation/fns";
 export type TriggerMeta = {
   source?: TriggerSource;
   triggerPropertyName?: string;
+  triggerKind?: TriggerKind;
 };
 
 /**
@@ -123,7 +125,11 @@ export function* executeAppAction(payload: ExecuteTriggerPayload): any {
     evaluateAndExecuteDynamicTrigger,
     dynamicString,
     type,
-    { source, triggerPropertyName },
+    {
+      source,
+      triggerPropertyName,
+      triggerKind: TriggerKind.APP_ACTION_EXECUTION,
+    },
     callbackData,
     globalContext,
   );

--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -26,6 +26,10 @@ export type TriggerSource = {
   isJSAction?: boolean;
   actionId?: string;
 };
+export enum TriggerKind {
+  APP_ACTION_EXECUTION = "APP_ACTION_EXECUTION", // Eg. Button onClick
+  JS_FUNCTION_EXECUTION = "JS_FUNCTION_EXECUTION", // Executing js function from jsObject page
+}
 
 export type ExecuteTriggerPayload = {
   dynamicString: string;

--- a/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
+++ b/app/client/src/constants/AppsmithActionConstants/ActionConstants.tsx
@@ -27,7 +27,7 @@ export type TriggerSource = {
   actionId?: string;
 };
 export enum TriggerKind {
-  APP_ACTION_EXECUTION = "APP_ACTION_EXECUTION", // Eg. Button onClick
+  EVENT_EXECUTION = "EVENT_EXECUTION", // Eg. Button onClick
   JS_FUNCTION_EXECUTION = "JS_FUNCTION_EXECUTION", // Executing js function from jsObject page
 }
 

--- a/app/client/src/sagas/EvalWorkerActionSagas.ts
+++ b/app/client/src/sagas/EvalWorkerActionSagas.ts
@@ -30,6 +30,7 @@ export type UpdateDataTreeMessageData = {
 
 import { sortJSExecutionDataByCollectionId } from "workers/Evaluation/JSObject/utils";
 import type { LintTreeSagaRequestData } from "workers/Linting/types";
+import AnalyticsUtil from "utils/AnalyticsUtil";
 
 export function* handleEvalWorkerRequestSaga(listenerChannel: Channel<any>) {
   while (true) {
@@ -109,6 +110,19 @@ export function* processTriggerHandler(message: any) {
   );
   if (messageType === MessageType.REQUEST)
     yield call(evalWorker.respond, message.messageId, result);
+}
+export function* handleJSExecutionLog(data: TMessage<{ data: string[] }>) {
+  const {
+    body: { data: executedFns },
+  } = data;
+
+  for (const executedFn of executedFns) {
+    AnalyticsUtil.logEvent("EXECUTE_ACTION", {
+      type: "JS",
+      name: executedFn,
+    });
+  }
+  yield call(logJSFunctionExecution, data);
 }
 
 export function* handleEvalWorkerMessage(message: TMessage<any>) {

--- a/app/client/src/sagas/EvalWorkerActionSagas.ts
+++ b/app/client/src/sagas/EvalWorkerActionSagas.ts
@@ -150,7 +150,7 @@ export function* handleEvalWorkerMessage(message: TMessage<any>) {
       break;
     }
     case MAIN_THREAD_ACTION.LOG_JS_FUNCTION_EXECUTION: {
-      yield call(logJSFunctionExecution, message);
+      yield call(handleJSExecutionLog, message);
       break;
     }
     case MAIN_THREAD_ACTION.PROCESS_BATCHED_TRIGGERS: {

--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -65,7 +65,10 @@ import {
 } from "actions/globalSearchActions";
 import type { TriggerMeta } from "@appsmith/sagas/ActionExecution/ActionExecutionSagas";
 import { executeActionTriggers } from "@appsmith/sagas/ActionExecution/ActionExecutionSagas";
-import { EventType } from "constants/AppsmithActionConstants/ActionConstants";
+import {
+  EventType,
+  TriggerKind,
+} from "constants/AppsmithActionConstants/ActionConstants";
 import {
   createMessage,
   SNIPPET_EXECUTION_FAILED,
@@ -401,6 +404,7 @@ function* executeAsyncJSFunction(
       type: ENTITY_TYPE.JSACTION,
     },
     triggerPropertyName: `${collectionName}.${action.name}`,
+    triggerKind: TriggerKind.JS_FUNCTION_EXECUTION,
   };
   const eventType = EventType.ON_JS_FUNCTION_EXECUTE;
   const response: JSFunctionExecutionResponse = yield call(

--- a/app/client/src/workers/Evaluation/fns/utils/ExecutionMetaData.ts
+++ b/app/client/src/workers/Evaluation/fns/utils/ExecutionMetaData.ts
@@ -23,11 +23,13 @@ export default class ExecutionMetaData {
     }
   }
   static getExecutionMetaData() {
-    const { source, triggerPropertyName } = ExecutionMetaData.triggerMeta || {};
+    const { source, triggerKind, triggerPropertyName } =
+      ExecutionMetaData.triggerMeta || {};
     return {
       triggerMeta: {
         source: { ...source } as TriggerSource,
         triggerPropertyName,
+        triggerKind,
       },
       eventType: ExecutionMetaData.eventType,
       enableJSVarUpdateTracking: ExecutionMetaData.enableJSVarUpdateTracking,

--- a/app/client/src/workers/Evaluation/fns/utils/TriggerEmitter.ts
+++ b/app/client/src/workers/Evaluation/fns/utils/TriggerEmitter.ts
@@ -147,13 +147,15 @@ TriggerEmitter.on(
   jsVariableUpdatesHandlerWrapper,
 );
 
-export const fnInvokeLogHandler = priorityBatchedActionHandler((data) => {
-  const set = new Set([...data]);
-  WorkerMessenger.ping({
-    method: MAIN_THREAD_ACTION.LOG_JS_FUNCTION_EXECUTION,
-    data: [...set],
-  });
-});
+export const fnInvokeLogHandler = priorityBatchedActionHandler<string>(
+  (data) => {
+    const set = new Set([...data]);
+    WorkerMessenger.ping({
+      method: MAIN_THREAD_ACTION.LOG_JS_FUNCTION_EXECUTION,
+      data: [...set],
+    });
+  },
+);
 
 TriggerEmitter.on(BatchKey.process_batched_fn_invoke_log, fnInvokeLogHandler);
 

--- a/app/client/src/workers/Evaluation/fns/utils/jsObjectFnFactory.ts
+++ b/app/client/src/workers/Evaluation/fns/utils/jsObjectFnFactory.ts
@@ -36,7 +36,7 @@ function saveExecutionData({
 
 function logJSExecution({ executionMetaData, jsFnFullName }: PostProcessorArg) {
   switch (executionMetaData.triggerMeta.triggerKind) {
-    case TriggerKind.APP_ACTION_EXECUTION: {
+    case TriggerKind.EVENT_EXECUTION: {
       TriggerEmitter.emit(BatchKey.process_batched_fn_invoke_log, jsFnFullName);
       break;
     }

--- a/app/client/src/workers/Evaluation/fns/utils/jsObjectFnFactory.ts
+++ b/app/client/src/workers/Evaluation/fns/utils/jsObjectFnFactory.ts
@@ -2,6 +2,7 @@ import { isPromise } from "workers/Evaluation/JSObject/utils";
 import { postJSFunctionExecutionLog } from "@appsmith/workers/Evaluation/JSObject/postJSFunctionExecution";
 import TriggerEmitter, { BatchKey } from "./TriggerEmitter";
 import ExecutionMetaData from "./ExecutionMetaData";
+import { TriggerKind } from "constants/AppsmithActionConstants/ActionConstants";
 
 declare global {
   interface Window {
@@ -11,48 +12,91 @@ declare global {
     ) => any;
   }
 }
+export type PostProcessorArg = {
+  executionMetaData: ReturnType<typeof ExecutionMetaData.getExecutionMetaData>;
+  jsFnFullName: string;
+  executionResponse: unknown;
+};
+
+export type PostProcessor = (args: PostProcessorArg) => void;
 export interface JSExecutionData {
   data: unknown;
   funcName: string;
 }
 
-function saveExecutionData(name: string, data: unknown) {
+function saveExecutionData({
+  executionResponse,
+  jsFnFullName,
+}: PostProcessorArg) {
   TriggerEmitter.emit(BatchKey.process_batched_fn_execution, {
-    name,
-    data,
+    name: jsFnFullName,
+    data: executionResponse,
   });
+}
+
+function logJSExecution({ executionMetaData, jsFnFullName }: PostProcessorArg) {
+  switch (executionMetaData.triggerMeta.triggerKind) {
+    case TriggerKind.APP_ACTION_EXECUTION: {
+      TriggerEmitter.emit(BatchKey.process_batched_fn_invoke_log, jsFnFullName);
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+  postJSFunctionExecutionLog(jsFnFullName);
 }
 
 export function jsObjectFunctionFactory<P extends ReadonlyArray<unknown>>(
   fn: (...args: P) => unknown,
   name: string,
-  postProcessors: Array<(name: string, res: unknown) => void> = [
-    saveExecutionData,
-    postJSFunctionExecutionLog,
-  ],
+  postProcessors: PostProcessor[] = [saveExecutionData, logJSExecution],
 ) {
   return function (this: unknown, ...args: P) {
     if (!ExecutionMetaData.getExecutionMetaData().enableJSFnPostProcessors) {
       return fn.call(this, ...args);
     }
+    const executionMetaData = ExecutionMetaData.getExecutionMetaData();
     try {
       const result = fn.call(this, ...args);
       if (isPromise(result)) {
         result.then((res) => {
-          postProcessors.forEach((p) => p(name, res));
+          postProcessors.forEach((p) =>
+            p({
+              executionMetaData,
+              jsFnFullName: name,
+              executionResponse: res,
+            }),
+          );
           return res;
         });
         result.catch((e) => {
-          postProcessors.forEach((p) => p(name, undefined));
+          postProcessors.forEach((p) =>
+            p({
+              executionMetaData,
+              jsFnFullName: name,
+              executionResponse: undefined,
+            }),
+          );
           throw e;
         });
       } else {
-        postProcessors.forEach((p) => p(name, result));
+        postProcessors.forEach((p) =>
+          p({
+            executionMetaData,
+            jsFnFullName: name,
+            executionResponse: result,
+          }),
+        );
       }
       return result;
     } catch (e) {
       postProcessors.forEach((postProcessor) => {
-        postProcessor(name, undefined);
+        postProcessor({
+          executionMetaData,
+          jsFnFullName: name,
+          executionResponse: undefined,
+        });
       });
       throw e;
     }


### PR DESCRIPTION
## Description

This PR introduces logging of js function execution

#### PR fixes following issue(s)
Fixes #23995 

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
