### PR TITLE
fix: Updating UI for members page and admin settings left pane upgrade tags

### DIFF
--- a/app/client/src/ce/pages/AdminSettings/LeftPane.tsx
+++ b/app/client/src/ce/pages/AdminSettings/LeftPane.tsx
@@ -113,13 +113,13 @@ export function Categories({
     });
   };
 
-  const onClickHandler = (category: string, needsUpgrade: boolean) => {
+  const onClickHandler = (category: string, showUpgradeTag: boolean) => {
     if (category === "general") {
       dispatch({
         type: ReduxActionTypes.FETCH_ADMIN_SETTINGS,
       });
     }
-    if (needsUpgrade) {
+    if (showUpgradeTag) {
       triggerAnalytics(category);
     }
   };
@@ -131,6 +131,7 @@ export function Categories({
           !!currentSubCategory && showSubCategory
             ? currentSubCategory == config.slug
             : currentCategory == config.slug;
+        const showUpgradeTag = config?.isFeatureEnabled === false;
         return (
           <CategoryItem key={config.slug}>
             <StyledLink
@@ -139,7 +140,7 @@ export function Categories({
                 active ? "active" : ""
               }`}
               onClick={() =>
-                onClickHandler(config.slug, config?.needsUpgrade || false)
+                onClickHandler(config.slug, showUpgradeTag || false)
               }
               to={
                 !parentCategory
@@ -150,13 +151,13 @@ export function Categories({
                     })
               }
             >
-              {config?.needsUpgrade ? (
+              {showUpgradeTag ? (
                 <Icon name="lock-2-line" />
               ) : (
                 config?.icon && <Icon name={config?.icon} size="md" />
               )}
               <SettingName active={active}>{config.title}</SettingName>
-              {config?.needsUpgrade &&
+              {showUpgradeTag &&
                 (config?.isEnterprise ? <EnterpriseTag /> : <BusinessTag />)}
             </StyledLink>
             {showSubCategory && (

--- a/app/client/src/ce/pages/AdminSettings/config/auditLogsConfig.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/auditLogsConfig.ts
@@ -14,5 +14,5 @@ export const config: AdminConfigType = {
   component: AuditLogsUpgradePage,
   title: "Audit logs",
   canSave: false,
-  needsUpgrade: true,
+  isFeatureEnabled: false,
 } as AdminConfigType;

--- a/app/client/src/ce/pages/AdminSettings/config/authentication/AuthPage.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/authentication/AuthPage.tsx
@@ -90,7 +90,6 @@ export type AuthMethodType = {
   label: string;
   subText?: string;
   image?: any;
-  needsUpgrade?: boolean;
   isConnected?: boolean;
   calloutBanner?: banner;
   icon?: string;

--- a/app/client/src/ce/pages/AdminSettings/config/branding/index.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/branding/index.tsx
@@ -20,5 +20,4 @@ export const config: AdminConfigType = {
   icon: "pantone",
   component: BrandingPage,
   isFeatureEnabled: isBrandingEnabled(featureFlags),
-  needsUpgrade: true,
 };

--- a/app/client/src/ce/pages/AdminSettings/config/general.tsx
+++ b/app/client/src/ce/pages/AdminSettings/config/general.tsx
@@ -78,7 +78,7 @@ export const APPSMITH_HIDE_WATERMARK_SETTING: Setting = {
   controlType: SettingTypes.CHECKBOX,
   label: "Appsmith watermark",
   text: "Show Appsmith watermark",
-  needsUpgrade: true,
+  isFeatureEnabled: false,
   isDisabled: () => true,
   textSuffix: <BrandingBadge />,
 };

--- a/app/client/src/ce/pages/AdminSettings/config/provisioning.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/provisioning.ts
@@ -14,6 +14,6 @@ export const config: AdminConfigType = {
   component: ProvisioningUpgradePage,
   title: "Provisioning",
   canSave: false,
-  needsUpgrade: true,
+  isFeatureEnabled: false,
   isEnterprise: true,
 } as AdminConfigType;

--- a/app/client/src/ce/pages/AdminSettings/config/types.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/types.ts
@@ -82,7 +82,7 @@ export type Setting = ControlType & {
   formName?: string;
   fieldName?: string;
   dropdownOptions?: Partial<SelectOptionProps>[];
-  needsUpgrade?: boolean;
+  isFeatureEnabled?: boolean;
   tooltip?: string;
 };
 
@@ -95,7 +95,6 @@ export interface Category {
   children?: Category[];
   icon?: string;
   categoryType: string;
-  needsUpgrade?: boolean;
   isEnterprise?: boolean;
   isFeatureEnabled?: boolean;
 }
@@ -136,7 +135,6 @@ export type AdminConfigType = {
   isConnected?: boolean;
   needsRefresh?: boolean;
   icon?: string;
-  needsUpgrade?: boolean;
   categoryType: CategoryType;
   isEnterprise?: boolean;
   isFeatureEnabled?: boolean;

--- a/app/client/src/ce/pages/AdminSettings/config/userlisting.ts
+++ b/app/client/src/ce/pages/AdminSettings/config/userlisting.ts
@@ -14,5 +14,5 @@ export const config: AdminConfigType = {
   component: AccessControlUpgradePage,
   title: "Access Control",
   canSave: false,
-  needsUpgrade: true,
+  isFeatureEnabled: false,
 } as AdminConfigType;

--- a/app/client/src/ce/pages/workspace/Members.tsx
+++ b/app/client/src/ce/pages/workspace/Members.tsx
@@ -52,52 +52,54 @@ export type PageProps = RouteComponentProps<{
 export const MembersWrapper = styled.div<{
   isMobile?: boolean;
 }>`
-  ${(props) => (props.isMobile ? "width: 100%; margin: auto" : null)}
-  table {
-    table-layout: fixed;
+  &.members-wrapper {
+    ${(props) => (props.isMobile ? "width: 100%; margin: auto" : null)}
+    table {
+      table-layout: fixed;
 
-    thead {
-      z-index: 1;
-      tr {
-        border-bottom: 1px solid var(--ads-v2-color-border);
-        th {
-          font-size: 14px;
-          font-weight: 500;
-          line-height: 1.5;
-          color: var(--ads-v2-color-fg);
-          padding: 8px 20px;
+      thead {
+        z-index: 1;
+        tr {
+          border-bottom: 1px solid var(--ads-v2-color-border);
+          th {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.5;
+            color: var(--ads-v2-color-fg);
+            padding: 8px 20px;
 
-          &:last-child {
-            width: 120px;
-          }
+            &:last-child {
+              width: 120px;
+            }
 
-          svg {
-            margin: auto 8px;
-            display: initial;
+            svg {
+              margin: auto 8px;
+              display: initial;
+            }
           }
         }
       }
-    }
 
-    tbody {
-      tr {
-        td {
-          word-break: break-word;
-          padding: 0 var(--ads-spaces-9);
-          border-bottom: none;
-          height: 40px;
+      tbody {
+        tr {
+          td {
+            word-break: break-word;
+            padding: 0 var(--ads-spaces-9);
+            border-bottom: none;
+            height: 40px;
 
-          &:first-child {
-            text-align: left;
-          }
+            &:first-child {
+              text-align: left;
+            }
 
-          .ads-v2-select {
-            width: fit-content;
-            > .rc-select-selector {
-              border: none;
+            .ads-v2-select {
+              width: fit-content;
+              > .rc-select-selector {
+                border: none;
 
-              > .rc-select-selection-item {
-                padding-left: 0;
+                > .rc-select-selection-item {
+                  padding-left: 0;
+                }
               }
             }
           }
@@ -472,7 +474,11 @@ export default function MemberSettings(props: PageProps) {
   };
 
   return (
-    <MembersWrapper data-testid="t--members-wrapper" isMobile={isMobile}>
+    <MembersWrapper
+      className="members-wrapper"
+      data-testid="t--members-wrapper"
+      isMobile={isMobile}
+    >
       <>
         {!isMobile && (
           <Table

--- a/app/client/src/pages/Settings/FormGroup/Checkbox.tsx
+++ b/app/client/src/pages/Settings/FormGroup/Checkbox.tsx
@@ -22,7 +22,7 @@ type CheckboxProps = {
   label?: React.ReactNode;
   id?: string;
   isDisabled?: boolean;
-  needsUpgrade?: boolean;
+  isFeatureEnabled?: boolean;
   text: string;
   labelSuffix?: React.ReactElement;
   isPropertyDisabled?: boolean;
@@ -85,7 +85,7 @@ export function CheckboxComponent({ setting }: SettingComponentProps) {
         >
           {setting.label}
         </Text>
-        {setting.needsUpgrade && <BusinessTag />}
+        {setting.isFeatureEnabled === false && <BusinessTag />}
       </div>
       <Field
         component={FieldCheckboxWithCheckboxText({
@@ -93,7 +93,7 @@ export function CheckboxComponent({ setting }: SettingComponentProps) {
           text: setting.text || "",
           id: setting.id,
           isDisabled: setting.isDisabled && setting.isDisabled(settings),
-          needsUpgrade: setting.needsUpgrade,
+          isFeatureEnabled: setting.isFeatureEnabled,
           labelSuffix: setting.textSuffix,
           isPropertyDisabled: isTenantConfig(setting.id)
             ? false

--- a/app/client/src/pages/Settings/config/ConfigFactory.ts
+++ b/app/client/src/pages/Settings/config/ConfigFactory.ts
@@ -44,7 +44,6 @@ export class ConfigFactory {
       slug: config.type,
       subText: config.subText,
       categoryType: config.categoryType,
-      needsUpgrade: config.needsUpgrade,
       isEnterprise: config.isEnterprise,
       needsRefresh: config.needsRefresh,
       isFeatureEnabled: config.isFeatureEnabled,


### PR DESCRIPTION
## Description

- Updating UI for members page to remove the borders between rows.
- Updating the condition for upgrade tags on the left pane of admin settings, to use feature flags instead.

#### PR fixes following issue(s)
Fixes [#26627](https://github.com/appsmithorg/appsmith/issues/26627)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [x] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
