### PR TITLE
ci: Cypress-only-fixes label workflow fix-IV

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -23,10 +23,10 @@ jobs:
         id: check_files_changed
         run: |
           filesChangedCount=$(echo "${{ steps.files.outputs.files_changed }}" | wc -l)
-           if [[ $filesChangedCount -gt 0 ]]; then
+          if [[ "$filesChangedCount" -gt 0 ]]; then
             echo "::set-output name=files_changed_count::$filesChangedCount"
            else
-            echo "No files changed in the specified folder."
+            echo "No files changed in the specified folder"
             exit 1
            fi
 


### PR DESCRIPTION
## Description
- This PR fixes the Add Cypress-Only-Fixes Label on PR Merge workflow