### PR TITLE
fix: revalidation logic 

### DIFF
--- a/app/client/src/sagas/EvaluationsSaga.ts
+++ b/app/client/src/sagas/EvaluationsSaga.ts
@@ -136,6 +136,7 @@ export function* updateDataTreeHandler(
     errors,
     evalMetaUpdates = [],
     evaluationOrder,
+    reValidatedPaths,
     isCreateFirstTree = false,
     isNewWidgetAdded,
     jsUpdates,
@@ -180,12 +181,13 @@ export function* updateDataTreeHandler(
   log.debug({ jsUpdates: jsUpdates });
   log.debug({ dataTree: updatedDataTree });
   logs?.forEach((evalLog: any) => log.debug(evalLog));
-  // Added type as any due to https://github.com/redux-saga/redux-saga/issues/1482
+
   yield call(
-    evalErrorHandler as any,
+    evalErrorHandler,
     errors,
     updatedDataTree,
     evaluationOrder,
+    reValidatedPaths,
     configTree,
     pathsToClearErrorsFor,
   );

--- a/app/client/src/sagas/PostEvaluationSagas.ts
+++ b/app/client/src/sagas/PostEvaluationSagas.ts
@@ -62,7 +62,7 @@ const getDebuggerErrors = (state: AppState) => state.ui.debugger.errors;
 function logLatestEvalPropertyErrors(
   currentDebuggerErrors: Record<string, Log>,
   dataTree: DataTree,
-  evaluationOrder: Array<string>,
+  evalAndValidationOrder: Array<string>,
   configTree: ConfigTree,
   pathsToClearErrorsFor?: any[],
 ) {
@@ -72,7 +72,7 @@ function logLatestEvalPropertyErrors(
     ...currentDebuggerErrors,
   };
 
-  for (const evaluatedPath of evaluationOrder) {
+  for (const evaluatedPath of evalAndValidationOrder) {
     const { entityName, propertyPath } =
       getEntityNameAndPropertyPath(evaluatedPath);
     const entity = dataTree[entityName];
@@ -221,18 +221,24 @@ export function* evalErrorHandler(
   errors: EvalError[],
   dataTree?: DataTree,
   evaluationOrder?: Array<string>,
+  reValidatedPaths?: Array<string>,
   configTree?: ConfigTree,
   pathsToClearErrorsFor?: any[],
-): any {
-  if (dataTree && evaluationOrder && configTree) {
+) {
+  if (dataTree && evaluationOrder && configTree && reValidatedPaths) {
     const currentDebuggerErrors: Record<string, Log> = yield select(
       getDebuggerErrors,
     );
+
+    const evalAndValidationOrder = new Set([
+      ...reValidatedPaths,
+      ...evaluationOrder,
+    ]);
     // Update latest errors to the debugger
     logLatestEvalPropertyErrors(
       currentDebuggerErrors,
       dataTree,
-      evaluationOrder,
+      [...evalAndValidationOrder],
       configTree,
       pathsToClearErrorsFor,
     );

--- a/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
+++ b/app/client/src/workers/Evaluation/evalTreeWithChanges.ts
@@ -20,6 +20,7 @@ export function evalTreeWithChanges(
   metaUpdates: EvalMetaUpdates = [],
 ) {
   let evalOrder: string[] = [];
+  let reValidatedPaths: string[] = [];
   let jsUpdates: Record<string, JSUpdate> = {};
   let unEvalUpdates: DataTreeDiff[] = [];
   let nonDynamicFieldValidationOrder: string[] = [];
@@ -51,6 +52,8 @@ export function evalTreeWithChanges(
       unEvalUpdates,
     );
 
+    reValidatedPaths = updateResponse.reValidatedPaths;
+
     setEvalContext({
       dataTree: dataTreeEvaluator.getEvalTree(),
       configTree: dataTreeEvaluator.getConfigTree(),
@@ -75,6 +78,7 @@ export function evalTreeWithChanges(
     errors,
     evalMetaUpdates,
     evaluationOrder: evalOrder,
+    reValidatedPaths,
     jsUpdates,
     logs,
     unEvalUpdates,

--- a/app/client/src/workers/Evaluation/handlers/evalTree.ts
+++ b/app/client/src/workers/Evaluation/handlers/evalTree.ts
@@ -31,6 +31,7 @@ export const CANVAS = "canvas";
 export default function (request: EvalWorkerSyncRequest) {
   const { data } = request;
   let evalOrder: string[] = [];
+  let reValidatedPaths: string[] = [];
   let jsUpdates: Record<string, JSUpdate> = {};
   let unEvalUpdates: DataTreeDiff[] = [];
   let nonDynamicFieldValidationOrder: string[] = [];
@@ -85,7 +86,7 @@ export default function (request: EvalWorkerSyncRequest) {
       staleMetaIds = dataTreeResponse.staleMetaIds;
     } else if (dataTreeEvaluator.hasCyclicalDependency || forceEvaluation) {
       if (dataTreeEvaluator && !isEmpty(allActionValidationConfig)) {
-        //allActionValidationConfigs may not be set in dataTreeEvaluatior. Therefore, set it explicitly via setter method
+        //allActionValidationConfigs may not be set in dataTreeEvaluator. Therefore, set it explicitly via setter method
         dataTreeEvaluator.setAllActionValidationConfig(
           allActionValidationConfig,
         );
@@ -155,6 +156,8 @@ export default function (request: EvalWorkerSyncRequest) {
         Object.keys(metaWidgets),
       );
 
+      reValidatedPaths = updateResponse.reValidatedPaths;
+
       setEvalContext({
         dataTree: dataTreeEvaluator.evalTree,
         configTree,
@@ -213,6 +216,7 @@ export default function (request: EvalWorkerSyncRequest) {
     errors,
     evalMetaUpdates,
     evaluationOrder: evalOrder,
+    reValidatedPaths,
     jsUpdates,
     logs,
     unEvalUpdates,

--- a/app/client/src/workers/Evaluation/types.ts
+++ b/app/client/src/workers/Evaluation/types.ts
@@ -47,6 +47,7 @@ export interface EvalTreeResponseData {
   errors: EvalError[];
   evalMetaUpdates: EvalMetaUpdates;
   evaluationOrder: string[];
+  reValidatedPaths: string[];
   jsUpdates: Record<string, JSUpdate>;
   logs: unknown[];
   unEvalUpdates: DataTreeDiff[];

--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -113,7 +113,7 @@ import {
 } from "./utils";
 import { isJSObjectFunction } from "workers/Evaluation/JSObject/utils";
 import {
-  reValidateEvalOrderDependentPaths,
+  getValidatedTree,
   validateActionProperty,
   validateAndParseWidgetProperty,
 } from "./validationUtils";
@@ -339,18 +339,17 @@ export default class DataTreeEvaluator {
     const validationStartTime = performance.now();
     // Validate Widgets
 
-    reValidateEvalOrderDependentPaths(
-      evaluationOrder,
-      evaluatedTree,
-      {
-        evalProps: this.evalProps,
-        dataTreeEvaluator: this,
-      },
-      this.oldConfigTree,
+    this.setEvalTree(
+      getValidatedTree(
+        evaluatedTree,
+        {
+          evalProps: this.evalProps,
+        },
+        this.oldConfigTree,
+      ),
     );
 
     const validationEndTime = performance.now();
-    this.setEvalTree(evaluatedTree);
 
     const timeTakenForEvalAndValidateFirstTree = {
       evaluation: getFixedTimeDifference(


### PR DESCRIPTION
## Description

Debugger logs were only updated according to the evaluation order earlier this led to an issue as after revalidation we need to update the debugger errors. 

#### PR fixes following issue(s)
Fixes #24905


#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

#### Test Plan

- Validation sanity test

#### Issues raised during DP testing


## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
