### PR TITLE
chore: Skip tests in server build if no changes in server files for ok-to-test command

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -21,12 +21,34 @@ jobs:
             PR: ${{ github.event.client_payload.pull_request.number }}.
             Perf tests will be available at <https://app.appsmith.com/app/performance-infra-dashboard/pr-details-638dd7cd2913ba43778b915e?pr=${{ github.event.client_payload.pull_request.number }}&runId=${{ github.run_id }}_${{github.run_attempt}}>
 
+  changeset:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          backend:
+            - 'app/server/**'
+
   server-build:
     name: server-build
+    needs: [changeset]
     uses: ./.github/workflows/server-build.yml
     secrets: inherit
     with:
       pr: ${{ github.event.client_payload.pull_request.number }}
+      skip-tests: ${{ needs.changeset.outputs.backend == 'false' }}
 
   client-build:
     name: client-build


### PR DESCRIPTION
Fixes #24700

These changes will allow the CI to skip tests if there are no changes in server folder when using ok-to-test command. This will save CI minutes