### PR TITLE
fix: auto expand data section in prop pane on connect data

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
@@ -1,6 +1,12 @@
 import { Classes } from "@blueprintjs/core";
 import type { ReactNode, Context } from "react";
-import React, { memo, useState, createContext, useCallback } from "react";
+import React, {
+  memo,
+  useState,
+  useEffect,
+  createContext,
+  useCallback,
+} from "react";
 import { Collapse } from "@blueprintjs/core";
 import styled from "styled-components";
 import { Colors } from "constants/Colors";
@@ -10,6 +16,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { getPropertySectionState } from "selectors/editorContextSelectors";
 import { getCurrentWidgetId } from "selectors/propertyPaneSelectors";
 import { setPropertySectionState } from "actions/propertyPaneActions";
+import { getIsOneClickBindingOptionsVisibility } from "selectors/oneClickBindingSelectors";
 
 const TagContainer = styled.div``;
 
@@ -105,7 +112,17 @@ export const PropertySection = memo((props: PropertySectionProps) => {
   } else {
     initialIsOpenState = !!isDefaultOpen;
   }
+
+  const className = props.name.split(" ").join("").toLowerCase();
+
   const [isOpen, setIsOpen] = useState(initialIsOpenState);
+  const connectDataClicked = useSelector(getIsOneClickBindingOptionsVisibility);
+
+  useEffect(() => {
+    if (connectDataClicked && className === "data" && !isOpen) {
+      handleSectionTitleClick();
+    }
+  }, [connectDataClicked]);
 
   const handleSectionTitleClick = useCallback(() => {
     if (props.collapsible)
@@ -123,7 +140,6 @@ export const PropertySection = memo((props: PropertySectionProps) => {
 
   if (!currentWidgetId) return null;
 
-  const className = props.name.split(" ").join("").toLowerCase();
   return (
     <SectionWrapper
       className={`t--property-pane-section-wrapper ${props.className}`}


### PR DESCRIPTION

## Description
- On table widget, when you click on `Connect data` , if the `Data` column in the prop pane is collapsed, the one click binding options dropdown open in absolute position (0,0) top left corner of the page. So auto expanding the data column when the user clicks on connect data.

#### PR fixes following issue(s)
Fixes #25254 

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
