### PR TITLE
fix: removes race conditions in recent perf optimisation

### DIFF
--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -147,37 +147,25 @@ export default class AppEditorEngine extends AppEngine {
 
   private *loadPluginsAndDatasources() {
     const isAirgappedInstance = isAirgapped();
-    const initActions: ReduxAction<unknown>[] = [
-      fetchPlugins(),
-      fetchDatasources(),
-    ];
-
-    if (!isAirgappedInstance) {
-      initActions.push(fetchMockDatasources() as ReduxAction<{ type: string }>);
-    }
-    initActions.push(fetchPageDSLs() as ReduxAction<{ type: string }>);
+    const initActions = [fetchPlugins(), fetchDatasources(), fetchPageDSLs()];
 
     const successActions = [
       ReduxActionTypes.FETCH_PLUGINS_SUCCESS,
       ReduxActionTypes.FETCH_DATASOURCES_SUCCESS,
-      ReduxActionTypes.FETCH_MOCK_DATASOURCES_SUCCESS,
       ReduxActionTypes.FETCH_PAGE_DSLS_SUCCESS,
-    ].filter((action) =>
-      !isAirgappedInstance
-        ? true
-        : action !== ReduxActionTypes.FETCH_MOCK_DATASOURCES_SUCCESS,
-    );
+    ];
 
     const errorActions = [
       ReduxActionErrorTypes.FETCH_PLUGINS_ERROR,
       ReduxActionErrorTypes.FETCH_DATASOURCES_ERROR,
-      ReduxActionErrorTypes.FETCH_MOCK_DATASOURCES_ERROR,
       ReduxActionErrorTypes.POPULATE_PAGEDSLS_ERROR,
-    ].filter((action) =>
-      !isAirgappedInstance
-        ? true
-        : action !== ReduxActionErrorTypes.FETCH_MOCK_DATASOURCES_ERROR,
-    );
+    ];
+
+    if (!isAirgappedInstance) {
+      initActions.push(fetchMockDatasources() as ReduxAction<{ type: string }>);
+      successActions.push(ReduxActionTypes.FETCH_MOCK_DATASOURCES_SUCCESS);
+      errorActions.push(ReduxActionErrorTypes.FETCH_MOCK_DATASOURCES_ERROR);
+    }
 
     const initActionCalls: boolean = yield call(
       failFastApiCalls,

--- a/app/client/src/sagas/PageSagas.tsx
+++ b/app/client/src/sagas/PageSagas.tsx
@@ -127,7 +127,7 @@ import {
 import WidgetFactory from "utils/WidgetFactory";
 import { toggleShowDeviationDialog } from "actions/onboardingActions";
 import { builderURL } from "RouteBuilder";
-import { failFastApiCalls } from "./InitSagas";
+import { failFastApiCalls, waitForWidgetConfigBuild } from "./InitSagas";
 import { hasManagePagePermission } from "@appsmith/utils/permissionHelpers";
 import { resizePublishedMainCanvasToLowestWidget } from "./WidgetOperationUtils";
 import { checkAndLogErrorsIfCyclicDependency } from "./helper";
@@ -302,6 +302,8 @@ export function* handleFetchedPage({
     yield call(clearEvalCache);
     // Set url params
     yield call(setDataUrl);
+    // Wait for widget config to be loaded before we can generate the canvas payload
+    yield call(waitForWidgetConfigBuild);
     // Get Canvas payload
     const canvasWidgetsPayload = getCanvasWidgetsPayload(
       fetchPageResponse,
@@ -412,6 +414,8 @@ export function* fetchPublishedPageSaga(
       yield call(clearEvalCache);
       // Set url params
       yield call(setDataUrl);
+      // Wait for widget config to load before we can get the canvas payload
+      yield call(waitForWidgetConfigBuild);
       // Get Canvas payload
       const canvasWidgetsPayload = getCanvasWidgetsPayload(response);
       // resize main canvas
@@ -1122,6 +1126,8 @@ export function* fetchPageDSLSaga(pageId: string) {
     });
     const isValidResponse: boolean = yield validateResponse(fetchPageResponse);
     if (isValidResponse) {
+      // Wait for the Widget config to be loaded before we can migrate the DSL
+      yield call(waitForWidgetConfigBuild);
       const { dsl, layoutId } = extractCurrentDSL(
         fetchPageResponse,
         isAutoLayout,

--- a/app/client/src/utils/DSLMigrations.ts
+++ b/app/client/src/utils/DSLMigrations.ts
@@ -754,6 +754,7 @@ export const migrateInitialValues = (currentDSL: DSLWidget) => {
 
 // A rudimentary transform function which updates the DSL based on its version.
 // A more modular approach needs to be designed.
+// This needs the widget config to be already built to migrate correctly
 export const transformDSL = (currentDSL: DSLWidget, newPage = false) => {
   if (currentDSL.version === undefined) {
     // Since this top level widget is a CANVAS_WIDGET,


### PR DESCRIPTION
We missed a race condition in: #25104 which caused some test cases to fail. This would rarely happen to any new apps in production but to ensure backwards compatibility we are updating the code itself