### PR TITLE
chore: Redis config don't write to filesystem at runtime

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -295,9 +295,7 @@ configure_supervisord() {
     fi
     if [[ $APPSMITH_REDIS_URL == *"localhost"* || $APPSMITH_REDIS_URL == *"127.0.0.1"* ]]; then
       cp "$SUPERVISORD_CONF_PATH/redis.conf" /etc/supervisor/conf.d/
-      # Initialize Redis rdb directory
-      local redis_db_path="$stacks_path/data/redis"
-      mkdir -p "$redis_db_path"
+      mkdir -p "$stacks_path/data/redis"
     fi
     if ! [[ -e "/appsmith-stacks/ssl/fullchain.pem" ]] || ! [[ -e "/appsmith-stacks/ssl/privkey.pem" ]]; then
       cp "$SUPERVISORD_CONF_PATH/cron.conf" /etc/supervisor/conf.d/

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -298,11 +298,6 @@ configure_supervisord() {
       # Initialize Redis rdb directory
       local redis_db_path="$stacks_path/data/redis"
       mkdir -p "$redis_db_path"
-      # Enable saving Redis session data to disk more often, so recent sessions aren't cleared on restart.
-      sed -i \
-        -e 's/^save 60 10000$/save 15 1/g' \
-        -e "s|^dir /var/lib/redis$|dir ${redis_db_path}|g" \
-        /etc/redis/redis.conf
     fi
     if ! [[ -e "/appsmith-stacks/ssl/fullchain.pem" ]] || ! [[ -e "/appsmith-stacks/ssl/privkey.pem" ]]; then
       cp "$SUPERVISORD_CONF_PATH/cron.conf" /etc/supervisor/conf.d/

--- a/deploy/docker/templates/supervisord/redis.conf
+++ b/deploy/docker/templates/supervisord/redis.conf
@@ -1,8 +1,8 @@
 [program:redis]
 directory=/etc/redis
-; The empty string is used to force Redis to log to stdout
-; so that supervisor can capture it
-command=redis-server redis.conf --daemonize no --logfile ""
+; The `--save` is for saving session data to disk more often, so recent sessions aren't cleared on restart.
+; The empty string to `--logfile` is for logging to stdout so that supervisor can capture it.
+command=redis-server --save 15 1 --dir /appsmith-stacks/data/redis --daemonize no --logfile ""
 priority=5
 autostart=true
 autorestart=true


### PR DESCRIPTION
Step towards not changing anything in the filesystem at runtime, except for things in `/tmp`.
