### PR TITLE
fix: moved jest to devdependencies for appsmithctl and updated dockerfile to exclude it during install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY ./deploy/docker/entrypoint.sh ./deploy/docker/scripts/* info.*json ./
 
 # Add util tools
 COPY ./deploy/docker/utils ./utils
-RUN cd ./utils && npm install && npm install -g .
+RUN cd ./utils && npm install --only=prod && npm install --only=prod -g .
 
 # Add process config to be run by supervisord
 COPY ./deploy/docker/templates/supervisord.conf /etc/supervisor/supervisord.conf

--- a/deploy/docker/utils/package.json
+++ b/deploy/docker/utils/package.json
@@ -14,11 +14,13 @@
   "dependencies": {
     "cli-progress": "^3.11.2",
     "dotenv": "10.0.0",
-    "jest": "^29.1.2",
     "mongodb": "^5.7.0",
     "nodemailer": "6.7.5",
     "readline-sync": "1.4.10",
     "shelljs": "0.8.5"
+  },
+  "devDependencies": {
+    "jest": "^29.1.2"
   },
   "bin": {
     "appsmithctl": "./bin/index.js"


### PR DESCRIPTION
Update:
- Mobed jest to` devDependenies` of package manifest.
- Updated Dockerfile to install utils with `--only=prod` arg for npm install cmds.

Tested manually