### PR TITLE
fix: fix execution of REST API query when dynamic binding is present in the URL

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
@@ -1,15 +1,17 @@
-import { agHelper, jsEditor } from "../../../../support/Objects/ObjectsCore";
-import * as _ from "../../../../support/Objects/ObjectsCore";
+const datasourceFormData = require("../../../../fixtures/datasources.json");
 
-describe("Test API execution with dynamic binding in URL", () => {
-  /* Create a JS Object and set TED API URL in an Appsmith store variable. */
-  it("1. Set URL in Appsmith store variable", () => {
+import { agHelper, jsEditor } from "../../../../support/Objects/ObjectsCore";
+import { apiPage } from "../../../../support/Objects/ObjectsCore";
+
+describe("Test API execution with dynamic binding in URL - Bug #24218", () => {
+  it("1. Test API execution with dynamic binding in URL", () => {
+    // Create JS Object to set Appsmith store variable to mockApiUrl
     jsEditor.CreateJSObject(
       `export default {
         myVar1: [],
         myVar2: {},
         myFun1 () {
-          storeValue("api_url", "http://host.docker.internal:5001/v1/dynamicrecords/getstudents");
+          storeValue("api_url", ${datasourceFormData["mockApiUrl"]});
         },
         myFun2: async function() {
         }
@@ -23,18 +25,15 @@ describe("Test API execution with dynamic binding in URL", () => {
       },
     );
 
-    agHelper.AssertAutoSave();
     jsEditor.RunJSObj();
-  });
 
-  /* Create an API with dynamic binding as URL and run it. */
-  it("2. Execute API", () => {
-    _.apiPage.CreateAndFillApi(
+    // Create API and set URL to {{appsmith.store.api_url}}
+    apiPage.CreateAndFillApi(
       "{{appsmith.store.api_url}}",
       "Api_with_dynamic_binding",
     );
-    _.apiPage.RunAPI();
-    _.apiPage.ResponseStatusCheck("200 OK");
-    _.agHelper.ActionContextMenuWithInPane("Delete");
+    apiPage.RunAPI();
+    apiPage.ResponseStatusCheck("200 OK");
+    agHelper.ActionContextMenuWithInPane("Delete");
   });
 });

--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
@@ -11,7 +11,7 @@ describe("Test API execution with dynamic binding in URL - Bug #24218", () => {
         myVar1: [],
         myVar2: {},
         myFun1 () {
-          storeValue("api_url", ${datasourceFormData["mockApiUrl"]});
+          storeValue("api_url", "${datasourceFormData["mockApiUrl"]}");
         },
         myFun2: async function() {
         }

--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
@@ -1,7 +1,10 @@
 const datasourceFormData = require("../../../../fixtures/datasources.json");
 
-import { agHelper, jsEditor } from "../../../../support/Objects/ObjectsCore";
-import { apiPage } from "../../../../support/Objects/ObjectsCore";
+import {
+  apiPage,
+  agHelper,
+  jsEditor,
+} from "../../../../support/Objects/ObjectsCore";
 
 describe("Test API execution with dynamic binding in URL - Bug #24218", () => {
   it("1. Test API execution with dynamic binding in URL", () => {

--- a/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/ApiTests/API_TestExecuteWithDynamicBindingInUrl_spec.ts
@@ -1,0 +1,40 @@
+import { agHelper, jsEditor } from "../../../../support/Objects/ObjectsCore";
+import * as _ from "../../../../support/Objects/ObjectsCore";
+
+describe("Test API execution with dynamic binding in URL", () => {
+  /* Create a JS Object and set TED API URL in an Appsmith store variable. */
+  it("1. Set URL in Appsmith store variable", () => {
+    jsEditor.CreateJSObject(
+      `export default {
+        myVar1: [],
+        myVar2: {},
+        myFun1 () {
+          storeValue("api_url", "http://host.docker.internal:5001/v1/dynamicrecords/getstudents");
+        },
+        myFun2: async function() {
+        }
+      }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: true,
+        prettify: true,
+      },
+    );
+
+    agHelper.AssertAutoSave();
+    jsEditor.RunJSObj();
+  });
+
+  /* Create an API with dynamic binding as URL and run it. */
+  it("2. Execute API", () => {
+    _.apiPage.CreateAndFillApi(
+      "{{appsmith.store.api_url}}",
+      "Api_with_dynamic_binding",
+    );
+    _.apiPage.RunAPI();
+    _.apiPage.ResponseStatusCheck("200 OK");
+    _.agHelper.ActionContextMenuWithInPane("Delete");
+  });
+});

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginError.java
@@ -29,6 +29,16 @@ public enum AppsmithPluginError implements BasePluginError{
             "{1}",
             "{2}"
     ),
+    PLUGIN_VALIDATE_DATASOURCE_ERROR(
+            500,
+            AppsmithPluginErrorCode.PLUGIN_VALIDATE_DATASOURCE_ERROR.getCode(),
+            "{0}",
+            AppsmithErrorAction.DEFAULT,
+            AppsmithPluginErrorCode.PLUGIN_VALIDATE_DATASOURCE_ERROR.getDescription(),
+            ErrorType.INTERNAL_ERROR,
+            "{1}",
+            "{2}"
+    ),
     PLUGIN_QUERY_TIMEOUT_ERROR(
             504,
             AppsmithPluginErrorCode.PLUGIN_QUERY_TIMEOUT_ERROR.getCode(),

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginErrorCode.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/exceptions/pluginExceptions/AppsmithPluginErrorCode.java
@@ -19,7 +19,8 @@ public enum AppsmithPluginErrorCode {
     PLUGIN_AUTHENTICATION_ERROR("PE-ATH-5000", "Datasource authentication error"),
     PLUGIN_UQI_WHERE_CONDITION_UNKNOWN("PE-UQI-5000", "Where condition could not be parsed"),
     GENERIC_STALE_CONNECTION("PE-STC-5000", "Secondary stale connection error"),
-    PLUGIN_EXECUTE_ARGUMENT_ERROR("PE-ARG-5000", "Wrong arguments provided")
+    PLUGIN_EXECUTE_ARGUMENT_ERROR("PE-ARG-5000", "Wrong arguments provided"),
+    PLUGIN_VALIDATE_DATASOURCE_ERROR("PE-DSE-5005", "Failed to validate datasource")
     ;
 
 

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
@@ -15,7 +15,8 @@ public class DatasourceUtils {
 
     protected static HeaderUtils headerUtils = new HeaderUtils();
 
-    public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
+    public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration,
+                                          boolean isEmbeddedDatasource) {
         /**
          * We don't verify whether the URL is in valid format because it can contain mustache template keys, and so
          * look invalid at this point, but become valid after mustache rendering. So we just check if URL field has
@@ -25,13 +26,19 @@ public class DatasourceUtils {
         Set<String> invalids = new HashSet<>();
 
         if (StringUtils.isEmpty(datasourceConfiguration.getUrl())) {
-            /**
-             * Deliberately skipping adding any invalidity message here because based on the current parsing logic the
-             * client can skip adding a URL to embedded datasource and instead add the entire URL to
-             * `actionConfiguration.path`.
-             * ref: https://theappsmith.slack.com/archives/C040LHZN03V/p1686478370473659?thread_ts=1686300736
-             * .679729&cid=C040LHZN03V
-             */
+            if (isEmbeddedDatasource) {
+                /**
+                 * Deliberately skipping adding any invalidity message here because based on the current parsing logic the
+                 * client can skip adding a URL to embedded datasource and instead add the entire URL to
+                 * `actionConfiguration.path`.
+                 * ref: https://theappsmith.slack.com/archives/C040LHZN03V/p1686478370473659?thread_ts=1686300736
+                 * .679729&cid=C040LHZN03V
+                 */
+            }
+            else {
+                invalids.add("Missing URL.");
+            }
+
         }
 
         final String contentTypeError = headerUtils.verifyContentType(datasourceConfiguration.getHeaders());

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/DatasourceUtils.java
@@ -25,7 +25,13 @@ public class DatasourceUtils {
         Set<String> invalids = new HashSet<>();
 
         if (StringUtils.isEmpty(datasourceConfiguration.getUrl())) {
-            invalids.add("Missing URL.");
+            /**
+             * Deliberately skipping adding any invalidity message here because based on the current parsing logic the
+             * client can skip adding a URL to embedded datasource and instead add the entire URL to
+             * `actionConfiguration.path`.
+             * ref: https://theappsmith.slack.com/archives/C040LHZN03V/p1686478370473659?thread_ts=1686300736
+             * .679729&cid=C040LHZN03V
+             */
         }
 
         final String contentTypeError = headerUtils.verifyContentType(datasourceConfiguration.getHeaders());

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/InitUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/restApiUtils/helpers/InitUtils.java
@@ -4,7 +4,6 @@ import com.appsmith.external.exceptions.pluginExceptions.AppsmithPluginError;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionResult;
 import com.appsmith.external.models.DatasourceConfiguration;
-import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
@@ -13,7 +12,7 @@ public class InitUtils {
     public String initializeRequestUrl(ActionConfiguration actionConfiguration,
                                             DatasourceConfiguration datasourceConfiguration ) {
         String path = (actionConfiguration.getPath() == null) ? "" : actionConfiguration.getPath();
-        return datasourceConfiguration.getUrl().trim() + path;
+        return datasourceConfiguration.getUrl().trim() + path.trim();
     }
 
     public void initializeResponseWithError(ActionExecutionResult result) {

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/DatasourceStorage.java
@@ -164,4 +164,8 @@ public class DatasourceStorage extends BaseDomain {
         this.setPluginId(pluginMap.get(this.getPluginId()));
         this.setIsRecentlyCreated(null);
     }
+
+    public boolean isEmbedded() {
+        return this.getDatasourceId() == null;
+    }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/BaseRestApiPluginExecutor.java
@@ -9,8 +9,8 @@ import com.appsmith.external.helpers.restApiUtils.helpers.DatasourceUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.HeaderUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.HintMessageUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.InitUtils;
-import com.appsmith.external.helpers.restApiUtils.helpers.SmartSubstitutionUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.RestAPIActivateUtils;
+import com.appsmith.external.helpers.restApiUtils.helpers.SmartSubstitutionUtils;
 import com.appsmith.external.helpers.restApiUtils.helpers.URIUtils;
 import com.appsmith.external.models.ActionConfiguration;
 import com.appsmith.external.models.ActionExecutionResult;
@@ -73,9 +73,22 @@ public class BaseRestApiPluginExecutor implements PluginExecutor<APIConnection>,
     }
 
     @Override
-    public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
+    public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration,
+                                          boolean isEmbeddedDatasource) {
         /* Use the default validation routine for REST API based plugins */
-        return datasourceUtils.validateDatasource(datasourceConfiguration);
+        return datasourceUtils.validateDatasource(datasourceConfiguration, isEmbeddedDatasource);
+    }
+
+    @Override
+    public Set<String> validateDatasource(DatasourceConfiguration datasourceConfiguration) {
+        /**
+         * This method is not expected to be used as the REST API based plugins may have embedded datasource. Instead
+         * the following variant should be used:
+         * validateDatasource(DatasourceConfiguration datasourceConfiguration, boolean isEmbeddedDatasource)
+         */
+        throw new AppsmithPluginException(AppsmithPluginError.PLUGIN_VALIDATE_DATASOURCE_ERROR, "This method should " +
+                "not be used for this plugin as it may have embedded datasource. Please use validateDatasource" +
+                "(dsConfig, isEmbedded).");
     }
 
     @Override

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/plugins/DatasourceUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/plugins/DatasourceUtilsTest.java
@@ -10,10 +10,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DatasourceUtilsTest {
     @Test
-    public void testValidateDatasourceSkipsEmptyUrlCheck() {
+    public void testValidateDatasourceSkipsEmptyUrlCheckIfEmbedded() {
         DatasourceConfiguration dsConfig = new DatasourceConfiguration();
         DatasourceUtils datasourceUtils = new DatasourceUtils();
-        Set<String> invalids = datasourceUtils.validateDatasource(dsConfig);
+        Set<String> invalids = datasourceUtils.validateDatasource(dsConfig, true);
         assertTrue(invalids.isEmpty());
+    }
+
+    @Test
+    public void testValidateDatasourceAddsEmptyUrlInvalidIfNotEmbedded() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        DatasourceUtils datasourceUtils = new DatasourceUtils();
+        Set<String> invalids = datasourceUtils.validateDatasource(dsConfig, false);
+        assertTrue(invalids.contains("Missing URL."));
     }
 }

--- a/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/plugins/DatasourceUtilsTest.java
+++ b/app/server/appsmith-interfaces/src/test/java/com/appsmith/external/plugins/DatasourceUtilsTest.java
@@ -1,0 +1,19 @@
+package com.appsmith.external.plugins;
+
+import com.appsmith.external.helpers.restApiUtils.helpers.DatasourceUtils;
+import com.appsmith.external.models.DatasourceConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DatasourceUtilsTest {
+    @Test
+    public void testValidateDatasourceSkipsEmptyUrlCheck() {
+        DatasourceConfiguration dsConfig = new DatasourceConfiguration();
+        DatasourceUtils datasourceUtils = new DatasourceUtils();
+        Set<String> invalids = datasourceUtils.validateDatasource(dsConfig);
+        assertTrue(invalids.isEmpty());
+    }
+}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
@@ -204,8 +204,10 @@ public class DatasourceStorageServiceCEImpl implements DatasourceStorageServiceC
         return pluginExecutorMono
                 .map(pluginExecutor -> {
                     DatasourceConfiguration datasourceConfiguration = datasourceStorage.getDatasourceConfiguration();
-                    if (datasourceConfiguration != null && !pluginExecutor.isDatasourceValid(datasourceConfiguration)) {
-                        invalids.addAll(pluginExecutor.validateDatasource(datasourceConfiguration));
+                    if (datasourceConfiguration != null && !pluginExecutor.isDatasourceValid(datasourceConfiguration,
+                            datasourceStorage.isEmbedded())) {
+                        invalids.addAll(pluginExecutor.validateDatasource(datasourceConfiguration,
+                                datasourceStorage.isEmbedded()));
                     }
 
                     return datasourceStorage;


### PR DESCRIPTION
## Description
- Earlier the client would by default set a URL in REST API query config in `datasource.url` path if it could not parse the URL properly. This made sure that `datasource.url` path was non-empty as long as user entered some value in the URL input box on the REST API query config page. However, this was changed recently to fix an issue related to showing the evaluated value of dynamic binding on the client. As per the current logic, the default path for the URL has been updated to `actionConfiguration.path`. Hence, for newer REST API queries where `datasource.url` is emtpy, a validation error shows up.  This PR includes changes to stop the empty URL validation check for embedded datasources on REST API datasource URL as it can be empty now for embedded datasource. 
- [Ref](https://theappsmith.slack.com/archives/C040LHZN03V/p1686478370473659?thread_ts=1686300736.679729&cid=C040LHZN03V)

#### PR fixes following issue(s)
Fixes #24218
  - Another fix required on client side for a different issue (Ade is working on it)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Cypress
- [x] JUnit
- [x] Manual

#### Test Plan
1. Write the following in JS Object
export default {
	myVar1: [],
	myVar2: {},
	myFun1 () {
		
		{{storeValue('api_url',"https://postman-echo.com/get")}}
		//	write code here
		//	this.myVar1 = [1,2,3]
	}
} 
Run it.
Create a new api and invoke GET - {{appsmith.store.api_url}}


2. Tried with following different APIs
	https://api.publicapis.org/entries
	https://official-joke-api.appspot.com/random_joke
        https://api.zippopotam.us/us/33162

3. Tried binding the storeValue api url in an input and text widget: e.g. {{storeValue('api_url',Text2.text)}} and then running API using that stored value. 

>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Test-plan-implementation#speedbreaker-features-to-consider-for-every-change) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans/_edit#areas-of-interest)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
