### PR TITLE
chore(deps): Remove pinned H2 database version

### DIFF
--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -27,7 +27,6 @@
 
     <properties>
         <deploy.disabled>true</deploy.disabled>
-        <h2.version>2.1.210</h2.version>
         <java.version>17</java.version>
         <javadoc.disabled>true</javadoc.disabled>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
We get `2.1.214` from Spring now, we don't need this override anymore.
