### PR TITLE
chore: add tests for bgNeutralSubtle + bgNeutralActive + bgPositives + bgNegatives

### DIFF
--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -60,6 +60,7 @@ export class DarkModeTheme implements ColorModeTheme {
       bgPositive: this.bgPositive.to("sRGB").toString(),
       bgPositiveHover: this.bgPositiveHover.to("sRGB").toString(),
       bgPositiveActive: this.bgPositiveActive.to("sRGB").toString(),
+      bgPositiveSubtle: this.bgPositiveSubtle.to("sRGB").toString(),
       bgPositiveSubtleHover: this.bgPositiveSubtleHover.to("sRGB").toString(),
       bgPositiveSubtleActive: this.bgPositiveSubtleActive.to("sRGB").toString(),
       bgNegative: this.bgNegative.to("sRGB").toString(),

--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -66,6 +66,7 @@ export class DarkModeTheme implements ColorModeTheme {
       bgNegative: this.bgNegative.to("sRGB").toString(),
       bgNegativeHover: this.bgNegativeHover.to("sRGB").toString(),
       bgNegativeActive: this.bgNegativeActive.to("sRGB").toString(),
+      bgNegativeSubtle: this.bgNegativeActive.to("sRGB").toString(),
       bgNegativeSubtleHover: this.bgNegativeSubtleHover.to("sRGB").toString(),
       bgNegativeSubtleActive: this.bgNegativeSubtleActive.to("sRGB").toString(),
       bgWarning: this.bgWarning.to("sRGB").toString(),

--- a/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/DarkModeTheme.ts
@@ -72,6 +72,7 @@ export class DarkModeTheme implements ColorModeTheme {
       bgWarning: this.bgWarning.to("sRGB").toString(),
       bgWarningHover: this.bgWarningHover.to("sRGB").toString(),
       bgWarningActive: this.bgWarningActive.to("sRGB").toString(),
+      bgWarningSubtle: this.bgWarningSubtle.to("sRGB").toString(),
       bgWarningSubtleHover: this.bgWarningSubtleHover.to("sRGB").toString(),
       bgWarningSubtleActive: this.bgWarningSubtleActive.to("sRGB").toString(),
 

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -72,6 +72,7 @@ export class LightModeTheme implements ColorModeTheme {
       bgWarning: this.bgWarning.to("sRGB").toString(),
       bgWarningHover: this.bgWarningHover.to("sRGB").toString(),
       bgWarningActive: this.bgWarningActive.to("sRGB").toString(),
+      bgWarningSubtle: this.bgWarningSubtle.to("sRGB").toString(),
       bgWarningSubtleHover: this.bgWarningSubtleHover.to("sRGB").toString(),
       bgWarningSubtleActive: this.bgWarningSubtleActive.to("sRGB").toString(),
 

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -60,6 +60,7 @@ export class LightModeTheme implements ColorModeTheme {
       bgPositive: this.bgPositive.to("sRGB").toString(),
       bgPositiveHover: this.bgPositiveHover.to("sRGB").toString(),
       bgPositiveActive: this.bgPositiveActive.to("sRGB").toString(),
+      bgPositiveSubtle: this.bgPositiveSubtle.to("sRGB").toString(),
       bgPositiveSubtleHover: this.bgPositiveSubtleHover.to("sRGB").toString(),
       bgPositiveSubtleActive: this.bgPositiveSubtleActive.to("sRGB").toString(),
       bgNegative: this.bgNegative.to("sRGB").toString(),

--- a/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
+++ b/app/client/packages/design-system/theming/src/color/src/LightModeTheme.ts
@@ -66,6 +66,7 @@ export class LightModeTheme implements ColorModeTheme {
       bgNegative: this.bgNegative.to("sRGB").toString(),
       bgNegativeHover: this.bgNegativeHover.to("sRGB").toString(),
       bgNegativeActive: this.bgNegativeActive.to("sRGB").toString(),
+      bgNegativeSubtle: this.bgNegativeActive.to("sRGB").toString(),
       bgNegativeSubtleHover: this.bgNegativeSubtleHover.to("sRGB").toString(),
       bgNegativeSubtleActive: this.bgNegativeSubtleActive.to("sRGB").toString(),
       bgWarning: this.bgWarning.to("sRGB").toString(),

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -391,3 +391,70 @@ describe("bgPositiveSubtleActive color", () => {
     expect(bgPositiveSubtleActive).toEqual("rgb(6.0555% 13.622% 1.2799%)");
   });
 });
+
+describe("bgNegative color", () => {
+  it("should return correct color when seed color is red (hue between 5 and 49) and chroma > 0.07", () => {
+    const { bgNegative } = new DarkModeTheme("oklch(0.55 0.22 27)").getColors();
+    expect(bgNegative).toEqual("rgb(83.034% 1.7746% 18.798%)");
+  });
+
+  it("should return correct color when seed color is red (hue between 5 and 49) but chroma is not greater than 0.07", () => {
+    const { bgNegative } = new DarkModeTheme("oklch(0.55 0.05 27)").getColors();
+    expect(bgNegative).toEqual("rgb(83.108% 4.6651% 10.252%)");
+  });
+
+  it("should return correct color when seed color is not red (hue outside 5-49) and chroma > 0.07", () => {
+    const { bgNegative } = new DarkModeTheme("oklch(0.55 0.22 60)").getColors();
+    expect(bgNegative).toEqual("rgb(83.108% 4.6651% 10.252%)");
+  });
+
+  it("should return correct color when seed color is not red (hue outside 5-49) and chroma is not greater than 0.07", () => {
+    const { bgNegative } = new DarkModeTheme("oklch(0.55 0.05 60)").getColors();
+    expect(bgNegative).toEqual("rgb(83.108% 4.6651% 10.252%)");
+  });
+});
+
+describe("bgNegativeHover color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeHover } = new DarkModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeHover).toEqual("rgb(87.347% 11.876% 22.315%)");
+  });
+});
+
+describe("bgNegativeActive color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeActive } = new DarkModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeActive).toEqual("rgb(77.305% 0% 13.994%)");
+  });
+});
+
+describe("bgNegativeSubtle color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeSubtle } = new DarkModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeSubtle).toEqual("rgb(77.305% 0% 13.994%)");
+  });
+});
+
+describe("bgNegativeSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeSubtleHover } = new DarkModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeSubtleHover).toEqual("rgb(29.827% 6.1224% 7.5796%)");
+  });
+});
+
+describe("bgNegativeSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeSubtleActive } = new DarkModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeSubtleActive).toEqual("rgb(24.04% 0.5234% 2.9937%)");
+  });
+});

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -458,3 +458,70 @@ describe("bgNegativeSubtleActive color", () => {
     expect(bgNegativeSubtleActive).toEqual("rgb(24.04% 0.5234% 2.9937%)");
   });
 });
