### PR TITLE
fix: Added embedded check for true env

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCE.java
@@ -92,5 +92,8 @@ public interface DatasourceServiceCE {
     Mono<String> getTrueEnvironmentId(
             String workspaceId, String environmentId, String pluginId, AclPermission aclPermission);
 
+    Mono<String> getTrueEnvironmentId(
+            String workspaceId, String environmentId, String pluginId, AclPermission aclPermission, boolean isEmbedded);
+
     Datasource createDatasourceFromDatasourceStorage(DatasourceStorage datasourceStorage);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceServiceCEImpl.java
@@ -734,6 +734,16 @@ public class DatasourceServiceCEImpl implements DatasourceServiceCE {
     @Override
     public Mono<String> getTrueEnvironmentId(
             String workspaceId, String environmentId, String pluginId, AclPermission aclPermission) {
+        return this.getTrueEnvironmentId(workspaceId, environmentId, pluginId, aclPermission, false);
+    }
+
+    @Override
+    public Mono<String> getTrueEnvironmentId(
+            String workspaceId,
+            String environmentId,
+            String pluginId,
+            AclPermission aclPermission,
+            boolean isEmbedded) {
         return Mono.just(FieldName.UNUSED_ENVIRONMENT_ID);
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImpl.java
@@ -184,12 +184,29 @@ public class ActionExecutionSolutionCEImpl implements ActionExecutionSolutionCE 
                                 branchName, executeActionDTO.getActionId(), actionPermission.getExecutePermission())
                         .flatMap(branchedAction -> {
                             executeActionDTO.setActionId(branchedAction.getId());
+
+                            boolean isEmbedded;
+                            if (executeActionDTO.getViewMode()) {
+                                isEmbedded = branchedAction
+                                                .getPublishedAction()
+                                                .getDatasource()
+                                                .getId()
+                                        == null;
+                            } else {
+                                isEmbedded = branchedAction
+                                                .getUnpublishedAction()
+                                                .getDatasource()
+                                                .getId()
+                                        == null;
+                            }
+
                             return Mono.just(executeActionDTO)
                                     .zipWith(datasourceService.getTrueEnvironmentId(
                                             branchedAction.getWorkspaceId(),
                                             environmentId,
                                             branchedAction.getPluginId(),
-                                            environmentPermission.getExecutePermission()));
+                                            environmentPermission.getExecutePermission(),
+                                            isEmbedded));
                         }))
                 .flatMap(tuple2 -> this.executeAction(tuple2.getT1(), tuple2.getT2())) // getTrue is temporary call
                 .name(ACTION_EXECUTION_SERVER_EXECUTION)

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -3,7 +3,9 @@ package com.appsmith.server.solutions.ce;
 import com.appsmith.external.datatypes.ClientDataType;
 import com.appsmith.external.dtos.ExecuteActionDTO;
 import com.appsmith.external.dtos.ParamProperty;
+import com.appsmith.external.models.ActionDTO;
 import com.appsmith.external.models.ActionExecutionResult;
+import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.Param;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.NewAction;
@@ -67,6 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -284,9 +287,13 @@ class ActionExecutionSolutionCEImplTest {
 
         NewAction newAction = new NewAction();
         newAction.setId("63285a3388e48972c7519b18");
+        Datasource datasource = new Datasource();
+        ActionDTO actionDTO = new ActionDTO();
+        actionDTO.setDatasource(datasource);
+        newAction.setUnpublishedAction(actionDTO);
         doReturn(Mono.just(FieldName.UNUSED_ENVIRONMENT_ID))
                 .when(datasourceService)
-                .getTrueEnvironmentId(any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()));
+                .getTrueEnvironmentId(any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()), anyBoolean());
         doReturn(Mono.just(mockResult)).when(executionSolutionSpy).executeAction(any(), any());
         doReturn(Mono.just(newAction)).when(newActionService).findByBranchNameAndDefaultActionId(any(), any(), any());
 
@@ -337,9 +344,13 @@ class ActionExecutionSolutionCEImplTest {
 
         NewAction newAction = new NewAction();
         newAction.setId("63285a3388e48972c7519b18");
+        Datasource datasource = new Datasource();
+        ActionDTO actionDTO = new ActionDTO();
+        actionDTO.setDatasource(datasource);
+        newAction.setUnpublishedAction(actionDTO);
         doReturn(Mono.just(FieldName.UNUSED_ENVIRONMENT_ID))
                 .when(datasourceService)
-                .getTrueEnvironmentId(any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()));
+                .getTrueEnvironmentId(any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()), anyBoolean());
         doReturn(Mono.just(mockResult)).when(executionSolutionSpy).executeAction(any(), any());
         doReturn(Mono.just(newAction)).when(newActionService).findByBranchNameAndDefaultActionId(any(), any(), any());
 

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/ce/ActionExecutionSolutionCEImplTest.java
@@ -293,7 +293,8 @@ class ActionExecutionSolutionCEImplTest {
         newAction.setUnpublishedAction(actionDTO);
         doReturn(Mono.just(FieldName.UNUSED_ENVIRONMENT_ID))
                 .when(datasourceService)
-                .getTrueEnvironmentId(any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()), anyBoolean());
+                .getTrueEnvironmentId(
+                        any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()), anyBoolean());
         doReturn(Mono.just(mockResult)).when(executionSolutionSpy).executeAction(any(), any());
         doReturn(Mono.just(newAction)).when(newActionService).findByBranchNameAndDefaultActionId(any(), any(), any());
 
@@ -350,7 +351,8 @@ class ActionExecutionSolutionCEImplTest {
         newAction.setUnpublishedAction(actionDTO);
         doReturn(Mono.just(FieldName.UNUSED_ENVIRONMENT_ID))
                 .when(datasourceService)
-                .getTrueEnvironmentId(any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()), anyBoolean());
+                .getTrueEnvironmentId(
+                        any(), any(), any(), Mockito.eq(environmentPermission.getExecutePermission()), anyBoolean());
         doReturn(Mono.just(mockResult)).when(executionSolutionSpy).executeAction(any(), any());
         doReturn(Mono.just(newAction)).when(newActionService).findByBranchNameAndDefaultActionId(any(), any(), any());
 


### PR DESCRIPTION
Changes to start to consider embedded datasources as oos in env