### PR TITLE
fix: Fixed corrupt validation error on page reload

### DIFF
--- a/app/client/src/workers/common/DataTreeEvaluator/validationUtils.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/validationUtils.ts
@@ -9,7 +9,6 @@ import type {
 import { get, isUndefined, set } from "lodash";
 import type { EvaluationError } from "utils/DynamicBindingUtils";
 import {
-  getEvalErrorPath,
   getEvalValuePath,
   isPathDynamicTrigger,
   PropertyEvaluationErrorType,
@@ -169,10 +168,7 @@ export function getValidatedTree(
           addErrorToEntityProperty({
             errors: evalErrors,
             evalProps,
-            fullPropertyPath: getEvalErrorPath(`${entityKey}.${property}`, {
-              isPopulated: false,
-              fullPath: true,
-            }),
+            fullPropertyPath: `${entityKey}.${property}`,
             dataTree: tree,
             configTree,
           });


### PR DESCRIPTION
## Description
`getValidatedTree` method which gets called during first tree setup sets errors into an invalid location causing the validation error to not show up on page reload. This PR fixes the error location.
>
>
#### PR fixes following issue(s)
Fixes #24664
>
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
