### PR TITLE
chore: [perf optimisations for large data sets] optimised extract info binding code

### DIFF
--- a/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
+++ b/app/client/src/workers/Evaluation/handlers/jsLibrary.ts
@@ -4,6 +4,7 @@ import {
 } from "@appsmith/constants/messages";
 import difference from "lodash/difference";
 import type { Def } from "tern";
+import { invalidEntityIdentifiers } from "workers/common/DependencyMap/utils";
 import {
   JSLibraries,
   libraryReservedIdentifiers,
@@ -145,7 +146,9 @@ export function installLibrary(request: EvalWorkerSyncRequest) {
 
     //Reserve accessor names.
     for (const acc of accessor) {
+      //we have to update invalidEntityIdentifiers as well
       libraryReservedIdentifiers[acc] = true;
+      invalidEntityIdentifiers[acc] = true;
     }
 
     return { success: true, defs, accessor };
@@ -165,7 +168,9 @@ export function uninstallLibrary(request: EvalWorkerSyncRequest) {
         //@ts-expect-error ignore
         self[key] = undefined;
       }
+      //we have to update invalidEntityIdentifiers as well
       delete libraryReservedIdentifiers[key];
+      delete invalidEntityIdentifiers[key];
     }
     return { success: true };
   } catch (e) {
@@ -189,7 +194,9 @@ export function loadLibraries(request: EvalWorkerSyncRequest) {
   const keysAfter = Object.keys(self);
   const newKeys = difference(keysAfter, keysBefore);
   for (const key of newKeys) {
+    //we have to update invalidEntityIdentifiers as well
     libraryReservedIdentifiers[key] = true;
+    invalidEntityIdentifiers[key] = true;
   }
   JSLibraries.push(...data);
   return { success: !message, message };

--- a/app/client/src/workers/common/DependencyMap/utils.ts
+++ b/app/client/src/workers/common/DependencyMap/utils.ts
@@ -56,7 +56,7 @@ export const extractInfoFromBinding = (
   const { references } = extractIdentifierInfoFromCode(
     script,
     self.evaluationVersion,
-    { ...invalidEntityIdentifiers, ...libraryReservedIdentifiers },
+    invalidEntityIdentifiers,
   );
   return extractInfoFromReferences(references, allPaths);
 };
@@ -214,10 +214,11 @@ export const mergeArrays = <T>(currentArr: T[], updateArr: T[]): T[] => {
  * they can refer to potentially dynamic entities.
  * Eg. "appsmith"
  */
-const invalidEntityIdentifiers: Record<string, unknown> = {
+export const invalidEntityIdentifiers: Record<string, unknown> = {
   ...JAVASCRIPT_KEYWORDS,
   ...APPSMITH_GLOBAL_FUNCTIONS,
   ...DEDICATED_WORKER_GLOBAL_SCOPE_IDENTIFIERS,
+  ...libraryReservedIdentifiers,
 };
 
 export function listEntityDependencies(

--- a/app/client/src/workers/common/JSLibrary/resetJSLibraries.ts
+++ b/app/client/src/workers/common/JSLibrary/resetJSLibraries.ts
@@ -4,6 +4,7 @@ import parser from "fast-xml-parser";
 import forge from "node-forge";
 import { defaultLibraries } from "./index";
 import { JSLibraries, libraryReservedIdentifiers } from "./index";
+import { invalidEntityIdentifiers } from "../DependencyMap/utils";
 
 const defaultLibImplementations = {
   lodash: _,
@@ -29,7 +30,9 @@ export function resetJSLibraries() {
       // @ts-expect-error: Types are not available
       self[key] = undefined;
     }
+    //we have to update invalidEntityIdentifiers as well
     delete libraryReservedIdentifiers[key];
+    delete invalidEntityIdentifiers[key];
   }
 
   JSLibraries.forEach((library) => {


### PR DESCRIPTION
## Description
Removed redundant copy operation around extractInfoFromBinding. This has brought an improvement to the setupUpdateTree function. Seen a reduction of eval computation by 60% when changing the table data from 3200 records to 10000 records.
#### PR fixes following issue(s)
Fixes #24753 

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)
>
>
>
## Testing
>
#### How Has This Been Tested?

>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
