### PR TITLE
feat: Add support for connecting to Redis clusters

### DIFF
--- a/app/server/appsmith-server/pom.xml
+++ b/app/server/appsmith-server/pom.xml
@@ -224,6 +224,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Needed for establishing pooled connections to ElastiCache Redis with cluster mode enabled. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.11.1</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite-engine</artifactId>

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
@@ -12,6 +12,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.observability.MicrometerTracingAdapter;
 import org.springframework.data.redis.core.ReactiveRedisOperations;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
@@ -28,6 +33,7 @@ import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.session.data.redis.config.annotation.web.server.EnableRedisWebSession;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,6 +53,31 @@ public class RedisConfig {
     @Bean
     ChannelTopic topic() {
         return new ChannelTopic("appsmith:queue");
+    }
+
+    @Bean
+    @Primary
+    public ReactiveRedisConnectionFactory reactiveRedisConnectionFactory() {
+        final URI redisUri = URI.create(System.getenv("APPSMITH_REDIS_URL"));
+        final String scheme = redisUri.getScheme();
+
+        switch (scheme) {
+            case "redis" -> {
+                return new LettuceConnectionFactory(redisUri.getHost(), redisUri.getPort());
+            }
+
+            case "redis-cluster" -> {
+                // For ElastiCache Redis with cluster mode enabled, with the configuration endpoint.
+                final LettuceClientConfiguration config = LettucePoolingClientConfiguration
+                    .builder()
+                    .build();
+                final RedisClusterConfiguration clusterConfig = new RedisClusterConfiguration();
+                clusterConfig.addClusterNode(new RedisNode(redisUri.getHost(), redisUri.getPort()));
+                return new LettuceConnectionFactory(clusterConfig, config);
+            }
+
+            default -> throw new InvalidRedisURIException("Invalid redis scheme: " + scheme);
+        }
     }
 
     @Bean
@@ -176,6 +207,12 @@ public class RedisConfig {
             }
 
             return fallback.deserialize(bytes);
+        }
+    }
+
+    private static class InvalidRedisURIException extends RuntimeException {
+        public InvalidRedisURIException(String message) {
+            super(message);
         }
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
@@ -8,12 +8,14 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.lettuce.core.resource.ClientResources;
 import io.micrometer.observation.ObservationRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
@@ -37,12 +39,16 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 @Configuration
 @Slf4j
 // Setting the maxInactiveInterval to 30 days
 @EnableRedisWebSession(maxInactiveIntervalInSeconds = 2592000)
 public class RedisConfig {
+
+    @Value("${appsmith.redis.url:}")
+    private String redisURL;
 
     /**
      * This is the topic to which we will publish & subscribe to. We can have multiple topics based on the messages
@@ -58,7 +64,7 @@ public class RedisConfig {
     @Bean
     @Primary
     public ReactiveRedisConnectionFactory reactiveRedisConnectionFactory() {
-        final URI redisUri = URI.create(System.getenv("APPSMITH_REDIS_URL"));
+        final URI redisUri = URI.create(redisURL);
         final String scheme = redisUri.getScheme();
 
         switch (scheme) {

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -53,6 +53,9 @@ sentry.send-default-pii=true
 sentry.debug=false
 sentry.environment=${APPSMITH_SENTRY_ENVIRONMENT:}
 
+# Redis Properties
+appsmith.redis.url=${APPSMITH_REDIS_URL}
+
 # Mail Properties
 # Email defaults to false, because, when true and the other SMTP properties are not set, Spring will try to use a
 #   default localhost:25 SMTP server and throw an error. If false, this error won't happen because there's no attempt

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -53,9 +53,6 @@ sentry.send-default-pii=true
 sentry.debug=false
 sentry.environment=${APPSMITH_SENTRY_ENVIRONMENT:}
 
-# Redis Properties
-spring.data.redis.url=${APPSMITH_REDIS_URL}
-
 # Mail Properties
 # Email defaults to false, because, when true and the other SMTP properties are not set, Spring will try to use a
 #   default localhost:25 SMTP server and throw an error. If false, this error won't happen because there's no attempt


### PR DESCRIPTION
This PR adds support to Appsmith server to be able to connect to ElastiCache Redis with cluster mode turned on. When the `APPSMITH_REDIS_URL` is set to `redis://...`, the current default behaviour is preserved. But if it is set to `redis-cluster://...`, then we setup a pooled connection with cluster mod enabled.
