### PR TITLE
chore(deps): Update and get CVE fixes for pip and semver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   && apt-get update && apt-get install --no-install-recommends --yes temurin-17-jdk \
   && pip install --no-cache-dir git+https://github.com/coderanger/supervisor-stdout@973ba19967cdaf46d9c1634d1675fc65b9574f6e \
   && python3 -m venv --prompt certbot /opt/certbot/venv \
-  && /opt/certbot/venv/bin/pip install --upgrade certbot setuptools \
+  && /opt/certbot/venv/bin/pip install --upgrade certbot setuptools pip \
   && ln -s /opt/certbot/venv/bin/certbot /usr/local/bin \
   && apt-get remove --yes git python3-pip python3-venv \
   && apt-get autoremove --yes
@@ -34,7 +34,9 @@ RUN curl --silent --show-error --location https://www.mongodb.org/static/pgp/ser
   && curl --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt update \
   && apt-get install --no-install-recommends --yes mongodb-org nodejs redis build-essential postgresql-13 \
-  && apt-get clean
+  && apt-get clean \
+  # This is to get semver 7.5.2, for a CVE fix, might be able to remove it with later versions on NodeJS.
+  && npm install -g npm@9.7.2
 
 # Clean up cache file - Service layer
 RUN rm -rf \


### PR DESCRIPTION
Get fixes for CVE-2022-25883 in npm:semver and CVE-2021-3572 in pypi:pip.