### PR TITLE
ci: Moved QC around, removed unit tests running with ok to test

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -24,7 +24,7 @@ defaults:
     working-directory: app/client
 
 jobs:
-  build:
+  client-build:
     runs-on: ubuntu-latest-8-cores
     # Only run this workflow for internally triggered events
     if: |

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -1,8 +1,6 @@
 name: Client Build
 
 on:
-  # This line enables manual triggering of this workflow.
-  workflow_dispatch:
   workflow_call:
     inputs:
       pr:
@@ -19,12 +17,6 @@ on:
         required: false
         type: string
         default: "false"
-
-  pull_request:
-    branches: [release, master]
-    paths:
-      - "app/client/**"
-      - "!app/client/cypress/manual_TestSuite/**"
 
 # Change the working directory for all the jobs in this workflow
 defaults:

--- a/.github/workflows/client-lint.yml
+++ b/.github/workflows/client-lint.yml
@@ -1,8 +1,6 @@
 name: Client Lint
 
 on:
-  # This line enables manual triggering of this workflow.
-  workflow_dispatch:
   workflow_call:
     inputs:
       pr:
@@ -15,26 +13,14 @@ on:
         type: string
         default: "false"
 
-  pull_request:
-    branches: [release, master]
-    paths:
-      - "app/client/**"
-      - "!app/client/cypress/manual_TestSuite/**"
-
 # Change the working directory for all the jobs in this workflow
 defaults:
   run:
     working-directory: app/client
 
 jobs:
-  build:
+  client-lint:
     runs-on: ubuntu-latest-8-cores
-    # Only run this workflow for internally triggered events
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     defaults:
       run:
         working-directory: app/client
@@ -47,19 +33,10 @@ jobs:
 
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        if: inputs.pr != 0
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
-
-      # Checkout the code in the current branch in case the workflow is called because of a branch push event
-      - name: Checkout the head commit of the branch
-        if: inputs.pr == 0
-
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result

--- a/.github/workflows/client-unit-tests.yml
+++ b/.github/workflows/client-unit-tests.yml
@@ -1,8 +1,6 @@
 name: Client Unit Tests
 
 on:
-  # This line enables manual triggering of this workflow.
-  workflow_dispatch:
   workflow_call:
     inputs:
       pr:
@@ -15,26 +13,14 @@ on:
         type: string
         default: "false"
 
-  pull_request:
-    branches: [release, master]
-    paths:
-      - "app/client/**"
-      - "!app/client/cypress/manual_TestSuite/**"
-
 # Change the working directory for all the jobs in this workflow
 defaults:
   run:
     working-directory: app/client
 
 jobs:
-  build:
+  client-build-and-tests:
     runs-on: ubuntu-latest-8-cores
-    # Only run this workflow for internally triggered events
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     defaults:
       run:
         working-directory: app/client
@@ -47,19 +33,10 @@ jobs:
 
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
-        if: inputs.pr != 0
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge
-
-      # Checkout the code in the current branch in case the workflow is called because of a branch push event
-      - name: Checkout the head commit of the branch
-        if: inputs.pr == 0
-
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       # In case this is second attempt try restoring status of the prior attempt from cache
       - name: Restore the previous run result

--- a/.github/workflows/client-unit-tests.yml
+++ b/.github/workflows/client-unit-tests.yml
@@ -19,7 +19,7 @@ defaults:
     working-directory: app/client
 
 jobs:
-  client-build-and-tests:
+  client-unit-tests:
     runs-on: ubuntu-latest-8-cores
     defaults:
       run:

