### PR TITLE
fix: WDS colors checks for non-achromatic seeds (dark mode)

### DIFF
--- a/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/DarkModeTheme.ts
@@ -121,7 +121,7 @@ export class DarkModeTheme implements ColorModeTheme {
       color.oklch.c = 0;
     }
 
-    if (this.seedIsAchromatic) {
+    if (!this.seedIsAchromatic) {
       color.oklch.c = 0.064;
     }
 
@@ -580,7 +580,7 @@ export class DarkModeTheme implements ColorModeTheme {
       color.oklch.c = 0;
     }
 
-    if (this.seedIsAchromatic) {
+    if (!this.seedIsAchromatic) {
       color.oklch.c = 0.024;
     }
 


### PR DESCRIPTION
See also #26168 