### PR TITLE
chore: disable allowprivilegeescalation in the securitycontext of helm chart

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/appsmithorg/appsmith
 home: https://www.appsmith.com/
 icon: https://assets.appsmith.com/appsmith-icon.png
-version: 2.0.4
+version: 2.0.5
 dependencies:
 - condition: redis.enabled
   name: redis

--- a/deploy/helm/Publish-helm-chart.md
+++ b/deploy/helm/Publish-helm-chart.md
@@ -8,6 +8,14 @@
 
 * Create S3 bucket for Helm chart (naming as `helm.appsmith.com` \- Hosting S3 as Static web requires bucket name be the same with the domain\)
 * Clone your Helm charts (ignore if already have Appsmith repo on machine)
+
+* Build Helm chart depencies
+
+```
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm dependency build ./deploy/helm    
+```
+
 * Package the local Helm chart
 
 ```
@@ -58,31 +66,55 @@ helm search repo appsmith --versions
 helm install appsmith appsmith/appsmith --version 1.4.1
 ```
 
-## Upgrade your Helm repository (If need)
+## Upgrade your Helm repository 
 
 * Modify the chart
+
+* Change working directory
+
+```
+cd /deploy/helm
+```
+
+* Build Helm chart depencies
+
+```
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm dependency build . 
+```
+
+* Note the latest appsmith helm-chart version 
+```
+helm repo add appsmith http://helm.appsmith.com
+helm update
+helm search repo appsmith
+```
+
+* Update current iteration of helm chart version by editing `Chart.yaml`
+
 * Package Helm chart
 
 ```
-helm package ./deploy/helm
+helm package .
 ```
 
 * Push the new version to the Helm repository in Amazon S3
 
 ```
-aws s3 cp ./appsmith-1.4.1.tgz s3://helm.appsmith.com
+aws s3 cp ./appsmith-<version>.tgz s3://helm.appsmith.com
 ```
 
-* Create index file
+* Merge the index file with existing index
 
 ```
-helm repo index --url http://helm.appsmith.com
+curl http://helm.appsmith.com -o index.yaml
+helm repo index --url http://helm.appsmith.com --merge index.yaml
 ```
 
-* Push new `index.yaml` file into S3 bucket
+* Push updated `index.yaml` file into S3 bucket
 
 ```
-aws s3 cp ./index.yaml s3://helm.appsmith.com
+aws s3 cp index.yaml s3://helm.appsmith.com
 ```
 
 * Verify the updated Helm chart

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -113,6 +113,8 @@ spec:
             - secretRef:
                 name: {{ .Values.secretName }}
             {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
       {{- if .Values.image.pullSecrets}}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecrets }}


### PR DESCRIPTION
Updated` appsmith/appsmith` helm-chart to` 2.0.5` with `allowPrivilegeEscalation` disabled.