### PR TITLE
chore: modified error handling when datasource storage is not found for execution

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceStorageServiceCEImpl.java
@@ -78,31 +78,30 @@ public class DatasourceStorageServiceCEImpl implements DatasourceStorageServiceC
                 .map(datasourceStorage -> {
                     datasourceStorage.prepareTransientFields(datasource);
                     return datasourceStorage;
-                })
-                .switchIfEmpty(
-                        Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.DATASOURCE)));
+                });
     }
 
     @Override
     public Mono<DatasourceStorage> findByDatasourceAndEnvironmentIdForExecution(
             Datasource datasource, String environmentId) {
-        return this.findByDatasourceAndEnvironmentId(datasource, environmentId).flatMap(datasourceStorage -> {
-            if (datasourceStorage.getDatasourceConfiguration() == null) {
-                return Mono.error(new AppsmithException(AppsmithError.NO_CONFIGURATION_FOUND_IN_DATASOURCE));
-            }
-            return Mono.just(datasourceStorage);
-        });
+        return this.findByDatasourceAndEnvironmentId(datasource, environmentId)
+                .flatMap(datasourceStorage -> {
+                    if (datasourceStorage.getDatasourceConfiguration() == null) {
+                        return Mono.error(new AppsmithException(AppsmithError.NO_CONFIGURATION_FOUND_IN_DATASOURCE));
+                    }
+
+                    return Mono.just(datasourceStorage);
+                })
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasource.getName())));
     }
 
     @Override
     public Flux<DatasourceStorage> findByDatasource(Datasource datasource) {
-        return this.findByDatasourceId(datasource.getId())
-                .map(datasourceStorage -> {
-                    datasourceStorage.prepareTransientFields(datasource);
-                    return datasourceStorage;
-                })
-                .switchIfEmpty(
-                        Mono.error(new AppsmithException(AppsmithError.NO_RESOURCE_FOUND, FieldName.DATASOURCE)));
+        return this.findByDatasourceId(datasource.getId()).map(datasourceStorage -> {
+            datasourceStorage.prepareTransientFields(datasource);
+            return datasourceStorage;
+        });
     }
 
     protected Mono<DatasourceStorage> findByDatasourceIdAndEnvironmentId(String datasourceId, String environmentId) {

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceStorageServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceStorageServiceTest.java
@@ -204,4 +204,25 @@ public class DatasourceStorageServiceTest {
                     .isEqualTo(AppsmithError.NO_CONFIGURATION_FOUND_IN_DATASOURCE.getAppErrorCode());
         });
     }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void verifyFindByDatasourceAndStorageIdGivesErrorWhenStorageIsAbsent() {
+        String datasourceId = "datasourceForUnsavedStorage";
+        String environmentIdOne = FieldName.UNUSED_ENVIRONMENT_ID;
+
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Datasource datasource = new Datasource();
+        datasource.setId(datasourceId);
+
+        Mono<DatasourceStorage> datasourceStorageMono =
+                datasourceStorageService.findByDatasourceAndEnvironmentIdForExecution(datasource, environmentIdOne);
+        StepVerifier.create(datasourceStorageMono).verifyErrorSatisfies(error -> {
+            assertThat(error).isInstanceOf(AppsmithException.class);
+            assertThat(((AppsmithException) error).getAppErrorCode())
+                    .isEqualTo(AppsmithError.NO_RESOURCE_FOUND.getAppErrorCode());
+        });
+    }
 }


### PR DESCRIPTION
## Description
> Error handling changes when we don't find any datasource storage
 - Ideally error should only be thrown when we are trying to execute/use datasource configuration in some ways, therefore it's not necessary to throw error. Additionally, Page load could be blocked due to this, hence removed throwing error from flows where no execution is happening, I.e fork, fetch
 
#### PR fixes following issue(s)
Fixes #25605 

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

#### How Has This Been Tested?
- [ ] Manual

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
