### PR TITLE
chore: Overriding the import @appsmith eslint rule on EE folder

### DIFF
--- a/app/client/.eslintrc.js
+++ b/app/client/.eslintrc.js
@@ -80,6 +80,14 @@ eslintConfig.overrides = [
         getRestrictedSyntaxOverrideForCodeEditor(eslintConfig),
     },
   },
+  {
+    files: ["**/ee/**/*"],
+    rules: {
+      ...eslintConfig.rules,
+      "@typescript-eslint/no-restricted-imports":
+        getRestrictedImportsOverrideForEE(eslintConfig),
+    },
+  },
 ];
 
 function getRestrictedImportsOverrideForCodeEditor(eslintConfig) {
@@ -115,6 +123,21 @@ function getRestrictedSyntaxOverrideForCodeEditor(eslintConfig) {
   }
 
   return [errorLevel, ...newRules];
+}
+
+function getRestrictedImportsOverrideForEE(eslintConfig) {
+  const [errorLevel, existingRules] =
+    eslintConfig.rules["@typescript-eslint/no-restricted-imports"];
+
+  const newPatterns = (existingRules.patterns ?? []).filter(
+    (i) => i.group[0] !== "**/ce/*",
+  );
+
+  if (newPatterns.length === 0) {
+    return ["off"];
+  }
+
+  return [errorLevel, { paths: existingRules.paths, patterns: newPatterns }];
 }
 
 module.exports = eslintConfig;

--- a/app/client/src/ee/.eslintrc
+++ b/app/client/src/ee/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/no-restricted-imports": "off"
-  }
-}


### PR DESCRIPTION
## Description

Overriding the import @appsmith eslint rule on EE folder

#### PR fixes following issue(s)
Fixes [#24183](https://github.com/appsmithorg/appsmith/issues/24183)

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
