### PR TITLE
chore: skip klona for eval updates (#27048)

### DIFF
--- a/app/client/src/workers/common/DataTreeEvaluator/index.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/index.ts
@@ -344,7 +344,8 @@ export default class DataTreeEvaluator {
     const evaluationOrder = this.sortedDependencies;
     // Evaluate
     const { evalMetaUpdates, evaluatedTree, staleMetaIds } = this.evaluateTree(
-      this.oldUnEvalTree,
+      //we need to deep clone oldUnEvalTree because evaluateTree will mutate it
+      klona(this.oldUnEvalTree),
       evaluationOrder,
       undefined,
       this.oldConfigTree,
@@ -781,6 +782,7 @@ export default class DataTreeEvaluator {
       evaluatedTree: newEvalTree,
       staleMetaIds,
     } = this.evaluateTree(
+      // should not clone evalTree unnessarily because it is anyways being overwritten in the subsequent statement
       this.evalTree,
       evaluationOrder,
       {
@@ -922,7 +924,7 @@ export default class DataTreeEvaluator {
   }
 
   evaluateTree(
-    oldUnevalTree: DataTree,
+    dataTree: DataTree,
     evaluationOrder: Array<string>,
     options: {
       isFirstTree: boolean;
@@ -939,9 +941,8 @@ export default class DataTreeEvaluator {
     evalMetaUpdates: EvalMetaUpdates;
     staleMetaIds: string[];
   } {
-    const tree = klona(oldUnevalTree);
     errorModifier.updateAsyncFunctions(
-      tree,
+      dataTree,
       this.getConfigTree(),
       this.dependencyMap,
     );
@@ -1167,7 +1168,7 @@ export default class DataTreeEvaluator {
               return set(currentTree, fullPropertyPath, evalPropertyValue);
           }
         },
-        tree,
+        dataTree,
       );
 
       return {
@@ -1180,7 +1181,7 @@ export default class DataTreeEvaluator {
         type: EvalErrorTypes.EVAL_TREE_ERROR,
         message: (error as Error).message,
       });
-      return { evaluatedTree: tree, evalMetaUpdates, staleMetaIds: [] };
+      return { evaluatedTree: dataTree, evalMetaUpdates, staleMetaIds: [] };
     }
   }
 
@@ -1465,7 +1466,9 @@ export default class DataTreeEvaluator {
     // setting parseValue in dataTree
     set(currentTree, fullPropertyPath, parsedValue);
     // setting evalPropertyValue in unParsedEvalTree
-    set(this.getUnParsedEvalTree(), fullPropertyPath, evalPropertyValue);
+    // cloning evalPropertyValue because parsedValue and evalPropertyValue could be equal, they both could share the same reference
+    //hence we are cloning evalPropertyValue to seperate them
+    set(this.getUnParsedEvalTree(), fullPropertyPath, klona(evalPropertyValue));
   }
 
   reValidateWidgetDependentProperty({

--- a/app/client/src/workers/common/DataTreeEvaluator/test.ts
+++ b/app/client/src/workers/common/DataTreeEvaluator/test.ts
@@ -16,6 +16,7 @@ import { replaceThisDotParams } from "./utils";
 import { isDataField } from "./utils";
 import widgets from "widgets";
 import type { WidgetConfiguration } from "WidgetProvider/constants";
+import { klona } from "klona";
 
 const widgetConfigMap: Record<
   string,
@@ -359,7 +360,7 @@ describe("DataTreeEvaluator", () => {
             nonDynamicFieldValidationOrder: nonDynamicFieldValidationOrder5,
             unEvalUpdates,
           } = dataTreeEvaluator.setupUpdateTree(
-            nestedArrayAccessorCyclicDependency.apiSuccessUnEvalTree,
+            klona(nestedArrayAccessorCyclicDependency.apiSuccessUnEvalTree),
             nestedArrayAccessorCyclicDependencyConfig.apiSuccessConfigTree,
           );
           dataTreeEvaluator.evalAndValidateSubTree(
@@ -423,7 +424,7 @@ describe("DataTreeEvaluator", () => {
           nonDynamicFieldValidationOrder,
           unEvalUpdates,
         } = dataTreeEvaluator.setupUpdateTree(
-          nestedArrayAccessorCyclicDependency.apiSuccessUnEvalTree,
+          klona(nestedArrayAccessorCyclicDependency.apiSuccessUnEvalTree),
           nestedArrayAccessorCyclicDependencyConfig.apiSuccessConfigTree,
         );
         dataTreeEvaluator.evalAndValidateSubTree(
@@ -470,7 +471,7 @@ describe("DataTreeEvaluator", () => {
           nonDynamicFieldValidationOrder: nonDynamicFieldValidationOrder2,
           unEvalUpdates,
         } = dataTreeEvaluator.setupUpdateTree(
-          nestedArrayAccessorCyclicDependency.apiSuccessUnEvalTree,
+          klona(nestedArrayAccessorCyclicDependency.apiSuccessUnEvalTree),
           nestedArrayAccessorCyclicDependencyConfig.apiSuccessConfigTree,
         );
         dataTreeEvaluator.evalAndValidateSubTree(


### PR DESCRIPTION
## Description
Klona operations are being performed on the dataTree for every evaluation cycle. This computation is heavy and scales up for large dataset. Over here we optimise code to limit klona deepClones for every evaluation cycles and noticed reduction of eval scripting time of upto 40% for apps hosting about 40000 records. Seen a 20-25% reduction in eval scripting in MISC test cases, these test cases host about 20000 records.
#### PR fixes following issue(s)
Fixes #27048

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)
## Testing
>
#### How Has This Been Tested?

- [x] Manual
- [ ] JUnit
- [ ] Jest
- [x] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
