### PR TITLE
ci: Cypress-only-fixes label workflow remove

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -1,10 +1,13 @@
 name: Add Cypress-Only-Fixes Label on PR Merge
+# on:
+#   pull_request:
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - release
+  # This line enables manual triggering of this workflow.
+  workflow_dispatch:
+    # types:
+    #   - closed
+    # branches:
+    #   - release
 
 jobs:
   add_label:


### PR DESCRIPTION
## Description
- This PR removed the Add Cypress-Only-Fixes Label on PR Merge workflow to run from PR merge until fixed