+
+describe("bgWarning color", () => {
+  it("should return correct color when seed color is yellow (hue between 60 and 115) and chroma > 0.09", () => {
+    const { bgWarning } = new DarkModeTheme("oklch(0.75 0.15 85)").getColors();
+    expect(bgWarning).toEqual("rgb(91.527% 60.669% 16.491%)");
+  });
+
+  it("should return correct color when seed color is yellow (hue between 60 and 115) but chroma is not greater than 0.09", () => {
+    const { bgWarning } = new DarkModeTheme("oklch(0.75 0.05 85)").getColors();
+    expect(bgWarning).toEqual("rgb(85.145% 64.66% 8.0286%)");
+  });
+
+  it("should return correct color when seed color is not yellow (hue outside 60-115) and chroma > 0.09", () => {
+    const { bgWarning } = new DarkModeTheme("oklch(0.75 0.15 50)").getColors();
+    expect(bgWarning).toEqual("rgb(85.145% 64.66% 8.0286%)");
+  });
+
+  it("should return correct color when seed color is not yellow (hue outside 60-115) and chroma is not greater than 0.09", () => {
+    const { bgWarning } = new DarkModeTheme("oklch(0.75 0.05 50)").getColors();
+    expect(bgWarning).toEqual("rgb(85.145% 64.66% 8.0286%)");
+  });
+});
+
+describe("bgWarningHover color", () => {
+  it("should return correct color", () => {
+    const { bgWarningHover } = new DarkModeTheme(
+      "oklch(0.75 0.05 50)",
+    ).getColors();
+    expect(bgWarningHover).toEqual("rgb(90.341% 69.671% 17.643%)");
+  });
+});
+
+describe("bgWarningActive color", () => {
+  it("should return correct color", () => {
+    const { bgWarningActive } = new DarkModeTheme(
+      "oklch(0.75 0.05 50)",
+    ).getColors();
+    expect(bgWarningActive).toEqual("rgb(78.726% 58.477% 0%)");
+  });
+});
+
+describe("bgWarningSubtle color", () => {
+  it("should return correct color", () => {
+    const { bgWarningSubtle } = new DarkModeTheme(
+      "oklch(0.75 0.05 50)",
+    ).getColors();
+    expect(bgWarningSubtle).toEqual("rgb(16.622% 12.537% 3.3792%)");
+  });
+});
+
+describe("bgWarningSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgWarningSubtleHover } = new DarkModeTheme(
+      "oklch(0.75 0.05 50)",
+    ).getColors();
+    expect(bgWarningSubtleHover).toEqual("rgb(19.571% 15.398% 6.3225%)");
+  });
+});
+
+describe("bgWarningSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgWarningSubtleActive } = new DarkModeTheme(
+      "oklch(0.75 0.05 50)",
+    ).getColors();
+    expect(bgWarningSubtleActive).toEqual("rgb(14.696% 10.673% 1.7722%)");
+  });
+});

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -298,3 +298,96 @@ describe("bgNeutralSubtle color", () => {
     expect(bgNeutralSubtle).toEqual("rgb(13.15% 13.15% 13.15%)");
   });
 });
+
+describe("bgNeutralSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgNeutralSubtleHover } = new DarkModeTheme(
+      "oklch(0.3 0.01 170)",
+    ).getColors();
+    expect(bgNeutralSubtleHover).toEqual("rgb(15.988% 15.988% 15.988%)");
+  });
+});
+
+describe("bgNeutralSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgNeutralSubtleActive } = new DarkModeTheme(
+      "oklch(0.3 0.01 170)",
+    ).getColors();
+    expect(bgNeutralSubtleActive).toEqual("rgb(11.304% 11.304% 11.304%)");
+  });
+});
+
+describe("bgPositive color", () => {
+  it("should return correct color when seed color is green (hue between 116 and 165) and chroma > 0.09", () => {
+    const { bgPositive } = new DarkModeTheme(
+      "oklch(0.62 0.17 145)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(33.244% 60.873% 10.585%)");
+  });
+
+  it("should return correct color when seed color is green (hue between 116 and 165) but chroma is 0.08", () => {
+    const { bgPositive } = new DarkModeTheme(
+      "oklch(0.62 0.08 145)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(18.515% 62.493% 23.87%)");
+  });
+
+  it("should return correct color when seed color is not green (hue outside 116-165) and chroma > 0.09", () => {
+    const { bgPositive } = new DarkModeTheme(
+      "oklch(0.62 0.17 100)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(18.515% 62.493% 23.87%)");
+  });
+
+  it("should return correct color when seed color is not green (hue outside 116-165) and chroma is 0.08", () => {
+    const { bgPositive } = new DarkModeTheme(
+      "oklch(0.62 0.08 100)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(18.515% 62.493% 23.87%)");
+  });
+});
+
+describe("bgPositiveHover color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveHover } = new DarkModeTheme(
+      "oklch(0.62 0.17 145)",
+    ).getColors();
+    expect(bgPositiveHover).toEqual("rgb(36.781% 64.586% 15.952%)");
+  });
+});
+
+describe("bgPositiveActive color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveActive } = new DarkModeTheme(
+      "oklch(0.62 0.17 145)",
+    ).getColors();
+    expect(bgPositiveActive).toEqual("rgb(28.549% 55.976% 0%)");
+  });
+});
+
+describe("bgPositiveSubtle color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveSubtle } = new DarkModeTheme(
+      "oklch(0.62 0.17 145)",
+    ).getColors();
+    expect(bgPositiveSubtle).toEqual("rgb(7.8895% 15.556% 2.8063%)");
+  });
+});
+
+describe("bgPositiveSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveSubtleHover } = new DarkModeTheme(
+      "oklch(0.62 0.17 145)",
+    ).getColors();
+    expect(bgPositiveSubtleHover).toEqual("rgb(10.689% 18.514% 5.7924%)");
+  });
+});
+
+describe("bgPositiveSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveSubtleActive } = new DarkModeTheme(
+      "oklch(0.62 0.17 145)",
+    ).getColors();
+    expect(bgPositiveSubtleActive).toEqual("rgb(6.0555% 13.622% 1.2799%)");
+  });
+});

