### PR TITLE
perf(ee): code-split the Settings page away

### DIFF
--- a/app/client/src/ce/AppRouter.tsx
+++ b/app/client/src/ce/AppRouter.tsx
@@ -47,7 +47,7 @@ import UserProfile from "pages/UserProfile";
 import { getCurrentUser } from "actions/authActions";
 import { getCurrentUserLoading } from "selectors/usersSelectors";
 import Setup from "pages/setup";
-import Settings from "@appsmith/pages/AdminSettings";
+import SettingsLoader from "@appsmith/pages/AdminSettings/loader";
 import SignupSuccess from "pages/setup/SignupSuccess";
 import type { ERROR_CODES } from "@appsmith/constants/ApiConstants";
 import TemplatesListLoader from "pages/Templates/loader";
@@ -100,7 +100,7 @@ export function Routes() {
         }
       />
       <SentryRoute
-        component={Settings}
+        component={SettingsLoader}
         exact
         path={ADMIN_SETTINGS_CATEGORY_PATH}
       />

--- a/app/client/src/ce/pages/AdminSettings/loader.tsx
+++ b/app/client/src/ce/pages/AdminSettings/loader.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import PageLoadingBar from "pages/common/PageLoadingBar";
+import { retryPromise } from "utils/AppsmithUtils";
+
+const Page = React.lazy(() =>
+  retryPromise(() => import(/* webpackChunkName: "settings" */ "./index")),
+);
+
+const AdminSettingsLoader = (props: any) => {
+  return (
+    <React.Suspense fallback={<PageLoadingBar />}>
+      <Page {...props} />
+    </React.Suspense>
+  );
+};
+
+export default AdminSettingsLoader;

--- a/app/client/src/ee/pages/AdminSettings/loader.tsx
+++ b/app/client/src/ee/pages/AdminSettings/loader.tsx
@@ -1,0 +1,2 @@
+export * from "ce/pages/AdminSettings/loader";
+export { default } from "ce/pages/AdminSettings/loader";


### PR DESCRIPTION
## Description

This pull request code-splits the Settings page away. In EE, this removes `react-json-view` and `react-datepicker` from the main bundle – and reduces the bundle size by 600 minified KBs.

Here’s the bundle before the change (with removed modules highlighted):

![CleanShot 2023-07-02 at 22 34 51@2x](https://github.com/appsmithorg/appsmith/assets/2953267/9eb05c15-5d19-4082-bdba-dfbf69655f89)

#### Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## Testing

- [x] Manual (minor, see below in the thread)

#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
