### PR TITLE
feat: granular widgets for canvas

### DIFF
--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/constants/CommonConstants.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/constants/CommonConstants.java
@@ -2,13 +2,27 @@ package com.appsmith.git.constants;
 
 public class CommonConstants {
     // This field will be useful when we migrate fields within JSON files (currently this will be useful for Git feature)
-    public static Integer fileFormatVersion = 4;
+    public static Integer fileFormatVersion = 5;
     public static String FILE_FORMAT_VERSION = "fileFormatVersion";
+
     public static final String CANVAS = "canvas";
+
     public static final String APPLICATION = "application";
     public static final String THEME = "theme";
     public static final String METADATA = "metadata";
     public static final String JSON_EXTENSION = ".json";
     public static final String JS_EXTENSION = ".js";
     public static final String TEXT_FILE_EXTENSION = ".txt";
+    public static final String WIDGETS = "widgets";
+    public static final String WIDGET_NAME = "widgetName";
+    public static final String WIDGET_ID = "widgetId";
+    public static final String PARENT_ID = "parentId";
+    public static final String WIDGET_TYPE = "type";
+    public static final String CHILDREN = "children";
+
+    public static final String CANVAS_WIDGET = "CANVAS_WIDGET";
+    public static final String MAIN_CONTAINER = "MainContainer";
+    public static final String DELIMITER_POINT = ".";
+    public static final String DELIMITER_PATH = "/";
+    public static final String EMPTY_STRING = "";
 }

