### PR TITLE
test: Cypress | Uncomment EE-Pin check in InputTruncateCheck_Spec.ts

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/InputTruncateCheck_Spec.ts
@@ -93,7 +93,7 @@ Object.entries(widgetsToTest).forEach(([widgetSelector, testConfig], index) => {
       if (index === 0) {
         configureApi();
       }
-      // entityExplorer.PinUnpinEntityExplorer(false);
+      entityExplorer.PinUnpinEntityExplorer(false);
       entityExplorer.DragDropWidgetNVerify(widgetSelector, 300, 200);
       entityExplorer.DragDropWidgetNVerify(draggableWidgets.BUTTON, 400, 400);
       //entityExplorer.SelectEntityByName(draggableWidgets.BUTTONNAME("1"));
@@ -110,7 +110,7 @@ Object.entries(widgetsToTest).forEach(([widgetSelector, testConfig], index) => {
         PROPERTY_SELECTOR.TextFieldName,
         `{{appsmith.store.textPayloadOnSubmit}}`,
       );
-      // entityExplorer.PinUnpinEntityExplorer(true);
+      entityExplorer.PinUnpinEntityExplorer(true);
     });
 
     it("2. StoreValue should have complete input value", () => {


### PR DESCRIPTION
## Description
- This PR uncomments the PinUnpinEntityExplorer() check in InputTruncateCheck_Spec.ts - as it is handled now to click on EE pin based on its presence in the application in this [PR](https://github.com/appsmithorg/appsmith/pull/25901/files#diff-491bdd1b772e351aca1199411640be4a848e84646253ddc249b7daad57bbbf1b) & merged to release.
- This PR is revert of [this PR change](https://github.com/appsmithorg/appsmith/pull/25919)