--- a/.github/workflows/docs/integration-tests-command.md
+++ b/.github/workflows/docs/integration-tests-command.md
@@ -1,0 +1,53 @@
+# Appsmith External Integration Test Workflow
+
+## Workflow Triggers
+
+This workflow is triggered by the "ok to test" command dispatch. It listens for the `repository_dispatch` event with the type `ok-to-test-command`.
+
+## Workflow Jobs
+
+### `notify`
+
+This job is responsible for notifying about the ongoing test run. It creates a comment on the associated pull request with details about the workflow run, commit, and links to various test results.
+
+### `server-build`
+
+The `server-build` job builds the server-side code. It uses the configuration defined in the `.github/workflows/server-build.yml` file. The job is skipped for running tests.
+
+### `client-build`
+
+The `client-build` job builds the client-side codebase. It uses the configuration from the `.github/workflows/client-build.yml` file and checks for test files.
+
+### `rts-build`
+
+The `rts-build` job builds the "rts" (real-time suggestions) package of the client-side codebase. It uses the configuration defined in the `.github/workflows/rts-build.yml` file.
+
+### `test-shared-modules`
+
+The `test-shared-modules` job runs tests for shared modules. It uses the configuration from the `.github/workflows/shared-modules.yml` file.
+
+### `test-appsmithctl`
+
+The `test-appsmithctl` job runs tests for the `appsmithctl` utility. It uses the configuration from the `.github/workflows/appsmithctl.yml` file.
+
+### `build-docker-image`
+
+The `build-docker-image` job builds and pushes the Docker image for the application. It depends on the successful completion of the `client-build`, `server-build`, and `rts-build` jobs. The Docker image is built with support for both `linux/arm64` and `linux/amd64` platforms.
+
+### `ci-test`
+
+The `ci-test` job runs continuous integration tests on the Docker image. It depends on the successful completion of the `build-docker-image` job.
+
+### `perf-test`
+
+The `perf-test` job performs performance tests on the Docker image. It depends on the successful completion of the `build-docker-image` job.
+
+### `ci-test-result`
+
+The `ci-test-result` job collects the results from the `ci-test` and `perf-test` jobs and generates a report. It always runs, and it processes the test results against known failures. The results are then added as a comment on the associated pull request.
+
+### `package`
+
+The `package` job creates a package for release. It runs only if all previous steps are successful and the reference is either the `release` or `master` branch. The package result is then marked as complete.
+
+Please note that this documentation is based on the information provided in the workflow file. For any specific details and further customization, refer to the actual content of the included `.yml` files for each job.

--- a/.github/workflows/docs/quality-checks.md
+++ b/.github/workflows/docs/quality-checks.md
@@ -1,0 +1,60 @@
+# GitHub Workflow Documentation: Quality Checks
+
+## Overview
+
+The "Quality checks" GitHub workflow is designed to perform various quality checks on your codebase, particularly when there's a pull request targeting the "release" or "master" branches. The workflow makes use of multiple jobs, each focusing on a specific quality check task.
+
+## Workflow Triggers
+
+The workflow is triggered automatically when a pull request is opened or updated, but only for pull requests targeting the "release" or "master" branches.
+
+```yaml
+on:
+  pull_request:
+    branches: [release, master]
+```
+
+## Workflow Jobs
+
+### `path-filter`
+
+The first job, named `path-filter`, filters the files changed in the pull request to determine which quality checks are applicable. It identifies files related to the server, client, and Cypress tests and sets appropriate output variables accordingly.
+
+Steps:
+
+1. Checks out the merged commit from the pull request and the base branch.
+2. Uses the `dorny/paths-filter` action to filter files and set output variables for "server," "client," and "cypress" changes.
+
+### `server-spotless`
+
+This job, named `server-spotless`, performs a code formatting check on the server-side codebase. It only runs if changes related to the server were detected by the `path-filter` job.
+
+### `server-unit-tests`
+
+The `server-unit-tests` job is responsible for running unit tests on the server-side code. It runs if changes related to the server were detected by the `path-filter` job.
+
+### `client-build`
+
+The `client-build` job handles the build process for the client-side codebase. It runs if changes related to the client were detected by the `path-filter` job.
+
+### `client-prettier`
+
+The `client-prettier` job performs code formatting checks on the client-side codebase using Prettier. It runs if changes related to the client were detected by the `path-filter` job.
+
+### `client-unit-tests`
+
+The `client-unit-tests` job runs unit tests for the client-side codebase. It runs if changes related to the client were detected by the `path-filter` job.
+
+### `client-lint`
+
+The `client-lint` job checks the client-side code for linting issues. It runs if changes related to the client were detected by the `path-filter` job.
+
+### `qc-result`
+
+The final job, `qc-result`, collects the results from all the previous jobs and determines whether the quality checks passed or failed. It always runs, regardless of the results of the previous jobs.
+
+Steps:
+
+1. Uses a Bash script to check the results of each job.
+2. If any of the previous jobs' results are "failure," the script echoes "Quality checks failed" and exits with an error code (1).
+3. If all previous jobs' results are successful, the script echoes "Quality checks successful" and exits with a success code (0).

