### PR TITLE
fix: ShowAlert with same texts, when invoked from different triggers are combined 

### DIFF
--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/PlatformFn_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/PlatformFn_spec.ts
@@ -164,7 +164,6 @@ describe("Tests functionality of platform function", () => {
       },
     );
     agHelper.Sleep();
-    jsEditor.SelectFunctionDropdown("showTwoSameToastMessageAlerts");
     jsEditor.RunJSObj();
     agHelper.AssertElementLength(locators._toastMsg, 2);
     agHelper.ValidateToastMessage("Hello World", 0);

--- a/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/PlatformFn_spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/PlatformFn_spec.ts
@@ -5,6 +5,7 @@ import {
   jsEditor,
   debuggerHelper,
   tedTestConfig,
+  locators,
 } from "../../../../support/Objects/ObjectsCore";
 
 describe("Tests functionality of platform function", () => {
@@ -143,5 +144,30 @@ describe("Tests functionality of platform function", () => {
       debuggerHelper.DebuggerLogsFilter("JSObject1.metaDataApiTest");
       debuggerHelper.DoesConsoleLogExist("Hello from setTimeout inside API");
     });
+  });
+
+  it("2.Bug 16135 ShowAlert with same texts, when invoked from different triggers are combined", () => {
+    jsEditor.CreateJSObject(
+      `export default {
+        showTwoSameToastMessageAlerts: () => {
+            showAlert( "Hello World" );
+            showAlert( "Hello World" );
+        },
+
+        }`,
+      {
+        paste: true,
+        completeReplace: true,
+        toRun: false,
+        shouldCreateNewJSObj: true,
+        prettify: false,
+      },
+    );
+    agHelper.Sleep();
+    jsEditor.SelectFunctionDropdown("showTwoSameToastMessageAlerts");
+    jsEditor.RunJSObj();
+    agHelper.AssertElementLength(locators._toastMsg, 2);
+    agHelper.ValidateToastMessage("Hello World", 0);
+    agHelper.ValidateToastMessage("Hello World", 1);
   });
 });

--- a/app/client/src/sagas/ActionExecution/ShowAlertActionSaga.ts
+++ b/app/client/src/sagas/ActionExecution/ShowAlertActionSaga.ts
@@ -5,6 +5,7 @@ import type { ToastKind } from "design-system";
 import type { TShowAlertDescription } from "workers/Evaluation/fns/showAlert";
 import { call } from "redux-saga/effects";
 import showToast from "sagas/ToastSagas";
+import { uniqueId } from "lodash";
 
 export default function* showAlertSaga(action: TShowAlertDescription) {
   const { payload } = action;
@@ -22,6 +23,7 @@ export default function* showAlertSaga(action: TShowAlertDescription) {
     payload.message,
     {
       kind: payload.style as ToastKind,
+      toastId: uniqueId("ToastId"),
     },
     { forceDisplay: true },
   );


### PR DESCRIPTION

## Description
The toaster component, part of the react design system, generates a unique id for each toast. The id is generated based on a content string and the options Json. When the content and options are identical, duplicate ids are generated. Toaster ignores any toast with duplicate IDs.  Explicitly passing a unique id overrides the internal id generation logic. This ensures that all toasters are displayed, even if the content and options are identical.


#### PR fixes following issue(s)
Fixes #16135 

#### Media
None

#### Type of change
- Bug fix (non-breaking change which fixes an issue)


## Testing
>
#### How Has This Been Tested?
- [x ] Manual
- [ x] Cypress
>
>
#### Test Plan
cypress test case is defined in 
`app/client/cypress/e2e/Regression/ServerSide/JsFunctionExecution/PlatformFn_spec.ts/2.Bug 16135 ShowAlert with same texts, when invoked from different triggers are combined
`

#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [x] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [x] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