--- a/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/DarkModeTheme.test.ts
@@ -2,249 +2,299 @@ import { DarkModeTheme } from "../src/DarkModeTheme";
 
 describe("bg color", () => {
   it("should return correct color when chroma is less than 0.04", () => {
-    const { bg: bg1 } = new DarkModeTheme("oklch(0.92 0.02 110)").getColors();
-    expect(bg1).toBe("rgb(4.3484% 4.3484% 4.3484%)");
+    const { bg } = new DarkModeTheme("oklch(0.92 0.02 110)").getColors();
+    expect(bg).toBe("rgb(4.3484% 4.3484% 4.3484%)");
   });
 
   it("should return correct color when chroma is greater than 0.04", () => {
-    const { bg: bg2 } = new DarkModeTheme("oklch(0.92 0.05 110)").getColors();
-    expect(bg2).toBe("rgb(5.3377% 4.7804% 0%)");
+    const { bg } = new DarkModeTheme("oklch(0.92 0.05 110)").getColors();
+    expect(bg).toBe("rgb(5.3377% 4.7804% 0%)");
   });
 });
 
 describe("bgAccent color", () => {
   it("should return correct color when lightness is less than 0.3", () => {
-    const { bgAccent: bgAccent1 } = new DarkModeTheme(
-      "oklch(0.2 0.09 231)",
-    ).getColors();
-    expect(bgAccent1).toBe("rgb(0% 19.987% 30.122%)");
+    const { bgAccent } = new DarkModeTheme("oklch(0.2 0.09 231)").getColors();
+    expect(bgAccent).toBe("rgb(0% 19.987% 30.122%)");
   });
 });
 
 describe("bgAccentHover color", () => {
   it("should return correct color when lightness is less than 0.3", () => {
-    const { bgAccentHover: bgAccentHover1 } = new DarkModeTheme(
+    const { bgAccentHover } = new DarkModeTheme(
       "oklch(0.2 0.09 231)",
     ).getColors();
-    expect(bgAccentHover1).toBe("rgb(0% 25.498% 37.079%)");
+    expect(bgAccentHover).toBe("rgb(0% 25.498% 37.079%)");
   });
 
   it("should return correct color when lightness is between 0.3 and 0.45", () => {
-    const { bgAccentHover: bgAccentHover2 } = new DarkModeTheme(
+    const { bgAccentHover } = new DarkModeTheme(
       "oklch(0.35 0.09 231)",
     ).getColors();
-    expect(bgAccentHover2).toBe("rgb(0% 29.954% 42.35%)");
+    expect(bgAccentHover).toBe("rgb(0% 29.954% 42.35%)");
   });
 
   it("should return correct color when lightness is between 0.45 and 0.77", () => {
-    const { bgAccentHover: bgAccentHover3 } = new DarkModeTheme(
+    const { bgAccentHover } = new DarkModeTheme(
       "oklch(0.50 0.09 231)",
     ).getColors();
-    expect(bgAccentHover3).toBe("rgb(15.696% 45.773% 58.926%)");
+    expect(bgAccentHover).toBe("rgb(15.696% 45.773% 58.926%)");
   });
 
   it("should return correct color when lightness is between 0.77 and 0.85, hue is outside 120-300, and chroma is greater than 0.04", () => {
-    const { bgAccentHover: bgAccentHover4 } = new DarkModeTheme(
+    const { bgAccentHover } = new DarkModeTheme(
       "oklch(0.80 0.09 150)",
     ).getColors();
-    expect(bgAccentHover4).toBe("rgb(51.184% 89.442% 60.062%)");
+    expect(bgAccentHover).toBe("rgb(51.184% 89.442% 60.062%)");
   });
 
   it("should return correct color when lightness is between 0.77 and 0.85, hue is inside 120-300, and chroma is greater than 0.04", () => {
-    const { bgAccentHover: bgAccentHover5 } = new DarkModeTheme(
+    const { bgAccentHover } = new DarkModeTheme(
       "oklch(0.80 0.09 110)",
     ).getColors();
-    expect(bgAccentHover5).toBe("rgb(85.364% 85.594% 0%)");
+    expect(bgAccentHover).toBe("rgb(85.364% 85.594% 0%)");
   });
 
   it("should return correct color when lightness is between 0.77 and 0.85, and chroma is less than 0.04", () => {
-    const { bgAccentHover: bgAccentHover6 } = new DarkModeTheme(
+    const { bgAccentHover } = new DarkModeTheme(
       "oklch(0.80 0.03 110)",
     ).getColors();
-    expect(bgAccentHover6).toBe("rgb(79.687% 80.239% 71.58%)");
+    expect(bgAccentHover).toBe("rgb(79.687% 80.239% 71.58%)");
   });
 
   it("should return correct color when lightness is greater than 0.85", () => {
-    const { bgAccentHover: bgAccentHover7 } = new DarkModeTheme(
+    const { bgAccentHover } = new DarkModeTheme(
       "oklch(0.90 0.03 110)",
     ).getColors();
-    expect(bgAccentHover7).toBe("rgb(78.426% 78.975% 70.34%)");
+    expect(bgAccentHover).toBe("rgb(78.426% 78.975% 70.34%)");
   });
 });
 
 describe("bgAccentActive color", () => {
   it("should return correct color when seedLightness is less than 0.4", () => {
-    const { bgAccentActive: bgAccentActive1 } = new DarkModeTheme(
+    const { bgAccentActive } = new DarkModeTheme(
       "oklch(0.2 0.09 231)",
     ).getColors();
-    expect(bgAccentActive1).toBe("rgb(0% 17.836% 27.428%)");
+    expect(bgAccentActive).toBe("rgb(0% 17.836% 27.428%)");
   });
 
   it("should return correct color when seedLightness is between 0.4 and 0.7", () => {
-    const { bgAccentActive: bgAccentActive2 } = new DarkModeTheme(
+    const { bgAccentActive } = new DarkModeTheme(
       "oklch(0.45 0.09 231)",
     ).getColors();
-    expect(bgAccentActive2).toBe("rgb(0% 32.155% 44.665%)");
+    expect(bgAccentActive).toBe("rgb(0% 32.155% 44.665%)");
   });
 
   it("should return correct color when seedLightness is between 0.7 and 0.85", () => {
-    const { bgAccentActive: bgAccentActive3 } = new DarkModeTheme(
+    const { bgAccentActive } = new DarkModeTheme(
       "oklch(0.75 0.09 231)",
     ).getColors();
-    expect(bgAccentActive3).toBe("rgb(37.393% 66.165% 80.119%)");
+    expect(bgAccentActive).toBe("rgb(37.393% 66.165% 80.119%)");
   });
 
   it("should return correct color when seedLightness is greater than or equal to 0.85", () => {
-    const { bgAccentActive: bgAccentActive4 } = new DarkModeTheme(
+    const { bgAccentActive } = new DarkModeTheme(
       "oklch(0.90 0.09 231)",
     ).getColors();
-    expect(bgAccentActive4).toBe("rgb(46.054% 74.898% 89.15%)");
+    expect(bgAccentActive).toBe("rgb(46.054% 74.898% 89.15%)");
   });
 });
 
 describe("bgAccentSubtle color", () => {
   it("should return correct color when seedLightness is greater than 0.25", () => {
-    const { bgAccentSubtle: bgAccentSubtle1 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.30 0.09 231)",
     ).getColors();
-    expect(bgAccentSubtle1).toBe("rgb(0% 14.671% 23.499%)");
+    expect(bgAccentSubtle).toBe("rgb(0% 14.671% 23.499%)");
   });
 
   it("should return correct color when seedLightness is less than 0.2", () => {
-    const { bgAccentSubtle: bgAccentSubtle2 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.15 0.09 231)",
     ).getColors();
-    expect(bgAccentSubtle2).toBe("rgb(0% 9.5878% 17.677%)");
+    expect(bgAccentSubtle).toBe("rgb(0% 9.5878% 17.677%)");
   });
 
   it("should return correct color when seedChroma is greater than 0.1", () => {
-    const { bgAccentSubtle: bgAccentSubtle3 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.30 0.15 231)",
     ).getColors();
-    expect(bgAccentSubtle3).toBe("rgb(0% 14.556% 23.9%)");
+    expect(bgAccentSubtle).toBe("rgb(0% 14.556% 23.9%)");
   });
 
   it("should return correct color when seedChroma is less than 0.04", () => {
-    const { bgAccentSubtle: bgAccentSubtle4 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.30 0.03 231)",
     ).getColors();
-    expect(bgAccentSubtle4).toBe("rgb(13.15% 13.15% 13.15%)");
+    expect(bgAccentSubtle).toBe("rgb(13.15% 13.15% 13.15%)");
   });
 });
 
 describe("bgAccentSubtle color", () => {
   it("should return correct color when seedLightness is greater than 0.25", () => {
-    const { bgAccentSubtle: bgAccentSubtle1 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.30 0.09 231)",
     ).getColors();
-    expect(bgAccentSubtle1).toBe("rgb(0% 14.671% 23.499%)");
+    expect(bgAccentSubtle).toBe("rgb(0% 14.671% 23.499%)");
   });
 
   it("should return correct color when seedLightness is less than 0.2", () => {
-    const { bgAccentSubtle: bgAccentSubtle2 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.15 0.09 231)",
     ).getColors();
-    expect(bgAccentSubtle2).toBe("rgb(0% 9.5878% 17.677%)");
+    expect(bgAccentSubtle).toBe("rgb(0% 9.5878% 17.677%)");
   });
 
   it("should return correct color when seedChroma is greater than 0.1", () => {
-    const { bgAccentSubtle: bgAccentSubtle3 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.30 0.15 231)",
     ).getColors();
-    expect(bgAccentSubtle3).toBe("rgb(0% 14.556% 23.9%)");
+    expect(bgAccentSubtle).toBe("rgb(0% 14.556% 23.9%)");
   });
 
   it("should return correct color when seedChroma is less than 0.04", () => {
-    const { bgAccentSubtle: bgAccentSubtle4 } = new DarkModeTheme(
+    const { bgAccentSubtle } = new DarkModeTheme(
       "oklch(0.30 0.03 231)",
     ).getColors();
-    expect(bgAccentSubtle4).toBe("rgb(13.15% 13.15% 13.15%)");
+    expect(bgAccentSubtle).toBe("rgb(13.15% 13.15% 13.15%)");
   });
 });
 
 describe("bgAccentSubtleHover color", () => {
   it("should return correct color for bgAccentSubtleHover1", () => {
-    const { bgAccentSubtleHover: bgAccentSubtleHover1 } = new DarkModeTheme(
+    const { bgAccentSubtleHover } = new DarkModeTheme(
       "oklch(0.35 0.09 70)",
     ).getColors();
-    expect(bgAccentSubtleHover1).toBe("rgb(25.181% 12.291% 0%)");
+    expect(bgAccentSubtleHover).toBe("rgb(25.181% 12.291% 0%)");
   });
 });
 
 describe("bgAccentSubtleActive color", () => {
   it("should return correct color for bgAccentSubtleActive1", () => {
-    const { bgAccentSubtleActive: bgAccentSubtleActive1 } = new DarkModeTheme(
+    const { bgAccentSubtleActive } = new DarkModeTheme(
       "oklch(0.35 0.09 70)",
     ).getColors();
-    expect(bgAccentSubtleActive1).toBe("rgb(19.651% 7.4427% 0%)");
+    expect(bgAccentSubtleActive).toBe("rgb(19.651% 7.4427% 0%)");
   });
 });
 
 describe("bgAssistive color", () => {
   it("should return correct color for bgAssistive1 when seed is achromatic", () => {
-    const { bgAssistive: bgAssistive1 } = new DarkModeTheme(
+    const { bgAssistive } = new DarkModeTheme(
       "oklch(0.95 0.03 170)",
     ).getColors();
-    expect(bgAssistive1).toBe("rgb(92.148% 92.148% 92.148%)");
+    expect(bgAssistive).toBe("rgb(92.148% 92.148% 92.148%)");
   });
 });
 
 describe("bgNeutral color", () => {
   it("should return correct color when lightness is less than 0.5", () => {
-    const { bgNeutral: bgNeutral1 } = new DarkModeTheme(
-      "oklch(0.3 0.09 231)",
-    ).getColors();
-    expect(bgNeutral1).toEqual("rgb(18.887% 23.77% 26.341%)");
+    const { bgNeutral } = new DarkModeTheme("oklch(0.3 0.09 231)").getColors();
+    expect(bgNeutral).toEqual("rgb(18.887% 23.77% 26.341%)");
   });
 
   it("should return correct color when chroma is less than 0.04", () => {
-    const { bgNeutral: bgNeutral2 } = new DarkModeTheme(
-      "oklch(0.95 0.02 170)",
-    ).getColors();
-    expect(bgNeutral2).toEqual("rgb(93.448% 93.448% 93.448%)");
+    const { bgNeutral } = new DarkModeTheme("oklch(0.95 0.02 170)").getColors();
+    expect(bgNeutral).toEqual("rgb(93.448% 93.448% 93.448%)");
   });
 
   it("should return correct color when hue is between 120 and 300 and chroma is not less than 0.04", () => {
-    const { bgNeutral: bgNeutral3 } = new DarkModeTheme(
-      "oklch(0.95 0.06 240)",
-    ).getColors();
-    expect(bgNeutral3).toEqual("rgb(89.041% 94.38% 98.38%)");
+    const { bgNeutral } = new DarkModeTheme("oklch(0.95 0.06 240)").getColors();
+    expect(bgNeutral).toEqual("rgb(89.041% 94.38% 98.38%)");
   });
 
   it("should return correct color when hue is not between 120 and 300 and chroma is not less than 0.04", () => {
-    const { bgNeutral: bgNeutral4 } = new DarkModeTheme(
-      "oklch(0.95 0.06 30)",
-    ).getColors();
-    expect(bgNeutral4).toEqual("rgb(96.118% 92.595% 91.947%)");
+    const { bgNeutral } = new DarkModeTheme("oklch(0.95 0.06 30)").getColors();
+    expect(bgNeutral).toEqual("rgb(96.118% 92.595% 91.947%)");
   });
 });
 
 describe("bgNeutralHover color", () => {
   it("should return correct color when lightness is greater than or equal to 0.85", () => {
-    const { bgNeutralHover: bgNeutralHover1 } = new DarkModeTheme(
+    const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.86 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover1).toEqual("rgb(73.075% 73.075% 73.075%)");
+    expect(bgNeutralHover).toEqual("rgb(73.075% 73.075% 73.075%)");
   });
 
   it("should return correct color when lightness is between 0.77 and 0.85", () => {
-    const { bgNeutralHover: bgNeutralHover2 } = new DarkModeTheme(
+    const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.80 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover2).toEqual("rgb(79.34% 79.34% 79.34%)");
+    expect(bgNeutralHover).toEqual("rgb(79.34% 79.34% 79.34%)");
   });
 
   it("should return correct color when lightness is between 0.45 and 0.77", () => {
-    const { bgNeutralHover: bgNeutralHover3 } = new DarkModeTheme(
+    const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.60 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover3).toEqual("rgb(53.715% 53.715% 53.715%)");
+    expect(bgNeutralHover).toEqual("rgb(53.715% 53.715% 53.715%)");
   });
 
   it("should return correct color when lightness is between 0.3 and 0.45", () => {
-    const { bgNeutralHover: bgNeutralHover4 } = new DarkModeTheme(
+    const { bgNeutralHover } = new DarkModeTheme(
       "oklch(0.35 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover4).toEqual("rgb(32.307% 32.307% 32.307%)");
+    expect(bgNeutralHover).toEqual("rgb(32.307% 32.307% 32.307%)");
+  });
+});
+
+describe("bgNeutralActive color", () => {
+  it("should return correct color when lightness is less than 0.4", () => {
+    const { bgNeutralActive } = new DarkModeTheme(
+      "oklch(0.39 0.03 170)",
+    ).getColors();
+    expect(bgNeutralActive).toEqual("rgb(28.06% 28.06% 28.06%)");
+  });
+
+  it("should return correct color when lightness is between 0.4 and 0.7", () => {
+    const { bgNeutralActive } = new DarkModeTheme(
+      "oklch(0.6 0.03 170)",
+    ).getColors();
+    expect(bgNeutralActive).toEqual("rgb(45.608% 45.608% 45.608%)");
+  });
+
+  it("should return correct color when lightness is between 0.7 and 0.85", () => {
+    const { bgNeutralActive } = new DarkModeTheme(
+      "oklch(0.8 0.03 170)",
+    ).getColors();
+    expect(bgNeutralActive).toEqual("rgb(68.134% 68.134% 68.134%)");
+  });
+
+  it("should return correct color when lightness is greater than or equal to 0.85", () => {
+    const { bgNeutralActive } = new DarkModeTheme(
+      "oklch(0.9 0.03 170)",
+    ).getColors();
+    expect(bgNeutralActive).toEqual("rgb(70.597% 70.597% 70.597%)");
+  });
+});
+
+describe("bgNeutralSubtle color", () => {
+  it("should return correct color when lightness is greater than 0.25", () => {
+    const { bgNeutralSubtle } = new DarkModeTheme(
+      "oklch(0.3 0.03 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(13.15% 13.15% 13.15%)");
+  });
+
+  it("should return correct color when lightness is less than 0.2", () => {
+    const { bgNeutralSubtle } = new DarkModeTheme(
+      "oklch(0.15 0.03 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(8.6104% 8.6104% 8.6104%)");
+  });
+
+  it("should return correct color when chroma is greater than 0.025", () => {
+    const { bgNeutralSubtle } = new DarkModeTheme(
+      "oklch(0.3 0.03 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(13.15% 13.15% 13.15%)");
+  });
+
+  it("should return correct color when chroma is less than 0.025 (achromatic)", () => {
+    const { bgNeutralSubtle } = new DarkModeTheme(
+      "oklch(0.3 0.01 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(13.15% 13.15% 13.15%)");
   });
 });

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -2,276 +2,323 @@ import { LightModeTheme } from "../src/LightModeTheme";
 
 describe("bg color", () => {
   it("should return correct color when lightness > 0.93", () => {
-    const { bg: bg1 } = new LightModeTheme("oklch(0.95 0.09 231)").getColors();
-    expect(bg1).toBe("rgb(84.831% 87.516% 88.974%)");
+    const { bg } = new LightModeTheme("oklch(0.95 0.09 231)").getColors();
+    expect(bg).toBe("rgb(84.831% 87.516% 88.974%)");
   });
 
   it("should return correct color when lightness < 0.93", () => {
-    const { bg: bg2 } = new LightModeTheme("oklch(0.92 0.09 231)").getColors();
-    expect(bg2).toBe("rgb(95.828% 98.573% 100%)");
+    const { bg } = new LightModeTheme("oklch(0.92 0.09 231)").getColors();
+    expect(bg).toBe("rgb(95.828% 98.573% 100%)");
   });
 
   it("should return correct color when hue > 120 && hue < 300", () => {
-    const { bg: bg3 } = new LightModeTheme("oklch(0.95 0.07 231)").getColors();
-    expect(bg3).toBe("rgb(84.831% 87.516% 88.974%)");
+    const { bg } = new LightModeTheme("oklch(0.95 0.07 231)").getColors();
+    expect(bg).toBe("rgb(84.831% 87.516% 88.974%)");
   });
 
   it("should return correct color when hue < 120 or hue > 300", () => {
-    const { bg: bg4 } = new LightModeTheme("oklch(0.92 0.07 110)").getColors();
-    expect(bg4).toBe("rgb(98.101% 98.258% 96.176%)");
+    const { bg } = new LightModeTheme("oklch(0.92 0.07 110)").getColors();
+    expect(bg).toBe("rgb(98.101% 98.258% 96.176%)");
   });
 
   it("should return correct color when chroma < 0.04", () => {
-    const { bg: bg5 } = new LightModeTheme("oklch(0.92 0.02 110)").getColors();
-    expect(bg5).toBe("rgb(98.026% 98.026% 98.026%)");
+    const { bg } = new LightModeTheme("oklch(0.92 0.02 110)").getColors();
+    expect(bg).toBe("rgb(98.026% 98.026% 98.026%)");
   });
 });
 
 describe("bgAccent color", () => {
   it("should return correct color when lightness > 0.93", () => {
-    const { bgAccent: bgAccent1 } = new LightModeTheme(
-      "oklch(0.95 0.09 231)",
-    ).getColors();
-    expect(bgAccent1).toBe("rgb(91.762% 98.141% 100%)");
+    const { bgAccent } = new LightModeTheme("oklch(0.95 0.09 231)").getColors();
+    expect(bgAccent).toBe("rgb(91.762% 98.141% 100%)");
   });
 });
 
 describe("bgAccentHover color", () => {
   it("should return correct color when lightness is less than 0.06", () => {
-    const { bgAccentHover: bgAccentHover1 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.05 0.09 231)",
     ).getColors();
-    expect(bgAccentHover1).toBe("rgb(0% 23.271% 34.263%)");
+    expect(bgAccentHover).toBe("rgb(0% 23.271% 34.263%)");
   });
 
   it("should return correct color when lightness is between 0.06 and 0.14", () => {
-    const { bgAccentHover: bgAccentHover2 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.08 0.09 231)",
     ).getColors();
-    expect(bgAccentHover2).toBe("rgb(0% 17.836% 27.428%)");
+    expect(bgAccentHover).toBe("rgb(0% 17.836% 27.428%)");
   });
 
   it("should return correct color when lightness is between 0.14 and 0.21 and hue is between 120 and 300", () => {
-    const { bgAccentHover: bgAccentHover3 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.17 0.09 231)",
     ).getColors();
-    expect(bgAccentHover3).toBe("rgb(0% 16.773% 26.103%)");
+    expect(bgAccentHover).toBe("rgb(0% 16.773% 26.103%)");
   });
 
   it("should return correct color when lightness is between 0.14 and 0.21 and hue is not between 120 and 300", () => {
-    const { bgAccentHover: bgAccentHover4 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.17 0.09 110)",
     ).getColors();
-    expect(bgAccentHover4).toBe("rgb(19.339% 18.943% 0%)");
+    expect(bgAccentHover).toBe("rgb(19.339% 18.943% 0%)");
   });
 
   it("should return correct color when lightness is between 0.21 and 0.4", () => {
-    const { bgAccentHover: bgAccentHover5 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.3 0.09 110)",
     ).getColors();
-    expect(bgAccentHover5).toBe("rgb(28.395% 28.425% 0%)");
+    expect(bgAccentHover).toBe("rgb(28.395% 28.425% 0%)");
   });
 
   it("should return correct color when lightness is between 0.4 and 0.7", () => {
-    const { bgAccentHover: bgAccentHover6 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.5 0.09 110)",
     ).getColors();
-    expect(bgAccentHover6).toBe("rgb(45.795% 46.287% 19.839%)");
+    expect(bgAccentHover).toBe("rgb(45.795% 46.287% 19.839%)");
   });
 
   it("should return correct color when lightness is greater than 0.7", () => {
-    const { bgAccentHover: bgAccentHover7 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.9 0.09 110)",
     ).getColors();
-    expect(bgAccentHover7).toBe("rgb(92.14% 93.271% 65.642%)");
+    expect(bgAccentHover).toBe("rgb(92.14% 93.271% 65.642%)");
   });
 
   it("should return correct color when lightness is greater than 0.93 and hue is between 60 and 115", () => {
-    const { bgAccentHover: bgAccentHover8 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.95 0.09 70)",
     ).getColors();
-    expect(bgAccentHover8).toBe("rgb(100% 90.701% 78.457%)");
+    expect(bgAccentHover).toBe("rgb(100% 90.701% 78.457%)");
   });
 
   it("should return correct color when lightness is greater than 0.93 and hue is not between 116 and 165", () => {
-    const { bgAccentHover: bgAccentHover9 } = new LightModeTheme(
+    const { bgAccentHover } = new LightModeTheme(
       "oklch(0.95 0.09 120)",
     ).getColors();
-    expect(bgAccentHover9).toBe("rgb(89.886% 97.8% 66.657%)");
+    expect(bgAccentHover).toBe("rgb(89.886% 97.8% 66.657%)");
   });
 });
 
 describe("bgAccentActive color", () => {
   it("should return correct color when lightness is less than 0.4", () => {
-    const { bgAccentActive: bgAccentActive1 } = new LightModeTheme(
+    const { bgAccentActive } = new LightModeTheme(
       "oklch(0.35 0.09 70)",
     ).getColors();
-    expect(bgAccentActive1).toBe("rgb(28.712% 15.185% 0%)");
+    expect(bgAccentActive).toBe("rgb(28.712% 15.185% 0%)");
   });
 
   it("should return correct color when lightness is between 0.4 and 0.7", () => {
-    const { bgAccentActive: bgAccentActive2 } = new LightModeTheme(
+    const { bgAccentActive } = new LightModeTheme(
       "oklch(0.50 0.09 70)",
     ).getColors();
-    expect(bgAccentActive2).toBe("rgb(49.27% 32.745% 10.549%)");
+    expect(bgAccentActive).toBe("rgb(49.27% 32.745% 10.549%)");
   });
 
   it("should return correct color when lightness is greater than or equal to 0.7", () => {
-    const { bgAccentActive: bgAccentActive3 } = new LightModeTheme(
+    const { bgAccentActive } = new LightModeTheme(
       "oklch(0.75 0.09 70)",
     ).getColors();
-    expect(bgAccentActive3).toBe("rgb(81.395% 63.124% 41.808%)");
+    expect(bgAccentActive).toBe("rgb(81.395% 63.124% 41.808%)");
   });
 
   it("should return correct color when lightness is greater than 0.93", () => {
-    const { bgAccentActive: bgAccentActive4 } = new LightModeTheme(
+    const { bgAccentActive } = new LightModeTheme(
       "oklch(0.95 0.09 70)",
     ).getColors();
-    expect(bgAccentActive4).toBe("rgb(100% 88.945% 74.563%)");
+    expect(bgAccentActive).toBe("rgb(100% 88.945% 74.563%)");
   });
 });
 
 describe("bgAccentSubtle color", () => {
   it("should return correct color when seedLightness is greater than 0.93", () => {
-    const { bgAccentSubtle: bgAccentSubtle1 } = new LightModeTheme(
+    const { bgAccentSubtle } = new LightModeTheme(
       "oklch(0.95 0.09 231)",
     ).getColors();
-    expect(bgAccentSubtle1).toBe("rgb(85.876% 96.17% 100%)");
+    expect(bgAccentSubtle).toBe("rgb(85.876% 96.17% 100%)");
   });
 
   it("should return correct color when seedLightness is less than 0.93", () => {
-    const { bgAccentSubtle: bgAccentSubtle2 } = new LightModeTheme(
+    const { bgAccentSubtle } = new LightModeTheme(
       "oklch(0.92 0.09 231)",
     ).getColors();
-    expect(bgAccentSubtle2).toBe("rgb(78.235% 93.705% 100%)");
+    expect(bgAccentSubtle).toBe("rgb(78.235% 93.705% 100%)");
   });
 
   it("should return correct color when seedChroma is greater than 0.09 and hue is between 116 and 165", () => {
-    const { bgAccentSubtle: bgAccentSubtle3 } = new LightModeTheme(
+    const { bgAccentSubtle } = new LightModeTheme(
       "oklch(0.95 0.10 120)",
     ).getColors();
-    expect(bgAccentSubtle3).toBe("rgb(90.964% 97.964% 71.119%)");
+    expect(bgAccentSubtle).toBe("rgb(90.964% 97.964% 71.119%)");
   });
 
   it("should return correct color when seedChroma is greater than 0.06 and hue is not between 116 and 165", () => {
-    const { bgAccentSubtle: bgAccentSubtle4 } = new LightModeTheme(
+    const { bgAccentSubtle } = new LightModeTheme(
       "oklch(0.95 0.07 170)",
     ).getColors();
-    expect(bgAccentSubtle4).toBe("rgb(75.944% 100% 91.359%)");
+    expect(bgAccentSubtle).toBe("rgb(75.944% 100% 91.359%)");
   });
 
   it("should return correct color when seedChroma is less than 0.04", () => {
-    const { bgAccentSubtle: bgAccentSubtle5 } = new LightModeTheme(
+    const { bgAccentSubtle } = new LightModeTheme(
       "oklch(0.95 0.03 170)",
     ).getColors();
-    expect(bgAccentSubtle5).toBe("rgb(94.099% 94.099% 94.099%)");
+    expect(bgAccentSubtle).toBe("rgb(94.099% 94.099% 94.099%)");
   });
 });
 
 describe("bgAccentSubtleHover color", () => {
   it("should return correct color", () => {
-    const { bgAccentSubtleHover: bgAccentSubtleHover1 } = new LightModeTheme(
+    const { bgAccentSubtleHover } = new LightModeTheme(
       "oklch(0.35 0.09 70)",
     ).getColors();
-    expect(bgAccentSubtleHover1).toBe("rgb(100% 91.599% 80.256%)");
+    expect(bgAccentSubtleHover).toBe("rgb(100% 91.599% 80.256%)");
   });
 });
 
 describe("bgAccentSubtleActive color", () => {
   it("should return correct color", () => {
-    const { bgAccentSubtleActive: bgAccentSubtleActive1 } = new LightModeTheme(
+    const { bgAccentSubtleActive } = new LightModeTheme(
       "oklch(0.35 0.09 70)",
     ).getColors();
-    expect(bgAccentSubtleActive1).toBe("rgb(100% 87.217% 72.911%)");
+    expect(bgAccentSubtleActive).toBe("rgb(100% 87.217% 72.911%)");
   });
 });
 
 describe("bgAssistive color", () => {
   it("should return correct color when seed is achromatic", () => {
-    const { bgAssistive: bgAssistive1 } = new LightModeTheme(
+    const { bgAssistive } = new LightModeTheme(
       "oklch(0.95 0.03 170)",
     ).getColors();
-    expect(bgAssistive1).toBe("rgb(5.1758% 5.1758% 5.1759%)");
+    expect(bgAssistive).toBe("rgb(5.1758% 5.1758% 5.1759%)");
   });
 });
 
 describe("bgNeutral color", () => {
   it("should return correct color when lightness is greater than 0.85", () => {
-    const { bgNeutral: bgNeutral1 } = new LightModeTheme(
+    const { bgNeutral } = new LightModeTheme(
       "oklch(0.95 0.03 170)",
     ).getColors();
-    expect(bgNeutral1).toEqual("rgb(94.099% 94.099% 94.099%)");
+    expect(bgNeutral).toEqual("rgb(94.099% 94.099% 94.099%)");
   });
 
   it("should return correct color when lightness is between 0.25 and 0.85", () => {
-    const { bgNeutral: bgNeutral2 } = new LightModeTheme(
-      "oklch(0.5 0.09 231)",
-    ).getColors();
-    expect(bgNeutral2).toEqual("rgb(21.658% 29.368% 33.367%)");
+    const { bgNeutral } = new LightModeTheme("oklch(0.5 0.09 231)").getColors();
+    expect(bgNeutral).toEqual("rgb(21.658% 29.368% 33.367%)");
   });
 
   it("should return correct color when chroma is less than 0.04", () => {
-    const { bgNeutral: bgNeutral3 } = new LightModeTheme(
+    const { bgNeutral } = new LightModeTheme(
       "oklch(0.95 0.02 170)",
     ).getColors();
-    expect(bgNeutral3).toEqual("rgb(94.099% 94.099% 94.099%)");
+    expect(bgNeutral).toEqual("rgb(94.099% 94.099% 94.099%)");
   });
 
   it("should return correct color when hue is between 120 and 300 and chroma is not less than 0.04", () => {
-    const { bgNeutral: bgNeutral4 } = new LightModeTheme(
+    const { bgNeutral } = new LightModeTheme(
       "oklch(0.95 0.06 240)",
     ).getColors();
-    expect(bgNeutral4).toEqual("rgb(87.409% 95.47% 100%)");
+    expect(bgNeutral).toEqual("rgb(87.409% 95.47% 100%)");
   });
 
   it("should return correct color when hue is not between 120 and 300 and chroma is not less than 0.04", () => {
-    const { bgNeutral: bgNeutral5 } = new LightModeTheme(
-      "oklch(0.95 0.06 30)",
-    ).getColors();
-    expect(bgNeutral5).toEqual("rgb(98.083% 92.81% 91.842%)");
+    const { bgNeutral } = new LightModeTheme("oklch(0.95 0.06 30)").getColors();
+    expect(bgNeutral).toEqual("rgb(98.083% 92.81% 91.842%)");
   });
 });
 
 describe("bgNeutralHover color", () => {
   it("should return correct color when lightness is less than 0.06", () => {
-    const { bgNeutralHover: bgNeutralHover1 } = new LightModeTheme(
+    const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.05 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover1).toEqual("rgb(16.952% 16.952% 16.952%)");
+    expect(bgNeutralHover).toEqual("rgb(16.952% 16.952% 16.952%)");
   });
 
   it("should return correct color when lightness is between 0.06 and 0.14", () => {
-    const { bgNeutralHover: bgNeutralHover2 } = new LightModeTheme(
+    const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.10 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover2).toEqual("rgb(12.222% 12.222% 12.222%)");
+    expect(bgNeutralHover).toEqual("rgb(12.222% 12.222% 12.222%)");
   });
 
   it("should return correct color when lightness is between 0.14 and 0.21", () => {
-    const { bgNeutralHover: bgNeutralHover3 } = new LightModeTheme(
+    const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.17 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover3).toEqual("rgb(12.222% 12.222% 12.222%)");
+    expect(bgNeutralHover).toEqual("rgb(12.222% 12.222% 12.222%)");
   });
 
   it("should return correct color when lightness is between 0.21 and 0.7", () => {
-    const { bgNeutralHover: bgNeutralHover4 } = new LightModeTheme(
+    const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.35 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover4).toEqual("rgb(17.924% 17.924% 17.924%)");
+    expect(bgNeutralHover).toEqual("rgb(17.924% 17.924% 17.924%)");
   });
 
   it("should return correct color when lightness is between 0.7 and 0.955", () => {
-    const { bgNeutralHover: bgNeutralHover5 } = new LightModeTheme(
+    const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.75 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover5).toEqual("rgb(62.05% 62.05% 62.05%)");
+    expect(bgNeutralHover).toEqual("rgb(62.05% 62.05% 62.05%)");
   });
 
   it("should return correct color when lightness is greater than or equal to 0.955", () => {
-    const { bgNeutralHover: bgNeutralHover6 } = new LightModeTheme(
+    const { bgNeutralHover } = new LightModeTheme(
       "oklch(0.96 0.03 170)",
     ).getColors();
-    expect(bgNeutralHover6).toEqual("rgb(92.148% 92.148% 92.148%)");
+    expect(bgNeutralHover).toEqual("rgb(92.148% 92.148% 92.148%)");
+  });
+});
+
+describe("bgNeutralActive color", () => {
+  it("should return correct color when lightness is less than 0.4", () => {
+    const { bgNeutralActive } = new LightModeTheme(
+      "oklch(0.35 0.03 170)",
+    ).getColors();
+    expect(bgNeutralActive).toEqual("rgb(10.396% 10.396% 10.396%)");
+  });
+
+  it("should return correct color when lightness is between 0.4 and 0.955", () => {
+    const { bgNeutralActive } = new LightModeTheme(
+      "oklch(0.80 0.03 170)",
+    ).getColors();
+    expect(bgNeutralActive).toEqual("rgb(60.846% 60.846% 60.846%)");
+  });
+
+  it("should return correct color when lightness is greater than or equal to 0.955", () => {
+    const { bgNeutralActive } = new LightModeTheme(
+      "oklch(0.96 0.03 170)",
+    ).getColors();
+    expect(bgNeutralActive).toEqual("rgb(90.204% 90.204% 90.204%)");
+  });
+});
+
+describe("bgNeutralSubtle color", () => {
+  it("should return correct color when lightness is greater than 0.93", () => {
+    const { bgNeutralSubtle } = new LightModeTheme(
+      "oklch(0.95 0.03 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(94.099% 94.099% 94.099%)");
+  });
+
+  it("should return correct color when lightness is less than or equal to 0.93", () => {
+    const { bgNeutralSubtle } = new LightModeTheme(
+      "oklch(0.92 0.03 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(90.851% 90.851% 90.851%)");
+  });
+
+  it("should return correct color when seedChroma is greater than 0.01", () => {
+    const { bgNeutralSubtle } = new LightModeTheme(
+      "oklch(0.92 0.1 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(88.517% 91.796% 90.467%)");
+  });
+
+  it("should return correct color when chroma is less than 0.04", () => {
+    const { bgNeutralSubtle } = new LightModeTheme(
+      "oklch(0.92 0.03 170)",
+    ).getColors();
+    expect(bgNeutralSubtle).toEqual("rgb(90.851% 90.851% 90.851%)");
   });
 });

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -417,3 +417,74 @@ describe("bgPositiveSubtleActive color", () => {
     expect(bgPositiveSubtleActive).toEqual("rgb(80.049% 98.746% 80.116%)");
   });
 });
+
+describe("bgNegative color", () => {
+  it("should return correct color when seed color is red (hue between 5 and 49) and chroma > 0.12", () => {
+    const { bgNegative } = new LightModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegative).toEqual("rgb(82.941% 0.9786% 21.484%)");
+  });
+
+  it("should return correct color when seed color is red (hue between 5 and 49) but chroma is not greater than 0.12", () => {
+    const { bgNegative } = new LightModeTheme("oklch(0.55 0.1 27)").getColors();
+    expect(bgNegative).toEqual("rgb(83.108% 4.6651% 10.252%)");
+  });
+
+  it("should return correct color when seed color is not red (hue outside 5-49) and chroma > 0.12", () => {
+    const { bgNegative } = new LightModeTheme(
+      "oklch(0.55 0.22 60)",
+    ).getColors();
+    expect(bgNegative).toEqual("rgb(83.108% 4.6651% 10.252%)");
+  });
+
+  it("should return correct color when seed color is not red (hue outside 5-49) and chroma is not greater than 0.12", () => {
+    const { bgNegative } = new LightModeTheme("oklch(0.55 0.1 60)").getColors();
+    expect(bgNegative).toEqual("rgb(83.108% 4.6651% 10.252%)");
+  });
+});
+
+describe("bgNegativeHover color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeHover } = new LightModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeHover).toEqual("rgb(90.138% 15.796% 27.164%)");
+  });
+});
+
+describe("bgNegativeActive color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeActive } = new LightModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeActive).toEqual("rgb(80.074% 0% 19.209%)");
+  });
+});
+
+describe("bgNegativeSubtle color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeSubtle } = new LightModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeSubtle).toEqual("rgb(80.074% 0% 19.209%)");
+  });
+});
+
+describe("bgNegativeSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeSubtleHover } = new LightModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeSubtleHover).toEqual("rgb(100% 93.507% 93.192%)");
+  });
+});
+
+describe("bgNegativeSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgNegativeSubtleActive } = new LightModeTheme(
+      "oklch(0.55 0.22 27)",
+    ).getColors();
+    expect(bgNegativeSubtleActive).toEqual("rgb(100% 88.131% 87.677%)");
+  });
+});

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -322,3 +322,98 @@ describe("bgNeutralSubtle color", () => {
     expect(bgNeutralSubtle).toEqual("rgb(90.851% 90.851% 90.851%)");
   });
 });
