### PR TITLE
chore: Move cleanup logs from cron to backend server

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/cron/CleanUpOldLogs.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/cron/CleanUpOldLogs.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 @Component
 public class CleanUpOldLogs {
 
-    private static final int CUTOFF_AGE = 7 * 24 * 60 * 60 * 1000;
+    private static final int CUTOFF_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days
 
     @Scheduled(cron = "0 0 0 * * SAT")
     public void cleanUpOldLogs() throws IOException {

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/cron/CleanUpOldLogs.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/cron/CleanUpOldLogs.java
@@ -1,0 +1,45 @@
+package com.appsmith.server.cron;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+@Slf4j
+@Component
+public class CleanUpOldLogs {
+
+    private static final int CUTOFF_AGE = 7 * 24 * 60 * 60 * 1000;
+
+    @Scheduled(cron = "0 0 0 * * SAT")
+    public void cleanUpOldLogs() throws IOException {
+        log.info("Cleaning up old logs");
+
+        final long cutoffTime = System.currentTimeMillis() - CUTOFF_AGE;
+
+        try (Stream<Path> walk = Files.walk(Paths.get("/appsmith-stacks/logs"))) {
+            walk.filter(path -> {
+                        try {
+                            return Files.isRegularFile(path)
+                                    && path.getFileName().toString().contains(".log")
+                                    && Files.getLastModifiedTime(path).toMillis() < cutoffTime;
+                        } catch (IOException e) {
+                            log.error("Failed to get last modified time for file {}", path, e);
+                        }
+                        return false;
+                    })
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            log.error("Failed to delete old log file {}", path, e);
+                        }
+                    });
+        }
+    }
+}

--- a/deploy/docker/fs/etc/cron.d/cleanup-logs
+++ b/deploy/docker/fs/etc/cron.d/cleanup-logs
@@ -1,1 +1,0 @@
-0 0 * * SUN root find /appsmith-stacks/logs/backend /appsmith-stacks/logs/rts/ /appsmith-stacks/logs/editor/ -name "*.log*" -type f -mtime +7 -delete


### PR DESCRIPTION
This is moving the cleanup script to delete old log files, from being a cron job, to being a scheduled task in the backend server. Why?

1. We want to support running Appsmith with readonly root, which is a request from security teams at enterprise companies.
2. Cron doesn't play nice. It wants to save a `.pid` file under `/var/run`, so it fails to start when running with readonly root. This is not configurable.
3. Since our use of cron is minimal only, we're moving away from it, especially since the backend server is already capable of running scheduled tasks.
4. This moves one job, there's still another. Based on experience from this, we'll work on the other.

Another advantage to doing this is that since this job is now running in the backend server, which has access to MongoDB and Redis, we can coordinate when running as a cluster, that only _one_ backend is running the clean up job. This is for much later though.
