### PR TITLE
fix: added error handling when no config found in datasourceStorage

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
@@ -86,7 +86,12 @@ public class DatasourceStorageServiceCEImpl implements DatasourceStorageServiceC
     @Override
     public Mono<DatasourceStorage> findByDatasourceAndEnvironmentIdForExecution(
             Datasource datasource, String environmentId) {
-        return this.findByDatasourceAndEnvironmentId(datasource, environmentId);
+        return this.findByDatasourceAndEnvironmentId(datasource, environmentId).flatMap(datasourceStorage -> {
+            if (datasourceStorage.getDatasourceConfiguration() == null) {
+                return Mono.error(new AppsmithException(AppsmithError.NO_CONFIGURATION_FOUND_IN_DATASOURCE));
+            }
+            return Mono.just(datasourceStorage);
+        });
     }
 
     @Override

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -224,8 +224,8 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
                 .findById(datasourceId, datasourcePermission.getEditPermission())
                 .switchIfEmpty(Mono.error(
                         new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasourceId)))
-                .flatMap(datasource ->
-                        datasourceStorageService.findByDatasourceAndEnvironmentId(datasource, environmentId))
+                .flatMap(datasource -> datasourceStorageService.findByDatasourceAndEnvironmentIdForExecution(
+                        datasource, environmentId))
                 .filter(DatasourceStorage::getIsValid)
                 .switchIfEmpty(Mono.error(
                         new AppsmithException(AppsmithError.INVALID_DATASOURCE, FieldName.DATASOURCE, datasourceId)));

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
@@ -50,8 +50,8 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
                 .findById(datasourceId, datasourcePermission.getExecutePermission())
                 .zipWhen(datasource -> datasourceService.getTrueEnvironmentId(
                         datasource.getWorkspaceId(), environmentId, datasource.getPluginId()))
-                .flatMap(tuple2 ->
-                        datasourceStorageService.findByDatasourceAndEnvironmentId(tuple2.getT1(), tuple2.getT2()))
+                .flatMap(tuple2 -> datasourceStorageService.findByDatasourceAndEnvironmentIdForExecution(
+                        tuple2.getT1(), tuple2.getT2()))
                 .flatMap(datasourceStorage -> getStructure(datasourceStorage, ignoreCache))
                 .onErrorMap(
                         IllegalArgumentException.class,

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceTriggerSolutionCEImpl.java
@@ -57,8 +57,9 @@ public class DatasourceTriggerSolutionCEImpl implements DatasourceTriggerSolutio
         Mono<DatasourceStorage> datasourceStorageMonoCached = datasourceMonoCached
                 .flatMap(datasource1 -> datasourceService
                         .getTrueEnvironmentId(datasource1.getWorkspaceId(), environmentId, datasource1.getPluginId())
-                        .zipWhen(trueEnvironmentId -> datasourceStorageService.findByDatasourceAndEnvironmentId(
-                                datasource1, trueEnvironmentId))
+                        .zipWhen(trueEnvironmentId ->
+                                datasourceStorageService.findByDatasourceAndEnvironmentIdForExecution(
+                                        datasource1, trueEnvironmentId))
                         .map(Tuple2::getT2))
                 .cache();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceStorageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceStorageServiceTest.java
@@ -1,9 +1,11 @@
 package com.appsmith.server.services;
 
 import com.appsmith.external.models.DBAuth;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.external.models.Endpoint;
+import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.Plugin;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.domains.Workspace;
@@ -168,6 +170,38 @@ public class DatasourceStorageServiceTest {
             assertThat(dbDatasourceStorage).isNotNull();
             assertThat(datasourceId).isEqualTo(dbDatasourceStorage.getDatasourceId());
             assertThat(environmentId).isEqualTo(dbDatasourceStorage.getEnvironmentId());
+        });
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void verifyFindByDatasourceAndStorageIdGivesErrorWhenNoConfigurationIsPresent() {
+
+        Plugin plugin = pluginService.findByPackageName("postgres-plugin").block();
+        String pluginId = plugin.getId();
+        String datasourceId = "datasourceForExecution";
+        String environmentIdOne = FieldName.UNUSED_ENVIRONMENT_ID;
+
+        DatasourceStorage datasourceStorage = new DatasourceStorage();
+        datasourceStorage.setDatasourceId(datasourceId);
+        datasourceStorage.setEnvironmentId(environmentIdOne);
+        datasourceStorage.setPluginId(pluginId);
+
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        datasourceStorageService.create(datasourceStorage).block();
+
+        Datasource datasource = new Datasource();
+        datasource.setId(datasourceId);
+        datasource.setPluginId(pluginId);
+
+        Mono<DatasourceStorage> datasourceStorageMono =
+                datasourceStorageService.findByDatasourceAndEnvironmentIdForExecution(datasource, environmentIdOne);
+        StepVerifier.create(datasourceStorageMono).verifyErrorSatisfies(error -> {
+            assertThat(error).isInstanceOf(AppsmithException.class);
+            assertThat(((AppsmithException) error).getAppErrorCode())
+                    .isEqualTo(AppsmithError.NO_CONFIGURATION_FOUND_IN_DATASOURCE.getAppErrorCode());
         });
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
@@ -424,6 +424,7 @@ public class DatasourceStructureSolutionTest {
         DatasourceStorage datasourceStorage = new DatasourceStorage();
         datasourceStorage.setDatasourceId(datasourceId);
         datasourceStorage.setEnvironmentId(defaultEnvironmentId);
+        datasourceStorage.setDatasourceConfiguration(new DatasourceConfiguration());
         datasourceStorage.setInvalids(new HashSet<>());
         datasourceStorage.getInvalids().add("random invalid");
 


### PR DESCRIPTION
## Description
> this Pr is regarding error handling when no DatasourceConfiguration is found in datasourceStorage, now we are erroring out with error message for no configuration found.

Fixes #25350

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
- [ ] Manual
- [ ] Jest
- [ ] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
