### PR TITLE
chore: Removed wrappedChildren in FlexComponent

### DIFF
--- a/app/client/src/layoutSystems/autolayout/common/FlexComponent.tsx
+++ b/app/client/src/layoutSystems/autolayout/common/FlexComponent.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 
 import type { RenderMode, WidgetType } from "constants/WidgetConstants";
-import { RenderModes } from "constants/WidgetConstants";
 import { WIDGET_PADDING } from "constants/WidgetConstants";
 import { useSelector } from "react-redux";
 import {
@@ -68,13 +67,6 @@ export function FlexComponent(props: AutoLayoutProps) {
   const stopEventPropagation = (e: any) => {
     !isSnipingMode && e.stopPropagation();
   };
-
-  const wrappedChildren = (children: ReactNode) =>
-    props.renderMode === RenderModes.PAGE ? (
-      <div className="w-full h-full">{children}</div>
-    ) : (
-      children
-    );
 
   const className = useMemo(
     () =>
@@ -145,7 +137,7 @@ export function FlexComponent(props: AutoLayoutProps) {
       onClickCapture={onClickFn}
       style={flexComponentStyle}
     >
-      {wrappedChildren(props.children)}
+      {props.children}
     </FlexWidget>
   );
 }

--- a/app/client/src/widgets/CameraWidget/component/index.tsx
+++ b/app/client/src/widgets/CameraWidget/component/index.tsx
@@ -96,6 +96,7 @@ const CameraContainer = styled.div<CameraContainerProps>`
   justify-content: center;
   overflow: hidden;
   height: 100%;
+  width: 100%;
   border-radius: ${({ borderRadius }) => borderRadius};
   box-shadow: ${({ boxShadow }) => boxShadow};
   background: ${({ disabled }) => (disabled ? Colors.GREY_3 : Colors.BLACK)};

--- a/app/client/src/widgets/CodeScannerWidget/component/index.tsx
+++ b/app/client/src/widgets/CodeScannerWidget/component/index.tsx
@@ -156,6 +156,7 @@ export interface DisabledOverlayerProps {
 
 const CodeScannerContainer = styled.div`
   height: 100%;
+  width: 100%;
 `;
 
 const DisabledOverlayer = styled.div<DisabledOverlayerProps>`

--- a/app/client/src/widgets/MapWidget/widget/index.tsx
+++ b/app/client/src/widgets/MapWidget/widget/index.tsx
@@ -29,6 +29,8 @@ const DisabledContainer = styled.div<{
 }>`
   background-color: white;
   height: 100%;
+  width: 100%;
+  overflow: scroll;
   text-align: center;
   display: flex;
   flex-direction: column;

--- a/app/client/src/widgets/SwitchWidget/component/index.tsx
+++ b/app/client/src/widgets/SwitchWidget/component/index.tsx
@@ -39,8 +39,7 @@ const SwitchComponentContainer = styled.div<{
   ${({ minHeight }) => `
     ${minHeight ? `min-height: ${minHeight}px;` : undefined}`};
 
-  ${({ width }) => `
-    ${width ? `width: ${width};` : undefined}`};
+  width: 100%;
 
   ${BlueprintControlTransform}
 `;

--- a/app/client/src/widgets/VideoWidget/component/index.tsx
+++ b/app/client/src/widgets/VideoWidget/component/index.tsx
@@ -36,6 +36,7 @@ const VideoWrapper = styled.div<{
   backgroundColor?: string;
 }>`
   height: 100%;
+  width: 100%;
 
   & video,
   & > div {


### PR DESCRIPTION
## Description
`wrappedChildren` is used to add a `div` around widget which sets 100% height and width. This happens only on deploy mode. This was added to make sure some widgets are getting properly displayed in deploy mode.
In this PR, we are removing it and make the necessary changes in the widget's code itself.

#### PR fixes following issue(s)
Fixes #27085 

#### Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
