### PR TITLE
fix: add null check for select options in table widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/select_spec_2.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/select_spec_2.ts
@@ -68,7 +68,7 @@ describe("Table widget v2: select column type test", function () {
     agHelper.GetNAssertContains(table._selectMenuItem, "No Results Found");
   });
 
-  it("2. should test that select column dropdown has no results found string when select option is {{null}} ", function () {
+  it("2. should test that select column dropdown has no results found string when select option is {{[null, null]}} ", function () {
     /**
      * Flow:
      * 1. Dnd table widget = DONE

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/select_spec_2.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/select_spec_2.ts
@@ -3,36 +3,13 @@ import {
   propPane,
   agHelper,
   draggableWidgets,
-  deployMode,
   table,
-  locators,
 } from "../../../../../../support/Objects/ObjectsCore";
-
-const TABLE_DATA_1 = `[
-      {
-        "step": "#1",
-        "task": "Drop a table",
-        "status": "✅",
-        "action": ""
-      },
-      {
-        "step": "#2",
-        "task": "Create a query fetch_users with the Mock DB",
-        "status": "--",
-        "action": ""
-      },
-      {
-        "step": "#3",
-        "task": "Bind the query using => fetch_users.data",
-        "status": "--",
-        "action": ""
-      }
-    ]`;
 
 describe("Table widget v2: select column type test", function () {
   before(() => {
     entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 300, 100);
-    propPane.EnterJSContext("Table data", TABLE_DATA_1);
+    table.AddSampleTableData();
   });
   it("1. should test that select column dropdown has no results found string when select option is {{null}} ", function () {
     /**

--- a/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/select_spec_2.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Widgets/TableV2/columnTypes/select_spec_2.ts
@@ -1,0 +1,101 @@
+import {
+  entityExplorer,
+  propPane,
+  agHelper,
+  draggableWidgets,
+  deployMode,
+  table,
+  locators,
+} from "../../../../../../support/Objects/ObjectsCore";
+
+const TABLE_DATA_1 = `[
+      {
+        "step": "#1",
+        "task": "Drop a table",
+        "status": "✅",
+        "action": ""
+      },
+      {
+        "step": "#2",
+        "task": "Create a query fetch_users with the Mock DB",
+        "status": "--",
+        "action": ""
+      },
+      {
+        "step": "#3",
+        "task": "Bind the query using => fetch_users.data",
+        "status": "--",
+        "action": ""
+      }
+    ]`;
+
+describe("Table widget v2: select column type test", function () {
+  before(() => {
+    entityExplorer.DragDropWidgetNVerify(draggableWidgets.TABLE, 300, 100);
+    propPane.EnterJSContext("Table data", TABLE_DATA_1);
+  });
+  it("1. should test that select column dropdown has no results found string when select option is {{null}} ", function () {
+    /**
+     * Flow:
+     * 1. Dnd table widget = DONE
+     * 2. Bind data to it = DONE
+     * 3. Convert step column to select type = DONE
+     * 4. Pass options to it as {{null}}, {{[null, null]}}
+     * 5. Check that in the table drop down you get No results found while editing and adding a row
+     */
+    propPane.TogglePropertyState("Allow adding a row", "On");
+
+    table.ChangeColumnType("step", "Select", "v2");
+    const colSettings = table._columnSettingsV2("step", "Edit");
+    agHelper.GetNClick(colSettings);
+    propPane.TogglePropertyState("Editable", "On");
+
+    //4
+    propPane.UpdatePropertyFieldValue("Options", "{{null}}");
+
+    // 5 while adding a new row
+    agHelper.GetNClick(table._addNewRow, 0, true);
+    agHelper.GetNClick(table._tableRow(0, 0, "v2"));
+    agHelper.GetNAssertContains(table._selectMenuItem, "No Results Found");
+
+    // 5 while editing a new row
+    agHelper.GetNClick(table._discardRow, 0, true);
+    agHelper.GetNClick(
+      table._tableRow(0, 0, "v2") + " " + table._editCellIconDiv,
+      0,
+      true,
+    );
+    agHelper.GetNAssertContains(table._selectMenuItem, "No Results Found");
+  });
+
+  it("2. should test that select column dropdown has no results found string when select option is {{null}} ", function () {
+    /**
+     * Flow:
+     * 1. Dnd table widget = DONE
+     * 2. Bind data to it = DONE
+     * 3. Convert step column to select type = DONE
+     * 4. Pass options to it as {{null}}, {{[null, null]}}
+     * 5. Check that in the table drop down you get No results found while editing and adding a row
+     */
+    propPane.NavigateBackToPropertyPane();
+
+    const colSettings = table._columnSettingsV2("step", "Edit");
+    agHelper.GetNClick(colSettings);
+
+    propPane.UpdatePropertyFieldValue("Options", "{{[null, null]}}");
+
+    // 5 while adding a new row
+    agHelper.GetNClick(table._addNewRow, 0, true);
+    agHelper.GetNClick(table._tableRow(0, 0, "v2"));
+    agHelper.GetNAssertContains(table._selectMenuItem, "No Results Found");
+
+    // 5 while editing a new row
+    agHelper.GetNClick(table._discardRow, 0, true);
+    agHelper.GetNClick(
+      table._tableRow(0, 0, "v2") + " " + table._editCellIconDiv,
+      0,
+      true,
+    );
+    agHelper.GetNAssertContains(table._selectMenuItem, "No Results Found");
+  });
+});

