### PR TITLE
fix: Removed learn more link for Aug 6 downtime message

### DIFF
--- a/app/server/appsmith-server/src/main/resources/productAlerts/productAlertMessages.json
+++ b/app/server/appsmith-server/src/main/resources/productAlerts/productAlertMessages.json
@@ -25,7 +25,6 @@
                 "messageId": "3",
                 "title": "Appsmith Cloud at app.appsmith.com will be down for 45 minutes at 5 AM UTC on Sunday, August 6, 2023.",
                 "message": "Appsmith Cloud will go through a scheduled upgrade to make it performant and scalable to all of you. This will take roughly 45 minutes at 5 AM UTC on Sunday, August 6, 2023. We will let you know when it comes back online on Discord.",
-                "learnMoreLink": "https://www.mongodb.com/docs/manual/release-notes/5.0-upgrade-replica-set",
                 "canDismiss": true,
                 "remindLaterDays": 5,
                 "context": "COMMON_CONFIG",


### PR DESCRIPTION
<img width="1476" alt="Screenshot 2023-08-01 at 8 02 18 PM" src="https://github.com/appsmithorg/appsmith/assets/5298848/fe6bd4be-9753-4609-8370-4d5fb71f175e">

Removes learn more link for Aug 6 downtime message.
