### PR TITLE
chore: [one click binding] allow switching between js mode and non js mode on property control

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/disableJSToggle_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/ActionExecution/disableJSToggle_spec.ts
@@ -84,7 +84,7 @@ describe("Disable JS toggle when Action selector code is not parsable", () => {
 
     propPane.EnterJSContext("onClick", codeSnippet);
     agHelper.Sleep(200);
-    propPane.AssertJSToggleDisabled("onClick");
+    propPane.AssertJSToggleState("onClick", "disabled");
   });
 
   it("should disable JS toggle when the code can't be parsed into UI", () => {
@@ -98,14 +98,14 @@ describe("Disable JS toggle when Action selector code is not parsable", () => {
     }}`;
     propPane.EnterJSContext("onClick", codeSnippet);
     agHelper.Sleep(200);
-    propPane.AssertJSToggleDisabled("onClick");
+    propPane.AssertJSToggleState("onClick", "disabled");
 
     //Bug 22180
     codeSnippet =
       "{{ (function(){ return Promise.race([ Api1.run({ name: 1 }), Api1.run({ name: 2 }) ]).then((res) => { showAlert(Winner: ${res.args.name}) }); })() }}";
     propPane.EnterJSContext("onClick", codeSnippet);
     agHelper.Sleep(200);
-    propPane.AssertJSToggleDisabled("onClick");
+    propPane.AssertJSToggleState("onClick", "disabled");
 
     // When Api1 is returned
     codeSnippet = `{{Api1.run().then(() => {
@@ -113,7 +113,7 @@ describe("Disable JS toggle when Action selector code is not parsable", () => {
     })}}`;
     propPane.EnterJSContext("onClick", codeSnippet);
     agHelper.Sleep(200);
-    propPane.AssertJSToggleDisabled("onClick");
+    propPane.AssertJSToggleState("onClick", "disabled");
 
     // When Api1.data is returned
     codeSnippet = `{{Api1.run().then(() => {
@@ -121,6 +121,6 @@ describe("Disable JS toggle when Action selector code is not parsable", () => {
     })}}`;
     propPane.EnterJSContext("onClick", codeSnippet);
     agHelper.Sleep(200);
-    propPane.AssertJSToggleDisabled("onClick");
+    propPane.AssertJSToggleState("onClick", "disabled");
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
@@ -93,19 +93,15 @@ describe("excludeForAirgap", "One click binding control", () => {
 
     propPane.ValidatePropertyFieldValue("Table data", "{{Query1.data}}");
 
-<<<<<<< HEAD
-    propPane.UpdatePropertyFieldValue("Table data", "");
-=======
-    _.propPane.AssertJSToggleState("Table data", "enabled");
+    propPane.AssertJSToggleState("Table data", "enabled");
 
-    _.propPane.UpdatePropertyFieldValue("Table data", "{{Query1.data1}}");
+    propPane.UpdatePropertyFieldValue("Table data", "{{Query1.data1}}");
 
-    _.propPane.AssertJSToggleState("Table data", "disabled");
+    propPane.AssertJSToggleState("Table data", "disabled");
 
-    _.propPane.UpdatePropertyFieldValue("Table data", "{{Query1.data}}");
+    propPane.UpdatePropertyFieldValue("Table data", "{{Query1.data}}");
 
-    _.propPane.AssertJSToggleState("Table data", "enabled");
->>>>>>> d04df34037 (feat: [one click binding] allow switching between js mode and non js mode on property control)
+    propPane.AssertJSToggleState("Table data", "enabled");
 
     propPane.ToggleJSMode("Table data", false);
 

--- a/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/OneClickBinding/PropertyControl_spec.ts
@@ -93,7 +93,19 @@ describe("excludeForAirgap", "One click binding control", () => {
 
     propPane.ValidatePropertyFieldValue("Table data", "{{Query1.data}}");
 
+<<<<<<< HEAD
     propPane.UpdatePropertyFieldValue("Table data", "");
+=======
+    _.propPane.AssertJSToggleState("Table data", "enabled");
+
+    _.propPane.UpdatePropertyFieldValue("Table data", "{{Query1.data1}}");
+
+    _.propPane.AssertJSToggleState("Table data", "disabled");
+
+    _.propPane.UpdatePropertyFieldValue("Table data", "{{Query1.data}}");
+
+    _.propPane.AssertJSToggleState("Table data", "enabled");
+>>>>>>> d04df34037 (feat: [one click binding] allow switching between js mode and non js mode on property control)
 
     propPane.ToggleJSMode("Table data", false);
 

--- a/app/client/cypress/support/Pages/PropertyPane.ts
+++ b/app/client/cypress/support/Pages/PropertyPane.ts
@@ -477,10 +477,10 @@ export class PropertyPane {
     cy.get(this.locator._jsToggle(property.toLowerCase())).click();
   }
 
-  public AssertJSToggleDisabled(property: string) {
-    cy.get(this.locator._jsToggle(property.toLowerCase())).should(
-      "be.disabled",
-    );
+  public AssertJSToggleState(property: string, state: "enabled" | "disabled") {
+    cy.get(
+      this.locator._jsToggle(property.toLowerCase().replaceAll(" ", "")),
+    ).should(`be.${state}`);
   }
 
   public AssertSelectValue(value: string) {

--- a/app/client/src/actions/controlActions.tsx
+++ b/app/client/src/actions/controlActions.tsx
@@ -65,6 +65,7 @@ export const setWidgetDynamicProperty = (
   propertyPath: string,
   isDynamic: boolean,
   shouldRejectDynamicBindingPathList = true,
+  skipValidation = false,
 ): ReduxAction<SetWidgetDynamicPropertyPayload> => {
   return {
     type: ReduxActionTypes.SET_WIDGET_DYNAMIC_PROPERTY,
@@ -73,6 +74,7 @@ export const setWidgetDynamicProperty = (
       propertyPath,
       isDynamic,
       shouldRejectDynamicBindingPathList,
+      skipValidation,
     },
   };
 };
@@ -124,6 +126,7 @@ export interface SetWidgetDynamicPropertyPayload {
   propertyPath: string;
   isDynamic: boolean;
   shouldRejectDynamicBindingPathList?: boolean;
+  skipValidation?: boolean;
 }
 
 export interface DeleteWidgetPropertyPayload {

--- a/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/index.tsx
+++ b/app/client/src/components/editorComponents/WidgetQueryGeneratorForm/CommonControls/DatasourceDropdown/index.tsx
@@ -34,7 +34,7 @@ function DatasourceDropdown() {
   }, [isSourceOpen]);
 
   return (
-    <SelectWrapper className="space-y-2">
+    <SelectWrapper>
       <Select
         className="t--one-click-binding-datasource-selector"
         dropdownClassName="one-click-binding-datasource-dropdown"

--- a/app/client/src/components/propertyControls/BaseControl.tsx
+++ b/app/client/src/components/propertyControls/BaseControl.tsx
@@ -8,6 +8,12 @@ import type { PropertyPaneControlConfig } from "constants/PropertyControlConstan
 import type { CodeEditorExpected } from "components/editorComponents/CodeEditor";
 import type { AdditionalDynamicDataTree } from "utils/autocomplete/customTreeTypeDefCreator";
 
+export type ControlMethods = Record<
+  "canDisplayValueInUI" | "shouldValidateValueOnDynamicPropertyOff",
+  | typeof BaseControl.canDisplayValueInUI
+  | typeof BaseControl.shouldValidateValueOnDynamicPropertyOff
+>;
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 class BaseControl<P extends ControlProps, S = {}> extends Component<P, S> {
   shoudUpdateProperty(propertyValue: unknown) {
@@ -66,6 +72,16 @@ class BaseControl<P extends ControlProps, S = {}> extends Component<P, S> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static canDisplayValueInUI(config: ControlData, value: any): boolean {
     return false;
+  }
+
+  //checks whether we need to validate the value when swtiching from js mode to non js mode
+  static shouldValidateValueOnDynamicPropertyOff(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    config?: ControlData,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    value?: any,
+  ): boolean {
+    return true;
   }
 
   // Only applicable for JSONFormComputeControl & ComputeTablePropertyControl

--- a/app/client/src/components/propertyControls/OneClickBindingControl.tsx
+++ b/app/client/src/components/propertyControls/OneClickBindingControl.tsx
@@ -1,6 +1,6 @@
 import WidgetQueryGeneratorForm from "components/editorComponents/WidgetQueryGeneratorForm";
 import React from "react";
-import type { ControlProps } from "./BaseControl";
+import type { ControlData, ControlProps } from "./BaseControl";
 import BaseControl from "./BaseControl";
 class OneClickBindingControl extends BaseControl<OneClickBindingControlProps> {
   constructor(props: OneClickBindingControlProps) {
@@ -15,9 +15,16 @@ class OneClickBindingControl extends BaseControl<OneClickBindingControlProps> {
    * Commenting out as we're not able to switch between the js modes without value being overwritten
    * with default value by platform
    */
-  // static canDisplayValueInUI(config: ControlData, value: string): boolean {
-  //   return /^{{[^.]*\.data}}$/gi.test(value);
-  // }
+  static canDisplayValueInUI(config: ControlData, value: any): boolean {
+    return [
+      /^{{[^.]*\.data}}$/gi, // {{query1.data}}
+      /^{{}}$/, // {{}}
+    ].some((d) => d.test(value));
+  }
+
+  static shouldValidateValueOnDynamicPropertyOff() {
+    return false;
+  }
 
   public onUpdatePropertyValue = (
     value = "",

--- a/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertyControl.tsx
@@ -182,7 +182,11 @@ const PropertyControl = memo((props: Props) => {
   } = enhancementFns || {};
 
   const toggleDynamicProperty = useCallback(
-    (propertyName: string, isDynamic: boolean) => {
+    (
+      propertyName: string,
+      isDynamic: boolean,
+      shouldValidateValueOnDynamicPropertyOff?: boolean,
+    ) => {
       AnalyticsUtil.logEvent("WIDGET_TOGGLE_JS_PROP", {
         widgetType: widgetProperties?.type,
         widgetName: widgetProperties?.widgetName,
@@ -209,6 +213,7 @@ const PropertyControl = memo((props: Props) => {
           propertyName,
           !isDynamic,
           shouldRejectDynamicBindingPathList,
+          !shouldValidateValueOnDynamicPropertyOff,
         ),
       );
     },
@@ -689,8 +694,9 @@ const PropertyControl = memo((props: Props) => {
     };
 
     const uniqId = btoa(`${widgetProperties.widgetId}.${propertyName}`);
-    const canDisplayValueInUI =
-      PropertyControlFactory.controlUIToggleValidation.get(config.controlType);
+    const controlMethods = PropertyControlFactory.controlMethods.get(
+      config.controlType,
+    );
 
     const customJSControl = getCustomJSControl();
 
@@ -713,7 +719,8 @@ const PropertyControl = memo((props: Props) => {
         }
 
         // disable button if value can't be represented in UI mode
-        if (!canDisplayValueInUI?.(config, value)) isToggleDisabled = true;
+        if (!controlMethods?.canDisplayValueInUI?.(config, value))
+          isToggleDisabled = true;
       }
 
       // Enable button if the value is same as the one defined in theme stylesheet.
@@ -774,7 +781,14 @@ const PropertyControl = memo((props: Props) => {
                     isDisabled={isToggleDisabled}
                     isSelected={isDynamic}
                     onClick={() =>
-                      toggleDynamicProperty(propertyName, isDynamic)
+                      toggleDynamicProperty(
+                        propertyName,
+                        isDynamic,
+                        controlMethods?.shouldValidateValueOnDynamicPropertyOff(
+                          config,
+                          propertyValue,
+                        ),
+                      )
                     }
                     size="sm"
                   />

--- a/app/client/src/sagas/WidgetOperationSagas.tsx
+++ b/app/client/src/sagas/WidgetOperationSagas.tsx
@@ -487,6 +487,7 @@ export function* setWidgetDynamicPropertySaga(
     isDynamic,
     propertyPath,
     shouldRejectDynamicBindingPathList = true,
+    skipValidation = false,
     widgetId,
   } = action.payload;
   const stateWidget: WidgetProps = yield select(getWidget, widgetId);
@@ -517,14 +518,27 @@ export function* setWidgetDynamicPropertySaga(
       );
     }
 
-    const { parsed } = yield call(
-      validateProperty,
-      propertyPath,
-      propertyValue,
-      widget,
-    );
+    /*
+     * We need to run the validation function to parse the value present in the
+     * js mode to use that in the non js mode.
+     *  - if the value is valid to be used on non js mode, we will use the same value
+     *  - if the value is invalid to be used on non js mode, we will use the default value
+     *    returned by the validation function.
+     *
+     * Sometimes (eg: in one click binding control) we don't want to do validation and retain the
+     * same value while switching from js to non js mode. use `skipValidation` flag to turn off validation.
+     */
 
-    widget = set(widget, propertyPath, parsed);
+    if (!skipValidation) {
+      const { parsed } = yield call(
+        validateProperty,
+        propertyPath,
+        propertyValue,
+        widget,
+      );
+
+      widget = set(widget, propertyPath, parsed);
+    }
   }
 
   widget.dynamicPropertyPathList = dynamicPropertyPathList;

--- a/app/client/src/utils/PropertyControlFactory.tsx
+++ b/app/client/src/utils/PropertyControlFactory.tsx
@@ -4,17 +4,14 @@ import type {
   ControlProps,
   ControlFunctions,
   ControlData,
+  ControlMethods,
 } from "components/propertyControls/BaseControl";
 import type BaseControl from "components/propertyControls/BaseControl";
 import { isArray } from "lodash";
 import type { AdditionalDynamicDataTree } from "./autocomplete/customTreeTypeDefCreator";
-
 class PropertyControlFactory {
   static controlMap: Map<ControlType, ControlBuilder<ControlProps>> = new Map();
-  static controlUIToggleValidation: Map<
-    ControlType,
-    typeof BaseControl.canDisplayValueInUI
-  > = new Map();
+  static controlMethods: Map<ControlType, ControlMethods> = new Map();
   static inputComputedValueMap: Map<
     ControlType,
     typeof BaseControl.getInputComputedValue
@@ -23,11 +20,11 @@ class PropertyControlFactory {
   static registerControlBuilder(
     controlType: ControlType,
     controlBuilder: ControlBuilder<ControlProps>,
-    validationFn: typeof BaseControl.canDisplayValueInUI,
+    controlMethods: ControlMethods,
     inputComputedValueFn: typeof BaseControl.getInputComputedValue,
   ) {
     this.controlMap.set(controlType, controlBuilder);
-    this.controlUIToggleValidation.set(controlType, validationFn);
+    this.controlMethods.set(controlType, controlMethods);
     this.inputComputedValueMap.set(controlType, inputComputedValueFn);
   }
 

--- a/app/client/src/utils/PropertyControlRegistry.tsx
+++ b/app/client/src/utils/PropertyControlRegistry.tsx
@@ -76,7 +76,11 @@ class PropertyControlRegistry {
               return <ControlWithAnalytics {...controlProps} />;
             },
           },
-          Control.canDisplayValueInUI,
+          {
+            canDisplayValueInUI: Control.canDisplayValueInUI,
+            shouldValidateValueOnDynamicPropertyOff:
+              Control.shouldValidateValueOnDynamicPropertyOff,
+          },
           Control.getInputComputedValue,
         );
       },


### PR DESCRIPTION


## Description
Now, on table data property of Table widget, we can switch between js mode and non js mode when there is a value.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/24354
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
