### PR TITLE
chore: [Analytics] Track open tabs with the same editor

### DIFF
--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -59,7 +59,7 @@ import {
 import { getFirstTimeUserOnboardingComplete } from "selectors/onboardingSelectors";
 import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 import { getAIPromptTriggered } from "utils/storage";
-import { trackOpenEditorTabs } from "../../utils/editor/EditorUtils";
+import { trackOpenEditorTabs } from "../../utils/editor/browserTabsTracking";
 
 export default class AppEditorEngine extends AppEngine {
   constructor(mode: APP_MODE) {

--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -59,6 +59,7 @@ import {
 import { getFirstTimeUserOnboardingComplete } from "selectors/onboardingSelectors";
 import { isAirgapped } from "@appsmith/utils/airgapHelpers";
 import { getAIPromptTriggered } from "utils/storage";
+import { trackOpenEditorTabs } from "../../utils/editor/EditorUtils";
 
 export default class AppEditorEngine extends AppEngine {
   constructor(mode: APP_MODE) {
@@ -202,10 +203,17 @@ export default class AppEditorEngine extends AppEngine {
     const currentApplication: ApplicationPayload = yield select(
       getCurrentApplication,
     );
+
+    const isAnotherTabOpen: boolean = yield call(
+      trackOpenEditorTabs,
+      currentApplication.id,
+    );
+
     if (currentApplication) {
       AnalyticsUtil.logEvent("EDITOR_OPEN", {
         appId: currentApplication.id,
         appName: currentApplication.name,
+        additionalTab: isAnotherTabOpen,
       });
     }
     yield put(loadGuidedTourInit());

--- a/app/client/src/entities/Engine/AppEditorEngine.ts
+++ b/app/client/src/entities/Engine/AppEditorEngine.ts
@@ -204,7 +204,7 @@ export default class AppEditorEngine extends AppEngine {
       getCurrentApplication,
     );
 
-    const isAnotherTabOpen: boolean = yield call(
+    const [isAnotherEditorTabOpen, currentTabs] = yield call(
       trackOpenEditorTabs,
       currentApplication.id,
     );
@@ -213,7 +213,8 @@ export default class AppEditorEngine extends AppEngine {
       AnalyticsUtil.logEvent("EDITOR_OPEN", {
         appId: currentApplication.id,
         appName: currentApplication.name,
-        additionalTab: isAnotherTabOpen,
+        isAnotherEditorTabOpen,
+        currentTabs,
       });
     }
     yield put(loadGuidedTourInit());

--- a/app/client/src/utils/editor/EditorUtils.ts
+++ b/app/client/src/utils/editor/EditorUtils.ts
@@ -23,7 +23,9 @@ const setCurrentTabs = (tabs: TabData) => {
 };
 
 let tabId: string;
-export const trackOpenEditorTabs = (appId: string): boolean => {
+export const trackOpenEditorTabs = (
+  appId: string,
+): [isOpenInAnotherTab: boolean, currentTabs: string[]] => {
   // Check if a tab id is created or else create one
   if (!tabId) {
     tabId = generateReactKey({ prefix: "tab:" });
@@ -42,6 +44,7 @@ export const trackOpenEditorTabs = (appId: string): boolean => {
     [tabId]: appId,
   };
   setCurrentTabs(newTabs);
-  // Return if current app is open in any other open tabs
-  return !!Object.values(currentTabs).indexOf(appId);
+  // if current app is open in any other open tabs
+  const isOpenInAnotherTab = Object.values(currentTabs).indexOf(appId) > -1;
+  return [isOpenInAnotherTab, Object.values(newTabs)];
 };

--- a/app/client/src/utils/editor/EditorUtils.ts
+++ b/app/client/src/utils/editor/EditorUtils.ts
@@ -1,7 +1,47 @@
 import { registerWidgets } from "../WidgetRegistry";
 import PropertyControlRegistry from "../PropertyControlRegistry";
+import { generateReactKey } from "../../widgets/WidgetUtils";
 
 export const editorInitializer = async () => {
   registerWidgets();
   PropertyControlRegistry.registerPropertyControlBuilders();
+};
+
+type TabData = { [tabId: string]: string };
+
+const LOCAL_STORAGE_KEY = "EDITOR_TABS_DATA";
+
+const getCurrentTabs = (): TabData => {
+  const currentTabsJSON = localStorage.getItem(LOCAL_STORAGE_KEY) || "{}";
+  const currentTabs: TabData = JSON.parse(currentTabsJSON);
+  return currentTabs;
+};
+
+const setCurrentTabs = (tabs: TabData) => {
+  const currentTabsJSON = JSON.stringify(tabs);
+  localStorage.setItem(LOCAL_STORAGE_KEY, currentTabsJSON);
+};
+
+let tabId: string;
+export const trackOpenEditorTabs = (appId: string): boolean => {
+  // Check if a tab id is created or else create one
+  if (!tabId) {
+    tabId = generateReactKey({ prefix: "tab:" });
+    // add event listener for closing tab and remove entry from local storage
+    window.addEventListener("beforeunload", () => {
+      // Remove entry from local storage
+      const currentTabs = getCurrentTabs();
+      delete currentTabs[tabId];
+      setCurrentTabs(currentTabs);
+    });
+  }
+  const currentTabs = getCurrentTabs();
+  // Update tabs data
+  const newTabs = {
+    ...currentTabs,
+    [tabId]: appId,
+  };
+  setCurrentTabs(newTabs);
+  // Return if current app is open in any other open tabs
+  return !!Object.values(currentTabs).indexOf(appId);
 };

--- a/app/client/src/utils/editor/EditorUtils.ts
+++ b/app/client/src/utils/editor/EditorUtils.ts
@@ -1,50 +1,7 @@
 import { registerWidgets } from "../WidgetRegistry";
 import PropertyControlRegistry from "../PropertyControlRegistry";
-import { generateReactKey } from "../../widgets/WidgetUtils";
 
 export const editorInitializer = async () => {
   registerWidgets();
   PropertyControlRegistry.registerPropertyControlBuilders();
-};
-
-type TabData = { [tabId: string]: string };
-
-const LOCAL_STORAGE_KEY = "EDITOR_TABS_DATA";
-
-const getCurrentTabs = (): TabData => {
-  const currentTabsJSON = localStorage.getItem(LOCAL_STORAGE_KEY) || "{}";
-  const currentTabs: TabData = JSON.parse(currentTabsJSON);
-  return currentTabs;
-};
-
-const setCurrentTabs = (tabs: TabData) => {
-  const currentTabsJSON = JSON.stringify(tabs);
-  localStorage.setItem(LOCAL_STORAGE_KEY, currentTabsJSON);
-};
-
-let tabId: string;
-export const trackOpenEditorTabs = (
-  appId: string,
-): [isOpenInAnotherTab: boolean, currentTabs: string[]] => {
-  // Check if a tab id is created or else create one
-  if (!tabId) {
-    tabId = generateReactKey({ prefix: "tab:" });
-    // add event listener for closing tab and remove entry from local storage
-    window.addEventListener("beforeunload", () => {
-      // Remove entry from local storage
-      const currentTabs = getCurrentTabs();
-      delete currentTabs[tabId];
-      setCurrentTabs(currentTabs);
-    });
-  }
-  const currentTabs = getCurrentTabs();
-  // Update tabs data
-  const newTabs = {
-    ...currentTabs,
-    [tabId]: appId,
-  };
-  setCurrentTabs(newTabs);
-  // if current app is open in any other open tabs
-  const isOpenInAnotherTab = Object.values(currentTabs).indexOf(appId) > -1;
-  return [isOpenInAnotherTab, Object.values(newTabs)];
 };

--- a/app/client/src/utils/editor/browserTabsTracking.ts
+++ b/app/client/src/utils/editor/browserTabsTracking.ts
@@ -1,0 +1,43 @@
+import { generateReactKey } from "../../widgets/WidgetUtils";
+
+type TabData = { [tabId: string]: string };
+
+const LOCAL_STORAGE_KEY = "EDITOR_TABS_DATA";
+
+const getCurrentTabs = (): TabData => {
+  const currentTabsJSON = localStorage.getItem(LOCAL_STORAGE_KEY) || "{}";
+  const currentTabs: TabData = JSON.parse(currentTabsJSON);
+  return currentTabs;
+};
+
+const setCurrentTabs = (tabs: TabData) => {
+  const currentTabsJSON = JSON.stringify(tabs);
+  localStorage.setItem(LOCAL_STORAGE_KEY, currentTabsJSON);
+};
+
+let tabId: string;
+export const trackOpenEditorTabs = (
+  appId: string,
+): [isOpenInAnotherTab: boolean, currentTabs: string[]] => {
+  // Check if a tab id is created or else create one
+  if (!tabId) {
+    tabId = generateReactKey({ prefix: "tab:" });
+    // add event listener for closing tab and remove entry from local storage
+    window.addEventListener("beforeunload", () => {
+      // Remove entry from local storage
+      const currentTabs = getCurrentTabs();
+      delete currentTabs[tabId];
+      setCurrentTabs(currentTabs);
+    });
+  }
+  const currentTabs = getCurrentTabs();
+  // Update tabs data
+  const newTabs = {
+    ...currentTabs,
+    [tabId]: appId,
+  };
+  setCurrentTabs(newTabs);
+  // if current app is open in any other open tabs
+  const isOpenInAnotherTab = Object.values(currentTabs).indexOf(appId) > -1;
+  return [isOpenInAnotherTab, Object.values(newTabs)];
+};


### PR DESCRIPTION
Added tracking for seeing open editor tabs with the same app. This is to check if the user is trying to edit the same app in multiple tabs and will help us make better decisions in Context Switching project

fixes #25141