### PR TITLE
fix: currency widget input boolean values

### DIFF
--- a/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/CurrencyInputWidget/widget/index.tsx
@@ -64,7 +64,7 @@ export function defaultValueValidation(
   }
   const decimalSeperator = getLocaleDecimalSeperator();
   const defaultDecimalSeperator = ".";
-  if (_.isObject(value)) {
+  if (_.isObject(value) || typeof value === "boolean") {
     return {
       isValid: false,
       parsed: JSON.stringify(value, null, 2),


### PR DESCRIPTION

## Description
This pull request has a fix for a currencyWidget Input that used to take {{false}} and {{true}} and convert them to 0 and 1 instead of throwing an error. Now if user enters a boolean value, they will be notified with an error message that input value must be a number.


#### PR fixes following issue(s)
Fixes # 24930


#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?

- [ ] Manual


## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


