### PR TITLE
fix: edit ds button was disabled due to no user perm in ds object

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
@@ -15,7 +15,8 @@ describe("Bug 25148 - Edit Datasource button was disabled on Authentication tab 
       dataSources.SaveDatasource();
       apiPage.CreateApi("API" + uid, "GET", true);
       apiPage.SelectPaneTab("Authentication");
-      cy.get(apiPage._saveAsDS).should("be.enabled");
+      // Last one if present on the authentication tab.
+      cy.get(apiPage._saveAsDS).last().should("be.enabled");
     });
   });
 });

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
@@ -1,0 +1,21 @@
+import * as _ from "../../../../support/Objects/ObjectsCore";
+
+const { agHelper, apiPage, dataSources } = _;
+let dsName: any;
+
+describe("Bug 6732 - this.params in IIFE function in API editor", () => {
+  it("1. this.params should be available in IIFE function in API editor", () => {
+    dataSources.NavigateToDSCreateNew();
+    agHelper.GenerateUUID();
+    cy.get("@guid").then((uid) => {
+      dsName = "AuthAPI " + uid;
+      dataSources.CreatePlugIn("Authenticated API");
+      agHelper.RenameWithInPane(dsName, false);
+      dataSources.FillAuthAPIUrl();
+      dataSources.SaveDatasource();
+      apiPage.CreateApi("API" + uid, "GET", true);
+      apiPage.SelectPaneTab("Authentication");
+      cy.get(apiPage._saveAsDS).should("be.enabled");
+    });
+  });
+});

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
@@ -3,8 +3,8 @@ import * as _ from "../../../../support/Objects/ObjectsCore";
 const { agHelper, apiPage, dataSources } = _;
 let dsName: any;
 
-describe("Bug 6732 - this.params in IIFE function in API editor", () => {
-  it("1. this.params should be available in IIFE function in API editor", () => {
+describe("Bug 25148 - Edit Datasource button was disabled on Authentication tab of Api action", () => {
+  it("1. Checking if the Edit datasource button is enabled or not", () => {
     dataSources.NavigateToDSCreateNew();
     agHelper.GenerateUUID();
     cy.get("@guid").then((uid) => {

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25148_Spec.ts
@@ -15,8 +15,9 @@ describe("Bug 25148 - Edit Datasource button was disabled on Authentication tab 
       dataSources.SaveDatasource();
       apiPage.CreateApi("API" + uid, "GET", true);
       apiPage.SelectPaneTab("Authentication");
+      agHelper.AssertElementEnabledDisabled(apiPage._saveAsDS, 0, false);
       // Last one if present on the authentication tab.
-      cy.get(apiPage._saveAsDS).last().should("be.enabled");
+      agHelper.AssertElementEnabledDisabled(apiPage._saveAsDS, 1, false);
     });
   });
 });

--- a/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
@@ -149,6 +149,10 @@ const mapStateToProps = (state: AppState, ownProps: any): ReduxStateProps => {
         datasourceFromDataSourceList.datasourceStorages[
           currentEnvironment
         ].datasourceId;
+
+      // Adding user permissions for datasource from datasourceFromDataSourceList
+      datasourceMerged.userPermissions =
+        datasourceFromDataSourceList.userPermissions || [];
     }
   }
 


### PR DESCRIPTION
## Description
Due to absence of `userPermissions` in Datasource object being sent to the Api authentication component, the `edit datasource` button was being disabled. Now the `userPermissions` with regard to datasource, is being added to its object to enable disable the `edit ds` button.

#### PR fixes following issue(s)
Fixes #25148 

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
