### PR TITLE
fix: update checks for updating the login source on successful authentication

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
@@ -93,21 +93,16 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
             // If and when we find a better way to do identify this, let's please move away from this approximation.
             // If the user object was created within the last 5 seconds, we treat it as a new user.
             isFromSignup = user.getCreatedAt().isAfter(Instant.now().minusSeconds(5));
-            // If user has previously signed up using password and now using OAuth as a sign in method we are removing
-            // form login method henceforth. This step is taken to avoid any security vulnerability in the login flow
-            // as we are not verifying the user emails at first sign up. In future if we implement the email
-            // verification this can be eliminated safely
 
-            // Adding check on source because of the following scenario.
-            // Scenario:
-            // 1. User is invited.
-            // 2. User signs in via any OAuth2 Authentication mechanism.
-            // User will not have the password field set, and hence, just checking that password is null, is an
-            // incomplete check. Checking the source will complete it.
-            if (user.getPassword() != null || LoginSource.FORM.equals(user.getSource())) {
+            // Check the existing login source with the authentication source and then update the login source,
+            // if they are not the same.
+            // Also, since this is OAuth2 authentication, we remove the password from user resource object, in order to
+            // invalidate any password which may have been set during a form login.
+            LoginSource authenticationLoginSource = LoginSource.fromString(
+                    ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId());
+            if (!authenticationLoginSource.equals(user.getSource())) {
                 user.setPassword(null);
-                user.setSource(LoginSource.fromString(
-                        ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
+                user.setSource(authenticationLoginSource);
                 // Update the user in separate thread
                 userRepository
                         .save(user)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/authentication/handlers/ce/AuthenticationSuccessHandlerCE.java
@@ -97,7 +97,14 @@ public class AuthenticationSuccessHandlerCE implements ServerAuthenticationSucce
             // form login method henceforth. This step is taken to avoid any security vulnerability in the login flow
             // as we are not verifying the user emails at first sign up. In future if we implement the email
             // verification this can be eliminated safely
-            if (user.getPassword() != null) {
+
+            // Adding check on source because of the following scenario.
+            // Scenario:
+            // 1. User is invited.
+            // 2. User signs in via any OAuth2 Authentication mechanism.
+            // User will not have the password field set, and hence, just checking that password is null, is an
+            // incomplete check. Checking the source will complete it.
+            if (user.getPassword() != null || LoginSource.FORM.equals(user.getSource())) {
                 user.setPassword(null);
                 user.setSource(LoginSource.fromString(
                         ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));


### PR DESCRIPTION
## Description
> Login source of users is not tagged properly, if they are invited and then directly login using an OAuth2 mechanism.
> With the change in checks post successful authentication, the users will have the correct login source.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/26519

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
- [x] Manual

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
