### PR TITLE
fix: When one public app is made private, other public apps in workspace should still be usable

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomApplicationRepositoryCE.java
@@ -80,4 +80,7 @@ public interface CustomApplicationRepositoryCE extends AppsmithRepository<Applic
             AclPermission permission);
 
     Mono<Application> findByNameAndWorkspaceId(String applicationName, String workspaceId, AclPermission permission);
+
+    Flux<String> getAllApplicationIdsInWorkspaceAccessibleToARoleWithPermission(
+            String workspaceId, AclPermission permission, String permissionGroupId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationServiceCEImpl.java
@@ -14,7 +14,6 @@ import com.appsmith.server.domains.ApplicationMode;
 import com.appsmith.server.domains.Asset;
 import com.appsmith.server.domains.GitApplicationMetadata;
 import com.appsmith.server.domains.GitAuth;
-import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.domains.Page;
 import com.appsmith.server.domains.QApplication;
 import com.appsmith.server.domains.Theme;
@@ -61,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.appsmith.server.acl.AclPermission.MANAGE_APPLICATIONS;
 import static com.appsmith.server.acl.AclPermission.READ_APPLICATIONS;
@@ -461,10 +461,16 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
         Map<String, Policy> applicationPolicyMap =
                 policySolution.generatePolicyFromPermissionWithPermissionGroup(READ_APPLICATIONS, permissionGroupId);
 
+        Flux<String> otherApplicationsForThisRoleFlux = repository
+                .getAllApplicationIdsInWorkspaceAccessibleToARoleWithPermission(
+                        application.getWorkspaceId(), READ_APPLICATIONS, permissionGroupId)
+                .filter(applicationId -> !application.getId().equals(applicationId))
+                .cache();
+
         List<Mono<Void>> updateInheritedDomainsList =
                 updatePoliciesForInheritingDomains(application, applicationPolicyMap, addViewAccess);
-        List<Mono<Void>> updateIndependentDomainsList =
-                updatePoliciesForIndependentDomains(application, permissionGroupId, addViewAccess);
+        List<Mono<Void>> updateIndependentDomainsList = updatePoliciesForIndependentDomains(
+                application, permissionGroupId, addViewAccess, otherApplicationsForThisRoleFlux);
 
         return Flux.fromIterable(updateInheritedDomainsList)
                 .flatMap(voidMono -> voidMono)
@@ -485,44 +491,80 @@ public class ApplicationServiceCEImpl extends BaseService<ApplicationRepository,
     }
 
     protected List<Mono<Void>> updatePoliciesForIndependentDomains(
-            Application application, String permissionGroupId, Boolean addViewAccess) {
+            Application application,
+            String permissionGroupId,
+            Boolean addViewAccess,
+            Flux<String> otherApplicationsWithAccessFlux) {
 
         List<Mono<Void>> list = new ArrayList<>();
 
         Map<String, Policy> datasourcePolicyMap = policySolution.generatePolicyFromPermissionWithPermissionGroup(
                 datasourcePermission.getExecutePermission(), permissionGroupId);
 
-        Mono<Void> updatedDatasourcesMono = newActionRepository
-                .findByApplicationId(application.getId())
-                .collectList()
-                .flatMap(actions -> {
-                    Set<String> datasourceIds = new HashSet<>();
-                    for (NewAction action : actions) {
-                        ActionDTO unpublishedAction = action.getUnpublishedAction();
-                        ActionDTO publishedAction = action.getPublishedAction();
+        Set<String> existingDatasourceIds = ConcurrentHashMap.newKeySet();
+        Set<String> newDatasourceIds = ConcurrentHashMap.newKeySet();
 
-                        if (unpublishedAction.getDatasource() != null
-                                && unpublishedAction.getDatasource().getId() != null) {
-                            datasourceIds.add(unpublishedAction.getDatasource().getId());
-                        }
+        Mono<Void> existingDatasourceIdsMono = otherApplicationsWithAccessFlux
+                .flatMap(ids -> newActionRepository.findByApplicationId(ids))
+                .map(action -> {
+                    ActionDTO unpublishedAction = action.getUnpublishedAction();
+                    ActionDTO publishedAction = action.getPublishedAction();
 
-                        if (publishedAction != null
-                                && publishedAction.getDatasource() != null
-                                && publishedAction.getDatasource().getId() != null) {
-                            datasourceIds.add(publishedAction.getDatasource().getId());
-                        }
+                    if (unpublishedAction.getDatasource() != null
+                            && unpublishedAction.getDatasource().getId() != null) {
+                        existingDatasourceIds.add(
+                                unpublishedAction.getDatasource().getId());
                     }
 
-                    // Update the datasource policies without permission since the applications and datasources are at
-                    // the same level in the hierarchy. A user may have permission to change view on application, but
-                    // may not have explicit permissions on the datasource.
-                    Mono<Void> updatedDatasourcesMono1 = policySolution
-                            .updateWithNewPoliciesToDatasourcesByDatasourceIdsWithoutPermission(
-                                    datasourceIds, datasourcePolicyMap, addViewAccess)
-                            .then();
+                    if (publishedAction != null
+                            && publishedAction.getDatasource() != null
+                            && publishedAction.getDatasource().getId() != null) {
+                        existingDatasourceIds.add(
+                                publishedAction.getDatasource().getId());
+                    }
+                    return action;
+                })
+                .then();
 
-                    return updatedDatasourcesMono1;
-                });
+        Mono<Void> newDatasourceIdsMono = newActionRepository
+                .findByApplicationId(application.getId())
+                .map(action -> {
+                    ActionDTO unpublishedAction = action.getUnpublishedAction();
+                    ActionDTO publishedAction = action.getPublishedAction();
+
+                    if (unpublishedAction.getDatasource() != null
+                            && unpublishedAction.getDatasource().getId() != null) {
+                        newDatasourceIds.add(unpublishedAction.getDatasource().getId());
+                    }
+
+                    if (publishedAction != null
+                            && publishedAction.getDatasource() != null
+                            && publishedAction.getDatasource().getId() != null) {
+                        newDatasourceIds.add(publishedAction.getDatasource().getId());
+                    }
+                    return action;
+                })
+                .then();
+
+        Mono<Set<String>> datasourceIdsMono = Mono.when(existingDatasourceIdsMono, newDatasourceIdsMono)
+                .then(Mono.fromCallable(() -> {
+                    // We want to change permissions for all the datasources related to the new application
+                    HashSet<String> datasourceIds = new HashSet<>(newDatasourceIds);
+                    // But disregard anything that is being used in other applications as well
+                    datasourceIds.removeAll(existingDatasourceIds);
+                    return datasourceIds;
+                }));
+
+        // Update the datasource policies without permission since the applications and datasources are at
+        // the same level in the hierarchy. A user may have permission to change view on application, but
+        // may not have explicit permissions on the datasource.
+        Mono<Void> updatedDatasourcesMono = datasourceIdsMono
+                .flatMapMany(datasourceIds -> {
+                    return policySolution.updateWithNewPoliciesToDatasourcesByDatasourceIdsWithoutPermission(
+                            datasourceIds, datasourcePolicyMap, addViewAccess);
+                })
+                .then();
+
         list.add(updatedDatasourcesMono);
 
         return list;

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ApplicationServiceCETest.java
@@ -73,6 +73,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1457,6 +1458,151 @@ public class ApplicationServiceCETest {
                             .containsAll(Set.of(manageActionPolicy, readActionPolicy, executeActionPolicy));
                 })
                 .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void
+            testPublicApp_whenMultiplePublicAppsInWorkspaceAndOneAccessRevoked_otherPublicAppRetainsAccessToWorkspaceLevelResources() {
+        Workspace toCreate = new Workspace();
+        toCreate.setName("Multiple Public Apps Test");
+        Workspace workspace = workspaceService.create(toCreate).block();
+        String workspaceId = workspace.getId();
+
+        String defaultEnvironmentId = workspaceService
+                .getDefaultEnvironmentId(workspaceId, environmentPermission.getExecutePermission())
+                .block();
+
+        // Create common datasource
+        Plugin plugin = pluginService.findByPackageName("restapi-plugin").block();
+        Datasource datasource = new Datasource();
+        datasource.setName("Public App Test");
+        datasource.setPluginId(plugin.getId());
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        datasource.setDatasourceConfiguration(datasourceConfiguration);
+        datasource.setWorkspaceId(workspaceId);
+
+        datasource.setDatasourceConfiguration(datasourceConfiguration);
+        DatasourceStorage datasourceStorage = new DatasourceStorage(datasource, defaultEnvironmentId);
+        HashMap<String, DatasourceStorageDTO> storages = new HashMap<>();
+        storages.put(defaultEnvironmentId, new DatasourceStorageDTO(datasourceStorage));
+        datasource.setDatasourceStorages(storages);
+
+        Datasource savedDatasource = datasourceService.create(datasource).block();
+
+        // Create first app to make public
+        Application application = new Application();
+        application.setName("firstAppToMakePublic");
+
+        Application createdApplication = applicationPageService
+                .createApplication(application, workspaceId)
+                .block();
+
+        String pageId = createdApplication.getPages().get(0).getId();
+
+        ActionDTO action = new ActionDTO();
+        action.setName("Public App Test action");
+        action.setPageId(pageId);
+        action.setDatasource(savedDatasource);
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        actionConfiguration.setHttpMethod(HttpMethod.GET);
+        action.setActionConfiguration(actionConfiguration);
+        layoutActionService.createSingleAction(action, Boolean.FALSE).block();
+
+        // Check datasource before making app public
+        PermissionGroup publicPermissionGroup =
+                permissionGroupService.getPublicPermissionGroup().block();
+
+        Datasource datasourceBeforePublicShare =
+                datasourceService.findById(savedDatasource.getId()).block();
+
+        Optional<Policy> policyBeforeOptional = datasourceBeforePublicShare.getPolicies().stream()
+                .filter(policy -> EXECUTE_DATASOURCES.getValue().equals(policy.getPermission()))
+                .findFirst();
+
+        Assertions.assertThat(policyBeforeOptional.isPresent()).isTrue();
+        Assertions.assertThat(policyBeforeOptional.get().getPermissionGroups())
+                .doesNotContain(publicPermissionGroup.getId());
+
+        // Make first application public
+        ApplicationAccessDTO applicationAccessDTO = new ApplicationAccessDTO();
+        applicationAccessDTO.setPublicAccess(true);
+        applicationService
+                .changeViewAccess(createdApplication.getId(), applicationAccessDTO)
+                .block();
+
+        Datasource datasourceAfterPublicShare =
+                datasourceService.findById(savedDatasource.getId()).block();
+
+        Optional<Policy> policyAfterOptional = datasourceAfterPublicShare.getPolicies().stream()
+                .filter(policy -> EXECUTE_DATASOURCES.getValue().equals(policy.getPermission()))
+                .findFirst();
+
+        Assertions.assertThat(policyAfterOptional.isPresent()).isTrue();
+        Assertions.assertThat(policyAfterOptional.get().getPermissionGroups()).contains(publicPermissionGroup.getId());
+
+        // Create a second app
+        Application application2 = new Application();
+        application2.setName("secondAppToMakePublic");
+
+        Application createdApplication2 = applicationPageService
+                .createApplication(application2, workspaceId)
+                .block();
+
+        String pageId2 = createdApplication2.getPages().get(0).getId();
+
+        ActionDTO action2 = new ActionDTO();
+        action2.setName("Public App Test action");
+        action2.setPageId(pageId2);
+        action2.setDatasource(savedDatasource);
+        ActionConfiguration actionConfiguration2 = new ActionConfiguration();
+        actionConfiguration2.setHttpMethod(HttpMethod.GET);
+        action2.setActionConfiguration(actionConfiguration2);
+        layoutActionService.createSingleAction(action2, Boolean.FALSE).block();
+
+        // Make second application public
+        ApplicationAccessDTO applicationAccessDTO2 = new ApplicationAccessDTO();
+        applicationAccessDTO2.setPublicAccess(true);
+        applicationService
+                .changeViewAccess(createdApplication2.getId(), applicationAccessDTO2)
+                .block();
+
+        // Now revoke public access from first app
+        applicationAccessDTO.setPublicAccess(false);
+        applicationService
+                .changeViewAccess(createdApplication.getId(), applicationAccessDTO)
+                .block();
+
+        // Check that datasource still has execute access
+        Datasource datasourceAfterRevokeOnePublicShare =
+                datasourceService.findById(savedDatasource.getId()).block();
+
+        Optional<Policy> policyAfterRevokeOneOptional = datasourceAfterRevokeOnePublicShare.getPolicies().stream()
+                .filter(policy -> EXECUTE_DATASOURCES.getValue().equals(policy.getPermission()))
+                .findFirst();
+
+        Assertions.assertThat(policyAfterRevokeOneOptional.isPresent()).isTrue();
+        Assertions.assertThat(policyAfterRevokeOneOptional.get().getPermissionGroups())
+                .contains(publicPermissionGroup.getId());
+
+        // Now revoke public access from second app
+        applicationAccessDTO2.setPublicAccess(false);
+        applicationService
+                .changeViewAccess(createdApplication2.getId(), applicationAccessDTO2)
+                .block();
+
+        // Check that datasource now does NOT have execute access
+        Datasource datasourceAfterRevokeAllPublicShare =
+                datasourceService.findById(savedDatasource.getId()).block();
+
+        Optional<Policy> policyAfterRevokeAllOptional = datasourceAfterRevokeAllPublicShare.getPolicies().stream()
+                .filter(policy -> EXECUTE_DATASOURCES.getValue().equals(policy.getPermission()))
+                .findFirst();
+
+        Assertions.assertThat(policyAfterRevokeAllOptional.isPresent()).isTrue();
+        Assertions.assertThat(policyAfterRevokeAllOptional.get().getPermissionGroups())
+                .doesNotContain(publicPermissionGroup.getId());
     }
 
     @Test


### PR DESCRIPTION
## Description
If two public apps used the same datasource, and access from one of them was revoked, the other public app also became unusable because datasource access gets revoked for the entire workspace. 

This PR selectively revokes datasource access only for those datasources that are being referred to in the current app, and nowhere else.

#### PR fixes following issue(s)
Fixes #25078 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [x] JUnit
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
