### PR TITLE
test: Cypress

### DIFF
--- a/app/client/cypress/support/Pages/DeployModeHelper.ts
+++ b/app/client/cypress/support/Pages/DeployModeHelper.ts
@@ -92,6 +92,9 @@ export class DeployMode {
     this.agHelper.GetNClick(this.locator._backToEditor, 0, true);
     this.agHelper.Sleep(2000);
     localStorage.setItem("inDeployedMode", "false");
+    this.agHelper.AssertElementAbsence(
+      this.locator._specificToast("There was an unexpcted error"),
+    ); //Assert that is not error toast in Edit mode when navigating back from Deploy mode
     this.assertHelper.AssertDocumentReady();
     this.assertHelper.AssertNetworkStatus("@getWorkspace");
     this.agHelper.AssertElementVisible(this.locator._dropHere); //Assert if canvas is visible after Navigating back!


### PR DESCRIPTION
## Description
- This PR adds the No Error toast to NavigateBacktoEditor() which sometimes results in Edit page not being load in CI runs
- Attempts to capture Widgets/Input/Input_spec.js [recent run failure](https://cloud.cypress.io/projects/eyxvp8/runs/36365/test-results?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D&testingTypesEnum=%5B%5D)
