### PR TITLE
fix: PhoneInputWidget crash on switching environment

### DIFF
--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -276,13 +276,13 @@ class PhoneInputWidget extends BaseInputWidget<
     ) {
       const formattedValue = this.getFormattedPhoneNumber(this.props.text);
 
-      formattedValue &&
+      if (formattedValue) {
         this.props.updateWidgetMetaProperty(
           "value",
           parseIncompletePhoneNumber(formattedValue),
         );
-      formattedValue &&
         this.props.updateWidgetMetaProperty("text", formattedValue);
+      }
     }
 
     // If defaultText property has changed, reset isDirty to false

--- a/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
+++ b/app/client/src/widgets/PhoneInputWidget/widget/index.tsx
@@ -276,11 +276,13 @@ class PhoneInputWidget extends BaseInputWidget<
     ) {
       const formattedValue = this.getFormattedPhoneNumber(this.props.text);
 
-      this.props.updateWidgetMetaProperty(
-        "value",
-        parseIncompletePhoneNumber(formattedValue),
-      );
-      this.props.updateWidgetMetaProperty("text", formattedValue);
+      formattedValue &&
+        this.props.updateWidgetMetaProperty(
+          "value",
+          parseIncompletePhoneNumber(formattedValue),
+        );
+      formattedValue &&
+        this.props.updateWidgetMetaProperty("text", formattedValue);
     }
 
     // If defaultText property has changed, reset isDirty to false


### PR DESCRIPTION
## Description
> Add a graceful handling to avoid crashing on soft refresh.
>
>
#### PR fixes following issue(s)
Fixes #26693 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan

1. Dragged and dropped phone input widget on canvas and deployed the app - Entered value and switched environments. 
2. Set a default value for phone input widget, and deployed the app - switched environments. 
3. Dragged and dropped  other input widgets [Currency / Input] - and deployed, switched environments

>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
