### PR TITLE
feat: new user signed up flag and show walkthough only if its set

### DIFF
--- a/app/client/src/components/editorComponents/ActionRightPane/SuggestedWidgets.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/SuggestedWidgets.tsx
@@ -49,8 +49,10 @@ import listWidgetIconSvg from "../../../widgets/ListWidget/icon.svg";
 import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
 import {
   getFeatureFlagShownStatus,
+  isUserSignedUpFlagSet,
   setFeatureFlagShownStatus,
 } from "utils/storage";
+import { getCurrentUser } from "selectors/usersSelectors";
 
 const BINDING_GUIDE_GIF =
   "https://s3.us-east-2.amazonaws.com/assets.appsmith.com/binding.gif";
@@ -341,6 +343,7 @@ function SuggestedWidgets(props: SuggestedWidgetProps) {
   const dataTree = useSelector(getDataTree);
   const canvasWidgets = useSelector(getWidgets);
   const applicationId = useSelector(getCurrentApplicationId);
+  const user = useSelector(getCurrentUser);
   const {
     isOpened: isWalkthroughOpened,
     popFeature,
@@ -443,8 +446,10 @@ function SuggestedWidgets(props: SuggestedWidgetProps) {
       FEATURE_FLAG.ab_ds_binding_enabled,
     );
 
+    const isNewUser = user && (await isUserSignedUpFlagSet(user.email));
     // Adding walkthrough tutorial
-    !isFeatureWalkthroughShown &&
+    isNewUser &&
+      !isFeatureWalkthroughShown &&
       pushFeature &&
       pushFeature({
         targetId: BINDING_SECTION_ID,

--- a/app/client/src/components/editorComponents/ActionRightPane/index.tsx
+++ b/app/client/src/components/editorComponents/ActionRightPane/index.tsx
@@ -51,8 +51,10 @@ import { fetchDatasourceStructure } from "actions/datasourceActions";
 import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
 import {
   getFeatureFlagShownStatus,
+  isUserSignedUpFlagSet,
   setFeatureFlagShownStatus,
 } from "utils/storage";
+import { getCurrentUser } from "selectors/usersSelectors";
 
 const SCHEMA_GUIDE_GIF =
   "https://s3.us-east-2.amazonaws.com/assets.appsmith.com/schema.gif";
@@ -274,6 +276,7 @@ function ActionSidebar({
   const widgets = useSelector(getWidgets);
   const applicationId = useSelector(getCurrentApplicationId);
   const pageId = useSelector(getCurrentPageId);
+  const user = useSelector(getCurrentUser);
   const { pushFeature } = useContext(WalkthroughContext) || {};
   const params = useParams<{
     pageId: string;
@@ -332,8 +335,10 @@ function ActionSidebar({
       FEATURE_FLAG.ab_ds_schema_enabled,
     );
 
+    const isNewUser = user && (await isUserSignedUpFlagSet(user.email));
     // Adding walkthrough tutorial
-    !isFeatureWalkthroughShown &&
+    isNewUser &&
+      !isFeatureWalkthroughShown &&
       pushFeature &&
       pushFeature({
         targetId: SCHEMA_SECTION_ID,

--- a/app/client/src/pages/setup/SignupSuccess.tsx
+++ b/app/client/src/pages/setup/SignupSuccess.tsx
@@ -14,6 +14,7 @@ import { Center } from "pages/setup/common";
 import { Spinner } from "design-system";
 import { isValidLicense } from "@appsmith/selectors/tenantSelectors";
 import { redirectUserAfterSignup } from "@appsmith/utils/signupHelpers";
+import { setUserSignedUpFlag } from "utils/storage";
 
 export function SignupSuccess() {
   const dispatch = useDispatch();
@@ -23,8 +24,11 @@ export function SignupSuccess() {
     "enableFirstTimeUserExperience",
   );
   const validLicense = useSelector(isValidLicense);
+  const user = useSelector(getCurrentUser);
+
   useEffect(() => {
     PerformanceTracker.stopTracking(PerformanceTransactionName.SIGN_UP);
+    user?.email && setUserSignedUpFlag(user?.email);
   }, []);
 
   const redirectUsingQueryParam = useCallback(
@@ -49,7 +53,6 @@ export function SignupSuccess() {
     redirectUsingQueryParam();
   }, []);
 
-  const user = useSelector(getCurrentUser);
   const { cloudHosting } = getAppsmithConfigs();
   const isCypressEnv = !!(window as any).Cypress;
 

--- a/app/client/src/utils/storage.ts
+++ b/app/client/src/utils/storage.ts
@@ -24,6 +24,7 @@ export const STORAGE_KEYS: {
     "FIRST_TIME_USER_ONBOARDING_TELEMETRY_CALLOUT_VISIBILITY",
   SIGNPOSTING_APP_STATE: "SIGNPOSTING_APP_STATE",
   FEATURE_WALKTHROUGH: "FEATURE_WALKTHROUGH",
+  USER_SIGN_UP: "USER_SIGN_UP",
 };
 
 const store = localforage.createInstance({
@@ -441,13 +442,55 @@ export const setFeatureFlagShownStatus = async (key: string, value: any) => {
 };
 
 export const getFeatureFlagShownStatus = async (key: string) => {
-  const flagsJSON: Record<string, any> | null = await store.getItem(
-    STORAGE_KEYS.FEATURE_WALKTHROUGH,
-  );
+  try {
+    const flagsJSON: Record<string, any> | null = await store.getItem(
+      STORAGE_KEYS.FEATURE_WALKTHROUGH,
+    );
 
-  if (typeof flagsJSON === "object" && flagsJSON) {
-    return !!flagsJSON[key];
+    if (typeof flagsJSON === "object" && flagsJSON) {
+      return !!flagsJSON[key];
+    }
+
+    return false;
+  } catch (error) {
+    log.error("An error occurred while reading FEATURE_WALKTHROUGH");
+    log.error(error);
   }
+};
 
-  return false;
+export const setUserSignedUpFlag = async (email: string) => {
+  try {
+    let userSignedUp: Record<string, any> | null = await store.getItem(
+      STORAGE_KEYS.USER_SIGN_UP,
+    );
+
+    if (typeof userSignedUp === "object" && userSignedUp) {
+      userSignedUp[email] = Date.now();
+    } else {
+      userSignedUp = { [email]: Date.now() };
+    }
+
+    await store.setItem(STORAGE_KEYS.USER_SIGN_UP, userSignedUp);
+    return true;
+  } catch (error) {
+    log.error("An error occurred while updating USER_SIGN_UP");
+    log.error(error);
+  }
+};
+
+export const isUserSignedUpFlagSet = async (email: string) => {
+  try {
+    const userSignedUp: Record<string, any> | null = await store.getItem(
+      STORAGE_KEYS.USER_SIGN_UP,
+    );
+
+    if (typeof userSignedUp === "object" && userSignedUp) {
+      return !!userSignedUp[email];
+    }
+
+    return false;
+  } catch (error) {
+    log.error("An error occurred while reading USER_SIGN_UP");
+    log.error(error);
+  }
 };


### PR DESCRIPTION
## Description
- Created a `USER_SIGN_UP` flag when the user lands on signup success page. It will have object with key as `emailId` & values as `created-on timestamp` and will be stored in indexDB.
- Show feature walkthrough to only users having `USER_SIGN_UP` flag set.


#### PR fixes following issue(s)
Fixes #25195
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
