### PR TITLE
chore: expand the widget so that the cell edit icon is visible

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/mongoDB_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/mongoDB_spec.ts
@@ -6,7 +6,7 @@ const oneClickBinding = new OneClickBinding();
 
 describe("one click binding mongodb datasource", function () {
   before(() => {
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE, 400);
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE, 800);
   });
 
   it("1. test connect datasource", () => {

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/mongoDB_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/TableWidget/mongoDB_spec.ts
@@ -6,7 +6,7 @@ const oneClickBinding = new OneClickBinding();
 
 describe("one click binding mongodb datasource", function () {
   before(() => {
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE, 800);
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE, 800, 800);
   });
 
   it("1. test connect datasource", () => {

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1443,7 +1443,9 @@ Cypress.Commands.add("hoverTableCell", (x, y) => {
 });
 
 Cypress.Commands.add("editTableCell", (x, y) => {
-  cy.get(`[data-colindex="${x}"][data-rowindex="${y}"] .t--editable-cell-icon`)
+  cy.get(
+    `[data-colindex="${x}"][data-rowindex="${y}"] .t--editable-cell-icon svg`,
+  )
     .invoke("show")
     .click({ force: true });
   cy.get(

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1446,7 +1446,6 @@ Cypress.Commands.add("editTableCell", (x, y) => {
   cy.get(`[data-colindex="${x}"][data-rowindex="${y}"] .t--editable-cell-icon`)
     .invoke("show")
     .click({ force: true });
-  cy.wait(500);
   cy.get(
     `[data-colindex="${x}"][data-rowindex="${y}"] .t--inlined-cell-editor input.bp3-input`,
   ).should("exist");

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1468,7 +1468,6 @@ Cypress.Commands.add("makeColumnEditable", (column) => {
 });
 
 Cypress.Commands.add("enterTableCellValue", (x, y, text) => {
-  cy.wait(500);
   cy.get(
     `[data-colindex="${x}"][data-rowindex="${y}"] .t--inlined-cell-editor input.bp3-input`,
   )

--- a/app/client/cypress/support/widgetCommands.js
+++ b/app/client/cypress/support/widgetCommands.js
@@ -1468,6 +1468,7 @@ Cypress.Commands.add("makeColumnEditable", (column) => {
 });
 
 Cypress.Commands.add("enterTableCellValue", (x, y, text) => {
+  cy.wait(500);
   cy.get(
     `[data-colindex="${x}"][data-rowindex="${y}"] .t--inlined-cell-editor input.bp3-input`,
   )


### PR DESCRIPTION
## Description
Fix expand the widget so that the cell edit icon is visible

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
