### PR TITLE
chore: fix ipv6 nginx startup error

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -381,7 +381,7 @@ init_loading_pages(){
   # The default NGINX configuration includes an IPv6 listen directive. But not all
   # servers support it, and we don't need it. So we remove it here before starting
   # NGINX. 
-  sed -i '/\[::\]:80 default_server;/d' /etc/nginx/sites-enabled/default  
+  sed -i '/\[::\]:80 default_server;/d' /etc/nginx/sites-available/default  
   local starting_page="/opt/appsmith/templates/appsmith_starting.html"
   local initializing_page="/opt/appsmith/templates/appsmith_initializing.html"
   local editor_load_page="/opt/appsmith/editor/loading.html" 

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -378,6 +378,10 @@ init_postgres || runEmbeddedPostgres=0
 }
 
 init_loading_pages(){
+  # The default NGINX configuration includes an IPv6 listen directive. But not all
+  # servers support it, and we don't need it. So we remove it here before starting
+  # NGINX. 
+  sed -i '/\[::\]:80 default_server;/d' /etc/nginx/sites-enabled/default  
   local starting_page="/opt/appsmith/templates/appsmith_starting.html"
   local initializing_page="/opt/appsmith/templates/appsmith_initializing.html"
   local editor_load_page="/opt/appsmith/editor/loading.html" 


### PR DESCRIPTION
Fixes: [24013](https://github.com/appsmithorg/appsmith/issues/24013)
The issue started with the introduction of adding of startup-events.
Because of the ipv6 header
```

server {
	listen 80 default_server;
        listen [::]:80 default_server;
}

```
 present in the 
`/etc/nginx/sites-enabled/default` and calling nginx
[here](https://github.com/appsmithorg/appsmith/blob/release/deploy/docker/entrypoint.sh#L392).

With this change we are removing ```listen [::]:80 default_server;```
from the file before starting nginx.

<img src="https://front.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_b69u4)