### PR TITLE
fix: signposting is showing up on non postgres screens

### DIFF
--- a/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
+++ b/app/client/src/pages/Editor/QueryEditor/EditorJSONtoForm.tsx
@@ -881,13 +881,14 @@ export function EditorJSONtoForm(props: Props) {
     dispatch(setDebuggerSelectedTab(tabKey));
   }, []);
 
+  const isPostgresPlugin = currentActionPluginName === PluginName.POSTGRES;
   const featureFlags = useSelector(selectFeatureFlags);
-  const editorMode =
-    currentActionPluginName === PluginName.POSTGRES
-      ? editorSQLModes.POSTGRESQL_WITH_BINDING
-      : editorSQLModes.MYSQL_WITH_BINDING;
+  const editorMode = isPostgresPlugin
+    ? editorSQLModes.POSTGRESQL_WITH_BINDING
+    : editorSQLModes.MYSQL_WITH_BINDING;
 
-  const isAIEnabledForPosting = isAIEnabled(featureFlags, editorMode);
+  const isAIEnabledForPosting =
+    isPostgresPlugin && isAIEnabled(featureFlags, editorMode);
 
   // close the debugger
   //TODO: move this to a common place


### PR DESCRIPTION
## Description
fix: signposting is showing up on non postgres screens

Fixes #25439 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
