### PR TITLE
fix: Block Action execution for Post UQI datasources like oracle

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ActionExecution/Block_Execution.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ActionExecution/Block_Execution.ts
@@ -22,7 +22,7 @@ describe("Block Action Execution when no field is present", () => {
       name = $dsName;
 
       agHelper.Sleep(1000);
-      dataSources.NavigateFromActiveDS(name, true);
+      dataSources.CreateQueryAfterDSSaved();
       agHelper.GetNClick(dataSources._templateMenu);
       dataSources.EnterQuery("SELECT * from users");
       dataSources.AssertRunButtonDisability(false);
@@ -38,7 +38,7 @@ describe("Block Action Execution when no field is present", () => {
       name = $dsName;
 
       agHelper.Sleep(1000);
-      dataSources.NavigateFromActiveDS(name, true);
+      dataSources.CreateQueryAfterDSSaved();
       agHelper.GetNClick(dataSources._templateMenu);
       dataSources.EnterQuery("SELECT * from users");
       dataSources.AssertRunButtonDisability(false);

--- a/app/client/cypress/e2e/Regression/ServerSide/ActionExecution/Block_Execution.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ActionExecution/Block_Execution.ts
@@ -15,9 +15,25 @@ describe("Block Action Execution when no field is present", () => {
     apiPage.AssertRunButtonDisability(false);
   });
 
-  it("1. Ensure Run button is disabled when no SQL body field is present", () => {
+  it("2. Ensure Run button is disabled when no SQL body field is present", () => {
     let name: any;
     dataSources.CreateDataSource("MySql", true, false);
+    cy.get("@dsName").then(($dsName) => {
+      name = $dsName;
+
+      agHelper.Sleep(1000);
+      dataSources.NavigateFromActiveDS(name, true);
+      agHelper.GetNClick(dataSources._templateMenu);
+      dataSources.EnterQuery("SELECT * from users");
+      dataSources.AssertRunButtonDisability(false);
+      dataSources.EnterQuery("");
+      dataSources.AssertRunButtonDisability(true);
+    });
+  });
+
+  it("3. Ensure Run button is disabled for Post UQI Datasources e.g. Oracle when no body data is present", () => {
+    let name: any;
+    dataSources.CreateDataSource("Oracle", true, false);
     cy.get("@dsName").then(($dsName) => {
       name = $dsName;
 

--- a/app/client/cypress/fixtures/datasources.json
+++ b/app/client/cypress/fixtures/datasources.json
@@ -48,6 +48,12 @@
   "redis-host": "host.docker.internal",
   "redis-port": "6379",
 
+  "oracle-host": "random-data",
+  "oracle-port": "40",
+  "oracle-name": "random-name",
+  "oracle-username": "random-username",
+  "oracle-password": "random-password",
+
   "OAuth_Username": "testuser@appsmith.com",
   "OAuth_Host": "http://localhost:6001",
   "OAuth_ApiUrl": "http://host.docker.internal:6001",

--- a/app/client/cypress/support/Pages/DataSources.ts
+++ b/app/client/cypress/support/Pages/DataSources.ts
@@ -13,6 +13,7 @@ const DataSourceKVP = {
   Firestore: "Firestore",
   Elasticsearch: "Elasticsearch",
   Redis: "Redis",
+  Oracle: "Oracle",
 }; //DataSources KeyValuePair
 
 export enum Widgets {
@@ -430,6 +431,32 @@ export class DataSources {
     );
     cy.get(this._password).type(
       password == "" ? datasourceFormData["postgres-password"] : password,
+    );
+  }
+
+  public FillOracleDSForm(
+    shouldAddTrailingSpaces = false,
+    username = "",
+    password = "",
+  ) {
+    const hostAddress = shouldAddTrailingSpaces
+      ? datasourceFormData["oracle-host"] + "  "
+      : datasourceFormData["oracle-host"];
+    const databaseName = shouldAddTrailingSpaces
+      ? datasourceFormData["oracle-name"] + "  "
+      : datasourceFormData["oracle-name"];
+    this.agHelper.UpdateInputValue(this._host, hostAddress);
+    this.agHelper.UpdateInputValue(
+      this._port,
+      datasourceFormData["oracle-port"].toString(),
+    );
+    cy.get(this._databaseName).clear().type(databaseName);
+    this.ExpandSectionByName("Authentication");
+    cy.get(this._username).type(
+      username == "" ? datasourceFormData["oracle-username"] : username,
+    );
+    cy.get(this._password).type(
+      password == "" ? datasourceFormData["oracle-password"] : password,
     );
   }
 
@@ -927,7 +954,8 @@ export class DataSources {
       | "Arango"
       | "Firestore"
       | "Elasticsearch"
-      | "Redis",
+      | "Redis"
+      | "Oracle",
     navigateToCreateNewDs = true,
     testNSave = true,
   ) {
@@ -943,6 +971,7 @@ export class DataSources {
         dataSourceName = dsType + " " + guid;
         this.agHelper.RenameWithInPane(dataSourceName, false);
         if (DataSourceKVP[dsType] == "PostgreSQL") this.FillPostgresDSForm();
+        else if (DataSourceKVP[dsType] == "Oracle") this.FillOracleDSForm();
         else if (DataSourceKVP[dsType] == "MySQL") this.FillMySqlDSForm();
         else if (DataSourceKVP[dsType] == "MongoDB") this.FillMongoDSForm();
         else if (DataSourceKVP[dsType] == "Microsoft SQL Server")

--- a/app/client/src/constants/QueryEditorConstants.ts
+++ b/app/client/src/constants/QueryEditorConstants.ts
@@ -10,6 +10,9 @@ export const SQL_DATASOURCES: Array<string> = [
   PluginName.MS_SQL,
   PluginName.MY_SQL,
   PluginName.ORACLE,
+  PluginName.SNOWFLAKE,
+  PluginName.ARANGODB,
+  PluginName.REDSHIFT,
 ];
 
 export const PLUGIN_PACKAGE_DBS = [

--- a/app/client/src/entities/Action/index.ts
+++ b/app/client/src/entities/Action/index.ts
@@ -34,6 +34,9 @@ export enum PluginName {
   GOOGLE_SHEETS = "Google Sheets",
   FIRESTORE = "Firestore",
   ORACLE = "Oracle",
+  SNOWFLAKE = "Snowflake",
+  ARANGODB = "ArangoDB",
+  REDSHIFT = "Redshift",
 }
 
 export enum PaginationType {

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -435,13 +435,15 @@ export function EditorJSONtoForm(props: Props) {
   );
 
   let actionBody = "";
-  if ("formData" in currentActionConfig?.actionConfiguration) {
-    // if the action has a formData (the action is postUQI e.g. Oracle)
-    actionBody =
-      currentActionConfig?.actionConfiguration?.formData.body?.data || "";
-  } else {
-    // if the action is pre UQI, the path is different e.g. mySQL
-    actionBody = currentActionConfig?.actionConfiguration?.body || "";
+  if (!!currentActionConfig?.actionConfiguration) {
+    if ("formData" in currentActionConfig?.actionConfiguration) {
+      // if the action has a formData (the action is postUQI e.g. Oracle)
+      actionBody =
+        currentActionConfig.actionConfiguration.formData?.body?.data || "";
+    } else {
+      // if the action is pre UQI, the path is different e.g. mySQL
+      actionBody = currentActionConfig.actionConfiguration?.body || "";
+    }
   }
 
   // if (the body is empty and the action is an sql datasource) or the user does not have permission, block action execution.

--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -434,8 +434,15 @@ export function EditorJSONtoForm(props: Props) {
     getPluginNameFromId(state, currentActionConfig?.pluginId || ""),
   );
 
-  // this gets the url of the current action
-  const actionBody = currentActionConfig?.actionConfiguration?.body || "";
+  let actionBody = "";
+  if ("formData" in currentActionConfig?.actionConfiguration) {
+    // if the action has a formData (the action is postUQI e.g. Oracle)
+    actionBody =
+      currentActionConfig?.actionConfiguration?.formData.body?.data || "";
+  } else {
+    // if the action is pre UQI, the path is different e.g. mySQL
+    actionBody = currentActionConfig?.actionConfiguration?.body || "";
+  }
 
   // if (the body is empty and the action is an sql datasource) or the user does not have permission, block action execution.
   const blockExecution =


### PR DESCRIPTION
The configProperty path for Post UQI datasource's body field  is stored in actionConfiguration.formData.body.data, other older pre UQI format SQL datasources  actionConfiguration.body. This adds a check for such post UQI datasources like Oracle.

Fixes #24350 

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
Tested the following for Oracle DS - 

1. Created oracle DS - and from review page, using new query button, created select/insert/update/delete queries and checked for run button functionality
2. From the schema of oracle DS, created select/insert/update/delete queries and checked for run button functionality
3. From the New Query add button on the Entity explorer, created select/insert/update/delete queries and checked for run button functionality>
4. Quick tested PostGreSQL query run, it is rightly disabled if query field is blank, and if anything entered into the query field, run gets enabled
5. Quick tested Snowflake query run, here noted that even if the query field is blank, the run button is enabled.

#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
