### PR TITLE
fix: migration for encryption

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration013UnsetEncryptionVersion2Fields.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration013UnsetEncryptionVersion2Fields.java
@@ -5,7 +5,6 @@ import com.appsmith.external.models.QAuthenticationDTO;
 import com.appsmith.external.models.QDatasource;
 import com.appsmith.external.models.QDatasourceConfiguration;
 import com.appsmith.server.constants.FieldName;
-import com.appsmith.server.migrations.utils.CompatibilityUtils;
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
@@ -65,7 +64,9 @@ public class Migration013UnsetEncryptionVersion2Fields {
                 .unset(REFRESH_TOKEN_QUALIFIED_NAME)
                 .unset(TOKEN_QUALIFIED_NAME)
                 .unset(CLIENT_SECRET_QUALIFIED_NAME)
-                .unset(TOKEN_RESPONSE_QUALIFIED_NAME);
+                .unset(TOKEN_RESPONSE_QUALIFIED_NAME)
+                .unset(ENCRYPTION_VERSION_FIELD_NAME)
+                .set(fieldName(QDatasource.datasource.isConfigured), Boolean.FALSE);
         mongoOperations.updateMulti(datasourcesToUpdateQuery, updateQuery, Datasource.class);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration013UnsetEncryptionVersion2Fields.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration013UnsetEncryptionVersion2Fields.java
@@ -5,7 +5,6 @@ import com.appsmith.external.models.QAuthenticationDTO;
 import com.appsmith.external.models.QDatasource;
 import com.appsmith.external.models.QDatasourceConfiguration;
 import com.appsmith.server.constants.FieldName;
-import com.appsmith.server.migrations.solutions.DatasourceStorageMigrationSolution;
 import com.appsmith.server.migrations.utils.CompatibilityUtils;
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -27,8 +26,8 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 
 
 @Slf4j
-@ChangeUnit(order = "110", id = "unset-not-encrypted-encryption-version-2-fields", author = " ")
-public class Migration110UnsetEncryptionVersion2Fields {
+@ChangeUnit(order = "013", id = "unset-not-encrypted-encryption-version-2-fields", author = " ")
+public class Migration013UnsetEncryptionVersion2Fields {
 
     private final MongoTemplate mongoTemplate;
     private static final int ENCRYPTION_VERSION = 2;
@@ -45,7 +44,7 @@ public class Migration110UnsetEncryptionVersion2Fields {
     private static final String REFRESH_TOKEN_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + REFRESH_TOKEN;
     private static final String TOKEN_RESPONSE_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + TOKEN_RESPONSE;
 
-    public Migration110UnsetEncryptionVersion2Fields(MongoTemplate mongoTemplate) {
+    public Migration013UnsetEncryptionVersion2Fields(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration110UnsetEncryptionVersion2Fields.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration110UnsetEncryptionVersion2Fields.java
@@ -39,21 +39,11 @@ public class Migration110UnsetEncryptionVersion2Fields {
 
     private static final String AUTHENTICATION_QUALIFIED_NAME =  DATASOURCE_CONFIGURATION_FIELD_NAME + DELIMITER + AUTHENTICATION_FIELD_NAME;
     private static final String AUTHENTICATION_RESPONSE_QUALIFIED_NAME =  AUTHENTICATION_QUALIFIED_NAME + DELIMITER + fieldName(QAuthenticationDTO.authenticationDTO.authenticationResponse);
-
-    // "datasourceConfiguration.authentication.password"
-    // "datasourceConfiguration.authentication.clientSecret"
-    // "datasourceConfiguration.authentication.authenticationResponse.token"
-    // "datasourceConfiguration.authentication.authenticationResponse.refreshToken"
-    // "datasourceConfiguration.authentication.authenticationResponse.tokenResponse"
     private static final String PASSWORD_QUALIFIED_NAME =  AUTHENTICATION_QUALIFIED_NAME + DELIMITER + PASSWORD;
     private static final String CLIENT_SECRET_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + CLIENT_SECRET;
     private static final String TOKEN_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + TOKEN;
     private static final String REFRESH_TOKEN_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + REFRESH_TOKEN;
     private static final String TOKEN_RESPONSE_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + TOKEN_RESPONSE;
-
-
-
-    private final DatasourceStorageMigrationSolution solution = new DatasourceStorageMigrationSolution();
 
     public Migration110UnsetEncryptionVersion2Fields(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration110UnsetEncryptionVersion2Fields.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration110UnsetEncryptionVersion2Fields.java
@@ -1,0 +1,121 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.external.models.Datasource;
+import com.appsmith.external.models.QAuthenticationDTO;
+import com.appsmith.external.models.QDatasource;
+import com.appsmith.external.models.QDatasourceConfiguration;
+import com.appsmith.server.constants.FieldName;
+import com.appsmith.server.migrations.solutions.DatasourceStorageMigrationSolution;
+import com.appsmith.server.migrations.utils.CompatibilityUtils;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import static com.appsmith.external.constants.CommonFieldName.CLIENT_SECRET;
+import static com.appsmith.external.constants.CommonFieldName.REFRESH_TOKEN;
+import static com.appsmith.external.constants.CommonFieldName.TOKEN;
+import static com.appsmith.external.constants.CommonFieldName.TOKEN_RESPONSE;
+import static com.appsmith.server.constants.ce.FieldNameCE.PASSWORD;
+import static com.appsmith.server.repositories.ce.BaseAppsmithRepositoryCEImpl.fieldName;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+
+@Slf4j
+@ChangeUnit(order = "110", id = "unset-not-encrypted-encryption-version-2-fields", author = " ")
+public class Migration110UnsetEncryptionVersion2Fields {
+
+    private final MongoTemplate mongoTemplate;
+    private static final int ENCRYPTION_VERSION = 2;
+    private static final String ENCRYPTION_VERSION_FIELD_NAME = "encryptionVersion";
+    private static final String DATASOURCE_CONFIGURATION_FIELD_NAME = fieldName(QDatasource.datasource.datasourceConfiguration);
+    private static final String AUTHENTICATION_FIELD_NAME = fieldName(QDatasourceConfiguration.datasourceConfiguration.authentication);
+    private static final String DELIMITER = ".";
+
+    private static final String AUTHENTICATION_QUALIFIED_NAME =  DATASOURCE_CONFIGURATION_FIELD_NAME + DELIMITER + AUTHENTICATION_FIELD_NAME;
+    private static final String AUTHENTICATION_RESPONSE_QUALIFIED_NAME =  AUTHENTICATION_QUALIFIED_NAME + DELIMITER + fieldName(QAuthenticationDTO.authenticationDTO.authenticationResponse);
+
+    // "datasourceConfiguration.authentication.password"
+    // "datasourceConfiguration.authentication.clientSecret"
+    // "datasourceConfiguration.authentication.authenticationResponse.token"
+    // "datasourceConfiguration.authentication.authenticationResponse.refreshToken"
+    // "datasourceConfiguration.authentication.authenticationResponse.tokenResponse"
+    private static final String PASSWORD_QUALIFIED_NAME =  AUTHENTICATION_QUALIFIED_NAME + DELIMITER + PASSWORD;
+    private static final String CLIENT_SECRET_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + CLIENT_SECRET;
+    private static final String TOKEN_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + TOKEN;
+    private static final String REFRESH_TOKEN_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + REFRESH_TOKEN;
+    private static final String TOKEN_RESPONSE_QUALIFIED_NAME = AUTHENTICATION_RESPONSE_QUALIFIED_NAME + DELIMITER + TOKEN_RESPONSE;
+
+
+
+    private final DatasourceStorageMigrationSolution solution = new DatasourceStorageMigrationSolution();
+
+    public Migration110UnsetEncryptionVersion2Fields(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void rollbackExecution() {
+        // We're handling rollbacks using marker fields, so we don't need to implement this
+    }
+
+    @Execution
+    public void executeMigration() {
+
+        Query datasourcesToUpdateQuery = query(findDatasourceToUnsetFieldsIn()).cursorBatchSize(1024);
+        datasourcesToUpdateQuery.fields().include(
+                fieldName(QDatasource.datasource.id),
+                fieldName(QDatasource.datasource.workspaceId),
+                fieldName(QDatasource.datasource.isConfigured),
+                fieldName(QDatasource.datasource.gitSyncId),
+                fieldName(QDatasource.datasource.invalids),
+                fieldName(QDatasource.datasource.hasDatasourceStorage),
+                fieldName(QDatasource.datasource.datasourceConfiguration)
+        );
+
+        final Query performanceOptimizedUpdateQuery = CompatibilityUtils
+                .optimizeQueryForNoCursorTimeout(mongoTemplate, datasourcesToUpdateQuery, Datasource.class);
+
+        mongoTemplate
+                .stream(performanceOptimizedUpdateQuery, Datasource.class)
+                .forEach(datasource -> {
+
+                    mongoTemplate.updateFirst(
+                            new Query()
+                                    .addCriteria(where(fieldName(QDatasource.datasource.id)).is(datasource.getId())),
+                            new Update()
+                                    .unset(PASSWORD_QUALIFIED_NAME)
+                                    .unset(REFRESH_TOKEN_QUALIFIED_NAME)
+                                    .unset(TOKEN_QUALIFIED_NAME)
+                                    .unset(CLIENT_SECRET_QUALIFIED_NAME)
+                                    .unset(TOKEN_RESPONSE_QUALIFIED_NAME),
+                            Datasource.class);
+                });
+    }
+
+        private Criteria findDatasourceToUnsetFieldsIn() {
+
+            return new Criteria().andOperator(
+                    //Older check for deleted
+                    new Criteria().orOperator(
+                        where(FieldName.DELETED).exists(false),
+                        where(FieldName.DELETED).is(false)
+                    ),
+                    //New check for deleted
+                    new Criteria().orOperator(
+                            where(FieldName.DELETED_AT).exists(false),
+                            where(FieldName.DELETED_AT).is(null)
+                    ),
+                    new Criteria().andOperator(
+                            where(ENCRYPTION_VERSION_FIELD_NAME).exists(true),
+                            where(ENCRYPTION_VERSION_FIELD_NAME).is(ENCRYPTION_VERSION)
+                    )
+            );
+    }
+
+}


### PR DESCRIPTION
## Description
> Unsetting auth fields in datasource docs to avoid decryption failure happening on update to appsmith-ee v1.9.20.5

#### PR fixes following issue(s)
Fixes #24267
#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Test product sanity on a sample db

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
