### PR TITLE
fix: Extend Forwarded header, if present

### DIFF
--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -19,6 +19,11 @@ map \$http_x_forwarded_host \$origin_host {
   '' \$host;
 }
 
+map \$http_forwarded \$final_forwarded {
+  default '\$http_forwarded, host=\$host;proto=\$scheme';
+  '' '';
+}
+
 # redirect log to stdout for supervisor to capture
 access_log /dev/stdout;
 
@@ -67,7 +72,8 @@ server {
   }
 
   proxy_set_header X-Forwarded-Proto \$origin_scheme;
-  proxy_set_header X-Forwarded-Host  \$origin_host;
+  proxy_set_header X-Forwarded-Host \$origin_host;
+  proxy_set_header Forwarded \$final_forwarded;
 
   location / {
     try_files /loading.html \$uri /index.html =404;

--- a/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-https.conf.template.sh
@@ -25,6 +25,11 @@ map \$http_x_forwarded_host \$origin_host {
   '' \$host;
 }
 
+map \$http_forwarded \$final_forwarded {
+  default '\$http_forwarded, host=\$host;proto=\$scheme';
+  '' '';
+}
+
 # redirect log to stdout for supervisor to capture
 access_log /dev/stdout;
 
@@ -70,6 +75,7 @@ server {
 
   proxy_set_header X-Forwarded-Proto \$origin_scheme;
   proxy_set_header X-Forwarded-Host \$origin_host;
+  proxy_set_header Forwarded \$final_forwarded;
 
   client_max_body_size 150m;
 


### PR DESCRIPTION
This is to fix OAuth redirect URI not being computed correctly, when deployed to CloudRun.

More details at http://sharats.me/drafts/story-of-a-forwarded-header.html.
