### PR TITLE
fix: JUnit testcases failures for EE codebase

### DIFF
--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/GitPrivateRepoCEImplTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/helpers/ce/GitPrivateRepoCEImplTest.java
@@ -3,6 +3,7 @@ package com.appsmith.server.helpers.ce;
 import com.appsmith.server.helpers.GitCloudServicesUtils;
 import com.appsmith.server.helpers.GitPrivateRepoHelper;
 import com.appsmith.server.services.ApplicationService;
+import com.appsmith.server.services.FeatureFlagService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,19 +12,19 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @Slf4j
-@DirtiesContext
 public class GitPrivateRepoCEImplTest {
 
     @Autowired
@@ -35,13 +36,23 @@ public class GitPrivateRepoCEImplTest {
     @MockBean
     ApplicationService applicationService;
 
+    /**
+     * Mocking is required as the methods are feature flagged in EE codebase which will call the super class method in
+     * case the feature is not supported
+     * Refer {@link com.appsmith.server.aspect.FeatureFlaggedMethodInvokerAspect}
+     */
+    @MockBean
+    FeatureFlagService featureFlagService;
+
     @BeforeEach
     void setup() {
         Mockito.when(gitCloudServicesUtils.getPrivateRepoLimitForOrg(anyString(), anyBoolean()))
                 .thenReturn(Mono.just(3));
+        Mockito.when(featureFlagService.check(any())).thenReturn(Mono.just(Boolean.FALSE));
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void isRepoLimitReached_connectedAppCountIsLessThanLimit_Success() {
 
         Mockito.when(applicationService.getGitConnectedApplicationsCountWithPrivateRepoByWorkspaceId(anyString()))
@@ -53,6 +64,7 @@ public class GitPrivateRepoCEImplTest {
     }
 
     @Test
+    @WithUserDetails(value = "api_user")
     public void isRepoLimitReached_connectedAppCountIsSameAsLimit_Success() {
 
         Mockito.when(applicationService.getGitConnectedApplicationsCountWithPrivateRepoByWorkspaceId(anyString()))
@@ -66,6 +78,7 @@ public class GitPrivateRepoCEImplTest {
     // This test is to check if the limit is reached when the count of connected apps is more than the limit
     // This happens when public visible git repo is synced with application and then the visibility is changed
     @Test
+    @WithUserDetails(value = "api_user")
     public void isRepoLimitReached_connectedAppCountIsMoreThanLimit_Success() {
 
         Mockito.when(applicationService.getGitConnectedApplicationsCountWithPrivateRepoByWorkspaceId(anyString()))


### PR DESCRIPTION
## Description
As we have started using the @FeatureFlagged for selectively calling the methods from different classes based on the feature flag support, this needs a valid user object to detect if the feature is supported for the current user. This PR adds the api_user context for running the testcases and also adds the mocking for FeatureFlagService which will be used only in EE codebase, but added here to avoid any future merge conflicts.