### PR TITLE
fix: Fix uqi query switching issue

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25982_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug25982_Spec.ts
@@ -1,0 +1,31 @@
+import { ObjectsRegistry } from "../../../../support/Objects/Registry";
+
+const dataSources = ObjectsRegistry.DataSources,
+  agHelper = ObjectsRegistry.AggregateHelper,
+  ee = ObjectsRegistry.EntityExplorer;
+
+describe("Fix UQI query switching", function () {
+  it("The command of the query must be preserved and should not default to initial value after changed.", function () {
+    dataSources.NavigateToDSCreateNew();
+    dataSources.CreateDataSource("Mongo", false, false);
+    dataSources.CreateQueryAfterDSSaved("", "MongoQuery");
+    dataSources.ValidateNSelectDropdown(
+      "Commands",
+      "Find document(s)",
+      "Insert document(s)",
+    );
+    dataSources.NavigateToDSCreateNew();
+    dataSources.CreateDataSource("S3", false, false);
+    dataSources.CreateQueryAfterDSSaved("", "S3Query");
+    dataSources.ValidateNSelectDropdown(
+      "Commands",
+      "List files in bucket",
+      "Create a new file",
+    );
+    ee.SelectEntityByName("MongoQuery", "Queries/JS");
+    dataSources.ValidateNSelectDropdown("Commands", "Insert document(s)");
+
+    ee.SelectEntityByName("S3Query", "Queries/JS");
+    dataSources.ValidateNSelectDropdown("Commands", "Create a new file");
+  });
+});

--- a/app/client/src/components/formControls/DropDownControl.tsx
+++ b/app/client/src/components/formControls/DropDownControl.tsx
@@ -201,13 +201,8 @@ function renderDropdown(
       });
 
       if (selectedValue !== tempSelectedValues) {
-        // when pre-selected value is not found in dropdown options,
-        // initializing dropdown to initial value instead of blank
-        const tempValues = !isNil(props?.initialValue)
-          ? (props.initialValue as string[])
-          : tempSelectedValues;
-        selectedValue = tempValues;
-        props.input?.onChange(tempValues);
+        selectedValue = tempSelectedValues;
+        props.input?.onChange(tempSelectedValues);
       }
 
       const isOptionDynamic = options.some((opt) => "disabled" in opt);


### PR DESCRIPTION
Whenever a switch is made between two UQI queries, the command default to the initial value even if the user had previously selected a value. This PR fixes that issue.


Fixes #25982 
Fixes #25088 

- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
