### PR TITLE
fix: JsonForm widgets button syles in property pane

### DIFF
--- a/app/client/src/entities/Widget/utils.ts
+++ b/app/client/src/entities/Widget/utils.ts
@@ -316,6 +316,34 @@ const getAllPathsFromPropertyConfigWithoutMemo = (
         }
         if (controlConfig.children) {
           const basePropertyPath = controlConfig.propertyName;
+          // update path configs for children
+          if (isUndefined(basePropertyPath)) {
+            controlConfig.children.forEach((childConfig: any) => {
+              const path = childConfig.propertyName;
+              const {
+                configBindingPaths,
+                configReactivePaths,
+                configTriggerPaths,
+                configValidationPaths,
+              } = checkPathsInConfig(childConfig, path);
+              bindingPaths = {
+                ...bindingPaths,
+                ...configBindingPaths,
+              };
+
+              reactivePaths = {
+                ...reactivePaths,
+                ...configReactivePaths,
+              };
+              triggerPaths = {
+                ...triggerPaths,
+                ...configTriggerPaths,
+              };
+              validationPaths = {
+                ...configValidationPaths,
+              };
+            });
+          }
           const widgetPropertyValue = get(widget, basePropertyPath, []);
           // Property in object structure
           if (


### PR DESCRIPTION

## Description
On changing the border radius and box shadow on "Submit" and "Reset" button changes are happening in widget according to selection but these changes should also reflect in property pane.

This PR fixes this issue
#### PR fixes following issue(s)
Fixes #24376

#### Media
[Screencast from 2023-06-30 08-39-59.webm](https://github.com/appsmithorg/appsmith/assets/85070570/dbed7781-d078-4fcd-a48e-458c7b0fcd83)

#### Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

- [x] Manual


## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
