### PR TITLE
fix: Add nginx-extras and remove Sever header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV LC_ALL C.UTF-8
 RUN apt-get update \
   && apt-get upgrade --yes \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
-    supervisor curl cron nfs-common certbot nginx gnupg wget netcat openssh-client \
+    supervisor curl cron nfs-common certbot nginx nginx-extras gnupg wget netcat openssh-client \
     software-properties-common gettext \
     python3-pip python3-requests python-setuptools git ca-certificates-java \
   && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add - \

--- a/deploy/docker/templates/nginx/nginx-app.conf.sh
+++ b/deploy/docker/templates/nginx/nginx-app.conf.sh
@@ -42,6 +42,7 @@ map \$http_forwarded \$final_forwarded {
 access_log /dev/stdout;
 
 server_tokens off;
+more_set_headers 'Server: ';
 
 server {
 


### PR DESCRIPTION
Removes this `Server` header in all responses from Appsmith.

```
curl -sSI http://localhost | grep 'server:'
```

It currently shows this:

```
server: nginx
```
