### PR TITLE
feat: Configurable api server timeout value on Nginx

### DIFF
--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -93,6 +93,10 @@ server {
   }
 
   location /api {
+    proxy_read_timeout ${APPSMITH_SERVER_TIMEOUT:-60};
+    proxy_connect_timeout ${APPSMITH_SERVER_TIMEOUT:-60};
+    proxy_send_timeout ${APPSMITH_SERVER_TIMEOUT:-60};
+  
     proxy_pass http://localhost:8080;
   }
 

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -110,6 +110,10 @@ server {
   }
 
   location /api {
+    proxy_read_timeout ${APPSMITH_SERVER_TIMEOUT:-60};
+    proxy_connect_timeout ${APPSMITH_SERVER_TIMEOUT:-60};
+    proxy_send_timeout ${APPSMITH_SERVER_TIMEOUT:-60};
+    
     proxy_pass http://localhost:8080;
   }
 


### PR DESCRIPTION
## Description
- The default request timeout on nginx is set to 60s. This feat allows users to configure custom nginx timeout value specified via the Environment variable `APPSMITH_SERVER_TIMEOUT`
- Solves https://github.com/appsmithorg/appsmith/issues/14535
## Testing
#### How Has This Been Tested?
- [ ] Manual
- [ ] Jest
- [ ] Cypress

