### PR TITLE
fix: Make manage users sentence cased & handle mobile UI when top banner is seen

### DIFF
--- a/app/client/cypress/e2e/Regression/ClientSide/Workspace/MemberRoles_Spec.ts
+++ b/app/client/cypress/e2e/Regression/ClientSide/Workspace/MemberRoles_Spec.ts
@@ -20,7 +20,7 @@ describe("Create new workspace and invite user & validate all roles", () => {
         Cypress.env("TESTUSERNAME1"),
         "App Viewer",
       );
-      _.agHelper.GetNClick(_.homePage._visibleTextSpan("Manage Users"));
+      _.agHelper.GetNClick(_.homePage._visibleTextSpan("Manage users"));
       _.homePage.NavigateToHome();
       _.homePage.CheckWorkspaceShareUsersCount(workspaceId, 2);
       _.homePage.CreateAppInWorkspace(workspaceId, appid);
@@ -32,7 +32,7 @@ describe("Create new workspace and invite user & validate all roles", () => {
     _.homePage.LogintoApp(Cypress.env("USERNAME"), Cypress.env("PASSWORD"));
     _.homePage.FilterApplication(appid, workspaceId);
     _.agHelper.GetNClick(_.homePage._shareWorkspace(workspaceId));
-    _.agHelper.GetNClick(_.homePage._visibleTextSpan("Manage Users"));
+    _.agHelper.GetNClick(_.homePage._visibleTextSpan("Manage users"));
     cy.get(".search-highlight").should("not.exist");
     _.agHelper.TypeText(
       _.homePage._searchUsersInput,

--- a/app/client/src/ce/pages/Applications/index.tsx
+++ b/app/client/src/ce/pages/Applications/index.tsx
@@ -112,8 +112,6 @@ export const WorkspaceDropDown = styled.div<{ isMobile?: boolean }>`
   ${({ isMobile }) =>
     isMobile &&
     `
-    position: sticky;
-    top: 0;
     background-color: #fff;
     z-index: ${Indices.Layer8};
   `}

--- a/app/client/src/pages/Editor/DataSourceEditor/DatasourceViewModeSchema.tsx
+++ b/app/client/src/pages/Editor/DataSourceEditor/DatasourceViewModeSchema.tsx
@@ -23,8 +23,7 @@ import {
 import Table from "pages/Editor/QueryEditor/Table";
 import { generateTemplateToUpdatePage } from "actions/pageActions";
 import { useParams } from "react-router";
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import type { ExplorerURLParams } from "ce/pages/Editor/Explorer/helpers";
+import type { ExplorerURLParams } from "@appsmith/pages/Editor/Explorer/helpers";
 import {
   getCurrentApplicationId,
   getPagePermissions,

--- a/app/client/src/pages/common/SubHeader.tsx
+++ b/app/client/src/pages/common/SubHeader.tsx
@@ -33,13 +33,18 @@ const SubHeaderWrapper = styled.div<{
   width: 100%;
   display: flex;
   justify-content: space-between;
-  ${(props) => (props.isBannerVisible ? "margin-top: 96px" : "")};
   background: var(--ads-v2-color-bg);
   z-index: ${({ isMobile }) => (isMobile ? Indices.Layer8 : Indices.Layer9)};
-  ${({ isMobile }) =>
+  ${({ isBannerVisible, isMobile }) =>
     isMobile
-      ? "padding: 12px 16px; margin: 0px;"
-      : `padding: ${CONTAINER_WRAPPER_PADDING} ${CONTAINER_WRAPPER_PADDING} 12px ${CONTAINER_WRAPPER_PADDING} ; position: sticky; top: 0; align-items: center;`}
+      ? `padding: 12px 16px;
+        position: sticky; ${
+          isBannerVisible ? "top: 80px; margin-top: 80px" : "top: 0; margin: 0"
+        };
+        `
+      : `padding: ${CONTAINER_WRAPPER_PADDING} ${CONTAINER_WRAPPER_PADDING} 12px ${CONTAINER_WRAPPER_PADDING} ; position: sticky; ${
+          isBannerVisible ? "top: 40px; margin-top: 40px" : "top: 0"
+        }; align-items: center;`}
 `;
 const SearchContainer = styled.div<{ isMobile?: boolean }>`
   width: ${({ isMobile }) => (isMobile ? `100%` : `350px`)};

--- a/app/client/src/pages/workspace/ManageUsers.tsx
+++ b/app/client/src/pages/workspace/ManageUsers.tsx
@@ -18,7 +18,7 @@ function ManageUsers({
       target="_self"
       to={`/workspace/${workspaceId}/settings/members`}
     >
-      Manage Users
+      Manage users
     </Link>
   ) : null;
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/exceptions/AppsmithError.java
@@ -202,7 +202,7 @@ public enum AppsmithError {
     USER_ALREADY_EXISTS_IN_WORKSPACE(
             400,
             AppsmithErrorCode.USER_ALREADY_EXISTS_IN_WORKSPACE.getCode(),
-            "The user {0} has already been added to the workspace with role {1}. To change the role, please navigate to `Manage Users` page.",
+            "The user {0} has already been added to the workspace with role {1}. To change the role, please navigate to `Manage users` page.",
             AppsmithErrorAction.DEFAULT,
             "User already exists in this workspace",
             ErrorType.BAD_REQUEST,


### PR DESCRIPTION
## Description

Make manage users sentence cased & handle mobile UI when top banner is seen

#### PR fixes following issue(s)
Fixes [#27339](https://github.com/appsmithorg/appsmith/issues/27339)

#### Type of change
- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)

## Testing

#### How Has This Been Tested?
- [x] Manual
- [ ] JUnit
- [ ] Jest
- [x] Cypress

## Checklist:
#### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] PR is being merged under a feature flag


#### QA activity:
- [ ] [Speedbreak features](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#speedbreakers-) have been covered
- [ ] Test plan covers all impacted features and [areas of interest](https://github.com/appsmithorg/TestSmith/wiki/Guidelines-for-test-plans#areas-of-interest-)
- [ ] Test plan has been peer reviewed by project stakeholders and other QA members
- [ ] Manually tested functionality on DP
- [ ] We had an implementation alignment call with stakeholders post QA Round 2
- [ ] Cypress test cases have been added and approved by SDET/manual QA
- [ ] Added `Test Plan Approved` label after Cypress tests were reviewed
- [ ] Added `Test Plan Approved` label after JUnit tests were reviewed
