### PR TITLE
fix: Update Google sheets datasource learn more link

### DIFF
--- a/app/client/src/constants/DocumentationLinks.ts
+++ b/app/client/src/constants/DocumentationLinks.ts
@@ -6,6 +6,7 @@ export enum DocsLink {
   CONNECT_DATA = "CONNECT_DATA",
   QUERY = "QUERY",
   TROUBLESHOOT_ERROR = "TROUBLESHOOT_ERROR",
+  CONNECT_G_SHEETS = "CONNECT_G_SHEETS",
 }
 
 const LinkData: Record<DocsLink, string> = {
@@ -19,6 +20,8 @@ const LinkData: Record<DocsLink, string> = {
     "https://docs.appsmith.com/core-concepts/data-access-and-binding/capturing-data-write",
   TROUBLESHOOT_ERROR:
     "https://docs.appsmith.com/help-and-support/troubleshooting-guide",
+  CONNECT_G_SHEETS:
+    "https://docs.appsmith.com/connect-data/reference/querying-google-sheets#connect-google-sheets",
 };
 
 export const openDoc = (type: DocsLink, link?: string, subType?: string) => {

--- a/app/client/src/pages/common/datasourceAuth/AuthMessage.tsx
+++ b/app/client/src/pages/common/datasourceAuth/AuthMessage.tsx
@@ -9,11 +9,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { getPluginTypeFromDatasourceId } from "selectors/entitiesSelector";
 import styled from "styled-components";
 import {
-  setGlobalSearchQuery,
-  toggleShowGlobalSearchModal,
-} from "actions/globalSearchActions";
-import AnalyticsUtil from "utils/AnalyticsUtil";
-import {
   GOOGLE_SHEETS_AUTHORIZE_DATASOURCE,
   GOOGLE_SHEETS_LEARN_MORE,
   createMessage,
@@ -21,6 +16,7 @@ import {
   DATASOURCE_INTERCOM_TEXT,
 } from "@appsmith/constants/messages";
 import { getAppsmithConfigs } from "@appsmith/configs";
+import { DocsLink, openDoc } from "constants/DocumentationLinks";
 const { intercomAppID } = getAppsmithConfigs();
 
 const StyledAuthMessage = styled.div<{ isInViewMode: boolean }>`
@@ -63,13 +59,7 @@ export default function AuthMessage(props: AuthMessageProps) {
   const handleDocumentationClick: any = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-    const query = "Google Sheets";
-    dispatch(setGlobalSearchQuery(query));
-    dispatch(toggleShowGlobalSearchModal());
-    AnalyticsUtil.logEvent("OPEN_OMNIBAR", {
-      source: "DATASOURCE_DOCUMENTATION_CLICK",
-      query,
-    });
+    openDoc(DocsLink.CONNECT_G_SHEETS);
   };
 
   const getCallOutLinks = () => {


### PR DESCRIPTION
Updates the Google Sheets learn more link to open docs in a new tab instead of omnibar search. Ref: #24278

Fixes #25004