+
+describe("bgNeutralSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgNeutralSubtleHover } = new LightModeTheme(
+      "oklch(0.92 0.1 170)",
+    ).getColors();
+
+    expect(bgNeutralSubtleHover).toEqual("rgb(91.102% 94.398% 93.061%)");
+  });
+});
+
+describe("bgNeutralSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgNeutralSubtleActive } = new LightModeTheme(
+      "oklch(0.92 0.1 170)",
+    ).getColors();
+
+    expect(bgNeutralSubtleActive).toEqual("rgb(87.229% 90.5% 89.174%)");
+  });
+});
+
+describe("bgPositive color", () => {
+  it("should return correct color when seed color is green (hue between 116 and 165) and chroma > 0.11", () => {
+    const { bgPositive } = new LightModeTheme(
+      "oklch(0.62 0.19 145)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(30.224% 61.63% 0%)");
+  });
+
+  it("should return correct color when seed color is green (hue between 116 and 165) but chroma is not greater than 0.11", () => {
+    const { bgPositive } = new LightModeTheme(
+      "oklch(0.62 0.1 145)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(6.7435% 63.436% 18.481%)");
+  });
+
+  it("should return correct color when seed color is not green (hue outside 116-165) and chroma > 0.11", () => {
+    const { bgPositive } = new LightModeTheme(
+      "oklch(0.62 0.19 100)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(6.7435% 63.436% 18.481%)");
+  });
+
+  it("should return correct color when seed color is not green (hue outside 116-165) and chroma is not greater than 0.11", () => {
+    const { bgPositive } = new LightModeTheme(
+      "oklch(0.62 0.1 100)",
+    ).getColors();
+    expect(bgPositive).toEqual("rgb(6.7435% 63.436% 18.481%)");
+  });
+});
+
+describe("bgPositiveHover color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveHover } = new LightModeTheme(
+      "oklch(0.62 0.19 100)",
+    ).getColors();
+    expect(bgPositiveHover).toEqual("rgb(18.172% 69.721% 25.266%)");
+  });
+});
+
+describe("bgPositiveActive color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveActive } = new LightModeTheme(
+      "oklch(0.62 0.19 100)",
+    ).getColors();
+    expect(bgPositiveActive).toEqual("rgb(0% 60.947% 15.563%)");
+  });
+});
+
+describe("bgPositiveSubtle color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveSubtle } = new LightModeTheme(
+      "oklch(0.62 0.19 100)",
+    ).getColors();
+    expect(bgPositiveSubtle).toEqual("rgb(81.329% 100% 81.391%)");
+  });
+});
+
+describe("bgPositiveSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveSubtleHover } = new LightModeTheme(
+      "oklch(0.62 0.19 100)",
+    ).getColors();
+    expect(bgPositiveSubtleHover).toEqual("rgb(84.848% 100% 84.841%)");
+  });
+});
+
+describe("bgPositiveSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgPositiveSubtleActive } = new LightModeTheme(
+      "oklch(0.62 0.19 100)",
+    ).getColors();
+    expect(bgPositiveSubtleActive).toEqual("rgb(80.049% 98.746% 80.116%)");
+  });
+});

