### PR TITLE
Fix/wds color bgaccent

### DIFF
--- a/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
@@ -9,8 +9,9 @@ export class DarkModeTheme implements ColorModeTheme {
   private readonly seedLightness: number;
   private readonly seedChroma: number;
   private readonly seedHue: number;
-  private readonly seedIsVeryDark: boolean;
   private readonly seedIsAchromatic: boolean;
+  private readonly seedIsCold: boolean;
+  private readonly seedIsVeryDark: boolean;
 
   constructor(color: ColorTypes) {
     const {
@@ -18,6 +19,7 @@ export class DarkModeTheme implements ColorModeTheme {
       color: seedColor,
       hue,
       isAchromatic,
+      isCold,
       isVeryDark,
       lightness,
     } = new ColorsAccessor(color);
@@ -25,6 +27,7 @@ export class DarkModeTheme implements ColorModeTheme {
     this.seedLightness = lightness;
     this.seedChroma = chroma;
     this.seedHue = hue;
+    this.seedIsCold = isCold;
     this.seedIsVeryDark = isVeryDark;
     this.seedIsAchromatic = isAchromatic;
   }
@@ -87,11 +90,75 @@ export class DarkModeTheme implements ColorModeTheme {
   }
 
   private get bgAccentHover() {
-    return this.bgAccent.clone().lighten(0.06);
+    const color = this.bgAccent.clone();
+
+    if (this.seedLightness < 0.3) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.05;
+    }
+
+    if (this.seedLightness >= 0.3 && this.seedLightness < 0.45) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.04;
+    }
+
+    if (this.seedLightness >= 0.45 && this.seedLightness < 0.77) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.03;
+    }
+
+    if (
+      this.seedLightness >= 0.77 &&
+      this.seedLightness < 0.85 &&
+      !this.seedIsAchromatic &&
+      this.seedIsCold
+    ) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.04;
+      color.oklch.c = this.bgAccent.oklch.c + 0.05;
+    }
+
+    if (
+      this.seedLightness >= 0.77 &&
+      this.seedLightness < 0.85 &&
+      !this.seedIsAchromatic &&
+      !this.seedIsCold
+    ) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.06;
+      color.oklch.c = this.bgAccent.oklch.c + 0.1;
+    }
+
+    if (
+      this.seedLightness >= 0.77 &&
+      this.seedLightness < 0.85 &&
+      this.seedIsAchromatic
+    ) {
+      color.oklch.l = this.bgAccent.oklch.l + 0.04;
+    }
+
+    if (this.seedLightness >= 0.85) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.07;
+    }
+
+    return color;
   }
 
   private get bgAccentActive() {
-    return this.bgAccentHover.clone().darken(0.1);
+    const color = this.bgAccent.clone();
+
+    if (this.seedLightness < 0.4) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.02;
+    }
+
+    if (this.seedLightness >= 0.4 && this.seedLightness < 0.7) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.04;
+    }
+
+    if (this.seedLightness >= 0.7 && this.seedLightness < 0.85) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.05;
+    }
+
+    if (this.seedLightness >= 0.85) {
+      color.oklch.l = this.bgAccent.oklch.l - 0.13;
+    }
+
+    return color;
   }
 
   // used only for generating child colors, not used as a token

--- a/app/client/packages/design-system/theming/src/color/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/LightModeTheme.ts
@@ -107,11 +107,11 @@ export class LightModeTheme implements ColorModeTheme {
     const color = this.bgAccent.clone();
 
     if (this.seedLightness < 0.06) {
-      color.oklch.l = this.seedLightness + 0.28;
+      color.oklch.l = this.bgAccent.oklch.l + 0.28;
     }
 
     if (this.seedLightness > 0.06 && this.seedLightness < 0.14) {
-      color.oklch.l = this.seedLightness + 0.2;
+      color.oklch.l = this.bgAccent.oklch.l + 0.2;
     }
 
     if (
@@ -119,7 +119,7 @@ export class LightModeTheme implements ColorModeTheme {
       this.seedLightness < 0.25 &&
       this.seedIsCold
     ) {
-      color.oklch.l = this.seedLightness + 0.1;
+      color.oklch.l = this.bgAccent.oklch.l + 0.1;
     }
 
     if (
@@ -127,19 +127,19 @@ export class LightModeTheme implements ColorModeTheme {
       this.seedLightness < 0.21 &&
       !this.seedIsCold
     ) {
-      color.oklch.l = this.seedLightness + 0.13;
+      color.oklch.l = this.bgAccent.oklch.l + 0.13;
     }
 
     if (this.seedLightness >= 0.21 && this.seedLightness < 0.4) {
-      color.oklch.l = this.seedLightness + 0.09;
+      color.oklch.l = this.bgAccent.oklch.l + 0.09;
     }
 
     if (this.seedLightness >= 0.4 && this.seedLightness < 0.7) {
-      color.oklch.l = this.seedLightness + 0.05;
+      color.oklch.l = this.bgAccent.oklch.l + 0.05;
     }
 
     if (this.seedLightness >= 0.7) {
-      color.oklch.l = this.seedLightness + 0.03;
+      color.oklch.l = this.bgAccent.oklch.l + 0.03;
     }
 
     if (this.seedIsVeryLight && this.seedIsYellow) {
@@ -161,15 +161,15 @@ export class LightModeTheme implements ColorModeTheme {
     const color = this.bgAccent.clone();
 
     if (this.seedLightness < 0.4) {
-      color.oklch.l = this.seedLightness - 0.04;
+      color.oklch.l = this.bgAccent.oklch.l - 0.04;
     }
 
     if (this.seedLightness >= 0.4 && this.seedLightness < 0.7) {
-      color.oklch.l = this.seedLightness - 0.02;
+      color.oklch.l = this.bgAccent.oklch.l - 0.02;
     }
 
     if (this.seedLightness >= 0.7) {
-      color.oklch.l = this.seedLightness - 0.01;
+      color.oklch.l = this.bgAccent.oklch.l - 0.01;
     }
 
     if (this.seedIsVeryLight) {


### PR DESCRIPTION
## Description

tl;dr Better logic and looks for dark mode `bgAccent*`, using correct reference lightness in light mode 

Fixes #24033 #24209   

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual

### Test Plan
Initial POC refinement, no testing necessary

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
