### PR TITLE
fix: Fixed auto indent on save in code editors that contains javascript objects

### DIFF
--- a/app/client/src/components/editorComponents/CodeEditor/modes.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/modes.ts
@@ -77,6 +77,18 @@ export const MULTIPLEXING_MODE_CONFIGS: MultiplexingModeConfigs = {
   graphql: undefined,
 };
 
+// This is to force codemirror to treat the contents between { and } as a JSON
+// and force the indentation to be 2 spaces.
+CodeMirror.defineMode("JSONJavascript", function (config) {
+  // @ts-expect-error: Types are not available
+  return CodeMirror.multiplexingMode(CodeMirror.getMode(config, "javascript"), {
+    open: "{",
+    close: "}",
+    mode: CodeMirror.getMode(config, "application/json"),
+    parseDelimiters: true,
+  });
+});
+
 Object.keys(MULTIPLEXING_MODE_CONFIGS).forEach((key) => {
   const multiplexConfig = MULTIPLEXING_MODE_CONFIGS[key as TEditorModes];
   if (!multiplexConfig) return;
@@ -89,7 +101,7 @@ Object.keys(MULTIPLEXING_MODE_CONFIGS).forEach((key) => {
         close: innerMode.close,
         delimStyle: "binding-brackets",
         mode: CodeMirror.getMode(config, {
-          name: "javascript",
+          name: "JSONJavascript",
         }),
       })),
     );


### PR DESCRIPTION
## Description
We have custom multiplexed modes for our code editors that dictates the mime-type of the text that is being typed ie. when you are typing inside {{ }}, code is treated as javascript. When a JS object is typed between {{ { name: "something", age: "something" } }} , code editor tries to parse the contents between the mustache binding, fails to understand it as a javascript object (this is the right behaviour and since an standalone object literal is not valid JS), falls back to treating it as a block statement and applies incorrect indent rule.
This PR creates an intermediate mode that tells codemirror to treat contents between { } as JSON, thereby applying right the indentation rules.

#### PR fixes following issue(s)
Fixes #25325

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
## Testing
>
#### How Has This Been Tested?
- [ ] Manual
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
