### PR TITLE
chore: remove the doPull flag from the git discard API

### DIFF
--- a/app/client/src/api/GitSyncAPI.tsx
+++ b/app/client/src/api/GitSyncAPI.tsx
@@ -172,10 +172,8 @@ class GitSyncAPI extends Api {
     });
   }
 
-  static discardChanges(applicationId: string, doPull: boolean) {
-    return Api.put(
-      `${GitSyncAPI.baseURL}/discard/app/${applicationId}?doPull=${doPull}`,
-    );
+  static discardChanges(applicationId: string) {
+    return Api.put(`${GitSyncAPI.baseURL}/discard/app/${applicationId}`);
   }
 }
 

--- a/app/client/src/sagas/GitSyncSagas.ts
+++ b/app/client/src/sagas/GitSyncSagas.ts
@@ -930,8 +930,7 @@ function* discardChanges() {
   let response: ApiResponse<GitDiscardResponse>;
   try {
     const appId: string = yield select(getCurrentApplicationId);
-    const doPull = true;
-    response = yield GitSyncAPI.discardChanges(appId, doPull);
+    response = yield GitSyncAPI.discardChanges(appId);
     const isValidResponse: boolean = yield validateResponse(
       response,
       false,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/GitControllerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/controllers/ce/GitControllerCE.java
@@ -253,7 +253,6 @@ public class GitControllerCE {
     @JsonView(Views.Public.class)
     @PutMapping("/discard/app/{defaultApplicationId}")
     public Mono<ResponseDTO<Application>> discardChanges(@PathVariable String defaultApplicationId,
-                                                         @RequestParam(required = false, defaultValue = "true") Boolean doPull,
                                                          @RequestHeader(name = FieldName.BRANCH_NAME) String branchName) {
         log.debug("Going to discard changes for branch {} with defaultApplicationId {}", branchName, defaultApplicationId);
         return service.discardChanges(defaultApplicationId, branchName)


### PR DESCRIPTION
## Description
After introducing the rebase with discard, this PR is to remove the old cold that was there to support pull flow with discard. 