### PR TITLE
ci: Remove installs of packages already available

### DIFF
--- a/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
+++ b/.github/workflows/on-demand-build-docker-image-deploy-preview.yml
@@ -207,23 +207,31 @@ jobs:
           ref: "refs/pull/${{ github.event.client_payload.pull_request.number }}/merge"
           fetch-depth: 0
 
+      - name: Print versions of tools
+        run: |
+          set -o errexit
+          set -o xtrace
+          aws --version || true
+          kubectl version || true
+          helm version || true
+
       - name: Install mongosh
         run: |
+          curl -fsSL https://pgp.mongodb.com/server-6.0.asc \
+            | sudo gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg --dearmor
+          echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" \
+            | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
           sudo apt-get update
-          sudo apt-get install -y wget gnupg
-          wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
-          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
-          sudo apt-get update
-          sudo apt-get install -y mongodb-mongosh
+          sudo apt-get install --yes mongodb-mongosh
+          echo "MongoSH version: $(mongosh --version)"
 
       - name: Install relevant packages
         run: |
-          which aws
-          sudo apt update -q && sudo apt install -y curl unzip less jq
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl && \
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
-          chmod 700 get_helm.sh; ./get_helm.sh
+          set -o errexit
+          # We still need Kubectl v1.23. Once we up the cluster version, we can get rid of this step.
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          kubectl version || true
 
       - name: Deploy Helm chart
         env:
@@ -241,7 +249,7 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           DB_URL: ${{ secrets.DB_URL }}
           DP_EFS_ID: ${{ secrets.APPSMITH_DP_EFS_ID }}
-          REDIS_URL: ${{ secrets.APPSMITH_DP_REDIS_URL }}          
+          REDIS_URL: ${{ secrets.APPSMITH_DP_REDIS_URL }}
         run: |
           echo "environment variables set to deploy the image" $IMAGE_HASH
           /bin/bash ./scripts/deploy_preview.sh


### PR DESCRIPTION
We're installing quite a few pieces of software, although they're already availble in the CI environments. See https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md.

This has led to one failure where it failed to download Helm (because of a sporadiv 403), where `helm` was already installed and this step wasn't even needed.

This PR does this:

1. Print the versions of the tools we need.
2. Install MongoSH v6.
3. Install Kubectl pinned to v1.23, since the one that comes by default is 1.28, which is too new.

References:

[As seen in this run](https://github.com/appsmithorg/appsmith/actions/runs/6121523768/job/16617184408).
<img width="562" alt="shot-2023-09-09-00-53-35@2x" src="https://github.com/appsmithorg/appsmith/assets/120119/cfe95a40-28cd-4a13-8071-58438e94ba69">

[MongoDB v6 installation](https://www.mongodb.com/docs/v6.0/tutorial/install-mongodb-on-ubuntu/#install-mongodb-community-edition).
