### PR TITLE
test: Cypress | CI Stabilize

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Git/GitImport/GitImport_spec.js
@@ -110,7 +110,7 @@ describe("Git import flow ", function () {
     cy.wait(500);
     cy.ReconnectDatasource("TEDMongo");
     cy.wait(500);
-    cy.fillMongoDatasourceForm();
+    dataSources.FillMongoDSForm();
     cy.get(datasourceEditor.sectionAuthentication).click();
     cy.testDatasource(true);
     agHelper.GetNClick(dataSources._saveDs);

--- a/app/client/cypress/e2e/Regression/ClientSide/Onboarding/FirstTimeUserOnboarding_spec.js
+++ b/app/client/cypress/e2e/Regression/ClientSide/Onboarding/FirstTimeUserOnboarding_spec.js
@@ -7,6 +7,7 @@ import {
   onboarding,
   draggableWidgets,
   debuggerHelper,
+  dataSources,
 } from "../../../../support/Objects/ObjectsCore";
 const datasource = require("../../../../locators/DatasourcesEditor.json");
 
@@ -118,7 +119,7 @@ describe("FirstTimeUserOnboarding", function () {
       cy.get(OnboardingLocator.checklistDatasourceBtn).click();
       cy.get(OnboardingLocator.datasourcePage).should("be.visible");
       cy.get(datasource.MongoDB).click();
-      cy.fillMongoDatasourceForm();
+      dataSources.FillMongoDSForm();
       cy.generateUUID().then((uid) => {
         datasourceName = `Mongo CRUD ds ${uid}`;
         cy.renameDatasource(datasourceName);

--- a/app/client/cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts
@@ -92,7 +92,7 @@ describe("Validate Elasticsearch DS", () => {
 
     agHelper.PressEnter();
 
-    agHelper.Sleep();
+    agHelper.Sleep(2000);
     dataSources.RunQuery();
     cy.get("@postExecute").then((resObj: any) => {
       expect(
@@ -143,6 +143,13 @@ describe("Validate Elasticsearch DS", () => {
       directInput: false,
       inputFieldName: "Body",
     });
+
+    agHelper
+      .GetElement(dataSources._bodyCodeMirror)
+      .type("{downarrow}".repeat(5));
+
+    agHelper.PressEnter();
+    agHelper.Sleep(2000);
     dataSources.RunQuery();
 
     cy.get("@postExecute").then((resObj: any) => {

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo_Spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo_Spec.js
@@ -1,6 +1,5 @@
 const queryLocators = require("../../../../locators/QueryEditor.json");
 const generatePage = require("../../../../locators/GeneratePage.json");
-const datasource = require("../../../../locators/DatasourcesEditor.json");
 const formControls = require("../../../../locators/FormControl.json");
 
 import {
@@ -27,14 +26,11 @@ describe("Validate Mongo query commands", function () {
   // });
 
   before("Creates a new Mongo datasource", function () {
-    cy.NavigateToDatasourceEditor();
-    cy.get(datasource.MongoDB).click();
-    cy.fillMongoDatasourceForm();
-    cy.generateUUID().then((uid) => {
-      datasourceName = `Mongo CRUD ds ${uid}`;
-      cy.renameDatasource(datasourceName);
+    dataSources.CreateDataSource("Mongo");
+    dataSources.CreateQueryAfterDSSaved();
+    cy.get("@dsName").then(($dsName) => {
+      datasourceName = $dsName;
     });
-    cy.testSaveDatasource();
   });
 
   it("1. Validate Raw query command, run and then delete the query", function () {

--- a/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo_Spec.js
+++ b/app/client/cypress/e2e/Regression/ServerSide/QueryPane/Mongo_Spec.js
@@ -34,7 +34,6 @@ describe("Validate Mongo query commands", function () {
   });
 
   it("1. Validate Raw query command, run and then delete the query", function () {
-    cy.NavigateToActiveDSQueryPane(datasourceName);
     // cy.get("@getPluginForm").should(
     //   "have.nested.property",
     //   "response.body.responseMeta.status",

--- a/app/client/cypress/support/Objects/DataManager.ts
+++ b/app/client/cypress/support/Objects/DataManager.ts
@@ -10,7 +10,7 @@ export class DataManager {
       mongo_authenticationAuthtype: "SCRAM-SHA-1",
       mongo_host: "host.docker.internal",
       mongo_port: 28017,
-      mongo_databaseName: "mongo_samples",
+      mongo_databaseName: "mongo_prod",
 
       postgres_host: "host.docker.internal",
       postgres_port: 5432,
@@ -104,7 +104,7 @@ export class DataManager {
       mongo_authenticationAuthtype: "SCRAM-SHA-1",
       mongo_host: "host.docker.internal",
       mongo_port: 28017,
-      mongo_databaseName: "mongo_samples2",
+      mongo_databaseName: "mongo_staging",
 
       postgres_host: "host.docker.internal",
       postgres_port: 5432,

--- a/app/client/cypress/support/dataSourceCommands.js
+++ b/app/client/cypress/support/dataSourceCommands.js
@@ -86,39 +86,6 @@ Cypress.Commands.add("testSaveDatasource", (expectedRes = true) => {
 });
 
 Cypress.Commands.add(
-  "fillMongoDatasourceForm",
-  (shouldAddTrailingSpaces = false) => {
-    const hostAddress = shouldAddTrailingSpaces
-      ? datasourceFormData["mongo-host"] + "  "
-      : datasourceFormData["mongo-host"];
-    // const databaseName = shouldAddTrailingSpaces
-    //   ? datasourceFormData["mongo-databaseName"] + "  "
-    //   : datasourceFormData["mongo-databaseName"];
-    cy.get(datasourceEditor["host"]).clear().type(hostAddress);
-    cy.get(datasourceEditor.port)
-      .clear()
-      .type(datasourceFormData["mongo-port"]);
-    //cy.get(datasourceEditor["port"]).type(datasourceFormData["mongo-port"]);
-    //cy.get(datasourceEditor["selConnectionType"]).click();
-    //cy.contains(datasourceFormData["connection-type"]).click();
-    //cy.get(datasourceEditor["defaultDatabaseName"]).type(databaseName);//is optional hence removing
-    cy.get(datasourceEditor["databaseName"])
-      .clear()
-      .type(datasourceFormData["mongo-databaseName"]);
-    // cy.get(datasourceEditor["username"]).type(
-    //   datasourceFormData["mongo-username"],
-    // );
-    // cy.get(datasourceEditor["password"]).type(
-    //   datasourceFormData["mongo-password"],
-    // );
-    // cy.get(datasourceEditor["authenticationAuthtype"]).click();
-    // cy.contains(datasourceFormData["mongo-authenticationAuthtype"]).click({
-    //   force: true,
-    // });
-  },
-);
-
-Cypress.Commands.add(
   "fillPostgresDatasourceForm",
   (shouldAddTrailingSpaces = false) => {
     const hostAddress = shouldAddTrailingSpaces
@@ -332,14 +299,6 @@ Cypress.Commands.add("createAmazonS3Datasource", () => {
   cy.get(datasourceEditor.AmazonS3).click();
   cy.fillAmazonS3DatasourceForm();
   cy.testSaveDatasource();
-});
-
-Cypress.Commands.add("fillMongoDatasourceFormWithURI", () => {
-  cy.xpath(datasourceEditor["mongoUriDropdown"]).click().wait(500);
-  cy.xpath(datasourceEditor["mongoUriYes"]).click().wait(500);
-  cy.xpath(datasourceEditor["mongoUriInput"]).type(
-    datasourceFormData["mongo-uri"],
-  );
 });
 
 Cypress.Commands.add("ReconnectDatasource", (datasource) => {

--- a/app/client/cypress_ci.config.ts
+++ b/app/client/cypress_ci.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       "cypress/e2e/**/spec_utility.ts",
       "cypress/e2e/GSheet/**/**/*",
       "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
+      "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
     ],
   },
 });

--- a/app/client/cypress_ci_custom.config.ts
+++ b/app/client/cypress_ci_custom.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       "cypress/e2e/GSheet/**/**/*",
       "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
       "cypress/e2e/EE/Enterprise/MultipleEnv/ME_airtable_spec.ts",
+      "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
     ],
   },
 });

--- a/app/client/cypress_ci_hosted.config.ts
+++ b/app/client/cypress_ci_hosted.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
     specPattern: [
       "cypress/e2e/Sanity/Datasources/Airtable_Basic_Spec.ts",
       "cypress/e2e/GSheet/**/**/*",
+      "cypress/e2e/Regression/ServerSide/Datasources/ElasticSearch_Basic_Spec.ts",
     ],
     testIsolation: false,
     excludeSpecPattern: ["cypress/e2e/**/spec_utility.ts"],


### PR DESCRIPTION
## Description
- This PR updates the Mongo fill method from js to ts [fillMongoDatasourceForm to FillMongoDSForm]
- Updates mongo_databaseName to match the prod & staging ds names
- Removes unused fillMongoDatasourceForm, fillMongoDatasourceFormWithURI js support methods
- Removed ElasticSearch_Basic_Spec.ts from PR runs & be done only in Scheduled runs

#### Type of change
- Script fix (non-breaking change which fixes an issue)

## Testing
>
#### How Has This Been Tested?

- [X] Cypress CI runs

## Checklist:
#### QA activity:
- [X] Added `Test Plan Approved` label after Cypress tests were reviewed
