### PR TITLE
ci: Use cache from release image to build faster

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           declare -a args
           if [[ "${{ inputs.pr }}" != 0 ]]; then
-            args+=(--cache-from "${{ vars.DOCKER_HUB_ORGANIZATION }}/${{ vars.DOCKER_HUB_REPO }}:release")
+            args+=(--cache-from "${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:release")
           fi
           docker build -t cicontainer "${args[@]}" .
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -77,7 +77,11 @@ jobs:
         if: steps.run_result.outputs.run_result != 'success'
         working-directory: "."
         run: |
-          docker build -t cicontainer .
+          declare -a args
+          if [[ "${{ inputs.pr }}" != 0 ]]; then
+            args+=(--cache-from "${{ vars.DOCKER_HUB_ORGANIZATION }}/${{ vars.DOCKER_HUB_REPO }}:release")
+          fi
+          docker build -t cicontainer "${args[@]}" .
 
       # Saving the docker image to tar file
       - name: Save Docker image to tar file


### PR DESCRIPTION
This should enable using unchanged layers from the `release` image, as a cache, and build PR images faster. We only do this for images built for PRs and not for direct `release` or `master` branches.
