### PR TITLE
chore: Prevent null tenantConfiguration, needed for EE

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java
@@ -120,6 +120,12 @@ public class TenantServiceCEImpl extends BaseService<TenantRepository, Tenant, S
         // We are doing this differently because `findBySlug` is a Mongo JPA query and not a custom Appsmith query
         return repository
                 .findBySlug(FieldName.DEFAULT)
+                .map(tenant -> {
+                    if (tenant.getTenantConfiguration() == null) {
+                        tenant.setTenantConfiguration(new TenantConfiguration());
+                    }
+                    return tenant;
+                })
                 .flatMap(tenant -> repository.setUserPermissionsInObject(tenant).switchIfEmpty(Mono.just(tenant)));
     }
 


### PR DESCRIPTION
This change is [already made in EE](https://github.com/appsmithorg/appsmith-ee/blob/9b9a39e488cfbaf4a8f7b8a2a4d1d05db77f950d/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/TenantServiceCEImpl.java#L123). This PR is about paying the back-sync debt.
