### PR TITLE
chore: Add APPSMITH_CLOUD_SERVICES_BASE_URL as build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ VOLUME [ "/appsmith-stacks" ]
 # Add backend server - Application Layer
 ARG JAR_FILE=./app/server/dist/server-*.jar
 ARG PLUGIN_JARS=./app/server/dist/plugins/*.jar
+
+ARG APPSMITH_CLOUD_SERVICES_BASE_URL
+ENV APPSMITH_CLOUD_SERVICES_BASE_URL=${APPSMITH_CLOUD_SERVICES_BASE_URL}
+
 ARG APPSMITH_SEGMENT_CE_KEY
 ENV APPSMITH_SEGMENT_CE_KEY=${APPSMITH_SEGMENT_CE_KEY}
 #Create the plugins directory


### PR DESCRIPTION
This will allow us to set a separate cloud-services URL during build time.
