### PR TITLE
ci: Default to release CS unless building for prod

### DIFF
--- a/.github/workflows/ad-hoc-deploy-preview.yml
+++ b/.github/workflows/ad-hoc-deploy-preview.yml
@@ -43,7 +43,7 @@ jobs:
   #                                                                 }
   #                                                               )'
   #         #TODO Add mongo URI as secret
-            
+
   server-build:
     name: server-build
     uses: ./.github/workflows/server-build.yml
@@ -145,6 +145,8 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           repository: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp
           tags: ${{ github.event.inputs.sub-domain-name }}
+          build-args: |
+            APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com
     outputs:
       imageHash: ${{ github.event.inputs.sub-domain-name }}
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -81,6 +81,9 @@ jobs:
           if [[ "${{ inputs.pr }}" != 0 ]]; then
             args+=(--cache-from "${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:release")
           fi
+          if [[ "${{ inputs.pr }}" != 0 || "${{ github.ref_name }}" != master ]]; then
+            args+=(--build-arg "APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com")
+          fi
           docker build -t cicontainer "${args[@]}" .
 
       # Saving the docker image to tar file

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -174,6 +174,8 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           repository: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp
           tags: ce-${{ github.event.client_payload.pull_request.number }}
+          build-args: |
+            APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com
     outputs:
       imageHash: ce-${{ github.event.client_payload.pull_request.number }}
 

--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -200,6 +200,7 @@ jobs:
           platforms: linux/arm64,linux/amd64
           build-args: |
             APPSMITH_SEGMENT_CE_KEY=${{ secrets.APPSMITH_SEGMENT_CE_KEY_RELEASE }}
+            APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com
           tags: |
             ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-ce:release
 


### PR DESCRIPTION
When running Appsmith release image, it's currently using production CS, which is causing a lot of incompatibility related errors since `release` moves much faster than prod.

This changes this. Note that for `:latest` and `:nightly` images, we do NOT change this default. There's no change for Docker images with those tags. We _only_ want change `:release` image, DP images, and images built for Cypress runs.
