### PR TITLE
fix: Text and icon align in dropdown propety control having both name and symbol

### DIFF
--- a/app/client/src/index.css
+++ b/app/client/src/index.css
@@ -248,3 +248,9 @@ div.bp3-popover-arrow {
 .reconnect-datasource-modal {
   z-index: 9 !important;
 }
+
+.ads-v2-select .rc-select-selector .rc-select-selection-item {
+  /* Currently added this fix. Maybe we need to fix it in design-system "Select" component */
+  display: flex !important;
+  gap: var(--ads-v2-spaces-3);
+}


### PR DESCRIPTION
## Description
This PR fixes the alignment of properties containing both name and symbol in the dropdown in property control.
#### PR fixes following issue(s)
Fixes #23859

#### Media

https://github.com/appsmithorg/appsmith/assets/85070570/899133c9-1a01-486d-b264-32010750de43


#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
