### PR TITLE
fix: config checks for generate page CRUD

### DIFF
--- a/app/client/src/ce/utils/Environments/index.tsx
+++ b/app/client/src/ce/utils/Environments/index.tsx
@@ -53,7 +53,7 @@ export const isEnvironmentConfigured = (
   return !!isConfigured ? isConfigured : false;
 };
 
-// function to check if the datasource is configured for the current environment
+// function to check if the datasource is configured for any environment
 export const doesAnyDsConfigExist = (
   datasource: Datasource | null,
   environment?: string,
@@ -65,14 +65,9 @@ export const doesAnyDsConfigExist = (
     if (envsList.length === 0) {
       isConfigured = false;
     } else {
-      if (envsList.includes(environment)) {
-        isConfigured =
-          datasource.datasourceStorages[environment]?.isConfigured || false;
-      } else {
-        // Allow user to create a query even though the config is not
-        // there for the current environment
-        isConfigured = true;
-      }
+      // Allow user to create a query even though the config is not
+      // there for the current environment
+      isConfigured = true;
     }
   }
   return isConfigured;

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/GeneratePageForm.tsx
@@ -405,7 +405,6 @@ function GeneratePageForm() {
     canCreateDatasource,
     datasources,
     generateCRUDSupportedPlugin,
-    isGoogleSheetPlugin,
   });
 
   const spreadSheetsProps = useSpreadSheets({

--- a/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/hooks.ts
+++ b/app/client/src/pages/Editor/GeneratePage/components/GeneratePageForm/hooks.ts
@@ -8,6 +8,7 @@ import { executeDatasourceQuery } from "actions/datasourceActions";
 import type { DropdownOption } from "design-system-old";
 import { useDispatch } from "react-redux";
 import { getCurrentEnvironment } from "@appsmith/utils/Environments";
+import { PluginPackageName } from "entities/Action";
 
 export const FAKE_DATASOURCE_OPTION = {
   CONNECT_NEW_DATASOURCE_OPTION: {
@@ -24,12 +25,10 @@ export const useDatasourceOptions = ({
   canCreateDatasource,
   datasources,
   generateCRUDSupportedPlugin,
-  isGoogleSheetPlugin,
 }: {
   canCreateDatasource: boolean;
   datasources: Datasource[];
   generateCRUDSupportedPlugin: GenerateCRUDEnabledPluginMap;
-  isGoogleSheetPlugin: boolean;
 }) => {
   const [dataSourceOptions, setDataSourceOptions] = useState<DropdownOptions>(
     [],
@@ -49,6 +48,10 @@ export const useDatasourceOptions = ({
     datasources.forEach(({ datasourceStorages, id, name, pluginId }) => {
       // Doing this since g sheets plugin is not supported for environments
       // and we need to show the option in the dropdown
+      const isGoogleSheetPlugin =
+        generateCRUDSupportedPlugin.hasOwnProperty(pluginId) &&
+        generateCRUDSupportedPlugin[pluginId] ===
+          PluginPackageName.GOOGLE_SHEETS;
       const datasourceStorage = isGoogleSheetPlugin
         ? Object.values(datasourceStorages)[0]
         : datasourceStorages[currentEnvironment];

--- a/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
+++ b/app/client/src/pages/Editor/IntegrationEditor/DatasourceCard.tsx
@@ -252,6 +252,19 @@ function DatasourceCard(props: DatasourceCardProps) {
     AnalyticsUtil.logEvent("DATASOURCE_CARD_DELETE_ACTION");
     dispatch(deleteDatasource({ id: datasource.id }));
   };
+  const isDSAuthorizedForQueryCreation = isDatasourceAuthorizedForQueryCreation(
+    datasource,
+    plugin,
+  );
+
+  const showReconnectButton = !(
+    isDSAuthorizedForQueryCreation &&
+    (envSupportedDs ? isEnvironmentConfigured(datasource, currentEnv) : true)
+  );
+
+  const showCreateNewActionButton = envSupportedDs
+    ? doesAnyDsConfigExist(datasource, currentEnv)
+    : true;
 
   return (
     <Wrapper
@@ -284,43 +297,38 @@ function DatasourceCard(props: DatasourceCardProps) {
             </Queries>
           </div>
           <ButtonsWrapper className="action-wrapper">
-            {supportTemplateGeneration &&
-              isDatasourceAuthorizedForQueryCreation(datasource, plugin) && (
-                <Button
-                  className={"t--generate-template"}
-                  kind="secondary"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    routeToGeneratePage();
-                  }}
-                  size="md"
-                >
-                  {createMessage(GENERATE_NEW_PAGE_BUTTON_TEXT)}
-                </Button>
-              )}
-            {envSupportedDs &&
-              !isEnvironmentConfigured(datasource, currentEnv) && (
-                <Button
-                  className={"t--reconnect-btn"}
-                  kind="secondary"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    editDatasource();
-                  }}
-                  size="md"
-                >
-                  {createMessage(RECONNECT_BUTTON_TEXT)}
-                </Button>
-              )}
-            {doesAnyDsConfigExist(datasource, currentEnv) && (
+            {supportTemplateGeneration && !showReconnectButton && (
+              <Button
+                className={"t--generate-template"}
+                kind="secondary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  routeToGeneratePage();
+                }}
+                size="md"
+              >
+                {createMessage(GENERATE_NEW_PAGE_BUTTON_TEXT)}
+              </Button>
+            )}
+            {showReconnectButton && (
+              <Button
+                className={"t--reconnect-btn"}
+                kind="secondary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  editDatasource();
+                }}
+                size="md"
+              >
+                {createMessage(RECONNECT_BUTTON_TEXT)}
+              </Button>
+            )}
+            {showCreateNewActionButton && (
               <NewActionButton
                 datasource={datasource}
-                disabled={
-                  !canCreateDatasourceActions ||
-                  !isDatasourceAuthorizedForQueryCreation(datasource, plugin)
-                }
+                disabled={!canCreateDatasourceActions || showReconnectButton}
                 eventFrom="active-datasources"
                 pluginType={plugin.type}
               />


### PR DESCRIPTION
## Description
Generate page crud was checking for the config from DS storage even for non env enabled datasources. This PR fixes that.

#### PR fixes following issue(s)
Fixes #25640 
