### PR TITLE
chore: Detect other NGINX and offer to kill

### DIFF
--- a/app/client/start-https.sh
+++ b/app/client/start-https.sh
@@ -245,8 +245,7 @@ $(if [[ $use_https == 1 ]]; then echo "
 
     server {
 $(if [[ $use_https == 1 ]]; then echo "
-        listen $https_listen_port ssl default_server;
-        http2 on;
+        listen $https_listen_port ssl http2 default_server;
         server_name $domain;
         ssl_certificate '$cert_file';
         ssl_certificate_key '$key_file';


### PR DESCRIPTION
In the `start-https.sh` script, detect if some other process is listening on the ports we need, and if yes, inform of this, and offer to kill and proceed.