--- a/.github/workflows/docs/quality-checks.md
+++ b/.github/workflows/docs/quality-checks.md
@@ -57,4 +57,4 @@ Steps:
 
 1. Uses a Bash script to check the results of each job.
 2. If any of the previous jobs' results are "failure," the script echoes "Quality checks failed" and exits with an error code (1).
-3. If all previous jobs' results are successful, the script echoes "Quality checks successful" and exits with a success code (0).
+3. In any other non-failing scenario (skipped steps or successful steps), the script echoes "Quality checks successful" and exits with a success code (0).

--- a/.github/workflows/docs/test-build-docker-image.md
+++ b/.github/workflows/docs/test-build-docker-image.md
@@ -1,0 +1,60 @@
+# Test, build and push Docker Image
+
+This GitHub workflow is triggered manually (`workflow_dispatch`) and automatically for pushes to the `release` and `master` branches. It is designed to perform various steps, including building and pushing Docker images, running tests, and creating release images.
+
+## Workflow Triggers
+
+The workflow can be manually triggered via the GitHub Actions UI by selecting "Run Workflow" from the actions dropdown. Additionally, it is triggered automatically for pushes to the `release` and `master` branches.
+
+```yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [release, master]
+    paths:
+      - "app/client/**"
+      - "app/server/**"
+      - "app/client/packages/rts/**"
+      - "!app/client/cypress/manual_TestSuite/**"
+```
+
+## Workflow Jobs
+
+### `server-build`
+
+This job, named `server-build`, is responsible for building the server-side code. It uses the configuration defined in `.github/workflows/server-build.yml`. It inherits secrets from the repository.
+
+### `client-build`
+
+The `client-build` job builds the client-side codebase. It uses the configuration from `.github/workflows/client-build.yml` and inherits secrets from the repository.
+
+### `rts-build`
+
+The `rts-build` job builds the "rts" (real-time suggestions) package of the client-side codebase. It uses the configuration defined in `.github/workflows/rts-build.yml` and inherits secrets from the repository.
+
+### `build-docker-image`
+
+This job, named `build-docker-image`, creates and pushes the Docker image for the application. It is dependent on the success of the `client-build`, `server-build`, and `rts-build` jobs. The Docker image is built with two platforms: `linux/arm64` and `linux/amd64`.
+
+### `perf-test`
+
+The `perf-test` job performs performance tests on the Docker image. It depends on the successful completion of the `build-docker-image` job.
+
+### `ci-test`
+
+The `ci-test` job runs continuous integration tests on the Docker image. It depends on the successful completion of the `build-docker-image` job.
+
+### `ci-test-result`
+
+The `ci-test-result` job collects the results from the `ci-test` job and determines whether the integration tests have passed or failed. It always runs, and it is triggered under the following conditions:
+- Manual workflow dispatch.
+- Push event to the repository.
+- Pull request review event with an approved review and originating from the same repository.
+
+### `package-release`
+
+The `package-release` job is responsible for creating a Docker image for release. It runs as soon as the docker image is ready, but only for the `release` branch. It uses OIDC token authentication between Depot and GitHub.
+
+### `package-master`
+
+The `package-master` job creates a Docker image for the `master` branch. It runs only if the tests are successful and is used for nightly builds. It uses OIDC token authentication between Depot and GitHub.

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -20,27 +20,7 @@ jobs:
             Commit: `${{ github.event.client_payload.slash_command.args.named.sha }}`.
             PR: ${{ github.event.client_payload.pull_request.number }}.
             Perf tests will be available at <https://app.appsmith.com/app/performance-infra-dashboard/pr-details-638dd7cd2913ba43778b915e?pr=${{ github.event.client_payload.pull_request.number }}&runId=${{ github.run_id }}_${{github.run_attempt}}>
-  changeset:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - uses: dorny/paths-filter@v2
-      id: filter
-      with:
-        base: ${{ github.event.client_payload.pull_request.base.ref }}
-        ref: ${{ github.event.client_payload.pull_request.head.sha }}
-        filters: |
-          backend:
-            - 'app/server/**'
-
+  
   server-build:
     name: server-build
     needs: [changeset]
@@ -48,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       pr: ${{ github.event.client_payload.pull_request.number }}
-      skip-tests: ${{ needs.changeset.outputs.backend == 'false' }}
+      skip-tests: true
 
   client-build:
     name: client-build

