### PR TITLE
fix: oauth empty config check

### DIFF
--- a/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
@@ -145,10 +145,7 @@ const mapStateToProps = (state: AppState, ownProps: any): ReduxStateProps => {
 
       // update the id in object to datasourceId, this is because the value in id post merge is the id of the datasource storage
       // and not of the datasource.
-      datasourceMerged.id =
-        datasourceFromDataSourceList.datasourceStorages[
-          currentEnvironment
-        ].datasourceId;
+      datasourceMerged.id = datasourceFromDataSourceList.id;
 
       // Adding user permissions for datasource from datasourceFromDataSourceList
       datasourceMerged.userPermissions =

--- a/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
+++ b/app/client/src/pages/Editor/APIEditor/ApiAuthentication.tsx
@@ -136,12 +136,13 @@ const mapStateToProps = (state: AppState, ownProps: any): ReduxStateProps => {
       (d) => d.id === datasourceFromAction.id,
     );
     if (datasourceFromDataSourceList) {
-      datasourceMerged = merge(
-        {},
-        datasourceFromAction,
-        // datasourceFromDataSourceList,
-        datasourceFromDataSourceList.datasourceStorages[currentEnvironment],
-      );
+      const { datasourceStorages } = datasourceFromDataSourceList;
+      let dsObjectToMerge = {};
+      // in case the datasource is not configured for the current environment, we just merge with empty object
+      if (datasourceStorages.hasOwnProperty(currentEnvironment)) {
+        dsObjectToMerge = datasourceStorages[currentEnvironment];
+      }
+      datasourceMerged = merge({}, datasourceFromAction, dsObjectToMerge);
 
       // update the id in object to datasourceId, this is because the value in id post merge is the id of the datasource storage
       // and not of the datasource.


### PR DESCRIPTION
## Description
In case the staging config is not present, the app crashes when user switched to staging config while keepng the authenticated tab open for an API connected to multiple env ds. Added a null check for the same and using the ds ID from the parent ds.

#### PR fixes following issue(s)
Fixes #25696 