### PR TITLE
fix: changing the index for datasourceStorageStructure collection

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration009RemoveStructureFromWithinDatasource.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration009RemoveStructureFromWithinDatasource.java
@@ -15,7 +15,7 @@ import org.springframework.data.mongodb.core.query.Update;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
 
-@ChangeUnit(order = "009", id = "remove-structure-from-within-datasource")
+@ChangeUnit(order = "009", id = "remove-structure-from-within-datasource-modified")
 public class Migration009RemoveStructureFromWithinDatasource {
 
     private final MongoOperations mongoOperations;
@@ -38,7 +38,7 @@ public class Migration009RemoveStructureFromWithinDatasource {
         DatabaseChangelog1.dropIndexIfExists(mongoTemplate, DatasourceStorageStructure.class, "dsConfigStructure_dsId_envId");
 
         DatabaseChangelog1.ensureIndexes(mongoTemplate, DatasourceStorageStructure.class,
-                DatabaseChangelog1.makeIndex("datasourceId", "envId")
+                DatabaseChangelog1.makeIndex("datasourceId", "environmentId")
                         .unique().named("dsConfigStructure_dsId_envId")
         );
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration012RenameIndexesWithLongNames.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration012RenameIndexesWithLongNames.java
@@ -108,7 +108,7 @@ public class Migration012RenameIndexesWithLongNames {
         // remove-structure-from-within-datasource
         dropIndexIfExists(mongoTemplate, DatasourceStorageStructure.class, "dsConfigStructure_datasourceId_envId_compound_index");
         DatabaseChangelog1.ensureIndexes(mongoTemplate, DatasourceStorageStructure.class,
-            DatabaseChangelog1.makeIndex("datasourceId", "envId")
+            DatabaseChangelog1.makeIndex("datasourceId", "environmentId")
                 .unique().named("dsConfigStructure_dsId_envId")
         );
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration015RemoveNullEnvIdDatasourceStrucutureDocuments.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/migrations/db/ce/Migration015RemoveNullEnvIdDatasourceStrucutureDocuments.java
@@ -1,0 +1,39 @@
+package com.appsmith.server.migrations.db.ce;
+
+import com.appsmith.external.models.DatasourceStorageStructure;
+import com.appsmith.server.constants.FieldName;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+@Slf4j
+@ChangeUnit(order = "015", id = "delete-null-envId-key-document", author = " ")
+public class Migration015RemoveNullEnvIdDatasourceStrucutureDocuments {
+
+    private final MongoTemplate mongoTemplate;
+    private static final String environmentId = FieldName.ENVIRONMENT_ID;
+    public Migration015RemoveNullEnvIdDatasourceStrucutureDocuments(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @RollbackExecution
+    public void rollbackExecution() {
+        // We're handling rollbacks using marker fields, so we don't need to implement this
+    }
+
+    @Execution
+    public void executeMigration() {
+        mongoTemplate.remove(new Query().addCriteria(nullEnvironmentIdCriterion()), DatasourceStorageStructure.class);
+    }
+
+    private Criteria nullEnvironmentIdCriterion() {
+        return new Criteria().orOperator(
+                Criteria.where(environmentId).is(null),
+                Criteria.where(environmentId).exists(false)
+        );
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.StringUtils;
@@ -342,4 +343,100 @@ public class DatasourceStructureSolutionTest {
                 })
                 .verifyComplete();
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void verifyDatasourceStorageStructureEntriesWithTwoEnvironmentId() {
+        doReturn(Mono.just(generateDatasourceStructureObject()))
+                .when(datasourceContextService).retryOnce(any(), any());
+
+        // creating an entry with environmentId as randomId and then
+        datasourceStructureService.
+                saveStructure(datasourceId, "randomId", generateDatasourceStructureObject())
+                .block();
+
+        datasourceStructureSolution.getStructure(datasourceId, Boolean.FALSE, defaultEnvironmentId).block();
+
+        Mono<DatasourceStorageStructure> datasourceStorageStructureMono =
+                datasourceStructureService.getByDatasourceIdAndEnvironmentId(datasourceId, defaultEnvironmentId);
+
+        StepVerifier
+                .create(datasourceStorageStructureMono)
+                .assertNext(datasourceStorageStructure -> {
+                    assertThat(datasourceStorageStructure.getDatasourceId()).isEqualTo(datasourceId);
+                    assertThat(datasourceStorageStructure.getEnvironmentId()).isEqualTo(defaultEnvironmentId);
+                })
+                .verifyComplete();
+
+        Mono<DatasourceStorageStructure> datasourceStorageStructureMonoWithRandomEnvironmentId =
+                datasourceStructureService.getByDatasourceIdAndEnvironmentId(datasourceId, "randomId");
+
+        StepVerifier
+                .create(datasourceStorageStructureMonoWithRandomEnvironmentId)
+                .assertNext(datasourceStorageStructure -> {
+                    assertThat(datasourceStorageStructure.getDatasourceId()).isEqualTo(datasourceId);
+                    assertThat(datasourceStorageStructure.getEnvironmentId()).isEqualTo("randomId");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void verifyDatasourceStorageStructureEntriesWithNullEnvironmentId() {
+        doReturn(Mono.just(generateDatasourceStructureObject()))
+                .when(datasourceContextService).retryOnce(any(), any());
+
+        // creating an entry with environmentId as randomId and then
+        datasourceStructureService.
+                saveStructure(datasourceId, null, generateDatasourceStructureObject())
+                .block();
+
+        datasourceStructureSolution.getStructure(datasourceId, Boolean.FALSE, defaultEnvironmentId).block();
+
+        Mono<DatasourceStorageStructure> datasourceStorageStructureMono =
+                datasourceStructureService.getByDatasourceIdAndEnvironmentId(datasourceId, defaultEnvironmentId);
+
+        StepVerifier
+                .create(datasourceStorageStructureMono)
+                .assertNext(datasourceStorageStructure -> {
+                    assertThat(datasourceStorageStructure.getDatasourceId()).isEqualTo(datasourceId);
+                    assertThat(datasourceStorageStructure.getEnvironmentId()).isEqualTo(defaultEnvironmentId);
+                })
+                .verifyComplete();
+
+        Mono<DatasourceStorageStructure> datasourceStorageStructureMonoWithNullEnvironmentId =
+                datasourceStructureService.getByDatasourceIdAndEnvironmentId(datasourceId, null);
+
+        StepVerifier
+                .create(datasourceStorageStructureMonoWithNullEnvironmentId)
+                .assertNext(datasourceStorageStructure -> {
+                    assertThat(datasourceStorageStructure.getDatasourceId()).isEqualTo(datasourceId);
+                    assertThat(datasourceStorageStructure.getEnvironmentId()).isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void verifyDuplicateKeyErrorOnSave() {
+        doReturn(Mono.just(generateDatasourceStructureObject()))
+                .when(datasourceContextService).retryOnce(any(), any());
+
+        datasourceStructureSolution.getStructure(datasourceId, Boolean.FALSE, defaultEnvironmentId).block();
+
+        DatasourceStorageStructure datasourceStorageStructure = new DatasourceStorageStructure();
+        datasourceStorageStructure.setDatasourceId(datasourceId);
+        datasourceStorageStructure.setEnvironmentId(defaultEnvironmentId);
+        datasourceStorageStructure.setStructure(new DatasourceStructure());
+
+        Mono<DatasourceStorageStructure>  datasourceStorageStructureMono =
+                datasourceStructureService.save(datasourceStorageStructure);
+
+        StepVerifier
+                .create(datasourceStorageStructureMono)
+                .verifyErrorSatisfies(error ->  {
+                    assertThat(error).isInstanceOf(DuplicateKeyException.class);
+                });
+    }
+
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
@@ -382,42 +382,6 @@ public class DatasourceStructureSolutionTest {
 
     @Test
     @WithUserDetails(value = "api_user")
-    public void verifyDatasourceStorageStructureEntriesWithNullEnvironmentId() {
-        doReturn(Mono.just(generateDatasourceStructureObject()))
-                .when(datasourceContextService).retryOnce(any(), any());
-
-        // creating an entry with environmentId as randomId and then
-        datasourceStructureService.
-                saveStructure(datasourceId, null, generateDatasourceStructureObject())
-                .block();
-
-        datasourceStructureSolution.getStructure(datasourceId, Boolean.FALSE, defaultEnvironmentId).block();
-
-        Mono<DatasourceStorageStructure> datasourceStorageStructureMono =
-                datasourceStructureService.getByDatasourceIdAndEnvironmentId(datasourceId, defaultEnvironmentId);
-
-        StepVerifier
-                .create(datasourceStorageStructureMono)
-                .assertNext(datasourceStorageStructure -> {
-                    assertThat(datasourceStorageStructure.getDatasourceId()).isEqualTo(datasourceId);
-                    assertThat(datasourceStorageStructure.getEnvironmentId()).isEqualTo(defaultEnvironmentId);
-                })
-                .verifyComplete();
-
-        Mono<DatasourceStorageStructure> datasourceStorageStructureMonoWithNullEnvironmentId =
-                datasourceStructureService.getByDatasourceIdAndEnvironmentId(datasourceId, null);
-
-        StepVerifier
-                .create(datasourceStorageStructureMonoWithNullEnvironmentId)
-                .assertNext(datasourceStorageStructure -> {
-                    assertThat(datasourceStorageStructure.getDatasourceId()).isEqualTo(datasourceId);
-                    assertThat(datasourceStorageStructure.getEnvironmentId()).isNull();
-                })
-                .verifyComplete();
-    }
-
-    @Test
-    @WithUserDetails(value = "api_user")
     public void verifyDuplicateKeyErrorOnSave() {
         doReturn(Mono.just(generateDatasourceStructureObject()))
                 .when(datasourceContextService).retryOnce(any(), any());


### PR DESCRIPTION
## Description

Have placed a more specific unique index on datasourceStorageStructure collection. Applying the index wouldn't cause any problems because of general uniqueness already existing.

> TLDR; changing the index for datasourceStorageStructure collection

#### PR fixes following issue(s)
Fixes #24628 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
- [ ] Manual

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
