### PR TITLE
fix: Application name does not show up sometimes

### DIFF
--- a/app/client/src/pages/Editor/EditorAppName/index.tsx
+++ b/app/client/src/pages/Editor/EditorAppName/index.tsx
@@ -52,6 +52,7 @@ const Container = styled.div`
     ${getTypographyByKey("h5")};
     line-height: ${(props) => props.theme.smallHeaderHeight} !important;
     padding: 0 ${(props) => props.theme.spaces[2]}px;
+    height: ${(props) => props.theme.smallHeaderHeight} !important;
   }
   &&&& .${Classes.EDITABLE_TEXT_INPUT} {
     margin-right: 20px;

--- a/app/client/src/pages/Editor/EditorHeader.tsx
+++ b/app/client/src/pages/Editor/EditorHeader.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useEffect, useState, lazy, Suspense } from "react";
 import styled, { ThemeProvider } from "styled-components";
 import classNames from "classnames";
-import { ReduxActionTypes } from "@appsmith/constants/ReduxActionConstants";
 import { APPLICATIONS_URL } from "constants/routes";
 import AppInviteUsersForm from "pages/workspace/AppInviteUsersForm";
 import AnalyticsUtil from "utils/AnalyticsUtil";
 import AppsmithLogo from "assets/images/appsmith_logo_square.png";
 import { Link } from "react-router-dom";
-import type { AppState } from "@appsmith/reducers";
 import {
   getCurrentApplicationId,
   getCurrentPageId,
@@ -18,14 +16,17 @@ import {
   getAllUsers,
   getCurrentWorkspaceId,
 } from "@appsmith/selectors/workspaceSelectors";
-import type { ConnectedProps } from "react-redux";
-import { connect, useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import DeployLinkButtonDialog from "components/designSystems/appsmith/header/DeployLinkButton";
-import { updateApplication } from "@appsmith/actions/applicationActions";
+import {
+  publishApplication,
+  updateApplication,
+} from "@appsmith/actions/applicationActions";
 import {
   getApplicationList,
   getIsSavingAppName,
   getIsErroredSavingAppName,
+  getCurrentApplication,
 } from "@appsmith/selectors/applicationSelectors";
 import EditorAppName from "./EditorAppName";
 import { getCurrentUser } from "selectors/usersSelectors";
@@ -207,18 +208,7 @@ const GlobalSearch = lazy(() => {
 
 const theme = getTheme(ThemeMode.LIGHT);
 
-// Seperating redux props types from props being passed to the component from a parent
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export function EditorHeader(props: PropsFromRedux) {
-  const {
-    applicationId,
-    currentApplication,
-    isPublishing,
-    pageId,
-    publishApplication,
-    workspaceId,
-  } = props;
+export function EditorHeader() {
   const [activeTab, setActiveTab] = useState("invite");
   const dispatch = useDispatch();
   const isSnipingMode = useSelector(snipingModeSelector);
@@ -229,6 +219,14 @@ export function EditorHeader(props: PropsFromRedux) {
   const applicationList = useSelector(getApplicationList);
   const isPreviewMode = useSelector(previewModeSelector);
   const signpostingEnabled = useSelector(getIsFirstTimeUserOnboardingEnabled);
+  const workspaceId = useSelector(getCurrentWorkspaceId);
+  const applicationId = useSelector(getCurrentApplicationId);
+  const currentApplication = useSelector(getCurrentApplication);
+  const isPublishing = useSelector(getIsPublishingApplication);
+  const pageId = useSelector(getCurrentPageId) as string;
+  const sharedUserList = useSelector(getAllUsers);
+  const currentUser = useSelector(getCurrentUser);
+
   const deployLink = useHref(viewerURL, { pageId });
   const isAppSettingsPaneWithNavigationTabOpen = useSelector(
     getIsAppSettingsPaneWithNavigationTabOpen,
@@ -242,7 +240,7 @@ export function EditorHeader(props: PropsFromRedux) {
 
   const handlePublish = () => {
     if (applicationId) {
-      publishApplication(applicationId);
+      dispatch(publishApplication(applicationId));
 
       const appName = currentApplication ? currentApplication.name : "";
       const pageCount = currentApplication?.pages?.length;
@@ -323,8 +321,8 @@ export function EditorHeader(props: PropsFromRedux) {
       dispatch(fetchUsersForWorkspace(workspaceId));
     }
   }, [workspaceId]);
-  const filteredSharedUserList = props.sharedUserList.filter(
-    (user) => user.username !== props.currentUser?.username,
+  const filteredSharedUserList = sharedUserList.filter(
+    (user) => user.username !== currentUser?.username,
   );
 
   return (
@@ -551,31 +549,4 @@ export function EditorHeader(props: PropsFromRedux) {
   );
 }
 
-const mapStateToProps = (state: AppState) => ({
-  pageName: state.ui.editor.currentPageName,
-  workspaceId: getCurrentWorkspaceId(state),
-  applicationId: getCurrentApplicationId(state),
-  currentApplication: state.ui.applications.currentApplication,
-  isPublishing: getIsPublishingApplication(state),
-  pageId: getCurrentPageId(state) as string,
-  sharedUserList: getAllUsers(state),
-  currentUser: getCurrentUser(state),
-});
-
-const mapDispatchToProps = (dispatch: any) => ({
-  publishApplication: (applicationId: string) => {
-    dispatch({
-      type: ReduxActionTypes.PUBLISH_APPLICATION_INIT,
-      payload: {
-        applicationId,
-      },
-    });
-  },
-});
-
-EditorHeader.whyDidYouRender = {
-  logOnDifferentValues: false,
-};
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
-export default connector(EditorHeader);
+export default EditorHeader;


### PR DESCRIPTION
## Description
We noticed that empty applications sometimes do not show the application name. This was caused by a style issue where the height of the component was defaulted to 1px even if the name actually exists in the component. To fix this, we are forcing the styles to always be set to the header height. 
Also refactored the Editor header component a bit.

#### PR fixes following issue(s)
Fixes #25457

#### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
