### PR TITLE
fix: open data section, collapse other section if walkthru opened for widget

### DIFF
--- a/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
@@ -17,6 +17,8 @@ import { getPropertySectionState } from "selectors/editorContextSelectors";
 import { getCurrentWidgetId } from "selectors/propertyPaneSelectors";
 import { setPropertySectionState } from "actions/propertyPaneActions";
 import { getIsOneClickBindingOptionsVisibility } from "selectors/oneClickBindingSelectors";
+import localStorage from "utils/localStorage";
+import { WIDGET_ID_SHOW_WALKTHROUGH } from "constants/WidgetConstants";
 
 const TagContainer = styled.div``;
 
@@ -139,6 +141,25 @@ export const PropertySection = memo((props: PropertySectionProps) => {
 
     setIsOpen(initialIsOpenState);
   }, [isContextOpen, isSearchResult, isDefaultOpen]);
+
+  // If the walkthrough is opened for widget Id, then only open the data section of property pane and collapse other sections.
+  const enableDataSectionOnly = async () => {
+    const widgetId: string | null = await localStorage.getItem(
+      WIDGET_ID_SHOW_WALKTHROUGH,
+    );
+
+    if (widgetId) {
+      if (className === "data") {
+        setIsOpen(true);
+      } else {
+        setIsOpen(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    enableDataSectionOnly();
+  }, []);
 
   if (!currentWidgetId) return null;
 


### PR DESCRIPTION
## Description
The property pane for this specific widget will only have the data section expanded if the walkthrough is launched for a specific widget after the API action result has been bound to any widget through new binding UI. This will happen for :
- new users
- users having feature flag `ab_ds_binding_enabled` value true
- when the user clicks on binding widget through suggested or sniping mode from right side pane of the action editor

`when all the above conditions meet`

figma link : https://www.figma.com/file/kbU9xPv44neCfv1FFo9Ndu/User-Activation?type=design&node-id=1149-74041&mode=design&t=sqLQ7DgClGfR31l9-4

#### PR fixes following issue(s)
Fixes #25419

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
