### PR TITLE
fix: Make sure updatable connections come back with decrypted tokens

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -155,7 +155,8 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
                             .getAuthenticationDTO(datasourceStorage
                                     .getDatasourceConfiguration()
                                     .getAuthentication()));
-            datasourceStorageMono = datasourceStorageService.save(datasourceStorage);
+            datasourceStorageMono = datasourceStorageService.updateDatasourceStorage(
+                    datasourceStorage, datasourceStorage.getEnvironmentId(), Boolean.FALSE);
         }
         return datasourceStorageMono.thenReturn(connection);
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/DatasourceContextServiceCEImpl.java
@@ -147,14 +147,12 @@ public class DatasourceContextServiceCEImpl implements DatasourceContextServiceC
 
     public Mono<Object> updateDatasourceAndSetAuthentication(Object connection, DatasourceStorage datasourceStorage) {
         Mono<DatasourceStorage> datasourceStorageMono = Mono.just(datasourceStorage);
-        if (connection instanceof UpdatableConnection) {
+        if (connection instanceof UpdatableConnection updatableConnection) {
             datasourceStorage.setUpdatedAt(Instant.now());
             datasourceStorage
                     .getDatasourceConfiguration()
-                    .setAuthentication(((UpdatableConnection) connection)
-                            .getAuthenticationDTO(datasourceStorage
-                                    .getDatasourceConfiguration()
-                                    .getAuthentication()));
+                    .setAuthentication(updatableConnection.getAuthenticationDTO(
+                            datasourceStorage.getDatasourceConfiguration().getAuthentication()));
             datasourceStorageMono = datasourceStorageService.updateDatasourceStorage(
                     datasourceStorage, datasourceStorage.getEnvironmentId(), Boolean.FALSE);
         }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -1,12 +1,15 @@
 package com.appsmith.server.services;
 
+import com.appsmith.external.helpers.restApiUtils.connections.OAuth2ClientCredentials;
 import com.appsmith.external.models.ApiKeyAuth;
+import com.appsmith.external.models.AuthenticationDTO;
 import com.appsmith.external.models.BasicAuth;
 import com.appsmith.external.models.DBAuth;
 import com.appsmith.external.models.Datasource;
 import com.appsmith.external.models.DatasourceConfiguration;
 import com.appsmith.external.models.DatasourceStorage;
 import com.appsmith.external.models.DatasourceStorageDTO;
+import com.appsmith.external.models.OAuth2;
 import com.appsmith.external.models.UpdatableConnection;
 import com.appsmith.external.plugins.PluginExecutor;
 import com.appsmith.external.services.EncryptionService;
@@ -544,5 +547,79 @@ public class DatasourceContextServiceTest {
 
         assertThat(datasourceContextIdentifier.getDatasourceId()).isEqualTo(sampleDatasourceId);
         assertThat(datasourceContextIdentifier.getEnvironmentId()).isEqualTo(defaultEnvironmentId);
+    }
+
+    @Test
+    @WithUserDetails(value = "api_user")
+    public void
+            testUpdateDatasourceAndSetAuthentication_withNoRealChange_keepsDatasourceConfigurationValuesDecrypted() {
+        Mockito.when(pluginExecutorHelper.getPluginExecutor(Mockito.any()))
+                .thenReturn(Mono.just(new MockPluginExecutor()));
+
+        Mono<Plugin> pluginMono = pluginService.findByPackageName("restapi-plugin");
+        Datasource datasource = new Datasource();
+        datasource.setName(
+                "testUpdateDatasourceAndSetAuthentication_withNoRealChange_keepsDatasourceConfigurationValuesDecrypted");
+        DatasourceConfiguration datasourceConfiguration = new DatasourceConfiguration();
+        datasourceConfiguration.setUrl("http://test.com");
+        OAuth2 authenticationDTO = new OAuth2();
+        String username = "username";
+        String password = "This is the decrypted value to test for";
+        authenticationDTO.setClientId(username);
+        authenticationDTO.setClientSecret(password);
+        authenticationDTO.setAccessTokenUrl("http://test.com");
+        authenticationDTO.setGrantType(OAuth2.Type.CLIENT_CREDENTIALS);
+        datasourceConfiguration.setAuthentication(authenticationDTO);
+        datasource.setWorkspaceId(workspaceId);
+
+        DatasourceStorageDTO datasourceStorageDTO = new DatasourceStorageDTO();
+        datasourceStorageDTO.setDatasourceConfiguration(datasourceConfiguration);
+        datasourceStorageDTO.setEnvironmentId(defaultEnvironmentId);
+        datasourceStorageDTO.setIsConfigured(Boolean.TRUE);
+
+        HashMap<String, DatasourceStorageDTO> storages = new HashMap<>();
+        storages.put(defaultEnvironmentId, datasourceStorageDTO);
+        datasource.setDatasourceStorages(storages);
+
+        final Datasource createdDatasource = pluginMono
+                .map(plugin -> {
+                    datasource.setPluginId(plugin.getId());
+                    return datasource;
+                })
+                .flatMap(datasourceService::create)
+                .block();
+
+        assert createdDatasource != null;
+
+        DatasourceStorage datasourceStorage = datasourceService
+                .findById(createdDatasource.getId())
+                .flatMap(datasource1 ->
+                        datasourceStorageService.findByDatasourceAndEnvironmentId(datasource1, defaultEnvironmentId))
+                .block();
+
+        OAuth2ClientCredentials oAuth2ClientCredentials = Mockito.mock(OAuth2ClientCredentials.class);
+        Mockito.when(oAuth2ClientCredentials.getAuthenticationDTO(Mockito.any()))
+                .thenCallRealMethod();
+
+        // Check that the value was decrypted before
+        DatasourceConfiguration savedDsConfig = datasourceStorage.getDatasourceConfiguration();
+        AuthenticationDTO auth1 = savedDsConfig.getAuthentication();
+        assertThat(auth1).isInstanceOf(OAuth2.class);
+        assertThat(((OAuth2) auth1).getClientSecret()).isEqualTo(password);
+
+        Mono<Object> resultMono = datasourceContextService.updateDatasourceAndSetAuthentication(
+                oAuth2ClientCredentials, datasourceStorage);
+
+        // Check that the value remains decrypted after
+        StepVerifier.create(resultMono)
+                .assertNext(result -> {
+                    DatasourceConfiguration newDsConfig = datasourceStorage.getDatasourceConfiguration();
+                    AuthenticationDTO auth2 = newDsConfig.getAuthentication();
+
+                    assertThat(auth2).isInstanceOf(OAuth2.class);
+
+                    assertThat(((OAuth2) auth2).getClientSecret()).isEqualTo(password);
+                })
+                .verifyComplete();
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/DatasourceContextServiceTest.java
@@ -422,6 +422,7 @@ public class DatasourceContextServiceTest {
 
         DatasourceStorage createdDatasourceStorage =
                 datasourceStorageService.createDatasourceStorageFromDatasourceStorageDTO(datasourceStorageDTO);
+        createdDatasourceStorage.setPluginId(createdDatasource.getPluginId());
 
         DatasourceContextIdentifier datasourceContextIdentifier =
                 new DatasourceContextIdentifier(createdDatasource.getId(), defaultEnvironmentId);


### PR DESCRIPTION
## Description
When going through REST API updatable connection flow (which is for every authenticated ds execution), we were using a method that does not decrypt values after saving the configuration in DB. This was causing requests to fail since the encrypted data would not be expected to make sense to these endpoints.

This was affecting anything marked as `@Encrypted` in a datasource configuration. Hence includes client credentials as well as self signed certificates in its scope.

Fixes #24910 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
- [x] Manual - with a server using a self signed certificate as well as one that uses OAuth2 (client creds)
- [x] JUnit
>
>
#### Test Plan
Tested this issue with Self Signed Certificate [Appsmith PR branch setup on local, SelfSigned Cert created locally with the help of this [Documentation](https://github.com/nidhi-nair/self-signed)]

1. Tested with Authentication type set to None
2. Tested with Authentication type set to OAuth2.0 with self-signed certificate

Both the scenarios work fine. 

>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
