### PR TITLE
chore: fix flaky signposting test

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Onboarding/SignpostingDiscovery_spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Onboarding/SignpostingDiscovery_spec.ts
@@ -37,6 +37,7 @@ describe("Signposting discovery", function () {
     agHelper.AssertElementVisibility(onboarding.locators.create_query);
     agHelper.AssertElementVisibility(locators._walkthrough_overlay);
     agHelper.GetNClick(onboarding.locators.create_query);
+    agHelper.AssertElementVisibility(dataSources._runQueryBtn, true, 0, 20000);
 
     // Switch to widget pane
     agHelper.AssertElementVisibility(onboarding.locators.explorer_widget_tab);


### PR DESCRIPTION
In the video for the failure it looks like we aren't waiting for the query to be created, the fix here waits for the query page to be visible after clicking on create query. 