### PR TITLE
chore: Add a check in chromatic workflow to run only on CE

### DIFF
--- a/.github/workflows/build-chromatic.yml
+++ b/.github/workflows/build-chromatic.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   chromatic-deployment:
+    if: github.repository == "appsmithorg/appsmith"
     runs-on: ubuntu-latest
    
     steps:


### PR DESCRIPTION
We don't want to run the chromatic build workflow on the EE repo. 
This PR adds a check in the workflow so that it runs only on the CE repo.