### PR TITLE
test: Cypress | AirtableSpec dropdown value fix

### DIFF
--- a/app/client/cypress/support/Pages/DataSources.ts
+++ b/app/client/cypress/support/Pages/DataSources.ts
@@ -526,7 +526,7 @@ export class DataSources {
     this.ValidateNSelectDropdown(
       "Authentication type",
       "Please select an option",
-      "Bearer token",
+      "Personal access token",
     );
     this.agHelper.UpdateInput(
       this.locator._inputFieldByName("Bearer token"),


### PR DESCRIPTION
## Description
 - This PR fixes the Airtable dropdown value change from ‘Bearer token’ to ‘Personal access token’

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Testing

#### How Has This Been Tested?

- [X] Cypress local run

## Checklist:
#### QA activity:
- [ ] Added `Test Plan Approved` label after changes were reviewed