### PR TITLE
fix: Fix missing cloud services URL when env variable is empty

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -138,6 +138,10 @@ unset_unused_variables() {
     unset APPSMITH_RECAPTCHA_SECRET_KEY
     unset APPSMITH_RECAPTCHA_ENABLED
   fi
+
+  if [[ -z "${APPSMITH_CLOUD_SERVICES_BASE_URL-}" ]]; then
+    unset APPSMITH_CLOUD_SERVICES_BASE_URL
+  fi
 }
 
 check_mongodb_uri() {


### PR DESCRIPTION
When `APPSMITH_CLOUD_SERVICES_BASE_URL` is an empty string, Spring's interpolation in `application.properties` doesn't take the default value. This PR sets up the `entrypoint.sh` script so that it'll `unset` this env variable, when it's empty.
