### PR TITLE
chore: refactor crud page flow to move plugin specific handling to plugin module

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -315,8 +315,14 @@ public interface PluginExecutor<C> extends ExtensionPoint, CrudTemplateService {
         return Mono.just(datasourceConfiguration);
     }
 
-    default Mono<Void> sanitizeGenerateCRUDPageTemplateInfo(List<ActionConfiguration> actionConfigurationList,
-                                                            Object... args) {
+    /**
+     * This method is supposed to provide help with any update required to template queries that are used to create
+     * the actual select, updated, insert etc. queries as part of the generate CRUD page feature. Any plugin that
+     * needs special handling should override this method. e.g. in case of the S3 plugin some special handling is
+     * required because (a) it uses UQI config form (b) it has concept of bucket instead of table.
+     */
+    default Mono<Void> sanitizeGenerateCRUDPageTemplateInfo(
+            List<ActionConfiguration> actionConfigurationList, Object... args) {
         return Mono.empty();
     }
 }

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/plugins/PluginExecutor.java
@@ -21,6 +21,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.util.function.Tuple2;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -312,5 +313,10 @@ public interface PluginExecutor<C> extends ExtensionPoint, CrudTemplateService {
 
     default Mono<DatasourceConfiguration> getDatasourceMetadata(DatasourceConfiguration datasourceConfiguration) {
         return Mono.just(datasourceConfiguration);
+    }
+
+    default Mono<Void> sanitizeGenerateCRUDPageTemplateInfo(List<ActionConfiguration> actionConfigurationList,
+                                                            Object... args) {
+        return Mono.empty();
     }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -1039,9 +1039,15 @@ public class AmazonS3Plugin extends BasePlugin {
                     .waitForUploadResult();
         }
 
+        /**
+         * This method is supposed to provide help with any update required to template queries that are used to create
+         * the actual select, updated, insert etc. queries as part of the generate CRUD page feature. Any plugin that
+         * needs special handling should override this method. e.g. in case of the S3 plugin some special handling is
+         * required because (a) it uses UQI config form (b) it has concept of bucket instead of table.
+         */
         @Override
-        public Mono<Void> sanitizeGenerateCRUDPageTemplateInfo(List<ActionConfiguration> actionConfigurationList,
-                                                               Object... args) {
+        public Mono<Void> sanitizeGenerateCRUDPageTemplateInfo(
+                List<ActionConfiguration> actionConfigurationList, Object... args) {
             if (isEmpty(actionConfigurationList)) {
                 return Mono.empty();
             }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/AmazonS3Plugin.java
@@ -87,6 +87,8 @@ import static com.external.plugins.constants.FieldName.BUCKET;
 import static com.external.plugins.constants.FieldName.COMMAND;
 import static com.external.plugins.constants.FieldName.CREATE_DATATYPE;
 import static com.external.plugins.constants.FieldName.CREATE_EXPIRY;
+import static com.external.plugins.constants.FieldName.KEY_BUCKET;
+import static com.external.plugins.constants.FieldName.KEY_DATA;
 import static com.external.plugins.constants.FieldName.LIST_EXPIRY;
 import static com.external.plugins.constants.FieldName.LIST_PAGINATE;
 import static com.external.plugins.constants.FieldName.LIST_PREFIX;
@@ -110,6 +112,7 @@ import static com.external.plugins.constants.S3PluginConstants.YES;
 import static com.external.utils.DatasourceUtils.getS3ClientBuilder;
 import static com.external.utils.TemplateUtils.getTemplates;
 import static java.lang.Boolean.TRUE;
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
 
 @Slf4j
 public class AmazonS3Plugin extends BasePlugin {
@@ -1034,6 +1037,23 @@ public class AmazonS3Plugin extends BasePlugin {
             transferManager
                     .upload(bucketName, path, inputStream, objectMetadata)
                     .waitForUploadResult();
+        }
+
+        @Override
+        public Mono<Void> sanitizeGenerateCRUDPageTemplateInfo(List<ActionConfiguration> actionConfigurationList,
+                                                               Object... args) {
+            if (isEmpty(actionConfigurationList)) {
+                return Mono.empty();
+            }
+
+            /* Add mapping to replace template bucket name with user chosen bucket everywhere in the template */
+            Map<String, String> mappedColumnsAndTableName = (Map<String, String>) args[0];
+            final String userSelectedBucketName = (String) args[1];
+            Map<String, Object> formData = actionConfigurationList.get(0).getFormData();
+            mappedColumnsAndTableName.put(
+                    (String) ((Map<?, ?>) formData.get(KEY_BUCKET)).get(KEY_DATA), userSelectedBucketName);
+
+            return Mono.empty();
         }
     }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/FieldName.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/main/java/com/external/plugins/constants/FieldName.java
@@ -36,4 +36,6 @@ public class FieldName {
     public static final String LIST_SORT = LIST + "." + SORT;
     public static final String LIST_PAGINATE = LIST + "." + PAGINATE;
     public static final String SMART_SUBSTITUTION = "smartSubstitution";
+    public static final String KEY_BUCKET = "bucket";
+    public static final String KEY_DATA = "data";
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
@@ -1514,8 +1514,10 @@ public class AmazonS3PluginTest {
         setDataValueSafelyInFormData(formData, "bucket", "templateBucket");
         actionConfiguration.setFormData(formData);
         AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
-        pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(List.of(actionConfiguration), mappedColumnsAndTableName,
-                userSelectedBucketName).block();
+        pluginExecutor
+                .sanitizeGenerateCRUDPageTemplateInfo(
+                        List.of(actionConfiguration), mappedColumnsAndTableName, userSelectedBucketName)
+                .block();
         assertEquals(userSelectedBucketName, mappedColumnsAndTableName.get("templateBucket"));
     }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
@@ -1504,8 +1504,9 @@ public class AmazonS3PluginTest {
         AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
         List<ActionConfiguration> actionConfigurationList = new ArrayList<>();
         Map<String, String> mappedColumnsAndTableName = new HashMap<>();
-        pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(actionConfigurationList, mappedColumnsAndTableName,
-                "test").block();
+        pluginExecutor
+                .sanitizeGenerateCRUDPageTemplateInfo(actionConfigurationList, mappedColumnsAndTableName, "test")
+                .block();
         assertEquals(0, actionConfigurationList.size());
         assertEquals(true, isEmpty(mappedColumnsAndTableName));
     }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
@@ -1497,4 +1497,25 @@ public class AmazonS3PluginTest {
                 .assertNext(result -> assertEquals(0, result.getInvalids().size()))
                 .verifyComplete();
     }
+
+    @Test
+    public void verify_sanitizeGenerateCRUDPageTemplateInfo_returnsEmptyMono_onEmptyActionConfig() {
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        StepVerifier.create(pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(List.of()))
+                .verifyComplete(); // this will fail if the Mono emits any data
+    }
+
+    @Test
+    public void verify_sanitizeGenerateCRUDPageTemplateInfo_addsInfoToReplaceTemplateBucket_withUserSelectedBucket() {
+        Map<String, String> mappedColumnsAndTableName = new HashMap<>();
+        String userSelectedBucketName = "userBucket";
+        ActionConfiguration actionConfiguration = new ActionConfiguration();
+        Map<String, Object> formData = new HashMap<>();
+        setDataValueSafelyInFormData(formData, "bucket", "templateBucket");
+        actionConfiguration.setFormData(formData);
+        AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
+        pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(List.of(actionConfiguration), mappedColumnsAndTableName,
+                userSelectedBucketName).block();
+        assertEquals(userSelectedBucketName, mappedColumnsAndTableName.get("templateBucket"));
+    }
 }

--- a/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
+++ b/app/server/appsmith-plugins/amazons3Plugin/src/test/java/com/external/plugins/AmazonS3PluginTest.java
@@ -98,6 +98,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 @Slf4j
 public class AmazonS3PluginTest {
@@ -1499,10 +1500,14 @@ public class AmazonS3PluginTest {
     }
 
     @Test
-    public void verify_sanitizeGenerateCRUDPageTemplateInfo_returnsEmptyMono_onEmptyActionConfig() {
+    public void verify_sanitizeGenerateCRUDPageTemplateInfo_doesNothing_onEmptyActionConfig() {
         AmazonS3Plugin.S3PluginExecutor pluginExecutor = new AmazonS3Plugin.S3PluginExecutor();
-        StepVerifier.create(pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(List.of()))
-                .verifyComplete(); // this will fail if the Mono emits any data
+        List<ActionConfiguration> actionConfigurationList = new ArrayList<>();
+        Map<String, String> mappedColumnsAndTableName = new HashMap<>();
+        pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(actionConfigurationList, mappedColumnsAndTableName,
+                "test").block();
+        assertEquals(0, actionConfigurationList.size());
+        assertEquals(true, isEmpty(mappedColumnsAndTableName));
     }
 
     @Test

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -392,13 +392,21 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
                             .map(ActionDTO::getActionConfiguration)
                             .collect(Collectors.toList());
 
-                    Mono<Void> sanitizeTemplateInfoMono =
-                            pluginExecutorHelper.getPluginExecutorFromPackageName(plugin.getPackageName())
-                            .flatMap(pluginExecutor -> pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(templateUnpublishedActionConfigList, mappedColumnsAndTableName, tableName));
+                    /**
+                     * Any plugin specific update to the template queries should be defined by overriding the
+                     * `sanitizeGenerateCRUDPageTemplateInfo` method in the respective plugin. In the default case no
+                     * changes are made to the template. e.g. please check the sanitizeGenerateCRUDPageTemplateInfo
+                     * method defined in AmazonS3Plugin.java .
+                     */
+                    Mono<Void> sanitizeTemplateInfoMono = pluginExecutorHelper
+                            .getPluginExecutorFromPackageName(plugin.getPackageName())
+                            .flatMap(pluginExecutor -> pluginExecutor.sanitizeGenerateCRUDPageTemplateInfo(
+                                    templateUnpublishedActionConfigList, mappedColumnsAndTableName, tableName));
 
                     log.debug("Going to update layout for page {} and layout {}", savedPageId, layoutId);
                     return sanitizeTemplateInfoMono
-                            .then(layoutActionService.updateLayout(savedPageId, page.getApplicationId(), layoutId, layout))
+                            .then(layoutActionService.updateLayout(
+                                    savedPageId, page.getApplicationId(), layoutId, layout))
                             .then(Mono.zip(
                                     Mono.just(datasourceStorage),
                                     Mono.just(templateActionList),

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -171,10 +171,10 @@ public class CreateDBTablePageSolutionTests {
     @WithUserDetails(value = "api_user")
     public void setup() {
 
-        Mockito.when(pluginExecutorHelper.getPluginExecutor(any()))
-                .thenReturn(Mono.just(spyMockPluginExecutor));
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(any())).thenReturn(Mono.just(spyMockPluginExecutor));
         Mockito.when(pluginExecutorHelper.getPluginExecutorFromPackageName(Mockito.anyString()))
-                .thenReturn(Mono.just(spyMockPluginExecutor)).thenReturn(Mono.just(spyMockPluginExecutor));
+                .thenReturn(Mono.just(spyMockPluginExecutor))
+                .thenReturn(Mono.just(spyMockPluginExecutor));
 
         if (testWorkspace == null) {
             Workspace workspace = new Workspace();
@@ -908,14 +908,17 @@ public class CreateDBTablePageSolutionTests {
     @WithUserDetails(value = "api_user")
     public void createPageWithNullPageIdForS3() {
         doAnswer(invocation -> {
-            List<ActionConfiguration> actionConfigurationList = invocation.getArgument(0);
-            Map<String, String> mappedColumnsAndTableName = invocation.getArgument(1);
-            String bucketName = invocation.getArgument(2);
-            Map<String, Object> formData = actionConfigurationList.get(0).getFormData();
-            mappedColumnsAndTableName.put(
-                    (String) ((Map<?, ?>) formData.get("bucket")).get("data"), bucketName);
-            return Mono.empty();
-        }).when(spyMockPluginExecutor).sanitizeGenerateCRUDPageTemplateInfo(any(), any(), any());
+                    List<ActionConfiguration> actionConfigurationList = invocation.getArgument(0);
+                    Map<String, String> mappedColumnsAndTableName = invocation.getArgument(1);
+                    String bucketName = invocation.getArgument(2);
+                    Map<String, Object> formData =
+                            actionConfigurationList.get(0).getFormData();
+                    mappedColumnsAndTableName.put(
+                            (String) ((Map<?, ?>) formData.get("bucket")).get("data"), bucketName);
+                    return Mono.empty();
+                })
+                .when(spyMockPluginExecutor)
+                .sanitizeGenerateCRUDPageTemplateInfo(any(), any(), any());
 
         resource.setApplicationId(testApp.getId());
         StringBuilder pluginName = new StringBuilder();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -163,7 +163,7 @@ public class CreateDBTablePageSolutionTests {
     @MockBean
     private PluginExecutorHelper pluginExecutorHelper;
 
-    private PluginExecutor mockPluginExecutor = spy(new MockPluginExecutor());
+    private PluginExecutor spyMockPluginExecutor = spy(new MockPluginExecutor());
 
     private final CRUDPageResourceDTO resource = new CRUDPageResourceDTO();
 
@@ -172,9 +172,9 @@ public class CreateDBTablePageSolutionTests {
     public void setup() {
 
         Mockito.when(pluginExecutorHelper.getPluginExecutor(any()))
-                .thenReturn(Mono.just(mockPluginExecutor));
+                .thenReturn(Mono.just(spyMockPluginExecutor));
         Mockito.when(pluginExecutorHelper.getPluginExecutorFromPackageName(Mockito.anyString()))
-                .thenReturn(Mono.just(mockPluginExecutor)).thenReturn(Mono.just(mockPluginExecutor));
+                .thenReturn(Mono.just(spyMockPluginExecutor)).thenReturn(Mono.just(spyMockPluginExecutor));
 
         if (testWorkspace == null) {
             Workspace workspace = new Workspace();
@@ -915,7 +915,7 @@ public class CreateDBTablePageSolutionTests {
             mappedColumnsAndTableName.put(
                     (String) ((Map<?, ?>) formData.get("bucket")).get("data"), bucketName);
             return Mono.empty();
-        }).when(mockPluginExecutor).sanitizeGenerateCRUDPageTemplateInfo(any(), any(), any());
+        }).when(spyMockPluginExecutor).sanitizeGenerateCRUDPageTemplateInfo(any(), any(), any());
 
         resource.setApplicationId(testApp.getId());
         StringBuilder pluginName = new StringBuilder();

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/solutions/CreateDBTablePageSolutionTests.java
@@ -907,6 +907,9 @@ public class CreateDBTablePageSolutionTests {
     @Test
     @WithUserDetails(value = "api_user")
     public void createPageWithNullPageIdForS3() {
+        /**
+         * Define handling for sanitizeGenerateCRUDPageTemplateInfo method for S3 plugin on spyMockPluginExecutor.
+         */
         doAnswer(invocation -> {
                     List<ActionConfiguration> actionConfigurationList = invocation.getArgument(0);
                     Map<String, String> mappedColumnsAndTableName = invocation.getArgument(1);


### PR DESCRIPTION
## Description
- Currently the server side code flow for generate CRUD page contains plugin specific check and plugin specific implementation in the common code module. This is a anti-pattern. This PR introduces a method in the plugin module such that each plugin can define their own implementation and the current code is refactored to remove any plugin specific check or handling. 
- Please note that there are other instances of plugin specific handling on the same page, those would be addressed as part of a separate pull request. The part that is being handled now should open up the way to introduce MsSQL CRUD page generation, hence this portion has been prioritized for now. 

#### PR fixes following issue(s)
Fixes #26290

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
- [x] Manual
- [x] JUnit

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
