### PR TITLE
fix: Fix blocked api execution for url path fields

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
+++ b/app/client/src/pages/Editor/APIEditor/CommonEditorForm.tsx
@@ -577,6 +577,8 @@ function CommonEditorForm(props: CommonFormPropsWithExtraParams) {
   // this gets the url of the current action's datasource
   const actionDatasourceUrl =
     currentActionConfig?.datasource?.datasourceConfiguration?.url || "";
+  const actionDatasourceUrlPath =
+    currentActionConfig?.actionConfiguration?.path || "";
   // this gets the name of the current action's datasource
   const actionDatasourceName = currentActionConfig?.datasource.name || "";
 
@@ -585,6 +587,7 @@ function CommonEditorForm(props: CommonFormPropsWithExtraParams) {
   // we block action execution.
   const blockExecution =
     (!actionDatasourceUrl &&
+      !actionDatasourceUrlPath &&
       actionDatasourceName === DEFAULT_DATASOURCE_NAME) ||
     !isExecutePermitted;
 


### PR DESCRIPTION
When only dynamic bindings are pasted in the API url, the run button is remains disabled.

Fixes #24297 

- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
