### PR TITLE
fix: NPE when TLS option not set at all

### DIFF
--- a/app/client/src/pages/Settings/config/email.ts
+++ b/app/client/src/pages/Settings/config/email.ts
@@ -109,7 +109,8 @@ export const config: AdminConfigType = {
                 smtpHost: settings["APPSMITH_MAIL_HOST"],
                 smtpPort: settings["APPSMITH_MAIL_PORT"],
                 fromEmail: settings["APPSMITH_MAIL_FROM"],
-                starttlsEnabled: settings["APPSMITH_MAIL_SMTP_TLS_ENABLED"],
+                starttlsEnabled:
+                  settings["APPSMITH_MAIL_SMTP_TLS_ENABLED"] || false,
                 username: settings["APPSMITH_MAIL_USERNAME"],
                 password: settings["APPSMITH_MAIL_PASSWORD"],
               },


### PR DESCRIPTION
When TLS option is not set at all on the backend's env variables, this value ends up being `null` in the frontend. This means the initial value for this will be `null` instead of `false`. But since the backend is expecting `true` or `false` here, it breaks when it sees a `null`.

We fix it by ensuring we always sent a concrete value, `false`, if we encounter a `null` or other such `false`-y values.