--- a/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
+++ b/app/client/packages/design-system/theming/src/color/tests/LightModeTheme.test.ts
@@ -488,3 +488,70 @@ describe("bgNegativeSubtleActive color", () => {
     expect(bgNegativeSubtleActive).toEqual("rgb(100% 88.131% 87.677%)");
   });
 });
+
+describe("bgWarning color", () => {
+  it("should return correct color when seed color is yellow (hue between 60 and 115) and chroma > 0.09", () => {
+    const { bgWarning } = new LightModeTheme("oklch(0.75 0.15 85)").getColors();
+    expect(bgWarning).toEqual("rgb(91.527% 60.669% 16.491%)");
+  });
+
+  it("should return correct color when seed color is yellow (hue between 60 and 115) but chroma is not greater than 0.09", () => {
+    const { bgWarning } = new LightModeTheme("oklch(0.75 0.05 85)").getColors();
+    expect(bgWarning).toEqual("rgb(85.145% 64.66% 8.0286%)");
+  });
+
+  it("should return correct color when seed color is not yellow (hue outside 60-115) and chroma > 0.09", () => {
+    const { bgWarning } = new LightModeTheme("oklch(0.75 0.15 85)").getColors();
+    expect(bgWarning).toEqual("rgb(91.527% 60.669% 16.491%)");
+  });
+
+  it("should return correct color when seed color is not yellow (hue outside 60-115) and chroma is not greater than 0.09", () => {
+    const { bgWarning } = new LightModeTheme("oklch(0.75 0.05 85)").getColors();
+    expect(bgWarning).toEqual("rgb(85.145% 64.66% 8.0286%)");
+  });
+});
+
+describe("bgWarningHover color", () => {
+  it("should return correct color", () => {
+    const { bgWarningHover } = new LightModeTheme(
+      "oklch(0.75 0.15 85)",
+    ).getColors();
+    expect(bgWarningHover).toEqual("rgb(95.533% 64.413% 21.716%)");
+  });
+});
+
+describe("bgWarningActive color", () => {
+  it("should return correct color", () => {
+    const { bgWarningActive } = new LightModeTheme(
+      "oklch(0.75 0.15 85)",
+    ).getColors();
+    expect(bgWarningActive).toEqual("rgb(90.198% 59.428% 14.545%)");
+  });
+});
+
+describe("bgWarningSubtle color", () => {
+  it("should return correct color", () => {
+    const { bgWarningSubtle } = new LightModeTheme(
+      "oklch(0.75 0.15 85)",
+    ).getColors();
+    expect(bgWarningSubtle).toEqual("rgb(100% 93.263% 83.925%)");
+  });
+});
+
+describe("bgWarningSubtleHover color", () => {
+  it("should return correct color", () => {
+    const { bgWarningSubtleHover } = new LightModeTheme(
+      "oklch(0.75 0.15 85)",
+    ).getColors();
+    expect(bgWarningSubtleHover).toEqual("rgb(100% 96.499% 91.027%)");
+  });
+});
+
+describe("bgWarningSubtleActive color", () => {
+  it("should return correct color", () => {
+    const { bgWarningSubtleActive } = new LightModeTheme(
+      "oklch(0.75 0.15 85)",
+    ).getColors();
+    expect(bgWarningSubtleActive).toEqual("rgb(100% 91.621% 80.174%)");
+  });
+});


### PR DESCRIPTION
Related #26018 

Added tests for 
- bgNeutralActive color
- bgNeutralSubtle color
- bgNeutralSubtleHover color
- bgNeutralSubtleActive color
- bgPositive color
- bgPositiveHover color
- bgPositiveActive color
- bgPositiveSubtle color
- bgPositiveSubtleHover color
- bgPositiveSubtleActive color
- bgNegative color
- bgNegativeHover color
- bgNegativeActive color
- bgNegativeSubtle color
- bgNegativeSubtleHover color
- bgNegativeSubtleActive color
- bgWarning color
- bgWarningHover color
- bgWarningActive color
- bgWarningSubtle color
- bgWarningSubtleHover color
- bgWarningSubtleActive color
