### PR TITLE
chore: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,5 @@ indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.java,*.md,pom.xml}]
+[{*.java,pom.xml}]
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# https://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.java,*.md,pom.xml}]
+indent_size = 4


### PR DESCRIPTION
An indentation syntax error on a workflow file caused all CI pipelines to break and fail. Adding a `.editorconfig` file with the correct expected indentation settings can help solve these problems. A couple of other things this will do for us:

1. Trailing whitespace is automatically removed. This causes a lot of noise diffs in PRs.
2. Newline at end of files is a Linux file expectation and this can ensure that. This also causes a lot of noise diffs in PRs.

The editors that majority of the team uses today, support EditorConfig out of the box. See https://editorconfig.org/#pre-installed.

There's a _lot_ of violations in the repo today, so I'm not adding a CI check right away. Let's check back in a month or two and assess if we want to look into a CI check.

I've had this file in my local clone for ~3 years now. 🙂
