### PR TITLE
fix: vertically stack lint errors in the tooltip (#24974)

### DIFF
--- a/app/client/src/globalStyles/CodemirrorHintStyles.ts
+++ b/app/client/src/globalStyles/CodemirrorHintStyles.ts
@@ -339,8 +339,8 @@ export const CodemirrorHintStyles = createGlobalStyle<{
       color: var(--ads-v2-color-fg);
 
       display: flex;
-      align-items: center;
-      gap: var(--ads-v2-spaces-3);
+      flex-direction: column;
+      align-items: flex-start;
 
       &.${LINT_TOOLTIP_JUSTIFIED_LEFT_CLASS} {
         transform: translate(-100%);


### PR DESCRIPTION
## Description
Fixes the style for linting errors in the tooltip.

Earlier, They were presented side by side in case of multiple errors.
Now, They will appear vertically stacked as shown in the screenshot attached below

#### PR fixes following issue(s)
Fixes #24974

#### Media
![image](https://github.com/appsmithorg/appsmith/assets/24988127/67679ad8-b910-46c8-b102-49d45014b9af)

#### Latest DP
https://appsmith-bda3x9h6s-get-appsmith.vercel.app

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
Locally tested.

#### How Has This Been Tested?
- [X] Manual
- [X] Jest

#### Test Plan
skip-testPlan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
