### PR TITLE
chore: Adding eslint rule for @appsmith imports

### DIFF
--- a/app/client/.eslintrc.js
+++ b/app/client/.eslintrc.js
@@ -42,6 +42,10 @@ const eslintConfig = {
             message:
               "Reason: Please don’t import Remix icons statically. (They won’t always be needed, but they *will* always be present in the bundle and will increase the bundle size.) Instead, please use the importRemixIcon wrapper from design-system-old (e.g. const StarIcon = importRemixIcon(() => import('remixicon-react/Star'))).",
           },
+          {
+            group: ["**/ce/*"],
+            message: "Reason: Please use @appsmith import instead.",
+          },
         ],
       },
     ],

--- a/app/client/src/ee/.eslintrc
+++ b/app/client/src/ee/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-restricted-imports": "off"
+  }
+}


### PR DESCRIPTION
## Description

Adding eslint rule for `@appsmith` imports to avoid a set of merge conflicts on community sync with the business edition repo.

#### PR fixes following issue(s)
Fixes [#24183](https://github.com/appsmithorg/appsmith/issues/24183)

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
