### PR TITLE
fix: Support connecting to Redis with SSL support

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/configurations/RedisConfig.java
@@ -19,6 +19,7 @@ import org.springframework.data.redis.connection.RedisConfiguration;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.observability.MicrometerTracingAdapter;
@@ -74,6 +75,15 @@ public class RedisConfig {
                         new RedisStandaloneConfiguration(redisUri.getHost(), redisUri.getPort());
                 fillAuthentication(redisUri, config);
                 return new LettuceConnectionFactory(config);
+            }
+
+            case "rediss" -> {
+                final RedisStandaloneConfiguration config =
+                        new RedisStandaloneConfiguration(redisUri.getHost(), redisUri.getPort());
+                fillAuthentication(redisUri, config);
+                final LettuceClientConfiguration clientConfig =
+                        LettucePoolingClientConfiguration.builder().useSsl().build();
+                return new LettuceConnectionFactory(config, clientConfig);
             }
 
             case "redis-cluster" -> {


### PR DESCRIPTION
Redis with SSL was supported, but was broken when we added support for connecting to Redis clusters.

This PR brings that support to `rediss://` URIs back.

To test, get a Redis Database provisioned on DigitalOcean, and use the URI from there and verify Appsmith comes up, when `APPSMITH_REDIS_URL` is set to it.
