### PR TITLE
feat: Add `/info` endpoint for details about the Appsmith version running

### DIFF
--- a/deploy/docker/fs/opt/appsmith/templates/nginx-app.conf.sh
+++ b/deploy/docker/fs/opt/appsmith/templates/nginx-app.conf.sh
@@ -118,6 +118,11 @@ fi
     try_files /loading.html \$uri /index.html =404;
   }
 
+  location = /info {
+    add_header Content-Type application/json;
+    alias /opt/appsmith/info.json;
+  }
+
   location ~ ^/static/(js|css|media)\b {
     # Files in these folders are hashed, so we can set a long cache time.
     add_header Cache-Control "max-age=31104000, immutable";  # 360 days


### PR DESCRIPTION
This just responds with the contents of `/opt/appsmith/info.json` as is, with a JSON content type.

This will enable showing the right date on the frontend, as well as on Flow. See [this Slack thread](https://theappsmith.slack.com/archives/C02MUD8DNUR/p1694762058953999?thread_ts=1694757060.520329&cid=C02MUD8DNUR) for the confusion we're solving for.
