### PR TITLE
fix: Use inheritance to invoke the method instead of looking for declared one in aspect invoker

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspect.java
@@ -78,7 +78,7 @@ public class FeatureFlaggedMethodInvokerAspect {
             Object service = applicationContext
                     .getBeansOfType(targetSuperClass)
                     .get(getSpringDefaultBeanName(targetSuperClass.getSimpleName()));
-            Method superMethod = targetSuperClass.getDeclaredMethod(method.getName(), method.getParameterTypes());
+            Method superMethod = targetSuperClass.getMethod(method.getName(), method.getParameterTypes());
             return superMethod.invoke(service, joinPoint.getArgs());
         } catch (Throwable e) {
             String errorMessage = "Exception while invoking super class method";

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspectTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/FeatureFlaggedMethodInvokerAspectTest.java
@@ -1,0 +1,82 @@
+package com.appsmith.server.aspect;
+
+import com.appsmith.server.aspect.component.TestComponent;
+import com.appsmith.server.featureflags.FeatureFlagEnum;
+import com.appsmith.server.services.FeatureFlagService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class FeatureFlaggedMethodInvokerAspectTest {
+
+    @MockBean
+    FeatureFlagService featureFlagService;
+
+    @Autowired
+    TestComponent testComponent;
+
+    private static String EE_RESPONSE = "ee_impl_method";
+    private static String CE_COMPATIBLE_RESPONSE = "ce_compatible_impl_method";
+    private static String CE_RESPONSE = "ce_impl_method";
+
+    @Test
+    void testEEOnlyMethod() {
+        Mono<String> resultMono = testComponent.eeOnlyMethod();
+        StepVerifier.create(resultMono).expectNext(EE_RESPONSE).verifyComplete();
+    }
+
+    @Test
+    void eeCeCompatibleDiffMethod_eeImplTest() {
+        Mockito.when(featureFlagService.check(eq(FeatureFlagEnum.TENANT_TEST_FEATURE)))
+                .thenReturn(Mono.just(true));
+        Mono<String> resultMono = testComponent.eeCeCompatibleDiffMethod();
+        StepVerifier.create(resultMono).expectNext(EE_RESPONSE).verifyComplete();
+    }
+
+    @Test
+    void eeCeCompatibleDiffMethod_ceCompatibleImplTest() {
+        Mockito.when(featureFlagService.check(eq(FeatureFlagEnum.TENANT_TEST_FEATURE)))
+                .thenReturn(Mono.just(false));
+        Mono<String> resultMono = testComponent.eeCeCompatibleDiffMethod();
+        StepVerifier.create(resultMono).expectNext(CE_COMPATIBLE_RESPONSE).verifyComplete();
+    }
+
+    @Test
+    void ceCECompatibleEeSameImplMethod_eeImplTest() {
+        Mono<String> resultMono = testComponent.ceCeCompatibleEeSameImplMethod();
+        StepVerifier.create(resultMono).expectNext(CE_RESPONSE).verifyComplete();
+    }
+
+    @Test
+    void ceCECompatibleEeSameImplMethod_ceCompatibleImplTest() {
+        Mono<String> resultMono = testComponent.ceCeCompatibleEeSameImplMethod();
+        StepVerifier.create(resultMono).expectNext(CE_RESPONSE).verifyComplete();
+    }
+
+    @Test
+    void ceEeDiffMethod_ceImplTest() {
+        Mockito.when(featureFlagService.check(eq(FeatureFlagEnum.TENANT_TEST_FEATURE)))
+                .thenReturn(Mono.just(false));
+        // As CE compatible version don't have the implementation, it will fallback to CE implementation
+        Mono<String> resultMono = testComponent.ceEeDiffMethod();
+        StepVerifier.create(resultMono).expectNext(CE_RESPONSE).verifyComplete();
+    }
+
+    @Test
+    void ceEeDiffMethod_eeImplTest() {
+        Mockito.when(featureFlagService.check(eq(FeatureFlagEnum.TENANT_TEST_FEATURE)))
+                .thenReturn(Mono.just(true));
+        Mono<String> resultMono = testComponent.ceEeDiffMethod();
+        StepVerifier.create(resultMono).expectNext(EE_RESPONSE).verifyComplete();
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponent.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponent.java
@@ -1,0 +1,9 @@
+package com.appsmith.server.aspect.component;
+
+import com.appsmith.server.aspect.component.ce_compatible.TestComponentCECompatible;
+import reactor.core.publisher.Mono;
+
+public interface TestComponent extends TestComponentCECompatible {
+
+    Mono<String> eeOnlyMethod();
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponentImpl.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/TestComponentImpl.java
@@ -1,0 +1,28 @@
+package com.appsmith.server.aspect.component;
+
+import com.appsmith.server.annotations.FeatureFlagged;
+import com.appsmith.server.aspect.component.ce_compatible.TestComponentCECompatibleImpl;
+import com.appsmith.server.featureflags.FeatureFlagEnum;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class TestComponentImpl extends TestComponentCECompatibleImpl implements TestComponent {
+
+    @Override
+    public Mono<String> eeOnlyMethod() {
+        return Mono.just("ee_impl_method");
+    }
+
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.TENANT_TEST_FEATURE)
+    @Override
+    public Mono<String> ceEeDiffMethod() {
+        return Mono.just("ee_impl_method");
+    }
+
+    @FeatureFlagged(featureFlagName = FeatureFlagEnum.TENANT_TEST_FEATURE)
+    @Override
+    public Mono<String> eeCeCompatibleDiffMethod() {
+        return Mono.just("ee_impl_method");
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCE.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCE.java
@@ -1,0 +1,12 @@
+package com.appsmith.server.aspect.component.ce;
+
+import reactor.core.publisher.Mono;
+
+public interface TestComponentCE {
+
+    Mono<String> ceCeCompatibleEeSameImplMethod();
+
+    // Method to test the case where the CE and EE interfaces have the same method name but different return types
+    // and no implementations in  CE compatible class
+    Mono<String> ceEeDiffMethod();
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCEImpl.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce/TestComponentCEImpl.java
@@ -1,0 +1,19 @@
+package com.appsmith.server.aspect.component.ce;
+
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class TestComponentCEImpl implements TestComponentCE {
+
+    @Override
+    public Mono<String> ceCeCompatibleEeSameImplMethod() {
+        return Mono.just("ce_impl_method");
+    }
+
+    @Override
+    public Mono<String> ceEeDiffMethod() {
+        // CE Implementation
+        return Mono.just("ce_impl_method");
+    }
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce_compatible/TestComponentCECompatible.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce_compatible/TestComponentCECompatible.java
@@ -1,0 +1,9 @@
+package com.appsmith.server.aspect.component.ce_compatible;
+
+import com.appsmith.server.aspect.component.ce.TestComponentCE;
+import reactor.core.publisher.Mono;
+
+public interface TestComponentCECompatible extends TestComponentCE {
+
+    Mono<String> eeCeCompatibleDiffMethod();
+}

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce_compatible/TestComponentCECompatibleImpl.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/aspect/component/ce_compatible/TestComponentCECompatibleImpl.java
@@ -1,0 +1,14 @@
+package com.appsmith.server.aspect.component.ce_compatible;
+
+import com.appsmith.server.aspect.component.ce.TestComponentCEImpl;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class TestComponentCECompatibleImpl extends TestComponentCEImpl implements TestComponentCECompatible {
+
+    @Override
+    public Mono<String> eeCeCompatibleDiffMethod() {
+        return Mono.just("ce_compatible_impl_method");
+    }
+}


### PR DESCRIPTION
## Description
As per earlier implementation we were using the reflection to find out the declared method in super class based on the feature flag status. This PR fallback to Java inheritance structure to get the method instead of specifically looking for the one within the class.  

#### PR fixes following issue(s)
Fixes https://github.com/appsmithorg/appsmith/issues/27065

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
