### PR TITLE
fix: WDS colors `bgAccent*`

### DIFF
--- a/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
@@ -9,15 +9,16 @@ export class DarkModeTheme implements ColorModeTheme {
   private readonly seedLightness: number;
   private readonly seedChroma: number;
   private readonly seedHue: number;
-  private readonly seedIsVeryDark: boolean;
   private readonly seedIsAchromatic: boolean;
-
-  constructor(color: ColorTypes) {
+  private readonly seedIsCold: boolean;
+  private readonly seedIsVeryDark: boolean;
+  constructor(private color: ColorTypes) {
     const {
       chroma,
       color: seedColor,
       hue,
       isAchromatic,
+      isCold,
       isVeryDark,
       lightness,
     } = new ColorsAccessor(color);
@@ -25,8 +26,9 @@ export class DarkModeTheme implements ColorModeTheme {
     this.seedLightness = lightness;
     this.seedChroma = chroma;
     this.seedHue = hue;
-    this.seedIsVeryDark = isVeryDark;
     this.seedIsAchromatic = isAchromatic;
+    this.seedIsCold = isCold;
+    this.seedIsVeryDark = isVeryDark;
   }
 
   public getColors = () => {
@@ -87,7 +89,53 @@ export class DarkModeTheme implements ColorModeTheme {
   }
 
   private get bgAccentHover() {
-    return this.bgAccent.clone().lighten(0.06);
+    const color = this.bgAccent.clone();
+
+    if (this.seedLightness < 0.3) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.05;
+    }
+
+    if (this.seedLightness >= 0.3 && this.seedLightness < 0.45) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.04;
+    }
+
+    if (this.seedLightness >= 0.45 && this.seedLightness < 0.77) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.03;
+    }
+
+    if (
+      this.seedLightness >= 0.77 &&
+      this.seedLightness < 0.85 &&
+      !this.seedIsAchromatic &&
+      this.seedIsCold
+    ) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.04;
+      color.oklch.c = this.bgAccent.oklch.c + 0.05;
+    }
+
+    if (
+      this.seedLightness >= 0.77 &&
+      this.seedLightness < 0.85 &&
+      !this.seedIsAchromatic &&
+      !this.seedIsCold
+    ) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.06;
+      color.oklch.c = this.bgAccent.oklch.c + 0.1;
+    }
+
+    if (
+      this.seedLightness >= 0.77 &&
+      this.seedLightness < 0.85 &&
+      this.seedIsAchromatic
+    ) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.04;
+    }
+
+    if (this.seedLightness >= 0.85) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.07;
+    }
+
+    return color;
   }
 
   private get bgAccentActive() {

--- a/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
@@ -12,6 +12,7 @@ export class DarkModeTheme implements ColorModeTheme {
   private readonly seedIsAchromatic: boolean;
   private readonly seedIsCold: boolean;
   private readonly seedIsVeryDark: boolean;
+
   constructor(private color: ColorTypes) {
     const {
       chroma,

--- a/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
@@ -139,7 +139,27 @@ export class DarkModeTheme implements ColorModeTheme {
   }
 
   private get bgAccentActive() {
-    return this.bgAccentHover.clone().darken(0.1);
+    const color = this.bgAccent.clone();
+
+    console.log("seed lightness: " + this.seedLightness);
+
+    if (this.seedLightness < 0.4) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.02;
+    }
+
+    if (this.seedLightness >= 0.4 && this.seedLightness < 0.7) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.04;
+    }
+
+    if (this.seedLightness >= 0.7 && this.seedLightness < 0.85) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.05;
+    }
+
+    if (this.seedLightness >= 0.85) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.13;
+    }
+
+    return color;
   }
 
   // used only for generating child colors, not used as a token

