### PR TITLE
fix: WDS `fgAccent` for achromatic seeds (dark mode)

### DIFF
--- a/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
@@ -599,7 +599,7 @@ export class DarkModeTheme implements ColorModeTheme {
         color.oklch.c = 0;
       }
 
-      if (this.seedIsAchromatic) {
+      if (!this.seedIsAchromatic) {
         color.oklch.c = 0.136;
       }
     }


### PR DESCRIPTION
Fixes #26145 