### PR TITLE
chore: print workflow information

### DIFF
--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -20,6 +20,33 @@ jobs:
             Commit: `${{ github.event.client_payload.slash_command.args.named.sha }}`.
             PR: ${{ github.event.client_payload.pull_request.number }}.
             Perf tests will be available at <https://app.appsmith.com/app/performance-infra-dashboard/pr-details-638dd7cd2913ba43778b915e?pr=${{ github.event.client_payload.pull_request.number }}&runId=${{ github.run_id }}_${{github.run_attempt}}>
+  changeset:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+    - name: View github event
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        echo "Issue body Github context"
+        #echo "$GITHUB_CONTEXT"
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.client_payload.pull_request.merge.ref }}
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        base: ${{ github.event.client_payload.pull_request.base.ref }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
+        filters: |
+          backend:
+            - 'app/server/**'
 
   server-build:
     name: server-build


### PR DESCRIPTION
This PR prints github event when ok-to-test command is run. This is needed for debugging optimization changes to skip server tests if there are no server side changes.