### PR TITLE
fix: Using correct permissions on datasource and application during crud page instead of edit permissions

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -226,7 +226,7 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
         Mono<NewPage> pageMono = getOrCreatePage(defaultApplicationId, defaultPageId, tableName, branchName);
 
         Mono<DatasourceStorage> datasourceStorageMono = datasourceService
-                .findById(datasourceId, datasourcePermission.getCreateActionPermission())
+                .findById(datasourceId, datasourcePermission.getActionCreatePermission())
                 .switchIfEmpty(Mono.error(
                         new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasourceId)))
                 .flatMap(datasource -> datasourceStorageService.findByDatasourceAndEnvironmentIdForExecution(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -226,7 +226,7 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
         Mono<NewPage> pageMono = getOrCreatePage(defaultApplicationId, defaultPageId, tableName, branchName);
 
         Mono<DatasourceStorage> datasourceStorageMono = datasourceService
-                .findById(datasourceId, datasourcePermission.getEditPermission())
+                .findById(datasourceId, datasourcePermission.getCreateActionPermission())
                 .switchIfEmpty(Mono.error(
                         new AppsmithException(AppsmithError.ACL_NO_RESOURCE_FOUND, FieldName.DATASOURCE, datasourceId)))
                 .flatMap(datasource -> datasourceStorageService.findByDatasourceAndEnvironmentIdForExecution(

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/CreateDBTablePageSolutionCEImpl.java
@@ -495,7 +495,10 @@ public class CreateDBTablePageSolutionCEImpl implements CreateDBTablePageSolutio
         }
 
         return applicationService
-                .findBranchedApplicationId(branchName, defaultApplicationId, applicationPermission.getEditPermission())
+                .findBranchedApplicationId(
+                        branchName, defaultApplicationId, applicationPermission.getPageCreatePermission())
+                .switchIfEmpty(Mono.error(new AppsmithException(
+                        AppsmithError.NO_RESOURCE_FOUND, FieldName.APPLICATION, defaultApplicationId)))
                 .flatMapMany(childApplicationId -> newPageService.findByApplicationId(
                         childApplicationId, pagePermission.getEditPermission(), false))
                 .collectList()

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCE.java
@@ -7,5 +7,5 @@ public interface DatasourcePermissionCE {
 
     AclPermission getExecutePermission();
 
-    AclPermission getCreateActionPermission();
+    AclPermission getActionCreatePermission();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCE.java
@@ -6,4 +6,6 @@ public interface DatasourcePermissionCE {
     AclPermission getDeletePermission();
 
     AclPermission getExecutePermission();
+
+    AclPermission getCreateActionPermission();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCEImpl.java
@@ -24,7 +24,7 @@ public class DatasourcePermissionCEImpl implements DatasourcePermissionCE, Domai
     }
 
     @Override
-    public AclPermission getCreateActionPermission() {
+    public AclPermission getActionCreatePermission() {
         return AclPermission.MANAGE_DATASOURCES;
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/solutions/ce/DatasourcePermissionCEImpl.java
@@ -22,4 +22,9 @@ public class DatasourcePermissionCEImpl implements DatasourcePermissionCE, Domai
     public AclPermission getExecutePermission() {
         return AclPermission.EXECUTE_DATASOURCES;
     }
+
+    @Override
+    public AclPermission getCreateActionPermission() {
+        return AclPermission.MANAGE_DATASOURCES;
+    }
 }


### PR DESCRIPTION
CRUD Page generation used edit datasource and edit application permissions till now. Updated the same to create page actions and create pages permissions respectively to support custom role creation on BE.

Fixes #26738