### PR TITLE
feat: default table name populated in query editor for mock datasources

### DIFF
--- a/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
@@ -6,6 +6,7 @@ import {
   assertHelper,
 } from "../../../support/Objects/ObjectsCore";
 let dsName: any;
+import formControls from "../../../locators/FormControl.json";
 
 describe(
   "excludeForAirgap",
@@ -43,6 +44,13 @@ describe(
       dataSources.CreateMockDB("Users").then((mockDBName) => {
         dsName = mockDBName;
         dataSources.CreateQueryAfterDSSaved();
+
+        // This will validate that query populated in editor uses existing table name
+        agHelper.VerifyCodeInputValue(
+          formControls.postgreSqlBody,
+          "SELECT * FROM public.users LIMIT 10;\n\n",
+        );
+
         dataSources.RunQueryNVerifyResponseViews(1);
         dataSources.NavigateToActiveTab();
         agHelper

--- a/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/MockDBs_Spec.ts
@@ -51,7 +51,7 @@ describe(
           "SELECT * FROM public.users LIMIT 10;\n\n",
         );
 
-        dataSources.RunQueryNVerifyResponseViews(1);
+        dataSources.RunQueryNVerifyResponseViews(10);
         dataSources.NavigateToActiveTab();
         agHelper
           .GetText(dataSources._queriesOnPageText(mockDBName))
@@ -60,7 +60,7 @@ describe(
           );
 
         entityExplorer.CreateNewDsQuery(mockDBName);
-        dataSources.RunQueryNVerifyResponseViews(1, true);
+        dataSources.RunQueryNVerifyResponseViews(10, true);
         dataSources.NavigateToActiveTab();
         agHelper
           .GetText(dataSources._queriesOnPageText(mockDBName))

--- a/app/client/src/pages/Editor/FormControl.tsx
+++ b/app/client/src/pages/Editor/FormControl.tsx
@@ -34,6 +34,7 @@ import TemplateMenu from "./QueryEditor/TemplateMenu";
 import { SQL_DATASOURCES } from "../../constants/QueryEditorConstants";
 import { getCurrentEnvironment } from "@appsmith/utils/Environments";
 import type { Datasource } from "entities/Datasource";
+import { getSQLPluginsMockTableName } from "utils/editorContextUtils";
 
 export interface FormControlProps {
   config: ControlProps;
@@ -75,6 +76,9 @@ function FormControl(props: FormControlProps) {
   const datasourceTableName: string = useSelector((state: AppState) =>
     getDatasourceFirstTableName(state, dsId),
   );
+  const isMockDS =
+    ((formValues as Action)?.datasource as any)?.isMock ||
+    (formValues as Datasource)?.isMock;
   const pluginTemplates: Record<string, any> = useSelector((state: AppState) =>
     getPluginTemplates(state),
   );
@@ -143,17 +147,20 @@ function FormControl(props: FormControlProps) {
       !convertFormToRaw &&
       SQL_DATASOURCES.includes(pluginName)
     ) {
+      const tableNameToBeReplaced = isMockDS
+        ? getSQLPluginsMockTableName(pluginId)
+        : datasourceTableName;
       const defaultTemplate = !!pluginTemplate
         ? pluginTemplate[DB_QUERY_DEFAULT_TEMPLATE_TYPE]
         : "";
       const smartTemplate = defaultTemplate
-        .replace(DB_QUERY_DEFAULT_TABLE_NAME, datasourceTableName)
+        .replace(DB_QUERY_DEFAULT_TABLE_NAME, tableNameToBeReplaced)
         .split("--")[0];
       dispatch(
         change(
           props?.formName || QUERY_EDITOR_FORM_NAME,
           props.config.configProperty,
-          !!datasourceTableName ? smartTemplate : defaultTemplate,
+          !!tableNameToBeReplaced ? smartTemplate : defaultTemplate,
         ),
       );
       updateQueryParams();

--- a/app/client/src/utils/editorContextUtils.ts
+++ b/app/client/src/utils/editorContextUtils.ts
@@ -6,10 +6,13 @@ import {
 } from "@appsmith/constants/forms";
 import { getCurrentEnvironment } from "@appsmith/utils/Environments";
 import { diff } from "deep-diff";
-import { PluginPackageName, PluginType } from "entities/Action";
+import { PluginName, PluginPackageName, PluginType } from "entities/Action";
 import type { Datasource } from "entities/Datasource";
 import { AuthenticationStatus, AuthType } from "entities/Datasource";
 import { get, isArray } from "lodash";
+import store from "store";
+import { getPlugin } from "selectors/entitiesSelector";
+import type { AppState } from "@appsmith/reducers";
 export function isCurrentFocusOnInput() {
   return (
     ["input", "textarea"].indexOf(
@@ -170,4 +173,23 @@ export function getFormDiffPaths(initialValues: any, currentValues: any) {
     });
   }
   return diffPaths;
+}
+
+/**
+ * Returns mock datasource default table name to be populated in query editor, based on plugin name
+ * @param pluginId string
+ * @returns string
+ */
+export function getSQLPluginsMockTableName(pluginId: string) {
+  const state: AppState = store.getState();
+  const plugin: Plugin | undefined = getPlugin(state, pluginId);
+
+  switch (plugin?.name) {
+    case PluginName.POSTGRES: {
+      return "public.users";
+    }
+    default: {
+      return "";
+    }
+  }
 }


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/appsmithorg/appsmith/issues/23960.

In above issue, we picked the first available entity (table/collection, etc) and show the user a read query by default. With a [[real datasource](https://www.notion.so/7b5b3f6302cc4a8e93f8ecd1a3965cad?pvs=21)](https://www.notion.so/7b5b3f6302cc4a8e93f8ecd1a3965cad?pvs=21), it is not possible to know which is the most meaningful entity to choose. However, with mock datasources, we do have the option because we own the underlying databases.

This PR adds that functionality, In case of Users mock DB, we will populate the query editor with `select * from public.users limit 10`, as Users mock DB contains users table.

#### PR fixes following issue(s)
Fixes #25247 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- New feature (non-breaking change which adds functionality)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [x] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [x] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
