### PR TITLE
fix: gsheets documentation issue fixed on datasource page

### DIFF
--- a/app/client/src/pages/common/datasourceAuth/AuthMessage.tsx
+++ b/app/client/src/pages/common/datasourceAuth/AuthMessage.tsx
@@ -6,13 +6,11 @@ import type { Datasource } from "entities/Datasource";
 import { ActionType } from "entities/Datasource";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { getPluginTypeFromDatasourceId } from "selectors/entitiesSelector";
-import styled from "styled-components";
 import {
-  setGlobalSearchQuery,
-  toggleShowGlobalSearchModal,
-} from "actions/globalSearchActions";
-import AnalyticsUtil from "utils/AnalyticsUtil";
+  getPlugin,
+  getPluginTypeFromDatasourceId,
+} from "selectors/entitiesSelector";
+import styled from "styled-components";
 import {
   GOOGLE_SHEETS_AUTHORIZE_DATASOURCE,
   GOOGLE_SHEETS_LEARN_MORE,
@@ -21,6 +19,8 @@ import {
   DATASOURCE_INTERCOM_TEXT,
 } from "@appsmith/constants/messages";
 import { getAppsmithConfigs } from "@appsmith/configs";
+import { DocsLink, openDoc } from "constants/DocumentationLinks";
+import type { Plugin } from "api/PluginApi";
 const { intercomAppID } = getAppsmithConfigs();
 
 const StyledAuthMessage = styled.div<{ isInViewMode: boolean }>`
@@ -55,6 +55,10 @@ export default function AuthMessage(props: AuthMessageProps) {
   const pluginType = useSelector((state: AppState) =>
     getPluginTypeFromDatasourceId(state, datasource.id),
   );
+  const pluginId: string = props?.datasource?.id || "";
+  const plugin: Plugin | undefined = useSelector((state) =>
+    getPlugin(state, pluginId),
+  );
   const handleOauthAuthorization: any = (e: React.MouseEvent) => {
     e.preventDefault();
     if (!pluginType || !pageId) return;
@@ -62,14 +66,7 @@ export default function AuthMessage(props: AuthMessageProps) {
   };
   const handleDocumentationClick: any = (e: React.MouseEvent) => {
     e.stopPropagation();
-    e.preventDefault();
-    const query = "Google Sheets";
-    dispatch(setGlobalSearchQuery(query));
-    dispatch(toggleShowGlobalSearchModal());
-    AnalyticsUtil.logEvent("OPEN_OMNIBAR", {
-      source: "DATASOURCE_DOCUMENTATION_CLICK",
-      query,
-    });
+    openDoc(DocsLink.QUERY, plugin?.documentationLink, plugin?.name);
   };
 
   const getCallOutLinks = () => {


### PR DESCRIPTION
## Description
This PR resolves documentation issue with google sheets. We see learn more CTA, when creating google sheets datasource, that takes us to the documentation for google sheets. Earlier we used to show documentation using modal from omnibar, now we have[ removed the documentation option itself from omnibar](https://github.com/appsmithorg/appsmith/pull/24787), thus it started failing. This PR fixes the issue

#### PR fixes following issue(s)
Fixes #25005 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [x] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
