### PR TITLE
fix: added expression to not include message after cutoff date using curre…

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/CommonConfig.java
@@ -19,6 +19,7 @@ import org.springframework.util.StringUtils;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -144,5 +145,9 @@ public class CommonConfig {
 
     public boolean isConnectedMongoVersionAvailable() {
         return mongoDBVersion != null;
+    }
+
+    public Long getCurrentTimeInstantEpochMilli() {
+        return Instant.now().toEpochMilli();
     }
 }

--- a/app/server/appsmith-server/src/main/resources/productAlerts/productAlertMessages.json
+++ b/app/server/appsmith-server/src/main/resources/productAlerts/productAlertMessages.json
@@ -28,7 +28,7 @@
                 "canDismiss": true,
                 "remindLaterDays": 5,
                 "context": "COMMON_CONFIG",
-                "applicabilityExpression": "isCloudHosting",
+                "applicabilityExpression": "isCloudHosting && (getCurrentTimeInstantEpochMilli < 1691300700000L)",
                 "precedenceIndex": 3
         }
 ]

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ProductAlertServiceCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/ProductAlertServiceCEImplTest.java
@@ -65,9 +65,24 @@ public class ProductAlertServiceCEImplTest {
     }
 
     @Test
-    public void getSingleApplicableMessage_cloudInstance_success() {
+    public void getSingleApplicableMessage_cloudInstance_precutOffDate() {
         ProductAlertServiceCE productAlertServiceCE = new ProductAlertServiceCEImpl(mapper, commonConfig);
         Mockito.when(commonConfig.isCloudHosting()).thenReturn(true);
+        Mockito.when(commonConfig.getCurrentTimeInstantEpochMilli()).thenReturn(1691127900000L);
+        Mono<List<ProductAlertResponseDTO>> productAlertResponseDTOMono =
+                productAlertServiceCE.getSingleApplicableMessage();
+        StepVerifier.create(productAlertResponseDTOMono)
+                .assertNext(productAlertResponseDTOs -> {
+                    assertThat(productAlertResponseDTOs.get(0).getMessageId()).isEqualTo(messages[2].getMessageId());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    public void getSingleApplicableMessage_cloudInstance_postcutOffDate() {
+        ProductAlertServiceCE productAlertServiceCE = new ProductAlertServiceCEImpl(mapper, commonConfig);
+        Mockito.when(commonConfig.isCloudHosting()).thenReturn(true);
+        Mockito.when(commonConfig.getCurrentTimeInstantEpochMilli()).thenReturn(1691473500000L);
         Mono<List<ProductAlertResponseDTO>> productAlertResponseDTOMono =
                 productAlertServiceCE.getSingleApplicableMessage();
         StepVerifier.create(productAlertResponseDTOMono)

--- a/app/server/appsmith-server/src/test/resources/productAlerts/productAlertMessages.json
+++ b/app/server/appsmith-server/src/test/resources/productAlerts/productAlertMessages.json
@@ -17,6 +17,16 @@
     "remindLaterDays": 5,
     "context": "STATIC",
     "applicabilityExpression": "true",
-    "precedenceIndex": 1
+    "precedenceIndex": 3
+  },
+  {
+    "messageId": "3",
+    "title": "alert3",
+    "learnMoreLink": "learnmorelink2",
+    "canDismiss": true,
+    "remindLaterDays": 5,
+    "context": "COMMON_CONFIG",
+    "applicabilityExpression": "isCloudHosting && (getCurrentTimeInstantEpochMilli < 1691300700000L)",
+    "precedenceIndex": 2
   }
 ]


### PR DESCRIPTION
## Description
> Remove cloud instance maintenance message after the cutoff time
#### PR fixes following issue(s)
Fixes #26047
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
## Testing
>
#### How Has This Been Tested?
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Covered in unit tests
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
