### PR TITLE
fix: Modal widget close after rename

### DIFF
--- a/app/client/src/sagas/WidgetBlueprintSagas.ts
+++ b/app/client/src/sagas/WidgetBlueprintSagas.ts
@@ -12,6 +12,7 @@ import { BlueprintOperationTypes } from "widgets/constants";
 import * as log from "loglevel";
 import { toast } from "design-system";
 import { getIsAutoLayout } from "selectors/canvasSelectors";
+import { getPropertiesToUpdate } from "./WidgetOperationSagas";
 
 function buildView(view: WidgetBlueprint["view"], widgetId: string) {
   const children = [];
@@ -128,6 +129,26 @@ export function* executeWidgetBlueprintOperations(
           updatePropertyPayloads.forEach((params: UpdatePropertyArgs) => {
             widgets[params.widgetId][params.propertyName] =
               params.propertyValue;
+            const { dynamicTriggerPathList } = getPropertiesToUpdate(
+              widgets[params.widgetId],
+              { [params.propertyName]: params.propertyValue },
+              [params.propertyName],
+            );
+            const widgetDynamicTriggerPathList =
+              widgets[params.widgetId].dynamicTriggerPathList;
+            //if dynamicTriggerPathList already exits on widget
+            if (
+              widgetDynamicTriggerPathList &&
+              Array.isArray(widgetDynamicTriggerPathList)
+            ) {
+              widgets[params.widgetId].dynamicTriggerPathList = [
+                ...dynamicTriggerPathList,
+                ...widgetDynamicTriggerPathList,
+              ];
+            } else {
+              widgets[params.widgetId].dynamicTriggerPathList =
+                dynamicTriggerPathList;
+            }
           });
         break;
     }


### PR DESCRIPTION
## Description
Added code to create "dynamicTriggetPathList" property on child IconButton and Button widget when Blueprint Operation MODIFY_PROPS add 'onClick' property to child widgets.

The issue is happening because when Modal Widget is created, the child widgets have onClick: closeModal reference of Modal widget but do not have dynamicTriggetPath: [{key: onClick}] property. This PR fixes this issue.
#### PR fixes following issue(s)
Fixes #23475

#### Media
[Screencast from 2023-06-25 18-32-26.webm](https://github.com/appsmithorg/appsmith/assets/85070570/18f418be-c26e-4d4e-ab97-ef3db23a6832)


#### Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
>
#### How Has This Been Tested?
- [x] Manual



## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
