### PR TITLE
fix: prevent click event on disabled next page button of table widget

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
@@ -37,7 +37,7 @@ describe("Test Create Api and Bind to Table widget V2", function () {
       .should("contain", "2");
   });
 
-  it("2. should check whether the next page button is disabled and not clickable when last page is reached", () => {
+  it("2. Bug #22477: should check whether the next page button is disabled and not clickable when last page is reached", () => {
     /**
      * Flow:
      * Update total records count to 20
@@ -47,6 +47,7 @@ describe("Test Create Api and Bind to Table widget V2", function () {
     propPane.UpdatePropertyFieldValue("Total Records", "20");
     agHelper.GetNClick(table._nextPage("v2"));
 
+    agHelper.GetElement(table._nextPage("v2")).should("have.attr", "disabled");
     agHelper.AssertElementAbsence(commonlocators._toastMsg);
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
@@ -15,10 +15,10 @@ describe("Test Create Api and Bind to Table widget V2", function () {
   });
   it("1. Create an API and Execute the API and bind with Table", function () {
     apiPage.CreateAndFillApi(
-      "http://localhost:5001/v1/" + this.dataSet.paginationParam,
+      this.dataSet.paginationUrl + this.dataSet.paginationParam,
     );
     agHelper.VerifyEvaluatedValue(
-      "http://localhost:5001/v1/" + "mock-api?records=20&page=1&size=10",
+      this.dataSet.paginationUrl + "mock-api?records=20&page=1&size=10",
     );
     apiPage.RunAPI();
     //Validate Table V2 with API data and then add a column

--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
@@ -4,6 +4,7 @@ import {
   entityExplorer,
   propPane,
   apiPage,
+  table,
 } from "../../../../support/Objects/ObjectsCore";
 
 describe("Test Create Api and Bind to Table widget V2", function () {
@@ -34,5 +35,18 @@ describe("Test Create Api and Bind to Table widget V2", function () {
     cy.get(`.t--widget-tablewidgetv2 .page-item`)
       .first()
       .should("contain", "2");
+  });
+
+  it("2. should check whether the next page button is disabled and not clickable when last page is reached", () => {
+    /**
+     * Flow:
+     * Update total records count to 20
+     * Click next page
+     */
+
+    propPane.UpdatePropertyFieldValue("Total Records", "20");
+    agHelper.GetNClick(table._nextPage("v2"));
+
+    agHelper.AssertElementAbsence(commonlocators._toastMsg);
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Binding/TableV2_Widget_API_Pagination_spec.js
@@ -15,10 +15,10 @@ describe("Test Create Api and Bind to Table widget V2", function () {
   });
   it("1. Create an API and Execute the API and bind with Table", function () {
     apiPage.CreateAndFillApi(
-      this.dataSet.paginationUrl + this.dataSet.paginationParam,
+      "http://localhost:5001/v1/" + this.dataSet.paginationParam,
     );
     agHelper.VerifyEvaluatedValue(
-      this.dataSet.paginationUrl + "mock-api?records=20&page=1&size=10",
+      "http://localhost:5001/v1/" + "mock-api?records=20&page=1&size=10",
     );
     apiPage.RunAPI();
     //Validate Table V2 with API data and then add a column
@@ -47,7 +47,7 @@ describe("Test Create Api and Bind to Table widget V2", function () {
     propPane.UpdatePropertyFieldValue("Total Records", "20");
     agHelper.GetNClick(table._nextPage("v2"));
 
-    agHelper.GetElement(table._nextPage("v2")).should("have.attr", "disabled");
+    agHelper.AssertAttribute(table._nextPage("v2"), "disabled", "disabled");
     agHelper.AssertElementAbsence(commonlocators._toastMsg);
   });
 });

--- a/app/client/src/widgets/TableWidgetV2/component/header/actions/index.tsx
+++ b/app/client/src/widgets/TableWidgetV2/component/header/actions/index.tsx
@@ -237,7 +237,13 @@ function Actions(props: ActionsPropsType) {
                 props.pageNo === props.pageCount - 1
               }
               onClick={() => {
-                props.nextPageClick();
+                if (
+                  !(
+                    !!props.totalRecordsCount &&
+                    props.pageNo === props.pageCount - 1
+                  )
+                )
+                  props.nextPageClick();
               }}
             >
               <Icon


### PR DESCRIPTION
## Description
This PR fixes the issue mentioned below by preventing the click event when the next page button is disabled and when it is table's last page.

#### PR fixes following issue(s)
Fixes #22477

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?

- [x] Manual
- [ ] Jest
- [ ] Cypress
    - should check whether the next page button is disabled and not clickable when last page is reached

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
