### PR TITLE
fix: git discard message

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/GitBugs_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/GitBugs_Spec.ts
@@ -117,17 +117,17 @@ describe("Git Bugs", function () {
       _.agHelper.GetNClick(_.locators._appNavigationSettingsShowTitle);
       _.agHelper.GetNClick(_.locators._publishButton);
       _.agHelper.WaitUntilEleAppear(_.locators._gitStatusChanges);
-      _.agHelper.GetNClick(_.locators._gitDiscardBtn);
-      _.agHelper.WaitUntilEleAppear(_.locators._gitDiscardCallout);
+      _.agHelper.GetNClick(_.gitSync._discardChanges);
+      _.agHelper.WaitUntilEleAppear(_.gitSync._discardCallout);
       _.agHelper.AssertContains(
         Cypress.env("MESSAGES").DISCARD_CHANGES_WARNING(),
         "exist",
-        _.locators._gitDiscardCallout,
+        _.gitSync._discardCallout,
       );
       _.agHelper.AssertContains(
         Cypress.env("MESSAGES").DISCARD_MESSAGE(),
         "exist",
-        _.locators._gitDiscardCallout,
+        _.gitSync._discardCallout,
       );
       _.agHelper.GetNClick(_.locators._dialogCloseButton);
     });

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/GitBugs_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/GitBugs_Spec.ts
@@ -85,7 +85,7 @@ describe("Git Bugs", function () {
       _.agHelper.GetNClick(_.locators._publishButton);
       _.agHelper.WaitUntilEleAppear(_.locators._gitStatusChanges);
       _.agHelper.AssertContains(
-        "Theme modified",
+        Cypress.env("MESSAGES").CHANGES_THEME(),
         "exist",
         _.locators._gitStatusChanges,
       );
@@ -98,16 +98,44 @@ describe("Git Bugs", function () {
       _.agHelper.GetNClick(_.locators._publishButton);
       _.agHelper.WaitUntilEleAppear(_.locators._gitStatusChanges);
       _.agHelper.AssertContains(
-        "Application settings modified",
+        Cypress.env("MESSAGES").CHANGES_APP_SETTINGS(),
         "exist",
         _.locators._gitStatusChanges,
       );
       _.agHelper.GetNClick(_.locators._dialogCloseButton);
     });
   });
+
+  it("5. Bug 24946 : Discard message is missing when only navigation settings are changed", function () {
+    _.gitSync.SwitchGitBranch("master");
+    _.gitSync.CreateGitBranch(`b24946`, true);
+    cy.get("@gitbranchName").then((branchName) => {
+      statusBranch = branchName;
+      _.agHelper.GetNClick(_.locators._appEditMenuBtn);
+      _.agHelper.GetNClick(_.locators._appEditMenuSettings);
+      _.agHelper.GetNClick(_.locators._appNavigationSettings);
+      _.agHelper.GetNClick(_.locators._appNavigationSettingsShowTitle);
+      _.agHelper.GetNClick(_.locators._publishButton);
+      _.agHelper.WaitUntilEleAppear(_.locators._gitStatusChanges);
+      _.agHelper.GetNClick(_.locators._gitDiscardBtn);
+      _.agHelper.WaitUntilEleAppear(_.locators._gitDiscardCallout);
+      _.agHelper.AssertContains(
+        Cypress.env("MESSAGES").DISCARD_CHANGES_WARNING(),
+        "exist",
+        _.locators._gitDiscardCallout,
+      );
+      _.agHelper.AssertContains(
+        Cypress.env("MESSAGES").DISCARD_MESSAGE(),
+        "exist",
+        _.locators._gitDiscardCallout,
+      );
+      _.agHelper.GetNClick(_.locators._dialogCloseButton);
+    });
+  });
+
   // skipping this test for now, will update test logic and create new PR for it
   // TODO Parthvi
