### PR TITLE
test: Cypress | Skip Airtable from CustomConfig

### DIFF
--- a/app/client/cypress_ci_custom.config.ts
+++ b/app/client/cypress_ci_custom.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     saveAllAttempts: true,
   },
   chromeWebSecurity: false,
-  viewportHeight: 1100,
+  viewportHeight: 1200,
   viewportWidth: 1400,
   scrollBehavior: "center",
   retries: {
@@ -50,6 +50,10 @@ export default defineConfig({
     },
     specPattern: "cypress/e2e/**/*.{js,ts}",
     testIsolation: false,
-    excludeSpecPattern: "cypress/e2e/**/spec_utility.ts",
+    excludeSpecPattern: [
+      "cypress/e2e/**/spec_utility.ts",
+      "cypress/e2e/GSheet/**/**/*",
+      "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
+    ],
   },
 });


### PR DESCRIPTION
## Description
- Since Airtable is external Datasource & the api call fails when multiple hit multiple times, skipping it from normal oktotest workflows since its run once per day via scheduled runs.

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Testing
#### How Has This Been Tested?
- [X] Cypress

## Checklist:
#### QA activity:
- [X] Added `Test Plan Approved` label after Cypress tests were reviewed