### PR TITLE
chore: Use cypress interceptors instead of wait to fix file csv flaky test

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
@@ -9,6 +9,7 @@ const ARRAY_CSV_HELPER_TEXT = `All non CSV, XLS(X), JSON or TSV filetypes will h
 const ObjectsRegistry =
   require("../../../../../support/Objects/Registry").ObjectsRegistry;
 let propPane = ObjectsRegistry.PropertyPane;
+let table = ObjectsRegistry.Table;
 
 describe("File picker widget v2", () => {
   before(() => {
@@ -48,7 +49,7 @@ describe("File picker widget v2", () => {
     agHelper.ValidateNetworkStatus("@updateLayout");
 
     // The table takes a bit of time to load the values in the cells
-    cy.wait(2000);
+    table.WaitUntilTableLoad(0, 0, "v2");
 
     cy.readTableV2dataPublish("1", "1").then((tabData) => {
       const tabValue = tabData;
@@ -74,7 +75,7 @@ describe("File picker widget v2", () => {
     agHelper.ValidateNetworkStatus("@updateLayout");
 
     // The table takes a bit of time to load the values in the cells
-    cy.wait(2000);
+    table.WaitUntilTableLoad(0, 0, "v2");
 
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("Sheet1");
@@ -106,7 +107,7 @@ describe("File picker widget v2", () => {
     agHelper.ValidateNetworkStatus("@updateLayout");
 
     // The table takes a bit of time to load the values in the cells
-    cy.wait(2000);
+    table.WaitUntilTableLoad(0, 0, "v2");
 
     cy.readTableV2dataPublish("0", "2").then((tabData) => {
       expect(tabData).to.contain("sunt aut facere");
@@ -122,7 +123,7 @@ describe("File picker widget v2", () => {
     agHelper.ValidateNetworkStatus("@updateLayout");
 
     // The table takes a bit of time to load the values in the cells
-    cy.wait(2000);
+    table.WaitUntilTableLoad(0, 0, "v2");
 
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("CONST");
@@ -159,7 +160,7 @@ describe("File picker widget v2", () => {
 
     agHelper.ValidateNetworkStatus("@updateLayout");
 
-    // The table takes a bit of time to load the values in the cells
+    // The text widget takes a bit of time to load the values
     cy.wait(2000);
 
     cy.get(locators._widgetInDeployed("textwidget")).should("have.text", "");

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
@@ -2,6 +2,7 @@ const commonlocators = require("../../../../../locators/commonlocators.json");
 import * as _ from "../../../../../support/Objects/ObjectsCore";
 import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
 const locator = ObjectsRegistry.CommonLocators;
+import { agHelper, locators } from "../../../../../support/Objects/ObjectsCore";
 
 const widgetName = "filepickerwidgetv2";
 const ARRAY_CSV_HELPER_TEXT = `All non CSV, XLS(X), JSON or TSV filetypes will have an empty value`;
@@ -35,7 +36,7 @@ describe("File picker widget v2", () => {
       `.t--property-control-dataformat ${commonlocators.helperText}`,
     ).contains(ARRAY_CSV_HELPER_TEXT);
 
-    cy.wait("@updateLayout");
+    agHelper.ValidateNetworkStatus("@updateLayout");
 
     cy.get(commonlocators.filePickerInput)
       .first()
@@ -44,7 +45,10 @@ describe("File picker widget v2", () => {
       });
 
     // wait for file to get uploaded
-    cy.wait("@updateLayout");
+    agHelper.ValidateNetworkStatus("@updateLayout");
+
+    // The table takes a bit of time to load the values in the cells
+    cy.wait(2000);
 
     cy.readTableV2dataPublish("1", "1").then((tabData) => {
       const tabValue = tabData;
@@ -55,7 +59,7 @@ describe("File picker widget v2", () => {
       expect(tabValue).to.be.equal("1000");
     });
     cy.get(
-      `${locator._widgetInDeployed(
+      `${locators._widgetInDeployed(
         "tablewidgetv2",
       )} .tbody .td[data-rowindex=${1}][data-colindex=${3}] input`,
     ).should("not.be.checked");
@@ -67,7 +71,10 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/TestSpreadsheet.xlsx", { force: true });
 
     // wait for file to get uploaded
-    cy.wait("@updateLayout");
+    agHelper.ValidateNetworkStatus("@updateLayout");
+
+    // The table takes a bit of time to load the values in the cells
+    cy.wait(2000);
 
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("Sheet1");
@@ -96,7 +103,10 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/largeJSONData.json", { force: true });
 
     // wait for file to get uploaded
-    cy.wait("@updateLayout");
+    agHelper.ValidateNetworkStatus("@updateLayout");
+
+    // The table takes a bit of time to load the values in the cells
+    cy.wait(2000);
 
     cy.readTableV2dataPublish("0", "2").then((tabData) => {
       expect(tabData).to.contain("sunt aut facere");
@@ -109,7 +119,10 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/Sample.tsv", { force: true });
 
     // wait for file to get uploaded
-    cy.wait("@updateLayout");
+    agHelper.ValidateNetworkStatus("@updateLayout");
+
+    // The table takes a bit of time to load the values in the cells
+    cy.wait(2000);
 
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("CONST");
@@ -127,7 +140,7 @@ describe("File picker widget v2", () => {
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(locator._widgetInDeployed("textwidget")).should(
+    cy.get(locators._widgetInDeployed("textwidget")).should(
       "contain",
       "data:application/json;base64",
     );
@@ -138,21 +151,24 @@ describe("File picker widget v2", () => {
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(locator._widgetInDeployed("textwidget")).should(
+    cy.get(locators._widgetInDeployed("textwidget")).should(
       "contain",
       "baseUrl",
     );
     cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
 
-    cy.wait("@updateLayout");
+    agHelper.ValidateNetworkStatus("@updateLayout");
 
-    cy.get(locator._widgetInDeployed("textwidget")).should("have.text", "");
+    // The table takes a bit of time to load the values in the cells
+    cy.wait(2000);
+
+    cy.get(locators._widgetInDeployed("textwidget")).should("have.text", "");
 
     cy.selectDropdownValue(commonlocators.filePickerDataFormat, "Binary");
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(locator._widgetInDeployed("textwidget")).should(
+    cy.get(locators._widgetInDeployed("textwidget")).should(
       "contain",
       "baseUrl",
     );

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
@@ -1,5 +1,7 @@
 const commonlocators = require("../../../../../locators/commonlocators.json");
 import * as _ from "../../../../../support/Objects/ObjectsCore";
+import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
+const locator = ObjectsRegistry.CommonLocators;
 
 const widgetName = "filepickerwidgetv2";
 const ARRAY_CSV_HELPER_TEXT = `All non CSV, XLS(X), JSON or TSV filetypes will have an empty value`;
@@ -32,6 +34,9 @@ describe("File picker widget v2", () => {
     cy.get(
       `.t--property-control-dataformat ${commonlocators.helperText}`,
     ).contains(ARRAY_CSV_HELPER_TEXT);
+
+    cy.wait("@updateLayout");
+
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/Test_csv.csv", {
@@ -39,7 +44,7 @@ describe("File picker widget v2", () => {
       });
 
     // wait for file to get uploaded
-    cy.wait(3000);
+    cy.wait("@updateLayout");
 
     cy.readTableV2dataPublish("1", "1").then((tabData) => {
       const tabValue = tabData;
@@ -50,9 +55,11 @@ describe("File picker widget v2", () => {
       expect(tabValue).to.be.equal("1000");
     });
     cy.get(
-      `.t--widget-tablewidgetv2 .tbody .td[data-rowindex=${1}][data-colindex=${3}] input`,
+      `${locator._widgetInDeployed(
+        "tablewidgetv2",
+      )} .tbody .td[data-rowindex=${1}][data-colindex=${3}] input`,
     ).should("not.be.checked");
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
 
     // Test for XLSX file
     cy.get(commonlocators.filePickerInput)
@@ -60,7 +67,7 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/TestSpreadsheet.xlsx", { force: true });
 
     // wait for file to get uploaded
-    cy.wait(3000);
+    cy.wait("@updateLayout");
 
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("Sheet1");
@@ -68,15 +75,12 @@ describe("File picker widget v2", () => {
     cy.readTableV2dataPublish("0", "1").then((tabData) => {
       expect(tabData).contains("Column A");
     });
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
 
     // Test for XLS file
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/SampleXLS.xls", { force: true });
-
-    // wait for file to get uploaded
-    cy.wait(3000);
 
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("Sheet1");
@@ -84,7 +88,7 @@ describe("File picker widget v2", () => {
     cy.readTableV2dataPublish("0", "1").then((tabData) => {
       expect(tabData).contains("Dulce");
     });
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
 
     // Test for JSON File
     cy.get(commonlocators.filePickerInput)
@@ -92,12 +96,12 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/largeJSONData.json", { force: true });
 
     // wait for file to get uploaded
-    cy.wait(3000);
+    cy.wait("@updateLayout");
 
     cy.readTableV2dataPublish("0", "2").then((tabData) => {
       expect(tabData).to.contain("sunt aut facere");
     });
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
 
     // Test for TSV File
     cy.get(commonlocators.filePickerInput)
@@ -105,12 +109,12 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/Sample.tsv", { force: true });
 
     // wait for file to get uploaded
-    cy.wait(3000);
+    cy.wait("@updateLayout");
 
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("CONST");
     });
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
 
     // Drag and drop a text widget for binding file data
     cy.dragAndDropToCanvas("textwidget", { x: 100, y: 100 });
@@ -123,27 +127,35 @@ describe("File picker widget v2", () => {
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(".t--widget-textwidget").should(
+    cy.get(locator._widgetInDeployed("textwidget")).should(
       "contain",
       "data:application/json;base64",
     );
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
 
     // Test for Text file
     cy.selectDropdownValue(commonlocators.filePickerDataFormat, "Text");
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(".t--widget-textwidget").should("contain", "baseUrl");
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
-    cy.wait(3000);
-    cy.get(".t--widget-textwidget").should("have.text", "");
+    cy.get(locator._widgetInDeployed("textwidget")).should(
+      "contain",
+      "baseUrl",
+    );
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+
+    cy.wait("@updateLayout");
+
+    cy.get(locator._widgetInDeployed("textwidget")).should("have.text", "");
 
     cy.selectDropdownValue(commonlocators.filePickerDataFormat, "Binary");
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(".t--widget-textwidget").should("contain", "baseUrl");
-    cy.get(".uppy-Dashboard-Item-action--remove").click({ force: true });
+    cy.get(locator._widgetInDeployed("textwidget")).should(
+      "contain",
+      "baseUrl",
+    );
+    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/Filepicker/FilePickerV2_CSV_spec.js
@@ -1,20 +1,19 @@
 const commonlocators = require("../../../../../locators/commonlocators.json");
-import * as _ from "../../../../../support/Objects/ObjectsCore";
-import { ObjectsRegistry } from "../../../../../support/Objects/Registry";
-const locator = ObjectsRegistry.CommonLocators;
-import { agHelper, locators } from "../../../../../support/Objects/ObjectsCore";
+import {
+  agHelper,
+  assertHelper,
+  locators,
+  propPane,
+  table,
+} from "../../../../../support/Objects/ObjectsCore";
 
 const widgetName = "filepickerwidgetv2";
 const ARRAY_CSV_HELPER_TEXT = `All non CSV, XLS(X), JSON or TSV filetypes will have an empty value`;
-const ObjectsRegistry =
-  require("../../../../../support/Objects/Registry").ObjectsRegistry;
-let propPane = ObjectsRegistry.PropertyPane;
-let table = ObjectsRegistry.Table;
 
 describe("File picker widget v2", () => {
   before(() => {
     cy.fixture("filePickerTableDSL").then((val) => {
-      _.agHelper.AddDsl(val);
+      agHelper.AddDsl(val);
     });
   });
 
@@ -27,9 +26,13 @@ describe("File picker widget v2", () => {
       commonlocators.filePickerDataFormat,
       "Array of Objects (CSV, XLS(X), JSON, TSV)",
     );
-    cy.get(commonlocators.filePickerDataFormat)
-      .last()
-      .should("have.text", "Array of Objects (CSV, XLS(X), JSON, TSV)");
+
+    agHelper.AssertText(
+      commonlocators.filePickerDataFormat,
+      "text",
+      "Array of Objects (CSV, XLS(X), JSON, TSV)",
+    );
+
     cy.get(
       `.t--property-control-dataformat ${commonlocators.helperText}`,
     ).should("exist");
@@ -37,7 +40,7 @@ describe("File picker widget v2", () => {
       `.t--property-control-dataformat ${commonlocators.helperText}`,
     ).contains(ARRAY_CSV_HELPER_TEXT);
 
-    agHelper.ValidateNetworkStatus("@updateLayout");
+    assertHelper.AssertNetworkStatus("@updateLayout", 200);
 
     cy.get(commonlocators.filePickerInput)
       .first()
@@ -46,7 +49,7 @@ describe("File picker widget v2", () => {
       });
 
     // wait for file to get uploaded
-    agHelper.ValidateNetworkStatus("@updateLayout");
+    assertHelper.AssertNetworkStatus("@updateLayout", 200);
 
     // The table takes a bit of time to load the values in the cells
     table.WaitUntilTableLoad(0, 0, "v2");
@@ -64,7 +67,8 @@ describe("File picker widget v2", () => {
         "tablewidgetv2",
       )} .tbody .td[data-rowindex=${1}][data-colindex=${3}] input`,
     ).should("not.be.checked");
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
 
     // Test for XLSX file
     cy.get(commonlocators.filePickerInput)
@@ -72,7 +76,7 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/TestSpreadsheet.xlsx", { force: true });
 
     // wait for file to get uploaded
-    agHelper.ValidateNetworkStatus("@updateLayout");
+    assertHelper.AssertNetworkStatus("@updateLayout", 200);
 
     // The table takes a bit of time to load the values in the cells
     table.WaitUntilTableLoad(0, 0, "v2");
@@ -83,7 +87,7 @@ describe("File picker widget v2", () => {
     cy.readTableV2dataPublish("0", "1").then((tabData) => {
       expect(tabData).contains("Column A");
     });
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
 
     // Test for XLS file
     cy.get(commonlocators.filePickerInput)
@@ -96,7 +100,7 @@ describe("File picker widget v2", () => {
     cy.readTableV2dataPublish("0", "1").then((tabData) => {
       expect(tabData).contains("Dulce");
     });
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
 
     // Test for JSON File
     cy.get(commonlocators.filePickerInput)
@@ -104,7 +108,7 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/largeJSONData.json", { force: true });
 
     // wait for file to get uploaded
-    agHelper.ValidateNetworkStatus("@updateLayout");
+    assertHelper.AssertNetworkStatus("@updateLayout", 200);
 
     // The table takes a bit of time to load the values in the cells
     table.WaitUntilTableLoad(0, 0, "v2");
@@ -112,7 +116,7 @@ describe("File picker widget v2", () => {
     cy.readTableV2dataPublish("0", "2").then((tabData) => {
       expect(tabData).to.contain("sunt aut facere");
     });
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
 
     // Test for TSV File
     cy.get(commonlocators.filePickerInput)
@@ -120,7 +124,7 @@ describe("File picker widget v2", () => {
       .selectFile("cypress/fixtures/Sample.tsv", { force: true });
 
     // wait for file to get uploaded
-    agHelper.ValidateNetworkStatus("@updateLayout");
+    assertHelper.AssertNetworkStatus("@updateLayout", 200);
 
     // The table takes a bit of time to load the values in the cells
     table.WaitUntilTableLoad(0, 0, "v2");
@@ -128,7 +132,7 @@ describe("File picker widget v2", () => {
     cy.readTableV2dataPublish("0", "0").then((tabData) => {
       expect(tabData).to.be.equal("CONST");
     });
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
 
     // Drag and drop a text widget for binding file data
     cy.dragAndDropToCanvas("textwidget", { x: 100, y: 100 });
@@ -141,38 +145,38 @@ describe("File picker widget v2", () => {
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(locators._widgetInDeployed("textwidget")).should(
-      "contain",
+    agHelper.GetNAssertContains(
+      locators._widgetInDeployed("textwidget"),
       "data:application/json;base64",
     );
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
 
     // Test for Text file
     cy.selectDropdownValue(commonlocators.filePickerDataFormat, "Text");
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(locators._widgetInDeployed("textwidget")).should(
-      "contain",
+    agHelper.GetNAssertContains(
+      locators._widgetInDeployed("textwidget"),
       "baseUrl",
     );
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
 
-    agHelper.ValidateNetworkStatus("@updateLayout");
+    assertHelper.AssertNetworkStatus("@updateLayout", 200);
 
     // The text widget takes a bit of time to load the values
     cy.wait(2000);
 
-    cy.get(locators._widgetInDeployed("textwidget")).should("have.text", "");
+    agHelper.AssertText(locators._widgetInDeployed("textwidget"), "text", "");
 
     cy.selectDropdownValue(commonlocators.filePickerDataFormat, "Binary");
     cy.get(commonlocators.filePickerInput)
       .first()
       .selectFile("cypress/fixtures/testdata.json", { force: true });
-    cy.get(locators._widgetInDeployed("textwidget")).should(
-      "contain",
+    agHelper.GetNAssertContains(
+      locators._widgetInDeployed("textwidget"),
       "baseUrl",
     );
-    cy.get(commonlocators.filePickerRemoveButton).click({ force: true });
+    agHelper.GetNClick(commonlocators.filePickerRemoveButton, 0, true);
   });
 });

--- a/app/client/cypress/locators/commonlocators.json
+++ b/app/client/cypress/locators/commonlocators.json
@@ -125,6 +125,7 @@
   "filePickerButton": ".t--widget-filepickerwidget",
   "filePickerInput": ".uppy-Dashboard-input",
   "filePickerUploadButton": ".uppy-StatusBar-actionBtn--upload",
+  "filePickerRemoveButton": ".uppy-Dashboard-Item-action--remove",
   "AddMoreFiles": ".uppy-DashboardContent-addMoreCaption",
   "filePickerOnFilesSelected": ".t--property-control-onfilesselected",
   "dataType": ".t--property-control-datatype input",


### PR DESCRIPTION
This PR fixes the flaky test seen in FilePickerV2_CSV_spec.js.

The fix has been to replace wait with network interceptors.