--- a/.github/workflows/integration-tests-command.yml
+++ b/.github/workflows/integration-tests-command.yml
@@ -23,7 +23,6 @@ jobs:
   
   server-build:
     name: server-build
-    needs: [changeset]
     uses: ./.github/workflows/server-build.yml
     secrets: inherit
     with:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -71,7 +71,7 @@ jobs:
     with:
       pr: ${{ github.event.pull_request.number }}
 
-  formatting-result:
+  qc-result:
     name: formatting-result
     needs: [server-formatting, server-unit-tests, client-formatting, client-unit-tests, client-lint]
     if: always()

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,4 +1,4 @@
-name: Formatting checks
+name: Quality checks
 
 on:
   pull_request:
@@ -35,6 +35,15 @@ jobs:
     with:
       pr: ${{ github.event.pull_request.number }}
 
+  server-unit-tests:
+    name: server-unit-tests
+    needs: path-filter
+    if: needs.path-filter.outputs.server == 'true'
+    uses: ./.github/workflows/server-build.yml
+    secrets: inherit
+    with:
+      pr: ${{ github.event.pull_request.number }}
+
   client-formatting:
     name: client-formatting
     needs: path-filter
@@ -44,9 +53,27 @@ jobs:
     with:
       pr: ${{ github.event.pull_request.number }}
 
+  client-unit-tests:
+    name: client-unit-tests
+    needs: path-filter
+    if: needs.path-filter.outputs.client == 'true'
+    uses: ./.github/workflows/client-unit-tests.yml
+    secrets: inherit
+    with:
+      pr: ${{ github.event.pull_request.number }}
+
+  client-lint:
+    name: client-lint
+    needs: path-filter
+    if: needs.path-filter.outputs.client == 'true'
+    uses: ./.github/workflows/client-lint.yml
+    secrets: inherit
+    with:
+      pr: ${{ github.event.pull_request.number }}
+
   formatting-result:
     name: formatting-result
-    needs: [server-formatting, client-formatting]
+    needs: [server-formatting, server-unit-tests, client-formatting, client-unit-tests, client-lint]
     if: always()
     runs-on: ubuntu-latest
     defaults:
@@ -55,10 +82,14 @@ jobs:
     steps:
       - name: Return status for formatting checks
         run: |
-          if [[ "${{ needs.server-formatting.result }}" == "failure" ||  "${{ needs.client-formatting.result }}" == "failure" ]]; then
-            echo "Formatting checks failed";
+          if [[ "${{ needs.server-formatting.result }}" == "failure" || \
+           "${{ needs.server-unit-tests.result }}" == "failure" || \
+           "${{ needs.client-formatting.result }}" == "failure" || \
+           "${{ needs.client-unit-tests.result }}" == "failure" || \
+           "${{ needs.client-lint.result }}" == "failure" ]]; then
+            echo "Quality checks failed";
             exit 1;
           else
-            echo "Formatting checks successful";
+            echo "Quality checks successful";
             exit 0;
           fi

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       server: ${{ steps.filter.outputs.server }}
-      client: ${{ steps.filter.outputs.client }}
+      client: ${{ steps.filter.outputs.client && !steps.filter.outputs.cypress }}
     steps:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Checkout the merged commit from PR and base branch
@@ -24,7 +24,9 @@ jobs:
             server:
               - 'app/server/**'
             client:
-              - 'app/client/**' && '!app/client/cypress/manual_TestSuite/**'
+              - 'app/client/**'
+            cypress:
+              - 'app/client/cypress/manual_TestSuite/**'
 
   server-spotless:
     name: server-spotless

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -72,7 +72,7 @@ jobs:
       pr: ${{ github.event.pull_request.number }}
 
   qc-result:
-    name: formatting-result
+    name: qc-result
     needs: [server-formatting, server-unit-tests, client-formatting, client-unit-tests, client-lint]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -24,8 +24,7 @@ jobs:
             server:
               - 'app/server/**'
             client:
-              - 'app/client/**'
-              - '!app/client/cypress/manual_TestSuite/**'
+              - 'app/client/**' && '!app/client/cypress/manual_TestSuite/**'
 
   server-spotless:
     name: server-spotless

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -25,9 +25,10 @@ jobs:
               - 'app/server/**'
             client:
               - 'app/client/**'
+              - '!app/client/cypress/manual_TestSuite/**'
 
