### PR TITLE
chore: Add info.json to Docker images

### DIFF
--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -164,6 +164,9 @@ jobs:
           echo "Cleaning up the tar files"
           rm app/client/packages/rts/dist/rts-dist.tar
 
+      - name: Generate info.json
+        run: scripts/generate_info_json.sh
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ COPY ./deploy/docker/templates/nginx/* \
   templates/
 
 # Add bootstrapfile
-COPY ./deploy/docker/entrypoint.sh ./deploy/docker/scripts/* ./
+COPY ./deploy/docker/entrypoint.sh ./deploy/docker/scripts/* info.*json ./
 
 # Add util tools
 COPY ./deploy/docker/utils ./utils

--- a/scripts/generate_info_json.sh
+++ b/scripts/generate_info_json.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+commit_sha="$(git rev-parse HEAD)"
+
+base_url="$(git remote get-url origin | sed 's,^git@github\.com:,https://github.com/,; s/\.git$//')"
+
+jq -n \
+  --arg commitSha "$commit_sha" \
+  --arg commitUrl "$base_url/commit/$commit_sha" \
+  --arg branch "$(git rev-parse --abbrev-ref HEAD)" \
+  --arg date "$(date -u -Iseconds)" \
+  --argjson isCI "${CI:-false}" \
+  '$ARGS.named' | tee "$(git rev-parse --show-toplevel)/info.json"


### PR DESCRIPTION
This adds a `/opt/appsmith/info.json` file to Docker images, with the following sample content:

```json
{
  "commitSha": "0521ba2c0d7a62cef3d4def66fc15b59cc34ceef",
  "commitUrl": "https://github.com/appsmithorg/appsmith/commit/0521ba2c0d7a62cef3d4def66fc15b59cc34ceef",
  "branch": "release",
  "date": "2023-08-02T12:52:53+00:00",
  "isCI": false
}
```

We're enabling this only for images built for DPs currently, and will then extend to other workflows as well.

Notice that we copy `info.*json` instead of `info.json`. The reason is so that the Docker build doesn't fail, even if the `info.json` file doesn't exist. This lets us publish this to each workflow in turn, slowly and carefully.

[Relevant Slack conversation](https://theappsmith.slack.com/archives/C02MUD8DNUR/p1686197957141419).
