### PR TITLE
fix: returning empty  datasourceStucture instead of empty on invalid

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
@@ -80,7 +80,9 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
                                                   boolean ignoreCache) {
 
         if (Boolean.FALSE.equals(datasourceStorage.getIsValid())) {
-            return Mono.empty();
+            return analyticsService.sendObjectEvent(AnalyticsEvents.DS_SCHEMA_FETCH_EVENT_FAILED,
+                            datasourceStorage, getAnalyticsPropertiesForTestEventStatus(datasourceStorage, false))
+                    .then(Mono.just(new DatasourceStructure()));
         }
 
         Mono<DatasourceStorageStructure> configurationStructureMono = datasourceStructureService


### PR DESCRIPTION
## Description
> TL;DR  now returning empty datasourceStructure object instead of Mono.empty, also added the analytics call back.

The issue has started in sentry because a snippet has recently been added to expect some response from server, if the response is empty it throws error 

Fixes #23675

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
- [x] Manual
- [x] Jest
- [ ] Cypress


## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
