### PR TITLE
fix: added createdAt to redis session key and user trait (#25702)

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserSessionDTO.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/dtos/UserSessionDTO.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Set;
 
@@ -27,6 +28,8 @@ public class UserSessionDTO {
     private String hashedEmail;
 
     private String name;
+
+    private Long createdAt;
 
     private LoginSource source;
 
@@ -70,6 +73,7 @@ public class UserSessionDTO {
         session.email = user.getEmail();
         session.hashedEmail = user.getHashedEmail();
         session.name = user.getName();
+        session.createdAt = user.getCreatedAt().getEpochSecond();
         session.source = user.getSource();
         session.state = user.getState();
         session.isEnabled = user.isEnabled();
@@ -106,6 +110,7 @@ public class UserSessionDTO {
         user.setEmail(email);
         user.setHashedEmail(hashedEmail);
         user.setName(name);
+        user.setCreatedAt(Instant.ofEpochSecond(createdAt));
         user.setSource(source);
         user.setState(state);
         user.setIsEnabled(isEnabled);

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCEImpl.java
@@ -73,7 +73,10 @@ public class CacheableFeatureFlagHelperCEImpl implements CacheableFeatureFlagHel
             userTraits.put("instanceId", instanceId);
             userTraits.put("tenantId", user.getTenantId());
             userTraits.put("isTelemetryOn", !commonConfig.isTelemetryDisabled());
-            userTraits.put("createdAt", user.getCreatedAt());
+            // for anonymous user, user.getCreatedAt() is null
+            if (user.getCreatedAt() != null) {
+                userTraits.put("createdAt", user.getCreatedAt().getEpochSecond());
+            }
             userTraits.put("defaultTraitsUpdatedAt", Instant.now().getEpochSecond());
             userTraits.put("type", "user");
             return userTraits;


### PR DESCRIPTION

## Description
> This PR adds the user createdAt trait in flagsmith for the user identifiers.

#### PR fixes following issue(s)
Fixes #25702 

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
- [x] Manual

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
