### PR TITLE
chore: Multiple environment instrumentation

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/AnalyticsConstantsCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/constants/ce/AnalyticsConstantsCE.java
@@ -2,6 +2,8 @@ package com.appsmith.server.constants.ce;
 
 public class AnalyticsConstantsCE {
     public static final String ENVIRONMENT_ID_SHORTNAME = "envId";
+    public static final String ENVIRONMENT_NAME_SHORTNAME = "envName";
+    public static final String ENVIRONMENT_NAME_DEFAULT = "";
     public static final String DATASOURCE_ID_SHORTNAME = "dsId";
     public static final String DATASOURCE_NAME_SHORTNAME = "dsName";
     public static final String DATASOURCE_IS_TEMPLATE_SHORTNAME = "dsIsTemplate";

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DatasourceAnalyticsUtils.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/helpers/DatasourceAnalyticsUtils.java
@@ -6,6 +6,7 @@ import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.external.models.DatasourceTestResult;
 import com.appsmith.external.models.OAuth2;
+import com.appsmith.server.constants.AnalyticsConstants;
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.HashMap;
@@ -40,8 +41,8 @@ public class DatasourceAnalyticsUtils {
     }
 
     public static Map<String, Object> getAnalyticsPropertiesForTestEventStatus(
-            DatasourceStorage datasourceStorage, boolean status, Throwable e) {
-        Map<String, Object> analyticsProperties = getAnalyticsPropertiesWithStorage(datasourceStorage);
+            DatasourceStorage datasourceStorage, boolean status, Throwable e, String environmentName) {
+        Map<String, Object> analyticsProperties = getAnalyticsPropertiesWithStorage(datasourceStorage, environmentName);
         analyticsProperties.put("isSuccess", status);
 
         if (e == null) {
@@ -56,27 +57,29 @@ public class DatasourceAnalyticsUtils {
     }
 
     public static Map<String, Object> getAnalyticsPropertiesForTestEventStatus(
-            DatasourceStorage datasourceStorage, boolean status) {
-        Map<String, Object> analyticsProperties = getAnalyticsPropertiesWithStorage(datasourceStorage);
+            DatasourceStorage datasourceStorage, boolean status, String environmentName) {
+        Map<String, Object> analyticsProperties = getAnalyticsPropertiesWithStorage(datasourceStorage, environmentName);
         analyticsProperties.put("isSuccess", status);
         analyticsProperties.put("errors", datasourceStorage.getInvalids());
         return analyticsProperties;
     }
 
     public static Map<String, Object> getAnalyticsPropertiesForTestEventStatus(
-            DatasourceStorage datasourceStorage, DatasourceTestResult datasourceTestResult) {
-        Map<String, Object> analyticsProperties = getAnalyticsPropertiesWithStorage(datasourceStorage);
+            DatasourceStorage datasourceStorage, DatasourceTestResult datasourceTestResult, String environmentName) {
+        Map<String, Object> analyticsProperties = getAnalyticsPropertiesWithStorage(datasourceStorage, environmentName);
         analyticsProperties.put("isSuccess", datasourceTestResult.isSuccess());
         analyticsProperties.put("errors", datasourceTestResult.getInvalids());
         return analyticsProperties;
     }
 
-    public static Map<String, Object> getAnalyticsPropertiesWithStorage(DatasourceStorage datasourceStorage) {
+    public static Map<String, Object> getAnalyticsPropertiesWithStorage(
+            DatasourceStorage datasourceStorage, String environmentName) {
         Map<String, Object> analyticsProperties = new HashMap<>();
         analyticsProperties.putAll(getAnalyticsProperties(datasourceStorage));
         analyticsProperties.put("pluginName", datasourceStorage.getPluginName());
         analyticsProperties.put("dsName", datasourceStorage.getName());
         analyticsProperties.put("envId", datasourceStorage.getEnvironmentId());
+        analyticsProperties.put(AnalyticsConstants.ENVIRONMENT_NAME_SHORTNAME, environmentName);
         DatasourceConfiguration dsConfig = datasourceStorage.getDatasourceConfiguration();
         if (dsConfig != null
                 && dsConfig.getAuthentication() != null

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCE.java
@@ -42,4 +42,6 @@ public interface DatasourceStorageServiceCE {
     DatasourceStorageDTO getDatasourceStorageDTOFromDatasource(Datasource datasource, String environmentId);
 
     DatasourceStorage getDatasourceStorageFromDatasource(Datasource datasource, String environmentId);
+
+    Mono<String> getEnvironmentNameFromEnvironmentIdForAnalytics(String environmentId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
@@ -331,4 +331,9 @@ public class DatasourceStorageServiceCEImpl implements DatasourceStorageServiceC
                 .flatMap(dbDatasourceStorage -> Mono.error(new AppsmithException(
                         AppsmithError.DUPLICATE_DATASOURCE_CONFIGURATION, datasourceId, environmentId)));
     }
+
+    @Override
+    public Mono<String> getEnvironmentNameFromEnvironmentIdForAnalytics(String environmentId) {
+        return Mono.just(FieldName.UNUSED_ENVIRONMENT_ID);
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -91,6 +91,8 @@ import static com.appsmith.server.constants.AnalyticsConstants.DATASOURCE_IS_MOC
 import static com.appsmith.server.constants.AnalyticsConstants.DATASOURCE_IS_TEMPLATE_SHORTNAME;
 import static com.appsmith.server.constants.AnalyticsConstants.DATASOURCE_NAME_SHORTNAME;
 import static com.appsmith.server.constants.AnalyticsConstants.ENVIRONMENT_ID_SHORTNAME;
+import static com.appsmith.server.constants.ce.AnalyticsConstantsCE.ENVIRONMENT_NAME_DEFAULT;
+import static com.appsmith.server.constants.ce.AnalyticsConstantsCE.ENVIRONMENT_NAME_SHORTNAME;
 import static com.appsmith.server.helpers.WidgetSuggestionHelper.getSuggestedWidgets;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -889,12 +891,15 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                         Mono.just(application),
                         sessionUserService.getCurrentUser(),
                         newPageService.getNameByPageId(actionDTO.getPageId(), executeActionDto.getViewMode()),
-                        pluginService.getById(actionDTO.getPluginId())))
+                        pluginService.getById(actionDTO.getPluginId()),
+                        datasourceStorageService.getEnvironmentNameFromEnvironmentIdForAnalytics(
+                                datasourceStorage.getEnvironmentId())))
                 .flatMap(tuple -> {
                     final Application application = tuple.getT1();
                     final User user = tuple.getT2();
                     final String pageName = tuple.getT3();
                     final Plugin plugin = tuple.getT4();
+                    final String environmentName = tuple.getT5();
 
                     final PluginType pluginType = actionDTO.getPluginType();
                     final String appMode = TRUE.equals(executeActionDto.getViewMode())
@@ -981,7 +986,9 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                             DATASOURCE_IS_MOCK_SHORTNAME,
                             ObjectUtils.defaultIfNull(datasourceStorage.getIsMock(), ""),
                             DATASOURCE_CREATED_AT_SHORTNAME,
-                            dsCreatedAt));
+                            dsCreatedAt,
+                            ENVIRONMENT_NAME_SHORTNAME,
+                            ObjectUtils.defaultIfNull(datasourceStorage.getIsMock(), ENVIRONMENT_NAME_DEFAULT)));
 
                     // Add the error message in case of erroneous execution
                     if (FALSE.equals(actionExecutionResult.getIsExecutionSuccess())) {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourceStructureSolutionCEImpl.java
@@ -75,12 +75,16 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
     @Override
     public Mono<DatasourceStructure> getStructure(DatasourceStorage datasourceStorage, boolean ignoreCache) {
 
+        Mono<String> environmentNameMonoCached = datasourceStorageService
+                .getEnvironmentNameFromEnvironmentIdForAnalytics(datasourceStorage.getEnvironmentId())
+                .cache();
+
         if (Boolean.FALSE.equals(datasourceStorage.getIsValid())) {
-            return analyticsService
-                    .sendObjectEvent(
+            return environmentNameMonoCached
+                    .zipWhen(environmentName -> analyticsService.sendObjectEvent(
                             AnalyticsEvents.DS_SCHEMA_FETCH_EVENT,
                             datasourceStorage,
-                            getAnalyticsPropertiesForTestEventStatus(datasourceStorage, false))
+                            getAnalyticsPropertiesForTestEventStatus(datasourceStorage, false, environmentName)))
                     .then(Mono.just(new DatasourceStructure()));
         }
 
@@ -126,21 +130,23 @@ public class DatasourceStructureSolutionCEImpl implements DatasourceStructureSol
 
                     return e;
                 })
-                .onErrorResume(error -> analyticsService
-                        .sendObjectEvent(
+                .onErrorResume(error -> environmentNameMonoCached
+                        .zipWhen(environmentName -> analyticsService.sendObjectEvent(
                                 AnalyticsEvents.DS_SCHEMA_FETCH_EVENT,
                                 datasourceStorage,
-                                getAnalyticsPropertiesForTestEventStatus(datasourceStorage, false, error))
+                                getAnalyticsPropertiesForTestEventStatus(
+                                        datasourceStorage, false, error, environmentName)))
                         .then(Mono.error(error)))
                 .flatMap(structure -> {
                     String datasourceId = datasourceStorage.getDatasourceId();
                     String environmentId = datasourceStorage.getEnvironmentId();
 
-                    return analyticsService
-                            .sendObjectEvent(
+                    return environmentNameMonoCached
+                            .zipWhen(environmentName -> analyticsService.sendObjectEvent(
                                     AnalyticsEvents.DS_SCHEMA_FETCH_EVENT,
                                     datasourceStorage,
-                                    getAnalyticsPropertiesForTestEventStatus(datasourceStorage, true, null))
+                                    getAnalyticsPropertiesForTestEventStatus(
+                                            datasourceStorage, true, null, environmentName)))
                             .then(
                                     !hasText(datasourceId)
                                             ? Mono.empty()


### PR DESCRIPTION
## Description
> CE support for adding instrumentation for environment name and environmentId in EE. 

EE needs instrumentation for 
- Environment Id
- Environment Name

in the below given flows, this PR is to address the required ce changes for the same, we have used a default environmentName `unused_env` for CE, this will be replaced in EE by the respective names in analytics

- [x] Execute Action
- [x] Test_Datasource_Failed
- [x] Test_Datasource_Success
- [x] update_DATASOURCE
- [x] Datasource_Schema_Fetch
- [x] Datasource_Schema_Fetch_Success
- [x] Datasource_Schema_Fetch_Failed

#### PR fixes following issue(s)
Fixes #https://github.com/appsmithorg/appsmith/issues/24955

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)
- Breaking change, this change will break EE, required PR to fix the issue: https://github.com/appsmithorg/appsmith-ee/pull/1847 

#### How Has This Been Tested?
- [ ] Manual

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag