### PR TITLE
test: Skip omnibar documentation test

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/OtherUIFeatures/Omnibar_spec.js
@@ -169,8 +169,8 @@ describe("Omnibar functionality test cases", () => {
 
     cy.xpath(omnibar.recentlyopenItem).eq(4).should("have.text", "Page1");
   });
-
-  it(
+  // skipping the test as search documenation feature is going to be removed
+  it.skip(
     "excludeForAirgap",
     "7. Verify documentation should open in new tab, on clicking open documentation",
     function () {


### PR DESCRIPTION
## Description

Skipping this test as it is dependent on docs link, which make it flaky whenever docs are updated and also this feature is getting removed soon: https://theappsmith.slack.com/archives/CNQ9Q91C0/p1684828154586489 

## Testing
 locally


## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
