### PR TITLE
feat: Add autocomplete support for table schema on SQL editor

### DIFF
--- a/app/client/src/ce/selectors/entitiesSelector.ts
+++ b/app/client/src/ce/selectors/entitiesSelector.ts
@@ -1141,6 +1141,7 @@ export const getAllDatasourceTableKeys = createSelector(
         tables[table.name] = "table";
         table.columns.forEach((column) => {
           tables[`${table.name}.${column.name}`] = column.type;
+          tables[`${column.name}`] = column.type;
         });
       }
     });

--- a/app/client/src/components/editorComponents/CodeEditor/utils/sqlHint.ts
+++ b/app/client/src/components/editorComponents/CodeEditor/utils/sqlHint.ts
@@ -46,7 +46,9 @@ export function getHintDetailsFromClassName(
   }
 }
 
-const MAX_NUMBER_OF_SQL_HINTS = 200;
+// Beyond 270 hints, the main thread task for rendering the hint tooltip becomes greater than 50ms
+// 50ms is the limit beyond which a task is considered a long task
+const MAX_NUMBER_OF_SQL_HINTS = 270;
 
 export function filterCompletions(completions: Hints) {
   completions.list = completions.list.slice(0, MAX_NUMBER_OF_SQL_HINTS);


### PR DESCRIPTION
## Description

This PR adds autocomplete support for table schema on SQL editor. It also increases (slightly) the number of showable autocompletion hint options to 270.


#### PR fixes following issue(s)
Fixes #27163 


#### Media
> A video or a GIF is preferred. when using Loom, don’t embed because it looks like it’s a GIF. instead, just link to the video
>
>
#### Type of change
- New feature (non-breaking change which adds functionality)

## Testing
>
#### How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Also list any relevant details for your test configuration.
> Delete anything that is not relevant
- [ ] Manual
- [ ] JUnit
- [ ] Jest
- [ ] Cypress
>
>
#### Test Plan
> Add Testsmith test cases links that relate to this PR
>
>
#### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)
>
>
>
## Checklist:
#### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
