### PR TITLE
chore: Fix cypress test blocker on ee

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/DatasourceSchema_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/DatasourceSchema_spec.ts
@@ -47,23 +47,27 @@ describe("Datasource form related tests", function () {
     dataSources.DeleteDatasouceFromWinthinDS(dataSourceName);
   });
 
-  it("3. Verify if schema (table and column) exist in query editor and searching works", () => {
-    featureFlagIntercept(
-      {
-        ab_ds_schema_enabled: true,
-      },
-      false,
-    );
-    agHelper.RefreshPage();
-    dataSources.CreateMockDB("Users");
-    dataSources.CreateQueryAfterDSSaved();
-    dataSources.VerifyTableSchemaOnQueryEditor("public.users");
-    ee.ExpandCollapseEntity("public.users");
-    dataSources.VerifyColumnSchemaOnQueryEditor("id");
-    dataSources.FilterAndVerifyDatasourceSchemaBySearch(
-      "gender",
-      true,
-      "column",
-    );
-  });
+  it(
+    "excludeForAirgap",
+    "3. Verify if schema (table and column) exist in query editor and searching works",
+    () => {
+      featureFlagIntercept(
+        {
+          ab_ds_schema_enabled: true,
+        },
+        false,
+      );
+      agHelper.RefreshPage();
+      dataSources.CreateMockDB("Users");
+      dataSources.CreateQueryAfterDSSaved();
+      dataSources.VerifyTableSchemaOnQueryEditor("public.users");
+      ee.ExpandCollapseEntity("public.users");
+      dataSources.VerifyColumnSchemaOnQueryEditor("id");
+      dataSources.FilterAndVerifyDatasourceSchemaBySearch(
+        "gender",
+        true,
+        "column",
+      );
+    },
+  );
 });


### PR DESCRIPTION
This PR fixes the failing cypress test DatasourceSchema_spec.ts on Appsmith-ee.


- Chore (housekeeping or task changes that don't impact user perception)

#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
