### PR TITLE
feat: WDS color `Negative`, states and `Subtle` variant

### DIFF
--- a/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
@@ -57,10 +57,10 @@ export class DarkModeTheme implements ColorModeTheme {
       bgPositiveSubtleHover: this.bgPositiveSubtleHover.to("sRGB").toString(),
       bgPositiveSubtleActive: this.bgPositiveSubtleActive.to("sRGB").toString(),
       bgNegative: this.bgNegative.to("sRGB").toString(),
-      bgNegativeHover: this.bgNegativeHover.toString(),
-      bgNegativeActive: this.bgNegativeActive.toString(),
-      bgNegativeSubtleHover: this.bgNegativeSubtleHover.toString(),
-      bgNegativeSubtleActive: this.bgNegativeSubtleActive.toString(),
+      bgNegativeHover: this.bgNegativeHover.to("sRGB").toString(),
+      bgNegativeActive: this.bgNegativeActive.to("sRGB").toString(),
+      bgNegativeSubtleHover: this.bgNegativeSubtleHover.to("sRGB").toString(),
+      bgNegativeSubtleActive: this.bgNegativeSubtleActive.to("sRGB").toString(),
       bgWarning: this.bgWarning.to("sRGB").toString(),
       bgWarningHover: this.bgWarningHover.toString(),
       bgWarningActive: this.bgWarningActive.toString(),
@@ -291,7 +291,7 @@ export class DarkModeTheme implements ColorModeTheme {
   private get bgPositiveSubtle() {
     const color = this.bgPositive.clone();
 
-    color.oklch.l = 0.3;
+    color.oklch.l = 0.25;
     color.oklch.c = 0.08;
 
     return color;
@@ -368,23 +368,46 @@ export class DarkModeTheme implements ColorModeTheme {
   }
 
   private get bgNegativeHover() {
-    return "#f24646";
+    const color = this.bgNegative.clone();
+
+    // Lightness of bgNegative is known, no additional checks like in bgAccentHover
+    color.oklch.l = color.oklch.l + 0.03;
+
+    return color;
   }
 
   private get bgNegativeActive() {
-    return "#e23b3b";
+    const color = this.bgNegative.clone();
+
+    // Lightness of bgNegative is known, no additional checks like in bgAccentActive
+    color.oklch.l = color.oklch.l - 0.04;
+
+    return color;
   }
 
   private get bgNegativeSubtle() {
-    return "#fff0f0";
+    const color = this.bgNegative.clone();
+
+    color.oklch.l = 0.2;
+    color.oklch.c = 0.08;
+
+    return color;
   }
 
   private get bgNegativeSubtleHover() {
-    return "#ffe0e0";
+    const color = this.bgNegativeSubtle.clone();
+
+    color.oklch.l = color.oklch.l + 0.03;
+
+    return color;
   }
 
   private get bgNegativeSubtleActive() {
-    return "#ffd1d1";
+    const color = this.bgNegativeSubtle.clone();
+
+    color.oklch.l = color.oklch.l - 0.02;
+
+    return color;
   }
 
   private get bgNeutral() {

--- a/app/client/packages/design-system/theming/src/color/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/LightModeTheme.ts
@@ -57,10 +57,10 @@ export class LightModeTheme implements ColorModeTheme {
       bgPositiveSubtleHover: this.bgPositiveSubtleHover.to("sRGB").toString(),
       bgPositiveSubtleActive: this.bgPositiveSubtleActive.to("sRGB").toString(),
       bgNegative: this.bgNegative.to("sRGB").toString(),
-      bgNegativeHover: this.bgNegativeHover.toString(),
-      bgNegativeActive: this.bgNegativeActive.toString(),
-      bgNegativeSubtleHover: this.bgNegativeSubtleHover.toString(),
-      bgNegativeSubtleActive: this.bgNegativeSubtleActive.toString(),
+      bgNegativeHover: this.bgNegativeHover.to("sRGB").toString(),
+      bgNegativeActive: this.bgNegativeActive.to("sRGB").toString(),
+      bgNegativeSubtleHover: this.bgNegativeSubtleHover.to("sRGB").toString(),
+      bgNegativeSubtleActive: this.bgNegativeSubtleActive.to("sRGB").toString(),
       bgWarning: this.bgWarning.to("sRGB").toString(),
       bgWarningHover: this.bgWarningHover.toString(),
       bgWarningActive: this.bgWarningActive.toString(),
@@ -388,23 +388,46 @@ export class LightModeTheme implements ColorModeTheme {
   }
 
   private get bgNegativeHover() {
-    return "#f24646";
+    const color = this.bgNegative.clone();
+
+    // Lightness of bgNegative is known, no additional checks like in bgAccentHover
+    color.oklch.l = color.oklch.l + 0.05;
+
+    return color;
   }
 
   private get bgNegativeActive() {
-    return "#e23b3b";
+    const color = this.bgNegative.clone();
+
+    // Lightness of bgNegative is known, no additional checks like in bgAccentActive
+    color.oklch.l = color.oklch.l - 0.02;
+
+    return color;
   }
 
   private get bgNegativeSubtle() {
-    return "#fff0f0";
+    const color = this.bgNegative.clone();
+
+    color.oklch.l = 0.94;
+    color.oklch.c = 0.06;
+
+    return color;
   }
 
   private get bgNegativeSubtleHover() {
-    return "#ffe0e0";
+    const color = this.bgNegativeSubtle.clone();
+
+    color.oklch.l = color.oklch.l + 0.02;
+
+    return color;
   }
 
   private get bgNegativeSubtleActive() {
-    return "#ffd1d1";
+    const color = this.bgNegativeSubtle.clone();
+
+    color.oklch.l = color.oklch.l - 0.01;
+
+    return color;
   }
 
   private get bgNeutral() {


### PR DESCRIPTION
## Description

tl;dr States and other derivatives of `bgNegative`. Also minor adjustment for `bgPositiveSubtle` in dark mode.

Fixes #24511 

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual

### Test Plan
Initial POC refinement, no testing necessary

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
