### PR TITLE
ci: Update docker/build-push-action to v4

### DIFF
--- a/.github/workflows/ad-hoc-deploy-preview.yml
+++ b/.github/workflows/ad-hoc-deploy-preview.yml
@@ -91,8 +91,6 @@ jobs:
       #                                                               }
       #                                                             }
       #                                                           )'
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
 
       # Check out merge commit
       - name: Checkout PR
@@ -138,15 +136,24 @@ jobs:
           echo "Cleaning up the tar files"
           rm app/client/packages/rts/dist/rts-dist.tar
 
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp
-          tags: ${{ github.event.inputs.sub-domain-name }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          pull: true
+          push: true
+          cache-from: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:release
+          tags: |
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp:${{ github.event.inputs.sub-domain-name }}
           build-args: |
             APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com
+
     outputs:
       imageHash: ${{ github.event.inputs.sub-domain-name }}
 
@@ -178,8 +185,6 @@ jobs:
                                                                 #    }
                                                                 #  }
                                                             #    )'
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
       - name: Checkout PR
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -120,9 +120,6 @@ jobs:
     if: success()
     steps:
 
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
-
       # Check out merge commit
       - name: Checkout PR
         uses: actions/checkout@v3
@@ -167,15 +164,24 @@ jobs:
           echo "Cleaning up the tar files"
           rm app/client/packages/rts/dist/rts-dist.tar
 
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp
-          tags: ce-${{ github.event.client_payload.pull_request.number }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          pull: true
+          push: true
+          cache-from: ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-${{ vars.EDITION }}:release
+          tags: |
+            ${{ vars.DOCKER_HUB_ORGANIZATION }}/appsmith-dp:${{ vars.EDITION }}-${{ github.event.client_payload.pull_request.number }}
           build-args: |
             APPSMITH_CLOUD_SERVICES_BASE_URL=https://release-cs.appsmith.com
+
     outputs:
       imageHash: ce-${{ github.event.client_payload.pull_request.number }}
 


### PR DESCRIPTION
The currently used `v1` is deprecated, and not recommended anymore. The `v4` changes a few things. Some details are in the following pages:

1. https://github.com/docker/build-push-action/blob/v2/UPGRADE.md
2. https://github.com/docker/build-push-action/blob/4fad532b9fdbfb80f436784834374a1c11834153/README.md#customizing

Essentially, in the current code, `build-args` isn't working. This should fix that.
