### PR TITLE
chore: Removed ff4j configuration in favour of Flagsmith

### DIFF
--- a/app/server/appsmith-server/src/main/resources/features/init-flags.xml
+++ b/app/server/appsmith-server/src/main/resources/features/init-flags.xml
@@ -3,13 +3,6 @@
     <autocreate>false</autocreate>
     <audit>false</audit>
     <features>
-        <feature uid="release_datasource_environments_enabled" enable="true"
-                 description="Introducing multiple execution environments for datasources">
-            <flipstrategy class="com.appsmith.server.featureflags.strategies.EmailBasedRolloutStrategy">
-                <param name="emails"
-                       value="me-eng1@appsmith.com,me-eng2@appsmith.com,me-qa1@appsmith.com,me-qa2@appsmith.com,me-demo@appsmith.com"/>
-            </flipstrategy>
-        </feature>
         <feature uid="MULTIPLE_PANES" enable="true" description="Have multiple panes in the Appsmith IDE">
             <flipstrategy class="com.appsmith.server.featureflags.strategies.EmailBasedRolloutStrategy">
                 <param name="emails" value="multipanes@appsmith.com,ndx@appsmith.com"/>


### PR DESCRIPTION
## Description
Removes ff4j configuration so that there is only one source of truth for ff configs for ME, ie, Flagsmith.

#### PR fixes following issue(s)
Fixes #25074 
Fixes #25075 

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
- [x] Manual
- [x] Cypress
