### PR TITLE
chore: log editor state on test failure

### DIFF
--- a/app/client/cypress/support/e2e.js
+++ b/app/client/cypress/support/e2e.js
@@ -43,6 +43,13 @@ Cypress.on("uncaught:exception", () => {
 });
 
 Cypress.on("fail", (error) => {
+  cy.window()
+    .its("store")
+    .invoke("getState")
+    .then((state) => {
+      cy.log(`Editor initialised: ${state.ui.editor.initialized}`);
+      cy.log(`Loading guided tour: ${state.ui.guidedTour.loading}`);
+    });
   throw error; // throw error to have test still fail
 });
 


### PR DESCRIPTION
Added some logs to be printed on failure. Hoping this would help in debugging the loading issue. Will remove it later once it is fixed.
Related to https://github.com/appsmithorg/appsmith/issues/23713