-  server-formatting:
-    name: server-formatting
+  server-spotless:
+    name: server-spotless
     needs: path-filter
     if: needs.path-filter.outputs.server == 'true'
     uses: ./.github/workflows/server-spotless.yml
@@ -44,8 +45,17 @@ jobs:
     with:
       pr: ${{ github.event.pull_request.number }}
 
-  client-formatting:
-    name: client-formatting
+  client-build:
+    name: client-build
+    needs: path-filter
+    if: needs.path-filter.outputs.client == 'true'
+    uses: ./.github/workflows/client-build.yml
+    secrets: inherit
+    with:
+      pr: ${{ github.event.pull_request.number }}
+
+  client-prettier:
+    name: client-prettier
     needs: path-filter
     if: needs.path-filter.outputs.client == 'true'
     uses: ./.github/workflows/client-prettier.yml
@@ -73,18 +83,19 @@ jobs:
 
   qc-result:
     name: qc-result
-    needs: [server-formatting, server-unit-tests, client-formatting, client-unit-tests, client-lint]
+    needs: [server-spotless, server-unit-tests, client-build, client-prettier, client-unit-tests, client-lint]
     if: always()
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     steps:
-      - name: Return status for formatting checks
+      - name: Return status for quality checks
         run: |
-          if [[ "${{ needs.server-formatting.result }}" == "failure" || \
+          if [[ "${{ needs.server-spotless.result }}" == "failure" || \
            "${{ needs.server-unit-tests.result }}" == "failure" || \
-           "${{ needs.client-formatting.result }}" == "failure" || \
+           "${{ needs.client-build.result }}" == "failure" || \
+           "${{ needs.client-prettier.result }}" == "failure" || \
            "${{ needs.client-unit-tests.result }}" == "failure" || \
            "${{ needs.client-lint.result }}" == "failure" ]]; then
             echo "Quality checks failed";

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -41,6 +41,7 @@ jobs:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Check out merged commit from PR and base branch
         uses: actions/checkout@v3
+        if: inputs.pr != 0
         with:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -2,8 +2,6 @@
 name: Appsmith Server Workflow
 
 on:
-  # This line enables manual triggering of this workflow.
-  workflow_dispatch:
   workflow_call:
     inputs:
       pr:
@@ -16,26 +14,14 @@ on:
         type: string
         default: "false"
 
-
-  pull_request:
-    branches: [release, master]
-    paths:
-      - "app/server/**"
-
 # Change the working directory for all the jobs in this workflow
 defaults:
   run:
     working-directory: app/server
 
 jobs:
-  build:
+  server-unit-tests:
     runs-on: ubuntu-latest-8-cores
-    # Only run this workflow for internally triggered events
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
 
     # Service containers to run with this job. Required for running tests
     services:
@@ -55,7 +41,6 @@ jobs:
       # Check out merge commit with the base branch in case this workflow is invoked via pull request
       - name: Check out merged commit from PR and base branch
         uses: actions/checkout@v3
-        if: inputs.pr != 0
         with:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr }}/merge

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -135,8 +135,9 @@ jobs:
             exit 1;
           fi
 
-  package:
-    needs: ci-test
+
+  package-release:
+    needs: build-docker-image
     runs-on: ubuntu-latest
     # Set permissions since we're using OIDC token authentication between Depot and GitHub
     permissions:
@@ -144,28 +145,9 @@ jobs:
       id-token: write
 
     # Run this job irrespective of tests failing, if this is the release branch; or only if the tests pass, if this is the master branch.
-    if: (success() && github.ref == 'refs/heads/master') ||
-      ( always() &&
-      (
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (
-      github.event_name == 'pull_request_review' &&
-      github.event.review.state == 'approved' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-      )
-      ) &&
-      github.ref == 'refs/heads/release'
-      )
+    if: ( always() && github.ref == 'refs/heads/release' )
 
     steps:
-      # Checkout the code
-      - name: Checkout the merged commit from PR and base branch
-        if: github.event_name == 'pull_request_review'
-        uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-
       - name: Checkout the head commit of the branch
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v3
@@ -200,12 +182,6 @@ jobs:
           echo "Cleaning up the tar files"
           rm app/client/packages/rts/dist/rts-dist.tar
 
-      # Here, the GITHUB_REF is of type /refs/head/<branch_name>. We extract branch_name from this by removing the
-      # first 11 characters. This can be used to build images for several branches
-      - name: Get the version to tag the Docker image
-        id: vars
-        run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
-
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
 
