### PR TITLE
fix: Add tenant feature flags to get all feature flags for user 

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCEImpl.java
@@ -14,6 +14,7 @@ import com.appsmith.server.exceptions.AppsmithException;
 import com.appsmith.server.featureflags.CachedFeatures;
 import com.appsmith.server.featureflags.CachedFlags;
 import com.appsmith.server.featureflags.FeatureFlagIdentityTraits;
+import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.repositories.TenantRepository;
 import com.appsmith.server.services.ConfigService;
 import com.appsmith.server.services.UserIdentifierService;
@@ -205,7 +206,9 @@ public class CacheableFeatureFlagHelperCEImpl implements CacheableFeatureFlagHel
                     return featuresRequestDTO;
                 })
                 .flatMap(this::getRemoteFeaturesForTenant)
-                .map(FeaturesResponseDTO::getFeatures);
+                .map(responseDTO -> CollectionUtils.isNullOrEmpty(responseDTO.getFeatures())
+                        ? new HashMap<>()
+                        : responseDTO.getFeatures());
     }
 
     /**

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/UserDataServiceCEImpl.java
@@ -303,14 +303,7 @@ public class UserDataServiceCEImpl extends BaseService<UserDataRepository, UserD
 
     @Override
     public Mono<Map<String, Boolean>> getFeatureFlagsForCurrentUser() {
-        return Mono.zip(featureFlagService.getAllFeatureFlagsForUser(), featureFlagService.getCurrentTenantFeatures())
-                .map(tuple -> {
-                    Map<String, Boolean> featureFlags = tuple.getT1();
-                    Map<String, Boolean> features = tuple.getT2();
-                    featureFlags.putAll(features);
-
-                    return featureFlags;
-                });
+        return featureFlagService.getAllFeatureFlagsForUser();
     }
 
     /**

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/FeatureFlagServiceCETest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/FeatureFlagServiceCETest.java
@@ -1,5 +1,6 @@
 package com.appsmith.server.services.ce;
 
+import com.appsmith.caching.components.CacheManager;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.dtos.ce.FeaturesResponseDTO;
 import com.appsmith.server.featureflags.CachedFeatures;
@@ -11,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.ff4j.FF4j;
 import org.ff4j.conf.XmlParser;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(SpringExtension.class)
@@ -48,6 +51,19 @@ public class FeatureFlagServiceCETest {
 
     @Autowired
     ReactiveRedisTemplate<String, Object> reactiveRedisTemplate;
+
+    @SpyBean
+    CacheManager cacheManager;
+
+    @BeforeEach
+    void setup() {
+        // Mock response to avoid any third party calls
+        doReturn(Mono.just(new FeaturesResponseDTO()))
+                .when(cacheableFeatureFlagHelper)
+                .getRemoteFeaturesForTenant(any());
+
+        doReturn(Mono.empty()).when(cacheManager).get(anyString(), anyString());
+    }
 
     @Test
     @WithUserDetails(value = "api_user")
@@ -98,6 +114,32 @@ public class FeatureFlagServiceCETest {
                 .assertNext(result -> {
                     assertNotNull(result);
                     assertTrue(result.containsKey(FeatureFlagEnum.TEST_FEATURE_3.toString()));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void testGetFeaturesForUser_overrideWithTenantFeature() {
+
+        // Assert feature flag is false before the tenant level flag overrides the existing flag
+        StepVerifier.create(featureFlagService.getAllFeatureFlagsForUser())
+                .assertNext(result -> {
+                    assertNotNull(result);
+                    assertFalse(result.get(FeatureFlagEnum.TEST_FEATURE_3.toString()));
+                })
+                .verifyComplete();
+
+        Map<String, Boolean> tenantFeatures = new HashMap<>();
+        tenantFeatures.put(FeatureFlagEnum.TEST_FEATURE_3.toString(), true);
+        FeaturesResponseDTO responseDTO = new FeaturesResponseDTO();
+        responseDTO.setFeatures(tenantFeatures);
+        doReturn(Mono.just(responseDTO)).when(cacheableFeatureFlagHelper).getRemoteFeaturesForTenant(any());
+        // Assert true for same feature flag after tenant level flag overrides the existing flag
+        StepVerifier.create(featureFlagService.getAllFeatureFlagsForUser())
+                .assertNext(result -> {
+                    assertNotNull(result);
+                    assertTrue(result.get(FeatureFlagEnum.TEST_FEATURE_3.toString()));
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
## Description
When we introduced the tenant level flags, it's not been added in get all flags for user instead we added these in the user data service to get all the feature flags for user. As we are progressing with 1 click upgrade-downgrade project to avoid future confusion around feature flagging I was hoping to expose single method to get all the relevant feature flags for user. This includes:
1. Local flags from ff4j
2. User level flags from Flagsmith
3. Tenant level flags from Flagsmith (These will be shared across the userbase with same tenantId)     
This PR unifies the flags with single method `getAllFeatureFlagsForUser`.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/26547

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [x] Manual
- [x] Junit

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
