### PR TITLE
feat: Provide a fallback for feature flags when server is unable to connect to CS

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCE.java
@@ -11,35 +11,25 @@ public interface CacheableFeatureFlagHelperCE {
 
     Mono<CachedFlags> fetchUserCachedFlags(String userIdentifier, User user);
 
+    Mono<CachedFlags> updateUserCachedFlags(String userIdentifier, CachedFlags cachedFlags);
+
     Mono<Void> evictUserCachedFlags(String userIdentifier);
-
-    /**
-     * To fetch the tenant current features via cache
-     * @param tenantId Id of the tenant
-     * @return Mono of CachedFeatures
-     */
-    Mono<CachedFeatures> fetchCachedTenantCurrentFeatures(String tenantId);
-
-    /**
-     * To evict the tenant current features cache
-     * @param tenantId Id of the tenant
-     * @return Mono of Void
-     */
-    Mono<Void> evictCachedTenantCurrentFeatures(String tenantId);
 
     /**
      * To fetch the tenant new features via cache
      * @param tenantId Id of the tenant
      * @return Mono of CachedFeatures
      */
-    Mono<CachedFeatures> fetchCachedTenantNewFeatures(String tenantId);
+    Mono<CachedFeatures> fetchCachedTenantFeatures(String tenantId);
+
+    Mono<CachedFeatures> updateCachedTenantFeatures(String tenantId, CachedFeatures cachedFeatures);
 
     /**
      * To evict the tenant new features cache
      * @param tenantId Id of the tenant
      * @return Mono of Void
      */
-    Mono<Void> evictCachedTenantNewFeatures(String tenantId);
+    Mono<Void> evictCachedTenantFeatures(String tenantId);
 
     /**
      * To get all tenant features from Cloud Services

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/CacheableFeatureFlagHelperCEImpl.java
@@ -55,6 +55,12 @@ public class CacheableFeatureFlagHelperCEImpl implements CacheableFeatureFlagHel
         });
     }
 
+    @Cache(cacheName = "featureFlag", key = "{#userIdentifier}")
+    @Override
+    public Mono<CachedFlags> updateUserCachedFlags(String userIdentifier, CachedFlags cachedFlags) {
+        return Mono.just(cachedFlags);
+    }
+
     private Mono<Map<String, Object>> getUserDefaultTraits(User user) {
         return configService.getInstanceId().map(instanceId -> {
             Map<String, Object> userTraits = new HashMap<>();
@@ -137,44 +143,25 @@ public class CacheableFeatureFlagHelperCEImpl implements CacheableFeatureFlagHel
     }
 
     /**
-     * To fetch the tenant current features via cache
-     * @param tenantId Id of the tenant
-     * @return Mono of CachedFeatures
-     */
-    @Cache(cacheName = "tenantCurrentFeatures", key = "{#tenantId}")
-    @Override
-    public Mono<CachedFeatures> fetchCachedTenantCurrentFeatures(String tenantId) {
-        // TODO: Add logic to fetch default or current features from persistent storage
-        // TODO: Store the current features to DB for safe storage
-        // TODO: Update cache and persistent storage with newFeatures when migration is applied
-        return Mono.empty();
-    }
-
-    /**
-     * To evict the tenant current features cache
-     * @param tenantId Id of the tenant
-     * @return Mono of Void
-     */
-    @CacheEvict(cacheName = "tenantCurrentFeatures", key = "{#tenantId}")
-    @Override
-    public Mono<Void> evictCachedTenantCurrentFeatures(String tenantId) {
-        return Mono.empty();
-    }
-
-    /**
      * To fetch the tenant new features via cache
      * @param tenantId Id of the tenant
      * @return Mono of CachedFeatures
      */
     @Cache(cacheName = "tenantNewFeatures", key = "{#tenantId}")
     @Override
-    public Mono<CachedFeatures> fetchCachedTenantNewFeatures(String tenantId) {
+    public Mono<CachedFeatures> fetchCachedTenantFeatures(String tenantId) {
         return this.forceAllRemoteFeaturesForTenant(tenantId).flatMap(flags -> {
             CachedFeatures cachedFeatures = new CachedFeatures();
             cachedFeatures.setRefreshedAt(Instant.now());
             cachedFeatures.setFeatures(flags);
             return Mono.just(cachedFeatures);
         });
+    }
+
+    @Cache(cacheName = "tenantNewFeatures", key = "{#tenantId}")
+    @Override
+    public Mono<CachedFeatures> updateCachedTenantFeatures(String tenantId, CachedFeatures cachedFeatures) {
+        return Mono.just(cachedFeatures);
     }
 
     /**
@@ -184,7 +171,7 @@ public class CacheableFeatureFlagHelperCEImpl implements CacheableFeatureFlagHel
      */
     @CacheEvict(cacheName = "tenantNewFeatures", key = "{#tenantId}")
     @Override
-    public Mono<Void> evictCachedTenantNewFeatures(String tenantId) {
+    public Mono<Void> evictCachedTenantFeatures(String tenantId) {
         return Mono.empty();
     }
 
@@ -212,10 +199,11 @@ public class CacheableFeatureFlagHelperCEImpl implements CacheableFeatureFlagHel
     }
 
     /**
-     * To get all tenant features from Cloud Services
+     * To get all tenant features from Cloud Services.
      * @param featuresRequestDTO FeaturesRequestDTO
      * @return Mono of Map
      */
+    @Override
     public Mono<FeaturesResponseDTO> getRemoteFeaturesForTenant(FeaturesRequestDTO featuresRequestDTO) {
         return WebClientUtils.create(cloudServicesConfig.getBaseUrl())
                 .post()
@@ -235,7 +223,8 @@ public class CacheableFeatureFlagHelperCEImpl implements CacheableFeatureFlagHel
                         e -> !(e instanceof AppsmithException),
                         e -> new AppsmithException(AppsmithError.CLOUD_SERVICES_ERROR, e.getMessage()))
                 .onErrorResume(error -> {
-                    log.debug("Received error from CS while fetching features: {}", error.getMessage());
+                    log.error("Received error from CS while fetching features: {}", error.getMessage(), error);
+                    // Don't throw the exception as the downstream method expects a valid response even if API fails
                     return Mono.just(new FeaturesResponseDTO());
                 });
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCE.java
@@ -47,7 +47,7 @@ public interface FeatureFlagServiceCE {
      * To get all features of the current tenant.
      * @return Mono of Map
      */
-    Mono<Map<String, Boolean>> getCurrentTenantFeatures();
+    Mono<Map<String, Boolean>> getTenantFeatures();
 
     /**
      * To force update all features of the current tenant.

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
@@ -133,8 +133,8 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
                                     .evictUserCachedFlags(userIdentifier)
                                     .then(cacheableFeatureFlagHelper.fetchUserCachedFlags(userIdentifier, user))
                                     .flatMap(cachedFlagsUpdated -> {
-                                        // If the call to CS to fetch the latest flags fails for some reason previous
-                                        // flags will act as a fallback value
+                                        // In case the retrieval of the latest flags from CS encounters an error, the
+                                        // previous flags will serve as a fallback value.
                                         if (cachedFlagsUpdated == null
                                                 || CollectionUtils.isNullOrEmpty(cachedFlagsUpdated.getFlags())) {
                                             return cacheableFeatureFlagHelper
@@ -177,7 +177,8 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
      */
     @Override
     public Mono<CachedFeatures> forceUpdateTenantFeatures(String tenantId) {
-        // If the call to CS to fetch the latest flags fails for some reason previous flags will act as a fallback value
+        // In case the retrieval of the latest flags from CS encounters an error, the previous flags will serve as a
+        // fallback value.
         return cacheableFeatureFlagHelper
                 .fetchCachedTenantFeatures(tenantId)
                 .flatMap(cachedFeatures -> cacheableFeatureFlagHelper

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/FeatureFlagServiceCEImpl.java
@@ -4,7 +4,9 @@ import com.appsmith.server.configurations.CloudServicesConfig;
 import com.appsmith.server.constants.FieldName;
 import com.appsmith.server.domains.User;
 import com.appsmith.server.featureflags.CachedFeatures;
+import com.appsmith.server.featureflags.CachedFlags;
 import com.appsmith.server.featureflags.FeatureFlagEnum;
+import com.appsmith.server.helpers.CollectionUtils;
 import com.appsmith.server.services.CacheableFeatureFlagHelper;
 import com.appsmith.server.services.ConfigService;
 import com.appsmith.server.services.SessionUserService;
@@ -100,7 +102,7 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
 
         // Combine local flags, remote flags, and tenant features, and merge them into a single map
         return localFlagsForUser.flatMap(localFlags -> this.getAllRemoteFeatureFlagsForUser()
-                .zipWith(this.getCurrentTenantFeatures())
+                .zipWith(this.getTenantFeatures())
                 .map(remoteAndTenantFlags -> {
                     Map<String, Boolean> combinedFlags = new HashMap<>(localFlags);
                     combinedFlags.putAll(remoteAndTenantFlags.getT1());
@@ -130,7 +132,17 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
                             return cacheableFeatureFlagHelper
                                     .evictUserCachedFlags(userIdentifier)
                                     .then(cacheableFeatureFlagHelper.fetchUserCachedFlags(userIdentifier, user))
-                                    .flatMap(cachedFlagsUpdated -> Mono.just(cachedFlagsUpdated.getFlags()));
+                                    .flatMap(cachedFlagsUpdated -> {
+                                        // If the call to CS to fetch the latest flags fails for some reason previous
+                                        // flags will act as a fallback value
+                                        if (cachedFlagsUpdated == null
+                                                || CollectionUtils.isNullOrEmpty(cachedFlagsUpdated.getFlags())) {
+                                            return cacheableFeatureFlagHelper
+                                                    .updateUserCachedFlags(userIdentifier, cachedFlags)
+                                                    .map(CachedFlags::getFlags);
+                                        }
+                                        return Mono.just(cachedFlagsUpdated.getFlags());
+                                    });
                         }
                     });
         });
@@ -144,7 +156,7 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
         return tenantService
                 .getDefaultTenantId()
                 .flatMap(defaultTenantId -> cacheableFeatureFlagHelper
-                        .fetchCachedTenantNewFeatures(defaultTenantId)
+                        .fetchCachedTenantFeatures(defaultTenantId)
                         .flatMap(cachedFeatures -> {
                             if (cachedFeatures.getRefreshedAt().until(Instant.now(), ChronoUnit.MINUTES)
                                     < this.tenantFeaturesCacheTimeMin) {
@@ -159,25 +171,34 @@ public class FeatureFlagServiceCEImpl implements FeatureFlagServiceCE {
     /**
      * Method to force update the tenant level feature flags. This will be utilised in scenarios where we don't want
      * to wait for the flags to get updated for cron scheduled time
+     *
      * @param tenantId  tenant for which the features need to be updated
      * @return          Cached features
      */
     @Override
     public Mono<CachedFeatures> forceUpdateTenantFeatures(String tenantId) {
+        // If the call to CS to fetch the latest flags fails for some reason previous flags will act as a fallback value
         return cacheableFeatureFlagHelper
-                .evictCachedTenantNewFeatures(tenantId)
-                .then(cacheableFeatureFlagHelper.fetchCachedTenantNewFeatures(tenantId));
+                .fetchCachedTenantFeatures(tenantId)
+                .flatMap(cachedFeatures -> cacheableFeatureFlagHelper
+                        .evictCachedTenantFeatures(tenantId)
+                        .then(cacheableFeatureFlagHelper.fetchCachedTenantFeatures(tenantId))
+                        .flatMap(features -> {
+                            if (CollectionUtils.isNullOrEmpty(features.getFeatures())) {
+                                return cacheableFeatureFlagHelper.updateCachedTenantFeatures(tenantId, cachedFeatures);
+                            }
+                            return Mono.just(features);
+                        }));
     }
 
     /**
      * To get all features of the current tenant.
      * @return Mono of Map
      */
-    public Mono<Map<String, Boolean>> getCurrentTenantFeatures() {
+    public Mono<Map<String, Boolean>> getTenantFeatures() {
         return tenantService
                 .getDefaultTenantId()
-                // TODO: Update to call fetchCachedTenantCurrentFeatures once default value storing is complete
-                .flatMap(cacheableFeatureFlagHelper::fetchCachedTenantNewFeatures)
+                .flatMap(cacheableFeatureFlagHelper::fetchCachedTenantFeatures)
                 .map(CachedFeatures::getFeatures);
     }
 }


### PR DESCRIPTION
## Description
PR to add the fallback mechanism when call to CS to fetch the feature flags at tenant as well as user level fails for some reason. With this PR once the feature flag response is received for the first time user will never lose the access of the feature.

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith-ee/issues/2130

#### Type of change
- New feature (non-breaking change which adds functionality)

## Testing
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [x] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
