### PR TITLE
chore: Perf regression fix

### DIFF
--- a/app/client/src/workers/common/DependencyMap/utils.ts
+++ b/app/client/src/workers/common/DependencyMap/utils.ts
@@ -19,7 +19,6 @@ import {
   DEDICATED_WORKER_GLOBAL_SCOPE_IDENTIFIERS,
   JAVASCRIPT_KEYWORDS,
 } from "constants/WidgetValidation";
-import { APPSMITH_GLOBAL_FUNCTIONS } from "components/editorComponents/ActionCreator/constants";
 import { libraryReservedIdentifiers } from "workers/common/JSLibrary";
 
 /** This function extracts validReferences and invalidReferences from a binding {{}}
@@ -155,7 +154,6 @@ export const mergeArrays = <T>(currentArr: T[], updateArr: T[]): T[] => {
  */
 export const invalidEntityIdentifiers: Record<string, unknown> = {
   ...JAVASCRIPT_KEYWORDS,
-  ...APPSMITH_GLOBAL_FUNCTIONS,
   ...DEDICATED_WORKER_GLOBAL_SCOPE_IDENTIFIERS,
   ...libraryReservedIdentifiers,
 };

--- a/app/client/src/workers/common/DependencyMap/utils.ts
+++ b/app/client/src/workers/common/DependencyMap/utils.ts
@@ -40,11 +40,7 @@ export const extractInfoFromBinding = (
   const { references } = extractIdentifierInfoFromCode(
     script,
     self.evaluationVersion,
-    {
-      ...JAVASCRIPT_KEYWORDS,
-      ...DEDICATED_WORKER_GLOBAL_SCOPE_IDENTIFIERS,
-      ...libraryReservedIdentifiers,
-    },
+    invalidEntityIdentifiers,
   );
   return getPrunedReferences(references, allKeys);
 };


### PR DESCRIPTION
## Description
Spread operator was introduced back in `extractInfoFromBinding` method in #25339 causing a performance regression. This PR reverts this change

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)
- Performance Fix
>
## Testing
>
#### How Has This Been Tested?
- [x] Manual
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
