### PR TITLE
fix: adding loading state on remote branch switching

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/GitBugs_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/GitBugs_Spec.ts
@@ -137,7 +137,12 @@ describe("Git Bugs", function () {
     });
   });
 
-  it("6. Bug 24920: Not able to discard app settings changes for the first time in git connected app ", function () {
+  it("6. Bug 24486 : Loading state for remote branches", function () {
+    _.gitSync.CreateRemoteBranch(repoName, "test-24486");
+    _.gitSync.SwitchGitBranch("origin/test-24486", false, true);
+  });
+
+  it("7. Bug 24920: Not able to discard app settings changes for the first time in git connected app ", function () {
     // add navigation settings changes
     _.agHelper.GetNClick(_.appSettings.locators._appSettings);
     _.agHelper.GetNClick(_.appSettings.locators._navigationSettingsTab);
@@ -150,7 +155,7 @@ describe("Git Bugs", function () {
     _.gitSync.VerifyChangeLog(false);
   });
 
-  it("7. Bug 23858 : Branch list in git sync modal is not scrollable", function () {
+  it("8. Bug 23858 : Branch list in git sync modal is not scrollable", function () {
     // create git branches
     _.gitSync.CreateGitBranch(tempBranch1, true);
     _.gitSync.CreateGitBranch(tempBranch2, true);
@@ -168,7 +173,7 @@ describe("Git Bugs", function () {
     _.agHelper.GetNClick(_.gitSync._dropdownmenu, 5);
     _.gitSync.CloseGitSyncModal();
   });
-  it("8. Bug 24206 : Open repository button is not functional in git sync modal", function () {
+  it("9. Bug 24206 : Open repository button is not functional in git sync modal", function () {
     _.gitSync.SwitchGitBranch("master");
     _.appSettings.OpenPaneAndChangeTheme("Moon");
     _.gitSync.CommitAndPush();

--- a/app/client/src/pages/Editor/gitSync/components/BranchListItem.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/BranchListItem.tsx
@@ -8,6 +8,14 @@ import { Tooltip, Text, Spinner } from "design-system";
 import { isEllipsisActive } from "utils/helpers";
 import { useSelector } from "react-redux";
 import { getBranchSwitchingDetails } from "selectors/gitSyncSelectors";
+import styled from "styled-components";
+
+const OptionsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+`;
 
 export function BranchListItem({
   active,
@@ -64,18 +72,20 @@ export function BranchListItem({
             {branch}
           </Text>
           {isDefault && <DefaultTag />}
-          {switchingToBranch === branch && isSwitchingBranch && (
-            <Spinner size="md" />
-          )}
         </span>
       </Tooltip>
-      {(hover || isMoreMenuOpen) && (
-        <BranchMoreMenu
-          branchName={branch}
-          open={isMoreMenuOpen}
-          setOpen={setIsMoreMenuOpen}
-        />
-      )}
+      <OptionsContainer>
+        {switchingToBranch === branch && isSwitchingBranch && (
+          <Spinner size="md" />
+        )}
+        {(hover || isMoreMenuOpen) && (
+          <BranchMoreMenu
+            branchName={branch}
+            open={isMoreMenuOpen}
+            setOpen={setIsMoreMenuOpen}
+          />
+        )}
+      </OptionsContainer>
     </BranchListItemContainer>
   );
 }

--- a/app/client/src/pages/Editor/gitSync/components/RemoteBranchListItem.tsx
+++ b/app/client/src/pages/Editor/gitSync/components/RemoteBranchListItem.tsx
@@ -1,11 +1,24 @@
 import React from "react";
-import { Tooltip } from "design-system";
+import { Spinner, Tooltip } from "design-system";
 import { isEllipsisActive } from "utils/helpers";
 import { Text, TextType } from "design-system-old";
 import { BranchListItemContainer } from "./BranchListItemContainer";
+import { useSelector } from "react-redux";
+import { getBranchSwitchingDetails } from "selectors/gitSyncSelectors";
+import styled from "styled-components";
+
+const OptionsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+`;
 
 export function RemoteBranchListItem({ branch, className, onClick }: any) {
   const textRef = React.useRef<HTMLSpanElement>(null);
+  const { isSwitchingBranch, switchingToBranch } = useSelector(
+    getBranchSwitchingDetails,
+  );
   return (
     <BranchListItemContainer
       active={false}
@@ -35,6 +48,11 @@ export function RemoteBranchListItem({ branch, className, onClick }: any) {
           {branch}
         </Text>
       </Tooltip>
+      <OptionsContainer>
+        {switchingToBranch === branch && isSwitchingBranch && (
+          <Spinner size="md" />
+        )}
+      </OptionsContainer>
     </BranchListItemContainer>
   );
 }


### PR DESCRIPTION
## Description
adds loading state when checking out to a remote branch

#### PR fixes following issue(s)
Fixes #25591 

#### Media
<img width="981" alt="image" src="https://github.com/appsmithorg/appsmith/assets/8724051/28fbef49-6da8-499d-b153-f4391ddf393c">


#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