--- a/app/client/packages/design-system/theming/src/color/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/LightModeTheme.ts
@@ -11,6 +11,7 @@ export class LightModeTheme implements ColorModeTheme {
   private readonly seedHue: number;
   private readonly seedIsAchromatic: boolean;
   private readonly seedIsCold: boolean;
+  private readonly seedIsRed: boolean;
   private readonly seedIsVeryLight: boolean;
   private readonly seedIsYellow: boolean;
 
@@ -21,6 +22,7 @@ export class LightModeTheme implements ColorModeTheme {
       hue,
       isAchromatic,
       isCold,
+      isRed,
       isVeryLight,
       isYellow,
       lightness,
@@ -31,6 +33,7 @@ export class LightModeTheme implements ColorModeTheme {
     this.seedHue = hue;
     this.seedIsAchromatic = isAchromatic;
     this.seedIsCold = isCold;
+    this.seedIsRed = isRed;
     this.seedIsVeryLight = isVeryLight;
     this.seedIsYellow = isYellow;
   }
@@ -49,16 +52,16 @@ export class LightModeTheme implements ColorModeTheme {
       fg: this.fg.toString(),
       fgAccent: this.fgAccent.toString(),
       fgOnAccent: this.fgOnAccent.toString(),
-      fgOnAssistive: this.fgOnAssistive.toString(),
       fgNeutral: this.fgNeutral.toString(),
       fgPositive: this.fgPositive,
       fgWarn: this.fgWarn,
       fgNegative: this.fgNegative,
+      fgOnAssistive: this.fgOnAssistive.toString(),
       // bd
       bdAccent: this.bdAccent.toString(),
+      bdFocus: this.bdFocus.toString(),
       bdNeutral: this.bdNeutral.toString(),
       bdNeutralHover: this.bdNeutralHover.toString(),
-      bdFocus: this.bdFocus.toString(),
       bdNegative: this.bdNegative,
       bdNegativeHover: this.bdNegativeHover,
     };
@@ -107,19 +110,19 @@ export class LightModeTheme implements ColorModeTheme {
     const color = this.bgAccent.clone();
 
     if (this.seedLightness < 0.06) {
-      color.oklch.l = this.seedLightness + 0.28;
+      color.oklch.l = this.bgAccent.oklch.l + 0.28;
     }
 
     if (this.seedLightness > 0.06 && this.seedLightness < 0.14) {
-      color.oklch.l = this.seedLightness + 0.2;
+      color.oklch.l = this.bgAccent.oklch.l + 0.2;
     }
 
     if (
       this.seedLightness >= 0.14 &&
-      this.seedLightness < 0.25 &&
+      this.seedLightness < 0.21 &&
       this.seedIsCold
     ) {
-      color.oklch.l = this.seedLightness + 0.1;
+      color.oklch.l = this.bgAccent.oklch.l + 0.1;
     }
 
     if (
@@ -127,19 +130,19 @@ export class LightModeTheme implements ColorModeTheme {
       this.seedLightness < 0.21 &&
       !this.seedIsCold
     ) {
-      color.oklch.l = this.seedLightness + 0.13;
+      color.oklch.l = this.bgAccent.oklch.l + 0.13;
     }
 
     if (this.seedLightness >= 0.21 && this.seedLightness < 0.4) {
-      color.oklch.l = this.seedLightness + 0.09;
+      color.oklch.l = this.bgAccent.oklch.l + 0.09;
     }
 
     if (this.seedLightness >= 0.4 && this.seedLightness < 0.7) {
-      color.oklch.l = this.seedLightness + 0.05;
+      color.oklch.l = this.bgAccent.oklch.l + 0.05;
     }
 
     if (this.seedLightness >= 0.7) {
-      color.oklch.l = this.seedLightness + 0.03;
+      color.oklch.l = this.bgAccent.oklch.l + 0.03;
     }
 
     if (this.seedIsVeryLight && this.seedIsYellow) {
@@ -161,15 +164,15 @@ export class LightModeTheme implements ColorModeTheme {
     const color = this.bgAccent.clone();
 
     if (this.seedLightness < 0.4) {
-      color.oklch.l = this.seedLightness - 0.04;
+      color.oklch.l = this.bgAccent.oklch.l - 0.04;
     }
 
     if (this.seedLightness >= 0.4 && this.seedLightness < 0.7) {
-      color.oklch.l = this.seedLightness - 0.02;
+      color.oklch.l = this.bgAccent.oklch.l - 0.02;
     }
 
     if (this.seedLightness >= 0.7) {
-      color.oklch.l = this.seedLightness - 0.01;
+      color.oklch.l = this.bgAccent.oklch.l - 0.01;
     }
 
     if (this.seedIsVeryLight) {
@@ -214,6 +217,27 @@ export class LightModeTheme implements ColorModeTheme {
 
   private get bgAssistive() {
     return this.fg.clone();
+  }
+
+  private get bgNegative() {
+    const color = this.bgAccent.clone();
+
+    color.oklch.h = 40;
+
+    if (this.seedIsRed) {
+      if (this.seedColor.oklch.h < 39) {
+        color.oklch.h = 50;
+      }
+      if (this.seedColor.oklch.h >= 39) {
+        color.oklch.h = 29;
+      }
+    }
+
+    if (color.oklch.c < 0.19) {
+      color.oklch.c = 0.19;
+    }
+
+    return color;
   }
 
   /*
@@ -285,7 +309,13 @@ export class LightModeTheme implements ColorModeTheme {
   }
 
   private get fgNegative() {
-    return "#d91921";
+    const color = this.bgNegative.clone();
+
+    if (this.bg.contrastAPCA(color) < 60) {
+      color.oklch.l = 50;
+    }
+
+    return color;
   }
 
   private get fgOnAssistive() {
@@ -308,6 +338,52 @@ export class LightModeTheme implements ColorModeTheme {
       color.oklch.l = 0.55;
       color.oklch.c = 0.25;
       return color;
+    }
+
+    return color;
+  }
+
+  private get bdFocus() {
+    const color = this.seedColor.clone();
+
+    color.oklch.h = this.seedHue - 180;
+
+    if (this.seedLightness > 0.7) {
+      color.oklch.l = 0.7;
+    }
+
+    return color;
+  }
+
+  private get bdNegative() {
+    const color = this.bdAccent.clone();
+
+    color.oklch.h = this.bgNegative.oklch.h;
+
+    if (color.oklch.c < 0.19) {
+      color.oklch.c = 0.19;
+    }
+
+    return color;
+  }
+
+  private get bdNegativeHover() {
+    const color = this.bdNegative.clone();
+
+    if (this.bdNegative.oklch.l < 0.06) {
+      color.oklch.l = color.oklch.l + 0.6;
+    }
+
+    if (this.bdNegative.oklch.l >= 0.06 && this.bdNegative.oklch.l < 0.25) {
+      color.oklch.l = color.oklch.l + 0.4;
+    }
+
+    if (this.bdNegative.oklch.l >= 0.25 && this.bdNegative.oklch.l < 0.5) {
+      color.oklch.l = color.oklch.l + 0.25;
+    }
+
+    if (this.bdNegative.oklch.l >= 0.5) {
+      color.oklch.l = color.oklch.l + 0.1;
     }
 
     return color;
@@ -349,25 +425,5 @@ export class LightModeTheme implements ColorModeTheme {
     }
 
     return color;
-  }
-
-  private get bdFocus() {
-    const color = this.seedColor.clone();
-
-    color.oklch.h = this.seedHue - 180;
-
-    if (this.seedLightness > 0.7) {
-      color.oklch.l = 0.7;
-    }
-
-    return color;
-  }
-
-  private get bdNegative() {
-    return "#d91921";
-  }
-
-  private get bdNegativeHover() {
-    return "#b90707";
   }
 }


### PR DESCRIPTION
## Description

tl;dr Better logic and looks for dark mode `bgAccent*`, using correct reference lightness in light mode 

Fixes #24033 #24209   

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual

### Test Plan
Initial POC refinement, no testing necessary

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
