### PR TITLE
chore: Graceful handling for empty CS URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN curl --silent --show-error --location https://www.mongodb.org/static/pgp/ser
   && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
   && curl --silent --show-error --location https://deb.nodesource.com/setup_16.x | bash - \
   && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
-  && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \ 
+  && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && apt-get install --no-install-recommends --yes mongodb-org=5.0.14 nodejs redis build-essential postgresql-13 \
   && apt-get clean \
@@ -53,7 +53,7 @@ ARG JAR_FILE=./app/server/dist/server-*.jar
 ARG PLUGIN_JARS=./app/server/dist/plugins/*.jar
 
 ARG APPSMITH_CLOUD_SERVICES_BASE_URL
-#ENV APPSMITH_CLOUD_SERVICES_BASE_URL=${APPSMITH_CLOUD_SERVICES_BASE_URL}
+ENV APPSMITH_CLOUD_SERVICES_BASE_URL=${APPSMITH_CLOUD_SERVICES_BASE_URL}
 
 ARG APPSMITH_SEGMENT_CE_KEY
 ENV APPSMITH_SEGMENT_CE_KEY=${APPSMITH_SEGMENT_CE_KEY}

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CloudServicesConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CloudServicesConfig.java
@@ -1,18 +1,24 @@
 package com.appsmith.server.configurations;
 
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @Getter
 public class CloudServicesConfig {
-    @Value("${appsmith.cloud_services.base_url}")
-    String baseUrl;
+    private String baseUrl;
 
     @Value("${appsmith.cloud_services.username}")
     private String username;
 
     @Value("${appsmith.cloud_services.password}")
     private String password;
+
+    @Autowired
+    public void setBaseUrl(@Value("${appsmith.cloud_services.base_url:}") String value) {
+        baseUrl = StringUtils.isEmpty(value) ? "https://cs.appsmith.com" : value;
+    }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SharedConfigImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SharedConfigImpl.java
@@ -1,12 +1,14 @@
 package com.appsmith.server.configurations;
 
 import com.appsmith.external.services.SharedConfig;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class SharedConfigImpl implements SharedConfig {
 
     @Value("${appsmith.codec.max-in-memory-size:10}")
@@ -15,8 +17,7 @@ public class SharedConfigImpl implements SharedConfig {
     @Value("${appsmith.plugin.response.size.max:5}")
     private float maxPluginResponseSize = 5;
 
-    @Value("${appsmith.cloud_services.base_url}")
-    private String cloudServicesBaseUrl;
+    private final CloudServicesConfig cloudServicesConfig;
 
     @Override
     public int getCodecSize() {
@@ -30,6 +31,6 @@ public class SharedConfigImpl implements SharedConfig {
 
     @Override
     public String getRemoteExecutionUrl() {
-        return cloudServicesBaseUrl + "/api/v1/actions/execute";
+        return cloudServicesConfig.getBaseUrl() + "/api/v1/actions/execute";
     }
 }

--- a/app/server/appsmith-server/src/main/resources/application.properties
+++ b/app/server/appsmith-server/src/main/resources/application.properties
@@ -76,7 +76,7 @@ admin.emails = ${APPSMITH_ADMIN_EMAILS:}
 emails.welcome.enabled = ${APPSMITH_EMAILS_WELCOME_ENABLED:true}
 
 # Appsmith Cloud Services
-appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:https://cs.appsmith.com}
+appsmith.cloud_services.base_url = ${APPSMITH_CLOUD_SERVICES_BASE_URL:}
 appsmith.cloud_services.username = ${APPSMITH_CLOUD_SERVICES_USERNAME:}
 appsmith.cloud_services.password = ${APPSMITH_CLOUD_SERVICES_PASSWORD:}
 github_repo = ${APPSMITH_GITHUB_REPO:}

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -138,10 +138,6 @@ unset_unused_variables() {
     unset APPSMITH_RECAPTCHA_SECRET_KEY
     unset APPSMITH_RECAPTCHA_ENABLED
   fi
-
-  if [[ -z "${APPSMITH_CLOUD_SERVICES_BASE_URL-}" ]]; then
-    unset APPSMITH_CLOUD_SERVICES_BASE_URL
-  fi
 }
 
 check_mongodb_uri() {


### PR DESCRIPTION
This will allow us to

1. Bake different CS URLs for release and master builds.
2. Be resilient to the CS URL being set to empty string, as opposed to not being set at all.
