### PR TITLE
fix: add datatype check for date field validity jsonform

### DIFF
--- a/app/client/src/widgets/JSONFormWidget/fields/DateField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/DateField.tsx
@@ -95,7 +95,7 @@ export const isValidType = (value: string) =>
     moment(value, format, true).isValid(),
   );
 
-const isValid = (schemaItem: DateFieldProps["schemaItem"], value?: string) =>
+const isValid = (schemaItem: DateFieldProps["schemaItem"], value?: unknown) =>
   !schemaItem.isRequired ||
   (typeof value === "string" && Boolean(value?.trim()));
 

--- a/app/client/src/widgets/JSONFormWidget/fields/DateField.tsx
+++ b/app/client/src/widgets/JSONFormWidget/fields/DateField.tsx
@@ -96,7 +96,8 @@ export const isValidType = (value: string) =>
   );
 
 const isValid = (schemaItem: DateFieldProps["schemaItem"], value?: string) =>
-  !schemaItem.isRequired || Boolean(value?.trim());
+  !schemaItem.isRequired ||
+  (typeof value === "string" && Boolean(value?.trim()));
 
 function DateField({
   fieldClassName,


### PR DESCRIPTION
## Description
This PR adds a check to the date field's value. Along with the existing checks we also check if the value is of type string.

This change solves the issue mentioned below that occurs whenever the defaultValue for the date field in the property pane is an array of string.

#### PR fixes following issue(s)
Fixes #24675

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?

- [x] Manual
- [ ] Jest
- [ ] Cypress

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
