### PR TITLE
fix: property pane if tabledata section doesn't exist, clear widget id

### DIFF
--- a/app/client/src/components/featureWalkthrough/walkthroughRenderer.tsx
+++ b/app/client/src/components/featureWalkthrough/walkthroughRenderer.tsx
@@ -216,14 +216,18 @@ const WalkthroughRenderer = ({
                     0 ${targetBounds.bh}, 
                     ${multipleHighlightsIds.reduce((acc, id) => {
                       const boundingRect = boundingRects[id];
-                      acc = `${acc} ${boundingRect.tx} ${boundingRect.bh}, 
-                      ${boundingRect.tx} ${boundingRect.ty}, 
-                      ${boundingRect.tx + boundingRect.tw} ${boundingRect.ty},
-                      ${boundingRect.tx + boundingRect.tw} ${
-                        boundingRect.ty + boundingRect.th
-                      }, 
-                      ${boundingRect.tx} ${boundingRect.ty + boundingRect.th}, 
-                      ${boundingRect.tx} ${boundingRect.bh},`;
+                      if (boundingRect) {
+                        acc = `${acc} ${boundingRect.tx} ${boundingRect.bh}, 
+                        ${boundingRect.tx} ${boundingRect.ty}, 
+                        ${boundingRect.tx + boundingRect.tw} ${boundingRect.ty},
+                        ${boundingRect.tx + boundingRect.tw} ${
+                          boundingRect.ty + boundingRect.th
+                        }, 
+                        ${boundingRect.tx} ${
+                          boundingRect.ty + boundingRect.th
+                        }, 
+                        ${boundingRect.tx} ${boundingRect.bh},`;
+                      }
                       return acc;
                     }, "")}
                     ${targetBounds.bw} ${targetBounds.bh}, 

--- a/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
+++ b/app/client/src/pages/Editor/PropertyPane/PropertySection.tsx
@@ -19,6 +19,7 @@ import { setPropertySectionState } from "actions/propertyPaneActions";
 import { getIsOneClickBindingOptionsVisibility } from "selectors/oneClickBindingSelectors";
 import localStorage from "utils/localStorage";
 import { WIDGET_ID_SHOW_WALKTHROUGH } from "constants/WidgetConstants";
+import { PROPERTY_PANE_ID } from "components/editorComponents/PropertyPaneSidebar";
 
 const TagContainer = styled.div``;
 
@@ -149,10 +150,17 @@ export const PropertySection = memo((props: PropertySectionProps) => {
     );
 
     if (widgetId) {
-      if (className === "data") {
-        setIsOpen(true);
+      const isWidgetIdTableDataExist = document.querySelector(
+        `#${PROPERTY_PANE_ID} [id='${btoa(widgetId + ".tableData")}']`,
+      );
+      if (isWidgetIdTableDataExist) {
+        if (className === "data") {
+          setIsOpen(true);
+        } else {
+          setIsOpen(false);
+        }
       } else {
-        setIsOpen(false);
+        await localStorage.removeItem(WIDGET_ID_SHOW_WALKTHROUGH);
       }
     }
   };


### PR DESCRIPTION
## Description
If the `WIDGET_ID_SHOW_WALKTHROUGH` localstorage key exists (which gets created when we bind the widget using suggested widget or new widget from action right side pane binding UI), and the property pane opened for current widget selected doesn't have the same widget id, then clear the key from local storage and do not collapse the property sections for the widget in property pane.

#### PR fixes following issue(s)
Fixes #26776 

#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
> Please delete options that are not relevant.
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Chore (housekeeping or task changes that don't impact user perception)
- This change requires a documentation update
>
>
>
## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [x] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