--- a/app/client/cypress/support/Pages/Table.ts
+++ b/app/client/cypress/support/Pages/Table.ts
@@ -26,7 +26,8 @@ type columnTypeValues =
   | "Date"
   | "Button"
   | "Menu button"
-  | "Icon button";
+  | "Icon button"
+  | "Select";
 
 export class Table {
   private agHelper = ObjectsRegistry.AggregateHelper;
@@ -142,6 +143,7 @@ export class Table {
     `.t--widget-tablewidgetv2 .thead .th:contains(${column})`;
   _addNewRow = ".t--add-new-row";
   _saveNewRow = ".t--save-new-row";
+  _discardRow = ".t--discard-new-row";
   _searchInput = ".t--search-input input";
   _bodyCell = (cellValue: string) =>
     `.t--table-text-cell:contains(${cellValue})`;
@@ -154,6 +156,7 @@ export class Table {
   _tableColumnHeaderMenuTrigger = (columnName: string) =>
     `${this._columnHeaderDiv(columnName)} .header-menu .bp3-popover2-target`;
   _columnHeaderMenu = ".bp3-menu";
+  _selectMenuItem = ".menu-item-text";
 
   public WaitUntilTableLoad(
     rowIndex = 0,

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
@@ -8,7 +8,6 @@ import { CellWrapper } from "../TableStyledWrappers";
 import type { EditableCellActions } from "widgets/TableWidgetV2/constants";
 import { BasicCell } from "./BasicCell";
 import { useCallback } from "react";
-import { isNil } from "lodash";
 
 const StyledSelectComponent = styled(SelectComponent)<{
   accentColor: string;
@@ -190,8 +189,6 @@ export const SelectCell = (props: SelectProps) => {
     .map((d: DropdownOption) => d.value)
     .indexOf(value);
 
-  const isOptionsNull = props.options && props.options.some((d) => isNil(d));
-
   if (isEditable && isCellEditable && isCellEditMode) {
     return (
       <StyledCellWrapper
@@ -225,7 +222,7 @@ export const SelectCell = (props: SelectProps) => {
           onClose={onClose}
           onFilterChange={onFilter}
           onOptionSelected={onSelect}
-          options={isOptionsNull ? [] : options}
+          options={options}
           placeholder={placeholderText}
           resetFilterTextOnClose={resetFilterTextOnClose}
           selectedIndex={selectedIndex}

--- a/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/cellComponents/SelectCell.tsx
@@ -8,6 +8,7 @@ import { CellWrapper } from "../TableStyledWrappers";
 import type { EditableCellActions } from "widgets/TableWidgetV2/constants";
 import { BasicCell } from "./BasicCell";
 import { useCallback } from "react";
+import { isNil } from "lodash";
 
 const StyledSelectComponent = styled(SelectComponent)<{
   accentColor: string;
@@ -189,6 +190,8 @@ export const SelectCell = (props: SelectProps) => {
     .map((d: DropdownOption) => d.value)
     .indexOf(value);
 
+  const isOptionsNull = props.options && props.options.some((d) => isNil(d));
+
   if (isEditable && isCellEditable && isCellEditMode) {
     return (
       <StyledCellWrapper
@@ -222,7 +225,7 @@ export const SelectCell = (props: SelectProps) => {
           onClose={onClose}
           onFilterChange={onFilter}
           onOptionSelected={onSelect}
-          options={options}
+          options={isOptionsNull ? [] : options}
           placeholder={placeholderText}
           resetFilterTextOnClose={resetFilterTextOnClose}
           selectedIndex={selectedIndex}

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.test.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.test.ts
@@ -517,6 +517,22 @@ describe("selectColumnOptionsValidation", () => {
       });
     });
 
+    it("should check that there are no null or undefined values", () => {
+      expect(
+        selectColumnOptionsValidation(
+          [null, { label: "2", value: "1" }],
+          {} as TableWidgetProps,
+          _,
+        ),
+      ).toEqual({
+        isValid: false,
+        parsed: [],
+        messages: [
+          `Invalid entry at index: 0. This value does not evaluate to type: { "label": string | number, "value": string | number | boolean }`,
+        ],
+      });
+    });
+
     it("should check that value should be an array of objects", () => {
       expect(
         selectColumnOptionsValidation([1, 2], {} as TableWidgetProps, _),

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -781,6 +781,7 @@ export function selectColumnOptionsValidation(
     _parsed,
     _message = "";
   let uniqueValues: Set<unknown>;
+  const invalidArrayValueMessage = `This value does not evaluate to type: { "label": string | number, "value": string | number | boolean }`;
   const invalidMessage = `This value does not evaluate to type Array<{ "label": string | number, "value": string | number | boolean }>`;
   const allowedValueTypes = ["string", "number", "boolean"];
   const allowedLabelTypes = ["string", "number"];
@@ -793,6 +794,15 @@ export function selectColumnOptionsValidation(
       rowIndex !== null ? ` Row: ${rowIndex}` : ""
     } index: ${optionIndex}.`;
   };
+
+  const generateInvalidArrayValueMessage = (
+    rowIndex: number | null,
+    optionIndex: number,
+  ) =>
+    `${generateErrorMessagePrefix(
+      rowIndex,
+      optionIndex,
+    )} ${invalidArrayValueMessage}`;
 
   const validateOption = (
     option: any,
@@ -901,10 +911,7 @@ export function selectColumnOptionsValidation(
               for (let j = 0; j < value[i].length; j++) {
                 if (_.isNil(value[i][j])) {
                   _isValid = false;
-                  _message = `${generateErrorMessagePrefix(
-                    i,
-                    j,
-                  )} This value does not evaluate to type: { "label": string | number, "value": string | number | boolean }`;
+                  _message = generateInvalidArrayValueMessage(i, j);
                   _parsed = [];
                   break;
                 }
@@ -926,10 +933,7 @@ export function selectColumnOptionsValidation(
           for (let i = 0; i < (value as Array<unknown>).length; i++) {
             if (_.isNil((value as Array<unknown>)[i])) {
               _isValid = false;
-              _message = `${generateErrorMessagePrefix(
-                null,
-                0,
-              )} This value does not evaluate to type: { "label": string | number, "value": string | number | boolean }`;
+              _message = generateInvalidArrayValueMessage(null, i);
               _parsed = [];
               break;
             }

--- a/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
+++ b/app/client/src/widgets/TableWidgetV2/widget/propertyUtils.ts
@@ -899,6 +899,15 @@ export function selectColumnOptionsValidation(
               uniqueValues = new Set();
 
               for (let j = 0; j < value[i].length; j++) {
+                if (_.isNil(value[i][j])) {
+                  _isValid = false;
+                  _message = `${generateErrorMessagePrefix(
+                    i,
+                    j,
+                  )} This value does not evaluate to type: { "label": string | number, "value": string | number | boolean }`;
+                  _parsed = [];
+                  break;
+                }
                 if ((_message = validateOption(value[i][j], i, j))) {
                   _isValid = false;
                   break;
@@ -915,6 +924,16 @@ export function selectColumnOptionsValidation(
           _parsed = value;
           _isValid = true;
           for (let i = 0; i < (value as Array<unknown>).length; i++) {
+            if (_.isNil((value as Array<unknown>)[i])) {
+              _isValid = false;
+              _message = `${generateErrorMessagePrefix(
+                null,
+                0,
+              )} This value does not evaluate to type: { "label": string | number, "value": string | number | boolean }`;
+              _parsed = [];
+              break;
+            }
+
             if (
               (_message = validateOption((value as Array<unknown>)[i], null, i))
             ) {


### PR DESCRIPTION
## Description
This PR passes a `[]` to the select component when some values in the select options that are passed to the select cell component are `null`.

This fixes issue where the table widget breaks when select options for the select column type contains `{{null}}` or `{{[null, null]}}`

#### PR fixes following issue(s)
Fixes #24857

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?

- [x] Manual
    - To test that table widget does not break when `{{[null]}}`, `{{[null, null]}}`, `{{null}}` is passed to select options or new row select options.
    - To test that table widget does not break when select options or new row select options contains API binding that does not have any data 
- [ ] Jest
- [x] Cypress
    - should test that select column dropdown has no results found string when select option is {{null}}
    - should test that select column dropdown has no results found string when select option is {{[null, null]}}  

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
