### PR TITLE
chore: Moving server restart timeout variables to tenant constants file

### DIFF
--- a/app/client/src/ce/constants/tenantConstants.ts
+++ b/app/client/src/ce/constants/tenantConstants.ts
@@ -1,1 +1,4 @@
 export const tenantConfigConnection: string[] = [];
+
+export const RESTART_POLL_TIMEOUT = 2 * 60 * 1000;
+export const RESTART_POLL_INTERVAL = 2000;

--- a/app/client/src/ce/sagas/SuperUserSagas.tsx
+++ b/app/client/src/ce/sagas/SuperUserSagas.tsx
@@ -25,6 +25,10 @@ import { EMAIL_SETUP_DOC } from "constants/ThirdPartyConstants";
 import { getCurrentTenant } from "@appsmith/actions/tenantActions";
 import { toast } from "design-system";
 import AnalyticsUtil from "utils/AnalyticsUtil";
+import {
+  RESTART_POLL_INTERVAL,
+  RESTART_POLL_TIMEOUT,
+} from "@appsmith/constants/tenantConstants";
 
 export function* FetchAdminSettingsSaga() {
   const response: ApiResponse = yield call(UserApi.fetchAdminSettings);
@@ -120,9 +124,6 @@ export function* SaveAdminSettingsSaga(
     });
   }
 }
-
-const RESTART_POLL_TIMEOUT = 2 * 60 * 1000;
-const RESTART_POLL_INTERVAL = 2000;
 
 export function* RestartServerPoll() {
   yield call(UserApi.restartServer);


### PR DESCRIPTION
## Description

Moving server restart timeout variables to tenant constants file

#### PR fixes following issue(s)
Fixes [#23212](https://github.com/appsmithorg/appsmith/issues/23212)

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
