### PR TITLE
fix: move static JSON parsers to local variables

### DIFF
--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/ArrayType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/ArrayType.java
@@ -12,7 +12,6 @@ import reactor.core.Exceptions;
 public class ArrayType implements AppsmithType {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
 
     @Override
     public boolean test(String s) {
@@ -23,6 +22,8 @@ public class ArrayType implements AppsmithType {
 
     @Override
     public String performSmartSubstitution(String s) {
+        JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
+
         try {
             JSONArray jsonArray = (JSONArray) parser.parse(s);
             return objectMapper.writeValueAsString(jsonArray);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/JsonObjectType.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/datatypes/JsonObjectType.java
@@ -22,7 +22,6 @@ public class JsonObjectType implements AppsmithType {
 
     private static final TypeAdapter<JsonObject> strictGsonObjectAdapter = new Gson().getAdapter(JsonObject.class);
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
 
     @Override
     public boolean test(String s) {
@@ -39,6 +38,7 @@ public class JsonObjectType implements AppsmithType {
 
     @Override
     public String performSmartSubstitution(String s) {
+        JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
         try {
             JSONObject jsonObject = (JSONObject) parser.parse(s);
             String jsonString = objectMapper.writeValueAsString(jsonObject);

--- a/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
+++ b/app/server/appsmith-interfaces/src/main/java/com/appsmith/external/helpers/DataTypeStringUtils.java
@@ -55,8 +55,6 @@ public class DataTypeStringUtils {
 
     private static ObjectMapper objectMapper = new ObjectMapper();
 
-    private static JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
-
     private static final TypeAdapter<JsonObject> strictGsonObjectAdapter = new Gson().getAdapter(JsonObject.class);
 
     @Deprecated(
@@ -222,6 +220,7 @@ public class DataTypeStringUtils {
         Map.Entry<String, String> parameter = new SimpleEntry<>(replacement, dataType.toString());
         insertedParams.add(parameter);
 
+        JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
         String updatedReplacement;
         switch (dataType) {
             case INTEGER:


### PR DESCRIPTION
## Description
- A user shared [error logs](https://theappsmith.slack.com/archives/C0341RERY4R/p1692015569650229) with us with this error: `Malicious payload, having non natural depths`. As per [this](https://stackoverflow.com/questions/76333714/azure-load-testing-error-o-a-j-e-j-j-jsonpostprocessor-net-minidev-json-parse) thread, this error could occur because `minidev` JSON parser is not thread safe. Currently, in some places we use the `minidev` JSON parser defined as a static variable that could be used concurrently by multiple threads. This PR replaces those static variable definitions with thread local variables.  

#### PR fixes following issue(s)
Fixes #26932 

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

>
## Testing
>
#### How Has This Been Tested?
- Not aware how to write automated test for this at the moment.

#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