--- a/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/DSLTransformerHelper.java
+++ b/app/server/appsmith-git/src/main/java/com/appsmith/git/helpers/DSLTransformerHelper.java
@@ -1,0 +1,169 @@
+package com.appsmith.git.helpers;
+
+import com.appsmith.git.constants.CommonConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DSLTransformerHelper {
+
+    public static Map<String, JSONObject> flatten(JSONObject jsonObject) {
+        Map<String, JSONObject> flattenedMap = new HashMap<>();
+        flattenObject(jsonObject, CommonConstants.EMPTY_STRING, flattenedMap);
+        return new TreeMap<>(flattenedMap);
+    }
+
+    private static void flattenObject(JSONObject jsonObject, String prefix, Map<String, JSONObject> flattenedMap) {
+        String widgetName = jsonObject.optString(CommonConstants.WIDGET_NAME);
+        if (widgetName.isEmpty()) {
+            return;
+        }
+
+        JSONArray children = jsonObject.optJSONArray(CommonConstants.CHILDREN);
+        if (children != null) {
+            // Check if the children object has type=CANVAS_WIDGET
+            jsonObject = removeChildrenIfNotCanvasWidget(jsonObject);
+            flattenedMap.put(prefix + widgetName, jsonObject);
+
+            for (int i = 0; i < children.length(); i++) {
+                JSONObject childObject = children.getJSONObject(i);
+                String childPrefix = prefix + widgetName + CommonConstants.DELIMITER_POINT;
+                flattenObject(childObject, childPrefix, flattenedMap);
+            }
+        } else {
+            flattenedMap.put(prefix + widgetName, jsonObject);
+        }
+    }
+
+    private static JSONObject removeChildrenIfNotCanvasWidget(JSONObject jsonObject) {
+        JSONArray children = jsonObject.optJSONArray(CommonConstants.CHILDREN);
+        if (children.length() == 1) {
+            JSONObject child = children.getJSONObject(0);
+            if (!CommonConstants.CANVAS_WIDGET.equals(child.optString(CommonConstants.WIDGET_TYPE))) {
+                jsonObject.remove(CommonConstants.CHILDREN);
+            } else {
+                JSONObject childCopy = new JSONObject(child.toString());
+                childCopy.remove(CommonConstants.CHILDREN);
+                JSONArray jsonArray = new JSONArray();
+                jsonArray.put(childCopy);
+                jsonObject.put(CommonConstants.CHILDREN, jsonArray);
+            }
+        } else {
+            jsonObject.remove(CommonConstants.CHILDREN);
+        }
+        return jsonObject;
+    }
+
+    public static boolean hasChildren(JSONObject jsonObject) {
+        JSONArray children = jsonObject.optJSONArray(CommonConstants.CHILDREN);
+        return children != null && children.length() > 0;
+    }
+
+    public static Map<String, List<String>> calculateParentDirectories(List<String> paths) {
+        Map<String, List<String>> parentDirectories = new HashMap<>();
+
+        paths = paths.stream().map(currentPath -> currentPath.replace(CommonConstants.JSON_EXTENSION, CommonConstants.EMPTY_STRING)).collect(Collectors.toList());
+        for (String path : paths) {
+            String[] directories = path.split(CommonConstants.DELIMITER_PATH);
+            int lastDirectoryIndex = directories.length - 1;
+
+            if (lastDirectoryIndex > 0 && directories[lastDirectoryIndex].equals(directories[lastDirectoryIndex - 1])) {
+                if (lastDirectoryIndex - 2 >= 0) {
+                    String parentDirectory = directories[lastDirectoryIndex - 2];
+                    List<String> pathsList = parentDirectories.getOrDefault(parentDirectory, new ArrayList<>());
+                    pathsList.add(path);
+                    parentDirectories.put(parentDirectory, pathsList);
+                }
+            } else {
+                String parentDirectory = directories[lastDirectoryIndex - 1];
+                List<String> pathsList = parentDirectories.getOrDefault(parentDirectory, new ArrayList<>());
+                pathsList.add(path);
+                parentDirectories.put(parentDirectory, pathsList);
+            }
+        }
+
+        return parentDirectories;
+    }
+
+    /*
+     * /Form1/Button1.json,
+     * /List1/List1.json,
+     * /List1/Container1/Text2.json,
+     * /List1/Container1/Image1.json,
+     * /Form1/Button2.json,
+     * /List1/Container1/Text1.json,
+     * /Form1/Text3.json,
+     * /Form1/Form1.json,
+     * /List1/Container1/Container1.json,
+     * /MainContainer.json
+     */
+    public static JSONObject getNestedDSL(Map<String, JSONObject> jsonMap, Map<String, List<String>> pathMapping) {
+        // start from the root
+        JSONObject dsl = jsonMap.get(CommonConstants.DELIMITER_PATH + CommonConstants.MAIN_CONTAINER + CommonConstants.JSON_EXTENSION);
+        for (String path : pathMapping.get(CommonConstants.MAIN_CONTAINER)) {
+            JSONObject child = getChildren(path, jsonMap, pathMapping);
+            JSONArray children = dsl.optJSONArray(CommonConstants.CHILDREN);
+            if (children == null) {
+                children = new JSONArray();
+                children.put(child);
+                dsl.put(CommonConstants.CHILDREN, children);
+            } else {
+                children.put(child);
+            }
+        }
+        return dsl;
+    }
+
+    public static JSONObject getChildren(String pathToWidget, Map<String, JSONObject> jsonMap, Map<String, List<String>> pathMapping) {
+        // Recursively get the children
+        List<String>  children =  pathMapping.get(getWidgetName(pathToWidget));
+        JSONObject parentObject = jsonMap.get(pathToWidget + CommonConstants.JSON_EXTENSION);
+        if (children != null) {
+            JSONArray childArray = new JSONArray();
+            for (String childWidget : children) {
+                childArray.put(getChildren(childWidget, jsonMap, pathMapping));
+            }
+            // Check if the parent object has type=CANVAS_WIDGET as children
+            // If yes, then add the children array to the CANVAS_WIDGET's children
+            appendChildren(parentObject, childArray);
+        }
+
+        return parentObject;
+    }
+
+    public static String getWidgetName(String path) {
+        String[] directories = path.split(CommonConstants.DELIMITER_PATH);
+        return directories[directories.length - 1];
+    }
+
+    public static JSONObject appendChildren(JSONObject parent, JSONArray childWidgets) {
+        JSONArray children = parent.optJSONArray(CommonConstants.CHILDREN);
+        if (children == null) {
+            parent.put(CommonConstants.CHILDREN, childWidgets);
+        } else {
+            // Is the children CANVAS_WIDGET
+            if (children.length() == 1) {
+                JSONObject childObject = children.getJSONObject(0);
+                if (CommonConstants.CANVAS_WIDGET.equals(childObject.optString(CommonConstants.WIDGET_TYPE))) {
+                    childObject.put(CommonConstants.CHILDREN, childWidgets);
+                }
+            } else {
+                parent.put(CommonConstants.CHILDREN, childWidgets);
+            }
+        }
+        return parent;
+    }
+}

--- a/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
+++ b/app/server/appsmith-git/src/test/java/com/appsmith/git/helpers/FileUtilsImplTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApplicationGitReference.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/models/ApplicationGitReference.java
@@ -22,6 +22,7 @@ public class ApplicationGitReference {
     Map<String, Object> actionCollections;
     Map<String, String> actionCollectionBody;
     Map<String, Object> pages;
+    Map<String, String> pageDsl;
     Map<String, Object> datasources;
     Map<String, Object> jsLibraries;
 


### PR DESCRIPTION
## Description
Today if we have more than one collaborator on a page, merging is an absolute nightmare. All of the widget config for a page is represented in one single giant JSON blob in canvas.json this makes it very hard to make isolated changes.

This PR is breaking down the git representation into smaller JSON files that are aggregated by the running app.

Fixes https://github.com/appsmithorg/appsmith/issues/17033

#### Type of change
- New feature (non-breaking change which adds functionality)

## Testing
#### How Has This Been Tested?
- [ ] Manual
- [ ] Jest
- [ ] Cypress
- [ ] JUnit

#### Test Plan
#### Issues raised during DP testing
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
