### PR TITLE
test: Cypress | CI Stabilize

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Debugger/Widget_property_navigation_spec.ts
@@ -2,8 +2,8 @@ import * as _ from "../../../../support/Objects/ObjectsCore";
 import OneClickBindingLocator from "../../../../locators/OneClickBindingLocator";
 
 describe("excludeForAirgap", "Widget property navigation", () => {
-  it("Collapsed field navigation", () => {
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.AUDIO, 100, 200);
+  it("1. Collapsed field navigation", () => {
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.AUDIO);
     _.propPane.EnterJSContext("animateloading", "{{test}}", true, false);
     _.debuggerHelper.AssertErrorCount(1);
     _.propPane.ToggleSection("general");
@@ -16,8 +16,8 @@ describe("excludeForAirgap", "Widget property navigation", () => {
     _.debuggerHelper.CloseBottomBar();
   });
 
-  it("Navigation to a nested panel", () => {
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TAB, 100, 200);
+  it("2. Navigation to a nested panel", () => {
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TAB);
     _.propPane.OpenTableColumnSettings("tab2");
     _.propPane.EnterJSContext("visible", "{{test}}", true, false);
     _.debuggerHelper.AssertErrorCount(1);
@@ -31,12 +31,9 @@ describe("excludeForAirgap", "Widget property navigation", () => {
     _.entityExplorer.SelectEntityByName("Tabs1");
     _.entityExplorer.DeleteWidgetFromEntityExplorer("Tabs1");
   });
-  it("Navigation to style tab in a nested panel", () => {
-    _.entityExplorer.DragDropWidgetNVerify(
-      _.draggableWidgets.BUTTON_GROUP,
-      100,
-      200,
-    );
+
+  it("3. Navigation to style tab in a nested panel", () => {
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.BUTTON_GROUP);
     _.propPane.OpenTableColumnSettings("groupButton2");
     _.agHelper.GetNClick(_.propPane._segmentedControl("MENU"));
     _.agHelper.GetNClick(_.propPane._addMenuItem);
@@ -55,12 +52,9 @@ describe("excludeForAirgap", "Widget property navigation", () => {
     _.entityExplorer.SelectEntityByName("ButtonGroup1");
     _.entityExplorer.DeleteWidgetFromEntityExplorer("ButtonGroup1");
   });
-  it("Collapsed field navigation for a nested panel", () => {
-    _.entityExplorer.DragDropWidgetNVerify(
-      _.draggableWidgets.MENUBUTTON,
-      100,
-      200,
-    );
+
+  it("4. Collapsed field navigation for a nested panel", () => {
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.MENUBUTTON);
     _.propPane.OpenTableColumnSettings("menuItem2");
     _.propPane.EnterJSContext("disabled", "{{test}}", true, false);
     _.propPane.ToggleSection("general");
@@ -70,6 +64,7 @@ describe("excludeForAirgap", "Widget property navigation", () => {
     _.debuggerHelper.ClickDebuggerIcon();
     _.debuggerHelper.ClicklogEntityLink();
     _.agHelper.GetElement(_.propPane._paneTitle).contains("Second Menu Item");
+    _.agHelper.Sleep();
     _.propPane.AssertIfPropertyIsVisible("disabled");
 
     _.debuggerHelper.CloseBottomBar();
@@ -77,12 +72,8 @@ describe("excludeForAirgap", "Widget property navigation", () => {
     _.entityExplorer.DeleteWidgetFromEntityExplorer("MenuButton1");
   });
 
-  it("JSONForm widget error navigation", () => {
-    _.entityExplorer.DragDropWidgetNVerify(
-      _.draggableWidgets.JSONFORM,
-      100,
-      200,
-    );
+  it("5. JSONForm widget error navigation", () => {
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.JSONFORM);
     _.propPane.OpenTableColumnSettings("date_of_birth");
 
     _.agHelper.SelectDropdownList("Field Type", "Object");
@@ -116,13 +107,9 @@ describe("excludeForAirgap", "Widget property navigation", () => {
     _.entityExplorer.DeleteWidgetFromEntityExplorer("JSONForm1");
   });
 
-  it("Should switch panels correctly", () => {
+  it("6. Should switch panels correctly", () => {
     _.agHelper.RefreshPage();
-    _.entityExplorer.DragDropWidgetNVerify(
-      _.draggableWidgets.MENUBUTTON,
-      100,
-      200,
-    );
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.MENUBUTTON);
     _.propPane.OpenTableColumnSettings("menuItem1");
 
     _.propPane.EnterJSContext("disabled", "{{test}}", true, false);
@@ -141,9 +128,10 @@ describe("excludeForAirgap", "Widget property navigation", () => {
     _.entityExplorer.SelectEntityByName("MenuButton1");
     _.entityExplorer.DeleteWidgetFromEntityExplorer("MenuButton1");
   });
-  it("Table widget validation regex", () => {
+
+  it("7. Table widget validation regex", () => {
     _.agHelper.RefreshPage();
-    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE, 100, 200);
+    _.entityExplorer.DragDropWidgetNVerify(_.draggableWidgets.TABLE);
     _.agHelper.GetNClick(OneClickBindingLocator.datasourceDropdownSelector);
     _.agHelper.GetNClick(
       OneClickBindingLocator.datasourceSelector("sample Movies"),

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/ConnectionErrors_Spec.ts
@@ -299,7 +299,7 @@ describe("Validate Empty DS error messages", () => {
         "S3 service provider",
         "Amazon S3",
         "Access key",
-        "AKIAVWHAAGIQCDT3C345",
+        Cypress.env("S3_ACCESS_KEY"),
       ]);
     });
   });

--- a/app/client/cypress/e2e/Regression/ServerSide/LoginTests/LoginFailure_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/LoginTests/LoginFailure_spec.js
@@ -14,11 +14,12 @@ describe("Login failure", function () {
       .then((location) => {
         appUrl = location.href.split("?")[0];
         cy.LogOutUser();
+        agHelper.Sleep(2000);
         agHelper.AssertElementVisible(homePage._username); //check if user is logged out & then try to visit app url
         cy.window({ timeout: 60000 }).then((win) => {
           win.location.href = appUrl;
         });
-        agHelper.Sleep(2000); //for page redirect to complete
+        agHelper.Sleep(3000); //for page redirect to complete
         assertHelper.AssertNetworkStatus("signUpLogin");
         agHelper.AssertElementVisible(homePage._username);
       })

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -1363,20 +1363,8 @@ export class AggregateHelper extends ReusableHelper {
     return this.GetElement(selector, timeout)
       .eq(index)
       .scrollIntoView()
-      .should("exist")
-      .wait(200)
       .should("be.visible");
-  }
-
-  public AssertElementNotVisible(
-    selector: ElementType,
-    index = 0,
-    timeout = 20000,
-  ) {
-    return this.GetElement(selector, timeout)
-      .eq(index)
-      .scrollIntoView()
-      .should("not.be.visible");
+    //return this.ScrollIntoView(selector, index, timeout).should("be.visible");//to find out why this is failing.
   }
 
   public CheckForErrorToast(error: string) {


### PR DESCRIPTION
## Description
- AssertElementVisible() revert due to CI failures
- Fixes dragdrop coordinates in Debugger/Widget_property_navigation_spec.ts
- Fixes S3 ACCESS_KEY in ConnectionErrors_Sepc.ts
- /LoginTests/LoginFailure_spec.js - another trial fix
- Remove unused method AssertElementNotVisible

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
- [X] Cypress local runs

## Checklist:
#### QA activity:
- [X] Added `Test Plan Approved` label after changes were reviewed
