### PR TITLE
fix: Fix NGINX config template path in cert provisioning script

### DIFF
--- a/deploy/docker/scripts/init_ssl_cert.sh
+++ b/deploy/docker/scripts/init_ssl_cert.sh
@@ -9,7 +9,7 @@ init_ssl_cert() {
   mkdir -p "$data_path/www"
 
   echo "Re-generating nginx config template with domain"
-  bash "/opt/appsmith/templates/nginx-app.conf.sh" "$APPSMITH_CUSTOM_DOMAIN" \
+  bash "/opt/appsmith/templates/nginx-app.conf.sh" "0" "$APPSMITH_CUSTOM_DOMAIN" \
     | envsubst "$(printf '$%s,' $(env | grep -Eo '^APPSMITH_[A-Z0-9_]+'))" \
     | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' \
     > /etc/nginx/sites-available/default

--- a/deploy/docker/scripts/init_ssl_cert.sh
+++ b/deploy/docker/scripts/init_ssl_cert.sh
@@ -9,10 +9,10 @@ init_ssl_cert() {
   mkdir -p "$data_path/www"
 
   echo "Re-generating nginx config template with domain"
-  bash "/opt/appsmith/templates/nginx-app-http.conf.template.sh" "$APPSMITH_CUSTOM_DOMAIN" >"/etc/nginx/conf.d/nginx_app.conf.template"
-
-  echo "Generating nginx configuration"
-  cat /etc/nginx/conf.d/nginx_app.conf.template | envsubst "$(printf '$%s,' $(env | grep -Eo '^APPSMITH_[A-Z0-9_]+'))" | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' >/etc/nginx/sites-available/default
+  bash "/opt/appsmith/templates/nginx-app.conf.sh" "$APPSMITH_CUSTOM_DOMAIN" \
+    | envsubst "$(printf '$%s,' $(env | grep -Eo '^APPSMITH_[A-Z0-9_]+'))" \
+    | sed -e 's|\${\(APPSMITH_[A-Z0-9_]*\)}||g' \
+    > /etc/nginx/sites-available/default
 
   echo "Start Nginx to verify certificate"
   nginx


### PR DESCRIPTION
The template script has been moved recently, but it hasn't been updated here.