### PR TITLE
fix: Input number default validation

### DIFF
--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -60,7 +60,7 @@ export function defaultValueValidation(
 
   const { inputType } = props;
 
-  if (_.isBoolean(value) || _.isNil(value) || _.isUndefined(value)) {
+  if (_.isBoolean(value) || _.isUndefined(value)) {
     return {
       isValid: false,
       parsed: value,
@@ -81,7 +81,7 @@ export function defaultValueValidation(
          */
         isValid = true;
         messages = [EMPTY_ERROR_MESSAGE];
-        parsed = 0;
+        parsed = null;
       } else if (!Number.isFinite(parsed)) {
         /*
          *  When parsed value is not a finite number

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -77,14 +77,14 @@ export function defaultValueValidation(
 
       if (_.isString(value) && value.trim() === "") {
         /*
-         *  When value is emtpy string
+         *  When value is empty string
          */
         isValid = true;
         messages = [EMPTY_ERROR_MESSAGE];
-        parsed = null;
+        parsed = 0;
       } else if (!Number.isFinite(parsed)) {
         /*
-         *  When parsed value is not a finite numer
+         *  When parsed value is not a finite number
          */
         isValid = false;
         messages = [NUMBER_ERROR_MESSAGE];

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -71,7 +71,11 @@ export function defaultValueValidation(
   let parsed;
   switch (inputType) {
     case "NUMBER":
-      parsed = Number(value);
+      if (_.isNil(value)) {
+        parsed = null;
+      } else {
+        parsed = Number(value);
+      }
 
       let isValid, messages;
 

--- a/app/client/src/widgets/InputWidgetV2/widget/index.tsx
+++ b/app/client/src/widgets/InputWidgetV2/widget/index.tsx
@@ -71,11 +71,7 @@ export function defaultValueValidation(
   let parsed;
   switch (inputType) {
     case "NUMBER":
-      if (_.isNil(value)) {
-        parsed = null;
-      } else {
-        parsed = Number(value);
-      }
+      parsed = Number(value);
 
       let isValid, messages;
 


### PR DESCRIPTION
## Description

To remove the validation error on refresh, we allow null to be a valid value for `Input.setValue(null)` when the input type is number. 


#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/25405

#### Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?

- [ ] Manual
- [ ] Jest
- [ ] Cypress

#### Test Plan

#### Issues raised during DP testing

## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
