### PR TITLE
chore: Readonly root FS for supervisord configuration

### DIFF
--- a/deploy/docker/fs/etc/supervisor/supervisord.conf
+++ b/deploy/docker/fs/etc/supervisor/supervisord.conf
@@ -1,7 +1,7 @@
 ; supervisor config file
 
 [unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
+file=%(ENV_TMP)s/supervisor.sock   ; (the path to the socket file)
 chmod=0700                       ; sockef file mode (default 0700)
 
 [inet_http_server]         ; inet (TCP) server disabled by default
@@ -10,9 +10,9 @@ port=*:9001        ; (ip_address:port specifier, *:port for all iface)
 ;password=123               ; (default is no password (open server))
 
 [supervisord]
-logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+logfile=/appsmith-stacks/logs/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=%(ENV_TMP)s/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/appsmith-stacks/logs/supervisor            ; ('AUTO' child log dir, default $TEMP)
 stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
 
@@ -23,7 +23,7 @@ stderr_logfile_maxbytes = 0
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix://%(ENV_TMP)s/supervisor.sock ; use a unix:// URL  for a unix socket
 
 ; The [include] section can just contain the "files" setting.  This
 ; setting can list multiple files (separated by whitespace or
@@ -32,13 +32,13 @@ serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 ; include files themselves.
 
 [include]
-files = /etc/supervisor/conf.d/*.conf
+files = %(ENV_SUPERVISORD_CONF_TARGET)s/*.conf
 
 ; This event listener is used to capture processes log
 ; and forward to container log using supervisor_stdout
 ; Ref: https://github.com/coderanger/supervisor-stdout
-[eventlistener:stdout] 
-command = supervisor_stdout 
-buffer_size = 100 
-events = PROCESS_LOG 
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
 result_handler = supervisor_stdout:event_handler

--- a/deploy/docker/fs/opt/appsmith/entrypoint.sh
+++ b/deploy/docker/fs/opt/appsmith/entrypoint.sh
@@ -4,7 +4,10 @@ set -e
 
 stacks_path=/appsmith-stacks
 
+export SUPERVISORD_CONF_TARGET="$TMP/supervisor-conf.d/"  # export for use in supervisord.conf
 export MONGODB_TMP_KEY_PATH="$TMP/mongodb-key"  # export for use in supervisor process mongodb.conf
+
+mkdir -pv "$SUPERVISORD_CONF_TARGET"
 
 # ip is a reserved keyword for tracking events in Mixpanel. Instead of showing the ip as is Mixpanel provides derived properties.
 # As we want derived props alongwith the ip address we are sharing the ip address in separate keys
@@ -284,27 +287,27 @@ check_setup_custom_ca_certificates() {
 }
 
 configure_supervisord() {
-  SUPERVISORD_CONF_PATH="/opt/appsmith/templates/supervisord"
-  if [[ -n "$(ls -A /etc/supervisor/conf.d)" ]]; then
-    rm -f "/etc/supervisor/conf.d/"*
+  local supervisord_conf_source="/opt/appsmith/templates/supervisord"
+  if [[ -n "$(ls -A "$SUPERVISORD_CONF_TARGET")" ]]; then
+    rm -f "$SUPERVISORD_CONF_TARGET"/*
   fi
 
-  cp -f "$SUPERVISORD_CONF_PATH/application_process/"*.conf /etc/supervisor/conf.d
+  cp -f "$supervisord_conf_source"/application_process/*.conf "$SUPERVISORD_CONF_TARGET"
 
   # Disable services based on configuration
   if [[ -z "${DYNO}" ]]; then
     if [[ $isUriLocal -eq 0 ]]; then
-      cp "$SUPERVISORD_CONF_PATH/mongodb.conf" /etc/supervisor/conf.d/
+      cp "$supervisord_conf_source/mongodb.conf" "$SUPERVISORD_CONF_TARGET"
     fi
     if [[ $APPSMITH_REDIS_URL == *"localhost"* || $APPSMITH_REDIS_URL == *"127.0.0.1"* ]]; then
-      cp "$SUPERVISORD_CONF_PATH/redis.conf" /etc/supervisor/conf.d/
+      cp "$supervisord_conf_source/redis.conf" "$SUPERVISORD_CONF_TARGET"
       mkdir -p "$stacks_path/data/redis"
     fi
     if ! [[ -e "/appsmith-stacks/ssl/fullchain.pem" ]] || ! [[ -e "/appsmith-stacks/ssl/privkey.pem" ]]; then
-      cp "$SUPERVISORD_CONF_PATH/cron.conf" /etc/supervisor/conf.d/
+      cp "$supervisord_conf_source/cron.conf" "$SUPERVISORD_CONF_TARGET"
     fi
     if [[ $runEmbeddedPostgres -eq 1 ]]; then
-      cp "$SUPERVISORD_CONF_PATH/postgres.conf" /etc/supervisor/conf.d/
+      cp "$supervisord_conf_source/postgres.conf" "$SUPERVISORD_CONF_TARGET"
       # Update hosts lookup to resolve to embedded postgres
       echo '127.0.0.1     mockdb.internal.appsmith.com' >> /etc/hosts
     fi
@@ -432,16 +435,13 @@ safe_init_postgres
 
 configure_supervisord
 
-CREDENTIAL_PATH="/etc/nginx/passwords"
-if ! [[ -e "$CREDENTIAL_PATH" ]]; then
-  echo "Generating Basic Authentication file"
-  printf "$APPSMITH_SUPERVISOR_USER:$(openssl passwd -apr1 $APPSMITH_SUPERVISOR_PASSWORD)" > "$CREDENTIAL_PATH"
-fi
+echo "$APPSMITH_SUPERVISOR_USER:$(openssl passwd -apr1 "$APPSMITH_SUPERVISOR_PASSWORD")" > "$TMP/nginx-passwords"
+
 # Ensure the restore path exists in the container, so an archive can be copied to it, if need be.
 mkdir -p /appsmith-stacks/data/{backup,restore}
 
 # Create sub-directory to store services log in the container mounting folder
-mkdir -p /appsmith-stacks/logs/{backend,cron,editor,rts,mongodb,redis,postgres,appsmithctl}
+mkdir -p /appsmith-stacks/logs/{supervisor,backend,cron,editor,rts,mongodb,redis,postgres,appsmithctl}
 
 # Stop nginx gracefully
 nginx -s quit


### PR DESCRIPTION
This is part of supporting running Appsmith with readonly root FS. This moves the supervisord configuration, and runtime files, like the unix socket file, and the PID file, to `$TMP`.
