### PR TITLE
fix: Table crashes when column width is greater than component width

### DIFF
--- a/app/client/src/widgets/TableWidgetV2/widget/reactTableUtils/getColumnsPureFn.tsx
+++ b/app/client/src/widgets/TableWidgetV2/widget/reactTableUtils/getColumnsPureFn.tsx
@@ -101,8 +101,10 @@ export const getColumnsPureFn: getColumns = (
       if the last column spills over resulting in horizontal scroll
     */
     const extraWidth = totalColumnWidth - componentWidth;
-    const lastColWidth = columns[lastColumnIndex].width || DEFAULT_COLUMN_WIDTH;
-    /*
+    if (columns[lastColumnIndex]) {
+      const lastColWidth =
+        columns[lastColumnIndex].width || DEFAULT_COLUMN_WIDTH;
+      /*
       Below if condition explanation:
       Condition 1: (lastColWidth > COLUMN_MIN_WIDTH)
         We will downsize the last column only if its greater than COLUMN_MIN_WIDTH
@@ -110,16 +112,17 @@ export const getColumnsPureFn: getColumns = (
         This condition checks whether the last column is the only column that is spilling over.
         If more than one columns are spilling over we won't downsize the last column
     */
-    if (lastColWidth > COLUMN_MIN_WIDTH && extraWidth < lastColWidth) {
-      const availableWidthForLastColumn = lastColWidth - extraWidth;
-      /*
+      if (lastColWidth > COLUMN_MIN_WIDTH && extraWidth < lastColWidth) {
+        const availableWidthForLastColumn = lastColWidth - extraWidth;
+        /*
         Below we are making sure last column width doesn't go lower than COLUMN_MIN_WIDTH again
         as availableWidthForLastColumn might go lower than COLUMN_MIN_WIDTH in some cases
       */
-      columns[lastColumnIndex].width =
-        availableWidthForLastColumn < COLUMN_MIN_WIDTH
-          ? COLUMN_MIN_WIDTH
-          : availableWidthForLastColumn;
+        columns[lastColumnIndex].width =
+          availableWidthForLastColumn < COLUMN_MIN_WIDTH
+            ? COLUMN_MIN_WIDTH
+            : availableWidthForLastColumn;
+      }
     }
   }
 


### PR DESCRIPTION
## Description
- When the table's column width is greater than the component width the table widget crashes.

> Links to Notion, Figma or any other documents that might be relevant to the PR
>
>
#### PR fixes following issue(s)
Fixes #25166 

#### Media
https://vdqm24wed6.vmaker.com/record/q4yZXh8n0uv7sVrl
>
#### Type of change

- Bug fix (non-breaking change which fixes an issue)


## Testing

#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
