### PR TITLE
chore: changing interface method

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCE.java
@@ -45,5 +45,5 @@ public interface WorkspaceServiceCE extends CrudService<Workspace, String> {
 
     Mono<Boolean> isCreateWorkspaceAllowed(Boolean isDefaultWorkspace);
 
-    Mono<String> getDefaultEnvironmentId(String workspaceId);
+    Mono<String> getDefaultEnvironmentId(String workspaceId, AclPermission aclPermission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/WorkspaceServiceCEImpl.java
@@ -239,7 +239,7 @@ public class WorkspaceServiceCEImpl extends BaseService<WorkspaceRepository, Wor
     }
 
     @Override
-    public Mono<String> getDefaultEnvironmentId(String workspaceId) {
+    public Mono<String> getDefaultEnvironmentId(String workspaceId, AclPermission aclPermission) {
         return Mono.just(FieldName.UNUSED_ENVIRONMENT_ID);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ApplicationForkingServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ApplicationForkingServiceCEImpl.java
@@ -146,7 +146,7 @@ public class ApplicationForkingServiceCEImpl implements ApplicationForkingServic
 
         return applicationMono
                 // We will be forking to the default environment in the new workspace
-                .zipWhen(application -> workspaceService.getDefaultEnvironmentId(application.getWorkspaceId()))
+                .zipWhen(application -> workspaceService.getDefaultEnvironmentId(application.getWorkspaceId(), null))
                 .flatMap(tuple -> {
                     String fromApplicationId = tuple.getT1().getId();
                     String sourceEnvironmentId = tuple.getT2();

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ForkExamplesWorkspaceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ForkExamplesWorkspaceServiceCEImpl.java
@@ -143,7 +143,7 @@ public class ForkExamplesWorkspaceServiceCEImpl implements ForkExamplesWorkspace
                     workspace.setSlug(null);
                     return workspaceService.createDefault(workspace, user);
                 })
-                .zipWhen(newWorkspace -> workspaceService.getDefaultEnvironmentId(templateWorkspaceId))
+                .zipWhen(newWorkspace -> workspaceService.getDefaultEnvironmentId(templateWorkspaceId, null))
                 .flatMap(tuple2 -> {
                     Workspace newWorkspace = tuple2.getT1();
                     String sourceEnvironmentId = tuple2.getT2();
@@ -576,7 +576,7 @@ public class ForkExamplesWorkspaceServiceCEImpl implements ForkExamplesWorkspace
     public Mono<Datasource> forkDatasource(
             String datasourceId, String toWorkspaceId, Boolean forkWithConfiguration, String sourceEnvironmentId) {
 
-        final Mono<String> destinationEnvironmentIdMono = workspaceService.getDefaultEnvironmentId(toWorkspaceId);
+        final Mono<String> destinationEnvironmentIdMono = workspaceService.getDefaultEnvironmentId(toWorkspaceId, null);
 
         final Mono<List<Datasource>> existingDatasourcesInNewWorkspaceMono = datasourceService
                 .getAllByWorkspaceIdWithoutStorages(toWorkspaceId, Optional.empty())

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ImportExportApplicationServiceCEImpl.java
@@ -214,7 +214,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
 
         Mono<String> defaultEnvironmentIdMono = applicationService
                 .findById(applicationId)
-                .flatMap(application -> workspaceService.getDefaultEnvironmentId(application.getWorkspaceId()));
+                .flatMap(application -> workspaceService.getDefaultEnvironmentId(application.getWorkspaceId(), null));
 
         /**
          * Since we are exporting for git, we only consider unpublished JS libraries
@@ -1059,7 +1059,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
                     }
                     return Mono.zip(existingDatasourceMono, Mono.just(workspace));
                 })
-                .zipWhen(objects -> workspaceService.getDefaultEnvironmentId(workspaceId))
+                .zipWhen(objects -> workspaceService.getDefaultEnvironmentId(workspaceId, null))
                 .flatMapMany(objects -> {
                     List<Datasource> existingDatasources = objects.getT1().getT1();
                     Workspace workspace = objects.getT1().getT2();
@@ -2064,7 +2064,7 @@ public class ImportExportApplicationServiceCEImpl implements ImportExportApplica
     public Mono<ApplicationImportDTO> getApplicationImportDTO(
             String applicationId, String workspaceId, Application application) {
         return findDatasourceByApplicationId(applicationId, workspaceId)
-                .zipWith(workspaceService.getDefaultEnvironmentId(workspaceId))
+                .zipWith(workspaceService.getDefaultEnvironmentId(workspaceId, null))
                 .map(tuple2 -> {
                     List<Datasource> datasources = tuple2.getT1();
                     String environmentId = tuple2.getT2();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -21,6 +21,7 @@ import com.appsmith.server.repositories.DatasourceRepository;
 import com.appsmith.server.repositories.NewActionRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
 import com.appsmith.server.solutions.DatasourcePermission;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,6 +93,9 @@ public class DatasourceContextServiceTest {
     @SpyBean
     DatasourceContextServiceImpl datasourceContextService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     String defaultEnvironmentId;
 
     String workspaceId;
@@ -108,7 +112,7 @@ public class DatasourceContextServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
     }
 
@@ -194,7 +198,7 @@ public class DatasourceContextServiceTest {
                 workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
         String workspaceId = workspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
         Datasource datasource = new Datasource();
@@ -262,7 +266,7 @@ public class DatasourceContextServiceTest {
                 workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
         String workspaceId = workspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
         Datasource datasource = new Datasource();
@@ -372,7 +376,7 @@ public class DatasourceContextServiceTest {
                 workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
         String workspaceId = workspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
         Datasource datasource = new Datasource();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceServiceTest.java
@@ -31,6 +31,7 @@ import com.appsmith.server.helpers.MockPluginExecutor;
 import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,6 +110,9 @@ public class DatasourceServiceTest {
     @MockBean
     PluginExecutorHelper pluginExecutorHelper;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     String workspaceId = "";
     private String defaultEnvironmentId;
 
@@ -124,7 +128,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
     }
 
@@ -147,7 +151,7 @@ public class DatasourceServiceTest {
                             Workspace workspace = tuple2.getT1();
                             Plugin plugin = tuple2.getT2();
                             return workspaceService
-                                    .getDefaultEnvironmentId(workspace.getId())
+                                    .getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission())
                                     .flatMap(environmentId -> {
                                         Datasource datasource = new Datasource();
                                         datasource.setWorkspaceId(workspace.getId());
@@ -170,7 +174,7 @@ public class DatasourceServiceTest {
                             Datasource datasource1 = tuple2.getT1();
                             final Workspace workspace2 = tuple2.getT2();
                             return workspaceService
-                                    .getDefaultEnvironmentId(workspace2.getId())
+                                    .getDefaultEnvironmentId(workspace2.getId(), environmentPermission.getExecutePermission())
                                     .flatMap(environmentId -> {
                                         Datasource datasource2 = new Datasource();
                                         datasource2.setWorkspaceId(workspace2.getId());
@@ -209,7 +213,7 @@ public class DatasourceServiceTest {
             workspaceId = workspace.getId();
 
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
         Datasource datasource = new Datasource();
         datasource.setName("DS-with-null-pluginId");
@@ -287,7 +291,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
         Mono<Plugin> pluginMono = pluginService.findByName("Not Installed Plugin Name");
         Datasource datasource = new Datasource();
@@ -337,7 +341,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Workspace> workspaceResponse = workspaceService.findById(workspaceId, READ_WORKSPACES);
@@ -439,7 +443,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Datasource datasource = new Datasource();
@@ -616,7 +620,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
 
@@ -674,7 +678,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
@@ -727,7 +731,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
@@ -796,7 +800,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
@@ -844,7 +848,7 @@ public class DatasourceServiceTest {
                 workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
         String workspaceId = createdWorkspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mono<Datasource> datasourceMono = Mono.zip(
                         workspaceRepository.findByName(name, AclPermission.READ_WORKSPACES),
@@ -923,7 +927,7 @@ public class DatasourceServiceTest {
                 workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
         String workspaceId = createdWorkspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mono<Datasource> datasourceMono = Mono.zip(
                         workspaceRepository.findByName(name, AclPermission.READ_WORKSPACES),
@@ -1013,7 +1017,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
@@ -1069,7 +1073,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
@@ -1123,7 +1127,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
@@ -1198,7 +1202,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("postgres-plugin");
@@ -1259,7 +1263,7 @@ public class DatasourceServiceTest {
                 workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
         String workspaceId = workspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mono<Workspace> workspaceResponse = workspaceService.findById(workspaceId, READ_WORKSPACES);
 
@@ -1352,7 +1356,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
         Datasource datasource = new Datasource();
@@ -1403,7 +1407,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
@@ -1469,7 +1473,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
         Datasource datasource = new Datasource();
@@ -1520,7 +1524,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
 
@@ -1635,7 +1639,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Datasource datasource = new Datasource();
@@ -1710,7 +1714,7 @@ public class DatasourceServiceTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
         Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
         Datasource datasource = new Datasource();
@@ -1792,7 +1796,7 @@ public class DatasourceServiceTest {
 
         Plugin plugin = pluginService.findByPackageName("restapi-plugin").block();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Datasource datasource = new Datasource();
         datasource.setPluginId(plugin.getId());

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/GitServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/GitServiceTest.java
@@ -47,6 +47,7 @@ import com.appsmith.server.migrations.JsonSchemaMigration;
 import com.appsmith.server.migrations.JsonSchemaVersions;
 import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -181,6 +182,9 @@ public class GitServiceTest {
     @Autowired
     private ThemeService themeService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     @BeforeEach
     public void setup() throws IOException, GitAPIException {
 
@@ -196,7 +200,7 @@ public class GitServiceTest {
                         .block();
                 workspaceId = workspace.getId();
                 defaultEnvironmentId =
-                        workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                        workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
             }
         }
 
@@ -3556,7 +3560,7 @@ public class GitServiceTest {
         final String testWorkspaceId =
                 workspaceService.create(workspace).map(Workspace::getId).block();
         String environmentId =
-                workspaceService.getDefaultEnvironmentId(testWorkspaceId).block();
+                workspaceService.getDefaultEnvironmentId(testWorkspaceId, environmentPermission.getExecutePermission()).block();
 
         GitConnectDTO gitConnectDTO = getConnectRequest("git@github.com:test/testGitImportRepo.git", testUserProfile);
         GitAuth gitAuth = gitService.generateSSHKey(null).block();
@@ -3618,7 +3622,7 @@ public class GitServiceTest {
         final String testWorkspaceId =
                 workspaceService.create(workspace).map(Workspace::getId).block();
         String environmentId =
-                workspaceService.getDefaultEnvironmentId(testWorkspaceId).block();
+                workspaceService.getDefaultEnvironmentId(testWorkspaceId, environmentPermission.getExecutePermission()).block();
 
         GitConnectDTO gitConnectDTO =
                 getConnectRequest("git@github.com:test/testGitImportRepoCancelledMidway.git", testUserProfile);

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/MockDataServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/MockDataServiceTest.java
@@ -17,6 +17,7 @@ import com.appsmith.server.helpers.PluginExecutorHelper;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.PluginRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,6 +91,9 @@ public class MockDataServiceTest {
     @MockBean
     PluginExecutorHelper pluginExecutorHelper;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     String workspaceId = "";
 
     Application testApp = null;
@@ -161,7 +165,7 @@ public class MockDataServiceTest {
 
         Mono<Workspace> workspaceResponse = workspaceService.findById(workspaceId, READ_WORKSPACES);
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         List<PermissionGroup> permissionGroups = workspaceResponse
                 .flatMapMany(savedWorkspace -> {
@@ -242,7 +246,7 @@ public class MockDataServiceTest {
 
         Mono<Workspace> workspaceResponse = workspaceService.findById(workspaceId, READ_WORKSPACES);
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         List<PermissionGroup> permissionGroups = workspaceResponse
                 .flatMapMany(savedWorkspace -> {
@@ -317,7 +321,7 @@ public class MockDataServiceTest {
                 workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
         String workspaceId = workspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Plugin pluginMono = pluginService.findByName("Installed Plugin Name").block();
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/WorkspaceServiceTest.java
@@ -30,6 +30,7 @@ import com.appsmith.server.repositories.DatasourceRepository;
 import com.appsmith.server.repositories.PermissionGroupRepository;
 import com.appsmith.server.repositories.UserRepository;
 import com.appsmith.server.repositories.WorkspaceRepository;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import com.appsmith.server.solutions.UserAndAccessManagementService;
 import com.mongodb.client.result.UpdateResult;
 import lombok.extern.slf4j.Slf4j;
@@ -147,6 +148,9 @@ public class WorkspaceServiceTest {
 
     @MockBean
     private PluginExecutorHelper pluginExecutorHelper;
+
+    @Autowired
+    EnvironmentPermission environmentPermission;
 
     @BeforeEach
     @WithUserDetails(value = "api_user")
@@ -1119,7 +1123,7 @@ public class WorkspaceServiceTest {
 
         // Create datasource for this workspace
         Mono<Datasource> datasourceMono = workspaceService
-                .getDefaultEnvironmentId(workspace1.getId())
+                .getDefaultEnvironmentId(workspace1.getId(), environmentPermission.getExecutePermission())
                 .zipWith(pluginService.findByPackageName("postgres-plugin"))
                 .flatMap(tuple2 -> {
                     String defaultEnvironmentId = tuple2.getT1();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ActionServiceCE_Test.java
@@ -51,6 +51,7 @@ import com.appsmith.server.services.PermissionGroupService;
 import com.appsmith.server.services.PluginService;
 import com.appsmith.server.services.UserService;
 import com.appsmith.server.services.WorkspaceService;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -163,6 +164,9 @@ public class ActionServiceCE_Test {
     @Autowired
     DatasourceRepository datasourceRepository;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     Application testApp = null;
 
     PageDTO testPage = null;
@@ -194,7 +198,7 @@ public class ActionServiceCE_Test {
             workspaceId = workspace.getId();
 
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         if (testApp == null && testPage == null) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
@@ -64,6 +64,7 @@ import com.appsmith.server.services.ThemeService;
 import com.appsmith.server.services.UserService;
 import com.appsmith.server.services.WorkspaceService;
 import com.appsmith.server.solutions.ApplicationFetcher;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import com.appsmith.server.solutions.ReleaseNotesService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -229,6 +230,9 @@ public class ApplicationServiceCETest {
     @Autowired
     SessionUserService sessionUserService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     String workspaceId;
     String defaultEnvironmentId;
 
@@ -258,7 +262,7 @@ public class ApplicationServiceCETest {
             workspaceId = workspace.getId();
 
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
             if (StringUtils.hasLength(gitConnectedApp.getId())) {
                 applicationPageService

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ApplicationForkingServiceTests.java
@@ -174,6 +174,9 @@ public class ApplicationForkingServiceTests {
     @Autowired
     private ImportExportApplicationService importExportApplicationService;
 
+    @Autowired
+    private EnvironmentPermission environmentPermission;
+
     @SneakyThrows
     @BeforeEach
     public void setup() {
@@ -191,7 +194,7 @@ public class ApplicationForkingServiceTests {
         sourceWorkspaceId = sourceWorkspace.getId();
 
         sourceEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(sourceWorkspaceId).block();
+                workspaceService.getDefaultEnvironmentId(sourceWorkspaceId, environmentPermission.getExecutePermission()).block();
 
         Application app1 = new Application();
         app1.setName("1 - public app");
@@ -603,7 +606,7 @@ public class ApplicationForkingServiceTests {
         Workspace createdSrcWorkspace = workspaceService.create(srcWorkspace).block();
 
         String createdSrcDefaultEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(createdSrcWorkspace.getId())
+                .getDefaultEnvironmentId(createdSrcWorkspace.getId(), environmentPermission.getExecutePermission())
                 .block();
 
         Application srcApplication = new Application();
@@ -693,7 +696,7 @@ public class ApplicationForkingServiceTests {
         Workspace createdWorkspace = workspaceService.create(workspace).block();
 
         String createdSrcDefaultEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(createdWorkspace.getId())
+                .getDefaultEnvironmentId(createdWorkspace.getId(), environmentPermission.getExecutePermission())
                 .block();
 
         Application application = new Application();
@@ -759,7 +762,7 @@ public class ApplicationForkingServiceTests {
         Workspace createdSrcWorkspace = workspaceService.create(workspace).block();
 
         String createdSrcDefaultEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(createdSrcWorkspace.getId())
+                .getDefaultEnvironmentId(createdSrcWorkspace.getId(), environmentPermission.getExecutePermission())
                 .block();
 
         Application application = new Application();
@@ -857,7 +860,7 @@ public class ApplicationForkingServiceTests {
         srcWorkspace = workspaceService.create(srcWorkspace).block();
 
         String srcDefaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(srcWorkspace.getId()).block();
+                workspaceService.getDefaultEnvironmentId(srcWorkspace.getId(), environmentPermission.getExecutePermission()).block();
 
         Application application = new Application();
         application.setName("delete-edit-mode-page-app");
@@ -933,7 +936,7 @@ public class ApplicationForkingServiceTests {
         Workspace createdWorkspace = workspaceService.create(workspace).block();
 
         String createdSrcDefaultEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(createdWorkspace.getId())
+                .getDefaultEnvironmentId(createdWorkspace.getId(), environmentPermission.getExecutePermission())
                 .block();
 
         Application application = new Application();
@@ -1014,7 +1017,7 @@ public class ApplicationForkingServiceTests {
         srcWorkspace = workspaceService.create(srcWorkspace).block();
 
         String createdSrcDefaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(srcWorkspace.getId()).block();
+                workspaceService.getDefaultEnvironmentId(srcWorkspace.getId(), environmentPermission.getExecutePermission()).block();
 
         Application application = new Application();
         application.setName("fork-internal-fields-app");
@@ -1054,7 +1057,7 @@ public class ApplicationForkingServiceTests {
         srcWorkspace = workspaceService.create(srcWorkspace).block();
 
         String srcDefaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(srcWorkspace.getId()).block();
+                workspaceService.getDefaultEnvironmentId(srcWorkspace.getId(), environmentPermission.getExecutePermission()).block();
 
         Application application = new Application();
         application.setName("app1");
@@ -1118,7 +1121,7 @@ public class ApplicationForkingServiceTests {
         String targetWorkspaceId = forkApplicationSetupResponse.getT2();
 
         String srcDefaultEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(srcApp.getWorkspaceId())
+                .getDefaultEnvironmentId(srcApp.getWorkspaceId(), environmentPermission.getExecutePermission())
                 .block();
 
         Mono<ApplicationImportDTO> resultMono = applicationForkingService
@@ -1147,7 +1150,7 @@ public class ApplicationForkingServiceTests {
         String targetWorkspaceId = forkApplicationSetupResponse.getT2();
 
         String srcDefaultEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(srcApp.getWorkspaceId())
+                .getDefaultEnvironmentId(srcApp.getWorkspaceId(), environmentPermission.getExecutePermission())
                 .block();
 
         Mono<ApplicationImportDTO> resultMono = applicationForkingService
@@ -1176,7 +1179,7 @@ public class ApplicationForkingServiceTests {
         String targetWorkspaceId = forkApplicationSetupResponse.getT2();
 
         String srcDefaultEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(srcApp.getWorkspaceId())
+                .getDefaultEnvironmentId(srcApp.getWorkspaceId(), environmentPermission.getExecutePermission())
                 .block();
 
         Mono<ApplicationImportDTO> resultMono = applicationForkingService

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/AuthenticationServiceTest.java
@@ -73,6 +73,9 @@ public class AuthenticationServiceTest {
     @Autowired
     WorkspaceService workspaceService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     @Test
     @WithUserDetails(value = "api_user")
     public void testGetAuthorizationCodeURL_missingDatasource() {
@@ -96,7 +99,7 @@ public class AuthenticationServiceTest {
         String workspaceId = testWorkspace.getId();
 
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
                 .thenReturn(Mono.just(new MockPluginExecutor()));
@@ -147,7 +150,7 @@ public class AuthenticationServiceTest {
         assert testWorkspace != null;
         String workspaceId = testWorkspace.getId();
         String defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
                 .thenReturn(Mono.just(new MockPluginExecutor()));

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -151,6 +151,9 @@ public class CreateDBTablePageSolutionTests {
     @Autowired
     ApplicationService applicationService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
 
     @MockBean
@@ -172,7 +175,7 @@ public class CreateDBTablePageSolutionTests {
             workspace.setName("Create-DB-Table-Page-Org");
             testWorkspace = workspaceService.create(workspace).block();
             testDefaultEnvironmentId = workspaceService
-                    .getDefaultEnvironmentId(testWorkspace.getId())
+                    .getDefaultEnvironmentId(testWorkspace.getId(), environmentPermission.getExecutePermission())
                     .block();
         }
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceStructureSolutionTest.java
@@ -84,6 +84,9 @@ public class DatasourceStructureSolutionTest {
     @SpyBean
     DatasourceStructureSolution datasourceStructureSolution;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     String workspaceId;
 
     String defaultEnvironmentId;
@@ -102,7 +105,7 @@ public class DatasourceStructureSolutionTest {
                     workspaceService.create(toCreate, apiUser, Boolean.FALSE).block();
             workspaceId = workspace.getId();
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceTriggerSolutionTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/DatasourceTriggerSolutionTest.java
@@ -72,6 +72,9 @@ public class DatasourceTriggerSolutionTest {
     @MockBean
     FeatureFlagService featureFlagService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     String workspaceId;
     String defaultEnvironmentId;
 
@@ -87,7 +90,7 @@ public class DatasourceTriggerSolutionTest {
         Workspace savedWorkspace = workspaceService.create(workspace).block();
         workspaceId = savedWorkspace.getId();
         defaultEnvironmentId =
-                workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
 
         Datasource datasource = new Datasource();
         datasource.setName("Datasource Trigger Database");

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ForkExamplesWorkspaceServiceTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ForkExamplesWorkspaceServiceTests.java
@@ -147,6 +147,9 @@ public class ForkExamplesWorkspaceServiceTests {
     @Autowired
     private PluginService pluginService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     public Mono<WorkspaceData> loadWorkspaceData(Workspace workspace) {
         final WorkspaceData data = new WorkspaceData();
         data.workspace = workspace;
@@ -161,7 +164,7 @@ public class ForkExamplesWorkspaceServiceTests {
                         getActionsInWorkspace(workspace).map(data.actions::add),
                         getActionCollectionsInWorkspace(workspace).map(data.actionCollections::add),
                         workspaceService
-                                .getDefaultEnvironmentId(workspace.getId())
+                                .getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission())
                                 .doOnSuccess(signal -> data.defaultEnvironmentId = signal))
                 .thenReturn(data);
     }
@@ -371,7 +374,7 @@ public class ForkExamplesWorkspaceServiceTests {
         newWorkspace.setName("Target Org 1");
         Workspace targetWorkspace = workspaceService.create(newWorkspace).block();
         String sourceEnvironmentId = workspaceService
-                .getDefaultEnvironmentId(sourceWorkspace.getId())
+                .getDefaultEnvironmentId(sourceWorkspace.getId(), environmentPermission.getExecutePermission())
                 .block();
 
         Mono<Void> cloneMono = Mono.just(sourceApplication)
@@ -410,7 +413,7 @@ public class ForkExamplesWorkspaceServiceTests {
                 .thenReturn(Mono.just(new MockPluginExecutor()))
                 .thenReturn(Mono.just(new MockPluginExecutor()));
         final Mono<WorkspaceData> resultMono = Mono.zip(
-                        workspaceService.getDefaultEnvironmentId(workspace.getId()),
+                        workspaceService.getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission()),
                         sessionUserService.getCurrentUser(),
                         pluginService.findByPackageName("restapi-plugin").map(Plugin::getId))
                 .flatMap(tuple -> {
@@ -472,7 +475,7 @@ public class ForkExamplesWorkspaceServiceTests {
 
         Workspace workspace = workspaceService.create(newWorkspace).block();
         final Mono<WorkspaceData> resultMono = Mono.zip(
-                        workspaceService.getDefaultEnvironmentId(workspace.getId()),
+                        workspaceService.getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission()),
                         sessionUserService.getCurrentUser())
                 .flatMap(tuple -> {
                     String environmentId = tuple.getT1();
@@ -534,7 +537,7 @@ public class ForkExamplesWorkspaceServiceTests {
 
         Workspace workspace = workspaceService.create(newWorkspace).block();
         final Mono<WorkspaceData> resultMono = Mono.zip(
-                        workspaceService.getDefaultEnvironmentId(workspace.getId()),
+                        workspaceService.getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission()),
                         sessionUserService.getCurrentUser(),
                         pluginService.findByPackageName("restapi-plugin").map(Plugin::getId))
                 .flatMap(tuple -> {
@@ -611,7 +614,7 @@ public class ForkExamplesWorkspaceServiceTests {
         newWorkspace.setName("Template Workspace 2");
         final Workspace workspace = workspaceService.create(newWorkspace).block();
         String environmentId =
-                workspaceService.getDefaultEnvironmentId(workspace.getId()).block();
+                workspaceService.getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission()).block();
         final User user = sessionUserService.getCurrentUser().block();
 
         final Application app1 = new Application();
@@ -813,7 +816,7 @@ public class ForkExamplesWorkspaceServiceTests {
         targetOrg.setName("Target Org 2");
 
         final Mono<WorkspaceData> resultMono = Mono.zip(
-                        workspaceService.getDefaultEnvironmentId(workspace.getId()),
+                        workspaceService.getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission()),
                         sessionUserService.getCurrentUser())
                 .flatMap(tuple -> {
                     String environmentId = tuple.getT1();
@@ -1047,7 +1050,7 @@ public class ForkExamplesWorkspaceServiceTests {
         targetOrg.setName("Target Org 2");
 
         final Mono<WorkspaceData> resultMono = Mono.zip(
-                        workspaceService.getDefaultEnvironmentId(workspace.getId()),
+                        workspaceService.getDefaultEnvironmentId(workspace.getId(), environmentPermission.getExecutePermission()),
                         sessionUserService.getCurrentUser())
                 .flatMap(tuple -> {
                     String environmentId = tuple.getT1();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCETest.java
@@ -48,6 +48,7 @@ import com.appsmith.server.services.PluginService;
 import com.appsmith.server.services.UserService;
 import com.appsmith.server.services.WorkspaceService;
 import com.appsmith.server.solutions.ActionExecutionSolution;
+import com.appsmith.server.solutions.EnvironmentPermission;
 import com.appsmith.server.solutions.ImportExportApplicationService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -149,6 +150,9 @@ public class ActionExecutionSolutionCETest {
     @SpyBean
     DatasourceStorageService datasourceStorageService;
 
+    @Autowired
+    EnvironmentPermission environmentPermission;
+
     Application testApp = null;
 
     PageDTO testPage = null;
@@ -180,7 +184,7 @@ public class ActionExecutionSolutionCETest {
             workspaceId = workspace.getId();
 
             defaultEnvironmentId =
-                    workspaceService.getDefaultEnvironmentId(workspaceId).block();
+                    workspaceService.getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission()).block();
         }
 
         if (testApp == null && testPage == null) {


### PR DESCRIPTION
## Description
 > PR for interface modification for rbac changes. 
 
 This PR is changing methods signature for getDefaultEnvironmentId by adding the `AclPermission` parameter.
 This param will be used to pass arguments to decide whether the user has access for a particular operation. If this argument is set to null, we don't require any permission.
 
 Although in CE all calls will consistently return a mono of unused_env, however In EE, this would be different.

#### PR fixes following issue(s)
Fixes # (issue number)

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

#### How Has This Been Tested?
- [ ] Manual
- [ ] Jest

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag
