### PR TITLE
fix: moved the logic of highlight walkthrough to widget boundary

### DIFF
--- a/app/client/src/components/editorComponents/WidgetComponentBoundary.tsx
+++ b/app/client/src/components/editorComponents/WidgetComponentBoundary.tsx
@@ -1,7 +1,9 @@
-import { WIDGET_COMPONENT_BOUNDARY_CLASS } from "constants/componentClassNameConstants";
 import type { ReactNode } from "react";
-import React from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
+
+import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
+import { WIDGET_COMPONENT_BOUNDARY_CLASS } from "constants/componentClassNameConstants";
 
 type Props = { children: ReactNode; widgetType: string };
 
@@ -11,8 +13,24 @@ const WidgetComponentBoundaryWrapper = styled.div`
 `;
 
 function WidgetComponentBoundary(props: Props) {
+  const { isOpened: isWalkthroughOpened, popFeature } =
+    useContext(WalkthroughContext) || {};
+
+  const closeWalkthrough = () => {
+    if (isWalkthroughOpened && popFeature) {
+      popFeature("WIDGET_CONTAINER");
+    }
+  };
+
+  const onClickHandler = () => {
+    closeWalkthrough();
+  };
+
   return (
-    <WidgetComponentBoundaryWrapper className={WIDGET_COMPONENT_BOUNDARY_CLASS}>
+    <WidgetComponentBoundaryWrapper
+      className={WIDGET_COMPONENT_BOUNDARY_CLASS}
+      onClick={onClickHandler}
+    >
       {props.children}
     </WidgetComponentBoundaryWrapper>
   );

--- a/app/client/src/widgets/ContainerWidget/component/index.tsx
+++ b/app/client/src/widgets/ContainerWidget/component/index.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import type {
   MouseEventHandler,
   PropsWithChildren,
@@ -18,7 +17,6 @@ import { useSelector } from "react-redux";
 import { getCurrentAppPositioningType } from "selectors/editorSelectors";
 import { AppPositioningTypes } from "reducers/entityReducers/pageListReducer";
 import { MAIN_CONTAINER_WIDGET_ID } from "constants/WidgetConstants";
-import WalkthroughContext from "components/featureWalkthrough/walkthroughContext";
 
 const StyledContainerComponent = styled.div<
   Omit<ContainerWrapperProps, "widgetId">
@@ -61,8 +59,6 @@ function ContainerComponentWrapper(
 ) {
   const containerRef: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
   const appPositioningType = useSelector(getCurrentAppPositioningType);
-  const { isOpened: isWalkthroughOpened, popFeature } =
-    useContext(WalkthroughContext) || {};
 
   useEffect(() => {
     if (!props.shouldScrollContents) {
@@ -121,17 +117,6 @@ function ContainerComponentWrapper(
     [props.onClickCapture],
   );
 
-  const closeWalkthrough = () => {
-    if (isWalkthroughOpened && popFeature) {
-      popFeature("WIDGET_CONTAINER");
-    }
-  };
-
-  const onClickHandler = (event: any) => {
-    closeWalkthrough();
-    if (props.onClick) props.onClick(event);
-  };
-
   return (
     <StyledContainerComponent
       // Before you remove: generateClassName is used for bounding the resizables within this canvas
@@ -148,7 +133,7 @@ function ContainerComponentWrapper(
       }`}
       data-widgetId={props.widgetId}
       dropDisabled={props.dropDisabled}
-      onClick={onClickHandler}
+      onClick={props.onClick}
       onClickCapture={props.onClickCapture}
       onMouseOver={onMouseOver}
       ref={containerRef}

--- a/app/client/src/widgets/WidgetUtils.ts
+++ b/app/client/src/widgets/WidgetUtils.ts
@@ -920,6 +920,10 @@ export const checkForOnClick = (e: React.MouseEvent<HTMLElement>) => {
     target &&
     target !== currentTarget
   ) {
+    /**
+     * NOTE: target.__reactProps$ returns undefined in cypress, therefore the below targetReactProps will be null.
+     * Due to this the traversed target element's react props such as onClick will get ignored.
+     **/
     const targetReactProps = findReactInstanceProps(target);
 
     const hasOnClickableEvent = Boolean(


### PR DESCRIPTION
## Description
This PR moves the logic of closing the highlight walkthrough to the widget boundary component. This allows us to retain the closure of walkthrough as well as retain the onItemClick event functionality of list widget.

#### PR fixes following issue(s)
Fixes #25941

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
    - should test that `onItemClick` event works when clicked on the blank space of the list item
    - should test that highlight walkthrough get closed when clicked on the widget.
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
