### PR TITLE
test: Cypress | (DI) S3 added validations + CI Stabilize

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
@@ -285,8 +285,9 @@ describe("Autocomplete tests", () => {
         cy.get(locators._codeMirrorTextArea)
           .eq(0)
           .focus()
+          .wait(200)
           .type(
-            "{downArrow}{downArrow}{leftArrow}{leftArrow}{leftArrow}{leftArrow}",
+            "{downArrow}{downArrow}{leftArrow}{leftArrow}{leftArrow}{leftArrow}{leftArrow}",
           )
           .type(".");
 

--- a/app/client/cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/GenerateCRUD/MongoURI_Spec.ts
@@ -93,7 +93,7 @@ describe("Validate Mongo URI CRUD with JSON Form", () => {
 
     agHelper.ClickButton("Update");
     agHelper.AssertElementAbsence(locators._toastMsg); //Validating fix for Bug 14063
-    table.ReadTableRowColumnData(8, 8, "v1", 200).then(($cellData) => {
+    table.ReadTableRowColumnData(8, 8, "v1", 2000).then(($cellData) => {
       expect($cellData).to.eq(
         "Write Your Story with Elegance: The Pen of Choice!",
       );

--- a/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/OnLoadTests/JSOnLoad2_Spec.ts
@@ -12,8 +12,7 @@ let datasourceName: any, jsName: any;
 
 describe("JSObjects OnLoad Actions tests", function () {
   before(() => {
-    homePage.NavigateToHome();
-    homePage.CreateNewWorkspace("JSOnLoadTest");
+    homePage.CreateNewWorkspace("JSOnLoadTest", true);
   });
 
   it("1. Tc #58 Verify JSOnPageload with ConfirmBefore calling - while imported", () => {

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
@@ -9,6 +9,8 @@ import {
   entityExplorer,
   dataSources,
   entityItems,
+  draggableWidgets,
+  propPane,
 } from "../../../../support/Objects/ObjectsCore";
 
 let datasourceName;
@@ -39,20 +41,15 @@ describe("Validate CRUD queries for Amazon S3 along with UI flow verifications",
   // });
 
   before("Creates a new Amazon S3 datasource", function () {
-    cy.NavigateToDatasourceEditor();
-    cy.get(datasource.AmazonS3).click({ force: true }).wait(1000);
-
-    cy.generateUUID().then((uid) => {
-      datasourceName = `S3 CRUD ds ${uid}`;
-      cy.renameDatasource(datasourceName);
-      cy.wrap(datasourceName).as("dSName");
-      cy.fillAmazonS3DatasourceForm();
-      cy.testSaveDatasource();
-      entityExplorer.ExpandCollapseEntity(datasourceName, false);
+    dataSources.CreateDataSource("S3");
+    cy.get("@dsName").then((dsName) => {
+      datasourceName = dsName;
     });
   });
 
-  it("1. Validate List Files in bucket (all existing files) command, run and then delete the query", () => {
+  it("1. Validate List Files in bucket (all existing files) command, run + Widget Binding", () => {
+    entityExplorer.DragDropWidgetNVerify(draggableWidgets.INPUT_V2);
+    propPane.UpdatePropertyFieldValue("Default value", "AutoTest");
     cy.NavigateToActiveDSQueryPane(datasourceName);
     dataSources.ValidateNSelectDropdown("Commands", "List files in bucket");
     dataSources.RunQuery({ toValidateResponse: false });
@@ -62,8 +59,8 @@ describe("Validate CRUD queries for Amazon S3 along with UI flow verifications",
         "Mandatory parameter 'Bucket name' is missing.",
       );
     });
+    agHelper.UpdateCodeInput(formControls.s3BucketName, "{{Input1.text}}"); //Widget Binding
 
-    cy.typeValueNValidate("AutoTest", formControls.s3BucketName);
     dataSources.RunQuery({ toValidateResponse: false });
     cy.wait(3000); //for new postExecute to come thru
     cy.wait("@postExecute").then(({ response }) => {

--- a/app/client/cypress/e2e/Sanity/Datasources/Arango_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Sanity/Datasources/Arango_Basic_Spec.ts
@@ -7,6 +7,7 @@ import {
   propPane,
   dataManager,
   locators,
+  homePage,
 } from "../../../support/Objects/ObjectsCore";
 import { Widgets } from "../../../support/Pages/DataSources";
 import { featureFlagIntercept } from "../../../support/Objects/FeatureFlags";
@@ -17,6 +18,8 @@ describe("Validate Arango & CURL Import Datasources", () => {
     containerName = "arangodb";
   before("Create a new Arango DS", () => {
     dataSources.StartContainerNVerify("Arango", containerName, 20000);
+    homePage.CreateNewWorkspace("ArangoDS", true);
+    homePage.CreateAppInWorkspace("ArangoDS", "ArangoDSApp");
     dataSources.CreateDataSource("ArangoDB");
     cy.get("@dsName").then(($dsName) => {
       dsName = $dsName;
@@ -337,11 +340,12 @@ describe("Validate Arango & CURL Import Datasources", () => {
       action: "Delete",
       entityType: entityItems.Api,
     }); //Deleting api created
+
     entityExplorer.ExpandCollapseEntity(dsName);
     entityExplorer.ActionContextMenuByEntityName({
       entityNameinLeftSidebar: dsName,
       action: "Refresh",
-    }); //needed for the deltion of ds to reflect
+    }); //needed for the deletion of ds to reflect
     agHelper.AssertElementVisibility(dataSources._noSchemaAvailable(dsName));
     //Deleting datasource finally
     dataSources.DeleteDatasouceFromActiveTab(dsName);

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,7 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
-
-
+cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
+cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
+cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -3,7 +3,6 @@ cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
 
 
 
-
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*
 

--- a/app/client/cypress/limited-tests.txt
+++ b/app/client/cypress/limited-tests.txt
@@ -1,7 +1,8 @@
 # To run only limited tests - give the spec names in below format:
-cypress/e2e/Regression/ClientSide/EmbedSettings/EmbedSettings_spec.js
-cypress/e2e/Regression/ClientSide/Autocomplete/JS_AC1_spec.ts
-cypress/e2e/Regression/ServerSide/QueryPane/S3_1_spec.js
+cypress/e2e/Regression/ClientSide/Templates/Fork_Template_spec.js
+
+
+
 
 # For running all specs - uncomment below:
 #cypress/e2e/**/**/*

--- a/app/client/cypress/support/AdminSettingsCommands.js
+++ b/app/client/cypress/support/AdminSettingsCommands.js
@@ -73,9 +73,10 @@ Cypress.Commands.add("waitForServerRestart", () => {
   cy.get(adminSettings.restartNotice).should("be.visible");
   // Wait for restart notice to not be visible with a timeout
   // Cannot use cy.get as mentioned in https://github.com/NoriSte/cypress-wait-until/issues/75#issuecomment-572685623
-  cy.waitUntil(() => !Cypress.$(adminSettings.restartNotice).length, {
-    timeout: 180000,
-  });
+  // cy.waitUntil(() => !Cypress.$(adminSettings.restartNotice).length, {
+  //   timeout: 180000,
+  // });
+  cy.get(adminSettings.restartNotice, { timeout: 180000 }).should("not.exist");
   cy.window().then((win) => {
     win.location.reload();
   });

--- a/app/client/cypress/support/AdminSettingsCommands.js
+++ b/app/client/cypress/support/AdminSettingsCommands.js
@@ -76,7 +76,7 @@ Cypress.Commands.add("waitForServerRestart", () => {
   // cy.waitUntil(() => !Cypress.$(adminSettings.restartNotice).length, {
   //   timeout: 180000,
   // });
-  cy.get(adminSettings.restartNotice, { timeout: 180000 }).should("not.exist");
+  cy.get(adminSettings.restartNotice, { timeout: 210000 }).should("not.exist");
   cy.window().then((win) => {
     win.location.reload();
   });


### PR DESCRIPTION
## Description
- This PR covers below:
- S3 Widget Binding added
- Skipped test fix - Autocomplete/JS_AC1_spec.ts fix
- ClientSide/EmbedSettings/EmbedSettings_spec.js - increased timeout for server restart hung
- ServerSide/GenerateCRUD/MongoURI_Spec.ts - trial fix - 2nd flaky case 
- Sanity/Datasources/Arango_Basic_Spec.ts - due to DS not appearing in EE

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
- [X] Cypress CI runs

## Checklist:
#### QA activity:
- [X] Added `Test Plan Approved` label after Cypress tests were reviewed