@@ -216,7 +192,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push release image to Docker Hub
-        if: success() && github.ref == 'refs/heads/release' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: success()
         uses: depot/build-push-action@v1
         with:
           context: .
@@ -225,10 +201,65 @@ jobs:
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}
           tags: |
-            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{steps.vars.outputs.tag}}
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:release
+
+  package-master:
+    needs: ci-test
+    runs-on: ubuntu-latest
+    # Set permissions since we're using OIDC token authentication between Depot and GitHub
+    permissions:
+      contents: read
+      id-token: write
+
+    # Run this job irrespective of tests failing, if this is the release branch; or only if the tests pass, if this is the master branch.
+    if: ( success() && github.ref == 'refs/heads/master' )
+
+    steps:
+      - name: Checkout the head commit of the branch
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v3
+
+      - name: Download the react build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: client-build
+          path: app/client
+
+      - name: Unpack the client build artifact
+        if: steps.run_result.outputs.run_result != 'success'
+        run: |
+          mkdir -p app/client/build
+          tar -xvf app/client/build.tar -C app/client/build
+
+      - name: Download the server build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: server-build
+          path: app/server/dist
+
+      - name: Download the rts build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: rts-dist
+          path: app/client/packages/rts/dist
+
+      - name: Untar the rts folder
+        run: |
+          tar -xvf app/client/packages/rts/dist/rts-dist.tar -C app/client/packages/rts/
+          echo "Cleaning up the tar files"
+          rm app/client/packages/rts/dist/rts-dist.tar
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push master image to Docker Hub with commit tag
-        if: success() && github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: success()
         uses: depot/build-push-action@v1
         with:
           context: .
@@ -239,25 +270,3 @@ jobs:
           tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:${{ github.sha }}
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:nightly
-
-      # - name: Check and push CI image to Docker Hub with commit tag
-      #   if: success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      #   working-directory: "."
-      #   run: |
-      #     if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-      #       tag=nightly
-      #     else
-      #       tag="${{ steps.vars.outputs.tag }}"
-      #     fi
-      #     docker run --detach --publish 80:80 --name appsmith \
-      #       "${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:$tag"
-      #     sleep 180
-      #     cd deploy/docker
-      #     if bash run-test.sh; then
-      #       echo "Fat container test passed. Pushing image."
-      #       docker push --all-tags ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce
-      #     else
-      #       echo "Fat container test FAILED. Not pushing image."
-      #       # Temporarily pushing even if test fails.
-      #       docker push --all-tags ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce
-      #     fi

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -144,7 +144,7 @@ jobs:
       contents: read
       id-token: write
 
-    # Run this job irrespective of tests failing, if this is the release branch; or only if the tests pass, if this is the master branch.
+    # Run this job as soon as the docker image is ready, if this is the release branch
     if: ( always() && github.ref == 'refs/heads/release' )
 
     steps:

--- a/app/client/.gitignore
+++ b/app/client/.gitignore
@@ -16,7 +16,7 @@ dist
 build.tar
 /build_airgap
 
-# misc
+# miscellaneous
 .DS_Store
 .env.local
 .env.development.local

--- a/app/client/.gitignore
+++ b/app/client/.gitignore
@@ -16,7 +16,7 @@ dist
 build.tar
 /build_airgap
 
-# miscellaneous
+# misc
 .DS_Store
 .env.local
 .env.development.local

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -1,5 +1,5 @@
 # Appsmith Server
 
-This is the server-side repository for the Appsmith framework.
+This is the server-side directory for the Appsmith framework.
 <br><br>
 For details on setting up your development machine, please refer to this [Setup Guide](../../contributions/ServerSetup.md).

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -1,5 +1,5 @@
 # Appsmith Server
 
-This is the server-side directory for the Appsmith framework.
+This is the server-side repository for the Appsmith framework.
 <br><br>
 For details on setting up your development machine, please refer to this [Setup Guide](../../contributions/ServerSetup.md).


### PR DESCRIPTION
QC now has all server and client side formatting and unit tests check. This would be a compulsory check for merge.
ok-to-test hence does not needs unit tests to run. This should reduce run times by half an hour.
TBD also now does not need Cypress to run at all before package. Since package never required tests to pass on release, this change simply reduces the time between pushing to release and the changes reflecting on release.app.appsmith.com 

A few other clean ups across the board.