### PR TITLE
chore: Add `X-Content-Type-Options` to all downstream responses

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -152,7 +152,7 @@ public class SecurityConfig {
                 .disable()
                 .addFilterAt(new CSRFFilter(), SecurityWebFiltersOrder.CSRF)
                 // Default security headers configuration from
-                // https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/headers.html.
+                // https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/headers.html
                 .headers()
                 .contentTypeOptions()
                 .disable()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -151,6 +151,14 @@ public class SecurityConfig {
                 .csrf()
                 .disable()
                 .addFilterAt(new CSRFFilter(), SecurityWebFiltersOrder.CSRF)
+                // Default security headers configuration from
+                // https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/headers.html.
+                .headers()
+                .contentTypeOptions()
+                .disable()
+                .frameOptions()
+                .disable()
+                .and()
                 .anonymous()
                 .principal(createAnonymousUser())
                 .and()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/SecurityConfig.java
@@ -154,8 +154,10 @@ public class SecurityConfig {
                 // Default security headers configuration from
                 // https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/headers.html
                 .headers()
+                // Disabled here because add it in NGINX instead.
                 .contentTypeOptions()
                 .disable()
+                // Disabled because we use CSP's `frame-ancestors` instead.
                 .frameOptions()
                 .disable()
                 .and()

--- a/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
+++ b/deploy/docker/templates/nginx/nginx-app-http.conf.template.sh
@@ -8,6 +8,11 @@ if [[ -z $CUSTOM_DOMAIN ]]; then
   CUSTOM_DOMAIN=_
 fi
 
+additional_downstream_headers='
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+add_header X-Content-Type-Options "nosniff";
+'
+
 cat <<EOF
 map \$http_x_forwarded_proto \$origin_scheme {
   default \$http_x_forwarded_proto;
@@ -44,6 +49,8 @@ server {
 
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
   add_header Content-Security-Policy "frame-ancestors ${APPSMITH_ALLOWED_FRAME_ANCESTORS-'self' *}";
+
+  $additional_downstream_headers
 
   location /.well-known/acme-challenge/ {
     root /appsmith-stacks/data/certificate/certbot;
@@ -82,6 +89,7 @@ server {
   location ~ ^/static/(js|css|media)\b {
     # Files in these folders are hashed, so we can set a long cache time.
     add_header Cache-Control "max-age=31104000, immutable";  # 360 days
+    $additional_downstream_headers
     access_log  off;
   }
 


### PR DESCRIPTION
So far, only calls that go to the Java backend, had the `X-Content-Type-Options` header in the responses. This PR adds them to all responses by

1. adding it to NGINX configuration.
2. removing it from Spring security's configuration, so we don't end up with _two_ `X-Content-Type-Options` headers in the response.
