### PR TITLE
fix: entity explorer issue with datasources is fixed

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
@@ -16,24 +16,26 @@ describe("Bug 26726: Datasource selected from entity explorer should be correctl
       // Select Users
       entityExplorer.SelectEntityByName("Users", "Datasources");
       agHelper.Sleep(200);
-      cy.get("[data-testid='t--entity-item-Users']").should(
-        "have.class",
+      agHelper.AssertClassExists(
+        dataSources._entityExplorerID("Users"),
         "active",
       );
 
       // Switch to Movies
       entityExplorer.SelectEntityByName("Movies", "Datasources");
       agHelper.Sleep(200);
-      cy.get("[data-testid='t--entity-item-Movies']").should(
-        "have.class",
+      agHelper.AssertClassExists(
+        dataSources._entityExplorerID("Movies"),
         "active",
       );
 
       // Switch to custom DS
       entityExplorer.SelectEntityByName(dsName, "Datasources");
       agHelper.Sleep(200);
-      const testId = "t--entity-item-" + dsName;
-      cy.get(`[data-testid='${testId}']`).should("have.class", "active");
+      agHelper.AssertClassExists(
+        dataSources._entityExplorerID(dsName),
+        "active",
+      );
 
       // Delete all datasources
       dataSources.DeleteDatasouceFromActiveTab("Users");

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
@@ -1,0 +1,44 @@
+import {
+  agHelper,
+  dataSources,
+  entityExplorer,
+} from "../../../../support/Objects/ObjectsCore";
+let dsName;
+
+describe("Bug 26726: Datasource selected from entity explorer should be correctly highlighted", function () {
+  it("1. Create users and movies mock datasources and switch between them through entity explorer, check the active state", function () {
+    dataSources.CreateMockDB("Users");
+    dataSources.CreateMockDB("Movies");
+    dataSources.NavigateToDSCreateNew();
+    dataSources.CreateDataSource("Postgres");
+    cy.get("@dsName").then(($dsName) => {
+      dsName = $dsName + "";
+      // Select Users
+      entityExplorer.SelectEntityByName("Users", "Datasources");
+      agHelper.Sleep(200);
+      cy.get("[data-testid='t--entity-item-Users']").should(
+        "have.class",
+        "active",
+      );
+
+      // Switch to Movies
+      entityExplorer.SelectEntityByName("Movies", "Datasources");
+      agHelper.Sleep(200);
+      cy.get("[data-testid='t--entity-item-Movies']").should(
+        "have.class",
+        "active",
+      );
+
+      // Switch to custom DS
+      entityExplorer.SelectEntityByName(dsName, "Datasources");
+      agHelper.Sleep(200);
+      const testId = "t--entity-item-" + dsName;
+      cy.get(`[data-testid='${testId}']`).should("have.class", "active");
+
+      // Delete all datasources
+      dataSources.DeleteDatasouceFromActiveTab("Users");
+      dataSources.DeleteDatasouceFromActiveTab("Movies");
+      dataSources.DeleteDatasouceFromActiveTab(dsName);
+    });
+  });
+});

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
@@ -5,42 +5,46 @@ import {
 } from "../../../../support/Objects/ObjectsCore";
 let dsName;
 
-describe("Bug 26726: Datasource selected from entity explorer should be correctly highlighted", function () {
-  it("1. Create users and movies mock datasources and switch between them through entity explorer, check the active state", function () {
-    dataSources.CreateMockDB("Users");
-    dataSources.CreateMockDB("Movies");
-    dataSources.NavigateToDSCreateNew();
-    dataSources.CreateDataSource("Postgres");
-    cy.get("@dsName").then(($dsName) => {
-      dsName = $dsName + "";
-      // Select Users
-      entityExplorer.SelectEntityByName("Users", "Datasources");
-      agHelper.Sleep(200);
-      agHelper.AssertClassExists(
-        dataSources._entityExplorerID("Users"),
-        "active",
-      );
+describe(
+  "excludeForAirgap",
+  "Bug 26726: Datasource selected from entity explorer should be correctly highlighted",
+  function () {
+    it("1. Create users and movies mock datasources and switch between them through entity explorer, check the active state", function () {
+      dataSources.CreateMockDB("Users");
+      dataSources.CreateMockDB("Movies");
+      dataSources.NavigateToDSCreateNew();
+      dataSources.CreateDataSource("Postgres");
+      cy.get("@dsName").then(($dsName) => {
+        dsName = $dsName + "";
+        // Select Users
+        entityExplorer.SelectEntityByName("Users", "Datasources");
+        agHelper.Sleep(200);
+        agHelper.AssertClassExists(
+          dataSources._entityExplorerID("Users"),
+          "active",
+        );
 
-      // Switch to Movies
-      entityExplorer.SelectEntityByName("Movies", "Datasources");
-      agHelper.Sleep(200);
-      agHelper.AssertClassExists(
-        dataSources._entityExplorerID("Movies"),
-        "active",
-      );
+        // Switch to Movies
+        entityExplorer.SelectEntityByName("Movies", "Datasources");
+        agHelper.Sleep(200);
+        agHelper.AssertClassExists(
+          dataSources._entityExplorerID("Movies"),
+          "active",
+        );
 
-      // Switch to custom DS
-      entityExplorer.SelectEntityByName(dsName, "Datasources");
-      agHelper.Sleep(200);
-      agHelper.AssertClassExists(
-        dataSources._entityExplorerID(dsName),
-        "active",
-      );
+        // Switch to custom DS
+        entityExplorer.SelectEntityByName(dsName, "Datasources");
+        agHelper.Sleep(200);
+        agHelper.AssertClassExists(
+          dataSources._entityExplorerID(dsName),
+          "active",
+        );
 
-      // Delete all datasources
-      dataSources.DeleteDatasouceFromActiveTab("Users");
-      dataSources.DeleteDatasouceFromActiveTab("Movies");
-      dataSources.DeleteDatasouceFromActiveTab(dsName);
+        // Delete all datasources
+        dataSources.DeleteDatasouceFromActiveTab("Users");
+        dataSources.DeleteDatasouceFromActiveTab("Movies");
+        dataSources.DeleteDatasouceFromActiveTab(dsName);
+      });
     });
-  });
-});
+  },
+);

--- a/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/BugTests/Bug26716_Spec.ts
@@ -7,7 +7,7 @@ let dsName;
 
 describe(
   "excludeForAirgap",
-  "Bug 26726: Datasource selected from entity explorer should be correctly highlighted",
+  "Bug 26716: Datasource selected from entity explorer should be correctly highlighted",
   function () {
     it("1. Create users and movies mock datasources and switch between them through entity explorer, check the active state", function () {
       dataSources.CreateMockDB("Users");

--- a/app/client/cypress/support/Pages/AggregateHelper.ts
+++ b/app/client/cypress/support/Pages/AggregateHelper.ts
@@ -1639,6 +1639,10 @@ export class AggregateHelper extends ReusableHelper {
       });
   }
 
+  public AssertClassExists(selector: string, className: string) {
+    cy.get(selector).should("have.class", className);
+  }
+
   //Not used:
   // private xPathToCss(xpath: string) {
   //     return xpath

--- a/app/client/cypress/support/Pages/DataSources.ts
+++ b/app/client/cypress/support/Pages/DataSources.ts
@@ -268,7 +268,7 @@ export class DataSources {
     "[data-widgetname-cy='update_file_name'] div[data-testid='input-container']";
   _s3MaxFileSizeAlert = "//p[@role='alert']";
   _entityExplorerID = (dsName: string) =>
-    "[data-testid='t--entity-item-" + dsName + "]";
+    "[data-testid='t--entity-item-" + dsName + "']";
 
   public AssertDSEditViewMode(mode: "Edit" | "View") {
     if (mode == "Edit") this.agHelper.AssertElementAbsence(this._editButton);

--- a/app/client/cypress/support/Pages/DataSources.ts
+++ b/app/client/cypress/support/Pages/DataSources.ts
@@ -267,6 +267,8 @@ export class DataSources {
   _s3EditFileName =
     "[data-widgetname-cy='update_file_name'] div[data-testid='input-container']";
   _s3MaxFileSizeAlert = "//p[@role='alert']";
+  _entityExplorerID = (dsName: string) =>
+    "[data-testid='t--entity-item-" + dsName + "]";
 
   public AssertDSEditViewMode(mode: "Edit" | "View") {
     if (mode == "Edit") this.agHelper.AssertElementAbsence(this._editButton);

--- a/app/client/src/pages/Editor/Explorer/Datasources.tsx
+++ b/app/client/src/pages/Editor/Explorer/Datasources.tsx
@@ -109,7 +109,7 @@ const Datasources = React.memo(() => {
           />
         );
       }),
-    [appWideDS, pageId],
+    [appWideDS, pageId, activeDatasourceId],
   );
 
   const onDatasourcesToggle = useCallback(

--- a/app/client/src/pages/Editor/Explorer/hooks.ts
+++ b/app/client/src/pages/Editor/Explorer/hooks.ts
@@ -104,11 +104,13 @@ export const useOtherDatasourcesInWorkspace = () => {
       },
       new Set(),
     );
-    return allDatasources.filter(
-      (ds) =>
-        !datasourceIdsUsedInCurrentApplication.has(ds.id) &&
-        ds.id !== TEMP_DATASOURCE_ID,
-    );
+    return allDatasources
+      .filter(
+        (ds) =>
+          !datasourceIdsUsedInCurrentApplication.has(ds.id) &&
+          ds.id !== TEMP_DATASOURCE_ID,
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
   }, [actions, allDatasources]);
   return otherDatasourcesInWorkspace;
 };
@@ -143,7 +145,6 @@ export const useDatasourceSuggestions = () => {
   const otherDatasourceInWorkspace = useOtherDatasourcesInWorkspace();
   if (datasourcesUsedInApplication.length >= MAX_DATASOURCE_SUGGESTIONS)
     return [];
-  otherDatasourceInWorkspace.reverse();
   return otherDatasourceInWorkspace.slice(
     0,
     MAX_DATASOURCE_SUGGESTIONS - datasourcesUsedInApplication.length,


### PR DESCRIPTION
## Description
This PR fixes issue with datasource not getting highlighted in entity explorer:

Suppose we have 3 datasources in our applications: Users, Movies, and one Postgres or MySQL datasource. Once we create these datasources, we can see them getting populated in entity explorer -> datasource section.

So there were two issues here:
- If I select Users, I am able to see the Users datasource info on the right pane but its not active in the entity explorer, Similarly If I switch to movies, right pane gets updated with movies info but in the entity explorer, we cannot see movies getting highlighted as thats the active selection
- If I am on Users datasource review page, I reload the page, now I can see active selection of Users being highlighted in the entity explorer, but now if we switch to Movies, right pane gets updated but in entity explorer Users is highlighted, which is incorrect

This issue occurred because we have used useMemo for `datasourceElements`, two dependency passed are appWideDS and pageId, whenever we switch between datasources, `activeDatasourceId` gets updated but since we have cached the whole datasource listing component without the dependency of `activeDatasourceId`, it does not recompute and shows the same state as before.

To fix the issue, `activeDatasourceId` needs to be passed in the dependency array. After adding this new dependency, another issue occurred with respect to entity explorer, The order of suggested datasources would change in entity explorer, This PR addresses that issue as well.
#### PR fixes following issue(s)
Fixes #26716 
> if no issue exists, please create an issue and ask the maintainers about this first
>
>
#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- Bug fix (non-breaking change which fixes an issue)
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [x] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [x] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