-  it.skip("5. Bug 24206 : Open repository button is not functional in git sync modal", function () {
+  it.skip("6. Bug 24206 : Open repository button is not functional in git sync modal", function () {
     _.gitSync.SwitchGitBranch("master");
     _.entityExplorer.DragDropWidgetNVerify("modalwidget", 50, 50);
     _.gitSync.CommitAndPush();

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -250,6 +250,4 @@ export class CommonLocators {
   _gitStatusChanges = "[data-testid='t--git-change-statuses']";
   _appNavigationSettings = "#t--navigation-settings-header";
   _appNavigationSettingsShowTitle = "#t--navigation-settings-application-title";
-  _gitDiscardBtn = ".t--discard-button";
-  _gitDiscardCallout = "[data-testid='t--discard-callout']";
 }

--- a/app/client/cypress/support/Objects/CommonLocators.ts
+++ b/app/client/cypress/support/Objects/CommonLocators.ts
@@ -250,4 +250,6 @@ export class CommonLocators {
   _gitStatusChanges = "[data-testid='t--git-change-statuses']";
   _appNavigationSettings = "#t--navigation-settings-header";
   _appNavigationSettingsShowTitle = "#t--navigation-settings-application-title";
+  _gitDiscardBtn = ".t--discard-button";
+  _gitDiscardCallout = "[data-testid='t--discard-callout']";
 }

--- a/app/client/cypress/support/Pages/GitSync.ts
+++ b/app/client/cypress/support/Pages/GitSync.ts
@@ -37,7 +37,9 @@ export class GitSync {
   private _openRepoButton = "[data-testid=t--git-repo-button]";
   private _commitButton = ".t--commit-button";
   private _commitCommentInput = ".t--commit-comment-input textarea";
-  private _discardChanges = ".t--discard-button";
+
+  public _discardChanges = ".t--discard-button";
+  public _discardCallout = "[data-testid='t--discard-callout']";
 
   OpenGitSyncModal() {
     this.agHelper.GetNClick(this._connectGitBottomBar);

--- a/app/client/src/ce/constants/messages.ts
+++ b/app/client/src/ce/constants/messages.ts
@@ -869,6 +869,8 @@ export const DISCARD_CHANGES = () => "Discard & pull";
 // GIT DEPLOY begin
 export const DEPLOY = () => "Deploy";
 export const DEPLOY_YOUR_APPLICATION = () => "Deploy your application";
+export const CHANGES_APP_SETTINGS = () => "Application settings modified";
+export const CHANGES_THEME = () => "Theme modified";
 export const CHANGES_SINCE_LAST_DEPLOYMENT = () =>
   "Changes since last deployment";
 export const CHANGES_ONLY_USER = () => "Changes since last commit";

--- a/app/client/src/pages/Editor/gitSync/components/DiscardChangesWarning.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/DiscardChangesWarning.tsx
@@ -20,6 +20,7 @@ export default function DiscardChangesWarning({
   return (
     <Container>
       <Callout
+        data-testid="t--discard-callout"
         isClosable
         kind="error"
         links={[

--- a/app/client/src/pages/Editor/gitSync/components/DiscardChangesWarning.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/DiscardChangesWarning.tsx
@@ -4,9 +4,6 @@ import {
   DISCARD_CHANGES_WARNING,
   DISCARD_MESSAGE,
 } from "@appsmith/constants/messages";
-import { useSelector } from "react-redux";
-import { getCurrentPageName } from "selectors/editorSelectors";
-import { getGitStatus } from "selectors/gitSyncSelectors";
 import { Callout, Text } from "design-system";
 import styled from "styled-components";
 
@@ -19,14 +16,6 @@ export default function DiscardChangesWarning({
 }: any) {
   const discardDocUrl =
     "https://docs.appsmith.com/advanced-concepts/version-control-with-git/commit-and-push";
-  const currentPageName = useSelector(getCurrentPageName) || "";
-  const modifiedPageList = useSelector(getGitStatus)?.modified.map(
-    (page: string) => page.toLocaleLowerCase(),
-  );
-  const isCurrentPageDiscardable =
-    modifiedPageList?.some((page: string) =>
-      page.includes(currentPageName.toLocaleLowerCase()),
-    ) || false;
 
   return (
     <Container>
@@ -44,7 +33,7 @@ export default function DiscardChangesWarning({
       >
         <Text kind="heading-xs">{createMessage(DISCARD_CHANGES_WARNING)}</Text>
         <br />
-        {isCurrentPageDiscardable ? createMessage(DISCARD_MESSAGE) : null}
+        {createMessage(DISCARD_MESSAGE)}
       </Callout>
     </Container>
   );

--- a/app/client/src/pages/Editor/gitSync/components/GitChangesList.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/GitChangesList.tsx
@@ -8,7 +8,9 @@ import {
 } from "selectors/gitSyncSelectors";
 import type { GitStatusData } from "reducers/uiReducers/gitSyncReducer";
 import {
+  CHANGES_APP_SETTINGS,
   CHANGES_FROM_APPSMITH,
+  CHANGES_THEME,
   createMessage,
   NOT_PUSHED_YET,
   TRY_TO_PULL,
@@ -79,12 +81,12 @@ const STATUS_MAP: GitStatusMap = {
     hasValue: (status?.behindCount || 0) > 0,
   }),
   [Kind.SETTINGS]: (status: GitStatusData) => ({
-    message: `Application settings modified`,
+    message: createMessage(CHANGES_APP_SETTINGS),
     iconName: "settings-2-line",
     hasValue: (status?.modified || []).includes("application.json"),
   }),
   [Kind.THEME]: (status: GitStatusData) => ({
-    message: `Theme modified`,
+    message: createMessage(CHANGES_THEME),
     iconName: "sip-line",
     hasValue: (status?.modified || []).includes("theme.json"),
   }),


### PR DESCRIPTION
## Description
Discard message were conditionally not shown. It caused a bug when only navigation settings were changed. Removed the condition to include the message every-time.

#### PR fixes following issue(s)
Fixes #24946 

#### Media

Before
<img width="1725" alt="image" src="https://github.com/appsmithorg/appsmith/assets/8724051/cc29a570-ef51-48af-9bb5-57cb9f26f7cb">


After
<img width="1728" alt="image" src="https://github.com/appsmithorg/appsmith/assets/8724051/31f543a2-f64b-4648-ba2f-2b5f3e452af3">




#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
